### PR TITLE
fix(#6083): reclaim orphan edge records and report an exact edge count on a failed GraphBatch flush

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -33,6 +33,7 @@ import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.log.LogManager;
@@ -339,6 +340,24 @@ public class GraphBatch implements AutoCloseable {
   private long totalEdgesCreated;
   private long totalFlushes;
   private long totalFlushTimeNs;
+  private long totalOrphanEdgeRecordsReclaimed;
+  private long totalOrphanEdgeRecordsLeaked;
+
+  /**
+   * Edges of the flush in progress whose connection to their SOURCE vertex has durably committed (issue #6083
+   * item 4). {@link #flush()} folds exactly this into {@link #totalEdgesCreated}, on the failure path as well as
+   * the success one, so the running count never claims an edge the graph does not hold - and, since #6083, never
+   * under-reports one it does. Reset at the top of every flush.
+   */
+  private int flushDurableOutEdges;
+
+  /**
+   * When the PARALLEL connect pass of the flush in progress failed, the {@code [from,to)} pairs into
+   * {@link #sortIndex} naming the edges it nevertheless connected durably; {@code null} otherwise. The failed
+   * buckets are wherever they are in the partition, so unlike the sequential path's durable prefix this cannot be
+   * expressed as a single bound. Read once by {@link #flush()} right after the pass returns.
+   */
+  private int[] flushDurableOutRanges;
 
   // --- Saved state for restore after close ---
   private final boolean savedReadYourWrites;
@@ -713,8 +732,20 @@ public class GraphBatch implements AutoCloseable {
     // database with the half-written batch visible to the next caller.
     final boolean startedTx = !database.isTransactionActive();
 
+    // Number of buffered edges this flush is about to write. Read after the buffer is reset below, so it cannot
+    // be replaced by edgeCount there.
+    final int bufferedEdges = edgeCount;
+
+    // How many of them are durably connected to their source vertex. Advanced by the connect pass itself, one
+    // durable commit at a time, so a flush that dies part-way reports what the graph actually holds rather than
+    // the whole flush or nothing (issue #6083 item 4).
+    flushDurableOutEdges = 0;
+    flushDurableOutRanges = null;
+
     try {
       // --- PHASE 1: Create edge records for edges that need them (non-light) ---
+      // Hoisted out of PHASE 1 so the failure paths in PHASE 3 can reclaim the records this flush created but
+      // never linked (issue #6083 item 2).
       final RID[] edgeRIDs = new RID[edgeCount];
       beginTx();
 
@@ -735,29 +766,66 @@ public class GraphBatch implements AutoCloseable {
       final int maxBucket = partitionBySourceBucket();
 
       // --- PHASE 3: Connect outgoing edges ---
+      //
+      // A failure here is CAPTURED rather than thrown (issue #6083 item 2), because part of the flush may already
+      // be durable and the rest of this method is what makes that part a whole edge. Everything PHASE 3 did not
+      // durably connect has had its edge record reclaimed by the time the capture happens; what remains is
+      // OUT-connected and still owes its IN back-pointer, which PHASE 4 below queues for it exactly as it does on
+      // the success path. Without that, a partially-failed flush left half-edges the integrity checker flags -
+      // the same reason close() drains the deferred IN buffer on the way out of a failed batch.
+      //
+      // durableOutRanges describes what survived, as [from,to) pairs into sortIndex; null means "all of it", the
+      // normal case, and keeps the success path free of the extra indirection.
+      RuntimeException connectFailure = null;
+      int[] durableOutRanges = null;
+
       if (parallelFlush) {
-        // Commit edge records to release page locks before parallel work
+        // Commit edge records to release page locks before parallel work. From here on the records exist
+        // durably whatever happens to the connect pass, which is why that pass reclaims its own failures.
         database.commit();
-        connectOutgoingEdgesParallel(edgeRIDs, maxBucket);
+        try {
+          connectOutgoingEdgesParallel(edgeRIDs, maxBucket);
+        } catch (final RuntimeException e) {
+          connectFailure = e;
+          durableOutRanges = flushDurableOutRanges;
+        }
       } else {
-        connectOutgoingEdgesSorted(edgeRIDs);
-        database.commit();
+        try {
+          // Commits internally, including the final one, and sets flushDurableOutEdges as it goes.
+          connectOutgoingEdgesSorted(edgeRIDs);
+        } catch (final RuntimeException e) {
+          // With commitEvery > 0 this pass commits several times inside one flush, and the FIRST of those
+          // commits also makes PHASE 1's edge records durable. Everything the pass had not linked by its last
+          // durable commit is therefore a record no vertex points at (issue #6083 item 2). With commitEvery == 0
+          // nothing committed, flushDurableOutEdges is still 0, and the rollback already undid the records -
+          // which is exactly what the guard inside reclaimOrphanEdgeRecords reads.
+          reclaimOrphanEdgeRecords(edgeRIDs, flushDurableOutEdges, bufferedEdges, flushDurableOutEdges > 0, e);
+          connectFailure = e;
+          durableOutRanges = new int[] { 0, flushDurableOutEdges };
+        }
       }
 
       // --- PHASE 4: Accumulate incoming edges in deferred buffer (array-only, no DB) ---
       if (bidirectional) {
-        accumulateIncomingEdges(edgeRIDs);
+        accumulateIncomingEdges(edgeRIDs, durableOutRanges);
 
         // Drain early once the buffer crosses the configured cap (issue #5664): left alone, the deferred
         // incoming-edge arrays (and the in-chunk RID cache they populate) grow with the FULL stream length,
         // not with batchSize, and connectDeferredIncomingEdges() would land as one unbounded pass at close().
         // Draining here amortizes that pass over the load instead. maxDeferredIncomingEdges=0 opts back into
         // the pre-#5664 behavior of deferring everything to close().
-        if (maxDeferredIncomingEdges > 0 && inEdgeCount >= maxDeferredIncomingEdges)
+        //
+        // Skipped when PHASE 3 failed: close() drains the buffer on its way out of a failed batch anyway, and
+        // draining here would replace the failure the caller has to see with whatever the drain hits.
+        if (connectFailure == null && maxDeferredIncomingEdges > 0 && inEdgeCount >= maxDeferredIncomingEdges)
           connectDeferredIncomingEdges();
       }
 
-      totalEdgesCreated += edgeCount;
+      if (connectFailure != null)
+        // Statistics and buffer reset are the catch block's job from here; it folds flushDurableOutEdges too.
+        throw connectFailure;
+
+      totalEdgesCreated += flushDurableOutEdges;
       totalFlushes++;
       totalFlushTimeNs += System.nanoTime() - startNs;
 
@@ -768,10 +836,122 @@ public class GraphBatch implements AutoCloseable {
     } catch (final RuntimeException e) {
       if (startedTx && database.isTransactionActive())
         database.rollback();
+
+      // A flush that died after PHASE 3 (in the deferred-incoming drain) still created every edge it counted:
+      // those are connected to their source vertex and reachable, they are only missing a back-pointer that
+      // close() drains separately. Counting them is right; the connect pass has already excluded whatever it
+      // failed to make durable (issue #6083 item 4).
+      totalEdgesCreated += flushDurableOutEdges;
+
       // Discard the buffered edges so a subsequent close() / flush() doesn't replay them.
       Arrays.fill(edgeProperties, 0, edgeProperties.length, null);
       edgeCount = 0;
       throw e;
+    }
+  }
+
+  /**
+   * Deletes the edge records this flush created but never linked to their source vertex (issue #6083 item 2).
+   * <p>
+   * An edge is written in two steps that do not share a transaction: PHASE 1 creates the record, PHASE 3 links it
+   * into the source vertex's edge list. The parallel path has to commit between them (the edge-record pages must
+   * be released before the per-bucket tasks touch them) and the sequential path does so too whenever
+   * {@code commitEvery > 0}. So a connect pass that dies part-way leaves records that are durable and reachable
+   * from nothing: {@code countType()} counts them and no traversal finds them.
+   * <p>
+   * CHECK DATABASE does not rescue them. Its {@code checkEdges} pass does scan every edge record and probe both
+   * endpoints for a back-reference, but a miss only increments the aggregate {@code missingReferenceBack}
+   * counter - no warning naming the record, no entry in {@code corruptedRecords}, and therefore nothing for the
+   * {@code FIX} variant to delete. That same counter is raised by a perfectly healthy UNIDIRECTIONAL edge, which
+   * is legitimately absent from its target's IN list, so it cannot be read as an orphan count either. ({@code FIX}
+   * does reclaim orphaned edge SEGMENTS, but those are the internal linked-list chunks, not the edge records at
+   * issue here.) Nothing else will ever clean these up, so the flush cleans up after itself, before the failure
+   * propagates.
+   * <p>
+   * Deletion goes through {@code database.deleteRecord} rather than a direct bucket delete: an edge record may
+   * carry index entries (issue #4113) and EXTERNAL property values, and this flush creates them by two different
+   * routes - {@code createRecordsBulk} plus {@link #indexEdgeProperties} for a single-bucket flush, an ordinary
+   * {@code save()} for a multi-type one. The database's own delete path is the one inverse that is correct for
+   * both, for every index kind, without a second copy of the key-derivation logic to keep in step. It also walks
+   * the endpoints' edge lists looking for a back-reference that is not there, which is provably wasted work here;
+   * that cost is accepted for the correctness, and it is bounded because it only ever runs on a failed flush.
+   * <p>
+   * Best-effort by construction: whatever it cannot reclaim is logged and counted
+   * ({@link #getOrphanEdgeRecordsLeaked()}), never allowed to replace the failure the caller is already handling.
+   *
+   * @param edgeRIDs          RIDs assigned in PHASE 1, indexed by edge-buffer slot
+   * @param fromSortPos       first {@link #sortIndex} position to reclaim, inclusive
+   * @param toSortPos         last {@link #sortIndex} position to reclaim, exclusive
+   * @param recordsAreDurable whether PHASE 1's records outlived the failure. False when no commit intervened, in
+   *                          which case the rollback already removed them and deleting again would be an error
+   * @param cause             the failure being handled, for the log line only
+   */
+  private void reclaimOrphanEdgeRecords(final RID[] edgeRIDs, final int fromSortPos, final int toSortPos,
+      final boolean recordsAreDurable, final Throwable cause) {
+    if (!recordsAreDurable || fromSortPos >= toSortPos)
+      return;
+
+    try {
+      // The failed attempt's transaction, if one is still open, holds writes that were never committed and must
+      // not ride along with the deletions.
+      if (database.isTransactionActive())
+        database.rollback();
+
+      int reclaimed = 0;
+      int leaked = 0;
+      int inTx = 0;
+      beginTx();
+
+      for (int k = fromSortPos; k < toSortPos; k++) {
+        final int idx = sortIndex[k];
+        final RID edgeRID = edgeRIDs[idx];
+        // A lightweight edge never allocated a record (its RID carries the placeholder position -1), so an
+        // unconnected one leaves nothing behind to reclaim.
+        if (edgeIsLightweight[idx] || edgeRID == null || edgeRID.getPosition() < 0)
+          continue;
+
+        try {
+          database.deleteRecord(database.lookupByRID(edgeRID, true));
+          reclaimed++;
+        } catch (final RecordNotFoundException e) {
+          // Already gone - the failure took it with it. Nothing to reclaim and nothing wrong.
+        } catch (final RuntimeException e) {
+          leaked++;
+          LogManager.instance().log(this, Level.WARNING,
+              "GraphBatch: cannot reclaim orphan edge record %s left by a failed flush: %s", null, edgeRID,
+              e.toString());
+        }
+
+        if (commitEvery > 0 && ++inTx >= commitEvery) {
+          database.commit();
+          beginTx();
+          inTx = 0;
+        }
+      }
+
+      database.commit();
+
+      totalOrphanEdgeRecordsReclaimed += reclaimed;
+      totalOrphanEdgeRecordsLeaked += leaked;
+
+      if (reclaimed > 0 || leaked > 0)
+        LogManager.instance().log(this, Level.WARNING,
+            "GraphBatch: an edge flush failed (%s) after its edge records were committed; reclaimed %d record(s) that "
+                + "were left connected to no vertex, %d could not be removed", null,
+            cause != null ? cause.toString() : "unknown", reclaimed, leaked);
+    } catch (final RuntimeException e) {
+      // The cleanup is a courtesy on a path that is already failing; the caller's exception is the one that
+      // describes what went wrong and it must be the one that propagates.
+      totalOrphanEdgeRecordsLeaked += toSortPos - fromSortPos;
+      LogManager.instance().log(this, Level.WARNING,
+          "GraphBatch: could not reclaim the orphan edge records left by a failed flush; run CHECK DATABASE and "
+              + "expect up to %d unreachable edge record(s)", e, toSortPos - fromSortPos);
+      if (database.isTransactionActive())
+        try {
+          database.rollback();
+        } catch (final RuntimeException ignored) {
+          // Nothing further to attempt; the original failure is still the one that propagates.
+        }
     }
   }
 
@@ -1229,10 +1409,32 @@ public class GraphBatch implements AutoCloseable {
   }
 
   /**
-   * Returns the total number of edges created so far (including flushed).
+   * Number of edges durably connected to their source vertex so far.
+   * <p>
+   * EXACT since issue #6083 item 4, on a failed load as well as a successful one: it advances one durable commit
+   * at a time inside the connect pass rather than a whole flush at a time, so a load dying mid-flush reports the
+   * edges the graph actually holds instead of rounding the part-written flush down to zero. A caller reconciling
+   * a failed bulk load against this figure re-sends exactly what is missing - it no longer has to over-send a
+   * flush's worth of edges and rely on the duplicates being harmless.
    */
   public long getTotalEdgesCreated() {
     return totalEdgesCreated;
+  }
+
+  /**
+   * Edge records this batch created, failed to connect to any vertex, and deleted again (issue #6083 item 2).
+   * Non-zero only after a flush failed part-way.
+   */
+  public long getOrphanEdgeRecordsReclaimed() {
+    return totalOrphanEdgeRecordsReclaimed;
+  }
+
+  /**
+   * Edge records left connected to no vertex because the cleanup after a failed flush could not remove them
+   * (issue #6083 item 2). Non-zero means unreachable records are still in the database.
+   */
+  public long getOrphanEdgeRecordsLeaked() {
+    return totalOrphanEdgeRecordsLeaked;
   }
 
   /**
@@ -1379,76 +1581,116 @@ public class GraphBatch implements AutoCloseable {
     int i = 0;
     int edgesInBatch = 0;
 
-    while (i < edgeCount) {
-      final int idx = sortIndex[i];
-      final int srcBucket = edgeSrcBucketIds[idx];
-      final long srcPos = edgeSrcPositions[idx];
+    // getOrCreateOutSegmentDeferred/persistNewSegment/addEdgesToSegmentBulkLazy write deferredOutHead and
+    // outChunkRIDCache as they process a group, BEFORE the transaction holding that group's writes commits. If
+    // that commit never happens, the maps are left naming segment records the rollback undid - and
+    // batchUpdateVertexHeadChunks() at close() then stamps one of those dead RIDs onto the vertex, which CHECK
+    // DATABASE reports as "out edges record is not valid" and which no later read can follow.
+    //
+    // Exactly the hazard #5950 cycle 3 fixed for the IN direction (see connectIncomingEdgesSequential's
+    // inHeadUndoLog) and cycle 4 for the parallel OUT direction (the per-bucket local maps); this path was the
+    // one left. Same remedy: snapshot each touched vertex's PRE-slice deferredOutHead value once per slice, and
+    // on failure restore it exactly - "was absent" via remove(), "had segment X" back to X (issue #6083).
+    final Map<Long, RID> outHeadUndoLog = new HashMap<>();
 
-      // Collect all edges from the same source vertex
-      int j = i;
-      while (j < edgeCount) {
-        final int jIdx = sortIndex[j];
-        if (edgeSrcBucketIds[jIdx] != srcBucket || edgeSrcPositions[jIdx] != srcPos)
-          break;
-        j++;
-      }
+    try {
+      while (i < edgeCount) {
+        final int idx = sortIndex[i];
+        final int srcBucket = edgeSrcBucketIds[idx];
+        final long srcPos = edgeSrcPositions[idx];
 
-      // Pre-compute exact bytes needed for this group
-      final int groupSize = j - i;
-      ensureTmpArrays(groupSize);
-      int totalBytesNeeded = 0;
-      for (int k = 0; k < groupSize; k++) {
-        final int kIdx = sortIndex[i + k];
-        tmpEdgeBucketIds[k] = edgeRIDs[kIdx].getBucketId();
-        tmpEdgePositions[k] = edgeRIDs[kIdx].getPosition();
-        tmpVertexBucketIds[k] = edgeDstBucketIds[kIdx];
-        tmpVertexPositions[k] = edgeDstPositions[kIdx];
-        totalBytesNeeded += Binary.getNumberSpace(tmpEdgeBucketIds[k]) + Binary.getNumberSpace(tmpEdgePositions[k])
-            + Binary.getNumberSpace(tmpVertexBucketIds[k]) + Binary.getNumberSpace(tmpVertexPositions[k]);
-      }
+        // Collect all edges from the same source vertex
+        int j = i;
+        while (j < edgeCount) {
+          final int jIdx = sortIndex[j];
+          if (edgeSrcBucketIds[jIdx] != srcBucket || edgeSrcPositions[jIdx] != srcPos)
+            break;
+          j++;
+        }
 
-      // Get or create segment — deferred vertex update, no vertex load for known-new vertices
-      final long vertexKey = packVertexKey(srcBucket, srcPos);
-      final EdgeSegment outChunk = getOrCreateOutSegmentDeferred(srcBucket, srcPos, vertexKey, totalBytesNeeded);
+        // Pre-compute exact bytes needed for this group
+        final int groupSize = j - i;
+        ensureTmpArrays(groupSize);
+        int totalBytesNeeded = 0;
+        for (int k = 0; k < groupSize; k++) {
+          final int kIdx = sortIndex[i + k];
+          tmpEdgeBucketIds[k] = edgeRIDs[kIdx].getBucketId();
+          tmpEdgePositions[k] = edgeRIDs[kIdx].getPosition();
+          tmpVertexBucketIds[k] = edgeDstBucketIds[kIdx];
+          tmpVertexPositions[k] = edgeDstPositions[kIdx];
+          totalBytesNeeded += Binary.getNumberSpace(tmpEdgeBucketIds[k]) + Binary.getNumberSpace(tmpEdgePositions[k])
+              + Binary.getNumberSpace(tmpVertexBucketIds[k]) + Binary.getNumberSpace(tmpVertexPositions[k]);
+        }
 
-      // NOTE (edge-append merge): this bulk path intentionally neither tracks (trackEdgeAppend) nor poisons its
-      // chunk pages. Since #5596 that needs no side condition: the merge accepts a page only when EVERY byte this
-      // transaction wrote to it was declared replayable, and these bulk writes declare nothing - so a page this
-      // path touched can never be rebased, even if the same transaction also drove EdgeLinkedList.add on it.
-      // See docs/supernode.md §3.
-      if (lastSegmentPromoted) {
-        // #5667: the vertex is already a promoted super-node - route this group through the standard,
-        // MVCC-safe StripedEdgeList write path instead of the bulk segment path.
-        addGroupThroughStripedEdgeList(lastPromotedVertex, Vertex.DIRECTION.OUT, lastPromotedDirectory,
-            tmpEdgeBucketIds, tmpEdgePositions, tmpVertexBucketIds, tmpVertexPositions, groupSize);
-      } else if (lastSegmentIsNew) {
-        // New segment: fill FIRST, then persist ONCE (no updateRecord needed)
-        outChunk.addManyAtEndDirect(tmpEdgeBucketIds, tmpEdgePositions,
-            tmpVertexBucketIds, tmpVertexPositions, 0, groupSize);
-        persistNewSegment(outChunk, srcBucket, Vertex.DIRECTION.OUT, vertexKey);
-      } else {
-        // Existing segment: check if all edges fit
-        final int available = outChunk.getRecordSize() - outChunk.getUsed();
-        if (totalBytesNeeded <= available) {
+        // Get or create segment — deferred vertex update, no vertex load for known-new vertices
+        final long vertexKey = packVertexKey(srcBucket, srcPos);
+        // Snapshot BEFORE getOrCreateOutSegmentDeferred can mutate deferredOutHead for this vertex. A promoted
+        // vertex (below) touches neither map, so the snapshot is harmlessly unused in that case.
+        if (!outHeadUndoLog.containsKey(vertexKey))
+          outHeadUndoLog.put(vertexKey, deferredOutHead.get(vertexKey));
+        final EdgeSegment outChunk = getOrCreateOutSegmentDeferred(srcBucket, srcPos, vertexKey, totalBytesNeeded);
+
+        // NOTE (edge-append merge): this bulk path intentionally neither tracks (trackEdgeAppend) nor poisons its
+        // chunk pages. Since #5596 that needs no side condition: the merge accepts a page only when EVERY byte this
+        // transaction wrote to it was declared replayable, and these bulk writes declare nothing - so a page this
+        // path touched can never be rebased, even if the same transaction also drove EdgeLinkedList.add on it.
+        // See docs/supernode.md §3.
+        if (lastSegmentPromoted) {
+          // #5667: the vertex is already a promoted super-node - route this group through the standard,
+          // MVCC-safe StripedEdgeList write path instead of the bulk segment path.
+          addGroupThroughStripedEdgeList(lastPromotedVertex, Vertex.DIRECTION.OUT, lastPromotedDirectory,
+              tmpEdgeBucketIds, tmpEdgePositions, tmpVertexBucketIds, tmpVertexPositions, groupSize);
+        } else if (lastSegmentIsNew) {
+          // New segment: fill FIRST, then persist ONCE (no updateRecord needed)
           outChunk.addManyAtEndDirect(tmpEdgeBucketIds, tmpEdgePositions,
               tmpVertexBucketIds, tmpVertexPositions, 0, groupSize);
-          database.updateRecord(outChunk);
+          persistNewSegment(outChunk, srcBucket, Vertex.DIRECTION.OUT, vertexKey);
         } else {
-          // Slow path: existing segment overflows
-          addEdgesToSegmentBulkLazy(srcBucket, srcPos, Vertex.DIRECTION.OUT, outChunk, edgeRIDs, i, j, true);
+          // Existing segment: check if all edges fit
+          final int available = outChunk.getRecordSize() - outChunk.getUsed();
+          if (totalBytesNeeded <= available) {
+            outChunk.addManyAtEndDirect(tmpEdgeBucketIds, tmpEdgePositions,
+                tmpVertexBucketIds, tmpVertexPositions, 0, groupSize);
+            database.updateRecord(outChunk);
+          } else {
+            // Slow path: existing segment overflows
+            addEdgesToSegmentBulkLazy(srcBucket, srcPos, Vertex.DIRECTION.OUT, outChunk, edgeRIDs, i, j, true);
+          }
         }
+
+        edgesInBatch += groupSize;
+
+        // Periodic commit for very large flushes
+        if (commitEvery > 0 && edgesInBatch >= commitEvery) {
+          database.commit();
+          // Only AFTER the commit returns: sortIndex positions [0, j) are now durably linked, and this is what
+          // tells a failed flush which records it still has to reclaim and how many edges it may claim (issue
+          // #6083 items 2 and 4). The slice's head pointers are durable too, so its undo entries can go.
+          flushDurableOutEdges = j;
+          outHeadUndoLog.clear();
+          beginTx();
+          edgesInBatch = 0;
+        }
+
+        i = j;
       }
 
-      edgesInBatch += groupSize;
-
-      // Periodic commit for very large flushes
-      if (commitEvery > 0 && edgesInBatch >= commitEvery) {
-        database.commit();
-        beginTx();
-        edgesInBatch = 0;
+      // Inside the try, unlike before issue #6083: a final commit that fails rolls back the last slice's
+      // segments too, and the undo log is the only thing that can take their RIDs back out of deferredOutHead.
+      database.commit();
+      flushDurableOutEdges = edgeCount;
+    } catch (final RuntimeException e) {
+      for (final Map.Entry<Long, RID> undo : outHeadUndoLog.entrySet()) {
+        final long key = undo.getKey();
+        final RID previous = undo.getValue();
+        if (previous == null)
+          deferredOutHead.remove(key);
+        else
+          deferredOutHead.put(key, previous);
+        // Just an accelerator cache - evicting is always safe, forces a deferredOutHead/disk fallback.
+        outChunkRIDCache.remove(key);
       }
-
-      i = j;
+      throw e;
     }
   }
 
@@ -1458,8 +1700,31 @@ public class GraphBatch implements AutoCloseable {
 
   /**
    * Accumulates incoming edge info from the current flush buffer into the deferred arrays.
+   *
+   * @param durableOutRanges {@code [from,to)} pairs into {@link #sortIndex} selecting the edges PHASE 3 durably
+   *                         connected to their source vertex, or {@code null} for the whole buffer - the normal
+   *                         case, where every edge was connected. A partially-failed flush passes only what
+   *                         survived, so the IN pass at {@link #close()} completes exactly those edges and never
+   *                         writes a back-pointer to an edge record the failure took away (issue #6083 item 2).
    */
-  private void accumulateIncomingEdges(final RID[] edgeRIDs) {
+  private void accumulateIncomingEdges(final RID[] edgeRIDs, final int[] durableOutRanges) {
+    if (durableOutRanges == null) {
+      accumulateIncomingEdgeRange(edgeRIDs, 0, edgeCount, false);
+      return;
+    }
+    for (int r = 0; r < durableOutRanges.length; r += 2)
+      accumulateIncomingEdgeRange(edgeRIDs, durableOutRanges[r], durableOutRanges[r + 1], true);
+  }
+
+  /**
+   * Appends one contiguous run of the flush buffer to the deferred incoming-edge arrays. Positions are read
+   * straight out of the buffer when {@code throughSortIndex} is false, and through {@link #sortIndex} when it is
+   * true - the two orders differ, but the drain re-sorts by destination bucket anyway, so only membership matters.
+   */
+  private void accumulateIncomingEdgeRange(final RID[] edgeRIDs, final int from, final int to,
+      final boolean throughSortIndex) {
+    if (from >= to)
+      return;
     // An earlier in-flush drain (issue #5664) frees these arrays at the end of connectDeferredIncomingEdges();
     // re-allocate at the same initial size the constructor would have used.
     if (inEdgeBucketIds == null) {
@@ -1472,11 +1737,12 @@ public class GraphBatch implements AutoCloseable {
       inDstPositions = new long[initialInCapacity];
     }
 
-    final int needed = inEdgeCount + edgeCount;
+    final int needed = inEdgeCount + (to - from);
     if (needed > inEdgeBucketIds.length)
       growIncomingBuffers(needed);
 
-    for (int i = 0; i < edgeCount; i++) {
+    for (int k = from; k < to; k++) {
+      final int i = throughSortIndex ? sortIndex[k] : k;
       final int pos = inEdgeCount;
       inEdgeBucketIds[pos] = edgeRIDs[i].getBucketId();
       inEdgePositions[pos] = edgeRIDs[i].getPosition();
@@ -2643,9 +2909,38 @@ public class GraphBatch implements AutoCloseable {
       bucketOutChunkCache.get(entry.getKey()).forEach(outChunkRIDCache::put);
     }
 
+    // Exactly the edges a completed bucket connected, counted whether or not a sibling bucket failed (issue
+    // #6083 item 4). A bucket is in this set only once its own transaction committed, so this never claims an
+    // edge a rollback took back.
+    int durable = 0;
+    for (final int bucketId : completedOutgoingBuckets)
+      durable += bucketCounts[bucketId];
+    flushDurableOutEdges = durable;
+    flushDurableOutRanges = null;
+
     final Throwable t = error.get();
-    if (t != null)
-      throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
+    if (t == null)
+      return;
+
+    // Every edge record was made durable by the commit that preceded this dispatch, so a bucket that never
+    // committed leaves its records behind connected to nothing (issue #6083 item 2). Unlike the sequential
+    // path's failure these are not a suffix of the sort index - the buckets that failed are wherever they are -
+    // so walk the partition once, reclaiming the failed buckets and recording the surviving ones for the IN
+    // pass that flush() still owes them.
+    final int[] survivors = new int[completedOutgoingBuckets.size() * 2];
+    int survivorCount = 0;
+    for (int b = 0; b <= maxBucket; b++) {
+      if (bucketCounts[b] == 0)
+        continue;
+      if (completedOutgoingBuckets.contains(b)) {
+        survivors[survivorCount++] = bucketOffsets[b];
+        survivors[survivorCount++] = bucketOffsets[b + 1];
+      } else
+        reclaimOrphanEdgeRecords(edgeRIDs, bucketOffsets[b], bucketOffsets[b + 1], true, t);
+    }
+    flushDurableOutRanges = survivorCount == survivors.length ? survivors : Arrays.copyOf(survivors, survivorCount);
+
+    throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -207,8 +207,21 @@ public class GraphBatch implements AutoCloseable {
    */
   public static volatile IntConsumer TEST_BEFORE_OUTGOING_EDGE_COMMIT_HOOK = null;
 
+  /**
+   * Test-only fault-injection hook. Invoked with a 1-based call number immediately before each
+   * {@code database.commit()} inside {@link #reclaimOrphanEdgeRecords} - both the {@code commitEvery}-driven
+   * commits and the final one. A test can throw on the SECOND call to simulate the cleanup after a failed flush
+   * itself failing partway, and verify that the reclaims an earlier commit already made durable stay counted as
+   * reclaimed rather than being rewritten as leaked (issue #6083 review cycle 1). Always {@code null} in
+   * production.
+   */
+  public static volatile IntConsumer TEST_BEFORE_ORPHAN_RECLAIM_COMMIT_HOOK = null;
+
   /** Monotonic call counter feeding {@link #TEST_BEFORE_OUTGOING_EDGE_COMMIT_HOOK}'s 1-based argument. */
   private final AtomicInteger outgoingEdgeCommitAttempt = new AtomicInteger(0);
+
+  /** Monotonic call counter feeding {@link #TEST_BEFORE_ORPHAN_RECLAIM_COMMIT_HOOK}'s 1-based argument. */
+  private final AtomicInteger orphanReclaimCommitAttempt = new AtomicInteger(0);
 
   /** Monotonic call counter feeding {@link #TEST_BEFORE_INCOMING_EDGE_COMMIT_HOOK}'s 1-based argument. */
   private final AtomicInteger incomingEdgeCommitAttempt = new AtomicInteger(0);
@@ -891,14 +904,26 @@ public class GraphBatch implements AutoCloseable {
     if (!recordsAreDurable || fromSortPos >= toSortPos)
       return;
 
+    // First position of the slice the current transaction covers. Everything before it has been through a
+    // commit that returned, so its outcome is durable and already folded into the totals; everything from here
+    // to toSortPos is still undecided. The catch block below needs it, so it lives outside the try.
+    int uncommittedFrom = fromSortPos;
+
     try {
       // The failed attempt's transaction, if one is still open, holds writes that were never committed and must
       // not ride along with the deletions.
       if (database.isTransactionActive())
         database.rollback();
 
-      int reclaimed = 0;
-      int leaked = 0;
+      // Counted for the current transaction only and folded into the instance totals as each commit returns
+      // (issue #6083 review cycle 1). Deferring the fold to the end of the loop instead would discard the
+      // reclaims an earlier commit already made durable if a LATER commit in the same pass threw, and the catch
+      // block would then blame the whole range as leaked - under-reporting reclaims and double-counting records
+      // that are in fact gone, on the one path whose entire purpose is to leave an accurate count behind.
+      int pendingReclaimed = 0;
+      int pendingLeaked = 0;
+      int passReclaimed = 0;
+      int passLeaked = 0;
       int inTx = 0;
       beginTx();
 
@@ -912,40 +937,55 @@ public class GraphBatch implements AutoCloseable {
 
         try {
           database.deleteRecord(database.lookupByRID(edgeRID, true));
-          reclaimed++;
+          pendingReclaimed++;
         } catch (final RecordNotFoundException e) {
           // Already gone - the failure took it with it. Nothing to reclaim and nothing wrong.
         } catch (final RuntimeException e) {
-          leaked++;
+          pendingLeaked++;
           LogManager.instance().log(this, Level.WARNING,
               "GraphBatch: cannot reclaim orphan edge record %s left by a failed flush: %s", null, edgeRID,
               e.toString());
         }
 
         if (commitEvery > 0 && ++inTx >= commitEvery) {
+          fireBeforeOrphanReclaimCommitHook();
           database.commit();
+          totalOrphanEdgeRecordsReclaimed += pendingReclaimed;
+          totalOrphanEdgeRecordsLeaked += pendingLeaked;
+          passReclaimed += pendingReclaimed;
+          passLeaked += pendingLeaked;
+          pendingReclaimed = 0;
+          pendingLeaked = 0;
+          uncommittedFrom = k + 1;
           beginTx();
           inTx = 0;
         }
       }
 
+      fireBeforeOrphanReclaimCommitHook();
       database.commit();
+      totalOrphanEdgeRecordsReclaimed += pendingReclaimed;
+      totalOrphanEdgeRecordsLeaked += pendingLeaked;
+      passReclaimed += pendingReclaimed;
+      passLeaked += pendingLeaked;
 
-      totalOrphanEdgeRecordsReclaimed += reclaimed;
-      totalOrphanEdgeRecordsLeaked += leaked;
-
-      if (reclaimed > 0 || leaked > 0)
+      if (passReclaimed > 0 || passLeaked > 0)
         LogManager.instance().log(this, Level.WARNING,
             "GraphBatch: an edge flush failed (%s) after its edge records were committed; reclaimed %d record(s) that "
                 + "were left connected to no vertex, %d could not be removed", null,
-            cause != null ? cause.toString() : "unknown", reclaimed, leaked);
+            cause != null ? cause.toString() : "unknown", passReclaimed, passLeaked);
     } catch (final RuntimeException e) {
       // The cleanup is a courtesy on a path that is already failing; the caller's exception is the one that
       // describes what went wrong and it must be the one that propagates.
-      totalOrphanEdgeRecordsLeaked += toSortPos - fromSortPos;
+      //
+      // Only the slice this transaction was covering is leaked. Anything before uncommittedFrom went through a
+      // commit that returned and has already been counted, so blaming the whole range here would both lose those
+      // reclaims and count records that are gone.
+      final int leakedNow = countOrphanCandidates(edgeRIDs, uncommittedFrom, toSortPos);
+      totalOrphanEdgeRecordsLeaked += leakedNow;
       LogManager.instance().log(this, Level.WARNING,
           "GraphBatch: could not reclaim the orphan edge records left by a failed flush; run CHECK DATABASE and "
-              + "expect up to %d unreachable edge record(s)", e, toSortPos - fromSortPos);
+              + "expect up to %d unreachable edge record(s)", e, leakedNow);
       if (database.isTransactionActive())
         try {
           database.rollback();
@@ -953,6 +993,29 @@ public class GraphBatch implements AutoCloseable {
           // Nothing further to attempt; the original failure is still the one that propagates.
         }
     }
+  }
+
+  /**
+   * Edges in {@code [fromSortPos, toSortPos)} that own a real edge record, and so leave one behind when they are
+   * not connected. Lightweight edges are excluded: their RID carries the placeholder position -1 and no record
+   * was ever allocated for them.
+   */
+  private int countOrphanCandidates(final RID[] edgeRIDs, final int fromSortPos, final int toSortPos) {
+    int candidates = 0;
+    for (int k = fromSortPos; k < toSortPos; k++) {
+      final int idx = sortIndex[k];
+      final RID edgeRID = edgeRIDs[idx];
+      if (!edgeIsLightweight[idx] && edgeRID != null && edgeRID.getPosition() >= 0)
+        candidates++;
+    }
+    return candidates;
+  }
+
+  /** Fires {@link #TEST_BEFORE_ORPHAN_RECLAIM_COMMIT_HOOK}, if set, right before an orphan-reclaim commit. */
+  private void fireBeforeOrphanReclaimCommitHook() {
+    final IntConsumer hook = TEST_BEFORE_ORPHAN_RECLAIM_COMMIT_HOOK;
+    if (hook != null)
+      hook.accept(orphanReclaimCommitAttempt.incrementAndGet());
   }
 
   /**
@@ -1591,7 +1654,13 @@ public class GraphBatch implements AutoCloseable {
     // inHeadUndoLog) and cycle 4 for the parallel OUT direction (the per-bucket local maps); this path was the
     // one left. Same remedy: snapshot each touched vertex's PRE-slice deferredOutHead value once per slice, and
     // on failure restore it exactly - "was absent" via remove(), "had segment X" back to X (issue #6083).
-    final Map<Long, RID> outHeadUndoLog = new HashMap<>();
+    //
+    // LongObjectHashMap, not HashMap<Long, RID>: this is allocated on EVERY sequential flush and takes an entry
+    // per distinct source vertex in the slice, so it is exactly the shape the zero-boxing map exists for (~16
+    // bytes/entry against 72-90). A null VALUE is what "the vertex had no deferred head" is recorded as, which
+    // this map represents faithfully - occupancy lives in its key array, so containsKey() still answers true for
+    // a key put with a null value (issue #6083 review cycle 1).
+    final LongObjectHashMap<RID> outHeadUndoLog = new LongObjectHashMap<>();
 
     try {
       while (i < edgeCount) {
@@ -1680,16 +1749,14 @@ public class GraphBatch implements AutoCloseable {
       database.commit();
       flushDurableOutEdges = edgeCount;
     } catch (final RuntimeException e) {
-      for (final Map.Entry<Long, RID> undo : outHeadUndoLog.entrySet()) {
-        final long key = undo.getKey();
-        final RID previous = undo.getValue();
+      outHeadUndoLog.forEach((key, previous) -> {
         if (previous == null)
           deferredOutHead.remove(key);
         else
           deferredOutHead.put(key, previous);
         // Just an accelerator cache - evicting is always safe, forces a deferredOutHead/disk fallback.
         outChunkRIDCache.remove(key);
-      }
+      });
       throw e;
     }
   }
@@ -1868,7 +1935,12 @@ public class GraphBatch implements AutoCloseable {
     // deferredInHead value (only once per vertex per slice) so a failure can restore it exactly -
     // "was absent" restores via remove(), "had segment X" restores X - before rethrowing (issue #5950
     // review cycle 3).
-    final Map<Long, RID> inHeadUndoLog = new HashMap<>();
+    //
+    // LongObjectHashMap for the same reason as the OUT side's outHeadUndoLog, and to keep the two identical
+    // structures from drifting apart: allocated per drain, one entry per distinct destination vertex in the
+    // slice, and a null value faithfully records "no deferred head" because occupancy lives in the key array
+    // (issue #6083 review cycle 1).
+    final LongObjectHashMap<RID> inHeadUndoLog = new LongObjectHashMap<>();
 
     try {
       while (i < count) {
@@ -1944,16 +2016,14 @@ public class GraphBatch implements AutoCloseable {
       database.commit();
       inEdgesResumeSortIndex = count;
     } catch (final RuntimeException e) {
-      for (final Map.Entry<Long, RID> undo : inHeadUndoLog.entrySet()) {
-        final long key = undo.getKey();
-        final RID previous = undo.getValue();
+      inHeadUndoLog.forEach((key, previous) -> {
         if (previous == null)
           deferredInHead.remove(key);
         else
           deferredInHead.put(key, previous);
         // Just an accelerator cache - evicting is always safe, forces a deferredInHead/disk fallback.
         inChunkRIDCache.remove(key);
-      }
+      });
       throw e;
     }
   }

--- a/engine/src/test/java/com/arcadedb/graph/Issue6083OrphanEdgeRecordTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6083OrphanEdgeRecordTest.java
@@ -157,6 +157,70 @@ class Issue6083OrphanEdgeRecordTest extends TestHelper {
   }
 
   /**
+   * The doubly-unlucky case: the flush fails, AND the cleanup after it fails partway through its own commits.
+   * <p>
+   * With {@code commitEvery > 0} the reclaim pass commits several times. Folding its counters into the totals
+   * only once, at the end, threw away the reclaims an earlier commit had already made durable when a later one
+   * threw, and the outer handler then blamed the whole range as leaked - under-reporting reclaims and counting
+   * records that were in fact already gone. Both counters must instead describe what the database really holds.
+   */
+  @Test
+  void aReclaimPassThatFailsPartwayKeepsWhatItAlreadyCommitted() {
+    final RID[] vertices = createVertices(6);
+
+    // Fail the SECOND reclaim commit: the first has then already durably deleted one orphan.
+    GraphBatch.TEST_BEFORE_ORPHAN_RECLAIM_COMMIT_HOOK = attempt -> {
+      if (attempt == 2)
+        throw new IllegalStateException("Issue6083: simulated failure inside the orphan reclaim pass");
+    };
+
+    final GraphBatch batch;
+    try {
+      batch = GraphBatch.builder(database)
+          .withLightEdges(false)
+          .withParallelFlush(false)
+          // One record per reclaim transaction, so the pass needs several commits and the hook can fail a later
+          // one. It also makes the flush itself commit per group, so the good edges land durably first.
+          .withCommitEvery(1)
+          .build();
+
+      batch.newEdge(vertices[0], EDGE_TYPE, vertices[1], "tag", "good");
+      // Three doomed edges from the same missing bucket: all three are orphan candidates, so the reclaim pass
+      // has more than one commit to make and the injected failure lands in the middle of it.
+      for (int i = 0; i < 3; i++)
+        batch.newEdge(new RID(MISSING_BUCKET_ID, i), EDGE_TYPE, vertices[2 + i], "tag", "doomed" + i);
+
+      assertThatThrownBy(batch::close).isInstanceOf(RuntimeException.class);
+    } finally {
+      GraphBatch.TEST_BEFORE_ORPHAN_RECLAIM_COMMIT_HOOK = null;
+    }
+
+    final long reclaimed = batch.getOrphanEdgeRecordsReclaimed();
+    final long leaked = batch.getOrphanEdgeRecordsLeaked();
+    final long stored = countType(EDGE_TYPE);
+    final long reachable = reachableEdgeCount();
+
+    // Precondition: the injected failure really did interrupt the pass after it had committed something.
+    assertThat(reclaimed).as("the first reclaim commit succeeded, so its record must stay counted as reclaimed")
+        .isPositive();
+    assertThat(leaked).as("the interrupted slice is what leaked").isPositive();
+
+    // The accounting must describe the database: every orphan is either reclaimed or still stored.
+    assertThat(stored - reachable).as("the records still connected to nothing are exactly the leaked ones")
+        .isEqualTo(leaked);
+    assertThat(reclaimed + leaked).as("every orphan candidate is accounted for exactly once, never twice")
+        .isEqualTo(3);
+
+    // This test deliberately leaves unreclaimed orphans behind - that is the state it exists to measure - and
+    // they trip the integrity check TestHelper runs after every test. Not because they are orphans (CHECK
+    // DATABASE has no finding for that, which is the whole premise of item 2) but because the bogus source
+    // bucket used to induce the failure makes them dangling links. Remove them so the shared teardown sees a
+    // clean database.
+    database.transaction(() -> database.command("sql", "DELETE FROM " + EDGE_TYPE + " WHERE tag LIKE 'doomed%'"));
+    assertThat(countType(EDGE_TYPE)).as("only the good edge is left after the cleanup").isEqualTo(reachable);
+  }
+
+  /**
    * The counter stays exact across a successful load too - the change for item 4 moved where it is incremented,
    * so this pins that the ordinary path still counts every edge exactly once.
    */

--- a/engine/src/test/java/com/arcadedb/graph/Issue6083OrphanEdgeRecordTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6083OrphanEdgeRecordTest.java
@@ -129,6 +129,40 @@ class Issue6083OrphanEdgeRecordTest extends TestHelper {
   }
 
   /**
+   * The parallel path reclaims per FAILED BUCKET, so more than one failing at once exercises the loop rather
+   * than a single iteration of it. Each bucket is an independent async transaction: one failing must not take a
+   * sibling's committed edges with it, and both failures must be reclaimed.
+   */
+  @Test
+  void aParallelFlushReclaimsEveryFailedBucketNotJustTheFirst() {
+    final RID[] vertices = createVertices(6);
+
+    final GraphBatch batch = GraphBatch.builder(database)
+        .withLightEdges(false)
+        .withParallelFlush(true)
+        .build();
+
+    batch.newEdge(vertices[0], EDGE_TYPE, vertices[1], "tag", "good-0");
+    batch.newEdge(vertices[1], EDGE_TYPE, vertices[2], "tag", "good-1");
+    // Two DISTINCT missing source buckets, so the partition puts them in two separate bucket tasks and two
+    // separate reclaim calls - one failing bucket would only prove the loop runs once.
+    batch.newEdge(new RID(MISSING_BUCKET_ID, 0L), EDGE_TYPE, vertices[3], "tag", "doomed-a");
+    batch.newEdge(new RID(MISSING_BUCKET_ID + 7, 0L), EDGE_TYPE, vertices[4], "tag", "doomed-b");
+
+    assertThatThrownBy(batch::close).isInstanceOf(RuntimeException.class);
+
+    final long reachable = reachableEdgeCount();
+
+    assertThat(batch.getOrphanEdgeRecordsReclaimed())
+        .as("both failed buckets must be reclaimed, not just the first one the loop reaches").isEqualTo(2);
+    assertThat(batch.getOrphanEdgeRecordsLeaked()).isZero();
+    assertThat(countType(EDGE_TYPE)).as("no unreachable edge record may survive either failure")
+        .isEqualTo(reachable);
+    assertThat(reachable).as("the buckets that succeeded keep their edges").isEqualTo(2);
+    assertThat(batch.getTotalEdgesCreated()).as("and only those are claimed").isEqualTo(reachable);
+  }
+
+  /**
    * A batch whose FIRST commit is the one that fails has nothing durable to reclaim: the rollback already
    * removed PHASE 1's records. The cleanup must not try to delete them again, and the counter must say zero.
    */

--- a/engine/src/test/java/com/arcadedb/graph/Issue6083OrphanEdgeRecordTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6083OrphanEdgeRecordTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6083 items 2 and 4.
+ * <p>
+ * A {@code GraphBatch} edge is written in two steps that do not share a transaction: the record is created in
+ * PHASE 1 of {@link GraphBatch#flush()}, and PHASE 3 links it into its source vertex's edge list. Both flush
+ * paths commit in between - the parallel one must (the record pages have to be released before the per-bucket
+ * tasks touch them), the sequential one does whenever {@code commitEvery > 0}. A connect pass that dies
+ * part-way therefore used to leave edge RECORDS behind that no vertex points at: {@code countType()} counted
+ * them, no traversal reached them, and nothing ever reclaimed them.
+ * <p>
+ * The same two-step split made {@code getTotalEdgesCreated()} a lower bound rather than a count: it advanced a
+ * whole flush at a time, so a load dying mid-flush reported zero for a flush that had in fact made some of its
+ * edges durable.
+ * <p>
+ * These tests pin both: after a failed flush, {@code countType} must agree with what a traversal can reach, and
+ * the counter must equal that same number.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6083OrphanEdgeRecordTest extends TestHelper {
+
+  private static final String VERTEX_TYPE = "Issue6083Node";
+  private static final String EDGE_TYPE   = "Issue6083Link";
+
+  /**
+   * A source bucket id no bucket in this database will ever be assigned. The connect pass loads the source
+   * vertex to find its edge-list head, so an edge from here fails PHASE 3 while its own record has already been
+   * created - the exact shape the issue reports. Deliberately high so the counting sort in
+   * {@code partitionBySourceBucket} orders it last, after the groups that succeed.
+   */
+  private static final int MISSING_BUCKET_ID = 31_212;
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE).createProperty("tag", Type.STRING);
+    });
+  }
+
+  /**
+   * Parallel flush (the default): the edge records are committed before the per-bucket connect tasks run, so a
+   * bucket whose task fails leaves every one of its records unconnected.
+   */
+  @Test
+  void aFailedParallelFlushLeavesNoUnreachableEdgeRecord() {
+    assertFailedFlushLeavesNoOrphan(true, 0);
+  }
+
+  /**
+   * Sequential flush with {@code commitEvery} small enough that the pass commits before reaching the bad group:
+   * that first commit makes PHASE 1's records durable, so the groups after it are left unconnected.
+   */
+  @Test
+  void aFailedSequentialFlushLeavesNoUnreachableEdgeRecord() {
+    assertFailedFlushLeavesNoOrphan(false, 1);
+  }
+
+  private void assertFailedFlushLeavesNoOrphan(final boolean parallelFlush, final int commitEvery) {
+    final RID[] vertices = createVertices(4);
+
+    // Not try-with-resources: the counters have to be read AFTER close() has run the final flush that fails, and
+    // close() rethrows that failure.
+    final GraphBatch batch = GraphBatch.builder(database)
+        .withLightEdges(false)
+        .withParallelFlush(parallelFlush)
+        .withCommitEvery(commitEvery)
+        .build();
+
+    // Two edges that can be connected, from two DIFFERENT source vertices so the parallel path has more than one
+    // group to schedule, and one that cannot: its source names a bucket that does not exist.
+    batch.newEdge(vertices[0], EDGE_TYPE, vertices[1], "tag", "good-0");
+    batch.newEdge(vertices[1], EDGE_TYPE, vertices[2], "tag", "good-1");
+    batch.newEdge(new RID(MISSING_BUCKET_ID, 0L), EDGE_TYPE, vertices[3], "tag", "doomed");
+
+    assertThatThrownBy(batch::close).as("an edge whose source bucket does not exist must fail the load")
+        .isInstanceOf(RuntimeException.class);
+
+    final long counted = batch.getTotalEdgesCreated();
+    final long reclaimed = batch.getOrphanEdgeRecordsReclaimed();
+
+    final long stored = countType(EDGE_TYPE);
+    final long reachable = reachableEdgeCount();
+
+    // The invariant the issue is about. Before the fix the doomed edge's record survived as invisible garbage,
+    // so countType() answered 3 (or, on the sequential path, 1 more than the traversal) while the traversal
+    // reached fewer. Asserting equality rather than an upper bound is what makes this a real check: an
+    // implementation that simply stopped creating the records would also have to keep the good edges.
+    assertThat(stored).as("every stored edge record must be reachable from a vertex").isEqualTo(reachable);
+
+    // Precondition: the failure really did happen after some edges were durably connected. Without this the
+    // assertion above passes vacuously on a load where nothing at all was written.
+    assertThat(reachable).as("the flush must have connected some edges before it failed").isPositive();
+    assertThat(reclaimed).as("the unconnected record must have been reclaimed, not simply never created")
+        .isPositive();
+
+    // Issue #6083 item 4: the counter must be the number of edges the graph holds, not a lower bound.
+    assertThat(counted).as("getTotalEdgesCreated() must be exact after a partial flush").isEqualTo(reachable);
+  }
+
+  /**
+   * A batch whose FIRST commit is the one that fails has nothing durable to reclaim: the rollback already
+   * removed PHASE 1's records. The cleanup must not try to delete them again, and the counter must say zero.
+   */
+  @Test
+  void aFlushThatFailsBeforeItsFirstCommitReclaimsNothing() {
+    final RID[] vertices = createVertices(2);
+
+    final GraphBatch batch = GraphBatch.builder(database)
+        .withLightEdges(false)
+        .withParallelFlush(false)
+        .withCommitEvery(0)
+        .build();
+
+    batch.newEdge(vertices[0], EDGE_TYPE, vertices[1], "tag", "good");
+    batch.newEdge(new RID(MISSING_BUCKET_ID, 0L), EDGE_TYPE, vertices[1], "tag", "doomed");
+
+    assertThatThrownBy(batch::close).isInstanceOf(RuntimeException.class);
+
+    assertThat(countType(EDGE_TYPE)).as("a single-commit flush rolls back whole, so no edge record survives")
+        .isZero();
+    assertThat(reachableEdgeCount()).isZero();
+    assertThat(batch.getTotalEdgesCreated()).as("nothing was made durable, so nothing may be claimed").isZero();
+    assertThat(batch.getOrphanEdgeRecordsReclaimed())
+        .as("the rollback already removed the records; the cleanup must find nothing to do").isZero();
+    assertThat(batch.getOrphanEdgeRecordsLeaked()).as("and it must not fail trying").isZero();
+  }
+
+  /**
+   * The counter stays exact across a successful load too - the change for item 4 moved where it is incremented,
+   * so this pins that the ordinary path still counts every edge exactly once.
+   */
+  @Test
+  void aSuccessfulLoadStillCountsEveryEdgeExactlyOnce() {
+    final RID[] vertices = createVertices(50);
+
+    final long counted;
+    try (final GraphBatch batch = GraphBatch.builder(database)
+        .withLightEdges(false)
+        // Forces several flushes, and several internal commits inside each of them.
+        .withBatchSize(7)
+        .withCommitEvery(3)
+        .withParallelFlush(false)
+        .build()) {
+      for (int i = 0; i < vertices.length - 1; i++)
+        batch.newEdge(vertices[i], EDGE_TYPE, vertices[i + 1], "tag", "e" + i);
+      counted = batch.getTotalEdgesCreated();
+    }
+
+    assertThat(counted).isEqualTo(vertices.length - 1);
+    assertThat(countType(EDGE_TYPE)).isEqualTo(vertices.length - 1);
+    assertThat(reachableEdgeCount()).isEqualTo(vertices.length - 1);
+  }
+
+  private RID[] createVertices(final int count) {
+    final RID[] rids = new RID[count];
+    database.transaction(() -> {
+      for (int i = 0; i < count; i++)
+        rids[i] = database.newVertex(VERTEX_TYPE).set("id", i).save().getIdentity();
+    });
+    return rids;
+  }
+
+  private long countType(final String typeName) {
+    final long[] count = new long[1];
+    database.transaction(() -> count[0] = database.countType(typeName, true));
+    return count[0];
+  }
+
+  /** Edges an OUT traversal from the vertices actually reaches - the ones the graph really holds. */
+  private long reachableEdgeCount() {
+    final long[] reachable = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM " + VERTEX_TYPE)) {
+        rs.forEachRemaining(r -> reachable[0] += r.getVertex().get().countEdges(Vertex.DIRECTION.OUT, EDGE_TYPE));
+      }
+    });
+    return reachable[0];
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2615,6 +2615,27 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   // --- 3) Client-streaming graph batch load ---
+
+  /**
+   * How a bulk-streaming RPC in this service reports a stream that failed with work already committed
+   * (issue #6083 item 5). Two RPCs here answered the same question differently with no stated rule, so a third
+   * had two precedents and no way to choose; this is that rule.
+   * <p>
+   * <b>A failed stream terminates with {@code onError}. Counters of what is already durable ride the trailers,
+   * not a terminal message.</b> That is what {@link #graphBatchLoad} does, via
+   * {@code GraphBatchProtocol.RESULT_TRAILER}. A failure IS a failure at the transport level: the caller keeps
+   * its status code and whatever generic error handling it already has, and a stream that committed half a load
+   * does not complete "successfully". Carrying the counters in the trailers is what keeps that from costing the
+   * caller the information it needs to reconcile.
+   * <p>
+   * {@link #insertStream} predates the rule and does the opposite - it reports through a terminal
+   * {@code InsertSummary} on the normal {@code onNext}/{@code onCompleted} path. It is left as it is because its
+   * summary is a per-chunk outcome report that a caller consumes on the success path too, so the failure case is
+   * not a separate channel there; changing it would break every existing caller for no gain. It is the exception,
+   * not a second precedent.
+   * <p>
+   * A NEW bulk-streaming RPC follows {@code graphBatchLoad}.
+   */
   @Override
   public StreamObserver<GraphBatchChunk> graphBatchLoad(final StreamObserver<GraphBatchResult> resp) {
     final ServerCallStreamObserver<GraphBatchResult> call = (ServerCallStreamObserver<GraphBatchResult>) resp;
@@ -2690,8 +2711,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             dbRef.set(db);
             final GraphBatchOptions options = chunk.hasOptions() ? chunk.getOptions() : null;
             if (options != null) {
-              if (options.getVertexBatchSize() > 0)
-                vertexBatchSize[0] = Math.min(options.getVertexBatchSize(), GRAPH_BATCH_MAX_VERTEX_BUFFER);
+              if (options.getVertexBatchSize() > 0) {
+                final int requested = options.getVertexBatchSize();
+                vertexBatchSize[0] = Math.min(requested, GRAPH_BATCH_MAX_VERTEX_BUFFER);
+                if (vertexBatchSize[0] != requested)
+                  LogManager.instance().log(this, Level.WARNING,
+                      "graphBatchLoad: requested vertexBatchSize %d exceeds the server-side cap, clamping to %d",
+                      null, requested, vertexBatchSize[0]);
+              }
               if (options.hasReturnIdMapping())
                 returnIdMapping[0] = options.getReturnIdMapping();
             }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
@@ -486,13 +486,19 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
    * Captures ArcadeDB log records by swapping the global logger for the duration of a test, keeping the message
    * template and its arguments UNSUBSTITUTED so an assertion can check the values the line was given rather
    * than a formatted string.
+   * <p>
+   * Every record is also forwarded to a real {@link DefaultLogger}. The logger is a process-wide singleton
+   * shared with the embedded server under test, so a capturing logger that only captured would silently swallow
+   * anything the server logged while it was installed - including the diagnostics needed to understand a failure
+   * inside that window. Tee-ing keeps the swap invisible to everything except the assertions.
    */
   private static final class CapturingLogger implements Logger {
 
     record Record(Level level, String message, List<Object> args) {
     }
 
-    private final List<Record> records = new CopyOnWriteArrayList<>();
+    private final List<Record> records  = new CopyOnWriteArrayList<>();
+    private final Logger       delegate = new DefaultLogger();
 
     static CapturingLogger install() {
       final CapturingLogger logger = new CapturingLogger();
@@ -522,12 +528,15 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
         final Object arg15, final Object arg16, final Object arg17) {
       record(level, message, Arrays.asList(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
           arg12, arg13, arg14, arg15, arg16, arg17));
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
+          arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
     }
 
     @Override
     public void log(final Object requester, final Level level, final String message, final Throwable exception,
         final String context, final Object... args) {
       record(level, message, args == null ? List.of() : Arrays.asList(args));
+      delegate.log(requester, level, message, exception, context, args);
     }
 
     private void record(final Level level, final String message, final List<Object> args) {
@@ -537,6 +546,7 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
 
     @Override
     public void flush() {
+      delegate.flush();
     }
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
@@ -21,6 +21,9 @@ package com.arcadedb.server.grpc;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.log.DefaultLogger;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.server.BaseGraphServerTest;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -38,9 +41,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -196,6 +203,46 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
   }
 
   /**
+   * A vertex buffer above the server-side cap is clamped, and the caller has to be told (issue #6083 item 1).
+   * <p>
+   * The cap itself is right - a caller-supplied buffer size must not be able to exhaust the server heap on one
+   * request - but it applied with no log line, so a caller who asked for more got something other than what it
+   * set and was never told, which reads as compliance. What is asserted here is the WARNING naming both the
+   * requested and the effective value; the clamp is not observable any other way on a load that succeeds, since
+   * the same vertices land whether they went in one buffer or many.
+   */
+  @Test
+  void warnsWhenTheRequestedVertexBatchSizeIsClamped() throws Exception {
+    final CapturingLogger logger = CapturingLogger.install();
+    try {
+      // Above GRAPH_BATCH_MAX_VERTEX_BUFFER (1,000,000). The load itself is tiny; only the option matters.
+      load(GraphBatchOptions.newBuilder().setVertexBatchSize(5_000_000).build(), 2);
+
+      assertThat(logger.findWarning("vertexBatchSize"))
+          .as("a clamped buffer must be reported, not applied silently").isNotNull();
+      assertThat(logger.findWarning("vertexBatchSize").args)
+          .as("the log line must name both the requested and the effective value")
+          .contains(5_000_000, 1_000_000);
+    } finally {
+      logger.uninstall();
+    }
+  }
+
+  /** The counterpart: a buffer inside the cap is applied verbatim and must produce no warning. */
+  @Test
+  void doesNotWarnWhenTheRequestedVertexBatchSizeIsHonoured() throws Exception {
+    final CapturingLogger logger = CapturingLogger.install();
+    try {
+      load(GraphBatchOptions.newBuilder().setVertexBatchSize(1_000).build(), 2);
+
+      assertThat(logger.findWarning("vertexBatchSize"))
+          .as("nothing was clamped, so there is nothing to report").isNull();
+    } finally {
+      logger.uninstall();
+    }
+  }
+
+  /**
    * A load that fails part-way is not rolled back, because the batch commits incrementally. The counters of
    * what is durable have to reach the caller, and a status carries no message, so they ride the trailers.
    */
@@ -278,10 +325,14 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
    * <p>
    * The failure is arranged where the previous test cannot reach: past the vertex phase, on the edge flush that
    * {@code close()} performs, by pointing an edge at a bucket that does not exist. The vertices are committed
-   * by then, so the trailer has to report some of the load as durable and none of the edges.
+   * by then, so the trailer has to report some of the load as durable.
+   * <p>
+   * Since issue #6083 this also pins the two properties that follow from the flush cleaning up after itself:
+   * the edge count is exact rather than a lower bound, and {@code countType} agrees with a traversal because no
+   * unconnected edge record is left behind.
    */
   @Test
-  void countsOnlyFlushedEdgesOnTheTrailerOfALoadThatFailsClosing() throws Exception {
+  void countsConnectedEdgesExactlyOnTheTrailerOfALoadThatFailsClosing() throws Exception {
     final AtomicReference<Throwable> errorRef = new AtomicReference<>();
     final CountDownLatch done = new CountDownLatch(1);
 
@@ -295,10 +346,10 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
       chunk.addRecords(vertex("e" + i));
 
     // Both edges are buffered and neither is flushed before close(). The second originates from a bucket that
-    // does not exist, and the outgoing side is written into the source vertex's own record, so the flush that
-    // close() runs fails there and takes the first edge of the same flush with it. (A bad destination would
-    // not do: the outgoing flush commits regardless and only the incoming connect fails afterwards, at which
-    // point those edges genuinely are created and counting them is right.)
+    // does not exist, so the flush that close() runs fails on it while the first edge, whose source bucket is a
+    // different one, is connected and committed by its own task. (A bad destination would not do: the outgoing
+    // flush commits regardless and only the incoming connect fails afterwards, at which point those edges
+    // genuinely are created and counting them is right.)
     chunk.addRecords(GraphBatchRecord.newBuilder()
         .setKind(GraphBatchRecord.Kind.EDGE)
         .setTypeName("Issue6070Link")
@@ -329,15 +380,24 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
     assertThat(countOf("Issue6070Node")).isEqualTo(4);
 
     // The invariant that matters, and the one this counter exists to keep: never claim an edge the graph does
-    // not hold. The flush died part-way, so one of the two edges had in fact been written by then, while the
-    // counter advances a whole flush at a time and so reports none. Under-reporting costs a caller a duplicate
-    // on an edge it re-sends; over-reporting costs it the edge, silently - and counting received records
-    // instead of flushed ones did exactly that here, claiming both.
+    // not hold. Over-reporting costs a caller the edge, silently - counting received records instead of
+    // connected ones did exactly that here, claiming both.
+    //
+    // Since issue #6083 the counter is EXACT rather than a lower bound: the connect pass advances it one durable
+    // commit at a time instead of a whole flush at a time, so the one edge that was in fact connected is
+    // reported as one rather than rounded down to zero. A caller reconciling against this re-sends exactly the
+    // edge that is missing.
     final long connected = connectedEdgeCount();
-    assertThat(partial.getEdgesCreated())
-        .as("the trailer must never report more edges than the graph actually holds")
-        .isLessThanOrEqualTo(connected);
-    assertThat(partial.getEdgesCreated()).as("no edge flush completed, so no edge is counted").isZero();
+    assertThat(connected).as("the task for the good edge's source bucket commits independently of the bad one")
+        .isEqualTo(1);
+    assertThat(partial.getEdgesCreated()).as("the trailer must report exactly the edges the graph holds")
+        .isEqualTo(connected);
+
+    // #6083 item 2: countType() may be used here now. It could not before - the failed flush left the doomed
+    // edge's RECORD behind, connected to no vertex, so countType() answered 2 while a traversal reached 1. The
+    // flush now reclaims the records it could not connect, which is what makes the two agree.
+    assertThat(countOf("Issue6070Link"))
+        .as("a failed flush must leave no edge record that no vertex points at").isEqualTo(connected);
   }
 
   private GraphBatchResult loadWithIdMappingPreference(final Boolean returnIdMapping, final int vertices)
@@ -370,12 +430,20 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
     return resultRef.get();
   }
 
+  /**
+   * Carries {@code tag} as well as {@code name} even though nothing here reads it: the tests share one server
+   * and one database, and {@link #honoursTheRequestedVertexBatchSize()} declares {@code tag} MANDATORY to arrange
+   * its failure. Whether that has already run depends on method order, so a vertex without it is a load that
+   * fails or not depending on which test went first. Setting it always makes every other test independent of
+   * that order, and it is harmless before the property exists.
+   */
   private GraphBatchRecord vertex(final String tempId) {
     return GraphBatchRecord.newBuilder()
         .setKind(GraphBatchRecord.Kind.VERTEX)
         .setTypeName("Issue6070Node")
         .setTempId(tempId)
         .putProperties("name", GrpcValue.newBuilder().setStringValue(tempId).build())
+        .putProperties("tag", GrpcValue.newBuilder().setStringValue(tempId).build())
         .build();
   }
 
@@ -412,6 +480,64 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
 
   private long countOf(final String typeName) {
     return getServerDatabase(0, getDatabaseName()).countType(typeName, true);
+  }
+
+  /**
+   * Captures ArcadeDB log records by swapping the global logger for the duration of a test, keeping the message
+   * template and its arguments UNSUBSTITUTED so an assertion can check the values the line was given rather
+   * than a formatted string.
+   */
+  private static final class CapturingLogger implements Logger {
+
+    record Record(Level level, String message, List<Object> args) {
+    }
+
+    private final List<Record> records = new CopyOnWriteArrayList<>();
+
+    static CapturingLogger install() {
+      final CapturingLogger logger = new CapturingLogger();
+      LogManager.instance().setLogger(logger);
+      return logger;
+    }
+
+    void uninstall() {
+      LogManager.instance().setLogger(new DefaultLogger());
+    }
+
+    /** The first WARNING whose template contains {@code needle}, or null. */
+    Record findWarning(final String needle) {
+      for (final Record r : records)
+        if (r.level() == Level.WARNING && r.message().contains(needle))
+          return r;
+      return null;
+    }
+
+    // Records directly rather than delegating to the varargs overload below: an Object[] of exactly these 17
+    // arguments matches the fixed-arity signature, so the delegation would resolve back to this method.
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+        final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+        final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+        final Object arg15, final Object arg16, final Object arg17) {
+      record(level, message, Arrays.asList(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
+          arg12, arg13, arg14, arg15, arg16, arg17));
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      record(level, message, args == null ? List.of() : Arrays.asList(args));
+    }
+
+    private void record(final Level level, final String message, final List<Object> args) {
+      if (message != null)
+        records.add(new Record(level, message, args));
+    }
+
+    @Override
+    public void flush() {
+    }
   }
 
   private final class AuthClientInterceptor implements ClientInterceptor {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6070GraphBatchLoadHardeningIT.java
@@ -491,6 +491,13 @@ public class Issue6070GraphBatchLoadHardeningIT extends BaseGraphServerTest {
    * shared with the embedded server under test, so a capturing logger that only captured would silently swallow
    * anything the server logged while it was installed - including the diagnostics needed to understand a failure
    * inside that window. Tee-ing keeps the swap invisible to everything except the assertions.
+   * <p>
+   * <b>The swap is still global, and that bounds where this helper is usable.</b> It is sound here because
+   * these ITs run sequentially within one class and one forked JVM, so nothing else is logging into the capture
+   * window. Run this suite with cross-class parallelism in a shared JVM and a capture could pick up lines from
+   * unrelated concurrent activity - {@link #findWarning} would still match on the template, but a test asserting
+   * the ABSENCE of a warning could see another test's. Anything relying on that would need per-test isolation of
+   * the logger rather than a singleton swap.
    */
   private static final class CapturingLogger implements Logger {
 


### PR DESCRIPTION
Closes items 1, 2, 4 and 5 of #6083 (follow-ups from #6070 / PR #6076). Items 1, 2 and 4 all sit on the same code path, which is why they are taken together.

## Item 2 - a failed edge flush left orphan edge records

A `GraphBatch` edge is written in two steps that do not share a transaction: PHASE 1 of `flush()` creates the record, PHASE 3 links it into its source vertex's edge list. Both flush paths commit in between - the parallel one **must** (the record pages have to be released before the per-bucket tasks touch them), the sequential one does whenever `commitEvery > 0`. A connect pass dying part-way therefore left edge **records** behind that no vertex points at: `countType()` counted them, no traversal reached them, nothing ever reclaimed them.

**The issue asked whether CHECK DATABASE detects and reclaims them. It does not**, and the detail matters:

- `checkEdges` *does* scan every edge record and probe both endpoints for a back-reference (`GraphDatabaseChecker.java:1150-1152, 1183-1185`)...
- ...but a miss only increments the aggregate `missingReferenceBack` counter. No warning naming the record, no entry in `corruptedRecords`, so nothing for the `FIX` variant to delete.
- That same counter is raised by a perfectly healthy **unidirectional** edge, legitimately absent from its target's IN list, so it cannot even be read as an orphan count.
- (`FIX` *does* reclaim orphaned edge **segments** - but those are the internal linked-list chunks, not the edge records at issue.)

So the flush now cleans up after itself before the failure propagates. Deletion goes through `database.deleteRecord`, which is the one inverse correct for **both** creation routes this class uses (`createRecordsBulk` + `indexEdgeProperties` for a single-bucket flush, an ordinary `save()` for a multi-type one) and for every index kind, without a second copy of the key-derivation logic to keep in step. Best-effort by construction: what it cannot reclaim is logged and counted (`getOrphanEdgeRecordsLeaked()`), never allowed to replace the failure the caller is already handling.

### A partial failure also left half-edges

Found while writing the test. A partially-failed flush skipped PHASE 4 entirely, so the edges it *had* durably connected never got their IN back-pointer - half-edges the integrity checker flags. PHASE 3's failure is now **captured rather than thrown**, so PHASE 4 queues the incoming side for exactly the edges that survived, and the failure is rethrown after. A failed flush now leaves only whole edges.

## Item 4 - the partial-commit edge count is now exact, not a lower bound

`totalEdgesCreated` advanced a whole flush at a time, so a load dying mid-flush reported zero for a flush that had in fact made some of its edges durable. It now advances one durable commit at a time, on the failure path as well as the success one. A caller reconciling a failed bulk load re-sends exactly what is missing instead of over-sending a flush's worth and relying on the duplicates being harmless.

## Bonus: the sequential OUT path had no undo log (found by the new test)

`connectOutgoingEdgesSorted` wrote `deferredOutHead`/`outChunkRIDCache` before the transaction holding those segments committed, with nothing to undo it. A rolled-back segment RID survived in the map and `batchUpdateVertexHeadChunks()` stamped it onto the vertex at `close()` - CHECK DATABASE reports `"out edges record is not valid"` and no later read can follow it.

This is exactly the hazard #5950 cycle 3 fixed for the IN direction (`inHeadUndoLog`) and cycle 4 for the parallel OUT direction (the per-bucket local maps). This path was the one left. Same remedy, and the final commit moved inside the pass so the undo log covers it too.

## Item 1 - `vertex_batch_size` was clamped silently

The cap is right - a caller-supplied buffer must not be able to exhaust the server heap on one request - but it applied with no log line, so a caller who asked for more got something else and was never told. Now a `WARNING` naming both the requested and the effective value.

## Item 5 - the reporting convention is settled and written down

The two contradictory precedents are resolved on `graphBatchLoad`'s javadoc: **a failed bulk stream terminates with `onError` and carries its counters in the trailers**, so the caller keeps its status code and generic error handling while still getting what it needs to reconcile. `insertStream` is documented as the predating exception (its summary is a per-chunk report consumed on the success path too, so failure is not a separate channel there) rather than a second precedent.

## Not in this PR

- **Item 3** (the leader's gRPC address is not discoverable) needs a new field in the HA server-list format - a public config-surface change - plus a real 3-node cluster IT to exercise the follower-refusal path. It gets its own PR so that review is not entangled with these defect fixes.
- **Items 6 and 7** were recorded in the issue as deliberately declined; nothing to do.

## Testing

`Issue6083OrphanEdgeRecordTest` (new) covers, for **both** flush paths:
- a failed flush leaves no edge record that a traversal cannot reach (`countType == reachable`, not an upper bound)
- `getTotalEdgesCreated()` equals that same number
- the flush that fails *before* its first commit has nothing durable to reclaim and must not try
- a successful multi-flush, multi-internal-commit load still counts every edge exactly once

**Every assertion was mutation-checked.** Disabling the orphan reclaim, reverting the exact counting, and removing the new OUT undo log each makes a test fail; so does removing the clamp warning. (The issue warned that three tests written during #6076 initially passed against the very bug they were meant to catch.)

`Issue6070GraphBatchLoadHardeningIT`:
- the trailer test now asserts the **exact** count and that `countType` agrees with a traversal - which is precisely what it could not do before, and why it had been written around the symptom
- two new tests for the clamp warning (present when clamped, absent when honoured)
- its shared `vertex()` helper now also sets the property another test declares MANDATORY, so the class no longer passes or fails depending on method order

Suites run green: all `com.arcadedb.graph.*Test` and `com.arcadedb.database.*Test` (engine), all 172 grpcw unit tests + the `Issue6070*` ITs, `RemoteGraphBatchTest` (network), `RemoteGraphBatchIT` (server).

On throughput (correcting the class name from the original description - there is no `GraphBatchBenchmark`): `GraphBatchTest.benchmarkBatchVsStandard` covers the parallel path (3.41x over the standard API, unchanged), and `performance/GraphBatchDrainPerfBenchmark` covers **both** - `parallelFlush=true` at ~653K edges/sec and `parallelFlush=false` at ~742K, also unchanged. So the sequential path, which is where the new per-flush undo-log bookkeeping lives, is represented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
