### PR TITLE
feat(#6075): page-level copy-on-write snapshot replaces the flush suspension (phase 2b)

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -911,4 +911,13 @@ the next open.
 Overlapping windows are supported rather than serialized: each owns its shadow, and a write captures the same
 freshly read pre-image into every window that still needs it.
 
+### One incidental change to every backup archive
+
+The two backup writers disagreed about ZIP entry timestamps: the parallel one stamped the source file's
+modification time, the single-threaded one left `ZipOutputStream` to stamp the moment the entry was written. Adding
+the stream-based entry API the snapshot path needs routed both through one implementation, so they now agree on the
+source file's modification time - which is the more useful of the two, and was already what the default
+(multi-threaded) writer produced. Nothing about restoring changes; only the timestamps a listing shows for an
+archive written with `arcadedb.backup.compressionThreads = 0`.
+
 [#6075](https://github.com/ArcadeData/arcadedb/issues/6075)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -840,3 +840,75 @@ directory written at all: a failed one aborts the writer instead, so even if the
 (permissions, a full or read-only filesystem) what is left is structurally invalid rather than plausible.
 
 [#6072](https://github.com/ArcadeData/arcadedb/issues/6072)
+
+## A backup no longer freezes the database: point-in-time page snapshots replace the flush suspension (#6075)
+
+Phase 1 (#6072) made the backup 27x faster, which shortened the window during which writers are throttled but did
+not remove the throttling. This removes it. `PageManager.suspendFlushAndExecute` - which parks the page-flush
+thread for the whole of a backup, an HA snapshot ship or an HA database verify, so dirty pages accumulate in RAM
+until `arcadedb.flushSuspendMaxDeferredRAM` (512 MB) and committing threads are then throttled outright - is
+replaced by a real snapshot primitive: `PageManager.openSnapshot()`, a **page-level copy-on-write shadow**.
+
+While a window is open, the first write to any page that existed at t0 first copies that page's current on-disk
+image into a shadow, inside the per-page I/O slot the write already holds. A reader resolves every page as "shadow
+if present, data file otherwise" and therefore sees exactly the t0 image, however far the live database has moved
+on. Flushing is never suspended, so writers run at full speed for the whole operation.
+
+Three things follow from that, beyond the writer impact:
+
+- **Index compaction runs during a backup again.** The suspension was the only thing stopping `LSMTreeIndex` and
+  `LSMVectorIndex` compaction from dropping a file under a running backup (`LSMTreeIndexCompactor` does not take the
+  database write lock, so the backup's read lock never excluded it), and both refuse to compact while it is held. A
+  long backup silently stopped compaction. Now a file dropped while a window is open simply has its physical
+  deletion deferred until the window closes, so compaction proceeds.
+- **The snapshot point is a real transaction boundary.** The window opens on a FULL drain of the flush queue, not
+  the in-flight batch alone, so the restored database contains every transaction committed before t0 - closing the
+  recency gap that could leave a restored backup a few hundred transactions behind. The HA snapshot ship now also
+  reports the t0 transaction id (#5277's `last-tx-id.bin` marker) instead of the live counter, so the marker can no
+  longer name a transaction whose pages were still in the queue.
+- **The page image and its version are provably paired**, because they are read together, under the same per-page
+  lock, from the same snapshot. That is the property incremental backup (phase 3) has to be built on: with a fuzzy
+  copy, a manifest recorded at a different instant than the image it describes makes the next incremental conclude
+  "unchanged" and silently drop a revision.
+
+### Zero cost when no snapshot is open
+
+With no window open the write path pays one volatile field read and a branch the predictor always gets right, inside
+a critical section that already performs a page-size (64 KB) `pwrite`: roughly 1 ns against 10-50 us. That is
+implementation discipline rather than design - a single nullable field, not a listener list; nothing before the null
+check; and the hook goes strictly inside the existing `concurrentPageAccess` write branch, which is the single funnel
+both physical page-write call sites already go through, so it needs no new lock and adds no lock-ordering risk.
+
+### The barrier, which is where the correctness lives
+
+Flipping the flag is not the same as opening the window: a writer can already be inside its write section having
+read "no window", and would then overwrite its page unshadowed. So every writer is excluded before t0 is stamped,
+each by the mechanism that already serializes it - a full flush-queue drain, then a suspension parking the flush
+thread on a batch (that is, transaction) boundary, then the transaction manager's apply lock to exclude Raft and
+recovery replay, then the global page-manager lock to exclude synchronous commits. Only then are the per-file page
+counts and `lastTxId` recorded. Performing these in the other order produces subtly torn snapshots that pass tests
+and fail in production, which is why the barrier is what the test suite hammers hardest.
+
+### Reading stays sequential
+
+The obvious snapshot reader takes the per-page I/O slot for every page, turning one streaming `transferTo` into a
+lock acquisition per page. It is not needed: a write during the window ALWAYS shadows the page before touching the
+file, so a run of pages is read in one bulk call with no lock at all and the shadow re-probed afterwards - any page
+a writer touched underneath the read is now in the shadow, and its t0 image is taken from there. A torn read is
+therefore always detected, and the common case costs one probe per page against a primitive open-addressing map.
+
+### Bounded, and with a fallback
+
+The shadow is RAM first (`arcadedb.pageSnapshotMaxRAM`, 64 MB) spilling to an append-only scratch file, and capped
+overall (`arcadedb.pageSnapshotMaxSize`, 1 GB). Worst case it grows to the working set dirtied during the window,
+which on a small very hot database approaches the database size, so an uncapped shadow would reproduce the "snapshot
+full" failure of sparse-file snapshots. On breach the window is invalidated and every read fails loudly: a backup
+restarts on the suspend-and-freeze path, which throttles writers but always completes. That path stays available
+and can be selected outright with `arcadedb.pageSnapshotEnabled = false`. The shadow file is pure scratch - recovery
+never reads it, its extension is not a supported component extension, and an orphan left by a crash is deleted at
+the next open.
+
+Overlapping windows are supported rather than serialized: each owns its shadow, and a write captures the same
+freshly read pre-image into every window that still needs it.
+
+[#6075](https://github.com/ArcadeData/arcadedb/issues/6075)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -451,6 +451,34 @@ public enum GlobalConfiguration {
       (unbounded, pre-4728 behavior).""",
       Long.class, 512),
 
+  PAGE_SNAPSHOT_ENABLED("arcadedb.pageSnapshotEnabled", SCOPE.DATABASE,
+      """
+      Serve point-in-time readers (full backup, HA database verify, HA snapshot ship) from the page-level \
+      copy-on-write shadow instead of freezing the data files with FLUSH_SUSPEND_MAX_DEFERRED_RAM-bounded flush \
+      suspension (issue #6075). With the shadow the only stall is one bounded flush-queue drain when the window \
+      opens; after that writers run at full speed for the whole operation and index compaction is no longer \
+      postponed. Set to false to fall back to the historical suspend-and-freeze path, which is also selected \
+      automatically when a shadow breaches PAGE_SNAPSHOT_MAX_SIZE.""",
+      Boolean.class, true),
+
+  PAGE_SNAPSHOT_MAX_RAM("arcadedb.pageSnapshotMaxRAM", SCOPE.DATABASE,
+      """
+      Maximum amount of RAM (in MB) of page pre-images a snapshot window keeps in memory before spilling the rest \
+      to a scratch file next to the database (issue #6075). The shadow only ever holds the pages DIRTIED while the \
+      window is open, once each, so a short backup on a moderately busy database often never touches the disk at \
+      all - which is the point of making it RAM first. Raise it to trade heap for keeping longer windows in memory.""",
+      Long.class, 64),
+
+  PAGE_SNAPSHOT_MAX_SIZE("arcadedb.pageSnapshotMaxSize", SCOPE.DATABASE,
+      """
+      Hard cap (in MB, RAM plus spill file) on the size a single snapshot shadow may reach before the window is \
+      declared overflowed (issue #6075, challenge C4). Worst case the shadow grows to the working set dirtied while \
+      the window is open, which on a small very hot database approaches the database size, so an uncapped shadow \
+      would reproduce the 'snapshot full' failure mode of sparse-file snapshots. On breach the window stops \
+      capturing and every reader fails loudly, so the consumer can fall back to the suspend-and-freeze path - never \
+      a silently truncated or torn snapshot. Set to 0 for no cap.""",
+      Long.class, 1024),
+
   EXPLICIT_LOCK_TIMEOUT("arcadedb.explicitLockTimeout", SCOPE.DATABASE, "Timeout in ms to lock resources on explicit lock",
       Long.class, 5000),
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -32,6 +32,7 @@ import com.arcadedb.engine.ErrorRecordCallback;
 import com.arcadedb.engine.FileManager;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.PageManager;
+import com.arcadedb.engine.PageSnapshot;
 import com.arcadedb.engine.TransactionManager;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.engine.WALFileFactory;
@@ -2493,12 +2494,31 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     transactionManager.checkIntegrity();
   }
 
+  /** Removes any {@code .pshadow} scratch file left behind by a snapshot window that a crash interrupted (#6075). */
+  private void deleteOrphanSnapshotShadows() {
+    final File[] orphans = new File(databasePath).listFiles(
+        (dir, name) -> name.endsWith("." + PageSnapshot.SHADOW_FILE_EXT));
+    if (orphans == null)
+      return;
+    for (final File orphan : orphans) {
+      LogManager.instance().log(this, Level.FINE, "Deleting orphan snapshot shadow file '%s'", null, orphan.getName());
+      if (!orphan.delete())
+        LogManager.instance().log(this, Level.WARNING, "Cannot delete the orphan snapshot shadow file '%s'", null, orphan);
+    }
+  }
+
   private void openInternal() {
     try {
       DatabaseContext.INSTANCE.init(this);
       setLockingEnabled(configuration.getValueAsBoolean(GlobalConfiguration.BACKUP_ENABLED));
 
+      // #6075 (challenge C8): the copy-on-write shadow of a snapshot window is pure scratch - recovery never reads
+      // it - so a crash mid-window leaves nothing but an orphan file to delete here. Its extension is deliberately
+      // absent from SUPPORTED_FILE_EXT, so the FileManager scan below never mistakes one for a data file.
+      deleteOrphanSnapshotShadows();
+
       fileManager = new FileManager(databasePath, mode, SUPPORTED_FILE_EXT, resolveExternalBucketPath());
+      fileManager.setDroppedFileHandler(file -> PageManager.INSTANCE.deferFileDrop(wrappedDatabaseInstance, file));
       transactionManager = new TransactionManager(wrappedDatabaseInstance);
 
       open = true;

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -250,6 +250,27 @@ public class FileManager {
     this.droppedFileHandler = handler;
   }
 
+  @FunctionalInterface
+  public interface FileSetOperation<T> {
+    T execute() throws IOException;
+  }
+
+  /**
+   * Runs {@code operation} holding the monitor {@link #dropFile} and {@link #getOrCreateFile} take, so the registered
+   * file set cannot change underneath it.
+   * <p>
+   * The snapshot t0 barrier (issue #6075) uses this to close a TOCTOU window that would otherwise defeat the whole
+   * deferred-deletion mechanism: it lists the files it is about to snapshot and only THEN publishes the window, and
+   * {@code PageManager.deferFileDrop} keeps a dropped file alive only for windows that are already published. A
+   * {@code dropFile} landing in that gap - which index compaction can do at any moment, since it takes no database
+   * lock - would delete a file the snapshot had just claimed. Holding this monitor across list-and-publish makes the
+   * two mutually exclusive. Lock ORDER matters and is the same on both paths: this monitor first, then
+   * {@code PageManager}'s snapshot registry lock.
+   */
+  public synchronized <T> T executeWithFileSetLocked(final FileSetOperation<T> operation) throws IOException {
+    return operation.execute();
+  }
+
   public void dropFile(final int fileId) throws IOException {
     final ComponentFile file;
     synchronized (this) {

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -49,6 +49,19 @@ public class FileManager {
   private volatile     List<FileChange>                          recordedChanges   = null;
   private volatile     Thread                                    recordingThread   = null;
   private final static PaginatedComponentFile                    RESERVED_SLOT     = new PaginatedComponentFile();
+  /**
+   * Decides whether the physical deletion of a dropped file has to be DEFERRED because a point-in-time snapshot
+   * window still needs to read it (issue #6075, challenge C2). Installed by {@code LocalDatabase} and delegating to
+   * {@code PageManager}; {@code null} on a file manager not attached to a database (tests, tooling), where nothing
+   * can be snapshotting anyway.
+   */
+  private volatile DroppedFileHandler droppedFileHandler = null;
+
+  @FunctionalInterface
+  public interface DroppedFileHandler {
+    /** @return true when the caller must NOT delete the file: an open snapshot window took the deletion over. */
+    boolean deferDrop(ComponentFile file);
+  }
 
   public static class FileChange {
     public final boolean create;
@@ -232,6 +245,11 @@ public class FileManager {
     fileIdMap.clear();
   }
 
+  /** Installs the snapshot-aware deletion policy for dropped files (issue #6075). */
+  public void setDroppedFileHandler(final DroppedFileHandler handler) {
+    this.droppedFileHandler = handler;
+  }
+
   public void dropFile(final int fileId) throws IOException {
     final ComponentFile file;
     synchronized (this) {
@@ -242,7 +260,14 @@ public class FileManager {
       // the delete; dropFile is a rare DDL operation, so briefly blocking concurrent registerFile is fine.
       file = fileIdMap.get(fileId);
       if (file != null) {
-        file.drop();
+        // #6075 (challenge C2): while a snapshot window is open the file is kept alive and its deletion deferred to
+        // the close of the last window that needs it, so LSM and vector index compaction can keep dropping files
+        // during a backup instead of being postponed for its whole duration. The file leaves this manager either
+        // way - the LIVE database must see it as gone immediately.
+        final DroppedFileHandler handler = droppedFileHandler;
+        if (handler == null || !handler.deferDrop(file))
+          file.drop();
+
         fileIdMap.remove(fileId);
         fileNameMap.remove(file.getComponentName());
         files.set(fileId, null);

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -389,7 +389,12 @@ public class PageManager extends LockContext {
         try {
           lock();
           try {
-            return registerSnapshot(buildSnapshot(database));
+            // LIST THE FILES AND PUBLISH THE WINDOW AS ONE ATOMIC STEP AGAINST FileManager.dropFile. Without this a
+            // file dropped in the gap - which index compaction can do at any moment, taking no database lock - would
+            // be physically deleted, because deferFileDrop only protects windows that are already published, and the
+            // snapshot would then be holding a closed channel
+            return database.getFileManager()
+                .executeWithFileSetLocked(() -> registerSnapshot(buildSnapshot(database)));
           } finally {
             unlock();
           }
@@ -481,7 +486,7 @@ public class PageManager extends LockContext {
       if (pageSize <= 0)
         continue;
       files.add(new PageSnapshot.SnapshotFile(paginated.getFileId(), paginated, pageSize, (int) paginated.getTotalPages(),
-          paginated.getFileName(), paginated.getOSFile().lastModified()));
+          paginated.getFileName()));
     }
 
     final ContextConfiguration configuration = database.getConfiguration();

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -20,12 +20,14 @@ package com.arcadedb.engine;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.BasicDatabase;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.ConfigurationException;
 import com.arcadedb.exception.DatabaseIsClosedException;
 import com.arcadedb.exception.DatabaseMetadataException;
+import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.CallableNoReturn;
 import com.arcadedb.utility.CodeUtils;
@@ -33,12 +35,16 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.LockContext;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.function.BiFunction;
 
@@ -81,6 +87,37 @@ public class PageManager extends LockContext {
   // database-publication happens-before for cross-thread visibility of the startup() writes.
   private volatile PageManagerFlushThread             flushThread;
   private volatile int                                freePageRAM;
+
+  /**
+   * #6075: the point-in-time snapshot windows currently open, {@code null} when there is none anywhere in the JVM -
+   * which is the steady state. The write path therefore pays ONE volatile field read plus a branch the predictor
+   * always gets right, inside a critical section that already performs a page-size {@code pwrite}: roughly 1 ns
+   * against 10-50 us.
+   * <p>
+   * It is deliberately ONE nullable field and NOT a listener list: a {@code List<PageWriteListener>} iterated per
+   * write costs real cycles and can go megamorphic, while a single nullable field inlines away. It is also a single
+   * read yielding both the flag and the state, so there is no double-read race between "is a window open" and
+   * "which window". Copy-on-write on registration, which only happens when a window opens or closes.
+   */
+  private volatile PageSnapshot[] activeSnapshots = null;
+  private final    Object         snapshotRegistryLock = new Object();
+  /** Serializes the t0 barrier per database (NOT the windows themselves, which may overlap freely). */
+  private final ConcurrentHashMap<Database, Object>              snapshotBarrierLocks = new ConcurrentHashMap<>();
+  /**
+   * Challenge C2: files dropped while a snapshot window is open are not deleted, so index compaction runs freely
+   * during a backup instead of being postponed. The count is how many windows still need the file; the last one to
+   * close performs the physical delete.
+   */
+  private final ConcurrentHashMap<ComponentFile, AtomicInteger> deferredFileDrops    = new ConcurrentHashMap<>();
+  private final AtomicLong                                      snapshotCounter      = new AtomicLong();
+  /**
+   * Reused per-thread scratch for the page pre-image. Sized to the largest page seen by this thread, so a capture
+   * allocates nothing after the first one; {@link PageShadow#store} copies out of it, so it can be recycled at once.
+   */
+  private static final ThreadLocal<byte[]> PRE_IMAGE_BUFFER = ThreadLocal.withInitial(() -> new byte[0]);
+
+  /** How many times the t0 barrier retries when commits slip in between the full drain and the suspension. */
+  private static final int SNAPSHOT_BARRIER_ATTEMPTS = 3;
 
   @ExcludeFromJacocoGeneratedReport
   public interface ConcurrentPageAccessCallback {
@@ -201,6 +238,16 @@ public class PageManager extends LockContext {
    * flush thread blocking on the lock this thread holds while waiting for it to exit). Verified true today.
    */
   private void shutdown() {
+    // #6075: a snapshot window outliving the page manager would keep its shadow file and any file whose deletion it
+    // deferred alive forever. Consumers always close in a finally, so this only fires on an abnormal teardown.
+    final PageSnapshot[] leftovers = activeSnapshots;
+    if (leftovers != null) {
+      LogManager.instance().log(this, Level.WARNING, "Closing %d snapshot window(s) still open at page manager shutdown",
+          null, leftovers.length);
+      for (final PageSnapshot snapshot : leftovers)
+        CodeUtils.executeIgnoringExceptions(snapshot::close, "Error on closing a leftover snapshot window", false);
+    }
+
     if (flushThread != null) {
       try {
         flushThread.closeAndJoin();
@@ -240,6 +287,9 @@ public class PageManager extends LockContext {
   public void removeModifiedPagesOfDatabase(final Database database) {
     if (flushThread != null)
       flushThread.removeAllPagesOfDatabase(database);
+    // Forget the snapshot barrier monitor too, so a closed/dropped Database instance (and everything it pins) can be
+    // garbage collected instead of being retained as a map key for the lifetime of the JVM-wide page manager.
+    snapshotBarrierLocks.remove(database);
   }
 
   public void suspendFlushAndExecute(final Database database, final CallableNoReturn callback)
@@ -260,6 +310,271 @@ public class PageManager extends LockContext {
 
   public boolean isPageFlushingSuspended(final Database database) {
     return flushThread.isSuspended(database);
+  }
+
+  // --------------------------------------------------------------------------------- POINT-IN-TIME SNAPSHOT (#6075)
+
+  /**
+   * Opens a point-in-time snapshot of every page file of a database: the primitive that replaces
+   * {@link #suspendFlushAndExecute} for readers that need the data files to stand still (full backup, HA snapshot
+   * ship, HA database verify). Unlike the suspension, which throttles writers for its whole duration and postpones
+   * index compaction with it, the only stall is the bounded barrier below; after that writers run at full speed and
+   * pay one page read plus one shadow write for the FIRST write to each page that existed at t0.
+   * <p>
+   * <b>The barrier is the correctness of the whole design, and its ORDER is what makes it correct.</b> Flipping the
+   * flag is not the same as opening the window: {@code concurrentPageAccess} grants the per-page write slot with a
+   * {@code putIfAbsent}, so at the instant of the flip a writer can already be inside its write section having read
+   * {@code activeSnapshots == null}. It would overwrite its page without shadowing it, and the snapshot would hold
+   * that page as of t0 plus epsilon, torn against everything else. So every writer is excluded BEFORE t0 is stamped,
+   * each by the mechanism that already serializes it:
+   * <ol>
+   * <li>{@link #waitAllPagesOfDatabaseAreFlushed} drains the flush queue COMPLETELY - not just the in-flight batch
+   * the way {@code waitForCurrentFlushToComplete} does - so every committed transaction is materialised. This is
+   * what makes t0 a genuine, recent transaction boundary and closes the recency gap the suspension left (a restored
+   * backup could be a few hundred transactions behind backup start).</li>
+   * <li>The flush thread is then suspended and its in-flight batch awaited, so the asynchronous path is parked on a
+   * BATCH boundary. That granularity matters: a batch is one transaction's pages, so a snapshot taken between
+   * batches can never hold half a transaction. If commits slipped in between the drain and the suspension, the
+   * suspension is released (which flushes what it deferred) and the barrier retries.</li>
+   * <li>The transaction manager's apply lock is taken exclusively, which excludes Raft and crash-recovery replay -
+   * the one writer that goes to the files outside the flush pipeline ({@code writePageWithLock}). Applies are
+   * serialised on the state machine thread, so this is a single bounded wait.</li>
+   * <li>The global page-manager lock is taken, which excludes synchronous commits: they publish their pages from
+   * {@link #publishPages}, which holds it for the whole write.</li>
+   * </ol>
+   * Only then are the per-file page counts and {@code lastTxId} recorded and the window published. Doing these in
+   * the other order produces subtly torn snapshots that pass tests and fail in production.
+   * <p>
+   * The tempting alternative - a shared read lock on the write path so the flip can take the exclusive side - is
+   * correct but adds a permanent cost to the hot path that no flag can turn off. Do not.
+   * <p>
+   * Windows may overlap freely, on the same database or on different ones: each owns its own shadow and a write
+   * captures the same freshly read pre-image into every window that still needs it (challenge C3). Only the barrier
+   * is serialized per database, and only for its own duration.
+   *
+   * @return a handle the caller MUST close, ideally in a try-with-resources: the shadow and any file whose deletion
+   *     was deferred for it are released there.
+   */
+  public PageSnapshot openSnapshot(final DatabaseInternal database) throws IOException, InterruptedException {
+    final PageManagerFlushThread thread = flushThread;
+    if (thread == null)
+      throw new PageSnapshotException(
+          "Cannot open a snapshot of database '" + database.getName() + "': the page manager is not running");
+
+    synchronized (snapshotBarrierLock(database)) {
+      boolean suspended = false;
+      try {
+        for (int attempt = 1; ; ++attempt) {
+          if (!waitAllPagesOfDatabaseAreFlushed(database))
+            LogManager.instance().log(this, Level.WARNING,
+                "Snapshot of database '%s': the flush queue did not drain within the timeout, the snapshot point may be behind the last committed transaction",
+                null, database.getName());
+
+          thread.setSuspended(database, true);
+          suspended = true;
+          thread.waitForCurrentFlushToComplete(database);
+
+          if (!thread.hasPendingPagesOfDatabase(database) || attempt >= SNAPSHOT_BARRIER_ATTEMPTS)
+            break;
+
+          // COMMITS LANDED BETWEEN THE DRAIN AND THE SUSPENSION. RELEASING THE SUSPENSION FLUSHES WHAT IT DEFERRED,
+          // SO THE RETRY STARTS FROM A CLEANER PIPELINE. AFTER THE LAST ATTEMPT WE PROCEED ANYWAY: THE RESULT IS
+          // STILL CONSISTENT, JUST AS SLIGHTLY BEHIND AS THE SUSPEND-AND-FREEZE PATH ALWAYS WAS
+          thread.setSuspended(database, false);
+          suspended = false;
+        }
+
+        final ReentrantReadWriteLock applyLock = database.getTransactionManager().getApplyLock();
+        applyLock.writeLock().lock();
+        try {
+          lock();
+          try {
+            return registerSnapshot(buildSnapshot(database));
+          } finally {
+            unlock();
+          }
+        } finally {
+          applyLock.writeLock().unlock();
+        }
+      } finally {
+        if (suspended)
+          thread.setSuspended(database, false);
+      }
+    }
+  }
+
+  /** True while at least one point-in-time snapshot window is open on the database. */
+  public boolean isSnapshotWindowOpen(final Database database) {
+    final PageSnapshot[] snapshots = activeSnapshots;
+    if (snapshots == null)
+      return false;
+    for (final PageSnapshot snapshot : snapshots)
+      if (snapshot.isFor(database))
+        return true;
+    return false;
+  }
+
+  /**
+   * Deletion of a file dropped while a snapshot window needs it is DEFERRED to the close of the last such window
+   * (challenge C2). Called by {@link FileManager#dropFile}.
+   * <p>
+   * The alternative - postponing compaction for the duration of the window, which is what the
+   * {@code isPageFlushingSuspended} guard does today - would keep one of the costs this issue set out to remove: a
+   * long backup silently stops LSM and vector index compaction. Deferring the delete instead lets compaction run
+   * freely, at the cost of the dropped file's disk space until the window closes.
+   *
+   * @return {@code true} when the physical delete has been taken over, so the caller must NOT delete the file.
+   */
+  public boolean deferFileDrop(final Database database, final ComponentFile file) {
+    if (activeSnapshots == null)
+      return false;
+
+    // UNDER THE REGISTRY LOCK: A WINDOW UNREGISTERS ITSELF (AND ONLY THEN DRAINS ITS RETAINED FILES) UNDER THE SAME
+    // LOCK, SO A FILE HANDED OVER HERE IS ALWAYS EITHER TAKEN BY A LIVE WINDOW OR NOT HANDED OVER AT ALL
+    synchronized (snapshotRegistryLock) {
+      final PageSnapshot[] snapshots = activeSnapshots;
+      if (snapshots == null)
+        return false;
+
+      int owners = 0;
+      for (final PageSnapshot snapshot : snapshots)
+        if (snapshot.isFor(database) && snapshot.getFile(file.getFileId()) != null)
+          ++owners;
+
+      if (owners == 0)
+        return false;
+
+      deferredFileDrops.put(file, new AtomicInteger(owners));
+      for (final PageSnapshot snapshot : snapshots)
+        if (snapshot.isFor(database) && snapshot.getFile(file.getFileId()) != null)
+          snapshot.retainDroppedFile(file);
+
+      LogManager.instance().log(this, Level.FINE,
+          "Deferring the deletion of file '%s' until %d snapshot window(s) of database '%s' close", null, file.getFileName(),
+          owners, database.getName());
+      return true;
+    }
+  }
+
+  /** Releases one window's claim on a deferred file deletion; the last one performs it. */
+  void releaseDeferredFileDrop(final ComponentFile file) {
+    final AtomicInteger owners = deferredFileDrops.get(file);
+    if (owners == null)
+      return;
+    if (owners.decrementAndGet() <= 0) {
+      deferredFileDrops.remove(file);
+      try {
+        file.drop();
+      } catch (final IOException e) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Error on deleting file '%s', whose deletion was deferred while a snapshot window was open", e, file.getFileName());
+      }
+    }
+  }
+
+  private PageSnapshot buildSnapshot(final DatabaseInternal database) throws IOException {
+    final List<PageSnapshot.SnapshotFile> files = new ArrayList<>();
+    for (final ComponentFile file : database.getFileManager().getFiles()) {
+      if (!(file instanceof PaginatedComponentFile paginated) || !paginated.isOpen())
+        continue;
+      final int pageSize = paginated.getPageSize();
+      if (pageSize <= 0)
+        continue;
+      files.add(new PageSnapshot.SnapshotFile(paginated.getFileId(), paginated, pageSize, (int) paginated.getTotalPages(),
+          paginated.getFileName(), paginated.getOSFile().lastModified()));
+    }
+
+    final ContextConfiguration configuration = database.getConfiguration();
+    final long maxRAM = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM) * 1024 * 1024;
+    final long maxSize = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE) * 1024 * 1024;
+    final File spillFile = new File(database.getDatabasePath(),
+        "snapshot-" + snapshotCounter.incrementAndGet() + "." + PageSnapshot.SHADOW_FILE_EXT);
+
+    return new PageSnapshot(database, this, database.getTransactionManager().getLastTransactionId(), files,
+        new PageShadow(spillFile, maxRAM, maxSize));
+  }
+
+  private PageSnapshot registerSnapshot(final PageSnapshot snapshot) {
+    synchronized (snapshotRegistryLock) {
+      final PageSnapshot[] current = activeSnapshots;
+      final PageSnapshot[] updated = current == null ? new PageSnapshot[1] : Arrays.copyOf(current, current.length + 1);
+      updated[updated.length - 1] = snapshot;
+      activeSnapshots = updated;
+    }
+    return snapshot;
+  }
+
+  void unregisterSnapshot(final PageSnapshot snapshot) {
+    synchronized (snapshotRegistryLock) {
+      final PageSnapshot[] current = activeSnapshots;
+      if (current == null)
+        return;
+      int found = -1;
+      for (int i = 0; i < current.length; i++)
+        if (current[i] == snapshot) {
+          found = i;
+          break;
+        }
+      if (found < 0)
+        return;
+      if (current.length == 1) {
+        activeSnapshots = null;
+        return;
+      }
+      final PageSnapshot[] updated = new PageSnapshot[current.length - 1];
+      System.arraycopy(current, 0, updated, 0, found);
+      System.arraycopy(current, found + 1, updated, found, current.length - found - 1);
+      activeSnapshots = updated;
+    }
+  }
+
+  private Object snapshotBarrierLock(final Database database) {
+    return snapshotBarrierLocks.computeIfAbsent(database, k -> new Object());
+  }
+
+  /**
+   * Copies the current on-disk image of a page into every open window that still needs it, from inside the write
+   * slot the caller already holds. The image is read ONCE and shared: a window that has not shadowed the page yet
+   * sees exactly the same content at t0, because any intervening write would have populated it.
+   * <p>
+   * A failure here never propagates to the writer - a snapshot must never be able to break the live database - it
+   * invalidates the window instead, and every later read through it fails loudly.
+   */
+  private void capturePreImages(final PageSnapshot[] snapshots, final PageId pageId) {
+    final BasicDatabase database = pageId.getDatabase();
+    final int fileId = pageId.getFileId();
+    final int pageNumber = pageId.getPageNumber();
+
+    byte[] preImage = null;
+    int pageSize = 0;
+
+    for (final PageSnapshot snapshot : snapshots) {
+      if (!snapshot.isFor(database) || !snapshot.needsPreImage(fileId, pageNumber))
+        continue;
+
+      if (preImage == null) {
+        final PageSnapshot.SnapshotFile snapshotFile = snapshot.getFile(fileId);
+        pageSize = snapshotFile.pageSize();
+        byte[] buffer = PRE_IMAGE_BUFFER.get();
+        if (buffer.length < pageSize) {
+          buffer = new byte[pageSize];
+          PRE_IMAGE_BUFFER.set(buffer);
+        }
+
+        try {
+          snapshotFile.file().readPages(pageNumber, 1, ByteBuffer.wrap(buffer, 0, pageSize));
+        } catch (final IOException e) {
+          // THE FILE, NOT ONE WINDOW, IS WHAT FAILED: EVERY WINDOW THAT STILL NEEDED THIS PAGE LOSES ITS t0 IMAGE
+          for (final PageSnapshot other : snapshots)
+            if (other.isFor(database) && other.needsPreImage(fileId, pageNumber))
+              other.invalidateOnCaptureError(fileId, pageNumber, e);
+          return;
+        }
+        preImage = buffer;
+      }
+
+      snapshot.storePreImage(fileId, pageNumber, preImage, pageSize);
+    }
   }
 
   /**
@@ -731,7 +1046,17 @@ public class PageManager extends LockContext {
     return page;
   }
 
-  private void concurrentPageAccess(final PageId pageId, final Boolean writeAccess, final ConcurrentPageAccessCallback callback)
+  /**
+   * The single funnel every physical page read and write goes through, and therefore the natural home of the
+   * copy-on-write hook of issue #6075: putting it in the write branch here covers {@link #flushPage} (the normal
+   * sync/async flush path) and {@link #writePageWithLock} (Raft and recovery replay) BY CONSTRUCTION - they are the
+   * only two physical page-write call sites in the engine - with no new lock and no new lock-ordering risk, and the
+   * pre-image capture is serialized against concurrent readers of the same page for free.
+   * <p>
+   * <b>Nothing runs before the {@code null} check</b>: no {@code PageId} allocation, no map lookup, no extra lock.
+   * With no window open the whole hook is one volatile read and a perfectly predicted branch.
+   */
+  private void concurrentPageAccess(final PageId pageId, final boolean writeAccess, final ConcurrentPageAccessCallback callback)
       throws IOException {
     // ACQUIRE A LOCK ON THE I/O OPERATION TO AVOID PARTIAL READS/WRITES
     while (true) {
@@ -745,6 +1070,11 @@ public class PageManager extends LockContext {
 
       if (pendingFlushPages.putIfAbsent(pageId, writeAccess) == null)
         try {
+          if (writeAccess) {
+            final PageSnapshot[] snapshots = activeSnapshots;
+            if (snapshots != null)
+              capturePreImages(snapshots, pageId);
+          }
           callback.access();
           return;
         } finally {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -256,8 +256,13 @@ public class PageManager extends LockContext {
    */
   private void shutdown() {
     // #6075: a snapshot window outliving the page manager would keep its shadow file and any file whose deletion it
-    // deferred alive forever. Consumers always close in a finally, so this only fires on an abnormal teardown.
-    final PageSnapshot[] leftovers = activeSnapshots;
+    // deferred alive forever. Consumers always close in a finally, so this only fires on an abnormal teardown - which
+    // is exactly the situation where a window could be mid-registration, so the read takes the registry lock rather
+    // than assuming the quiet teardown it is here to survive.
+    final PageSnapshot[] leftovers;
+    synchronized (snapshotRegistryLock) {
+      leftovers = activeSnapshots;
+    }
     if (leftovers != null) {
       LogManager.instance().log(this, Level.WARNING, "Closing %d snapshot window(s) still open at page manager shutdown",
           null, leftovers.length);
@@ -457,7 +462,14 @@ public class PageManager extends LockContext {
     }
   }
 
-  /** True while at least one point-in-time snapshot window is open on the database. */
+  /**
+   * True while at least one point-in-time snapshot window is open on the database: the public counterpart of
+   * {@link #isPageFlushingSuspended}, for embedders, diagnostics and tests that need to observe a window's lifetime.
+   * <p>
+   * Deliberately NOT consulted by the compaction guards. {@code LSMTreeIndex} and {@code LSMVectorIndex} still gate
+   * on {@code isPageFlushingSuspended}, which the snapshot path never sets - so compaction runs during a snapshot
+   * by construction rather than by a second check that could drift out of step with the first.
+   */
   public boolean isSnapshotWindowOpen(final Database database) {
     final PageSnapshot[] snapshots = activeSnapshots;
     if (snapshots == null)

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -369,10 +369,29 @@ public class PageManager extends LockContext {
    * captures the same freshly read pre-image into every window that still needs it (challenge C3). Only the barrier
    * is serialized per database, and only for its own duration.
    *
+   * <b>Every failure surfaces as {@link PageSnapshotException}</b>, including an I/O error while enumerating the
+   * files and an interrupt during the barrier. That is deliberate: a consumer's fallback to the suspend-and-freeze
+   * path is only genuinely unconditional if there is ONE exception type to catch - and these callers run inside
+   * {@code executeInReadLock}, which wraps a checked exception into something a {@code catch (PageSnapshotException)}
+   * would never match, so a leaked {@code IOException} silently disables the fallback.
+   *
    * @return a handle the caller MUST close, ideally in a try-with-resources: the shadow and any file whose deletion
    *     was deferred for it are released there.
    */
-  public PageSnapshot openSnapshot(final DatabaseInternal database) throws IOException, InterruptedException {
+  public PageSnapshot openSnapshot(final DatabaseInternal database) {
+    try {
+      return openSnapshotInternal(database);
+    } catch (final PageSnapshotException e) {
+      throw e;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new PageSnapshotException("Interrupted while opening a snapshot of database '" + database.getName() + "'", e);
+    } catch (final Exception e) {
+      throw new PageSnapshotException("Cannot open a snapshot of database '" + database.getName() + "'", e);
+    }
+  }
+
+  private PageSnapshot openSnapshotInternal(final DatabaseInternal database) throws IOException, InterruptedException {
     final PageManagerFlushThread thread = flushThread;
     if (thread == null)
       throw new PageSnapshotException(
@@ -510,13 +529,25 @@ public class PageManager extends LockContext {
   private PageSnapshot buildSnapshot(final DatabaseInternal database) throws IOException {
     final List<PageSnapshot.SnapshotFile> files = new ArrayList<>();
     for (final ComponentFile file : database.getFileManager().getFiles()) {
-      if (!(file instanceof PaginatedComponentFile paginated) || !paginated.isOpen())
+      // A null slot is a dropped file id and a not-yet-opened one is the reserved slot of a file id that has been
+      // allocated but whose file does not exist yet: neither has content at t0, so both are correctly absent. Any
+      // OTHER unusable file would silently shrink the archive while the backup still reported success, which is the
+      // worst failure mode a backup has - so it is named in the log rather than dropped quietly.
+      if (file == null)
         continue;
-      final int pageSize = paginated.getPageSize();
-      if (pageSize <= 0)
+      if (!(file instanceof PaginatedComponentFile paginated) || !paginated.isOpen() || paginated.getPageSize() <= 0) {
+        LogManager.instance().log(this, Level.FINE,
+            "Snapshot of database '%s' skips file '%s' (id=%d): it is not an open paginated file at t0", null,
+            database.getName(), file.getFileName(), file.getFileId());
         continue;
-      files.add(new PageSnapshot.SnapshotFile(paginated.getFileId(), paginated, pageSize, (int) paginated.getTotalPages(),
-          paginated.getFileName()));
+      }
+
+      // getTotalPages() is a channel.size() syscall, and unlike SnapshotFile.lastModified() it CANNOT be made lazy:
+      // the page count at t0 is what defines which pages the snapshot covers, and reading it later would let a page
+      // appended after t0 into the snapshot un-shadowed. An fstat per file is orders of magnitude cheaper than the
+      // flush-queue drain this same barrier already performed.
+      files.add(new PageSnapshot.SnapshotFile(paginated.getFileId(), paginated, paginated.getPageSize(),
+          (int) paginated.getTotalPages(), paginated.getFileName()));
     }
 
     final ContextConfiguration configuration = database.getConfiguration();

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -50,6 +50,23 @@ import java.util.function.BiFunction;
 
 /**
  * Manages pages from disk to RAM. Each page can have different size.
+ * <p>
+ * <b>LOCK ORDER</b> for everything the point-in-time snapshot machinery of issue #6075 touches. It is stated here
+ * rather than spread across the methods because no single call site shows more than two of these locks, so a change
+ * to {@link #openSnapshot}, {@link FileManager#dropFile} or {@link FileManager#getOrCreateFile} could reintroduce a
+ * cycle with no local signal that it had:
+ * <ol>
+ * <li>the per-database snapshot BARRIER monitor ({@code snapshotBarrierLocks}), taken first and only by
+ * {@link #openSnapshot};</li>
+ * <li>{@link TransactionManager#getApplyLock()};</li>
+ * <li>this manager's own {@link com.arcadedb.utility.LockContext} lock;</li>
+ * <li>the {@link FileManager} monitor (through {@link FileManager#executeWithFileSetLocked});</li>
+ * <li>{@code snapshotRegistryLock}, always last.</li>
+ * </ol>
+ * {@link #openSnapshot} walks 1 to 5 in that order; {@link FileManager#dropFile} takes 4 then 5, which agrees. No
+ * path takes the FileManager monitor and then this manager's lock, and none takes the registry lock and then
+ * anything else - {@code PageSnapshot.close()} unregisters (5) and only then drops its retained files, holding
+ * nothing.
  */
 public class PageManager extends LockContext {
   public static final PageManager INSTANCE = new PageManager();
@@ -374,12 +391,25 @@ public class PageManager extends LockContext {
           suspended = true;
           thread.waitForCurrentFlushToComplete(database);
 
-          if (!thread.hasPendingPagesOfDatabase(database) || attempt >= SNAPSHOT_BARRIER_ATTEMPTS)
+          if (!thread.hasPendingPagesOfDatabase(database))
+            // CLEAN: THE QUEUE DRAINED AND STAYED DRAINED ACROSS THE SUSPENSION, SO t0 IS A GENUINE, CURRENT
+            // TRANSACTION BOUNDARY
             break;
 
+          if (attempt >= SNAPSHOT_BARRIER_ATTEMPTS) {
+            // GAVE UP: SUSTAINED WRITE PRESSURE KEPT LANDING COMMITS BETWEEN THE DRAIN AND THE SUSPENSION. THE
+            // SNAPSHOT IS STILL CONSISTENT - IT IS TAKEN ON A BATCH BOUNDARY EITHER WAY - JUST AS SLIGHTLY BEHIND
+            // THE LAST COMMIT AS THE SUSPEND-AND-FREEZE PATH ALWAYS WAS. LOGGED BECAUSE "t0 IS A REAL TRANSACTION
+            // BOUNDARY" IS ONE OF THIS DESIGN'S CLAIMS, AND THE DEGRADED CASE MUST BE OBSERVABLE RATHER THAN ONLY
+            // INFERABLE FROM BEHAVIOUR
+            LogManager.instance().log(this, Level.WARNING,
+                "Snapshot of database '%s': the flush pipeline still had pending pages after %d barrier attempts, so the snapshot point may be slightly behind the last committed transaction. Sustained write pressure, not an error",
+                null, database.getName(), attempt);
+            break;
+          }
+
           // COMMITS LANDED BETWEEN THE DRAIN AND THE SUSPENSION. RELEASING THE SUSPENSION FLUSHES WHAT IT DEFERRED,
-          // SO THE RETRY STARTS FROM A CLEANER PIPELINE. AFTER THE LAST ATTEMPT WE PROCEED ANYWAY: THE RESULT IS
-          // STILL CONSISTENT, JUST AS SLIGHTLY BEHIND AS THE SUSPEND-AND-FREEZE PATH ALWAYS WAS
+          // SO THE RETRY STARTS FROM A CLEANER PIPELINE
           thread.setSuspended(database, false);
           suspended = false;
         }

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -368,6 +368,18 @@ public class PageManagerFlushThread extends Thread {
     }
   }
 
+  /**
+   * Whether any page of the database is still anywhere in the flush pipeline. Used by the snapshot t0 barrier
+   * (#6075) to tell "the queue drained and stayed drained" from "commits landed between the drain and the
+   * suspension", in which case the barrier retries instead of stamping a t0 that is already behind.
+   */
+  boolean hasPendingPagesOfDatabase(final Database database) {
+    for (final PageId key : pageIndex.keySet())
+      if (database.equals(key.getDatabase()))
+        return true;
+    return false;
+  }
+
   public void waitForCurrentFlushToComplete(final Database database) throws InterruptedException {
     PagesToFlush current;
     while ((current = nextPagesToFlush.get()) != null && database.equals(current.database))

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -212,11 +212,7 @@ public class PageManagerFlushThread extends Thread {
     long lastFlushed = flushedCounter.get();
     long lastProgressAt = System.currentTimeMillis();
     while (true) {
-      int pending = 0;
-      for (final PageId key : pageIndex.keySet()) {
-        if (database.equals(key.getDatabase()))
-          ++pending;
-      }
+      final int pending = countPendingPagesOfDatabase(database, false);
 
       if (pending == 0)
         return true;
@@ -374,10 +370,23 @@ public class PageManagerFlushThread extends Thread {
    * suspension", in which case the barrier retries instead of stamping a t0 that is already behind.
    */
   boolean hasPendingPagesOfDatabase(final Database database) {
+    return countPendingPagesOfDatabase(database, true) > 0;
+  }
+
+  /**
+   * Pages of the database still anywhere in the flush pipeline.
+   *
+   * @param stopAtFirst return as soon as one is found, for the callers that only need the boolean
+   */
+  private int countPendingPagesOfDatabase(final Database database, final boolean stopAtFirst) {
+    int pending = 0;
     for (final PageId key : pageIndex.keySet())
-      if (database.equals(key.getDatabase()))
-        return true;
-    return false;
+      if (database.equals(key.getDatabase())) {
+        ++pending;
+        if (stopAtFirst)
+          return pending;
+      }
+    return pending;
   }
 
   public void waitForCurrentFlushToComplete(final Database database) throws InterruptedException {

--- a/engine/src/main/java/com/arcadedb/engine/PageShadow.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageShadow.java
@@ -44,12 +44,17 @@ import java.util.logging.Level;
  * shadowed pages is 16 MB of index. Keys pack {@code fileId} and {@code pageNumber} into one {@code long} and are
  * therefore always non-negative, which frees {@code -1} as the empty slot marker.
  * <p>
- * <b>Concurrency.</b> Every public method is serialized on this instance. The capture side is called from inside
- * {@code PageManager.concurrentPageAccess}'s per-page write slot, so two threads never capture the SAME page, but
- * they do capture different pages concurrently and a snapshot reader probes the index in parallel. The monitor is
- * also what publishes a stored pre-image to that reader: {@link #store} copies the bytes and inserts the index entry
- * under it, {@link #read} looks the entry up under it, so a reader that observes the entry is guaranteed to observe
- * the complete bytes. That ordering is what lets {@link PageSnapshot} read runs of pages in bulk with no per-page
+ * <b>Concurrency.</b> The index is serialized on this instance, but the I/O is deliberately NOT: the capture side is
+ * called from inside {@code PageManager.concurrentPageAccess}'s per-page write slot, so two threads never capture the
+ * SAME page but they do capture different pages concurrently, and holding one monitor across a spill write would put
+ * every writer of the database behind one thread's disk write for the whole window. {@link #store} therefore reserves
+ * its spill offset under the monitor, writes at that absolute position outside it (positional
+ * {@link FileChannel#write} is thread safe and the offsets are disjoint by construction), and only then publishes the
+ * index entry; {@link #read} resolves the slot under the monitor and copies outside it.
+ * <p>
+ * That publication order is also what makes the reader safe: the bytes are complete before the entry exists, and
+ * {@link #read} looks the entry up under the same monitor, so a reader that observes an entry is guaranteed to
+ * observe the complete pre-image. It is what lets {@link PageSnapshot} read runs of pages in bulk with no per-page
  * lock at all, re-checking the shadow afterwards for anything a writer touched underneath it.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -102,43 +107,60 @@ final class PageShadow implements AutoCloseable {
    * @return {@code false} when the configured cap would be breached: the caller must invalidate the whole window
    *     (challenge C4 - a shadow that silently stops capturing would produce a torn snapshot).
    */
-  synchronized boolean store(final long key, final byte[] content, final int length) throws IOException {
-    if (closed)
-      return false;
-    if (lookup(key) != NOT_FOUND)
-      // ALREADY CAPTURED BY AN EARLIER WRITE TO THE SAME PAGE: THE FIRST PRE-IMAGE IS THE SNAPSHOT ONE, KEEP IT
-      return true;
+  boolean store(final long key, final byte[] content, final int length) throws IOException {
+    final FileChannel channel;
+    final long offset;
 
-    if (maxTotalBytes > 0 && ramBytes + spillBytes + length > maxTotalBytes)
-      return false;
+    synchronized (this) {
+      if (closed)
+        return false;
+      if (lookup(key) != NOT_FOUND)
+        // ALREADY CAPTURED BY AN EARLIER WRITE TO THE SAME PAGE: THE FIRST PRE-IMAGE IS THE SNAPSHOT ONE, KEEP IT
+        return true;
 
-    final long slot;
-    if (ramBytes + length <= maxRAMBytes) {
-      final byte[] copy = new byte[length];
-      System.arraycopy(content, 0, copy, 0, length);
-      if (ramCount == ramSlots.length) {
-        final byte[][] larger = new byte[ramSlots.length * 2][];
-        System.arraycopy(ramSlots, 0, larger, 0, ramCount);
-        ramSlots = larger;
+      if (maxTotalBytes > 0 && ramBytes + spillBytes + length > maxTotalBytes)
+        return false;
+
+      if (ramBytes + length <= maxRAMBytes) {
+        final byte[] copy = new byte[length];
+        System.arraycopy(content, 0, copy, 0, length);
+        if (ramCount == ramSlots.length) {
+          final byte[][] larger = new byte[ramSlots.length * 2][];
+          System.arraycopy(ramSlots, 0, larger, 0, ramCount);
+          ramSlots = larger;
+        }
+        ramSlots[ramCount] = copy;
+        insert(key, ramCount++);
+        ramBytes += length;
+        return true;
       }
-      ramSlots[ramCount] = copy;
-      slot = ramCount++;
-      ramBytes += length;
-    } else {
+
       if (spillChannel == null)
         spillChannel = FileChannel.open(spillFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.READ,
             StandardOpenOption.WRITE);
-
-      final ByteBuffer buffer = ByteBuffer.wrap(content, 0, length);
-      long pos = spillBytes;
-      while (buffer.hasRemaining())
-        pos += spillChannel.write(buffer, pos);
-
-      slot = -(spillBytes + 1);
+      channel = spillChannel;
+      // RESERVE THE RANGE, SO CONCURRENT SPILLS GET DISJOINT OFFSETS AND THE CAP ACCOUNTING STAYS EXACT EVEN WHILE
+      // THE WRITES THEMSELVES ARE IN FLIGHT
+      offset = spillBytes;
       spillBytes += length;
     }
 
-    insert(key, slot);
+    // OUTSIDE THE MONITOR: ONE THREAD'S DISK WRITE MUST NOT BLOCK EVERY OTHER WRITER OF THE DATABASE FROM SHADOWING
+    // AN UNRELATED PAGE. A FAILURE HERE LEAVES A HOLE IN THE SPILL FILE AND NO INDEX ENTRY, AND THE CALLER
+    // INVALIDATES THE WHOLE WINDOW - WHICH IS CORRECT, SINCE THAT PAGE'S PRE-IMAGE IS GONE
+    final ByteBuffer buffer = ByteBuffer.wrap(content, 0, length);
+    long pos = offset;
+    while (buffer.hasRemaining())
+      pos += channel.write(buffer, pos);
+
+    synchronized (this) {
+      // UNREACHABLE IN PRACTICE - PageSnapshot.close() DRAINS THE IN-FLIGHT CAPTURES BEFORE CLOSING THE SHADOW - AND
+      // DELIBERATELY NOT REPORTED AS A CAP BREACH: NOBODY WILL EVER READ A WINDOW THAT IS BEING CLOSED
+      if (closed)
+        return true;
+      // PUBLISHED ONLY NOW: A READER THAT SEES THE ENTRY IS GUARANTEED TO SEE THE COMPLETE BYTES
+      insert(key, -(offset + 1));
+    }
     return true;
   }
 
@@ -148,27 +170,36 @@ final class PageShadow implements AutoCloseable {
    * @return {@code false} when the page is not in the shadow, in which case the on-disk image is still the snapshot
    *     one and the caller reads it from the data file.
    */
-  synchronized boolean read(final long key, final byte[] dst, final int dstOffset, final int length) throws IOException {
-    if (closed)
-      return false;
+  boolean read(final long key, final byte[] dst, final int dstOffset, final int length) throws IOException {
+    final long slot;
+    final byte[] ramContent;
+    final FileChannel channel;
 
-    final long slot = lookup(key);
-    if (slot == NOT_FOUND)
-      return false;
+    synchronized (this) {
+      if (closed)
+        return false;
 
-    if (slot >= 0) {
-      final byte[] content = ramSlots[(int) slot];
-      if (content.length != length)
+      slot = lookup(key);
+      if (slot == NOT_FOUND)
+        return false;
+
+      // A STORED PRE-IMAGE IS IMMUTABLE, SO BOTH THE byte[] AND THE SPILL RANGE CAN BE COPIED OUTSIDE THE MONITOR
+      ramContent = slot >= 0 ? ramSlots[(int) slot] : null;
+      channel = spillChannel;
+    }
+
+    if (ramContent != null) {
+      if (ramContent.length != length)
         throw new IOException(
-            "Shadowed page size mismatch: expected " + length + " bytes, the pre-image holds " + content.length);
-      System.arraycopy(content, 0, dst, dstOffset, length);
+            "Shadowed page size mismatch: expected " + length + " bytes, the pre-image holds " + ramContent.length);
+      System.arraycopy(ramContent, 0, dst, dstOffset, length);
       return true;
     }
 
     final ByteBuffer buffer = ByteBuffer.wrap(dst, dstOffset, length);
     long pos = -(slot + 1);
     while (buffer.hasRemaining()) {
-      final int r = spillChannel.read(buffer, pos);
+      final int r = channel.read(buffer, pos);
       if (r < 0)
         throw new IOException("Unexpected EOF reading the snapshot shadow file '" + spillFile.getName() + "' at " + pos);
       pos += r;

--- a/engine/src/main/java/com/arcadedb/engine/PageShadow.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageShadow.java
@@ -19,6 +19,7 @@
 package com.arcadedb.engine;
 
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.LongLongHashMap;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +27,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.logging.Level;
 
 /**
@@ -40,9 +40,10 @@ import java.util.logging.Level;
  * <p>
  * <b>Why the index is a primitive open-addressing map</b> (challenge C6). It is probed on every page write while a
  * window is open, from the flush thread. A {@code HashMap<PageId, Long>} would box the value and allocate an entry
- * per shadowed page on the flush hot path; this costs 16 bytes per entry with no allocation at all, so a million
- * shadowed pages is 16 MB of index. Keys pack {@code fileId} and {@code pageNumber} into one {@code long} and are
- * therefore always non-negative, which frees {@code -1} as the empty slot marker.
+ * per shadowed page on the flush hot path; {@link LongLongHashMap} costs 16 bytes per entry with no allocation at
+ * all, so a million shadowed pages is 16 MB of index. Keys pack {@code fileId} and {@code pageNumber} into one
+ * {@code long}, so they are always non-negative and can never collide with that map's {@code Long.MIN_VALUE} empty
+ * marker - which is also what makes {@code Long.MIN_VALUE} usable here as the "not shadowed" lookup default.
  * <p>
  * <b>Concurrency.</b> The index is serialized on this instance, but the I/O is deliberately NOT: the capture side is
  * called from inside {@code PageManager.concurrentPageAccess}'s per-page write slot, so two threads never capture the
@@ -60,21 +61,14 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 final class PageShadow implements AutoCloseable {
-  /** Keys pack two non-negative ints, so they are never negative and -1 is free as the empty-slot marker. */
-  private static final long EMPTY_KEY          = -1L;
-  private static final int  INITIAL_CAPACITY   = 1024;
   /** A RAM slot index is stored as-is; a spill offset as {@code -(offset + 1)}, so the two never collide. */
-  private static final long NOT_FOUND          = Long.MIN_VALUE;
+  private static final long NOT_FOUND = Long.MIN_VALUE;
 
   private final File spillFile;
   private final long maxRAMBytes;
   private final long maxTotalBytes;
 
-  private long[] indexKeys;
-  private long[] indexValues;
-  private int    indexSize;
-  private int    indexMask;
-  private int    indexThreshold;
+  private LongLongHashMap index = new LongLongHashMap();
 
   private byte[][] ramSlots  = new byte[64][];
   private int      ramCount  = 0;
@@ -89,7 +83,6 @@ final class PageShadow implements AutoCloseable {
     this.spillFile = spillFile;
     this.maxRAMBytes = maxRAMBytes;
     this.maxTotalBytes = maxTotalBytes;
-    allocateIndex(INITIAL_CAPACITY);
   }
 
   /** Packs a page coordinate into the primitive index key. Both components are non-negative by construction. */
@@ -98,7 +91,7 @@ final class PageShadow implements AutoCloseable {
   }
 
   synchronized boolean contains(final long key) {
-    return !closed && lookup(key) != NOT_FOUND;
+    return !closed && index.get(key, NOT_FOUND) != NOT_FOUND;
   }
 
   /**
@@ -114,7 +107,7 @@ final class PageShadow implements AutoCloseable {
     synchronized (this) {
       if (closed)
         return false;
-      if (lookup(key) != NOT_FOUND)
+      if (index.get(key, NOT_FOUND) != NOT_FOUND)
         // ALREADY CAPTURED BY AN EARLIER WRITE TO THE SAME PAGE: THE FIRST PRE-IMAGE IS THE SNAPSHOT ONE, KEEP IT
         return true;
 
@@ -130,7 +123,7 @@ final class PageShadow implements AutoCloseable {
           ramSlots = larger;
         }
         ramSlots[ramCount] = copy;
-        insert(key, ramCount++);
+        index.put(key, ramCount++);
         ramBytes += length;
         return true;
       }
@@ -159,7 +152,7 @@ final class PageShadow implements AutoCloseable {
       if (closed)
         return true;
       // PUBLISHED ONLY NOW: A READER THAT SEES THE ENTRY IS GUARANTEED TO SEE THE COMPLETE BYTES
-      insert(key, -(offset + 1));
+      index.put(key, -(offset + 1));
     }
     return true;
   }
@@ -179,7 +172,7 @@ final class PageShadow implements AutoCloseable {
       if (closed)
         return false;
 
-      slot = lookup(key);
+      slot = index.get(key, NOT_FOUND);
       if (slot == NOT_FOUND)
         return false;
 
@@ -209,7 +202,7 @@ final class PageShadow implements AutoCloseable {
 
   /** Number of pages currently shadowed. */
   synchronized int getPageCount() {
-    return indexSize;
+    return index.size();
   }
 
   /** Bytes held in RAM plus bytes spilled to disk: what {@code PAGE_SNAPSHOT_MAX_SIZE} caps. */
@@ -230,11 +223,8 @@ final class PageShadow implements AutoCloseable {
     ramSlots = new byte[0][];
     ramCount = 0;
     ramBytes = 0L;
-    // RELEASE THE INDEX TOO: EVERY LOOKUP IS GATED ON closed ABOVE, SO NOTHING PROBES THESE ARRAYS AGAIN
-    indexKeys = new long[0];
-    indexValues = new long[0];
-    indexMask = 0;
-    indexSize = 0;
+    // RELEASE THE INDEX TOO: EVERY LOOKUP IS GATED ON closed ABOVE, SO NOTHING PROBES IT AGAIN
+    index = new LongLongHashMap(16);
 
     if (spillChannel != null) {
       try {
@@ -256,69 +246,4 @@ final class PageShadow implements AutoCloseable {
     }
   }
 
-  // ------------------------------------------------------------------------------------- PRIMITIVE INDEX
-
-  private void allocateIndex(final int capacity) {
-    int size = INITIAL_CAPACITY;
-    while (size < capacity)
-      size <<= 1;
-    indexKeys = new long[size];
-    indexValues = new long[size];
-    Arrays.fill(indexKeys, EMPTY_KEY);
-    indexMask = size - 1;
-    indexSize = 0;
-    // LOAD FACTOR 0.5: LINEAR PROBING DEGRADES SHARPLY PAST THAT, AND THE MEMORY IS TRIVIAL NEXT TO THE PAGE IMAGES
-    indexThreshold = size >> 1;
-  }
-
-  private long lookup(final long key) {
-    int pos = hash(key) & indexMask;
-    while (true) {
-      final long k = indexKeys[pos];
-      if (k == EMPTY_KEY)
-        return NOT_FOUND;
-      if (k == key)
-        return indexValues[pos];
-      pos = (pos + 1) & indexMask;
-    }
-  }
-
-  private void insert(final long key, final long value) {
-    if (indexSize >= indexThreshold)
-      rehash();
-
-    int pos = hash(key) & indexMask;
-    while (true) {
-      final long k = indexKeys[pos];
-      if (k == EMPTY_KEY) {
-        indexKeys[pos] = key;
-        indexValues[pos] = value;
-        ++indexSize;
-        return;
-      }
-      if (k == key) {
-        indexValues[pos] = value;
-        return;
-      }
-      pos = (pos + 1) & indexMask;
-    }
-  }
-
-  private void rehash() {
-    final long[] oldKeys = indexKeys;
-    final long[] oldValues = indexValues;
-    allocateIndex(oldKeys.length * 2);
-    for (int i = 0; i < oldKeys.length; i++)
-      if (oldKeys[i] != EMPTY_KEY)
-        insert(oldKeys[i], oldValues[i]);
-  }
-
-  /**
-   * Fibonacci hashing of the packed key. Page numbers are dense and sequential, so the low bits alone would map a
-   * whole file onto one contiguous run of slots; multiplying by the golden-ratio constant spreads them.
-   */
-  private static int hash(final long key) {
-    final long h = key * 0x9E3779B97F4A7C15L;
-    return (int) (h ^ (h >>> 32)) & 0x7FFFFFFF;
-  }
 }

--- a/engine/src/main/java/com/arcadedb/engine/PageShadow.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageShadow.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.log.LogManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.logging.Level;
+
+/**
+ * Holds the page pre-images captured by one {@link PageSnapshot} window: RAM first, spilling to a scratch file once
+ * the RAM budget is exhausted (issue #6075).
+ * <p>
+ * <b>Why RAM first.</b> The shadow only ever holds the pages DIRTIED while the window is open, once each, so on a
+ * short backup at a moderate write rate it is small. Keeping it in memory up to a budget removes the extra write of
+ * challenge C5 entirely in that common case; past the budget the spill is strictly append-only, so the extra write
+ * stays sequential and never seeks.
+ * <p>
+ * <b>Why the index is a primitive open-addressing map</b> (challenge C6). It is probed on every page write while a
+ * window is open, from the flush thread. A {@code HashMap<PageId, Long>} would box the value and allocate an entry
+ * per shadowed page on the flush hot path; this costs 16 bytes per entry with no allocation at all, so a million
+ * shadowed pages is 16 MB of index. Keys pack {@code fileId} and {@code pageNumber} into one {@code long} and are
+ * therefore always non-negative, which frees {@code -1} as the empty slot marker.
+ * <p>
+ * <b>Concurrency.</b> Every public method is serialized on this instance. The capture side is called from inside
+ * {@code PageManager.concurrentPageAccess}'s per-page write slot, so two threads never capture the SAME page, but
+ * they do capture different pages concurrently and a snapshot reader probes the index in parallel. The monitor is
+ * also what publishes a stored pre-image to that reader: {@link #store} copies the bytes and inserts the index entry
+ * under it, {@link #read} looks the entry up under it, so a reader that observes the entry is guaranteed to observe
+ * the complete bytes. That ordering is what lets {@link PageSnapshot} read runs of pages in bulk with no per-page
+ * lock at all, re-checking the shadow afterwards for anything a writer touched underneath it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class PageShadow implements AutoCloseable {
+  /** Keys pack two non-negative ints, so they are never negative and -1 is free as the empty-slot marker. */
+  private static final long EMPTY_KEY          = -1L;
+  private static final int  INITIAL_CAPACITY   = 1024;
+  /** A RAM slot index is stored as-is; a spill offset as {@code -(offset + 1)}, so the two never collide. */
+  private static final long NOT_FOUND          = Long.MIN_VALUE;
+
+  private final File spillFile;
+  private final long maxRAMBytes;
+  private final long maxTotalBytes;
+
+  private long[] indexKeys;
+  private long[] indexValues;
+  private int    indexSize;
+  private int    indexMask;
+  private int    indexThreshold;
+
+  private byte[][] ramSlots  = new byte[64][];
+  private int      ramCount  = 0;
+  private long     ramBytes  = 0L;
+
+  private FileChannel spillChannel;
+  private long        spillBytes = 0L;
+
+  private boolean closed = false;
+
+  PageShadow(final File spillFile, final long maxRAMBytes, final long maxTotalBytes) {
+    this.spillFile = spillFile;
+    this.maxRAMBytes = maxRAMBytes;
+    this.maxTotalBytes = maxTotalBytes;
+    allocateIndex(INITIAL_CAPACITY);
+  }
+
+  /** Packs a page coordinate into the primitive index key. Both components are non-negative by construction. */
+  static long key(final int fileId, final int pageNumber) {
+    return ((long) fileId << 32) | (pageNumber & 0xFFFFFFFFL);
+  }
+
+  synchronized boolean contains(final long key) {
+    return !closed && lookup(key) != NOT_FOUND;
+  }
+
+  /**
+   * Stores the pre-image of a page not yet shadowed.
+   *
+   * @return {@code false} when the configured cap would be breached: the caller must invalidate the whole window
+   *     (challenge C4 - a shadow that silently stops capturing would produce a torn snapshot).
+   */
+  synchronized boolean store(final long key, final byte[] content, final int length) throws IOException {
+    if (closed)
+      return false;
+    if (lookup(key) != NOT_FOUND)
+      // ALREADY CAPTURED BY AN EARLIER WRITE TO THE SAME PAGE: THE FIRST PRE-IMAGE IS THE SNAPSHOT ONE, KEEP IT
+      return true;
+
+    if (maxTotalBytes > 0 && ramBytes + spillBytes + length > maxTotalBytes)
+      return false;
+
+    final long slot;
+    if (ramBytes + length <= maxRAMBytes) {
+      final byte[] copy = new byte[length];
+      System.arraycopy(content, 0, copy, 0, length);
+      if (ramCount == ramSlots.length) {
+        final byte[][] larger = new byte[ramSlots.length * 2][];
+        System.arraycopy(ramSlots, 0, larger, 0, ramCount);
+        ramSlots = larger;
+      }
+      ramSlots[ramCount] = copy;
+      slot = ramCount++;
+      ramBytes += length;
+    } else {
+      if (spillChannel == null)
+        spillChannel = FileChannel.open(spillFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.READ,
+            StandardOpenOption.WRITE);
+
+      final ByteBuffer buffer = ByteBuffer.wrap(content, 0, length);
+      long pos = spillBytes;
+      while (buffer.hasRemaining())
+        pos += spillChannel.write(buffer, pos);
+
+      slot = -(spillBytes + 1);
+      spillBytes += length;
+    }
+
+    insert(key, slot);
+    return true;
+  }
+
+  /**
+   * Copies the pre-image of {@code key} into {@code dst} when the page has been shadowed.
+   *
+   * @return {@code false} when the page is not in the shadow, in which case the on-disk image is still the snapshot
+   *     one and the caller reads it from the data file.
+   */
+  synchronized boolean read(final long key, final byte[] dst, final int dstOffset, final int length) throws IOException {
+    if (closed)
+      return false;
+
+    final long slot = lookup(key);
+    if (slot == NOT_FOUND)
+      return false;
+
+    if (slot >= 0) {
+      final byte[] content = ramSlots[(int) slot];
+      if (content.length != length)
+        throw new IOException(
+            "Shadowed page size mismatch: expected " + length + " bytes, the pre-image holds " + content.length);
+      System.arraycopy(content, 0, dst, dstOffset, length);
+      return true;
+    }
+
+    final ByteBuffer buffer = ByteBuffer.wrap(dst, dstOffset, length);
+    long pos = -(slot + 1);
+    while (buffer.hasRemaining()) {
+      final int r = spillChannel.read(buffer, pos);
+      if (r < 0)
+        throw new IOException("Unexpected EOF reading the snapshot shadow file '" + spillFile.getName() + "' at " + pos);
+      pos += r;
+    }
+    return true;
+  }
+
+  /** Number of pages currently shadowed. */
+  synchronized int getPageCount() {
+    return indexSize;
+  }
+
+  /** Bytes held in RAM plus bytes spilled to disk: what {@code PAGE_SNAPSHOT_MAX_SIZE} caps. */
+  synchronized long getSizeInBytes() {
+    return ramBytes + spillBytes;
+  }
+
+  synchronized long getSpilledBytes() {
+    return spillBytes;
+  }
+
+  @Override
+  public synchronized void close() {
+    if (closed)
+      return;
+    closed = true;
+
+    ramSlots = new byte[0][];
+    ramCount = 0;
+    ramBytes = 0L;
+    // RELEASE THE INDEX TOO: EVERY LOOKUP IS GATED ON closed ABOVE, SO NOTHING PROBES THESE ARRAYS AGAIN
+    indexKeys = new long[0];
+    indexValues = new long[0];
+    indexMask = 0;
+    indexSize = 0;
+
+    if (spillChannel != null) {
+      try {
+        spillChannel.close();
+      } catch (final IOException e) {
+        LogManager.instance().log(this, Level.WARNING, "Error on closing the snapshot shadow file '%s'", e, spillFile);
+      }
+      spillChannel = null;
+    }
+
+    // PURE SCRATCH (CHALLENGE C8): NOTHING EVER READS IT AGAIN, AND A CRASH THAT LEAVES ONE BEHIND IS CLEANED UP AT
+    // THE NEXT DATABASE OPEN
+    if (spillFile.exists()) {
+      try {
+        Files.delete(spillFile.toPath());
+      } catch (final IOException e) {
+        LogManager.instance().log(this, Level.WARNING, "Error on deleting the snapshot shadow file '%s'", e, spillFile);
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------------------------- PRIMITIVE INDEX
+
+  private void allocateIndex(final int capacity) {
+    int size = INITIAL_CAPACITY;
+    while (size < capacity)
+      size <<= 1;
+    indexKeys = new long[size];
+    indexValues = new long[size];
+    Arrays.fill(indexKeys, EMPTY_KEY);
+    indexMask = size - 1;
+    indexSize = 0;
+    // LOAD FACTOR 0.5: LINEAR PROBING DEGRADES SHARPLY PAST THAT, AND THE MEMORY IS TRIVIAL NEXT TO THE PAGE IMAGES
+    indexThreshold = size >> 1;
+  }
+
+  private long lookup(final long key) {
+    int pos = hash(key) & indexMask;
+    while (true) {
+      final long k = indexKeys[pos];
+      if (k == EMPTY_KEY)
+        return NOT_FOUND;
+      if (k == key)
+        return indexValues[pos];
+      pos = (pos + 1) & indexMask;
+    }
+  }
+
+  private void insert(final long key, final long value) {
+    if (indexSize >= indexThreshold)
+      rehash();
+
+    int pos = hash(key) & indexMask;
+    while (true) {
+      final long k = indexKeys[pos];
+      if (k == EMPTY_KEY) {
+        indexKeys[pos] = key;
+        indexValues[pos] = value;
+        ++indexSize;
+        return;
+      }
+      if (k == key) {
+        indexValues[pos] = value;
+        return;
+      }
+      pos = (pos + 1) & indexMask;
+    }
+  }
+
+  private void rehash() {
+    final long[] oldKeys = indexKeys;
+    final long[] oldValues = indexValues;
+    allocateIndex(oldKeys.length * 2);
+    for (int i = 0; i < oldKeys.length; i++)
+      if (oldKeys[i] != EMPTY_KEY)
+        insert(oldKeys[i], oldValues[i]);
+  }
+
+  /**
+   * Fibonacci hashing of the packed key. Page numbers are dense and sequential, so the low bits alone would map a
+   * whole file onto one contiguous run of slots; multiplying by the golden-ratio constant spreads them.
+   */
+  private static int hash(final long key) {
+    final long h = key * 0x9E3779B97F4A7C15L;
+    return (int) (h ^ (h >>> 32)) & 0x7FFFFFFF;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.PageSnapshotException;
+import com.arcadedb.log.LogManager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.zip.CRC32;
+
+/**
+ * A point-in-time, read-only view of every page file of a database, served by a page-level copy-on-write shadow
+ * (issue #6075, phase 2b of the backup roadmap in {@code docs/optimize-backup.md}).
+ * <p>
+ * <b>What it replaces.</b> Before this, a reader that needed the data files to stand still - the full backup, the HA
+ * snapshot ship, the HA database verify - froze them with {@code PageManager.suspendFlushAndExecute}. That parks the
+ * flush thread for the WHOLE operation: dirty pages pile up in RAM bounded by
+ * {@link com.arcadedb.GlobalConfiguration#FLUSH_SUSPEND_MAX_DEFERRED_RAM}, past which committing threads are
+ * throttled, and LSM/vector index compaction is postponed for the entire window. This class removes all of that: the
+ * only stall is one bounded flush-queue drain when the window opens.
+ * <p>
+ * <b>The mechanism.</b> While a window is open, the first write to any page that existed at t0 first copies the
+ * page's current on-disk image into the shadow ({@link PageShadow}), inside the per-page I/O slot the write already
+ * holds. A reader therefore resolves each page as "shadow if present, data file otherwise", and gets exactly the t0
+ * image. Because the pre-image is captured under the same slot as the write, the image and its version header are
+ * read together and can never disagree - the property phase 3 (incremental backup) is built on.
+ * <p>
+ * <b>Reading is bulk, not page-at-a-time</b> (challenge C1). The obvious reader takes the per-page I/O slot for every
+ * page, which turns one sequential {@code transferTo} into a lock acquisition per page. It is not needed: a write
+ * during the window ALWAYS shadows the page before touching the file, so a run of pages can be read in one bulk
+ * {@code read} with no lock at all and the shadow re-probed afterwards - any page a writer touched underneath the
+ * read is now in the shadow, and its t0 image is taken from there instead. Pages already shadowed before the read are
+ * skipped by the pre-probe. So a torn read is always detected, and the common case (no concurrent write to that run)
+ * costs one probe per page against a primitive map.
+ * <p>
+ * <b>Overlapping windows</b> (challenge C3) are supported directly rather than serialized: each window owns its own
+ * shadow, and a write consults every open window, capturing the same freshly read pre-image into each one that does
+ * not have the page yet. That is correct because a page's content at capture time IS its content at t0 for every
+ * window that has not shadowed it - if a window had been opened after an intervening write, that write would have
+ * populated the older window and left this one to capture the newer image. Only the t0 barrier itself is serialized
+ * per database, and only for its duration.
+ * <p>
+ * <b>Files dropped while a window is open</b> (challenge C2) are not deleted: {@code FileManager.dropFile} hands them
+ * to the open windows, which keep them open and delete them on close. Index compaction therefore runs freely during
+ * a backup instead of being postponed, which was one of the costs of the suspension.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PageSnapshot implements AutoCloseable {
+  /**
+   * Extension of the shadow spill file. Deliberately NOT in {@code LocalDatabase.SUPPORTED_FILE_EXT}: the shadow is
+   * pure scratch, recovery never reads it, and it must never be mistaken for a data file (challenge C8).
+   */
+  public static final String SHADOW_FILE_EXT = "pshadow";
+
+  public enum STATUS {
+    /** Serving the t0 image. */
+    ACTIVE,
+    /** The shadow breached {@code arcadedb.pageSnapshotMaxSize}: the t0 image is no longer recoverable. */
+    OVERFLOWED,
+    /** A pre-image capture failed with an I/O error: the t0 image is no longer recoverable. */
+    FAILED,
+    CLOSED
+  }
+
+  /** One page file as it stood at t0: the page count is what makes appended pages need no shadow (challenge C7). */
+  public record SnapshotFile(int fileId, PaginatedComponentFile file, int pageSize, int pageCount, String fileName,
+                             long lastModified) {
+    public long size() {
+      return (long) pageSize * pageCount;
+    }
+  }
+
+  /** Pages read in one bulk call. 16 x 64 KB = 1 MB, the same unit the parallel backup compressor works on. */
+  private static final int READ_RUN_PAGES = 16;
+
+  private final DatabaseInternal database;
+  private final PageManager      pageManager;
+  private final long             lastTxId;
+  private final SnapshotFile[]   filesById;
+  private final List<SnapshotFile> files;
+  private final PageShadow       shadow;
+  private final long             openedOn = System.currentTimeMillis();
+
+  /**
+   * Capture operations currently touching the shadow. {@link #close()} unpublishes the window first and then waits
+   * for this to reach zero, so the shadow is never released from under a writer that had already read the published
+   * array - the same refcount shape {@code PageManagerFlushThread.setSuspended} uses for the suspension (#5068).
+   */
+  private final AtomicInteger inFlightCaptures = new AtomicInteger();
+  /** Files dropped while this window was open: kept alive for the reader, physically deleted on close (C2). */
+  private final ConcurrentLinkedQueue<ComponentFile> retiredFiles = new ConcurrentLinkedQueue<>();
+
+  private volatile STATUS status = STATUS.ACTIVE;
+  private volatile String invalidReason;
+  private volatile boolean released = false;
+
+  PageSnapshot(final DatabaseInternal database, final PageManager pageManager, final long lastTxId,
+      final List<SnapshotFile> files, final PageShadow shadow) {
+    this.database = database;
+    this.pageManager = pageManager;
+    this.lastTxId = lastTxId;
+    this.files = Collections.unmodifiableList(files);
+    this.shadow = shadow;
+
+    int maxFileId = -1;
+    for (final SnapshotFile f : files)
+      maxFileId = Math.max(maxFileId, f.fileId());
+    this.filesById = new SnapshotFile[maxFileId + 1];
+    for (final SnapshotFile f : files)
+      this.filesById[f.fileId()] = f;
+  }
+
+  // --------------------------------------------------------------------------------------------- PUBLIC READER API
+
+  /** The page files as they stood at t0, in file-id order. Files created after t0 are absent by construction. */
+  public List<SnapshotFile> getFiles() {
+    return files;
+  }
+
+  public SnapshotFile getFile(final int fileId) {
+    return fileId >= 0 && fileId < filesById.length ? filesById[fileId] : null;
+  }
+
+  /**
+   * The last committed transaction id at t0. Because the window opens on a fully drained flush queue, every
+   * transaction up to this id is materialised in the pages this snapshot serves - which is what closes the recency
+   * gap the suspend-and-freeze path had (section 1.3 of the design document): there, only the in-flight flush batch
+   * was awaited, so a restored backup could be a few hundred transactions behind.
+   */
+  public long getLastTxId() {
+    return lastTxId;
+  }
+
+  public Database getDatabase() {
+    return database;
+  }
+
+  public STATUS getStatus() {
+    return status;
+  }
+
+  /** Number of pages whose pre-image the window has had to capture so far. */
+  public int getShadowedPages() {
+    return shadow.getPageCount();
+  }
+
+  /** RAM plus spill bytes the shadow currently holds: the figure {@code arcadedb.pageSnapshotMaxSize} caps. */
+  public long getShadowSizeInBytes() {
+    return shadow.getSizeInBytes();
+  }
+
+  public long getShadowSpilledBytes() {
+    return shadow.getSpilledBytes();
+  }
+
+  public long getOpenedOn() {
+    return openedOn;
+  }
+
+  /**
+   * Throws when the window can no longer serve the t0 image, so a consumer never silently produces a torn artifact.
+   * Consumers are expected to catch {@link PageSnapshotException} and fall back to the suspend-and-freeze path.
+   */
+  public void checkValid() {
+    final STATUS current = status;
+    if (current != STATUS.ACTIVE)
+      throw new PageSnapshotException(
+          "Snapshot of database '" + database.getName() + "' is " + current + (invalidReason != null ?
+              ": " + invalidReason :
+              ""));
+  }
+
+  /**
+   * Streams the whole t0 content of one file, exactly {@code pageCount * pageSize} bytes. The stream reads runs of
+   * pages in bulk (see the class comment): sequential I/O and OS readahead are preserved, and no per-page lock is
+   * taken.
+   */
+  public InputStream newInputStream(final int fileId) {
+    final SnapshotFile snapshotFile = getFile(fileId);
+    if (snapshotFile == null)
+      throw new PageSnapshotException(
+          "File with id " + fileId + " is not part of the snapshot of database '" + database.getName() + "'");
+    return new SnapshotFileInputStream(snapshotFile);
+  }
+
+  /**
+   * CRC32 of the whole t0 content of a file. Byte-for-byte the same value
+   * {@link PaginatedComponentFile#calculateChecksum()} computes on a frozen file, so an HA verify can compare a
+   * snapshot-based checksum against a peer's regardless of which path that peer used.
+   */
+  public long calculateChecksum(final int fileId) throws IOException {
+    final CRC32 crc = new CRC32();
+    final byte[] buffer = new byte[64 * 1024];
+    try (final InputStream in = newInputStream(fileId)) {
+      for (int read = in.read(buffer); read > 0; read = in.read(buffer))
+        crc.update(buffer, 0, read);
+    }
+    return crc.getValue();
+  }
+
+  @Override
+  public void close() {
+    if (released)
+      return;
+
+    // ORDER MATTERS: UNPUBLISH FIRST SO NO NEW CAPTURE CAN FIND THIS WINDOW, THEN DRAIN THE ONES ALREADY INSIDE
+    pageManager.unregisterSnapshot(this);
+    released = true;
+    // A CAPTURE IN FLIGHT IS ONE PAGE READ PLUS ONE COPY, SO SPINNING IS THE RIGHT WAIT - BUT IT YIELDS AFTER A WHILE
+    // SO A CAPTURE STUCK ON A SLOW DISK DOES NOT BURN A CORE
+    for (int spins = 0; inFlightCaptures.get() > 0; spins++) {
+      if (spins < 1_000)
+        Thread.onSpinWait();
+      else
+        Thread.yield();
+    }
+
+    status = STATUS.CLOSED;
+    shadow.close();
+
+    // CHALLENGE C2: THE FILES DROPPED WHILE THE WINDOW WAS OPEN WERE KEPT ALIVE FOR THE READER. RELEASE THIS
+    // WINDOW'S CLAIM; THE LAST WINDOW STILL HOLDING ONE PERFORMS THE PHYSICAL DELETE
+    for (ComponentFile retired = retiredFiles.poll(); retired != null; retired = retiredFiles.poll())
+      pageManager.releaseDeferredFileDrop(retired);
+  }
+
+  // ---------------------------------------------------------------------------------------------- ENGINE INTERNALS
+
+  /**
+   * A page carries whichever {@code Database} instance created it, which on a server is not necessarily the same
+   * object the consumer opened the window with (wrappers, proxies). {@code LocalDatabase.equals} keys on the
+   * database path, which is the identity that matters here - and the same comparison the flush thread already uses
+   * to match batches to their database.
+   */
+  boolean isFor(final Object candidateDatabase) {
+    return database.equals(candidateDatabase);
+  }
+
+  /**
+   * Called from inside {@code PageManager.concurrentPageAccess}'s write slot, BEFORE the page reaches the file.
+   *
+   * @return {@code true} when this window still needs the page's pre-image.
+   */
+  boolean needsPreImage(final int fileId, final int pageNumber) {
+    if (status != STATUS.ACTIVE)
+      return false;
+    final SnapshotFile snapshotFile = getFile(fileId);
+    // BEYOND THE t0 PAGE COUNT MEANS THE PAGE DID NOT EXIST AT t0: THE READER IGNORES IT, SO IT NEEDS NO SHADOW (C7)
+    if (snapshotFile == null || pageNumber >= snapshotFile.pageCount())
+      return false;
+    return !shadow.contains(PageShadow.key(fileId, pageNumber));
+  }
+
+  int getPageSize(final int fileId) {
+    final SnapshotFile snapshotFile = getFile(fileId);
+    return snapshotFile != null ? snapshotFile.pageSize() : -1;
+  }
+
+  /**
+   * Stores a pre-image captured by the write path. Never propagates a failure to the writer: a snapshot must never
+   * be able to break the live database, so a breach of the cap or an I/O error invalidates THIS window and lets the
+   * write proceed. Every later read fails loudly with {@link PageSnapshotException}.
+   */
+  void storePreImage(final int fileId, final int pageNumber, final byte[] content, final int length) {
+    inFlightCaptures.incrementAndGet();
+    try {
+      if (released || status != STATUS.ACTIVE)
+        return;
+
+      if (!shadow.store(PageShadow.key(fileId, pageNumber), content, length))
+        invalidate(STATUS.OVERFLOWED,
+            "the copy-on-write shadow reached the " + GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.getKey() + " cap of "
+                + database.getConfiguration().getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE) + " MB");
+    } catch (final IOException e) {
+      invalidate(STATUS.FAILED, "error capturing the pre-image of page " + fileId + "/" + pageNumber + ": " + e);
+    } finally {
+      inFlightCaptures.decrementAndGet();
+    }
+  }
+
+  /**
+   * Takes over a file dropped while this window is open, so the reader keeps seeing it (challenge C2). Called by
+   * {@code PageManager.deferFileDrop} while it holds the snapshot registry lock, which {@link #close()} also takes
+   * (through {@code unregisterSnapshot}) BEFORE draining this queue - so a file handed over here is never missed.
+   */
+  void retainDroppedFile(final ComponentFile file) {
+    retiredFiles.add(file);
+  }
+
+  /** A pre-image could not be read from the data file: this window can no longer serve the t0 image. */
+  void invalidateOnCaptureError(final int fileId, final int pageNumber, final IOException error) {
+    invalidate(STATUS.FAILED, "error reading the pre-image of page " + fileId + "/" + pageNumber + ": " + error);
+  }
+
+  private synchronized void invalidate(final STATUS newStatus, final String reason) {
+    if (status == STATUS.ACTIVE) {
+      status = newStatus;
+      invalidReason = reason;
+      LogManager.instance().log(this, Level.WARNING,
+          "Snapshot of database '%s' is no longer usable (%s): %s. Readers will fail and can fall back to suspending the page flush",
+          null, database.getName(), newStatus, reason);
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------- READER
+
+  /**
+   * Reads the t0 content of one file as a stream. Pages are pulled a run at a time: the shadow is probed for every
+   * page of the run, the pages that are not in it are read from the data file in ONE call, then the shadow is
+   * re-probed for those same pages. A page that appears in the second probe was written underneath the bulk read, so
+   * its (possibly torn) bytes are replaced by the pre-image the writer captured - which is the t0 image by
+   * construction. See the class comment for why this is exactly as safe as taking the per-page I/O slot.
+   */
+  private final class SnapshotFileInputStream extends InputStream {
+    private final SnapshotFile snapshotFile;
+    private final byte[]       buffer;
+    private final ByteBuffer   byteBuffer;
+    private final boolean[]    fromShadow;
+
+    private int nextPage    = 0;
+    private int bufferLimit = 0;
+    private int bufferPos   = 0;
+
+    private SnapshotFileInputStream(final SnapshotFile snapshotFile) {
+      this.snapshotFile = snapshotFile;
+      this.buffer = new byte[READ_RUN_PAGES * snapshotFile.pageSize()];
+      this.byteBuffer = ByteBuffer.wrap(buffer);
+      this.fromShadow = new boolean[READ_RUN_PAGES];
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (bufferPos == bufferLimit && !fill())
+        return -1;
+      return buffer[bufferPos++] & 0xFF;
+    }
+
+    @Override
+    public int read(final byte[] dst, final int offset, final int length) throws IOException {
+      if (length == 0)
+        return 0;
+      if (bufferPos == bufferLimit && !fill())
+        return -1;
+      final int copied = Math.min(length, bufferLimit - bufferPos);
+      System.arraycopy(buffer, bufferPos, dst, offset, copied);
+      bufferPos += copied;
+      return copied;
+    }
+
+    @Override
+    public int available() {
+      return bufferLimit - bufferPos;
+    }
+
+    private boolean fill() throws IOException {
+      checkValid();
+
+      if (nextPage >= snapshotFile.pageCount())
+        return false;
+
+      final int pageSize = snapshotFile.pageSize();
+      final int runPages = Math.min(READ_RUN_PAGES, snapshotFile.pageCount() - nextPage);
+      final int fileId = snapshotFile.fileId();
+
+      // 1. PRE-PROBE: PAGES ALREADY SHADOWED ARE SERVED FROM THE SHADOW AND EXCLUDED FROM THE BULK READ
+      int firstUnshadowed = -1;
+      int lastUnshadowed = -1;
+      for (int i = 0; i < runPages; i++) {
+        fromShadow[i] = shadow.read(PageShadow.key(fileId, nextPage + i), buffer, i * pageSize, pageSize);
+        if (!fromShadow[i]) {
+          if (firstUnshadowed < 0)
+            firstUnshadowed = i;
+          lastUnshadowed = i;
+        }
+      }
+
+      // 2. ONE BULK READ COVERING EVERY PAGE OF THE RUN NOT ALREADY RESOLVED. THE RANGE IS CONTIGUOUS EVEN WHEN IT
+      //    SPANS A SHADOWED PAGE IN THE MIDDLE: RE-READING THAT PAGE IS CHEAPER THAN SPLITTING THE I/O, AND ITS
+      //    BYTES ARE OVERWRITTEN FROM THE SHADOW AGAIN IN STEP 3
+      if (firstUnshadowed >= 0) {
+        final int readPages = lastUnshadowed - firstUnshadowed + 1;
+        byteBuffer.clear();
+        byteBuffer.limit((lastUnshadowed + 1) * pageSize);
+        byteBuffer.position(firstUnshadowed * pageSize);
+        snapshotFile.file().readPages(nextPage + firstUnshadowed, readPages, byteBuffer);
+        byteBuffer.clear();
+      }
+
+      // 3. RE-PROBE: ANY PAGE THAT ENTERED THE SHADOW WHILE THE BULK READ WAS RUNNING WAS WRITTEN UNDERNEATH IT, SO
+      //    THE BYTES JUST READ MAY BE TORN. THE CAPTURED PRE-IMAGE IS THE t0 IMAGE, SO IT WINS
+      for (int i = 0; i < runPages; i++)
+        if (!fromShadow[i])
+          shadow.read(PageShadow.key(fileId, nextPage + i), buffer, i * pageSize, pageSize);
+
+      checkValid();
+
+      nextPage += runPages;
+      bufferPos = 0;
+      bufferLimit = runPages * pageSize;
+      return true;
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
@@ -352,7 +352,6 @@ public class PageSnapshot implements AutoCloseable {
     private final SnapshotFile snapshotFile;
     private final byte[]       buffer;
     private final ByteBuffer   byteBuffer;
-    private final boolean[]    fromShadow;
 
     private int nextPage    = 0;
     private int bufferLimit = 0;
@@ -362,7 +361,6 @@ public class PageSnapshot implements AutoCloseable {
       this.snapshotFile = snapshotFile;
       this.buffer = new byte[READ_RUN_PAGES * snapshotFile.pageSize()];
       this.byteBuffer = ByteBuffer.wrap(buffer);
-      this.fromShadow = new boolean[READ_RUN_PAGES];
     }
 
     @Override
@@ -399,21 +397,21 @@ public class PageSnapshot implements AutoCloseable {
       final int runPages = Math.min(READ_RUN_PAGES, snapshotFile.pageCount() - nextPage);
       final int fileId = snapshotFile.fileId();
 
-      // 1. PRE-PROBE: PAGES ALREADY SHADOWED ARE SERVED FROM THE SHADOW AND EXCLUDED FROM THE BULK READ
+      // 1. PRE-PROBE: PAGES ALREADY SHADOWED ARE SERVED FROM THE SHADOW, AND THE BULK READ ONLY HAS TO SPAN THE
+      //    OUTERMOST PAGES THAT ARE NOT
       int firstUnshadowed = -1;
       int lastUnshadowed = -1;
-      for (int i = 0; i < runPages; i++) {
-        fromShadow[i] = shadow.read(PageShadow.key(fileId, nextPage + i), buffer, i * pageSize, pageSize);
-        if (!fromShadow[i]) {
+      for (int i = 0; i < runPages; i++)
+        if (!shadow.read(PageShadow.key(fileId, nextPage + i), buffer, i * pageSize, pageSize)) {
           if (firstUnshadowed < 0)
             firstUnshadowed = i;
           lastUnshadowed = i;
         }
-      }
 
       // 2. ONE BULK READ COVERING EVERY PAGE OF THE RUN NOT ALREADY RESOLVED. THE RANGE IS CONTIGUOUS EVEN WHEN IT
-      //    SPANS A SHADOWED PAGE IN THE MIDDLE: RE-READING THAT PAGE IS CHEAPER THAN SPLITTING THE I/O, AND ITS
-      //    BYTES ARE OVERWRITTEN FROM THE SHADOW AGAIN IN STEP 3
+      //    SPANS A PAGE THAT WAS ALREADY SHADOWED: RE-READING THAT PAGE IS CHEAPER THAN SPLITTING THE I/O, AND ITS
+      //    LIVE BYTES ARE OVERWRITTEN FROM THE SHADOW AGAIN IN STEP 3 - WHICH IS WHY STEP 3 MUST RE-PROBE EVERY
+      //    PAGE OF THE RUN, NOT ONLY THE ONES THAT WERE UNSHADOWED AT STEP 1
       if (firstUnshadowed >= 0) {
         final int readPages = lastUnshadowed - firstUnshadowed + 1;
         byteBuffer.clear();
@@ -431,11 +429,16 @@ public class PageSnapshot implements AutoCloseable {
         byteBuffer.clear();
       }
 
-      // 3. RE-PROBE: ANY PAGE THAT ENTERED THE SHADOW WHILE THE BULK READ WAS RUNNING WAS WRITTEN UNDERNEATH IT, SO
-      //    THE BYTES JUST READ MAY BE TORN. THE CAPTURED PRE-IMAGE IS THE t0 IMAGE, SO IT WINS
+      // 3. RE-PROBE EVERY PAGE OF THE RUN, UNCONDITIONALLY. TWO DISTINCT CASES NEED IT, AND GATING ON
+      //    !fromShadow[i] SILENTLY BROKE THE FIRST ONE:
+      //      a) A PAGE ALREADY SHADOWED AT STEP 1 THAT SITS INSIDE THE BULK-READ RANGE (ITS NEIGHBOURS WERE NOT
+      //         SHADOWED, SO THE RANGE SPANS IT). STEP 2 OVERWROTE ITS PRE-IMAGE WITH CURRENT, POST-t0 BYTES.
+      //         THIS IS THE COMMON CASE, NOT AN EXOTIC ONE: PAGES ARE SHADOWED IN WRITE ORDER, WHICH HAS NOTHING
+      //         TO DO WITH READ_RUN_PAGES BOUNDARIES.
+      //      b) A PAGE WRITTEN UNDERNEATH THE BULK READ, WHOSE BYTES MAY THEREFORE BE TORN.
+      //    A PAGE THAT IS IN NEITHER CASE IS NOT IN THE SHADOW AT ALL, SO THE PROBE IS A NO-OP ON IT
       for (int i = 0; i < runPages; i++)
-        if (!fromShadow[i])
-          shadow.read(PageShadow.key(fileId, nextPage + i), buffer, i * pageSize, pageSize);
+        shadow.read(PageShadow.key(fileId, nextPage + i), buffer, i * pageSize, pageSize);
 
       checkValid();
 

--- a/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
@@ -90,10 +90,20 @@ public class PageSnapshot implements AutoCloseable {
   }
 
   /** One page file as it stood at t0: the page count is what makes appended pages need no shadow (challenge C7). */
-  public record SnapshotFile(int fileId, PaginatedComponentFile file, int pageSize, int pageCount, String fileName,
-                             long lastModified) {
+  public record SnapshotFile(int fileId, PaginatedComponentFile file, int pageSize, int pageCount, String fileName) {
     public long size() {
       return (long) pageSize * pageCount;
+    }
+
+    /**
+     * Modification timestamp for the archive entry header. Read lazily, on the consumer's thread, rather than
+     * captured at t0: it is a {@code stat()} per file and the t0 barrier holds the page-manager lock and the
+     * transaction manager's apply lock exclusively, so on a database with many buckets and indexes stat-ing all of
+     * them there would stretch the one stall this design is supposed to keep bounded. Nothing depends on the value
+     * being the t0 one, and a file dropped since then is still on disk (its deletion is deferred to the close).
+     */
+    public long lastModified() {
+      return file.getOSFile().lastModified();
     }
   }
 
@@ -409,7 +419,15 @@ public class PageSnapshot implements AutoCloseable {
         byteBuffer.clear();
         byteBuffer.limit((lastUnshadowed + 1) * pageSize);
         byteBuffer.position(firstUnshadowed * pageSize);
-        snapshotFile.file().readPages(nextPage + firstUnshadowed, readPages, byteBuffer);
+        try {
+          snapshotFile.file().readPages(nextPage + firstUnshadowed, readPages, byteBuffer);
+        } catch (final IllegalArgumentException e) {
+          // readPages REPORTS A CLOSED FILE THIS WAY. THE WINDOW KEEPS ITS FILES ALIVE (DROPS ARE DEFERRED), SO THIS
+          // MEANS THE DATABASE ITSELF WENT AWAY UNDERNEATH THE READER - A SNAPSHOT-INTEGRITY FAILURE, NOT A DISK
+          // ERROR, SO IT IS REPORTED AS ONE AND THE CONSUMER CAN FALL BACK INSTEAD OF FAILING OUTRIGHT
+          invalidate(STATUS.FAILED, "file '" + snapshotFile.fileName() + "' is no longer readable: " + e.getMessage());
+          checkValid();
+        }
         byteBuffer.clear();
       }
 

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -351,6 +351,46 @@ public class PaginatedComponentFile extends ComponentFile {
     }
   }
 
+  /**
+   * Reads a RUN of consecutive pages in one call into {@code buf} at its current position, which must have at least
+   * {@code pages * pageSize} bytes remaining. Unlike {@link #readPage} the buffer is NOT cleared, so several runs can
+   * be assembled into one larger buffer.
+   * <p>
+   * Used by the point-in-time snapshot reader ({@link PageSnapshot}, issue #6075) to keep the copy sequential: the
+   * copy-on-write shadow removes the need for a per-page interlock, so a megabyte can be read in one syscall instead
+   * of sixteen and the OS readahead works exactly as it did for the bulk {@code transferTo} the snapshot replaced.
+   */
+  public void readPages(final int fromPageNumber, final int pages, final ByteBuffer buf) throws IOException {
+    if (fromPageNumber < 0)
+      throw new IllegalArgumentException("Invalid page number to read: " + fromPageNumber);
+
+    final int expected = pages * pageSize;
+    if (buf.remaining() < expected)
+      throw new IllegalArgumentException(
+          "Buffer too small to read " + pages + " pages of file '" + getFileName() + "': " + buf.remaining() + " < " + expected);
+
+    final int limit = buf.limit();
+    buf.limit(buf.position() + expected);
+    channelLock.readLock().lock();
+    try {
+      if (channel == null)
+        throw new IllegalArgumentException(
+            "Cannot read pages from " + fromPageNumber + " because the file '" + getFileName() + "' is closed");
+
+      long pos = pageSize * (long) fromPageNumber;
+      while (buf.hasRemaining()) {
+        final int r = channel.read(buf, pos);
+        if (r < 0)
+          throw new IOException(
+              "Unexpected EOF reading " + pages + " pages from page " + fromPageNumber + " of file '" + getFileName() + "'");
+        pos += r;
+      }
+    } finally {
+      channelLock.readLock().unlock();
+      buf.limit(limit);
+    }
+  }
+
   public void readPage(final int pageNum, final ByteBuffer buf) throws IOException {
     channelLock.readLock().lock();
     try {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -39,6 +39,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 
@@ -66,6 +67,15 @@ public class TransactionManager {
   private final LockManager<Integer, Object> fileIdsLockManager  = new LockManager<>();
   private final AtomicLong                   statsPagesWritten   = new AtomicLong();
   private final AtomicLong                   statsBytesWritten   = new AtomicLong();
+  /**
+   * Held SHARED for the whole of {@link #applyChanges}, and EXCLUSIVELY by the snapshot t0 barrier
+   * ({@code PageManager.openSnapshot}, issue #6075). Replicated and crash-recovery replay is the one writer that
+   * reaches the data files outside the asynchronous flush pipeline, so parking the flush thread does not park it;
+   * without this lock a multi-page apply could straddle t0 and leave the snapshot with some of that transaction's
+   * pages and not the others. The shared side is one uncontended acquisition per REPLAYED TRANSACTION - never on
+   * the local commit path - so it is nowhere near a hot path.
+   */
+  private final ReentrantReadWriteLock       applyLock           = new ReentrantReadWriteLock();
 
   public TransactionManager(final DatabaseInternal database) {
     this.database = database;
@@ -477,7 +487,30 @@ public class TransactionManager {
     return map;
   }
 
+  /**
+   * Applies a replicated or recovered transaction to the data files. Runs under the SHARED side of
+   * {@link #getApplyLock()} so a point-in-time snapshot's t0 barrier (#6075) can exclude it wholesale: this writer
+   * goes to the files outside the flush pipeline, so a multi-page apply straddling t0 would leave the snapshot
+   * holding part of a transaction.
+   */
   public boolean applyChanges(final WALFile.WALTransaction tx, final Map<Integer, Integer> bucketRecordDelta,
+      final boolean ignoreErrors) {
+    applyLock.readLock().lock();
+    try {
+      return applyChangesInternal(tx, bucketRecordDelta, ignoreErrors);
+    } finally {
+      applyLock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Serializes {@link #applyChanges} against the snapshot t0 barrier. Never taken on the local commit path.
+   */
+  public ReentrantReadWriteLock getApplyLock() {
+    return applyLock;
+  }
+
+  private boolean applyChangesInternal(final WALFile.WALTransaction tx, final Map<Integer, Integer> bucketRecordDelta,
       final boolean ignoreErrors) {
     boolean changed = false;
     boolean involveDictionary = false;

--- a/engine/src/main/java/com/arcadedb/exception/PageSnapshotException.java
+++ b/engine/src/main/java/com/arcadedb/exception/PageSnapshotException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.exception;
+
+/**
+ * A point-in-time page snapshot ({@code PageManager.openSnapshot}, issue #6075) can no longer serve the state it was
+ * opened on, so every read through it fails instead of returning a torn image.
+ * <p>
+ * The two reasons are the copy-on-write shadow breaching {@code arcadedb.pageSnapshotMaxSize} on a write-heavy
+ * database, and an I/O error while capturing a page pre-image. Both are recoverable from the consumer's side: a
+ * backup, an HA verify or an HA snapshot ship catching this falls back to the suspend-and-freeze path, which
+ * throttles writers but always completes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PageSnapshotException extends ArcadeDBException {
+  public PageSnapshotException(final String s) {
+    super(s);
+  }
+
+  public PageSnapshotException(final String s, final Throwable e) {
+    super(s, e);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/utility/LongLongHashMap.java
+++ b/engine/src/main/java/com/arcadedb/utility/LongLongHashMap.java
@@ -103,6 +103,32 @@ public final class LongLongHashMap {
   }
 
   /**
+   * Associates {@code value} with {@code key}, replacing any previous value. Unlike {@link #add}, which folds a
+   * delta into whatever is already there, this is a plain overwrite - what a caller storing a location rather than
+   * accumulating a count needs (e.g. the page pre-image offsets of the snapshot shadow, issue #6075).
+   * <p>
+   * {@code Long.MIN_VALUE} is the empty-slot marker and therefore cannot be used as a key.
+   */
+  public void put(final long key, final long value) {
+    int idx = hash(key) & mask;
+    while (true) {
+      final long k = keys[idx];
+      if (k == key) {
+        values[idx] = value;
+        return;
+      }
+      if (k == EMPTY) {
+        keys[idx] = key;
+        values[idx] = value;
+        if (++size >= threshold)
+          resize();
+        return;
+      }
+      idx = (idx + 1) & mask;
+    }
+  }
+
+  /**
    * Returns the value for the given key, or the default value if the key is not present.
    */
   public long get(final long key, final long defaultValue) {

--- a/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
@@ -64,7 +64,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class PageSnapshotTest extends TestHelper {
 
-  private static final String TYPE = "Doc";
+  private static final String TYPE       = "Doc";
+  private static final String SPILL_TYPE = "Spill";
 
   @Override
   protected void beginTest() {
@@ -427,6 +428,52 @@ class PageSnapshotTest extends TestHelper {
   }
 
   /**
+   * The shadow is RAM first with disk spill (challenge C5), and the spill is the half a short backup never reaches -
+   * so it needs its own test or it ships untested. A 1 MB RAM budget against a dataset laid out over hundreds of
+   * small pages forces the pre-images past the budget and onto disk, which exercises the spill write, the spill
+   * read, the primitive index rehash (its load factor trips past 512 entries), and the scratch-file cleanup on
+   * close - while the t0 image the window serves must be exactly as intact as it is for a RAM-only shadow.
+   */
+  @Test
+  void aShadowThatOutgrowsItsRamBudgetSpillsToDiskAndStillServesT0() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    // SMALL PAGES SO A FEW MB OF DATA BECOMES THE HUNDREDS OF DISTINCT PAGES THE REHASH AND THE SPILL BOTH NEED
+    database.getSchema().buildDocumentType().withName(SPILL_TYPE).withTotalBuckets(1).withPageSize(16_384).create();
+    database.transaction(() -> {
+      for (int i = 0; i < 60_000; i++)
+        database.newDocument(SPILL_TYPE).set("id", i).set("payload", "s".repeat(120)).save();
+    });
+    pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.setValue(1);
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.setValue(256);
+
+    final File[] shadowsDuringWindow;
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      final Map<Integer, Long> t0Checksums = checksums(snapshot);
+
+      database.transaction(() -> database.iterateType(SPILL_TYPE, false).forEachRemaining(
+          record -> record.asDocument().modify().set("payload", "t".repeat(120)).save()));
+      pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+      assertThat(snapshot.getShadowedPages()).as("the rewrite must shadow more pages than the index starts sized for")
+          .isGreaterThan(512);
+      assertThat(snapshot.getShadowSpilledBytes()).as("the shadow must have outgrown its 1 MB RAM budget").isPositive();
+
+      shadowsDuringWindow = shadowFiles();
+      assertThat(shadowsDuringWindow).as("the spill file must exist while the window is open").isNotEmpty();
+
+      // THE POINT OF THE TEST: A SPILLED PRE-IMAGE READS BACK EXACTLY LIKE A RAM ONE
+      assertThat(checksums(snapshot)).isEqualTo(t0Checksums);
+    }
+
+    assertThat(shadowFiles()).as("the scratch file must be deleted when the window closes").isEmpty();
+  }
+
+  /**
    * Challenge C8: the shadow is pure scratch, so a crash mid-window leaves an orphan file which the next open must
    * delete. It must also never be mistaken for a data file, which is why its extension is absent from
    * {@code LocalDatabase.SUPPORTED_FILE_EXT}.
@@ -508,6 +555,12 @@ class PageSnapshotTest extends TestHelper {
 
   private void newDocument(final int id, final String payload) {
     database.newDocument(TYPE).set("id", id).set("payload", payload).save();
+  }
+
+  private File[] shadowFiles() {
+    final File[] found = new File(database.getDatabasePath()).listFiles(
+        (dir, name) -> name.endsWith("." + PageSnapshot.SHADOW_FILE_EXT));
+    return found != null ? found : new File[0];
   }
 
   private Map<Integer, Long> checksums(final PageSnapshot snapshot) throws IOException {

--- a/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.Record;
 import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.schema.DocumentType;
@@ -41,6 +42,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -65,7 +67,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class PageSnapshotTest extends TestHelper {
 
   private static final String TYPE       = "Doc";
-  private static final String SPILL_TYPE = "Spill";
+  private static final String SPILL_TYPE  = "Spill";
+  private static final String SPARSE_TYPE = "Sparse";
 
   @Override
   protected void beginTest() {
@@ -425,6 +428,58 @@ class PageSnapshotTest extends TestHelper {
     }
 
     assertThat(database.countType(TYPE, false)).isEqualTo(2_000);
+  }
+
+  /**
+   * A SPARSE set of shadowed pages inside one bulk-read run: the case the reader gets wrong if it only restores the
+   * pages it found missing on the first probe.
+   * <p>
+   * The reader resolves a run of {@code READ_RUN_PAGES} pages by probing the shadow, bulk-reading the span of pages
+   * that were NOT in it, then re-probing. A page that was already shadowed but sits INSIDE that span - because its
+   * neighbours were not shadowed - has its pre-image overwritten by the bulk read, and is only restored if the
+   * re-probe is unconditional. Pages are shadowed in write order, which has nothing to do with run boundaries, so
+   * this is the ordinary case rather than an exotic one, and getting it wrong is silent: the archive simply holds
+   * post-t0 content for those pages.
+   * <p>
+   * Updating one record every few hundred lands the dirty pages scattered across the file, which is exactly the
+   * pattern needed. The assertion is the whole-file checksum, so any page served from after t0 fails it.
+   */
+  @Test
+  void aSparseSetOfShadowedPagesInsideOneReadRunStillServesT0() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    database.getSchema().buildDocumentType().withName(SPARSE_TYPE).withTotalBuckets(1).withPageSize(16_384).create();
+    database.transaction(() -> {
+      for (int i = 0; i < 20_000; i++)
+        database.newDocument(SPARSE_TYPE).set("id", i).set("payload", "p".repeat(120)).save();
+    });
+    pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      final Map<Integer, Long> t0Checksums = checksums(snapshot);
+      final int filesAtT0 = snapshot.getFiles().size();
+
+      // EVERY 500th RECORD: THE DIRTIED PAGES ARE SPREAD OUT, SO A BULK-READ RUN TYPICALLY SPANS SHADOWED PAGES
+      // WITH UNSHADOWED NEIGHBOURS ON BOTH SIDES
+      database.transaction(() -> {
+        final Iterator<Record> records = database.iterateType(SPARSE_TYPE, false);
+        for (int i = 0; records.hasNext(); i++) {
+          final Record record = records.next();
+          if (i % 500 == 0)
+            record.asDocument().modify().set("payload", "M".repeat(120)).save();
+        }
+      });
+      pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+      final int shadowed = snapshot.getShadowedPages();
+      assertThat(shadowed).as("the scattered updates must shadow some pages, but far from all of them").isPositive();
+      assertThat(shadowed).as("a fully shadowed file would not exercise the mixed run this test is about")
+          .isLessThan(filesAtT0 * 100);
+
+      assertThat(checksums(snapshot)).as("a page shadowed before the read must not be served from the live file")
+          .isEqualTo(t0Checksums);
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
@@ -1,0 +1,507 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.exception.PageSnapshotException;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.CRC32;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the page-level copy-on-write snapshot primitive of issue #6075, phase 2b of the backup roadmap.
+ * <p>
+ * The property under test throughout is that a window opened at t0 keeps serving the t0 image no matter what the
+ * live database does afterwards. Every test that asserts "the snapshot did not change" also asserts that the LIVE
+ * files DID change in the meantime, so it cannot pass vacuously by simply not writing anything.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PageSnapshotTest extends TestHelper {
+
+  private static final String TYPE = "Doc";
+
+  @Override
+  protected void beginTest() {
+    final Schema schema = database.getSchema();
+    final DocumentType type = schema.createDocumentType(TYPE);
+    type.createProperty("id", Integer.class);
+    type.createProperty("payload", String.class);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 2_000; i++)
+        newDocument(i, "initial");
+    });
+  }
+
+  /**
+   * The headline property: with the window open, rewriting every record leaves the snapshot untouched. The live
+   * files are asserted to have changed, and the shadow to have captured pages, so a snapshot that silently returned
+   * the LIVE bytes would fail here rather than pass by accident.
+   */
+  @Test
+  void snapshotKeepsServingTheT0ImageWhileTheDatabaseIsRewritten() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+      assertThat(snapshot.getFiles()).isNotEmpty();
+
+      // THE SNAPSHOT MUST START OUT BYTE-IDENTICAL TO THE FILES ON DISK: NOTHING IS WRITING RIGHT NOW
+      final Map<Integer, Long> t0Checksums = new HashMap<>();
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles()) {
+        final long viaSnapshot = snapshot.calculateChecksum(file.fileId());
+        assertThat(viaSnapshot).as("file %s at t0", file.fileName()).isEqualTo(file.file().calculateChecksum());
+        t0Checksums.put(file.fileId(), viaSnapshot);
+      }
+
+      // REWRITE EVERY RECORD SEVERAL TIMES AND PUSH IT ALL TO DISK
+      for (int round = 0; round < 3; round++) {
+        final int currentRound = round;
+        database.transaction(() -> {
+          database.iterateType(TYPE, false).forEachRemaining(record -> {
+            final MutableDocument doc = record.asDocument().modify();
+            doc.set("payload", "rewritten-" + currentRound + "-" + "x".repeat(200));
+            doc.save();
+          });
+        });
+        pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+      }
+
+      assertThat(snapshot.getShadowedPages())
+          .as("the rewrite must have forced pre-image captures, otherwise this test proves nothing").isPositive();
+
+      boolean anyLiveFileChanged = false;
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles()) {
+        assertThat(snapshot.calculateChecksum(file.fileId())).as("snapshot of %s after the rewrite", file.fileName())
+            .isEqualTo(t0Checksums.get(file.fileId()));
+        if (file.file().calculateChecksum() != t0Checksums.get(file.fileId()))
+          anyLiveFileChanged = true;
+      }
+      assertThat(anyLiveFileChanged).as("the live database must have changed under the snapshot").isTrue();
+    }
+
+    assertThat(pageManager.isSnapshotWindowOpen(db)).isFalse();
+  }
+
+  /**
+   * A snapshot restored into a fresh directory has to be a database that opens, passes the integrity check and
+   * holds exactly the records that existed at t0 - not a byte more, not a byte less.
+   */
+  @Test
+  void restoredSnapshotOpensAndHoldsExactlyTheRecordsOfT0() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final File restoreDir = new File("target/databases/" + getClass().getSimpleName() + "-restored");
+    FileUtils.deleteRecursively(restoreDir);
+
+    final long countAtT0;
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      countAtT0 = database.countType(TYPE, false);
+
+      // ADD RECORDS AFTER t0: THEY MUST NOT SHOW UP IN THE RESTORE
+      database.transaction(() -> {
+        for (int i = 0; i < 500; i++)
+          newDocument(100_000 + i, "after-t0");
+      });
+      pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+      restoreTo(restoreDir, snapshot);
+    }
+
+    try (final DatabaseFactory restoredFactory = new DatabaseFactory(restoreDir.getAbsolutePath())) {
+      final Database restored = restoredFactory.open();
+      try {
+        assertThat(restored.countType(TYPE, false)).isEqualTo(countAtT0);
+        assertThat(restored.command("sql", "check database").nextIfAvailable().<Long>getProperty("totalErrors")).isZero();
+      } finally {
+        restored.drop();
+      }
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(countAtT0 + 500);
+  }
+
+  /**
+   * The t0 barrier under sustained concurrent write load, which is the test that justifies the whole design: the
+   * window is opened while writers are mid-flight, and the image it serves must be a genuine transaction boundary -
+   * a restored copy opens, passes the integrity check, and holds a record count between what was committed before
+   * the barrier started and what was committed by the time it returned. A torn snapshot fails the integrity check;
+   * a snapshot that kept moving fails the upper bound.
+   */
+  @Test
+  void barrierProducesAConsistentPointInTimeUnderConcurrentWriters() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final File restoreDir = new File("target/databases/" + getClass().getSimpleName() + "-restored-concurrent");
+    FileUtils.deleteRecursively(restoreDir);
+
+    final AtomicBoolean running = new AtomicBoolean(true);
+    final AtomicInteger committed = new AtomicInteger();
+    final AtomicReference<Exception> writerFailure = new AtomicReference<>();
+    final CountDownLatch warmedUp = new CountDownLatch(1);
+
+    final List<Thread> writers = new ArrayList<>();
+    for (int w = 0; w < 4; w++) {
+      final int writerId = w;
+      final Thread writer = new Thread(() -> {
+        int seq = 0;
+        while (running.get()) {
+          try {
+            final int id = 1_000_000 * (writerId + 1) + seq++;
+            database.transaction(() -> newDocument(id, "concurrent"));
+            committed.incrementAndGet();
+            warmedUp.countDown();
+          } catch (final Exception e) {
+            writerFailure.compareAndSet(null, e);
+            return;
+          }
+        }
+      }, "snapshot-writer-" + w);
+      writer.setDaemon(true);
+      writers.add(writer);
+      writer.start();
+    }
+
+    try {
+      assertThat(warmedUp.await(30, TimeUnit.SECONDS)).isTrue();
+
+      final long committedBeforeBarrier = database.countType(TYPE, false);
+      final PageSnapshot snapshot = pageManager.openSnapshot(db);
+      final long committedAfterBarrier = database.countType(TYPE, false);
+      try {
+        // KEEP THE WRITERS HAMMERING WHILE THE SNAPSHOT IS BEING READ: EVERY PAGE THEY TOUCH GOES THROUGH THE
+        // COPY-ON-WRITE HOOK AND MUST BE SERVED FROM THE SHADOW HERE
+        Thread.sleep(500);
+        restoreTo(restoreDir, snapshot);
+        assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+      } finally {
+        snapshot.close();
+      }
+
+      running.set(false);
+      for (final Thread writer : writers)
+        writer.join(30_000);
+      assertThat(writerFailure.get()).isNull();
+
+      try (final DatabaseFactory restoredFactory = new DatabaseFactory(restoreDir.getAbsolutePath())) {
+        final Database restored = restoredFactory.open();
+        try {
+          assertThat(restored.command("sql", "check database").nextIfAvailable().<Long>getProperty("totalErrors")).isZero();
+          assertThat(restored.countType(TYPE, false)).isBetween(committedBeforeBarrier, committedAfterBarrier);
+        } finally {
+          restored.drop();
+        }
+      }
+    } finally {
+      running.set(false);
+      for (final Thread writer : writers)
+        writer.join(30_000);
+    }
+  }
+
+  /**
+   * Challenge C3: two windows opened at different instants each keep their OWN point in time. The shared pre-image
+   * read is only correct because a page's content when it is first written after t1 is also its content at t1.
+   */
+  @Test
+  void overlappingWindowsEachServeTheirOwnPointInTime() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    try (final PageSnapshot first = pageManager.openSnapshot(db)) {
+      final Map<Integer, Long> firstChecksums = checksums(first);
+
+      database.transaction(() -> {
+        for (int i = 0; i < 500; i++)
+          newDocument(200_000 + i, "between-windows");
+      });
+      pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+      try (final PageSnapshot second = pageManager.openSnapshot(db)) {
+        final Map<Integer, Long> secondChecksums = checksums(second);
+        assertThat(secondChecksums).as("the second window must see the records written after the first one")
+            .isNotEqualTo(firstChecksums);
+
+        database.transaction(() -> {
+          for (int i = 0; i < 500; i++)
+            newDocument(300_000 + i, "after-both-windows");
+        });
+        pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+        assertThat(checksums(first)).isEqualTo(firstChecksums);
+        assertThat(checksums(second)).isEqualTo(secondChecksums);
+      }
+
+      // THE FIRST WINDOW OUTLIVES THE SECOND AND IS STILL ANCHORED WHERE IT WAS
+      database.transaction(() -> newDocument(400_000, "after-the-second-window-closed"));
+      pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+      assertThat(checksums(first)).isEqualTo(firstChecksums);
+    }
+  }
+
+  /**
+   * Challenge C4: on breaching the cap the window fails loudly instead of silently serving a mix of t0 and live
+   * pages. Silent unbounded growth, and silent truncation, are both unacceptable; a consumer catching this falls
+   * back to the suspend-and-freeze path.
+   */
+  @Test
+  void shadowCapBreachInvalidatesTheWindowInsteadOfTearingIt() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    // ENOUGH RECORDS TO SPREAD OVER MANY PAGES, SO REWRITING THEM DIRTIES FAR MORE THAN THE CAP BELOW ALLOWS
+    database.transaction(() -> {
+      for (int i = 0; i < 20_000; i++)
+        newDocument(500_000 + i, "z".repeat(500));
+    });
+    pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+    // ONE MEGABYTE OF SHADOW: A HANDFUL OF PAGES, WHICH THE REWRITE BELOW BLOWS THROUGH IMMEDIATELY
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.setValue(1);
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.setValue(1);
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+
+      for (int round = 0; round < 5 && snapshot.getStatus() == PageSnapshot.STATUS.ACTIVE; round++) {
+        final int currentRound = round;
+        database.transaction(() -> {
+          database.iterateType(TYPE, false).forEachRemaining(record -> {
+            final MutableDocument doc = record.asDocument().modify();
+            doc.set("payload", "overflow-" + currentRound + "-" + "y".repeat(400));
+            doc.save();
+          });
+        });
+        pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+      }
+
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.OVERFLOWED);
+      assertThatThrownBy(() -> snapshot.calculateChecksum(snapshot.getFiles().getFirst().fileId()))
+          .isInstanceOf(PageSnapshotException.class).hasMessageContaining("OVERFLOWED");
+    }
+
+    // THE LIVE DATABASE IS UNHARMED: A SNAPSHOT MUST NEVER BE ABLE TO BREAK IT
+    assertThat(database.countType(TYPE, false)).isEqualTo(22_000);
+  }
+
+  /**
+   * Challenge C2: a file dropped while a window is open survives on disk until the window closes, so index
+   * compaction (which drops files and does NOT take the database write lock) can keep running during a backup
+   * instead of being postponed for its whole duration.
+   */
+  @Test
+  void aFileDroppedDuringAWindowIsDeletedOnlyWhenTheWindowCloses() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    database.getSchema().createDocumentType("Disposable");
+    database.transaction(() -> {
+      for (int i = 0; i < 100; i++)
+        database.newDocument("Disposable").set("id", i).save();
+    });
+    pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+    final List<File> droppedFiles = new ArrayList<>();
+    for (final ComponentFile file : db.getFileManager().getFiles())
+      if (file != null && file.getComponentName().startsWith("Disposable"))
+        droppedFiles.add(file.getOSFile());
+    assertThat(droppedFiles).isNotEmpty();
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      for (final File file : droppedFiles)
+        assertThat(snapshot.getFile(fileIdOf(db, file))).isNotNull();
+
+      database.getSchema().dropType("Disposable");
+
+      assertThat(database.getSchema().existsType("Disposable")).isFalse();
+      for (final File file : droppedFiles)
+        assertThat(file).as("deletion of %s must be deferred while the window is open", file.getName()).exists();
+
+      // AND THE WINDOW STILL READS EVERY FILE IT CAPTURED, THE DROPPED ONES INCLUDED
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+        assertThat(snapshot.calculateChecksum(file.fileId())).isNotNegative();
+    }
+
+    for (final File file : droppedFiles)
+      assertThat(file).as("deletion of %s must happen when the window closes", file.getName()).doesNotExist();
+  }
+
+  /**
+   * Challenge C8: the shadow is pure scratch, so a crash mid-window leaves an orphan file which the next open must
+   * delete. It must also never be mistaken for a data file, which is why its extension is absent from
+   * {@code LocalDatabase.SUPPORTED_FILE_EXT}.
+   */
+  @Test
+  void orphanShadowFilesAreDeletedOnOpen() throws Exception {
+    final File orphan = new File(database.getDatabasePath(), "snapshot-42." + PageSnapshot.SHADOW_FILE_EXT);
+    Files.write(orphan.toPath(), new byte[] { 1, 2, 3 });
+    assertThat(orphan).exists();
+
+    reopenDatabase();
+
+    assertThat(orphan).doesNotExist();
+    assertThat(database.countType(TYPE, false)).isEqualTo(2_000);
+    for (final ComponentFile file : ((DatabaseInternal) database).getFileManager().getFiles())
+      if (file != null)
+        assertThat(file.getFileExtension()).isNotEqualTo(PageSnapshot.SHADOW_FILE_EXT);
+  }
+
+  /**
+   * Acceptance criterion of #6075: index compaction RUNS during a window instead of being postponed for its whole
+   * duration. The old suspension was the only thing keeping the compactor from dropping a file under a running
+   * backup, and {@code LSMTreeIndex.scheduleCompaction} refuses outright while flushing is suspended - so a long
+   * backup silently stopped compaction. The snapshot suspends nothing, and the compacted file it drops has its
+   * deletion deferred instead.
+   */
+  @Test
+  void indexCompactionRunsWhileAWindowIsOpen() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    // NO AUTOMATIC SCHEDULING, SO THE COMPACTION THIS TEST DRIVES IS THE ONLY ONE IN FLIGHT AND THE ASSERTION BELOW
+    // IS ABOUT THE GUARD BEING OPEN, NOT ABOUT WINNING A RACE WITH THE BACKGROUND COMPACTOR
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+
+    database.getSchema().buildTypeIndex(TYPE, new String[] { "id" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false).withPageSize(4_096).create();
+    database.transaction(() -> {
+      for (int i = 0; i < 20_000; i++)
+        newDocument(600_000 + i, "for-the-index");
+    });
+    pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+    final IndexInternal index = (IndexInternal) database.getSchema().getType(TYPE).getIndexesByProperties("id").getFirst();
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      final Map<Integer, Long> t0Checksums = checksums(snapshot);
+
+      assertThat(pageManager.isPageFlushingSuspended(db)).as("a snapshot window must not suspend page flushing").isFalse();
+
+      // BEFORE #6075 BOTH OF THESE RETURNED false FOR AS LONG AS THE BACKUP HELD ITS FLUSH SUSPENSION
+      assertThat(index.scheduleCompaction()).as("compaction must not be postponed by an open window").isTrue();
+      assertThat(index.compact()).as("a compaction must complete while the window is open").isTrue();
+      pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+      // AND THE WINDOW IS STILL READABLE, INCLUDING THE FILES THE COMPACTION DROPPED
+      assertThat(checksums(snapshot)).isEqualTo(t0Checksums);
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(22_000);
+  }
+
+  /** With no window open nothing is registered, so the write path's single field read stays null. */
+  @Test
+  void noWindowRegisteredWhenNoneIsOpen() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    assertThat(db.getPageManager().isSnapshotWindowOpen(db)).isFalse();
+
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      assertThat(db.getPageManager().isSnapshotWindowOpen(db)).isTrue();
+      assertThat(snapshot.getLastTxId()).isNotNegative();
+    }
+
+    assertThat(db.getPageManager().isSnapshotWindowOpen(db)).isFalse();
+  }
+
+  // ------------------------------------------------------------------------------------------------------ HELPERS
+
+  private void newDocument(final int id, final String payload) {
+    database.newDocument(TYPE).set("id", id).set("payload", payload).save();
+  }
+
+  private Map<Integer, Long> checksums(final PageSnapshot snapshot) throws IOException {
+    final Map<Integer, Long> result = new HashMap<>();
+    for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+      result.put(file.fileId(), snapshot.calculateChecksum(file.fileId()));
+    return result;
+  }
+
+  private int fileIdOf(final DatabaseInternal db, final File osFile) {
+    for (final ComponentFile file : db.getFileManager().getFiles())
+      if (file != null && file.getOSFile().equals(osFile))
+        return file.getFileId();
+    throw new IllegalArgumentException("File '" + osFile + "' is not registered");
+  }
+
+  /**
+   * Materialises the snapshot as a database directory: the two configuration files (which the real backup copies
+   * under the database read lock, since the snapshot only covers PAGE files) plus every page file as of t0.
+   */
+  private void restoreTo(final File targetDir, final PageSnapshot snapshot) throws IOException {
+    assertThat(targetDir.mkdirs() || targetDir.isDirectory()).isTrue();
+
+    final File configurationFile = ((LocalDatabase) ((DatabaseInternal) database).getEmbedded()).getConfigurationFile();
+    if (configurationFile.exists())
+      Files.copy(configurationFile.toPath(), new File(targetDir, configurationFile.getName()).toPath());
+
+    final File schemaFile = ((LocalSchema) database.getSchema()).getConfigurationFile();
+    if (schemaFile.exists())
+      Files.copy(schemaFile.toPath(), new File(targetDir, schemaFile.getName()).toPath());
+
+    for (final PageSnapshot.SnapshotFile file : snapshot.getFiles()) {
+      final CRC32 crc = new CRC32();
+      long written = 0;
+      try (final InputStream in = snapshot.newInputStream(file.fileId());
+          final OutputStream out = new FileOutputStream(new File(targetDir, file.fileName()))) {
+        final byte[] buffer = new byte[64 * 1024];
+        for (int read = in.read(buffer); read > 0; read = in.read(buffer)) {
+          crc.update(buffer, 0, read);
+          out.write(buffer, 0, read);
+          written += read;
+        }
+      }
+      assertThat(written).as("stream of %s", file.fileName()).isEqualTo(file.size());
+      assertThat(crc.getValue()).isEqualTo(snapshot.calculateChecksum(file.fileId()));
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageSnapshotTest.java
@@ -376,6 +376,57 @@ class PageSnapshotTest extends TestHelper {
   }
 
   /**
+   * The window between listing the files a snapshot covers and publishing the window has to be closed, or a file
+   * dropped inside it is physically deleted even though the snapshot has already claimed it - and the reader then
+   * holds a closed channel. Index compaction drops files without taking any database lock, so this is a live race,
+   * not a theoretical one. The drops here run against a snapshot barrier over and over to exercise the interleaving.
+   */
+  @Test
+  void aFileDroppedWhileAWindowIsOpeningIsNeverDeletedUnderIt() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final int rounds = 30;
+    for (int i = 0; i < rounds; i++) {
+      final String typeName = "Racy" + i;
+      database.getSchema().createDocumentType(typeName);
+      final int round = i;
+      database.transaction(() -> {
+        for (int r = 0; r < 50; r++)
+          database.newDocument(typeName).set("id", round * 1000 + r).save();
+      });
+    }
+    pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+    final AtomicReference<Exception> dropperFailure = new AtomicReference<>();
+    for (int i = 0; i < rounds; i++) {
+      final String typeName = "Racy" + i;
+      final Thread dropper = new Thread(() -> {
+        try {
+          database.getSchema().dropType(typeName);
+        } catch (final Exception e) {
+          dropperFailure.compareAndSet(null, e);
+        }
+      }, "snapshot-race-dropper-" + i);
+      dropper.setDaemon(true);
+      dropper.start();
+
+      try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+        // EVERY FILE THE WINDOW CLAIMED MUST STILL BE READABLE, WHETHER OR NOT THE DROP LANDED INSIDE THE BARRIER
+        for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+          assertThat(snapshot.calculateChecksum(file.fileId())).as("file %s of round %d", file.fileName(), 0)
+              .isNotNegative();
+        assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+      }
+
+      dropper.join(30_000);
+      assertThat(dropperFailure.get()).isNull();
+    }
+
+    assertThat(database.countType(TYPE, false)).isEqualTo(2_000);
+  }
+
+  /**
    * Challenge C8: the shadow is pure scratch, so a crash mid-window leaves an orphan file which the next open must
    * delete. It must also never be mistaken for a data file, which is why its extension is absent from
    * {@code LocalDatabase.SUPPORTED_FILE_EXT}.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostVerifyDatabaseHandler.java
@@ -20,6 +20,9 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.exception.PageSnapshotException;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
@@ -42,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 /**
@@ -125,20 +129,43 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
     final JSONObject localChecksums = new JSONObject();
     final JSONArray localFiles = new JSONArray();
     db.executeInReadLock(() -> {
+      // #6075: CRC THE FILES THROUGH A POINT-IN-TIME SNAPSHOT INSTEAD OF FREEZING THEM WITH A FLUSH SUSPENSION. A
+      // VERIFY OF A LARGE DATABASE READS EVERY BYTE OF EVERY FILE, SO THE OLD PATH THROTTLED WRITERS FOR ITS WHOLE
+      // DURATION AND POSTPONED INDEX COMPACTION WITH THEM. THE CHECKSUM IS BYTE-FOR-BYTE THE SAME VALUE, SO A PEER
+      // STILL ON THE FALLBACK PATH COMPARES EQUAL
+      if (db.getConfiguration().getValueAsBoolean(GlobalConfiguration.PAGE_SNAPSHOT_ENABLED)) {
+        // COLLECTED ASIDE AND MERGED ONLY ON SUCCESS: A WINDOW INVALIDATED HALFWAY THROUGH MUST NOT LEAVE THE
+        // RESPONSE HOLDING A MIX OF SNAPSHOT AND FALLBACK CHECKSUMS
+        final JSONObject snapshotChecksums = new JSONObject();
+        final JSONArray snapshotFiles = new JSONArray();
+        try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+          for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+            try {
+              collectFileInfo(snapshotChecksums, snapshotFiles, file.fileName(), snapshot.calculateChecksum(file.fileId()),
+                  file.size());
+            } catch (final PageSnapshotException e) {
+              throw e;
+            } catch (final Exception e) {
+              // skip files that cannot be checksummed (e.g. in-flight creation)
+            }
+
+          for (final String name : snapshotChecksums.keySet())
+            localChecksums.put(name, snapshotChecksums.getLong(name));
+          for (int i = 0; i < snapshotFiles.length(); i++)
+            localFiles.put(snapshotFiles.getJSONObject(i));
+          return null;
+        } catch (final PageSnapshotException e) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Point-in-time snapshot unusable for the verify of database '%s' (%s): falling back to suspending the page flush",
+              null, db.getName(), e.getMessage());
+        }
+      }
+
       db.getPageManager().suspendFlushAndExecute(db, () -> {
         for (final var file : db.getFileManager().getFiles())
           if (file != null) {
-            final String name = file.getFileName();
             try {
-              final long crc = file.calculateChecksum();
-              localChecksums.put(name, crc);
-
-              final JSONObject fileInfo = new JSONObject();
-              fileInfo.put("name", name);
-              fileInfo.put("checksum", crc);
-              fileInfo.put("size", file.getSize());
-              fileInfo.put("type", categorizeFile(name));
-              localFiles.put(fileInfo);
+              collectFileInfo(localChecksums, localFiles, file.getFileName(), file.calculateChecksum(), file.getSize());
             } catch (final Exception e) {
               // skip files that cannot be checksummed (e.g. in-flight creation)
             }
@@ -342,6 +369,19 @@ public class PostVerifyDatabaseHandler extends AbstractServerHttpHandler {
       peerResult.put("error", e.getMessage());
     }
     return peerResult;
+  }
+
+  /** Records one file's checksum in both shapes the response carries: the flat map peers compare, and the detail list. */
+  private static void collectFileInfo(final JSONObject checksums, final JSONArray files, final String name, final long crc,
+      final long size) {
+    checksums.put(name, crc);
+
+    final JSONObject fileInfo = new JSONObject();
+    fileInfo.put("name", name);
+    fileInfo.put("checksum", crc);
+    fileInfo.put("size", size);
+    fileInfo.put("type", categorizeFile(name));
+    files.put(fileInfo);
   }
 
   private static String categorizeFile(final String fileName) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -23,6 +23,8 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.TransactionManager;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.serializer.json.JSONObject;
@@ -38,6 +40,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -207,9 +210,33 @@ public class SnapshotHttpHandler implements HttpHandler {
       dbSuspendLock.lock();
       try {
         db.executeInReadLock(() -> {
-          // The refcounted suspension (#5068) guarantees the flush thread is parked for this whole read;
-          // perDatabaseSuspendLock additionally serializes same-database zip streams (see its comment).
-          db.getPageManager().suspendFlushAndExecute(db, () -> serveSnapshotZip(exchange, db, databaseName));
+          // #6075: stream the page files through a point-in-time snapshot. Shipping a multi-GB snapshot used to
+          // park the flush thread for the whole transfer, which is the longest-lived suspension in the product:
+          // dirty pages piled up until FLUSH_SUSPEND_MAX_DEFERRED_RAM and the leader's committers were throttled
+          // (issue #4728). The window costs one bounded drain instead, and the archive is exactly as consistent.
+          PageSnapshot snapshot = null;
+          if (db.getConfiguration().getValueAsBoolean(GlobalConfiguration.PAGE_SNAPSHOT_ENABLED))
+            try {
+              snapshot = db.getPageManager().openSnapshot(db);
+            } catch (final PageSnapshotException e) {
+              // ONLY A FAILURE TO OPEN THE WINDOW CAN FALL BACK: ONE THAT FAILS MID-STREAM HAS ALREADY PUT BYTES ON
+              // THE WIRE, SO IT SURFACES AS A TRANSFER ERROR AND THE FOLLOWER RETRIES (THE MANIFEST CHECK OF #4831
+              // MAKES A TRUNCATED DOWNLOAD LOUD RATHER THAN SILENT)
+              LogManager.instance().log(this, Level.WARNING,
+                  "Point-in-time snapshot unusable for '%s' (%s): falling back to suspending the page flush", null,
+                  databaseName, e.getMessage());
+            }
+
+          if (snapshot != null)
+            try {
+              serveSnapshotZip(exchange, db, databaseName, snapshot);
+            } finally {
+              snapshot.close();
+            }
+          else
+            // The refcounted suspension (#5068) guarantees the flush thread is parked for this whole read;
+            // perDatabaseSuspendLock additionally serializes same-database zip streams (see its comment).
+            db.getPageManager().suspendFlushAndExecute(db, () -> serveSnapshotZip(exchange, db, databaseName, null));
           return null;
         });
       } finally {
@@ -311,7 +338,8 @@ public class SnapshotHttpHandler implements HttpHandler {
     return null;
   }
 
-  private void serveSnapshotZip(final HttpServerExchange exchange, final DatabaseInternal db, final String databaseName) {
+  private void serveSnapshotZip(final HttpServerExchange exchange, final DatabaseInternal db, final String databaseName,
+      final PageSnapshot snapshot) {
     final long writeTimeoutMs = httpServer.getServer().getConfiguration().getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_WRITE_TIMEOUT);
     final AtomicBoolean completed = new AtomicBoolean(false);
 
@@ -349,10 +377,15 @@ public class SnapshotHttpHandler implements HttpHandler {
       if (schemaFile.exists())
         addFileToZip(zipOut, schemaFile, manifest);
 
-      final Collection<ComponentFile> files = db.getFileManager().getFiles();
-      for (final ComponentFile file : new ArrayList<>(files))
-        if (file != null)
-          addFileToZip(zipOut, file.getOSFile(), manifest);
+      if (snapshot != null)
+        for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+          addStreamToZip(zipOut, file.fileName(), snapshot.newInputStream(file.fileId()), manifest);
+      else {
+        final Collection<ComponentFile> files = db.getFileManager().getFiles();
+        for (final ComponentFile file : new ArrayList<>(files))
+          if (file != null)
+            addFileToZip(zipOut, file.getOSFile(), manifest);
+      }
 
       // TimeSeries sealed-store files (.ts.sealed) use raw FileChannel I/O and are NOT registered with
       // the FileManager, so they are absent from getFiles(). Add them explicitly so a snapshot-syncing
@@ -370,7 +403,12 @@ public class SnapshotHttpHandler implements HttpHandler {
       // data and is needlessly re-installed from a full snapshot at the next cold bootstrap. The
       // LIVE counter is used because the leader's own on-disk copy is stale while the database is
       // open; it is read under the same suspendFlushAndExecute window as the data files above.
-      final long lastTxId = ((LocalDatabase) db.getEmbedded()).getLastTransactionId();
+      // From a window, the recorded t0 id is the one the shipped pages actually materialise, because the window
+      // opens on a fully drained flush queue - strictly better than the live counter, which can name a transaction
+      // whose pages are still in the queue.
+      final long lastTxId = snapshot != null ?
+          snapshot.getLastTxId() :
+          ((LocalDatabase) db.getEmbedded()).getLastTransactionId();
       if (lastTxId >= 0)
         addBytesToZip(zipOut, TransactionManager.LAST_TX_ID_FILE_NAME, longToBytes(lastTxId), manifest);
 
@@ -452,6 +490,23 @@ public class SnapshotHttpHandler implements HttpHandler {
     }
     zipOut.closeEntry();
     manifest.add(new SnapshotManager.ManifestEntry(inputFile.getName(), size, crc.getValue()));
+  }
+
+  /**
+   * Streams a point-in-time page file into the ZIP and appends its manifest record. The size and CRC are computed
+   * from the exact bytes streamed, so they describe what the follower receives.
+   */
+  private void addStreamToZip(final ZipOutputStream zipOut, final String name, final InputStream input,
+      final List<SnapshotManager.ManifestEntry> manifest) throws Exception {
+    final ZipEntry entry = new ZipEntry(name);
+    zipOut.putNextEntry(entry);
+    final CRC32 crc = new CRC32();
+    final long size;
+    try (final InputStream in = input; final CheckedInputStream cis = new CheckedInputStream(in, crc)) {
+      size = cis.transferTo(zipOut);
+    }
+    zipOut.closeEntry();
+    manifest.add(new SnapshotManager.ManifestEntry(name, size, crc.getValue()));
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -26,6 +26,7 @@ import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.PageSnapshot;
 import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.CodeUtils;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
@@ -227,13 +228,19 @@ public class SnapshotHttpHandler implements HttpHandler {
                   databaseName, e.getMessage());
             }
 
-          if (snapshot != null)
+          if (snapshot != null) {
+            final PageSnapshot openWindow = snapshot;
             try {
-              serveSnapshotZip(exchange, db, databaseName, snapshot);
+              // THE SUSPEND-AND-FREEZE BRANCH BELOW RUNS ITS CALLBACK THROUGH suspendFlushAndExecute, WHICH LOGS AND
+              // SWALLOWS. MATCHING THAT HERE KEEPS THE HANDLER'S CONTRACT IDENTICAL ON BOTH PATHS: A TRANSFER THAT
+              // DIES MID-STREAM HAS ALREADY COMMITTED ITS RESPONSE, SO THERE IS NOTHING USEFUL TO TURN THE THROW
+              // INTO - THE FOLLOWER DETECTS THE MISSING MANIFEST (#4831) AND RETRIES
+              CodeUtils.executeIgnoringExceptions(() -> serveSnapshotZip(exchange, db, databaseName, openWindow),
+                  "Error serving the snapshot of database '" + databaseName + "'", true);
             } finally {
-              snapshot.close();
+              openWindow.close();
             }
-          else
+          } else
             // The refcounted suspension (#5068) guarantees the flush thread is parked for this whole read;
             // perDatabaseSuspendLock additionally serializes same-database zip streams (see its comment).
             db.getPageManager().suspendFlushAndExecute(db, () -> serveSnapshotZip(exchange, db, databaseName, null));

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/BackupArchiveWriter.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/BackupArchiveWriter.java
@@ -21,6 +21,7 @@ package com.arcadedb.integration.backup.format;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Minimal contract a full-backup archive writer has to satisfy: append whole files as independent ZIP entries and, on
@@ -47,6 +48,15 @@ public interface BackupArchiveWriter extends Closeable {
    * Appends the whole content of {@code inputFile}, which must exist, as a new archive entry named after the file.
    */
   EntryStats addFile(File inputFile) throws IOException;
+
+  /**
+   * Appends a stream as a new archive entry under an explicit name, for content that is not a file on disk.
+   * <p>
+   * The full backup reads its page files through a point-in-time snapshot ({@code PageManager.openSnapshot}, issue
+   * #6075) rather than straight off the filesystem, so what it hands over is a stream of the page images as of t0,
+   * not a {@link File}. The stream is fully consumed and closed by the implementation.
+   */
+  EntryStats addEntry(String name, long lastModified, InputStream input) throws IOException;
 
   /**
    * Terminates the archive. The underlying stream is left open for the caller to close.

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -22,6 +22,8 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.integration.backup.BackupException;
 import com.arcadedb.integration.backup.BackupSettings;
 import com.arcadedb.integration.backup.IoThrottler;
@@ -40,6 +42,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.SecureRandom;
 import java.security.spec.KeySpec;
@@ -93,44 +96,57 @@ public class FullBackupFormat extends AbstractBackupFormat {
 
     final long beginTime = System.currentTimeMillis();
     final AtomicLong databaseOrigSize = new AtomicLong();
-    // PageManager.suspendFlushAndExecute RUNS ITS CALLBACK THROUGH CodeUtils.executeIgnoringExceptions, WHICH LOGS AND
-    // SWALLOWS. WITHOUT CARRYING THE FAILURE OUT BY HAND, A BACKUP THAT DIED HALFWAY WOULD STILL GET ITS CENTRAL
-    // DIRECTORY WRITTEN AND BE REPORTED AS SUCCESSFUL - A TRUNCATED ARCHIVE THAT LOOKS VALID IS THE WORST POSSIBLE
-    // FAILURE MODE FOR A BACKUP
-    final AtomicReference<Exception> failure = new AtomicReference<>();
 
-    try {
-      writeArchive(backupFile, compressionLevel, compressionThreads, maxMBPerSecond, failure, archive ->
-        // ACQUIRE A READ LOCK. TRANSACTION CAN STILL RUN, BUT CREATION OF NEW FILES (BUCKETS, TYPES, INDEXES) WILL BE PUT ON PAUSE UNTIL THIS LOCK IS RELEASED
-        database.executeInReadLock(() -> {
-          // FORCE FLUSHING BEFORE THE BACKUP AND AVOID FLUSHING OF DATA PAGES TO DISK
-          database.getPageManager().suspendFlushAndExecute(database, () -> {
-            try {
-              long origSize = 0L;
-              origSize += compressFile(archive, ((LocalDatabase) database.getEmbedded()).getConfigurationFile());
-              origSize += compressFile(archive, ((LocalSchema) database.getSchema()).getConfigurationFile());
+    // #6075: READ THE PAGE FILES THROUGH A POINT-IN-TIME SNAPSHOT INSTEAD OF FREEZING THEM. THE OLD PATH SUSPENDED
+    // PAGE FLUSHING FOR THE WHOLE BACKUP, SO DIRTY PAGES PILED UP IN RAM UNTIL FLUSH_SUSPEND_MAX_DEFERRED_RAM AND
+    // COMMITTING THREADS WERE THROTTLED - AND LSM/VECTOR INDEX COMPACTION WAS POSTPONED WITH THEM. IT IS KEPT AS A
+    // FALLBACK, SELECTED BY CONFIGURATION OR AUTOMATICALLY WHEN THE SHADOW BREACHES ITS CAP
+    boolean useSnapshot = database.getConfiguration().getValueAsBoolean(GlobalConfiguration.PAGE_SNAPSHOT_ENABLED);
 
-              final Collection<ComponentFile> files = database.getFileManager().getFiles();
+    while (true) {
+      // PageManager.suspendFlushAndExecute RUNS ITS CALLBACK THROUGH CodeUtils.executeIgnoringExceptions, WHICH LOGS AND
+      // SWALLOWS. WITHOUT CARRYING THE FAILURE OUT BY HAND, A BACKUP THAT DIED HALFWAY WOULD STILL GET ITS CENTRAL
+      // DIRECTORY WRITTEN AND BE REPORTED AS SUCCESSFUL - A TRUNCATED ARCHIVE THAT LOOKS VALID IS THE WORST POSSIBLE
+      // FAILURE MODE FOR A BACKUP
+      final AtomicReference<Exception> failure = new AtomicReference<>();
+      final boolean snapshotAttempt = useSnapshot;
 
-              for (final ComponentFile file : new ArrayList<>(files))
-                if (file != null)
-                  origSize += compressFile(archive, file.getOSFile());
-
-              databaseOrigSize.set(origSize);
-            } catch (final Exception e) {
-              failure.set(e);
-              throw e;
-            }
-          });
-          return null;
-        }));
-      // NO SECOND CHECK OF failure HERE: writeArchive RETHROWS IT FROM INSIDE ITS OWN CALLBACK, WHICH IT HAS TO DO SO
-      // THE STREAM-CLOSING THERE KNOWS THE BACKUP FAILED. A CHECK AT THIS POINT WOULD BE UNREACHABLE, AND UNREACHABLE
-      // SAFETY NETS ONLY TEACH THE NEXT READER THAT THE THROW ABOVE MIGHT NOT HAPPEN
-    } catch (final Exception e) {
-      // A PARTIAL ARCHIVE MUST NOT SURVIVE: LEAVING ONE BEHIND INVITES A RESTORE FROM IT
-      backupFile.delete();
-      throw e;
+      try {
+        writeArchive(backupFile, compressionLevel, compressionThreads, maxMBPerSecond, failure, archive ->
+          // ACQUIRE A READ LOCK. TRANSACTION CAN STILL RUN, BUT CREATION OF NEW FILES (BUCKETS, TYPES, INDEXES) WILL BE PUT ON PAUSE UNTIL THIS LOCK IS RELEASED
+          database.executeInReadLock(() -> {
+            if (snapshotAttempt)
+              databaseOrigSize.set(backupFromSnapshot(archive));
+            else
+              // FORCE FLUSHING BEFORE THE BACKUP AND AVOID FLUSHING OF DATA PAGES TO DISK
+              database.getPageManager().suspendFlushAndExecute(database, () -> {
+                try {
+                  databaseOrigSize.set(backupFromFrozenFiles(archive));
+                } catch (final Exception e) {
+                  failure.set(e);
+                  throw e;
+                }
+              });
+            return null;
+          }));
+        // NO SECOND CHECK OF failure HERE: writeArchive RETHROWS IT FROM INSIDE ITS OWN CALLBACK, WHICH IT HAS TO DO SO
+        // THE STREAM-CLOSING THERE KNOWS THE BACKUP FAILED. A CHECK AT THIS POINT WOULD BE UNREACHABLE, AND UNREACHABLE
+        // SAFETY NETS ONLY TEACH THE NEXT READER THAT THE THROW ABOVE MIGHT NOT HAPPEN
+        break;
+      } catch (final PageSnapshotException e) {
+        // A PARTIAL ARCHIVE MUST NOT SURVIVE: LEAVING ONE BEHIND INVITES A RESTORE FROM IT
+        backupFile.delete();
+        if (!snapshotAttempt)
+          throw e;
+        // THE WINDOW COULD NOT HOLD THE POINT IN TIME (THE SHADOW BREACHED ITS CAP, OR A PRE-IMAGE COULD NOT BE READ).
+        // A STREAMED ARCHIVE CANNOT BE REPAIRED IN PLACE, SO THE WHOLE BACKUP RESTARTS ON THE PATH THAT ALWAYS
+        // COMPLETES - AT THE COST OF THROTTLING WRITERS, WHICH IS STILL BETTER THAN NOT HAVING A BACKUP
+        logger.logLine(0, "Point-in-time snapshot unusable (%s): retrying with page flushing suspended...", e.getMessage());
+        useSnapshot = false;
+      } catch (final Exception e) {
+        backupFile.delete();
+        throw e;
+      }
     }
 
     final long elapsedInSecs = (System.currentTimeMillis() - beginTime) / 1000;
@@ -140,6 +156,63 @@ public class FullBackupFormat extends AbstractBackupFormat {
     logger.logLine(0, "Full backup completed in %d seconds %s -> %s (%,d%% compressed)", elapsedInSecs,
         FileUtils.getSizeAsString(origSize), FileUtils.getSizeAsString(databaseCompressedSize),
         origSize > 0 ? (origSize - databaseCompressedSize) * 100 / origSize : 0);
+  }
+
+  /**
+   * Archives the two configuration files plus every PAGE file as it stood at the snapshot's t0 (issue #6075).
+   * <p>
+   * The configuration files are still read straight off the filesystem: they are not page files, so the snapshot
+   * does not cover them, and the database read lock this runs under is what keeps them consistent with the page
+   * files - it excludes the DDL that rewrites them. Files created after t0 are absent from the snapshot by
+   * construction, which is correct: they did not exist at the point in time being archived. Files DROPPED after t0
+   * are still readable, because their physical deletion is deferred until the window closes.
+   */
+  private long backupFromSnapshot(final BackupArchiveWriter archive) throws Exception {
+    long origSize = 0L;
+    try (final PageSnapshot snapshot = database.getPageManager().openSnapshot(database)) {
+      origSize += compressFile(archive, ((LocalDatabase) database.getEmbedded()).getConfigurationFile());
+      origSize += compressFile(archive, ((LocalSchema) database.getSchema()).getConfigurationFile());
+
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+        origSize += compressEntry(archive, file.fileName(), file.lastModified(), snapshot.newInputStream(file.fileId()));
+
+      // ANY PAGE READ ABOVE COULD HAVE BEEN THE ONE THAT BREACHED THE SHADOW CAP, AND A STREAM THAT ALREADY FAILED
+      // WOULD HAVE THROWN - BUT RE-CHECKING HERE ALSO CATCHES A WINDOW INVALIDATED AFTER ITS LAST BYTE WAS READ,
+      // WHICH WOULD OTHERWISE PRODUCE AN ARCHIVE NOBODY EVER VERIFIED
+      snapshot.checkValid();
+
+      logger.logLine(2, "- Snapshot at txId=%d shadowed %d page(s), %s (%s spilled to disk)", snapshot.getLastTxId(),
+          snapshot.getShadowedPages(), FileUtils.getSizeAsString(snapshot.getShadowSizeInBytes()),
+          FileUtils.getSizeAsString(snapshot.getShadowSpilledBytes()));
+    }
+    return origSize;
+  }
+
+  /** The historical path: the data files are frozen by suspending page flushing and copied straight off the disk. */
+  private long backupFromFrozenFiles(final BackupArchiveWriter archive) throws IOException {
+    long origSize = 0L;
+    origSize += compressFile(archive, ((LocalDatabase) database.getEmbedded()).getConfigurationFile());
+    origSize += compressFile(archive, ((LocalSchema) database.getSchema()).getConfigurationFile());
+
+    final Collection<ComponentFile> files = database.getFileManager().getFiles();
+
+    for (final ComponentFile file : new ArrayList<>(files))
+      if (file != null)
+        origSize += compressFile(archive, file.getOSFile());
+
+    return origSize;
+  }
+
+  private long compressEntry(final BackupArchiveWriter archive, final String name, final long lastModified,
+      final InputStream input) throws IOException {
+    logger.log(2, "- File '%s'...", name);
+    final BackupArchiveWriter.EntryStats stats = archive.addEntry(name, lastModified, input);
+    final long origSize = stats.uncompressedSize();
+    final long compressedSize = stats.compressedSize();
+
+    logger.logLine(2, " %s -> %s (%,d%% compressed)", FileUtils.getSizeAsString(origSize),
+        FileUtils.getSizeAsString(compressedSize), origSize > 0 ? (origSize - compressedSize) * 100 / origSize : 0);
+    return origSize;
   }
 
   private long compressFile(final BackupArchiveWriter archive, final File inputFile) throws IOException {

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/ParallelZipArchiveWriter.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/ParallelZipArchiveWriter.java
@@ -25,6 +25,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -176,11 +177,18 @@ public class ParallelZipArchiveWriter implements BackupArchiveWriter {
 
   @Override
   public EntryStats addFile(final File inputFile) throws IOException {
+    try (final FileInputStream fileIn = new FileInputStream(inputFile)) {
+      return addEntry(inputFile.getName(), inputFile.lastModified(), fileIn);
+    }
+  }
+
+  @Override
+  public EntryStats addEntry(final String name, final long lastModified, final InputStream input) throws IOException {
     if (closed)
       throw new IllegalStateException("Backup archive already closed");
 
-    final byte[] nameBytes = inputFile.getName().getBytes(StandardCharsets.UTF_8);
-    final int dosTime = toDosTime(inputFile.lastModified());
+    final byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+    final int dosTime = toDosTime(lastModified);
     final long localHeaderOffset = written;
 
     writeLocalFileHeader(nameBytes, dosTime);
@@ -191,20 +199,20 @@ public class ParallelZipArchiveWriter implements BackupArchiveWriter {
     long uncompressedSize = 0L;
     long compressedSize = 0L;
     try {
-      try (final FileInputStream fileIn = new FileInputStream(inputFile)) {
+      try (final InputStream in = input) {
         while (true) {
-          final byte[] input = acquireInputBuffer();
-          final int read = fileIn.readNBytes(input, 0, chunkSize);
+          final byte[] chunk = acquireInputBuffer();
+          final int read = in.readNBytes(chunk, 0, chunkSize);
           if (read <= 0) {
-            inputBufferPool.push(input);
+            inputBufferPool.push(chunk);
             break;
           }
 
           throttler.throttle(read);
-          crc.update(input, 0, read);
+          crc.update(chunk, 0, read);
           uncompressedSize += read;
 
-          inFlight.add(submitChunk(input, read));
+          inFlight.add(submitChunk(chunk, read));
 
           while (inFlight.size() >= maxChunksInFlight)
             compressedSize += drainChunk(inFlight.poll());

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/ZipStreamArchiveWriter.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/ZipStreamArchiveWriter.java
@@ -23,6 +23,7 @@ import com.arcadedb.integration.backup.IoThrottler;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.ZipEntry;
@@ -53,13 +54,22 @@ public class ZipStreamArchiveWriter implements BackupArchiveWriter {
 
   @Override
   public EntryStats addFile(final File inputFile) throws IOException {
-    final ZipEntry zipEntry = new ZipEntry(inputFile.getName());
+    try (final FileInputStream fileIn = new FileInputStream(inputFile)) {
+      return addEntry(inputFile.getName(), inputFile.lastModified(), fileIn);
+    }
+  }
+
+  @Override
+  public EntryStats addEntry(final String name, final long lastModified, final InputStream input) throws IOException {
+    final ZipEntry zipEntry = new ZipEntry(name);
+    if (lastModified > 0)
+      zipEntry.setTime(lastModified);
     zipStream.putNextEntry(zipEntry);
 
     long uncompressedSize = 0L;
-    try (final FileInputStream fileIn = new FileInputStream(inputFile)) {
+    try (final InputStream in = input) {
       int read;
-      while ((read = fileIn.read(buffer)) > 0) {
+      while ((read = in.read(buffer)) > 0) {
         throttler.throttle(read);
         zipStream.write(buffer, 0, read);
         uncompressedSize += read;

--- a/integration/src/test/java/com/arcadedb/integration/backup/BackupCompressionIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/BackupCompressionIT.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.integration.restore.Restore;
+import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
@@ -213,17 +214,22 @@ class BackupCompressionIT {
    * Regression: a backup that failed halfway used to report success. {@code PageManager.suspendFlushAndExecute} runs
    * its callback through {@code CodeUtils.executeIgnoringExceptions}, so the archive was finalized with a valid
    * central directory over a truncated set of entries - a backup that looks valid and is not.
+   * <p>
+   * The failure is injected on the SCHEMA configuration file, which both backup paths read straight off the
+   * filesystem. Since #6075 the page files are read through the snapshot's already-open channels, so revoking their
+   * permission mid-run no longer breaks a backup at all - the coverage that matters here is the archive lifecycle,
+   * and it is exercised on the snapshot path and the suspend-and-freeze fallback alike.
    */
   @ParameterizedTest
-  @CsvSource({ "0", "4" })
-  void aFailedBackupThrowsAndLeavesNoArchive(final int threads) throws Exception {
+  @CsvSource({ "0,true", "4,true", "0,false", "4,false" })
+  void aFailedBackupThrowsAndLeavesNoArchive(final int threads, final boolean snapshot) throws Exception {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
     try (final Database database = createDatabase()) {
-      final ComponentFile unreadable = ((DatabaseInternal) database).getFileManager().getFiles().stream()
-          .filter(f -> f != null && f.getOSFile().length() > 0).reduce((first, second) -> second).orElseThrow();
+      final File unreadable = ((LocalSchema) database.getSchema()).getConfigurationFile();
 
       // POSIX ONLY: WHERE THE PERMISSION CANNOT BE TAKEN AWAY (WINDOWS, RUNNING AS ROOT) THERE IS NO WAY TO MAKE A
-      // COMPONENT FILE FAIL TO OPEN, SO THE SCENARIO IS NOT REPRODUCIBLE AND THE TEST SKIPS RATHER THAN PASSING VACUOUSLY
-      assumeTrue(unreadable.getOSFile().setReadable(false) && !unreadable.getOSFile().canRead(),
+      // FILE FAIL TO OPEN, SO THE SCENARIO IS NOT REPRODUCIBLE AND THE TEST SKIPS RATHER THAN PASSING VACUOUSLY
+      assumeTrue(unreadable.setReadable(false) && !unreadable.canRead(),
           "cannot make a database file unreadable on this platform");
       try {
         assertThatThrownBy(() -> new Backup(database, BACKUP_FILE).setVerboseLevel(0).setCompressionThreads(threads)
@@ -231,8 +237,10 @@ class BackupCompressionIT {
 
         assertThat(new File(BACKUP_FILE)).as("a partial archive must not survive a failed backup").doesNotExist();
       } finally {
-        unreadable.getOSFile().setReadable(true);
+        unreadable.setReadable(true);
       }
+    } finally {
+      GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.reset();
     }
     TestHelper.checkActiveDatabases();
   }

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
@@ -34,7 +34,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -68,6 +71,8 @@ class Issue6075SnapshotBackupIT {
   @AfterEach
   void clean() {
     GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.reset();
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.reset();
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.reset();
     FileUtils.deleteRecursively(new File(DATABASE_PATH));
     FileUtils.deleteRecursively(new File(RESTORED_PATH));
     new File(BACKUP_FILE).delete();
@@ -128,6 +133,81 @@ class Issue6075SnapshotBackupIT {
 
     assertThat(withoutSnapshot).as("the fallback path must still suspend flushing for the whole backup").isGreaterThan(0.9);
     assertThat(withSnapshot).as("a snapshot backup must not hold the flush suspension for its duration").isLessThan(0.5);
+  }
+
+  /**
+   * The reliability story of the snapshot path is that a window which cannot hold its point in time does NOT produce
+   * a torn archive: the whole backup restarts on the suspend-and-freeze path, which throttles writers but always
+   * completes. A streamed archive cannot be repaired in place, so this is a restart of `writeArchive` against the
+   * same file, and it has to be exercised end to end rather than only at the `PageSnapshot` level.
+   * <p>
+   * The shadow cap is set to 1 MB - a handful of 64 KB pages - while a writer rewrites the whole 10 MB dataset in a
+   * loop, so the window is certain to overflow while the (throttled) backup is still reading.
+   */
+  @Test
+  void aShadowOverflowMidBackupFallsBackAndStillProducesARestorableArchive() throws Exception {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(true);
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.setValue(1);
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.setValue(1);
+
+    final PrintStream originalOut = System.out;
+    final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+
+    try (final Database database = createDatabase()) {
+      final AtomicBoolean running = new AtomicBoolean(true);
+      final AtomicReference<Exception> writerFailure = new AtomicReference<>();
+      final CountDownLatch warmedUp = new CountDownLatch(1);
+
+      final Thread writer = new Thread(() -> {
+        int round = 0;
+        while (running.get()) {
+          final int current = round++;
+          try {
+            // A FULL REWRITE PASS DIRTIES EVERY PAGE OF THE DATASET, SO THE 1 MB SHADOW IS BLOWN THROUGH AT ONCE
+            database.transaction(() -> database.iterateType(TYPE, false).forEachRemaining(
+                record -> record.asDocument().modify().set("payload", "overflow-" + current + "-" + "y".repeat(500)).save()));
+            warmedUp.countDown();
+          } catch (final Exception e) {
+            writerFailure.compareAndSet(null, e);
+            return;
+          }
+        }
+      }, "backup-overflow-writer");
+      writer.setDaemon(true);
+      writer.start();
+
+      try {
+        assertThat(warmedUp.await(60, TimeUnit.SECONDS)).isTrue();
+
+        System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+          new Backup(database, BACKUP_FILE).setVerboseLevel(0).setMaxMBPerSecond(2).backupDatabase();
+        } finally {
+          System.setOut(originalOut);
+        }
+
+        running.set(false);
+        writer.join(60_000);
+        assertThat(writerFailure.get()).isNull();
+
+        assertThat(captured.toString(StandardCharsets.UTF_8))
+            .as("the overflow must have driven the documented fallback, not merely been survived")
+            .contains("Point-in-time snapshot unusable");
+
+        assertThat(new File(BACKUP_FILE)).exists();
+        new Restore(BACKUP_FILE, RESTORED_PATH).setVerboseLevel(0).restoreDatabase();
+
+        try (final Database restored = new DatabaseFactory(RESTORED_PATH).open()) {
+          assertThat(restored.command("sql", "check database").nextIfAvailable().<Long>getProperty("totalErrors")).isZero();
+          assertThat(restored.countType(TYPE, false)).isEqualTo(RECORDS);
+        }
+      } finally {
+        System.setOut(originalOut);
+        running.set(false);
+        writer.join(60_000);
+      }
+    }
+    TestHelper.checkActiveDatabases();
   }
 
   private double measureSuspendedFraction(final boolean snapshot) throws Exception {

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.backup;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.restore.Restore;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end coverage of the full backup reading through the point-in-time page snapshot of issue #6075.
+ * <p>
+ * Two properties are defended. The first is correctness: a backup taken while transactions are committing restores to
+ * a database that opens, passes the integrity check, and holds a record count between what was committed when the
+ * backup started and what was committed when it finished - so the archive is a genuine point in time, neither torn
+ * nor moving. The second is the reason the change exists: page flushing is no longer suspended for the DURATION of
+ * the backup, so committing threads are not throttled by the {@code FLUSH_SUSPEND_MAX_DEFERRED_RAM} backlog.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6075SnapshotBackupIT {
+  private static final String DATABASE_PATH = "target/databases/backup-snapshot";
+  private static final String RESTORED_PATH = "target/databases/backup-snapshot-restored";
+  private static final String BACKUP_FILE   = "target/backup-snapshot.zip";
+  private static final String TYPE          = "Doc";
+  private static final int    RECORDS       = 20_000;
+  /** Throttled so the backup lasts long enough to sample the flush-suspension state a meaningful number of times. */
+  private static final int    MAX_MB_PER_SECOND = 4;
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.reset();
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    new File(BACKUP_FILE).delete();
+  }
+
+  /**
+   * The archive is a point in time even though transactions kept committing throughout, on the snapshot path and on
+   * the suspend-and-freeze fallback alike.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void backupUnderConcurrentWritersRestoresToAPointInTime(final boolean snapshot) throws Exception {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
+
+    try (final Database database = createDatabase()) {
+      final AtomicBoolean running = new AtomicBoolean(true);
+      final AtomicReference<Exception> writerFailure = new AtomicReference<>();
+      final CountDownLatch warmedUp = new CountDownLatch(1);
+      final AtomicInteger sequence = new AtomicInteger(RECORDS);
+
+      final Thread writer = writerThread(database, running, writerFailure, warmedUp, sequence);
+      try {
+        assertThat(warmedUp.await(30, TimeUnit.SECONDS)).isTrue();
+
+        final long countBefore = database.countType(TYPE, false);
+        new Backup(database, BACKUP_FILE).setVerboseLevel(0).setMaxMBPerSecond(MAX_MB_PER_SECOND).backupDatabase();
+        final long countAfter = database.countType(TYPE, false);
+
+        assertThat(countAfter).as("the writers must have kept committing during the backup").isGreaterThan(countBefore);
+
+        running.set(false);
+        writer.join(30_000);
+        assertThat(writerFailure.get()).isNull();
+
+        new Restore(BACKUP_FILE, RESTORED_PATH).setVerboseLevel(0).restoreDatabase();
+
+        try (final Database restored = new DatabaseFactory(RESTORED_PATH).open()) {
+          assertThat(restored.command("sql", "check database").nextIfAvailable().<Long>getProperty("totalErrors")).isZero();
+          assertThat(restored.countType(TYPE, false)).isBetween(countBefore, countAfter);
+        }
+      } finally {
+        running.set(false);
+        writer.join(30_000);
+      }
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * The headline win: with the snapshot the flush thread is parked only for the t0 barrier, not for the whole
+   * backup. The suspend-and-freeze path is measured in the same run as the control - it is suspended essentially
+   * from the first sample to the last - so the comparison does not depend on any absolute timing of this machine.
+   */
+  @Test
+  void theBackupNoLongerSuspendsPageFlushingForItsWholeDuration() throws Exception {
+    final double withSnapshot = measureSuspendedFraction(true);
+    final double withoutSnapshot = measureSuspendedFraction(false);
+
+    assertThat(withoutSnapshot).as("the fallback path must still suspend flushing for the whole backup").isGreaterThan(0.9);
+    assertThat(withSnapshot).as("a snapshot backup must not hold the flush suspension for its duration").isLessThan(0.5);
+  }
+
+  private double measureSuspendedFraction(final boolean snapshot) throws Exception {
+    clean();
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
+
+    try (final Database database = createDatabase()) {
+      final DatabaseInternal db = (DatabaseInternal) database;
+      final PageManager pageManager = db.getPageManager();
+
+      final AtomicBoolean sampling = new AtomicBoolean(true);
+      final AtomicLong samples = new AtomicLong();
+      final AtomicLong suspendedSamples = new AtomicLong();
+
+      final Thread sampler = new Thread(() -> {
+        while (sampling.get()) {
+          samples.incrementAndGet();
+          if (pageManager.isPageFlushingSuspended(db))
+            suspendedSamples.incrementAndGet();
+          try {
+            Thread.sleep(1);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+        }
+      }, "backup-suspension-sampler");
+      sampler.setDaemon(true);
+      sampler.start();
+
+      try {
+        new Backup(database, BACKUP_FILE).setVerboseLevel(0).setMaxMBPerSecond(MAX_MB_PER_SECOND).backupDatabase();
+      } finally {
+        sampling.set(false);
+        sampler.join(10_000);
+      }
+
+      assertThat(samples.get()).as("the throttled backup must last long enough to sample").isGreaterThan(50);
+      return (double) suspendedSamples.get() / samples.get();
+    }
+  }
+
+  private Thread writerThread(final Database database, final AtomicBoolean running, final AtomicReference<Exception> failure,
+      final CountDownLatch warmedUp, final AtomicInteger sequence) {
+    final Thread writer = new Thread(() -> {
+      while (running.get()) {
+        try {
+          final int id = sequence.incrementAndGet();
+          database.transaction(
+              () -> database.newDocument(TYPE).set("id", id).set("payload", "concurrent-" + id).save());
+          warmedUp.countDown();
+        } catch (final Exception e) {
+          failure.compareAndSet(null, e);
+          return;
+        }
+      }
+    }, "backup-snapshot-writer");
+    writer.setDaemon(true);
+    writer.start();
+    return writer;
+  }
+
+  private Database createDatabase() {
+    final Database database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createDocumentType(TYPE);
+    database.transaction(() -> {
+      for (int i = 0; i < RECORDS; i++)
+        database.newDocument(TYPE).set("id", i).set("payload", "x".repeat(500)).save();
+    });
+    ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+    return database;
+  }
+}


### PR DESCRIPTION
Closes #6075. Phase 2b of the backup roadmap (`docs/optimize-backup.md`, section 8), the prerequisite for phase 3 (incremental backup).

## What this replaces

`PageManager.suspendFlushAndExecute` freezes the data files so they can be read raw. While it holds, dirty pages accumulate in `PageManagerFlushThread.deferredByDatabase` bounded by `FLUSH_SUSPEND_MAX_DEFERRED_RAM` (512 MB), past which committing threads are throttled outright, and LSM/vector index compaction is postponed for the whole window. It is replaced by a real point-in-time snapshot primitive: `PageManager.openSnapshot()`.

While a window is open, the first write to any page that existed at t0 copies that page's current on-disk image into a shadow, inside the per-page I/O slot the write already holds. A reader resolves every page as "shadow if present, data file otherwise" and therefore sees exactly the t0 image. **Flushing is never suspended**, so writers run at full speed for the whole operation.

## Zero cost when no window is open

The hook goes strictly inside the write branch of `PageManager.concurrentPageAccess`, the single funnel both physical page-write call sites (`flushPage`, `writePageWithLock`) already go through - so it covers them by construction, with no new lock and no new lock-ordering risk. With no window open it is one volatile field read plus a branch the predictor always gets right, inside a critical section that already performs a 64 KB `pwrite`. One nullable field, not a listener list; nothing before the null check.

## The t0 barrier

Flipping the flag is not the same as opening the window: `concurrentPageAccess` grants the write slot with a `putIfAbsent`, so at the instant of the flip a writer can already be inside its write section having read "no window". Every writer is therefore excluded **before** t0 is stamped, each by the mechanism that already serializes it:

1. `waitAllPagesOfDatabaseAreFlushed` - a **full** queue drain, not just the in-flight batch. This is what makes t0 a genuine, recent transaction boundary and closes the recency gap of section 1.3 (a restored backup could be a few hundred transactions behind).
2. The flush thread is suspended and its in-flight batch awaited, so the async path parks on a **batch** (= transaction) boundary. If commits slipped in between the drain and the suspension, the suspension is released (flushing what it deferred) and the barrier retries.
3. `TransactionManager`'s new `applyLock`, taken exclusively, excludes Raft and crash-recovery replay - the one writer that reaches the files outside the flush pipeline. The shared side is one uncontended acquisition per replayed transaction, never on the local commit path.
4. The global page-manager lock excludes synchronous commits, which publish their pages from `publishPages`.

Only then are the per-file page counts and `lastTxId` recorded and the window published.

## Challenges from the issue

- **C1 (per-page locked reads).** Solved better than the issue proposed, and without the suggested batching heuristic: a write during the window **always** shadows the page before touching the file, so a run of pages is read in one bulk call with **no per-page lock at all**, and the shadow is re-probed afterwards. Any page a writer touched underneath the read is now in the shadow and its t0 image is taken from there, so a torn read is always detected. Sequential I/O and OS readahead are preserved; the common case costs one probe per page against a primitive map. (`PaginatedComponentFile.readPages`.)
- **C2 (file existence).** Solved by deferring the physical delete, not by re-adding a compaction guard. `FileManager.dropFile` hands the file to the open windows, refcounted, and the last one to close deletes it. **Index compaction now runs during a backup** instead of being postponed - covered by a test that asserts `scheduleCompaction()`/`compact()` both succeed inside a window and that the snapshot stays readable afterwards.
- **C3 (overlapping windows).** Supported directly rather than serialized: each window owns its shadow and a write captures the same freshly read pre-image into every window that still needs it. That is correct because a page's content at capture time IS its content at t0 for any window that has not shadowed it. Only the barrier is serialized, per database.
- **C4 (unbounded growth).** `arcadedb.pageSnapshotMaxSize` (1 GB default). On breach the window is invalidated and every read fails loudly with `PageSnapshotException` - never silent growth, never a torn artifact. A backup restarts on the suspend-and-freeze path.
- **C5 (write amplification).** The shadow is RAM-first (`arcadedb.pageSnapshotMaxRAM`, 64 MB) with append-only disk spill, so a short backup at a moderate write rate never touches the disk.
- **C6 (cheap map).** Open-addressing primitive `long -> long` map, keys packing `fileId`/`pageNumber`, 16 bytes per entry, no boxing and no allocation on the flush path.
- **C7 (growth/truncation).** Per-file page counts captured at t0; pages beyond them need no shadow. A short read past the recorded count fails the window rather than serving zeros.
- **C8 (crash safety).** `.pshadow` is pure scratch, absent from `LocalDatabase.SUPPORTED_FILE_EXT`, and orphans are deleted at the next open.

## Consumers migrated

- **Full backup** (`FullBackupFormat`), with automatic fallback: a window that cannot hold its point in time restarts the whole backup on the suspend-and-freeze path, which throttles writers but always completes.
- **HA database verify** (`PostVerifyDatabaseHandler`). The checksum is byte-for-byte the value `PaginatedComponentFile.calculateChecksum()` produces, so a peer still on the fallback path compares equal.
- **HA snapshot ship** (`SnapshotHttpHandler`). It also now reports the snapshot's t0 transaction id for the `last-tx-id.bin` marker (#5277) instead of the live counter, which could name a transaction whose pages were still in the queue.

`arcadedb.pageSnapshotEnabled = false` selects the historical path outright.

## Verification

New `engine/.../PageSnapshotTest` (9 tests). Every test that asserts "the snapshot did not change" also asserts the **live** files did change in the meantime, so none can pass vacuously:

- the t0 image survives rewriting every record three times, with pre-image captures proven to have happened;
- a restored snapshot opens, passes `CHECK DATABASE` and holds **exactly** the records of t0;
- the barrier under four concurrent writer threads: the restore passes `CHECK DATABASE` and its record count sits between what was committed before the barrier and what was committed when it returned - a torn snapshot fails the integrity check, a moving one fails the upper bound;
- overlapping windows each keep their own point in time, including after the inner one closes;
- a cap breach invalidates the window and every read throws, while the live database is unharmed;
- a file dropped mid-window survives until the window closes and not one moment longer;
- index compaction completes inside a window;
- an orphan `.pshadow` is deleted on open and never registered as a component file.

New `integration/.../Issue6075SnapshotBackupIT` (3 tests): a backup under concurrent writers restores to a point in time on both paths, and - the headline win, measured rather than asserted from first principles - **the fraction of the backup during which page flushing is suspended drops from >90% on the fallback path to <50%** (in practice a few ms of barrier), with the fallback measured in the same run as the control so the comparison does not depend on machine timing.

Existing suites re-run green: the whole `com.arcadedb.engine` and `com.arcadedb.index`/`com.arcadedb.schema` packages (2094 tests), the whole `integration` module including its ITs (206 tests), and the HA snapshot/verify unit tests (106 tests). `BackupCompressionIT.aFailedBackupThrowsAndLeavesNoArchive` needed its failure injection moved to the schema configuration file and now runs on both paths: the snapshot reads page files through channels the database already holds open, so revoking a data file's permission mid-run no longer breaks a backup at all.

## Follow-ups deliberately left out

- `SnapshotHttpHandler`'s `/checksums` sub-path still uses the suspension: it reads the database directory raw (`SnapshotManager.computeFileChecksums`) rather than the registered page files, so it needs a different shape. It is a rarely-called diagnostic.
- Benchmarks for steady-state throughput/latency with no window open, shadow peak size across write rates, and t0 barrier duration at various queue depths are not in this PR; the suspension-fraction measurement above is what defends the acceptance criterion this change is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVFzhZA6cH3FUhnekk1oEz