### PR TITLE
fix: remove Claude author tag from check-license-allowlist.py

### DIFF
--- a/.github/scripts/check-license-allowlist.py
+++ b/.github/scripts/check-license-allowlist.py
@@ -39,8 +39,6 @@
 # Usage:
 #   check-license-allowlist.py <path-to-THIRD-PARTY.txt>
 #
-# @author Claude
-#
 import sys
 
 # Every family in CLAUDE.md's ALLOWED list, plus ISC (already used - org.mindrot:jbcrypt


### PR DESCRIPTION
## Summary
- Removes `# @author Claude` from `.github/scripts/check-license-allowlist.py`, which was left in place when PR #6079 merged.

## Background
PR #6079 (issue #5651, Maven license allow-list enforcement) added `check-license-allowlist.py`. The Claude review bot's comment on that PR flagged, under "Must fix":

> `.github/scripts/check-license-allowlist.py:89` - `# @author Claude` violates this repo's own `CLAUDE.md` ("don't add Claude as author of any source code"), which this very PR is quoting and extending elsewhere.

The PR was merged (`01b021ab4`) before that comment landed / was addressed, so the tag shipped to `main`. This PR just removes it, matching the convention used by the script's neighbors (no `@author` tag at all, rather than substituting a human name, since no human author was specified).

## Test plan
- [x] `bash .github/scripts/tests/test-ci-scripts.sh` - all 45 checks pass, including the `check-license-allowlist.py` suite (unaffected by a comment-only change)
- [x] pre-commit hooks passed on commit