### PR TITLE
fix: derive component file names deterministically on rename

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
@@ -84,22 +84,16 @@ public abstract class PaginatedComponent extends Component {
     reservedPageCounter.set(pageCount.get());
   }
 
-  public void rename(final String newName) throws IOException {
+  public void rename(final String newComponentName) throws IOException {
     // #4928: the bounded wait can give up on a wedged flush. Renaming with pages still in flight would let
     // the flush thread write to the file under its old identity: abort loudly instead, the rename can be
     // retried once the flush recovers.
     if (!PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(database))
       throw new IOException("Cannot rename component '" + componentName
           + "': pages are still pending flush after the no-progress timeout (see arcadedb.flushAllPagesTimeout)");
-    file.rename(newName);
-
-    // Derive the new component name from the renamed OS file name.
-    // PaginatedComponentFile.rename() preserves the bucket suffix in the filename
-    // (e.g., "ASKED_0.3.65536.v1.bucket"), so extract everything before the first "."
-    // to get the correct component name including the bucket index.
-    final String newOsFileName = file.getOSFile().getName();
-    final int dotPos = newOsFileName.indexOf('.');
-    final String newComponentName = dotPos >= 0 ? newOsFileName.substring(0, dotPos) : newName;
+    // The argument is the new component name, not a type name and not a file name: the file layer recomposes the
+    // '.fileId.pageSize.vVersion.ext' tail itself, so nothing here has to locate where the name ends.
+    file.renameComponent(newComponentName);
 
     database.getFileManager().renameFile(componentName, newComponentName);
     componentName = newComponentName;

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -154,6 +154,14 @@ public class PaginatedComponentFile extends ComponentFile {
     }
   }
 
+  /**
+   * Renames the underlying OS file. {@code newFileName} is the complete file name, tail included; a name without a
+   * path separator is resolved against the current parent directory.
+   * <p>
+   * To change only the component name and keep the {@code .fileId.pageSize.vVersion.ext} tail, call
+   * {@link #renameComponent(String)}: this method cannot infer where the component name ends, and every heuristic
+   * for doing so is wrong for a name that itself contains the delimiter being searched for.
+   */
   public void rename(final String newFileName) throws IOException {
     channelLock.writeLock().lock();
     try {
@@ -161,20 +169,10 @@ public class PaginatedComponentFile extends ComponentFile {
       LogManager.instance().log(this, Level.FINE, "Renaming file %s (id=%d) to %s...", null, filePath, fileId, newFileName);
 
       final File newFile;
-      if (newFileName.contains(File.separator) || (File.separatorChar != '/' && newFileName.contains("/"))) {
-        // newFileName is an absolute path (e.g., from removeTempSuffix)
+      if (newFileName.indexOf(File.separatorChar) > -1 || newFileName.indexOf('/') > -1)
         newFile = new File(newFileName);
-      } else if (newFileName.contains(".") && newFileName.contains("_")) {
-        // newFileName is already a complete filename, but not an absolute path
+      else
         newFile = new File(osFile.getParentFile(), newFileName);
-      } else {
-        // newFileName is a component name, append the suffix from original file
-        final int suffixStart = osFile.getName().indexOf("_");
-        if (suffixStart < 0)
-          throw new IOException("Original file name '" + osFile.getName() + "' does not contain '_' to extract suffix");
-        final String newFilePath = newFileName + osFile.getName().substring(suffixStart);
-        newFile = new File(osFile.getParentFile(), newFilePath);
-      }
       try {
         Files.move(osFile.getAbsoluteFile().toPath(), newFile.getAbsoluteFile().toPath(), StandardCopyOption.ATOMIC_MOVE);
         open(newFile.getAbsolutePath(), mode);
@@ -185,6 +183,20 @@ public class PaginatedComponentFile extends ComponentFile {
     } finally {
       channelLock.writeLock().unlock();
     }
+  }
+
+  /**
+   * Renames only the component name, recomposing the file name from the fields the open-time parser already
+   * resolved. Nothing is inferred from either the current or the new name, so a component name containing '.' or
+   * '_' round-trips like any other.
+   */
+  public void renameComponent(final String newComponentName) throws IOException {
+    if (newComponentName == null || newComponentName.isEmpty())
+      throw new IOException("Invalid component name '" + newComponentName + "'");
+    if (newComponentName.indexOf(File.separatorChar) > -1 || newComponentName.indexOf('/') > -1)
+      throw new IOException("Component name '" + newComponentName + "' cannot contain a path separator");
+
+    rename(newComponentName + "." + fileId + "." + pageSize + ".v" + version + "." + fileExtension);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -29,6 +29,7 @@ import com.arcadedb.engine.ComponentFactory;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.index.EmptyIndexCursor;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexCursorEntry;
@@ -618,7 +619,10 @@ public class HashIndex implements IndexInternal {
         if (newComponentName != null)
           bucket.rename(newComponentName);
       } catch (final IOException e) {
-        throw new IndexException("Error on renaming index file for hash index '" + name + "'", e);
+        // SchemaException, matching LSMTreeIndex.updateTypeName(): this runs inside LocalDocumentType.rename(),
+        // whose rollback catches IOException and SchemaException. An IndexException (a sibling, not a subclass)
+        // would escape that rollback and leave the renamed files behind an unsaved schema.
+        throw new SchemaException("Error on renaming index file for hash index '" + name + "'", e);
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -41,6 +41,7 @@ import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.IndexMetadata;
+import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryComparator;
@@ -606,10 +607,13 @@ public class HashIndex implements IndexInternal {
 
   @Override
   public void updateTypeName(final String newTypeName) {
+    final String oldTypeName = metadata.typeName;
     metadata.typeName = newTypeName;
     if (bucket != null) {
       try {
-        bucket.getComponentFile().rename(newTypeName);
+        // Rename through the component so the component name and the FileManager map follow the file.
+        bucket.rename(LocalSchema.rebaseComponentName(bucket.getName(), oldTypeName, newTypeName,
+            getDatabase().getSchema().getEncoding()));
       } catch (final IOException e) {
         throw new IndexException("Error on renaming index file for hash index '" + name + "'", e);
       }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -611,9 +611,12 @@ public class HashIndex implements IndexInternal {
     metadata.typeName = newTypeName;
     if (bucket != null) {
       try {
-        // Rename through the component so the component name and the FileManager map follow the file.
-        bucket.rename(LocalSchema.rebaseComponentName(bucket.getName(), oldTypeName, newTypeName,
-            getDatabase().getSchema().getEncoding()));
+        // Rename through the component so the component name and the FileManager map follow the file. A null result
+        // means the index sits on a bucket attached with addBucket(), whose name does not follow the type name.
+        final String newComponentName = LocalSchema.rebaseComponentName(bucket.getName(), oldTypeName, newTypeName,
+            getDatabase().getSchema().getEncoding());
+        if (newComponentName != null)
+          bucket.rename(newComponentName);
       } catch (final IOException e) {
         throw new IndexException("Error on renaming index file for hash index '" + name + "'", e);
       }

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -609,7 +609,6 @@ public class HashIndex implements IndexInternal {
   @Override
   public void updateTypeName(final String newTypeName) {
     final String oldTypeName = metadata.typeName;
-    metadata.typeName = newTypeName;
     if (bucket != null) {
       try {
         // Rename through the component so the component name and the FileManager map follow the file. A null result
@@ -625,6 +624,9 @@ public class HashIndex implements IndexInternal {
         throw new SchemaException("Error on renaming index file for hash index '" + name + "'", e);
       }
     }
+    // Only once the file actually moved: on failure the caller reverts the type to its old name, and metadata
+    // already pointing at the new one would leave the index disagreeing with both the type and the file.
+    metadata.typeName = newTypeName;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -246,10 +246,13 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
 
   @Override
   public void updateTypeName(final String newTypeName) {
+    final String oldTypeName = metadata.typeName;
     metadata.typeName = newTypeName;
     if (mutable != null) {
       try {
-        mutable.getComponentFile().rename(newTypeName);
+        // Rename through the component so the component name and the FileManager map follow the file.
+        mutable.rename(LocalSchema.rebaseComponentName(mutable.getName(), oldTypeName, newTypeName,
+            getDatabase().getSchema().getEncoding()));
       } catch (IOException e) {
         throw new SchemaException("Error on renaming index file for index '" + name + "'", e);
       }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -250,9 +250,12 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
     metadata.typeName = newTypeName;
     if (mutable != null) {
       try {
-        // Rename through the component so the component name and the FileManager map follow the file.
-        mutable.rename(LocalSchema.rebaseComponentName(mutable.getName(), oldTypeName, newTypeName,
-            getDatabase().getSchema().getEncoding()));
+        // Rename through the component so the component name and the FileManager map follow the file. A null result
+        // means the index sits on a bucket attached with addBucket(), whose name does not follow the type name.
+        final String newComponentName = LocalSchema.rebaseComponentName(mutable.getName(), oldTypeName, newTypeName,
+            getDatabase().getSchema().getEncoding());
+        if (newComponentName != null)
+          mutable.rename(newComponentName);
       } catch (IOException e) {
         throw new SchemaException("Error on renaming index file for index '" + name + "'", e);
       }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -247,7 +247,6 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
   @Override
   public void updateTypeName(final String newTypeName) {
     final String oldTypeName = metadata.typeName;
-    metadata.typeName = newTypeName;
     if (mutable != null) {
       try {
         // Rename through the component so the component name and the FileManager map follow the file. A null result
@@ -260,6 +259,9 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
         throw new SchemaException("Error on renaming index file for index '" + name + "'", e);
       }
     }
+    // Only once the file actually moved: on failure the caller reverts the type to its old name, and metadata
+    // already pointing at the new one would leave the index disagreeing with both the type and the file.
+    metadata.typeName = newTypeName;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -205,7 +205,7 @@ public class LocalDocumentType implements DocumentType {
       for (Bucket bucket : buckets) {
         final String oldBucketName = bucket.getName();
 
-        ((LocalBucket) bucket).rename(newName);
+        ((LocalBucket) bucket).rename(LocalSchema.rebaseComponentName(oldBucketName, oldName, newName, schema.getEncoding()));
 
         removedBuckets.add(bucket);
 
@@ -232,8 +232,8 @@ public class LocalDocumentType implements DocumentType {
       for (Bucket bucket : removedBuckets) {
         try {
           final String newBucketName = bucket.getName();
-          final String oldBucketName = oldName + newBucketName.substring(newBucketName.lastIndexOf("_"));
-          ((LocalBucket) bucket).rename(oldBucketName);
+          ((LocalBucket) bucket).rename(
+              LocalSchema.rebaseComponentName(newBucketName, newName, oldName, schema.getEncoding()));
         } catch (IOException ex) {
           corrupted = true;
         }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -205,7 +205,12 @@ public class LocalDocumentType implements DocumentType {
       for (Bucket bucket : buckets) {
         final String oldBucketName = bucket.getName();
 
-        ((LocalBucket) bucket).rename(LocalSchema.rebaseComponentName(oldBucketName, oldName, newName, schema.getEncoding()));
+        final String newBucketName = LocalSchema.rebaseComponentName(oldBucketName, oldName, newName, schema.getEncoding());
+        if (newBucketName == null)
+          // Bucket attached with addBucket() under a name of its own: it does not follow the type name.
+          continue;
+
+        ((LocalBucket) bucket).rename(newBucketName);
 
         removedBuckets.add(bucket);
 
@@ -223,7 +228,9 @@ public class LocalDocumentType implements DocumentType {
 
       schema.saveConfiguration();
 
-    } catch (IOException e) {
+      // SchemaException too: it is a RuntimeException, and letting it past this catch would leave the buckets
+      // already renamed on disk with a schema.json that still names the old files.
+    } catch (IOException | SchemaException e) {
       name = oldName;
       schema.types.put(oldName, this);
       schema.types.remove(newName);
@@ -232,8 +239,12 @@ public class LocalDocumentType implements DocumentType {
       for (Bucket bucket : removedBuckets) {
         try {
           final String newBucketName = bucket.getName();
-          ((LocalBucket) bucket).rename(
-              LocalSchema.rebaseComponentName(newBucketName, newName, oldName, schema.getEncoding()));
+          final String restoredName = LocalSchema.rebaseComponentName(newBucketName, newName, oldName,
+              schema.getEncoding());
+          if (restoredName == null)
+            corrupted = true;
+          else
+            ((LocalBucket) bucket).rename(restoredName);
         } catch (IOException ex) {
           corrupted = true;
         }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -200,6 +200,7 @@ public class LocalDocumentType implements DocumentType {
     final String oldName = name;
 
     final List<Bucket> removedBuckets = new ArrayList<>();
+    final List<TypeIndex> renamedIndexes = new ArrayList<>();
 
     try {
       for (Bucket bucket : buckets) {
@@ -223,8 +224,12 @@ public class LocalDocumentType implements DocumentType {
       schema.types.remove(oldName);
       schema.types.put(newName, this);
 
-      for (TypeIndex idx : getAllIndexes(false))
+      // Registered before the call, not after: updateTypeName() walks the index's own per-bucket sub-indexes, so a
+      // failure part way through leaves that index half renamed and it has to be rolled back too.
+      for (TypeIndex idx : getAllIndexes(false)) {
+        renamedIndexes.add(idx);
         idx.updateTypeName(newName);
+      }
 
       schema.saveConfiguration();
 
@@ -236,6 +241,17 @@ public class LocalDocumentType implements DocumentType {
       schema.types.remove(newName);
 
       boolean corrupted = false;
+
+      // Unwound in reverse: indexes were renamed last, so they are restored first. 'name' is already back to the
+      // old value above, which is what TypeIndex.updateTypeName() recomputes its logic name from.
+      for (TypeIndex idx : renamedIndexes) {
+        try {
+          idx.updateTypeName(oldName);
+        } catch (Exception ex) {
+          corrupted = true;
+        }
+      }
+
       for (Bucket bucket : removedBuckets) {
         try {
           final String newBucketName = bucket.getName();

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -598,7 +598,14 @@ public class LocalSchema implements Schema {
   public static String rebaseComponentName(final String componentName, final String oldTypeName, final String newTypeName,
       final String encoding) {
     final String oldPrefix = FileUtils.encode(oldTypeName, encoding);
-    if (!componentName.startsWith(oldPrefix))
+
+    // Every derived name is '<encodedTypeName>_<something>': '_<index>' for a bucket, plus '_out_edges'/'_in_edges'
+    // or '_<timestamp>' for what hangs off it. Requiring the '_' is what separates a derived name from an attached
+    // bucket that merely happens to start with the type name, e.g. "OrderArchive" on type "Order": a bare prefix
+    // match would rebase that one too, which is the same infer-the-boundary-from-content mistake this method exists
+    // to remove.
+    if (componentName.length() <= oldPrefix.length() || !componentName.startsWith(oldPrefix)
+        || componentName.charAt(oldPrefix.length()) != '_')
       return null;
 
     return FileUtils.encode(newTypeName, encoding) + componentName.substring(oldPrefix.length());

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -586,13 +586,20 @@ public class LocalSchema implements Schema {
    * verbatim. The suffix carries the bucket index, the {@code _out_edges}/{@code _in_edges} marker and the index
    * timestamp, so it must not be re-derived by searching for a delimiter: both '_' and '.' are legal inside a type
    * name and any such search picks the wrong one.
+   * <p>
+   * Returns {@code null} when the component name is not derived from the old type name, which is the case for a
+   * bucket created on its own and attached with {@link DocumentType#addBucket} (and for anything named after such a
+   * bucket). A name that was never built from the type name must not follow it when the type is renamed, so the
+   * caller leaves that component untouched.
+   * <p>
+   * The result needs no further validation: it is {@link FileUtils#encode}d, and the suffix it carries came from a
+   * name that was validated by {@link #checkValidBucketName} when its bucket was created.
    */
   public static String rebaseComponentName(final String componentName, final String oldTypeName, final String newTypeName,
       final String encoding) {
     final String oldPrefix = FileUtils.encode(oldTypeName, encoding);
     if (!componentName.startsWith(oldPrefix))
-      throw new SchemaException(
-          "Cannot rename component '" + componentName + "': it does not start with the expected prefix '" + oldPrefix + "'");
+      return null;
 
     return FileUtils.encode(newTypeName, encoding) + componentName.substring(oldPrefix.length());
   }

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -519,6 +519,8 @@ public class LocalSchema implements Schema {
   public LocalBucket createBucket(final String bucketName, final int pageSize, final String parentDirectory, final int version) {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
 
+    checkValidBucketName(bucketName);
+
     if (bucketMap.containsKey(bucketName))
       throw new SchemaException("Cannot create bucket '" + bucketName + "' because already exists");
 
@@ -555,6 +557,44 @@ public class LocalSchema implements Schema {
         throw new SchemaException("Cannot create bucket '" + bucketName + "' (error=" + e + ")", e);
       }
     });
+  }
+
+  /**
+   * A bucket name becomes the last path segment of its component file, so it must address a file inside the
+   * database directory and nothing else. A type name reaches the same place already percent-encoded by
+   * {@link FileUtils#encode} (which escapes both separators), so a bucket created directly is the only unencoded
+   * route in.
+   * <p>
+   * Dots inside the name are deliberately allowed: the component-file name is parsed right-to-left, peeling the
+   * fixed {@code .fileId.pageSize.vVersion.ext} tail, so a dot in the name survives the round trip. Only a name
+   * that is exactly "." or ".." references a directory.
+   */
+  public static void checkValidBucketName(final String bucketName) {
+    if (bucketName == null || bucketName.isEmpty())
+      throw new SchemaException("Invalid bucket name '" + bucketName + "'");
+
+    if (bucketName.indexOf('/') > -1 || bucketName.indexOf('\\') > -1 || ".".equals(bucketName) || "..".equals(bucketName))
+      throw new SchemaException("Invalid bucket name '" + bucketName + "': it cannot reference a path");
+
+    // '*' is left untouched by URLEncoder and is not a legal file name character on Windows.
+    if (bucketName.indexOf('*') > -1)
+      throw new SchemaException("Invalid bucket name '" + bucketName + "': it cannot contain '*'");
+  }
+
+  /**
+   * Re-bases a component name built as {@code <encodedTypeName><suffix>} onto a new type name, keeping the suffix
+   * verbatim. The suffix carries the bucket index, the {@code _out_edges}/{@code _in_edges} marker and the index
+   * timestamp, so it must not be re-derived by searching for a delimiter: both '_' and '.' are legal inside a type
+   * name and any such search picks the wrong one.
+   */
+  public static String rebaseComponentName(final String componentName, final String oldTypeName, final String newTypeName,
+      final String encoding) {
+    final String oldPrefix = FileUtils.encode(oldTypeName, encoding);
+    if (!componentName.startsWith(oldPrefix))
+      throw new SchemaException(
+          "Cannot rename component '" + componentName + "': it does not start with the expected prefix '" + oldPrefix + "'");
+
+    return FileUtils.encode(newTypeName, encoding) + componentName.substring(oldPrefix.length());
   }
 
   public String getEncoding() {

--- a/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
@@ -59,6 +59,9 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
 
         // The bucket index and the edge marker both live in the suffix, which is carried over untouched.
         final String newBucketName = LocalSchema.rebaseComponentName(oldBucketName, oldName, newName, schema.getEncoding());
+        if (newBucketName == null)
+          // Edge bucket of a bucket attached with addBucket(): named after that bucket, not after the type.
+          continue;
 
         ((LocalBucket) bucket).rename(newBucketName);
 
@@ -68,15 +71,21 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
         schema.bucketMap.put(bucket.getName(), (LocalBucket) bucket);
       }
 
-    } catch (IOException e) {
+      // SchemaException too: it is a RuntimeException, and letting it past this catch would leave the edge buckets
+      // already renamed on disk with a schema.json that still names the old files.
+    } catch (IOException | SchemaException e) {
       super.rename(oldName);
 
       boolean corrupted = false;
       for (Bucket bucket : removedBuckets) {
         try {
           final String newBucketName = bucket.getName();
-          ((LocalBucket) bucket).rename(
-              LocalSchema.rebaseComponentName(newBucketName, newName, oldName, schema.getEncoding()));
+          final String restoredName = LocalSchema.rebaseComponentName(newBucketName, newName, oldName,
+              schema.getEncoding());
+          if (restoredName == null)
+            corrupted = true;
+          else
+            ((LocalBucket) bucket).rename(restoredName);
         } catch (IOException ex) {
           corrupted = true;
         }

--- a/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
@@ -53,16 +53,12 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
       for (Bucket bucket : additionalBuckets) {
         final String oldBucketName = bucket.getName();
 
-        String newBucketName;
-        if (oldBucketName.endsWith(GraphEngine.OUT_EDGES_SUFFIX)) {
-          newBucketName = oldBucketName.substring(0, oldBucketName.length() - GraphEngine.OUT_EDGES_SUFFIX.length());
-        } else if (oldBucketName.endsWith(GraphEngine.IN_EDGES_SUFFIX)) {
-          newBucketName = oldBucketName.substring(0, oldBucketName.length() - GraphEngine.IN_EDGES_SUFFIX.length());
-        } else
+        if (!oldBucketName.endsWith(GraphEngine.OUT_EDGES_SUFFIX) && !oldBucketName.endsWith(GraphEngine.IN_EDGES_SUFFIX))
           throw new SchemaException(
               "Cannot rename bucket '" + oldBucketName + "' because it does not follow the naming convention");
 
-        newBucketName = newName + newBucketName.substring(newBucketName.lastIndexOf("_"));
+        // The bucket index and the edge marker both live in the suffix, which is carried over untouched.
+        final String newBucketName = LocalSchema.rebaseComponentName(oldBucketName, oldName, newName, schema.getEncoding());
 
         ((LocalBucket) bucket).rename(newBucketName);
 
@@ -79,8 +75,8 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
       for (Bucket bucket : removedBuckets) {
         try {
           final String newBucketName = bucket.getName();
-          final String oldBucketName = oldName + newBucketName.substring(newBucketName.lastIndexOf("_"));
-          ((LocalBucket) bucket).rename(oldBucketName);
+          ((LocalBucket) bucket).rename(
+              LocalSchema.rebaseComponentName(newBucketName, newName, oldName, schema.getEncoding()));
         } catch (IOException ex) {
           corrupted = true;
         }

--- a/engine/src/test/java/com/arcadedb/schema/BucketNameValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/BucketNameValidationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.SchemaException;
+import com.arcadedb.query.sql.parser.Identifier;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A bucket name is used verbatim as the last segment of the component file path, so it must not be able to
+ * address anything outside the database directory. Type names reach the same place already percent-encoded by
+ * {@link com.arcadedb.utility.FileUtils#encode}, which escapes both separators; a bucket created directly is
+ * the only unencoded route and therefore the one that needs the check.
+ */
+class BucketNameValidationTest extends TestHelper {
+
+  /** Names that address a different directory, either by separator or by being a directory sentinel. */
+  private static final List<String> ESCAPING_NAMES = List.of("../escaped", "../../escaped", "sub/nested", "sub\\nested",
+      "/absolute", "\\absolute", "..", ".");
+
+  @Test
+  void createBucketRejectsNamesThatLeaveTheDatabaseDirectory() {
+    final File databaseDirectory = new File(database.getDatabasePath());
+    final File parent = databaseDirectory.getParentFile();
+    final int filesInParentBefore = parent.listFiles().length;
+
+    for (final String name : ESCAPING_NAMES)
+      assertThatThrownBy(() -> database.getSchema().createBucket(name))
+          .as("bucket name '%s' must be rejected", name)
+          .isInstanceOf(SchemaException.class);
+
+    // Nothing may have been created next to the database directory.
+    assertThat(parent.listFiles().length).isEqualTo(filesInParentBefore);
+  }
+
+  @Test
+  void createBucketViaSqlRejectsNamesThatLeaveTheDatabaseDirectory() {
+    final File parent = new File(database.getDatabasePath()).getParentFile();
+    final int filesInParentBefore = parent.listFiles().length;
+
+    // Identifier.quote() backtick-quotes and escapes, so the name the engine receives is the one intended here.
+    // Building the statement by hand would let the lexer eat a backslash as an escape and change the name.
+    final List<String> accepted = new ArrayList<>();
+    for (final String name : ESCAPING_NAMES) {
+      try {
+        database.command("sql", "create bucket " + Identifier.quote(name));
+        accepted.add(name);
+      } catch (final Exception e) {
+        assertThat(e).as("bucket name '%s'", name).hasMessageContaining("Invalid bucket name");
+      }
+    }
+    assertThat(accepted).as("bucket names accepted through SQL that address another directory").isEmpty();
+
+    assertThat(parent.listFiles().length).isEqualTo(filesInParentBefore);
+  }
+
+  @Test
+  void createBucketRejectsNullAndEmptyNames() {
+    assertThatThrownBy(() -> database.getSchema().createBucket(null)).isInstanceOf(SchemaException.class);
+    assertThatThrownBy(() -> database.getSchema().createBucket("")).isInstanceOf(SchemaException.class);
+  }
+
+  /**
+   * Dots are legal: the component-file name is parsed right-to-left, peeling the fixed
+   * {@code .fileId.pageSize.vVersion.ext} tail, so a dot in the name survives the round trip. Only a name that
+   * is exactly "." or ".." is a directory reference. This is what allows a Neo4j label such as {@code my.label}
+   * to be imported without renaming it.
+   */
+  @Test
+  void createBucketAcceptsDotsInsideTheName() {
+    for (final String name : List.of("my.bucket", "acme.crm.Customer", "a..b", "....", "dash-label", "trailing."))
+      assertThatCode(() -> database.getSchema().createBucket(name))
+          .as("bucket name '%s' must be accepted", name)
+          .doesNotThrowAnyException();
+
+    for (final String name : List.of("my.bucket", "acme.crm.Customer", "a..b", "....", "dash-label", "trailing."))
+      assertThat(database.getSchema().existsBucket(name)).as("bucket '%s' must exist", name).isTrue();
+  }
+
+  /**
+   * A dotted type name must still be creatable, since that is the whole point of allowing dots through. The
+   * bucket it derives is {@code <encodedTypeName>_<index>}.
+   */
+  @Test
+  void createTypeWithDotsInNameDerivesADottedBucket() {
+    database.getSchema().createVertexType("acme.Customer", 1);
+
+    assertThat(database.getSchema().existsType("acme.Customer")).isTrue();
+    assertThat(database.getSchema().getType("acme.Customer").getBuckets(false).getFirst().getName())
+        .isEqualTo("acme.Customer_0");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
@@ -149,6 +149,56 @@ class TypeRenameComponentNamingTest extends TestHelper {
     });
   }
 
+  /**
+   * A bucket whose own name merely starts with the type name is not derived from it. Only
+   * {@code <encodedType>_<something>} is, so the boundary has to be the '_' and not a bare prefix match, otherwise
+   * renaming "Order" would rewrite an attached "OrderArchive" into "OrdersArchive".
+   */
+  @Test
+  void renameTypeLeavesAloneACustomBucketSharingTheTypeNamePrefix() {
+    database.transaction(() -> database.getSchema().createDocumentType("Order", 1));
+    database.transaction(() -> database.getSchema().getType("Order")
+        .addBucket(database.getSchema().createBucket("OrderArchive")));
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO BUCKET:OrderArchive SET p1 = 'a'");
+      database.command("sql", "INSERT INTO Order SET p1 = 'b'");
+    });
+
+    database.getSchema().getType("Order").rename("Orders");
+
+    final var bucketNames = database.getSchema().getType("Orders").getBuckets(false).stream().map(b -> b.getName()).toList();
+    assertThat(bucketNames).containsExactlyInAnyOrder("Orders_0", "OrderArchive");
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.getSchema().existsBucket("OrderArchive")).isTrue();
+    assertThat(database.countType("Orders", true)).isEqualTo(2L);
+  }
+
+  /** The HASH index rename path is separate from the LSM one and had no coverage. */
+  @Test
+  void renameTypeWithHashIndexKeepsIndexUsableAfterReopen() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Ha_shed", 1).createProperty("code", Type.STRING);
+      database.getSchema().buildTypeIndex("Ha_shed", new String[] { "code" })
+          .withType(Schema.INDEX_TYPE.HASH).withUnique(true).create();
+    });
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.newDocument("Ha_shed").set("code", "c" + i).save();
+    });
+
+    database.getSchema().getType("Ha_shed").rename("hash.renamed");
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.countType("hash.renamed", true)).isEqualTo(10L);
+    database.transaction(() -> assertThat(
+        database.query("sql", "select from `hash.renamed` where code = 'c7'").stream().count()).isEqualTo(1L));
+  }
+
   @Test
   void renameTypeWithIndexKeepsIndexUsableAfterReopen() {
     database.getSchema().createVertexType("In_Dexed", 1).createProperty("code", Type.STRING)

--- a/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
@@ -20,12 +20,20 @@ package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.SchemaException;
+import com.arcadedb.index.TypeIndex;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Renaming a type re-derives the file name of every component it owns. That used to be done by guessing where
@@ -217,6 +225,87 @@ class TypeRenameComponentNamingTest extends TestHelper {
     assertThat(database.countType("idx.renamed", true)).isEqualTo(10L);
     database.transaction(() -> assertThat(
         database.query("sql", "select from `idx.renamed` where code = 'c7'").stream().count()).isEqualTo(1L));
+  }
+
+  /**
+   * The bucket loop rolls back what it renamed, and so must the index loop that runs after it. With two indexes, a
+   * failure on the second used to leave the first one's file renamed on disk and its {@code metadata.typeName}
+   * already flipped, while the type itself reverted, so the schema and the files disagreed.
+   * <p>
+   * The failure is injected by parking a directory on the path the last index's file is about to move to:
+   * {@code Files.move} cannot replace a directory, so it raises the {@code IOException} the rename path wraps.
+   */
+  @Test
+  void aFailedIndexRenameRollsBackTheIndexesAlreadyRenamed() throws IOException {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("Multi", 1);
+      type.createProperty("p1", Type.STRING);
+      type.createProperty("p2", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "p1");
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "p2");
+    });
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.newDocument("Multi").set("p1", "a" + i).set("p2", "b" + i).save();
+    });
+
+    final List<TypeIndex> indexes = new ArrayList<>(database.getSchema().getType("Multi").getAllIndexes(false));
+    assertThat(indexes).as("two indexes are needed for a mid-loop failure").hasSize(2);
+
+    // Block the LAST index the rename loop will reach, so at least one earlier index is renamed before the failure.
+    final File databaseDirectory = new File(database.getDatabasePath());
+    final String blockedComponent = indexes.getLast().getIndexesOnBuckets()[0].getName();
+    final File blockedFile = fileStartingWith(databaseDirectory, blockedComponent + ".");
+    final File parked = new File(databaseDirectory,
+        blockedFile.getName().replace("Multi_0_", "renamed.Multi_0_"));
+    assertThat(parked.mkdir()).as("fault injection: park a directory on the target path").isTrue();
+
+    final Map<String, Long> filesBefore = componentFileSizes(databaseDirectory);
+
+    try {
+      assertThatThrownBy(() -> database.getSchema().getType("Multi").rename("renamed.Multi"))
+          .isInstanceOf(SchemaException.class);
+
+      // The type and every component it owns are back where they started.
+      assertThat(database.getSchema().existsType("Multi")).isTrue();
+      assertThat(database.getSchema().existsType("renamed.Multi")).isFalse();
+      assertThat(componentFileSizes(databaseDirectory))
+          .as("every component file is back under its original name").isEqualTo(filesBefore);
+    } finally {
+      parked.delete();
+    }
+
+    // And the type still works, before and after a reopen.
+    assertThat(database.countType("Multi", true)).isEqualTo(10L);
+    database.transaction(() -> {
+      assertThat(database.query("sql", "select from Multi where p1 = 'a3'").stream().count()).isEqualTo(1L);
+      assertThat(database.query("sql", "select from Multi where p2 = 'b4'").stream().count()).isEqualTo(1L);
+    });
+
+    reopen();
+
+    assertThat(database.countType("Multi", true)).isEqualTo(10L);
+    database.transaction(() -> {
+      assertThat(database.query("sql", "select from Multi where p1 = 'a3'").stream().count()).isEqualTo(1L);
+      assertThat(database.query("sql", "select from Multi where p2 = 'b4'").stream().count()).isEqualTo(1L);
+    });
+  }
+
+  private static File fileStartingWith(final File directory, final String prefix) {
+    for (final File f : directory.listFiles())
+      if (f.isFile() && f.getName().startsWith(prefix))
+        return f;
+    throw new AssertionError("No component file starting with '" + prefix + "' in " + directory);
+  }
+
+  /** Name -> size for every component file, so a rollback that left a file renamed shows up as a key difference. */
+  private static Map<String, Long> componentFileSizes(final File directory) {
+    final Map<String, Long> files = new TreeMap<>();
+    for (final File f : directory.listFiles())
+      if (f.isFile() && !f.getName().endsWith(".json") && !f.getName().endsWith(".bin") && !f.getName().endsWith(".wal")
+          && !f.getName().endsWith(".lck"))
+        files.put(f.getName(), f.length());
+    return files;
   }
 
   private void createVertexTypeWithRecords(final String typeName, final int records) {

--- a/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
@@ -111,6 +111,44 @@ class TypeRenameComponentNamingTest extends TestHelper {
         .isEqualTo(10L));
   }
 
+  /**
+   * A bucket attached with {@link DocumentType#addBucket} carries a name of its own (see
+   * {@code Issue774AddBucketWithIndexTest}, which attaches "O202203" to type "Order"). That name is not derived
+   * from the type name, so it must stay put when the type is renamed rather than be rebased onto the new name or
+   * abort the rename half-way through.
+   */
+  @Test
+  void renameTypeWithCustomNamedBucketLeavesThatBucketAlone() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("Order", 1);
+      type.createProperty("p1", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "p1");
+    });
+    database.transaction(() -> database.getSchema().getType("Order")
+        .addBucket(database.getSchema().createBucket("O202203")));
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO BUCKET:O202203 SET p1 = 'a'");
+      database.command("sql", "INSERT INTO Order SET p1 = 'b'");
+    });
+
+    database.getSchema().getType("Order").rename("Orders");
+
+    assertThat(database.getSchema().existsType("Orders")).isTrue();
+    // The default bucket followed the type, the manually attached one kept its own name.
+    final var bucketNames = database.getSchema().getType("Orders").getBuckets(false).stream().map(b -> b.getName()).toList();
+    assertThat(bucketNames).containsExactlyInAnyOrder("Orders_0", "O202203");
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.getSchema().existsType("Orders")).isTrue();
+    assertThat(database.countType("Orders", true)).isEqualTo(2L);
+    database.transaction(() -> {
+      assertThat(database.query("sql", "SELECT FROM Orders WHERE p1 = 'a'").stream().count()).isEqualTo(1L);
+      assertThat(database.query("sql", "SELECT FROM Orders WHERE p1 = 'b'").stream().count()).isEqualTo(1L);
+    });
+  }
+
   @Test
   void renameTypeWithIndexKeepsIndexUsableAfterReopen() {
     database.getSchema().createVertexType("In_Dexed", 1).createProperty("code", Type.STRING)

--- a/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Renaming a type re-derives the file name of every component it owns. That used to be done by guessing where
+ * the component name ended: the first '_' for the bucket suffix and the first '.' for the extension tail, plus a
+ * "does the new name look like a complete file name?" test of {@code contains(".") && contains("_")}. Each guess
+ * is wrong for a name that itself contains the character being searched for, so a type named {@code Und_Er} was
+ * renamed into a mangled file name and a type renamed to {@code na_me.dot} lost its
+ * {@code .fileId.pageSize.vVersion.ext} tail entirely, which makes the reopen scan skip the file as an unknown
+ * extension and silently drop the records.
+ * <p>
+ * The suffix is now taken from the component name the file parser already resolved, so these tests pin the
+ * naming for every combination of '_' and '.' on both sides of the rename.
+ */
+class TypeRenameComponentNamingTest extends TestHelper {
+
+  /** {@code <componentName>.<fileId>.<pageSize>.v<version>.<ext>} */
+  private static final Pattern COMPONENT_FILE = Pattern.compile("^.+\\.\\d+\\.\\d+\\.v\\d+\\.[A-Za-z_]+$");
+
+  @Test
+  void renameTypeWhoseNameContainsUnderscore() {
+    createVertexTypeWithRecords("Und_Er", 10);
+
+    database.getSchema().getType("Und_Er").rename("Other");
+
+    assertRenamed("Und_Er", "Other", 10);
+  }
+
+  @Test
+  void renameTypeToNameContainingDot() {
+    createVertexTypeWithRecords("Plain", 10);
+
+    database.getSchema().getType("Plain").rename("ren.amed");
+
+    assertRenamed("Plain", "ren.amed", 10);
+  }
+
+  @Test
+  void renameTypeToNameContainingBothDotAndUnderscore() {
+    createVertexTypeWithRecords("Src", 10);
+
+    database.getSchema().getType("Src").rename("na_me.dot");
+
+    assertRenamed("Src", "na_me.dot", 10);
+  }
+
+  @Test
+  void renameDottedTypeToAnotherDottedName() {
+    createVertexTypeWithRecords("acme.Customer", 10);
+
+    database.getSchema().getType("acme.Customer").rename("acme.crm.Client");
+
+    assertRenamed("acme.Customer", "acme.crm.Client", 10);
+  }
+
+  @Test
+  void renameVertexTypeWithEdgesPreservesEdgeBucketMarkers() {
+    database.getSchema().createVertexType("Us_er", 1);
+    database.getSchema().createVertexType("Question", 1);
+    database.getSchema().createEdgeType("POS_TED", 1);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        final var user = database.newVertex("Us_er").set("name", "user" + i).save();
+        final var question = database.newVertex("Question").set("title", "q" + i).save();
+        user.newEdge("POS_TED", question, true, new Object[0]);
+      }
+    });
+
+    database.getSchema().getType("Us_er").rename("re.named");
+
+    // The out/in edge buckets belong to the vertex type and must keep their marker suffix.
+    final var edgeBuckets = database.getSchema().getType("re.named").getInvolvedBuckets().stream()
+        .map(b -> b.getName()).filter(n -> n.endsWith("_out_edges") || n.endsWith("_in_edges")).toList();
+    assertThat(edgeBuckets).hasSize(2);
+    assertThat(edgeBuckets).allSatisfy(n -> assertThat(n).startsWith("re.named_0_"));
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.countType("re.named", true)).isEqualTo(10L);
+    assertThat(database.countType("POS_TED", true)).isEqualTo(10L);
+    database.transaction(() -> assertThat(database.query("sql", "select expand(out('POS_TED')) from `re.named`").stream().count())
+        .isEqualTo(10L));
+  }
+
+  @Test
+  void renameTypeWithIndexKeepsIndexUsableAfterReopen() {
+    database.getSchema().createVertexType("In_Dexed", 1).createProperty("code", Type.STRING)
+        .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.newVertex("In_Dexed").set("code", "c" + i).save();
+    });
+
+    database.getSchema().getType("In_Dexed").rename("idx.renamed");
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.countType("idx.renamed", true)).isEqualTo(10L);
+    database.transaction(() -> assertThat(
+        database.query("sql", "select from `idx.renamed` where code = 'c7'").stream().count()).isEqualTo(1L));
+  }
+
+  private void createVertexTypeWithRecords(final String typeName, final int records) {
+    database.getSchema().createVertexType(typeName, 1);
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++)
+        database.newVertex(typeName).set("k", i).save();
+    });
+  }
+
+  private void assertRenamed(final String oldName, final String newName, final int records) {
+    assertThat(database.getSchema().existsType(oldName)).isFalse();
+    assertThat(database.getSchema().existsType(newName)).isTrue();
+    assertThat(database.countType(newName, true)).as("records right after rename").isEqualTo((long) records);
+
+    // The bucket keeps its index suffix and nothing else: a leaked fragment of the old name (e.g. "Other_Er_0"
+    // after renaming "Und_Er") is exactly the mangling this pins.
+    final var buckets = database.getSchema().getType(newName).getBuckets(false);
+    for (int i = 0; i < buckets.size(); i++)
+      assertThat(buckets.get(i).getName()).isEqualTo(newName + "_" + i);
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.getSchema().existsType(newName)).as("type survives reopen").isTrue();
+    assertThat(database.countType(newName, true)).as("records survive reopen").isEqualTo((long) records);
+  }
+
+  /**
+   * Every component file must still carry its {@code .fileId.pageSize.vVersion.ext} tail. A file that lost it is
+   * not reported as an error on reopen: the directory scan just does not recognise the extension and skips it, so
+   * without this check the data loss is invisible until a count comes back short.
+   */
+  private void assertComponentFileNamesAreWellFormed() {
+    final File[] files = new File(database.getDatabasePath()).listFiles();
+    assertThat(files).isNotNull();
+    for (final File f : files) {
+      final String name = f.getName();
+      // Database-level files, not components: configuration/schema/statistics json, last-tx-id.bin, txlog wal, lock.
+      if (name.endsWith(".json") || name.endsWith(".bin") || name.endsWith(".wal") || name.endsWith(".lck"))
+        continue;
+      assertThat(COMPONENT_FILE.matcher(name).matches())
+          .as("component file '%s' lost its '.fileId.pageSize.vVersion.ext' tail", name).isTrue();
+    }
+  }
+
+  private void reopen() {
+    final String databasePath = database.getDatabasePath();
+    database.close();
+    database = new DatabaseFactory(databasePath).open();
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
@@ -113,9 +112,8 @@ public class Neo4jImporter {
       .optionalStart().appendLiteral('[').appendZoneRegionId().appendLiteral(']').optionalEnd()
       .optionalEnd()
       .toFormatter();
-  // Allow-list for imported labels: ASCII letters, digits, underscore, hyphen and space only. Excluding '.', '/' and '\'
-  // makes path-traversal sequences structurally impossible in the on-disk bucket file names derived from these labels.
-  private final static Pattern                        SAFE_LABEL               = Pattern.compile("[A-Za-z0-9_ -]+");
+  // Vertex type holding the nodes that carry no label, and the super type of every label-derived type.
+  private final static String                         ROOT_NODE_TYPE           = "Node";
 
   // Neo4j ID -> packed ArcadeDB RID mapping, populated during vertex pass.
   // Uses primitive LongLongMap for numeric IDs (common case), falls back to HashMap for non-numeric IDs.
@@ -233,7 +231,7 @@ public class Neo4jImporter {
   }
 
   private void syncSchema() throws IOException {
-    final VertexType rootNodeType = database.getSchema().buildVertexType().withName("Node")
+    final VertexType rootNodeType = database.getSchema().buildVertexType().withName(ROOT_NODE_TYPE)
         .withTotalBuckets(bucketsPerType).withIgnoreIfExists(true).create();
     rootNodeType.getOrCreateProperty("id", Type.STRING);
     rootNodeType.getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, new String[] { "id" }, indexPageSize);
@@ -241,7 +239,13 @@ public class Neo4jImporter {
     readFile(json -> {
       switch (json.getString("type")) {
       case "node":
+        // A node with no labels is kept on the root type rather than dropped: it still carries an id and properties,
+        // and the alternative is silent data loss.
         final Pair<String, List<String>> labels = typeNameFromLabels(json);
+        if (labels == null) {
+          inferPropertyType(json, ROOT_NODE_TYPE);
+          break;
+        }
 
         if (!database.getSchema().existsType(labels.getFirst())) {
           final VertexType type = database.getSchema().buildVertexType().withName(labels.getFirst())
@@ -342,12 +346,11 @@ public class Neo4jImporter {
 
           final Pair<String, List<String>> type = typeNameFromLabels(json);
           if (type == null) {
-            log("- found vertex in line %d without labels. Skip it.", lineNumber.get());
+            log("- found vertex in line %d without labels. Importing it as '%s'.", lineNumber.get(), ROOT_NODE_TYPE);
             context.warnings.incrementAndGet();
-            return null;
           }
 
-          final String typeName = type.getFirst();
+          final String typeName = type != null ? type.getFirst() : ROOT_NODE_TYPE;
           final String id = json.getString("id");
 
           try {
@@ -425,7 +428,7 @@ public class Neo4jImporter {
                 context.createdEdges.get() / elapsed * 1000);
           }
 
-          final String type = validateLabel(json.getString("label"));
+          final String type = json.has("label") && !json.isNull("label") ? validateLabel(json.getString("label")) : null;
           if (type == null) {
             log("- found edge in line %d without labels. Skip it.", lineNumber.get());
             context.warnings.incrementAndGet();
@@ -711,11 +714,39 @@ public class Neo4jImporter {
     return null;
   }
 
-  // Validates untrusted import labels against a strict allow-list before they become on-disk bucket file names. Only
-  // letters, digits, underscore, hyphen and space are accepted; path separators and '..' cannot appear by construction.
+  /**
+   * Validates an untrusted import label before it becomes a type name and, through it, an on-disk file name.
+   * <p>
+   * Neo4j allows any string in a backtick-quoted label, and almost all of them survive here: a type name is
+   * percent-encoded on its way to the bucket name, and the component-file name is parsed right-to-left off its
+   * fixed {@code .fileId.pageSize.vVersion.ext} tail, so dots, accents and colons round-trip. Only four classes of
+   * label are refused, and each of them for a reason that cannot be encoded away.
+   */
   private static String validateLabel(final String label) {
-    if (label != null && !SAFE_LABEL.matcher(label).matches())
-      throw new ImportException("Invalid label: must not contain path separators or '..'");
+    if (label == null)
+      return null;
+
+    if (label.isEmpty())
+      throw new ImportException("Invalid label: it cannot be empty");
+
+    // Would address a file outside the database directory once used as a bucket name.
+    if (label.indexOf('/') > -1 || label.indexOf('\\') > -1 || ".".equals(label) || "..".equals(label))
+      throw new ImportException("Invalid label '" + label + "': it cannot contain path separators or be '.' or '..'");
+
+    // Left untouched by percent-encoding and not a legal file name character on Windows.
+    if (label.indexOf('*') > -1)
+      throw new ImportException("Invalid label '" + label + "': it cannot contain '*'");
+
+    // The labels of a multi-label node are joined with this separator to build the composite type name, so a label
+    // containing it would be indistinguishable from a composite of two labels.
+    if (label.contains(Labels.LABEL_SEPARATOR))
+      throw new ImportException("Invalid label '" + label + "': '" + Labels.LABEL_SEPARATOR
+          + "' is reserved to join the labels of a multi-label node");
+
+    // TypeBuilder refuses a comma in a type name: an index name embeds its property list as "Type[a,b]".
+    if (label.indexOf(',') > -1)
+      throw new ImportException("Invalid label '" + label + "': it cannot contain ','");
+
     return label;
   }
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterLabelCharactersIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterLabelCharactersIT.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -64,7 +65,6 @@ class Neo4jImporterLabelCharactersIT {
       // The dotted names have to be reachable from SQL, which means backtick-quoted.
       assertThat(db.query("sql", "select expand(out(`HAS.ORDER`)) from `acme.Customer`").stream().count()).isEqualTo(1L);
     }
-    cleanUp();
   }
 
   /**
@@ -87,7 +87,6 @@ class Neo4jImporterLabelCharactersIT {
       // The three unlabelled nodes are kept on the root type instead of being dropped.
       assertThat(db.countType("Node", false)).isEqualTo(3L);
     }
-    cleanUp();
   }
 
   @Test
@@ -106,15 +105,11 @@ class Neo4jImporterLabelCharactersIT {
 
   private void assertRejected(final String label, final String expectedMessageFragment) {
     final String content = "{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"" + label + "\"],\"properties\":{\"name\":\"x\"}}\n";
-    try {
-      assertThatThrownBy(() -> new Neo4jImporter(new ByteArrayInputStream(content.getBytes()),
-          (" -d " + DATABASE_PATH + " -o").split(" ")).run())
-          .as("label '%s'", label)
-          .isInstanceOf(ImportException.class)
-          .hasMessageContaining(expectedMessageFragment);
-    } finally {
-      cleanUp();
-    }
+    assertThatThrownBy(() -> new Neo4jImporter(new ByteArrayInputStream(content.getBytes()),
+        (" -d " + DATABASE_PATH + " -o").split(" ")).run())
+        .as("label '%s'", label)
+        .isInstanceOf(ImportException.class)
+        .hasMessageContaining(expectedMessageFragment);
   }
 
   private void runImport(final String content) throws Exception {
@@ -122,7 +117,8 @@ class Neo4jImporterLabelCharactersIT {
     TestHelper.checkActiveDatabases();
   }
 
-  private void cleanUp() {
+  @AfterEach
+  void cleanUp() {
     FileUtils.deleteRecursively(new File(DATABASE_PATH));
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterLabelCharactersIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterLabelCharactersIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Neo4j accepts any string as a label once it is backtick-quoted, so a real export routinely carries labels the
+ * importer used to refuse: dots, accents, colons. The engine stores those fine (a type name is percent-encoded on
+ * its way to the file name, and the component-file name is parsed right-to-left so a dot in it survives), so the
+ * importer only has to refuse what actually cannot round-trip.
+ */
+class Neo4jImporterLabelCharactersIT {
+  private final static String DATABASE_PATH = "target/databases/neo4j-imported-labels";
+
+  @Test
+  void importLabelsWithDotsAccentsAndColons() throws Exception {
+    final StringBuilder content = new StringBuilder();
+    content.append("{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"acme.Customer\"],\"properties\":{\"name\":\"Alice\"}}\n");
+    content.append("{\"type\":\"node\",\"id\":\"1\",\"labels\":[\"acme.crm.Order\"],\"properties\":{\"code\":\"o1\"}}\n");
+    content.append("{\"type\":\"node\",\"id\":\"2\",\"labels\":[\"Ünïcøde\"],\"properties\":{\"name\":\"Zoe\"}}\n");
+    content.append("{\"type\":\"node\",\"id\":\"3\",\"labels\":[\"with space\"],\"properties\":{\"name\":\"Sam\"}}\n");
+    content.append("{\"id\":\"r0\",\"type\":\"relationship\",\"label\":\"HAS.ORDER\",\"properties\":{},");
+    content.append("\"start\":{\"id\":\"0\",\"labels\":[\"acme.Customer\"]},\"end\":{\"id\":\"1\",\"labels\":[\"acme.crm.Order\"]}}\n");
+
+    runImport(content.toString());
+
+    try (final Database db = new DatabaseFactory(DATABASE_PATH).open()) {
+      assertThat(db.getSchema().existsType("acme.Customer")).isTrue();
+      assertThat(db.getSchema().existsType("acme.crm.Order")).isTrue();
+      assertThat(db.getSchema().existsType("Ünïcøde")).isTrue();
+      assertThat(db.getSchema().existsType("with space")).isTrue();
+      assertThat(db.getSchema().existsType("HAS.ORDER")).isTrue();
+
+      assertThat(db.countType("acme.Customer", false)).isEqualTo(1L);
+      assertThat(db.countType("HAS.ORDER", false)).isEqualTo(1L);
+
+      // The dotted names have to be reachable from SQL, which means backtick-quoted.
+      assertThat(db.query("sql", "select expand(out(`HAS.ORDER`)) from `acme.Customer`").stream().count()).isEqualTo(1L);
+    }
+    cleanUp();
+  }
+
+  /**
+   * A node with no labels used to throw NullPointerException out of the schema pass, before the vertex pass could
+   * reach its "skip it" branch. Such nodes now land in the root {@code Node} type rather than being lost.
+   */
+  @Test
+  void importNodesWithoutLabels() throws Exception {
+    final StringBuilder content = new StringBuilder();
+    content.append("{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"Person\"],\"properties\":{\"name\":\"Alice\"}}\n");
+    content.append("{\"type\":\"node\",\"id\":\"1\",\"properties\":{\"name\":\"NoLabel\"}}\n");
+    content.append("{\"type\":\"node\",\"id\":\"2\",\"labels\":[],\"properties\":{\"name\":\"EmptyLabels\"}}\n");
+    content.append("{\"type\":\"node\",\"id\":\"3\",\"labels\":null,\"properties\":{\"name\":\"NullLabels\"}}\n");
+
+    runImport(content.toString());
+
+    try (final Database db = new DatabaseFactory(DATABASE_PATH).open()) {
+      assertThat(db.getSchema().existsType("Person")).isTrue();
+      assertThat(db.countType("Person", false)).isEqualTo(1L);
+      // The three unlabelled nodes are kept on the root type instead of being dropped.
+      assertThat(db.countType("Node", false)).isEqualTo(3L);
+    }
+    cleanUp();
+  }
+
+  @Test
+  void stillRejectLabelsThatCannotRoundTrip() {
+    // Path separators and the directory sentinels would address a file outside the database directory.
+    assertRejected("../../etc/evil", "path separator");
+    assertRejected("dir/sub", "path separator");
+    assertRejected("dir\\\\sub", "path separator");
+    assertRejected("..", "path separator");
+    assertRejected(".", "path separator");
+    // '*' is not a legal file name character on Windows and is left untouched by percent-encoding.
+    assertRejected("sta*r", "'*'");
+    // '~' joins the labels of a multi-label node into a composite type name, so it cannot appear inside one.
+    assertRejected("a~b", "reserved");
+  }
+
+  private void assertRejected(final String label, final String expectedMessageFragment) {
+    final String content = "{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"" + label + "\"],\"properties\":{\"name\":\"x\"}}\n";
+    try {
+      assertThatThrownBy(() -> new Neo4jImporter(new ByteArrayInputStream(content.getBytes()),
+          (" -d " + DATABASE_PATH + " -o").split(" ")).run())
+          .as("label '%s'", label)
+          .isInstanceOf(ImportException.class)
+          .hasMessageContaining(expectedMessageFragment);
+    } finally {
+      cleanUp();
+    }
+  }
+
+  private void runImport(final String content) throws Exception {
+    new Neo4jImporter(new ByteArrayInputStream(content.getBytes()), (" -d " + DATABASE_PATH + " -o").split(" ")).run();
+    TestHelper.checkActiveDatabases();
+  }
+
+  private void cleanUp() {
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+  }
+}


### PR DESCRIPTION
## Problem

Renaming a type re-derives the file name of every component it owns. That was done by guessing where the component name ended:

- `PaginatedComponentFile.rename()` branched on `newFileName.contains(".") && newFileName.contains("_")` to decide whether the argument was already a complete file name, and otherwise spliced the suffix starting at the **first** `_` of the current file name.
- `PaginatedComponent.rename()` re-derived the new component name from the **first** `.` of the renamed OS file name.
- `LocalDocumentType`, `LocalVertexType`, `LSMTreeIndex` and `HashIndex` had each grown their own incompatible variant of the same splice.

Every one of those guesses is wrong for a name that contains the character being searched for, and both `_` and `.` are legal in a type name.

Observed today on `main`:

| rename | result |
|---|---|
| `Und_Er` -> `Other` | files become `Other_Er_0.14...`, `Other_0_Er_0_in_edges.16...` |
| `Plain` -> `ren.amed` | `NumberFormatException`, stray zero-byte file, orphaned edge bucket, **records lost** |
| `Src` -> `na_me.dot` | file moved to a literal `na_me.dot`, losing its `.fileId.pageSize.vVersion.ext` tail |

The last case is silent: `FileManager.scanDirectoryForComponentFiles` computes an unrecognised extension and skips the file, so the records disappear with no error until a count comes back short.

## Change

- `PaginatedComponentFile.renameComponent(String)` recomposes the file name from the fields the open-time parser already resolved (`fileId`, `pageSize`, `version`, `fileExtension`). Nothing is inferred from either the old or the new name. `rename(String)` is reduced to plain path resolution.
- `PaginatedComponent.rename()` takes a **component name** and no longer re-parses the OS file name.
- `LocalSchema.rebaseComponentName()` is the single shared formula: `encode(newType) + componentName.substring(encode(oldType).length())`. The suffix carrying the bucket index, the `_out_edges`/`_in_edges` marker and the index timestamp is preserved verbatim. Used by the bucket, edge-bucket and index rename paths.
- `LSMTreeIndex`/`HashIndex.updateTypeName` rename through the component, so the component name and the `FileManager` map follow the file instead of going stale.
- `LocalSchema.createBucket` validates the name. A bucket name is the last segment of its component file path and, unlike a type name, is not percent-encoded on the way there.

### Neo4j importer

With the naming made consistent, the importer's allow-list (`[A-Za-z0-9_ -]+`) is no longer needed. It rejected labels a real Neo4j export routinely carries (dots, accents, colons) even though the engine stores them fine: a type name is percent-encoded on its way to the bucket name, and the component file name is parsed right-to-left off its fixed tail, so a dot in it round-trips.

It now refuses only what cannot round-trip: path separators and the `.`/`..` sentinels, `*` (untouched by percent-encoding, illegal on Windows), the `~` used to join the labels of a multi-label node, and `,` (which `TypeBuilder` rejects for type names).

Nodes with **no labels** are kept on the root `Node` type in both passes. `syncSchema()` used to throw `NullPointerException` on them, before `parseVertices()` could reach its "skip it" branch, so the previous graceful-skip behaviour was unreachable.

## Tests

Three new classes, 11 tests. 9 of the 11 were confirmed failing against the unmodified code before the fix.

- `TypeRenameComponentNamingTest` pins the naming for every combination of `_` and `.` on both sides of a rename, plus edge buckets and an index, and asserts every component file still carries its tail (the invariant that catches the silent-skip case).
- `BucketNameValidationTest` covers the rejected names through both the schema API and SQL DDL, and pins that dots stay legal.
- `Neo4jImporterLabelCharactersIT` covers dotted/accented/spaced labels, dotted relationship types, unlabelled nodes, and the labels still refused.

Verified: full engine suite 11686 tests with one pre-existing failure (`Issue5279ConcurrentUpdateTest.growingUpdatesUnderContentionKeepTheDatabaseConsistent`, which fails 3/3 on a clean `main` at c66f0c8ec and is unrelated); full Neo4j importer suite green including the two pre-existing rejection tests; full reactor build clean.

### Independent importer fix in the same change

`parseEdges()` now guards the `"label"` lookup with `has()`/`isNull()` before reading it, matching what `syncSchema()` already did. `JSONObject.getString()` throws on a missing key, so a relationship record without a label used to abort the whole import rather than being skipped with a warning, which also made the `type == null` skip branch immediately below it unreachable. This is separate from the node "no labels" NPE described above.

### Follow-up from review

A bucket created with `createBucket()` and attached with `addBucket()` carries a name of its own, not derived from the type name (`Issue774AddBucketWithIndexTest` attaches `"O202203"` to type `"Order"`). `rebaseComponentName()` required the type-name prefix and threw `SchemaException` for those, and since that is a `RuntimeException` while `rename()` only rolled back on `IOException`, the throw escaped the rollback: buckets renamed earlier in the loop kept their new file names while `saveConfiguration()` never ran.

`rebaseComponentName()` now returns `null` for a component name not derived from the type name, and the bucket, edge-bucket and index paths skip it. The rollback paths also catch `SchemaException`, and treat a name they cannot rebase back as corruption rather than passing `null` to the file layer. Covered by `TypeRenameComponentNamingTest.renameTypeWithCustomNamedBucketLeavesThatBucketAlone`, confirmed reproducing the reported failure before the fix.


### New constraint on type names

`createBucket()` validates unconditionally, including the `encode(typeName) + "_" + i` names `TypeBuilder` generates, and `URLEncoder` leaves `*` unescaped. So `createVertexType("Foo*Bar")` (and the SQL equivalents) now fails at bucket-creation time rather than producing a file name that is illegal on Windows. This is a new restriction on type names, not only bucket names. It applies to creation only, so existing databases containing such a name still open.

### Second follow-up from review

- `rebaseComponentName()` decided whether a component belonged to the type with a bare prefix match, so an attached bucket whose own name merely starts with the type name was treated as derived: renaming `Order` rewrote an attached `OrderArchive` into `OrdersArchive`. Every derived name is `<encodedTypeName>_<something>`, so the check now requires that `_`. Covered by `renameTypeLeavesAloneACustomBucketSharingTheTypeNamePrefix`, confirmed reproducing before the fix.
- `HashIndex.updateTypeName()` wrapped its `IOException` in `IndexException`, a sibling of `SchemaException` rather than a subclass, so it slipped past the widened rollback in `LocalDocumentType.rename()`. It now throws `SchemaException`, matching `LSMTreeIndex.updateTypeName()`. The HASH rename path also gained coverage (`renameTypeWithHashIndexKeepsIndexUsableAfterReopen`), which it had none of.


### Third follow-up from review: index rollback

`rename()` renames the type's indexes in a loop after the bucket loop, and the rollback restored only the buckets. With two indexes, a failure on the second left the first one's file renamed on disk and its metadata pointing at the new type name while the type itself reverted.

The indexes renamed so far are now tracked like `removedBuckets` and replayed back to the old name, with a failure to restore one marking the type corrupted, matching the bucket loop. An index is registered *before* its `updateTypeName()` call, not after: that call walks the index's own per-bucket sub-indexes, so a failure part way through leaves that index half renamed and it needs rolling back too. The unwind runs indexes first, since they were renamed last.

`aFailedIndexRenameRollsBackTheIndexesAlreadyRenamed` injects the failure by parking a directory on the path the last index's file is about to move to, so `Files.move` raises the `IOException` the rename path wraps. Confirmed failing before the fix, leaving a `renamed.Multi_0_<timestamp>` index file behind next to a correctly-reverted `Multi_0` bucket.

This also gives the rollback path its first test on this branch or on `main`.
