### PR TITLE
fix(#6069): fold the bucket record-count delta on RESTORE DOCUMENT/VERTEX/EDGE

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -441,6 +441,10 @@ public class GraphEngine {
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(targetRid.getBucketId());
     final MutableVertex shell = database.newVertex(typeName);
     bucket.restoreRecordAtPosition(targetRid.getPosition(), shell);
+    // #6069: restoreRecordAtPosition only does the physical page write, same as bucket create/delete; the caller
+    // owns folding the transaction's cached bucket record-count delta by the same +1 a normal create applies (see
+    // LocalDatabase.createRecord / RestoreStatementSupport.restoreRecordAndUpdateCount for the SQL-statement path).
+    database.getTransaction().updateBucketRecordDelta(bucket.getFileId(), +1);
 
     final Set<RID> asSet = Set.of(targetRid);
     final long[] counts = reconnectEdgesFromSurvivors(asSet, asSet);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreDocumentStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreDocumentStatement.java
@@ -64,7 +64,7 @@ public class RestoreDocumentStatement extends SimpleExecStatement {
     RestoreStatementSupport.applyBody(doc, insertBody, context);
 
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
-    final RID restoredRid = bucket.restoreRecordAtPosition(rid.getPosition(), doc);
+    final RID restoredRid = RestoreStatementSupport.restoreRecordAndUpdateCount(database, bucket, rid.getPosition(), doc);
 
     final ResultInternal result = new ResultInternal(database);
     result.setProperty("operation", "restore document");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreEdgeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreEdgeStatement.java
@@ -83,7 +83,7 @@ public class RestoreEdgeStatement extends SimpleExecStatement {
     RestoreStatementSupport.applyBody(shell, insertBody, context);
 
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
-    final RID restoredRid = bucket.restoreRecordAtPosition(rid.getPosition(), shell);
+    final RID restoredRid = RestoreStatementSupport.restoreRecordAndUpdateCount(database, bucket, rid.getPosition(), shell);
 
     final ResultInternal result = new ResultInternal(database);
     result.setProperty("operation", "restore edge");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreStatementSupport.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreStatementSupport.java
@@ -18,7 +18,11 @@
  */
 package com.arcadedb.query.sql.parser;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -29,6 +33,20 @@ import com.arcadedb.query.sql.executor.CommandContext;
  */
 final class RestoreStatementSupport {
   private RestoreStatementSupport() {
+  }
+
+  /**
+   * Restores {@code record} at {@code position} in {@code bucket} and folds the transaction's cached bucket
+   * record-count delta by the same +1 a normal {@code createRecord} applies (see
+   * {@code LocalDatabase.createRecord}). {@link LocalBucket#restoreRecordAtPosition} only performs the physical
+   * page write and, like bucket-level create/delete, leaves this logical bookkeeping to the caller - every RESTORE
+   * statement wants it, so it lives here once instead of being repeated (and forgotten, #6069) at each call site.
+   */
+  static RID restoreRecordAndUpdateCount(final DatabaseInternal database, final LocalBucket bucket, final long position,
+      final Record record) {
+    final RID restoredRid = bucket.restoreRecordAtPosition(position, record);
+    database.getTransaction().updateBucketRecordDelta(bucket.getFileId(), +1);
+    return restoredRid;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreVertexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreVertexStatement.java
@@ -73,7 +73,7 @@ public class RestoreVertexStatement extends SimpleExecStatement {
     RestoreStatementSupport.applyBody(shell, insertBody, context);
 
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
-    final RID restoredRid = bucket.restoreRecordAtPosition(rid.getPosition(), shell);
+    final RID restoredRid = RestoreStatementSupport.restoreRecordAndUpdateCount(database, bucket, rid.getPosition(), shell);
 
     final Set<RID> asSet = Set.of(restoredRid);
     final long[] counts = database.getGraphEngine().reconnectEdgesFromSurvivors(asSet, asSet);

--- a/engine/src/test/java/com/arcadedb/graph/RestoreVertexAtTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/RestoreVertexAtTest.java
@@ -118,6 +118,27 @@ class RestoreVertexAtTest extends TestHelper {
     });
   }
 
+  @Test
+  void restoreVertexAtUpdatesBucketRecordCount() {
+    // #6069: GraphEngine.restoreVertexAt shares LocalBucket.restoreRecordAtPosition with the SQL RESTORE
+    // statements and had the same missing +1 on the bucket's cached record-count delta.
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final RID[] vertex = new RID[3];
+    database.transaction(() -> {
+      for (int i = 0; i < 3; i++)
+        vertex[i] = database.newVertex(VERTEX_TYPE).set("name", "v" + i).save().getIdentity();
+    });
+
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(vertex[1].getBucketId());
+    database.transaction(() -> database.command("sql", "DELETE FROM " + vertex[1]));
+    assertThat(bucket.count()).isEqualTo(2);
+
+    database.transaction(() -> db.getGraphEngine().restoreVertexAt(vertex[1], VERTEX_TYPE));
+
+    assertThat(bucket.count()).isEqualTo(3);
+  }
+
   private static int count(final Iterable<Edge> edges) {
     int n = 0;
     for (final Edge ignored : edges)

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RestoreSqlStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RestoreSqlStatementTest.java
@@ -192,6 +192,35 @@ class RestoreSqlStatementTest extends TestHelper {
   }
 
   @Test
+  void restoreEdgeUpdatesBucketRecordCount() {
+    // #6069: the same missing +1 as RESTORE DOCUMENT/VERTEX, exercised on RESTORE EDGE's own bucket - flagged as
+    // untested by the PR #6082 code review even though the fix is the identical one-line change routed through the
+    // same RestoreStatementSupport.restoreRecordAndUpdateCount() helper as RestoreDocumentStatement.
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final RID[] v1 = new RID[1];
+    final RID[] v2 = new RID[1];
+    final RID[] edgeRid = new RID[3];
+
+    database.transaction(() -> {
+      final var a = database.newVertex(VERTEX_TYPE).set("name", "a").save();
+      final var b = database.newVertex(VERTEX_TYPE).set("name", "b").save();
+      v1[0] = a.getIdentity();
+      v2[0] = b.getIdentity();
+      for (int i = 0; i < 3; i++)
+        edgeRid[i] = a.newEdge(EDGE_TYPE, b).set("i", i).save().getIdentity();
+    });
+
+    final LocalBucket edgeBucket = (LocalBucket) db.getSchema().getBucketById(edgeRid[1].getBucketId());
+    database.transaction(() -> database.command("sql", "DELETE FROM " + edgeRid[1]));
+    assertThat(edgeBucket.count()).isEqualTo(2);
+
+    database.transaction(() -> database.command("sql",
+        "RESTORE EDGE " + EDGE_TYPE + " RID " + edgeRid[1] + " FROM " + v1[0] + " TO " + v2[0] + " SET i = 1"));
+
+    assertThat(edgeBucket.count()).isEqualTo(3);
+  }
+
+  @Test
   void restoreDocumentUpdatesBucketRecordCount() {
     // #6069: RESTORE DOCUMENT put the record back but never folded the bucket's cached-count delta the way a
     // normal INSERT does, so count(*) kept reporting one fewer than a full scan - and the drift is persisted in

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RestoreSqlStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RestoreSqlStatementTest.java
@@ -192,6 +192,52 @@ class RestoreSqlStatementTest extends TestHelper {
   }
 
   @Test
+  void restoreDocumentUpdatesBucketRecordCount() {
+    // #6069: RESTORE DOCUMENT put the record back but never folded the bucket's cached-count delta the way a
+    // normal INSERT does, so count(*) kept reporting one fewer than a full scan - and the drift is persisted in
+    // statistics.json, so it survives a reopen too. A normal SQL DELETE (unlike the raw bucket.deleteRecord() the
+    // other tests in this class use to simulate an out-of-band delete) DOES fold its -1 correctly, so this test
+    // isolates RESTORE's own missing +1 rather than conflating it with delete-path bookkeeping.
+    final RID[] rid = new RID[3];
+    database.transaction(() -> {
+      for (int i = 0; i < 3; i++)
+        rid[i] = database.newDocument(DOC_TYPE).set("i", i).save().getIdentity();
+    });
+
+    database.transaction(() -> database.command("sql", "DELETE FROM " + rid[1]));
+    assertThat(countByQuery()).isEqualTo(2);
+    assertThat(countByScan()).isEqualTo(2);
+
+    database.transaction(
+        () -> database.command("sql", "RESTORE DOCUMENT " + DOC_TYPE + " RID " + rid[1] + " SET i = 1"));
+
+    assertThat(countByScan()).isEqualTo(3);
+    assertThat(countByQuery()).isEqualTo(3);
+
+    reopenDatabase();
+
+    assertThat(countByScan()).isEqualTo(3);
+    assertThat(countByQuery()).isEqualTo(3);
+  }
+
+  private long countByQuery() {
+    try (ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM " + DOC_TYPE)) {
+      return rs.next().<Number>getProperty("c").longValue();
+    }
+  }
+
+  private long countByScan() {
+    long scanned = 0;
+    try (ResultSet rs = database.query("sql", "SELECT FROM " + DOC_TYPE)) {
+      while (rs.hasNext()) {
+        rs.next();
+        scanned++;
+      }
+    }
+    return scanned;
+  }
+
+  @Test
   void restoreRefusesAnOccupiedSlotViaSql() {
     final DatabaseInternal db = (DatabaseInternal) database;
     final RID[] rid = new RID[1];


### PR DESCRIPTION
## Summary
- `LocalBucket.restoreRecordAtPosition()` only performs the physical page write for RESTORE DOCUMENT/VERTEX/EDGE, exactly like bucket-level `createRecord`/`deleteRecord` - the caller is responsible for folding the transaction's cached bucket record-count delta (the one `count(*)` reads as an O(1) fast path, see `LocalDatabase.createRecord`).
- Every RESTORE statement, and the `GraphEngine.restoreVertexAt` Java API, restored the record but never applied the `+1` a normal create does. `count(*)` kept reporting one fewer than a full scan after a restore, and since the delta is persisted in `statistics.json`, the drift survived a reopen too.
- Added `RestoreStatementSupport.restoreRecordAndUpdateCount()` so the fix lives in one place shared by RESTORE DOCUMENT/VERTEX/EDGE instead of being repeated (and re-forgotten) at each call site, and applied the same `+1` directly in `GraphEngine.restoreVertexAt`.

Fixes #6069.

## Test plan
- [x] New regression test `RestoreSqlStatementTest.restoreDocumentUpdatesBucketRecordCount` reproduces the issue's exact repro (SQL DELETE, then RESTORE DOCUMENT, then compare `count(*)` vs a full scan, including after a database reopen) - confirmed red before the fix, green after.
- [x] New regression test `RestoreVertexAtTest.restoreVertexAtUpdatesBucketRecordCount` covers the same missing delta on the `GraphEngine.restoreVertexAt` Java API - confirmed red before the fix, green after.
- [x] `mvn -pl engine test` for `RestoreSqlStatementTest`, `RestoreVertexAtTest`, `RestoreRecordAtPositionTest`, `Issue5149CountStarCacheDriftTest`, `Issue5152CountRecomputeRaceTest` all pass.
- [x] Full `com.arcadedb.query.sql.executor.**` and `com.arcadedb.graph.**` packages pass with no regressions.
- [x] `mvn compile` across the whole reactor succeeds.