### PR TITLE
fix(#5668): deflake RaftReplicationMaterializedViewIT and Issue5410AbandonedTicketReleaseIT

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
@@ -44,7 +44,12 @@ import java.util.logging.Level;
 public abstract class BaseRaftHATest extends BaseGraphServerTest {
 
   private static final int  BASE_RAFT_PORT          = 2434;
-  private static final long RESYNC_RETRY_TIMEOUT_MS = 30_000;
+  // 60s, not 30s: CI runners for this job are consistently ~3x slower than a local run for this
+  // kind of cross-node convergence wait (issue #5668 measured 15.3s locally vs 42.7s on a CI
+  // runner for the same assertion), and both withResyncRetry() and awaitValue()/awaitCountOn()
+  // return as soon as the condition is met - a longer ceiling only matters on the genuinely-slow
+  // or genuinely-stuck path, never on the common fast path.
+  private static final long RESYNC_RETRY_TIMEOUT_MS = 60_000;
 
   /**
    * Returns the peer ID for a given server index in the test cluster.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
@@ -44,12 +44,21 @@ import java.util.logging.Level;
 public abstract class BaseRaftHATest extends BaseGraphServerTest {
 
   private static final int  BASE_RAFT_PORT          = 2434;
-  // 60s, not 30s: CI runners for this job are consistently ~3x slower than a local run for this
-  // kind of cross-node convergence wait (issue #5668 measured 15.3s locally vs 42.7s on a CI
-  // runner for the same assertion), and both withResyncRetry() and awaitValue()/awaitCountOn()
-  // return as soon as the condition is met - a longer ceiling only matters on the genuinely-slow
-  // or genuinely-stuck path, never on the common fast path.
-  private static final long RESYNC_RETRY_TIMEOUT_MS = 60_000;
+  // 120s: two independent CI runs of this PR (runs 31578870619 and 31587763511) each showed
+  // Issue5410AbandonedTicketReleaseIT stall for the ENTIRE poll budget - once at 30s, once at 60s -
+  // immediately after RaftMigrationCompactionRaceIT (a 72k-record, 24-compaction-round, 12-writer-
+  // thread IT) ran in the same shared, reused JVM fork (failsafe reuseForks=true/forkCount=1 for the
+  // whole module). Both stalls were confirmed real via the test's own embedded log timestamps, not a
+  // log-flush artifact. Not reproducible locally in isolation, nor under an emulated 4-CPU/3.9GB-heap
+  // constraint matching the CI runner - only in the full-suite adjacency. The project's own
+  // engine-concurrency skill documents ArcadeStateMachine.notifyInstallSnapshotFromLeader as a
+  // not-yet-migrated user of the JDK common ForkJoinPool, which is also shared with JDK GC/reference
+  // handler internals - exactly the "long-running [GC-heavy] work starves engine work" failure shape
+  // this looks like. This bump is a mitigation, not a fix: it only widens the ceiling on the rare
+  // stalled path (withResyncRetry()/awaitValue()/awaitCountOn() all return as soon as the condition
+  // is met), while the real fix - isolating heavy ITs into their own fork, or migrating the common-
+  // pool caller - is tracked as a follow-up rather than attempted here.
+  private static final long RESYNC_RETRY_TIMEOUT_MS = 120_000;
 
   /**
    * Returns the peer ID for a given server index in the test cluster.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedTicketReleaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5410AbandonedTicketReleaseIT.java
@@ -86,6 +86,7 @@ class Issue5410AbandonedTicketReleaseIT extends BaseRaftHATest {
 
     leaderDb.transaction(() -> {
       final MutableVertex v = leaderDb.newVertex(VERTEX_TYPE);
+      v.set("id", 1);
       v.set("name", "baseline");
       v.save();
     });
@@ -120,6 +121,7 @@ class Issue5410AbandonedTicketReleaseIT extends BaseRaftHATest {
     try {
       leaderDb.begin();
       final MutableVertex v = leaderDb.newVertex(VERTEX_TYPE);
+      v.set("id", 2);
       v.set("name", "abandoned");
       v.save();
       leaderDb.commit();
@@ -135,23 +137,17 @@ class Issue5410AbandonedTicketReleaseIT extends BaseRaftHATest {
 
     // The abandoned entry reaches quorum and every node - including the leader, via the
     // abandonedLocalTransactions path - converges on both vertices (the #4790 contract).
-    final long deadline = System.currentTimeMillis() + 30_000;
-    boolean converged = false;
-    while (System.currentTimeMillis() < deadline && !converged) {
-      for (int i = 0; i < getServerCount(); i++)
-        waitForReplicationIsCompleted(i);
-      converged = true;
-      for (int i = 0; i < getServerCount(); i++)
-        if (getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true) != 2L) {
-          converged = false;
-          break;
-        }
-      if (!converged)
-        Thread.sleep(250);
-    }
-
+    // awaitCountOn() polls the actual data on each node directly rather than trusting
+    // waitForReplicationIsCompleted()'s Raft-index snapshot: that helper only waits for a
+    // follower to catch up to wherever the leader's applied index happens to be *right now*,
+    // which says nothing about whether the leader itself has finished applying the abandoned
+    // entry via the recovery path exercised here. Each node also gets its own poll budget
+    // instead of one shared deadline across the whole cluster, so a slow CI runner (#5668,
+    // observed as a hard "expected: 2L but was: 1L" once the old single 30s budget elapsed)
+    // costs time rather than a failure, and on a genuine stall the assertion reports the count
+    // the node actually reached.
     for (int i = 0; i < getServerCount(); i++)
-      assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
+      assertThat(awaitCountOn(i, VERTEX_TYPE, 2L))
           .as("Node %d must hold both vertices", i)
           .isEqualTo(2L);
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationMaterializedViewIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationMaterializedViewIT.java
@@ -42,38 +42,37 @@ class RaftReplicationMaterializedViewIT extends BaseRaftHATest {
   @Test
   void materializedViewReplicates() throws Exception {
     // Find the leader - schema changes must be issued on the leader for Raft replication
-    int leaderIndexTmp = -1;
-    for (int i = 0; i < getServerCount(); i++) {
-      final RaftHAPlugin plugin = getRaftPlugin(i);
-      if (plugin != null && plugin.isLeader()) {
-        leaderIndexTmp = i;
-        break;
-      }
-    }
-    assertThat(leaderIndexTmp).as("Expected to find a Raft leader").isGreaterThanOrEqualTo(0);
-    final int leaderIndex = leaderIndexTmp;
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("Expected to find a Raft leader").isGreaterThanOrEqualTo(0);
 
-    final Database[] databases = new Database[getServerCount()];
-    for (int i = 0; i < getServerCount(); i++) {
-      databases[i] = getServer(i).getDatabase(getDatabaseName());
-      if (databases[i].isTransactionActive())
-        databases[i].commit();
-    }
+    // Every database handle below is resolved fresh inside withResyncRetry() rather than cached
+    // once up front: a bootstrap-mismatch snapshot reinstall can still be in flight right after
+    // cluster startup (observed in #5668, CI run 30676355936 - a DatabaseIsClosedException out of
+    // Database.getSchema() a few milliseconds into the test), and a handle resolved before that
+    // point is exactly the stale-handle shape #5977 already documents on BaseRaftHATest.
 
-    // Create source type and insert data on leader
-    databases[leaderIndex].getSchema().createDocumentType("RaftMetric");
+    // Create source type on leader
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().createDocumentType("RaftMetric");
+      return null;
+    });
 
     // Wait for schema replication before checking all servers
     for (int i = 0; i < getServerCount(); i++)
       waitForReplicationIsCompleted(i);
 
-    for (final Database db : databases)
-      assertThat(db.getSchema().existsType("RaftMetric"))
-          .as("All servers should have RaftMetric type").isTrue();
+    for (int i = 0; i < getServerCount(); i++) {
+      final boolean exists = withResyncRetry(i, db -> db.getSchema().existsType("RaftMetric"));
+      assertThat(exists).as("All servers should have RaftMetric type").isTrue();
+    }
 
-    databases[leaderIndex].transaction(() -> {
-      databases[leaderIndex].newDocument("RaftMetric").set("name", "cpu").set("value", 80).save();
-      databases[leaderIndex].newDocument("RaftMetric").set("name", "mem").set("value", 60).save();
+    // Insert data on leader
+    withResyncRetry(leaderIndex, db -> {
+      db.transaction(() -> {
+        db.newDocument("RaftMetric").set("name", "cpu").set("value", 80).save();
+        db.newDocument("RaftMetric").set("name", "mem").set("value", 60).save();
+      });
+      return null;
     });
 
     // Wait for data replication
@@ -81,50 +80,58 @@ class RaftReplicationMaterializedViewIT extends BaseRaftHATest {
       waitForReplicationIsCompleted(i);
 
     // Create materialized view on leader
-    databases[leaderIndex].getSchema().buildMaterializedView()
+    withResyncRetry(leaderIndex, db -> db.getSchema().buildMaterializedView()
         .withName("RaftHighMetrics")
         .withQuery("SELECT name, value FROM RaftMetric WHERE value > 70")
-        .create();
+        .create());
 
     // Wait for materialized view schema to replicate
     for (int i = 0; i < getServerCount(); i++)
       waitForReplicationIsCompleted(i);
 
     // Verify view exists on all servers
-    for (final Database db : databases)
-      assertThat(db.getSchema().existsMaterializedView("RaftHighMetrics"))
-          .as("All servers should have RaftHighMetrics materialized view").isTrue();
+    for (int i = 0; i < getServerCount(); i++) {
+      final boolean exists = withResyncRetry(i, db -> db.getSchema().existsMaterializedView("RaftHighMetrics"));
+      assertThat(exists).as("All servers should have RaftHighMetrics materialized view").isTrue();
+    }
 
     // Verify schema file contains the view definition on all servers
-    for (final Database db : databases) {
-      final String content = readSchemaFile(db);
+    for (int i = 0; i < getServerCount(); i++) {
+      final String content = withResyncRetry(i, RaftReplicationMaterializedViewIT::readSchemaFile);
       assertThat(content).contains("RaftHighMetrics");
       assertThat(content).contains("materializedViews");
     }
 
     // Query view on a replica
     final int replicaIndex = (leaderIndex + 1) % getServerCount();
-    try (final var rs = databases[replicaIndex].query("sql", "SELECT FROM RaftHighMetrics")) {
-      assertThat(rs.stream().count()).isEqualTo(1L);
-    }
+    final long viewRowCount = withResyncRetry(replicaIndex, db -> {
+      try (final var rs = db.query("sql", "SELECT FROM RaftHighMetrics")) {
+        return rs.stream().count();
+      }
+    });
+    assertThat(viewRowCount).isEqualTo(1L);
 
     // Drop the view on leader
-    databases[leaderIndex].getSchema().dropMaterializedView("RaftHighMetrics");
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().dropMaterializedView("RaftHighMetrics");
+      return null;
+    });
 
     // Wait for drop replication
     for (int i = 0; i < getServerCount(); i++)
       waitForReplicationIsCompleted(i);
 
     // Verify view is gone on all servers
-    for (final Database db : databases)
-      assertThat(db.getSchema().existsMaterializedView("RaftHighMetrics"))
-          .as("All servers should not have RaftHighMetrics after drop").isFalse();
+    for (int i = 0; i < getServerCount(); i++) {
+      final boolean exists = withResyncRetry(i, db -> db.getSchema().existsMaterializedView("RaftHighMetrics"));
+      assertThat(exists).as("All servers should not have RaftHighMetrics after drop").isFalse();
+    }
 
-    for (final Database db : databases)
-      assertThat(readSchemaFile(db)).doesNotContain("RaftHighMetrics");
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(withResyncRetry(i, RaftReplicationMaterializedViewIT::readSchemaFile)).doesNotContain("RaftHighMetrics");
   }
 
-  private String readSchemaFile(final Database database) {
+  private static String readSchemaFile(final Database database) {
     try {
       return FileUtils.readFileAsString(database.getSchema().getEmbedded().getConfigurationFile());
     } catch (final IOException e) {


### PR DESCRIPTION
## What does this PR do?

Fixes two of the intermittent `ha-integration-tests` failures tracked in #5668 by giving each test a resync-safe way to read cluster state, fixes a latent bug in the test harness usage that was uncovered once the timing race was removed, and widens the shared convergence-poll budget after this PR's own CI run showed it was still on the edge for this job's runners.

### RaftReplicationMaterializedViewIT

Resolved `Database` handles for all 3 servers once up front and closed over those cached handles in lambdas for the rest of the test. A bootstrap-mismatch snapshot reinstall racing test start closes and replaces the database out from under a handle already resolved, throwing `DatabaseIsClosedException` (seen on `main`, CI run 30676355936):

```
com.arcadedb.exception.DatabaseIsClosedException: graph
  at LocalDatabase.checkDatabaseIsOpen
  at LocalDatabase.getSchema
  at RaftReplicatedDatabase.getSchema
  at ServerDatabase.getSchema
  at RaftReplicationMaterializedViewIT.materializedViewReplicates(...:71)
```

`BaseRaftHATest.withResyncRetry()` already exists for exactly this shape (issue #5977) and is used by three other HA ITs (`RaftReadConsistencyBookmarkIT`, `Issue5492TruncateBatchNotReplicatedIT`, `Issue5655CypherCommitsOnInnerDatabaseIT`). This test had no defense against it at all. Fix: remove the cached `databases[]` array; every database access now resolves a fresh handle through `withResyncRetry()`.

### Issue5410AbandonedTicketReleaseIT

Used a hand-rolled convergence loop bounded by a single 30-second deadline shared across the whole cluster, polling via `waitForReplicationIsCompleted(i)` (a Raft-index snapshot check) before asserting vertex counts directly. `waitForReplicationIsCompleted()` is the wrong signal here: it only waits for a follower to catch up to wherever the **leader's own** applied index happens to be *right now*, which says nothing about whether the leader itself has finished applying the abandoned entry through the recovery path this test exercises. On a slow CI runner the 30s deadline can elapse with a node still short (`expected: 2L but was: 1L`, PR #5640 run 30667085992).

Fix: replaced the loop with the existing `awaitCountOn()` helper, called once per server so each node gets its own poll budget instead of one shared budget for the whole cluster, and polls the actual row data directly instead of a Raft-index snapshot.

### A second, unrelated bug this surfaced

Once the timing race was removed, the test still failed deterministically (100% reproduction, 3/3 local runs) with `expected: 2L but was: 0L` on every node, not just a slow one. Instrumenting the test showed `SELECT FROM AbandonedTicket` returning both rows on all three nodes - replication and convergence were correct - while `awaitCountOn()` stayed at 0 for the full 30s budget every time.

The cause: `BaseRaftHATest.countOn()` (which `awaitCountOn()` polls) deliberately queries `SELECT count(id) AS cnt FROM ...` rather than `count(*)`, to avoid reading a stale cached per-bucket counter (`count(*)` reads that cache; `count(id)` forces an actual scan). Every other caller of this helper (`Issue5492TruncateBatchNotReplicatedIT`, `Issue5655CypherCommitsOnInnerDatabaseIT`, `Issue5492SchemaWalNotShippedIT`) inserts records with an explicit `id` property for exactly this reason. `Issue5410AbandonedTicketReleaseIT`'s vertices only ever set `name`, so `count(id)` was always 0 regardless of replication state - the assertion could never pass, independent of any race. Fix: set `id` on both the baseline and abandoned vertices, matching the convention the shared helper already assumes everywhere else it's used.

### A third round: this PR's own CI run still failed Issue5410AbandonedTicketReleaseIT

After pushing the two fixes above, this PR's own `ha-integration-tests` CI run ([31578870619](https://github.com/ArcadeData/arcadedb/actions/runs/31578870619)) still failed `Issue5410AbandonedTicketReleaseIT` - but with a *different*, genuine symptom this time: `[Node 2 must hold both vertices] expected: 2L but was: 1L`, 42.86s elapsed, after the full 30s per-node budget ran out. Not the id-property bug (fixed above), and not the old shared-deadline bug (also fixed above, and per-node budgets are independent so node 2 alone got its own full 30s) - this was a real "still converging" case on a slower runner.

Issue #5668 itself already measured this job's CI runners at roughly 3x slower than local for this exact kind of cross-node convergence wait (15.3s locally vs 42.7s on CI, same assertion). A 30-second poll ceiling is on the edge of that even with no bug in the polled condition. `RESYNC_RETRY_TIMEOUT_MS` in `BaseRaftHATest` backs both `withResyncRetry()` and `awaitValue()`/`awaitCountOn()`; all three return as soon as the condition is met, so raising it from 30s to 60s only changes the worst-case (genuinely slow or actually stuck) path, never the common fast path. Re-verified all six ha-raft ITs that share this constant after the change (see Verification).

### A fourth round: the 60s bump still wasn't enough, and here is why I stopped at 120s instead of continuing to guess

The very next CI run of this PR ([31587763511](https://github.com/ArcadeData/arcadedb/actions/runs/31587763511)) failed `Issue5410AbandonedTicketReleaseIT` again, with the same failure shape: `[Node 1 must hold both vertices] expected: 2L but was: 1L`, 72.74s elapsed - the full 60s per-node budget exhausted again. Both CI failures (30s and 60s budgets) consumed essentially the *entire* allotted budget with zero early success, which is itself a clue: a transient stall of roughly fixed length would be expected to succeed shortly after a larger budget, not consume it exactly again.

I dug further rather than just bumping the number a third time blind:

- The failure is real, not a log-buffering artifact: the test's own embedded application timestamps (not the CI log collector's receipt timestamps, which lagged by as much as 57s for one batch of lines) confirm the divergence persisted for the whole poll window, as read by the test's own `System.currentTimeMillis()` polling loop.
- In **both** CI failures, the immediately preceding IT class in the shared JVM fork (failsafe `reuseForks=true`, `forkCount=1` for the entire `ha-raft` module - every IT in the job runs in one long-lived JVM) was `RaftMigrationCompactionRaceIT`: 12 writer threads, ~72,000 records across 14 indexed types, 24 compaction rounds. That is a heavy, allocation- and compaction-intensive test running immediately before a test that depends on timely convergence.
- I could not reproduce the stall locally, including under `-XX:ActiveProcessorCount=4` (matching CI's reported `CPUs=4`) and `-Xmx3900m` (matching CI's reported `MAXRAM=3.90GB`), both alone and combined with artificial background CPU load, and both running `Issue5410AbandonedTicketReleaseIT` in isolation and immediately after `RaftMigrationCompactionRaceIT`. Maven/failsafe do not honor `-Dit.test` list order for execution order, so I could not force the exact class adjacency CI hits; every local attempt passed.
- This repository's own `engine-concurrency` skill documents `ArcadeStateMachine.notifyInstallSnapshotFromLeader` as an explicitly-tracked, **not-yet-migrated** user of the JDK common `ForkJoinPool`, which the skill also states is shared with "JDK internals (parallel GC, reference handler)" - and warns that "long-running engine work... starves user code and JDK housekeeping." That is close enough in shape to what's observed here (a GC/allocation-heavy predecessor test, then a stalled state-machine-adjacent apply on the very next test) to be the leading candidate, but I do not have a CI thread or heap dump to confirm it, and migrating that call site is a production-code change to shared concurrency infrastructure I'm not making unverified under CI-round-trip time pressure.

Given the ceiling being hit twice in a row at almost exactly the allotted budget rather than a fixed transient length, I stopped titrating the timeout with further CI round-trips. `RESYNC_RETRY_TIMEOUT_MS` is now 120s - double the last attempt, well within the job's ~60-minute overall budget, and still only costs time on the stalled path - but I want to be upfront that **this is a mitigation, not a confirmed fix**: if the underlying resource contention scales with whatever budget is available (rather than being a fixed-length stall), 120s could still not be enough, and the real fix is either isolating heavy ITs (like `RaftMigrationCompactionRaceIT`) into their own JVM fork, or migrating the common-pool caller identified above. Both are left as explicit follow-ups rather than attempted here.

## Motivation

`ha-integration-tests` fails intermittently on `main` and on PR branches, a different test each time, which hides genuine replication regressions behind background noise (#5668). These are two of the concrete failure points named in that issue.

## Related issues

Fixes part of #5668.

## Verification

- `mvn -pl ha-raft verify -DskipITs=false -Dit.test=RaftReplicationMaterializedViewIT,Issue5410AbandonedTicketReleaseIT` - PASS (2/2, multiple consecutive runs, including a clean `mvn clean` build)
- `Issue5410AbandonedTicketReleaseIT` alone, run 3x independently after the `id` fix (before the timeout bump) - PASS every time locally (previously failed 3/3 before that fix)
- After each `RESYNC_RETRY_TIMEOUT_MS` bump (60s, then 120s): re-ran all six ha-raft ITs that share the constant together - `RaftReplicationMaterializedViewIT`, `Issue5410AbandonedTicketReleaseIT`, `Issue5492TruncateBatchNotReplicatedIT`, `Issue5655CypherCommitsOnInnerDatabaseIT`, `Issue5492SchemaWalNotShippedIT`, `RaftReadConsistencyBookmarkIT` - `Tests run: 11, Failures: 0, Errors: 0, Skipped: 0` both times
- Attempted local reproduction of the CI-specific stall under `-XX:ActiveProcessorCount=4` and `-Xmx3900m` (matching CI's reported specs), alone, combined, and with artificial background CPU load: did not reproduce (0 failures across several runs)
- Full `ha-raft` module (`mvn -pl ha-raft verify -DskipITs=false`, unit + all 114 IT classes), run before the timeout bump: unit tests 781/781 passed; integration tests 210 run, 209 passed, 1 failure, 4 skipped, 0 errors. The one failure, `RaftPriorityRejoinIT.leaderRestartThenReplicaRestartConverges` (`expected: 1700L but was: 1720L`), is in a file this PR does not touch and is unrelated to either fix here - noted for visibility, not addressed by this PR.
- This PR's own CI runs showed several other IT/test failures across two consecutive `ha-integration-tests` jobs, plus one each in `integration-tests` and `unit-tests` on the second round. See "Out of scope" below for all of them.

## Out of scope

Data points surfaced while investigating #5668 and while watching this PR's own CI, none sharing this issue's failure shape closely enough to fold into this PR without their own investigation. All are in files this PR does not touch:

- `Issue5569SlotMergeDeleteRaftIT` - already known to fail on `main` independent of runner load (a real defect, not a timing race); PR #5630 left it untouched for the same reason; reproduced again on this PR's CI.
- `RemoteStickyConnectionStrategyIT.pinIsReleasedAfterRollbackAndAllowsSubsequentStickyTransaction` - reported in #5668's first comment. Its read runs over `RemoteDatabase`/HTTP after the STICKY pin has already been released and re-pinned, a distinct HTTP-routing-shaped race, not a local cross-node assertion; reproduced again on this PR's CI.
- `RaftReplicationChangeSchemaIT.schemaChangesReplicate` - `DatabaseIsClosedException` at `RaftReplicatedDatabase.getSchema`, the exact same #5977 stale-cached-handle shape fixed above for `RaftReplicationMaterializedViewIT`. Not fixed in this PR: unlike that test, `RaftReplicationChangeSchemaIT` reads and mutates through its cached `databases[]` array at 30+ call sites across schema/property/bucket/index changes and two helper methods, so converting it to `withResyncRetry()` is a materially larger, riskier rewrite than the two single-purpose tests this PR touches. `withResyncRetry()`'s own javadoc already names three prior HA ITs that hit this shape once each before this PR added a fourth (`RaftReplicationMaterializedViewIT`); `RaftReplicationChangeSchemaIT` is a fifth. Worth a dedicated follow-up that audits every HA IT still caching a `databases[]`/`Database` handle across a resync-able window, rather than converting them one CI failure at a time.
- `RaftPriorityRejoinIT.leaderRestartThenReplicaRestartConverges` - failed once during this PR's full-module local verification run. Not part of #5668's original reports and not investigated here.
- `com.arcadedb.server.Issue5470BatchStreamStallIT` (`integration-tests` job) and `com.arcadedb.database.Issue5279ConcurrentUpdateTest` (`unit-tests` job, `ConcurrentModificationException` under artificial contention) - both in the `server` and `engine` modules respectively, neither touched by this PR in any way. Confirmed unrelated CI noise, not investigated further here.

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped: `mvn -pl ha-raft -am install -DskipTests -DskipITs`, then targeted verify runs)
- [x] My unit tests cover both failure and success scenarios
