### PR TITLE
fix(#6085): scope studio-e2e 'Returned' locator to results panel

### DIFF
--- a/e2e-studio/tests/graph-context-menu.spec.ts
+++ b/e2e-studio/tests/graph-context-menu.spec.ts
@@ -83,7 +83,7 @@ test.describe('ArcadeDB Studio Graph Context Menu Tests', () => {
       if (await expandButton.isVisible({ timeout: 2000 })) {
         await expandButton.first().click();
         await page.waitForLoadState('networkidle');
-        await expect(page.getByText('Returned')).toBeVisible({ timeout: 10000 }).catch(() => {});
+        await expect(page.locator('.result-stats').getByText('Returned')).toBeVisible({ timeout: 10000 }).catch(() => {});
       } else {
         // Method 2: Use programmatic expansion via cytoscape API
         await page.evaluate(() => {
@@ -112,7 +112,7 @@ test.describe('ArcadeDB Studio Graph Context Menu Tests', () => {
         (window as any).editor.setValue('SELECT FROM Beer WHERE out().size() > 0 LIMIT 3');
       });
       await page.locator('[data-testid="execute-query-button"]').click();
-      await expect(page.getByText('Returned')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('.result-stats').getByText('Returned')).toBeVisible({ timeout: 15000 });
       await page.waitForLoadState('networkidle');
     }
 

--- a/e2e-studio/tests/graph-styling.spec.ts
+++ b/e2e-studio/tests/graph-styling.spec.ts
@@ -115,7 +115,7 @@ test.describe('ArcadeDB Studio Graph Styling and HTML Labels', () => {
     });
     await page.locator('[data-testid="execute-query-button"]').click();
 
-    await expect(page.getByText('Returned')).toBeVisible();
+    await expect(page.locator('.result-stats').getByText('Returned')).toBeVisible();
     await page.waitForLoadState('networkidle');
 
     // Switch to Graph tab - results default to Table view

--- a/e2e-studio/tests/query-beer-database.spec.ts
+++ b/e2e-studio/tests/query-beer-database.spec.ts
@@ -53,8 +53,8 @@ test.describe('ArcadeDB Studio Beer Database Query', () => {
     await page.locator('[data-testid="execute-query-button"]').click();
 
     // Wait for query results to load
-    await expect(page.getByText('Returned')).toBeVisible();
-    await expect(page.getByText('records in')).toBeVisible();
+    await expect(page.locator('.result-stats').getByText('Returned')).toBeVisible();
+    await expect(page.locator('.result-stats').getByText('records in')).toBeVisible();
 
     // Verify that 10 records were returned
     await expect(page.getByText('10', { exact: true }).first()).toBeVisible();
@@ -114,8 +114,8 @@ test.describe('ArcadeDB Studio Beer Database Query', () => {
     await page.locator('[data-testid="execute-query-button"]').click();
 
     // Wait for query results to load
-    await expect(page.getByText('Returned')).toBeVisible();
-    await expect(page.getByText('records in')).toBeVisible();
+    await expect(page.locator('.result-stats').getByText('Returned')).toBeVisible();
+    await expect(page.locator('.result-stats').getByText('records in')).toBeVisible();
 
     // Verify that 1 record was returned
     await expect(page.getByText('1', { exact: true }).first()).toBeVisible();

--- a/e2e-studio/utils/test-utils.ts
+++ b/e2e-studio/utils/test-utils.ts
@@ -129,7 +129,10 @@ export class ArcadeStudioTestHelper {
     await this.page.locator('[data-testid="execute-query-button"]').click();
 
     // Wait for results with network stability
-    await expect(this.page.getByText('Returned')).toBeVisible({
+    // Scoped to .result-stats: an unscoped getByText('Returned') is a substring match that
+    // also resolves against the (hidden but DOM-present) server settings table, whose
+    // GRAPH_SUPERNODE_THRESHOLD description contains "...is returned at a position...".
+    await expect(this.page.locator('.result-stats').getByText('Returned')).toBeVisible({
       timeout: TEST_CONFIG.timeouts.query
     });
     await this.page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary
- `studio-e2e-tests` is chronically red on `main` itself: `page.getByText('Returned')` in `ArcadeStudioTestHelper.executeQuery` (`e2e-studio/utils/test-utils.ts:132`) is an unanchored substring locator, and it now also resolves against the (hidden but DOM-present) server settings table, whose `GRAPH_SUPERNODE_THRESHOLD` description contains "...is returned at a position...". Playwright's strict mode correctly refuses to disambiguate the two matches, so every spec that routes through `executeQuery` / `setupGraphWithData` / the `graphReady` fixture times out.
- Scope the locator to `.result-stats`, the container that actually wraps the `Returned N records in M ms` label in `query.html`, instead of matching anywhere on the page.
- Applied the same fix to the handful of specs that inlined the identical unscoped `page.getByText('Returned')` / `page.getByText('records in')` pattern directly (`graph-context-menu.spec.ts`, `graph-styling.spec.ts`, `query-beer-database.spec.ts`), since they hit the same ambiguity for the same reason.

## Root cause detail
`getByText()` is a case-insensitive substring match by default. All Studio tab panels (including the server settings tab) are included in `index.html` and mounted in the DOM at once, just hidden via inactive `.tab-pane`s - so the settings table's config descriptions are present and matchable even though that tab was never opened.

## Test plan
- [x] Built `server` + `studio` from this branch and ran `ArcadeDBServer` from source (classes on classpath, no Docker) with a `Beer` database imported the same way CI's `global-setup.ts` does.
- [x] Reproduced the bug directly: unscoped `page.getByText('Returned')` resolves to 2 elements (the results label and the `GRAPH_SUPERNODE_THRESHOLD` description cell); confirmed the fix resolves to exactly 1 visible element.
- [x] Ran the full `e2e-studio` Playwright suite (13 spec files) against that live server: 83 passed, 1 pre-existing `test.skip`, 0 failed.
- [x] `git diff --stat` confirms only the 4 intended test files changed; no application/engine code touched.

🔗 Fixes #6085