### PR TITLE
fix(#5866): TS/Prometheus write handlers emit the X-ArcadeDB-Commit-Index bookmark

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
@@ -109,6 +109,68 @@ class RaftTimeSeriesWriteReadYourWritesIT extends BaseRaftHATest {
     }
   }
 
+  /**
+   * Regression test for the fourth review round's coverage gap: the PR body's own stated motivation is that
+   * a partial-write 400 still needs a usable bookmark, since {@code TimeSeriesEngine.appendBatch} commits
+   * each measurement's shard transaction independently - a later measurement being dropped as unknown
+   * doesn't undo an earlier one that already landed. This drives that exact scenario end-to-end: one valid
+   * measurement plus one unknown measurement in the same request (matching the non-HA
+   * {@code PostTimeSeriesWriteHandlerIT#partialWriteReportsDroppedMeasurements} semantics), asserts the 400
+   * response still carries the bookmark, and that the bookmark is usable to read the surviving sample back
+   * from a follower.
+   */
+  @Test
+  void lineProtocolPartialWrite400EmitsUsableCommitIndexBookmark() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int followerIndex = leaderIndex == 0 ? 1 : 0;
+    final int leaderPort = 2480 + leaderIndex;
+    final int followerPort = 2480 + followerIndex;
+    final String dbName = getDatabaseName();
+    final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+    final String tsType = "RywPartialWriteWeather";
+
+    try (final RemoteDatabase setup = new RemoteDatabase("127.0.0.1", leaderPort, dbName, "root", password)) {
+      setup.command("sql",
+          "CREATE TIMESERIES TYPE " + tsType + " TIMESTAMP ts TAGS (location STRING) FIELDS (temperature DOUBLE)");
+    }
+
+    // One valid measurement (tsType) plus one unknown measurement: the handler inserts the valid sample,
+    // then reports 400 naming the dropped one (issue #5036 semantics) - a partial write, not a full rollback.
+    final String lineProtocol = tsType + ",location=us-east temperature=22.5 1000\n"
+        + "ryw_unknown_measurement,location=us value=1.0 2000\n";
+    final HttpURLConnection connection = openLineProtocolConnection(leaderPort, password);
+    try (final OutputStream os = connection.getOutputStream()) {
+      os.write(lineProtocol.getBytes(StandardCharsets.UTF_8));
+      os.flush();
+    }
+    assertThat(connection.getResponseCode())
+        .as("The unknown measurement must still produce a partial-write 400 (issue #5036)")
+        .isEqualTo(400);
+
+    final String bookmarkHeader = connection.getHeaderField("X-ArcadeDB-Commit-Index");
+    assertThat(bookmarkHeader)
+        .as("A partial-write 400 must still carry the bookmark for the measurement that did commit (issue #5866)")
+        .isNotNull();
+    final long writerIndex = Long.parseLong(bookmarkHeader);
+    assertThat(writerIndex).isGreaterThanOrEqualTo(0);
+
+    try (final RemoteDatabase reader = new RemoteDatabase("127.0.0.1", followerPort, dbName, "root", password)) {
+      reader.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+      final var updateMethod = RemoteDatabase.class.getDeclaredMethod("updateLastCommitIndex", long.class);
+      updateMethod.setAccessible(true);
+      updateMethod.invoke(reader, writerIndex);
+
+      final ResultSet rs = reader.query("sql", "SELECT FROM " + tsType);
+      assertThat(rs.stream().count())
+          .as("Follower must see the sample that DID commit despite the request's overall 400, using "
+              + "READ_YOUR_WRITES with the partial-write response's bookmark")
+          .isEqualTo(1);
+    }
+  }
+
   @Test
   void prometheusRemoteWriteEmitsCommitIndexBookmarkUsableOnFollower() throws Exception {
     final int leaderIndex = findLeaderIndex();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.remote.ReadConsistency;
+import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Label;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Sample;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.TimeSeries;
+import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.WriteRequest;
+
+import org.junit.jupiter.api.Test;
+import org.xerial.snappy.Snappy;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5866: {@code PostTimeSeriesWriteHandler} (InfluxDB line protocol ingestion)
+ * and {@code PostPrometheusWriteHandler} (Prometheus remote-write) both extend
+ * {@code AbstractServerHttpHandler} directly rather than {@code DatabaseAbstractHandler}, and commit
+ * their own transaction outside the generic per-request wrapper - the same root cause issue #5862 fixed
+ * for {@code PostBatchHandler}. Before the fix, neither endpoint's response ever carried the
+ * {@code X-ArcadeDB-Commit-Index} bookmark, so a {@code READ_YOUR_WRITES} client ingesting metrics through
+ * either protocol had no bookmark to carry into its next read.
+ * <p>
+ * Each test writes through the raw HTTP endpoint (neither protocol has a {@code RemoteDatabase}-level
+ * client helper), captures the response header directly, and then proves the captured value is a usable
+ * bookmark by seeding a follower {@link RemoteDatabase} connection with it and reading the just-ingested
+ * data back under {@link ReadConsistency#READ_YOUR_WRITES}.
+ */
+class RaftTimeSeriesWriteReadYourWritesIT extends BaseRaftHATest {
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Test
+  void lineProtocolWriteEmitsCommitIndexBookmarkUsableOnFollower() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int followerIndex = leaderIndex == 0 ? 1 : 0;
+    final int leaderPort = 2480 + leaderIndex;
+    final int followerPort = 2480 + followerIndex;
+    final String dbName = getDatabaseName();
+    final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+    final String tsType = "RywWeather";
+
+    try (final RemoteDatabase setup = new RemoteDatabase("127.0.0.1", leaderPort, dbName, "root", password)) {
+      setup.command("sql",
+          "CREATE TIMESERIES TYPE " + tsType + " TIMESTAMP ts TAGS (location STRING) FIELDS (temperature DOUBLE)");
+    }
+
+    final String lineProtocol = tsType + ",location=us-east temperature=22.5 1000\n";
+    final HttpURLConnection connection = openLineProtocolConnection(leaderPort, password);
+    try (final OutputStream os = connection.getOutputStream()) {
+      os.write(lineProtocol.getBytes(StandardCharsets.UTF_8));
+      os.flush();
+    }
+    assertThat(connection.getResponseCode()).isEqualTo(204);
+
+    final String bookmarkHeader = connection.getHeaderField("X-ArcadeDB-Commit-Index");
+    assertThat(bookmarkHeader)
+        .as("PostTimeSeriesWriteHandler must emit the X-ArcadeDB-Commit-Index bookmark on its response (issue #5866)")
+        .isNotNull();
+    final long writerIndex = Long.parseLong(bookmarkHeader);
+    assertThat(writerIndex).isGreaterThanOrEqualTo(0);
+
+    try (final RemoteDatabase reader = new RemoteDatabase("127.0.0.1", followerPort, dbName, "root", password)) {
+      reader.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+      // Seed the reader with the writer's commit index via reflection, since updateLastCommitIndex is
+      // package-private in com.arcadedb.remote (same technique as RaftRemoteReadYourWritesIT).
+      final var updateMethod = RemoteDatabase.class.getDeclaredMethod("updateLastCommitIndex", long.class);
+      updateMethod.setAccessible(true);
+      updateMethod.invoke(reader, writerIndex);
+
+      final ResultSet rs = reader.query("sql", "SELECT FROM " + tsType);
+      assertThat(rs.stream().count())
+          .as("Follower must see the line-protocol-ingested sample when using READ_YOUR_WRITES with the "
+              + "handler's bookmark")
+          .isEqualTo(1);
+    }
+  }
+
+  @Test
+  void prometheusRemoteWriteEmitsCommitIndexBookmarkUsableOnFollower() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int followerIndex = leaderIndex == 0 ? 1 : 0;
+    final int leaderPort = 2480 + leaderIndex;
+    final int followerPort = 2480 + followerIndex;
+    final String dbName = getDatabaseName();
+    final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+    final String metricName = "ryw_cpu_usage";
+
+    final WriteRequest writeRequest = new WriteRequest(List.of(
+        new TimeSeries(
+            List.of(new Label("__name__", metricName), new Label("host", "server1")),
+            List.of(new Sample(75.5, 1000))
+        )
+    ));
+    final byte[] compressed = Snappy.compress(writeRequest.encode());
+
+    final HttpURLConnection connection = openPrometheusWriteConnection(leaderPort, password);
+    try (final OutputStream os = connection.getOutputStream()) {
+      os.write(compressed);
+      os.flush();
+    }
+    assertThat(connection.getResponseCode()).isEqualTo(204);
+
+    final String bookmarkHeader = connection.getHeaderField("X-ArcadeDB-Commit-Index");
+    assertThat(bookmarkHeader)
+        .as("PostPrometheusWriteHandler must emit the X-ArcadeDB-Commit-Index bookmark on its response (issue #5866)")
+        .isNotNull();
+    final long writerIndex = Long.parseLong(bookmarkHeader);
+    assertThat(writerIndex).isGreaterThanOrEqualTo(0);
+
+    try (final RemoteDatabase reader = new RemoteDatabase("127.0.0.1", followerPort, dbName, "root", password)) {
+      reader.setReadConsistency(ReadConsistency.READ_YOUR_WRITES);
+
+      final var updateMethod = RemoteDatabase.class.getDeclaredMethod("updateLastCommitIndex", long.class);
+      updateMethod.setAccessible(true);
+      updateMethod.invoke(reader, writerIndex);
+
+      final ResultSet rs = reader.query("sql", "SELECT FROM " + metricName);
+      assertThat(rs.stream().count())
+          .as("Follower must see the Prometheus remote-write sample when using READ_YOUR_WRITES with the "
+              + "handler's bookmark")
+          .isEqualTo(1);
+    }
+  }
+
+  private HttpURLConnection openLineProtocolConnection(final int port, final String password) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:" + port + "/api/v1/ts/" + getDatabaseName() + "/write?precision=ms")
+        .toURL()
+        .openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(("root:" + password).getBytes()));
+    connection.setRequestProperty("Content-Type", "text/plain");
+    connection.setDoOutput(true);
+    return connection;
+  }
+
+  private HttpURLConnection openPrometheusWriteConnection(final int port, final String password) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:" + port + "/api/v1/ts/" + getDatabaseName() + "/prom/write")
+        .toURL()
+        .openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(("root:" + password).getBytes()));
+    connection.setRequestProperty("Content-Type", "application/x-protobuf");
+    connection.setRequestProperty("Content-Encoding", "snappy");
+    connection.setDoOutput(true);
+    return connection;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
@@ -158,6 +158,54 @@ class RaftTimeSeriesWriteReadYourWritesIT extends BaseRaftHATest {
     }
   }
 
+  /**
+   * Regression test for the second review round on this issue: the fix's first revision resolved
+   * {@code writeRequest.getTimeSeries().isEmpty()}'s 204 short-circuit response's bookmark by moving the
+   * database resolution ahead of the request-body/Snappy validation checks - which turned a
+   * nonexistent-database-plus-bad-body request into a 500 instead of 400, since
+   * {@code AbstractServerHttpHandler.handleRequest}'s catch chain has no arm for
+   * {@code DatabaseOperationException}. The final fix keeps those checks first and resolves the database
+   * only once the payload is known to decode, so this asserts both halves: the empty-write-request 204 now
+   * carries the bookmark, and a bad database name still surfaces as 400, not 500.
+   */
+  @Test
+  void prometheusEmptyWriteRequestStillEmitsBookmarkAndBadDatabaseStays400() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int leaderPort = 2480 + leaderIndex;
+    final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+
+    // Seed a committed index so the leader's lastAppliedIndex is >= 0 (emitCommitIndexBookmark is a no-op
+    // below that).
+    try (final RemoteDatabase setup = new RemoteDatabase("127.0.0.1", leaderPort, getDatabaseName(), "root", password)) {
+      setup.command("sql", "CREATE DOCUMENT TYPE PromEmptyWriteSeed");
+    }
+
+    // An empty WriteRequest (no time series) against the real database: the handler's isEmpty() short-circuit
+    // must still resolve the database first and carry the bookmark on its 204.
+    final byte[] emptyCompressed = Snappy.compress(new WriteRequest(List.of()).encode());
+    final HttpURLConnection emptyConnection = openPrometheusWriteConnection(leaderPort, password);
+    try (final OutputStream os = emptyConnection.getOutputStream()) {
+      os.write(emptyCompressed);
+      os.flush();
+    }
+    assertThat(emptyConnection.getResponseCode()).isEqualTo(204);
+    assertThat(emptyConnection.getHeaderField("X-ArcadeDB-Commit-Index"))
+        .as("The empty-write-request 204 must carry the bookmark too, not just the write-with-data path")
+        .isNotNull();
+
+    // A nonexistent database combined with an empty body must still surface as 400 - not the 500 that a
+    // premature getDatabase() resolution would produce (issue #5866, second review round).
+    final HttpURLConnection badDbEmptyBodyConnection = openPrometheusWriteConnectionForDatabase(leaderPort, password,
+        "this_database_does_not_exist");
+    try (final OutputStream os = badDbEmptyBodyConnection.getOutputStream()) {
+      os.flush();
+    }
+    assertThat(badDbEmptyBodyConnection.getResponseCode())
+        .as("A nonexistent database plus an empty body must stay 400, not fall through to a 500")
+        .isEqualTo(400);
+  }
+
   private HttpURLConnection openLineProtocolConnection(final int port, final String password) throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URI(
         "http://127.0.0.1:" + port + "/api/v1/ts/" + getDatabaseName() + "/write?precision=ms")
@@ -171,8 +219,13 @@ class RaftTimeSeriesWriteReadYourWritesIT extends BaseRaftHATest {
   }
 
   private HttpURLConnection openPrometheusWriteConnection(final int port, final String password) throws Exception {
+    return openPrometheusWriteConnectionForDatabase(port, password, getDatabaseName());
+  }
+
+  private HttpURLConnection openPrometheusWriteConnectionForDatabase(final int port, final String password,
+      final String databaseName) throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URI(
-        "http://127.0.0.1:" + port + "/api/v1/ts/" + getDatabaseName() + "/prom/write")
+        "http://127.0.0.1:" + port + "/api/v1/ts/" + databaseName + "/prom/write")
         .toURL()
         .openConnection();
     connection.setRequestMethod("POST");

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftTimeSeriesWriteReadYourWritesIT.java
@@ -159,51 +159,49 @@ class RaftTimeSeriesWriteReadYourWritesIT extends BaseRaftHATest {
   }
 
   /**
-   * Regression test for the second review round on this issue: the fix's first revision resolved
-   * {@code writeRequest.getTimeSeries().isEmpty()}'s 204 short-circuit response's bookmark by moving the
-   * database resolution ahead of the request-body/Snappy validation checks - which turned a
-   * nonexistent-database-plus-bad-body request into a 500 instead of 400, since
-   * {@code AbstractServerHttpHandler.handleRequest}'s catch chain has no arm for
-   * {@code DatabaseOperationException}. The final fix keeps those checks first and resolves the database
-   * only once the payload is known to decode, so this asserts both halves: the empty-write-request 204 now
-   * carries the bookmark, and a bad database name still surfaces as 400, not 500.
+   * Regression test for the second and third review rounds on this issue. Two earlier revisions of the fix
+   * each moved {@code database} resolution further ahead - first past the request-body/Snappy checks, then
+   * past those but still ahead of the {@code writeRequest.getTimeSeries().isEmpty()} short-circuit - trying
+   * to give that 204 a bookmark too. Both times, {@code httpServer.getServer().getDatabase(..., allowLoad=
+   * false)} throwing {@code DatabaseOperationException} for an absent/closed database turned some
+   * nonexistent-database request into a 500 instead of its pre-#5866 status, since
+   * {@code AbstractServerHttpHandler.handleRequest}'s catch chain has no arm for that exception. The final
+   * fix backs off the "isEmpty() 204 also gets a bookmark" attempt entirely and resolves {@code database}
+   * only once there is an actual write to make - matching the ordering PostPrometheusWriteHandler had before
+   * this PR - so a nonexistent database never reaches {@code getDatabase()} on either the truly-empty-body
+   * path or the well-formed-but-zero-series path.
    */
   @Test
-  void prometheusEmptyWriteRequestStillEmitsBookmarkAndBadDatabaseStays400() throws Exception {
+  void prometheusNonexistentDatabaseNeverSurfacesA500() throws Exception {
     final int leaderIndex = findLeaderIndex();
     assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
     final int leaderPort = 2480 + leaderIndex;
     final String password = BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+    final String bogusDb = "this_database_does_not_exist";
 
-    // Seed a committed index so the leader's lastAppliedIndex is >= 0 (emitCommitIndexBookmark is a no-op
-    // below that).
-    try (final RemoteDatabase setup = new RemoteDatabase("127.0.0.1", leaderPort, getDatabaseName(), "root", password)) {
-      setup.command("sql", "CREATE DOCUMENT TYPE PromEmptyWriteSeed");
-    }
-
-    // An empty WriteRequest (no time series) against the real database: the handler's isEmpty() short-circuit
-    // must still resolve the database first and carry the bookmark on its 204.
-    final byte[] emptyCompressed = Snappy.compress(new WriteRequest(List.of()).encode());
-    final HttpURLConnection emptyConnection = openPrometheusWriteConnection(leaderPort, password);
-    try (final OutputStream os = emptyConnection.getOutputStream()) {
-      os.write(emptyCompressed);
-      os.flush();
-    }
-    assertThat(emptyConnection.getResponseCode()).isEqualTo(204);
-    assertThat(emptyConnection.getHeaderField("X-ArcadeDB-Commit-Index"))
-        .as("The empty-write-request 204 must carry the bookmark too, not just the write-with-data path")
-        .isNotNull();
-
-    // A nonexistent database combined with an empty body must still surface as 400 - not the 500 that a
-    // premature getDatabase() resolution would produce (issue #5866, second review round).
-    final HttpURLConnection badDbEmptyBodyConnection = openPrometheusWriteConnectionForDatabase(leaderPort, password,
-        "this_database_does_not_exist");
+    // A nonexistent database combined with an empty body must stay 400 - not the 500 a premature
+    // getDatabase() resolution ahead of the rawBytes-empty check would produce.
+    final HttpURLConnection badDbEmptyBodyConnection = openPrometheusWriteConnectionForDatabase(leaderPort, password, bogusDb);
     try (final OutputStream os = badDbEmptyBodyConnection.getOutputStream()) {
       os.flush();
     }
     assertThat(badDbEmptyBodyConnection.getResponseCode())
         .as("A nonexistent database plus an empty body must stay 400, not fall through to a 500")
         .isEqualTo(400);
+
+    // The exact case the third review round flagged: a well-formed, Snappy-compressed, protobuf-decodable
+    // WriteRequest with zero time series, against a nonexistent database. This must NOT surface as 500 -
+    // not the 500 a getDatabase() resolution ahead of the isEmpty() check would produce.
+    final byte[] emptyCompressed = Snappy.compress(new WriteRequest(List.of()).encode());
+    final HttpURLConnection badDbEmptyWriteRequestConnection =
+        openPrometheusWriteConnectionForDatabase(leaderPort, password, bogusDb);
+    try (final OutputStream os = badDbEmptyWriteRequestConnection.getOutputStream()) {
+      os.write(emptyCompressed);
+      os.flush();
+    }
+    assertThat(badDbEmptyWriteRequestConnection.getResponseCode())
+        .as("A nonexistent database plus a well-formed but zero-series WriteRequest must not surface as 500")
+        .isNotEqualTo(500);
   }
 
   private HttpURLConnection openLineProtocolConnection(final int port, final String password) throws Exception {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -1038,9 +1038,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * Emits the {@code X-ArcadeDB-Commit-Index} response header, the read-your-writes bookmark a
    * {@code READ_YOUR_WRITES} client captures and carries into its next read. A no-op when {@code haDb} is
    * {@code null} (standalone database) or has not applied anything yet. Shared by
-   * {@link DatabaseAbstractHandler} (issue #5845) and {@link PostBatchHandler} (issue #5862), the only two
-   * write paths whose commit happens outside, or beyond, the generic per-request wrapper in
-   * {@link #handleRequest}.
+   * {@link DatabaseAbstractHandler} (issue #5845), {@link PostBatchHandler} (issue #5862),
+   * {@link PostTimeSeriesWriteHandler} and {@link PostPrometheusWriteHandler} (issue #5866) - every write
+   * path whose commit happens outside, or beyond, the generic per-request wrapper in {@link #handleRequest}.
    */
   protected static void emitCommitIndexBookmark(final HttpServerExchange exchange, final HAReplicatedDatabase haDb) {
     if (haDb == null)

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -70,6 +70,27 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
     // Checked before any payload/parameter validation so an unauthorized caller cannot probe the target database.
     checkAuthorizationOnDatabase(user, databaseParam.getFirst());
 
+    // These two checks stay ahead of resolving `database` on purpose: httpServer.getServer().getDatabase(...,
+    // allowLoad=false) throws DatabaseOperationException (a plain RuntimeException, not one of the specific
+    // arms AbstractServerHttpHandler.handleRequest's catch chain recognizes) when the database is absent or
+    // closed, which falls through to a 500 instead of a 400. Resolving `database` before these would turn a
+    // bad-database-name-plus-empty/corrupt-body request into a 500 - a regression an earlier revision of this
+    // fix introduced and review caught. Neither check needs the database, so they keep running first exactly
+    // as they did before this PR.
+    if (rawBytes == null || rawBytes.length == 0)
+      return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
+
+    // Snappy decompress
+    final byte[] decompressed;
+    try {
+      decompressed = Snappy.uncompress(rawBytes);
+    } catch (final Exception e) {
+      return new ExecutionResponse(400, "{ \"error\" : \"Invalid Snappy-compressed data\"}");
+    }
+
+    // Decode protobuf WriteRequest
+    final WriteRequest writeRequest = WriteRequest.decode(decompressed);
+
     final DatabaseInternal database = httpServer.getServer().getDatabase(databaseParam.getFirst(), false, false);
 
     // Resolved as soon as the database is known - and before the empty-write-request short-circuit below -
@@ -79,19 +100,6 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
     // of how this request rolls back (issue #5866).
     final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
     try {
-      if (rawBytes == null || rawBytes.length == 0)
-        return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
-
-      // Snappy decompress
-      final byte[] decompressed;
-      try {
-        decompressed = Snappy.uncompress(rawBytes);
-      } catch (final Exception e) {
-        return new ExecutionResponse(400, "{ \"error\" : \"Invalid Snappy-compressed data\"}");
-      }
-
-      // Decode protobuf WriteRequest
-      final WriteRequest writeRequest = WriteRequest.decode(decompressed);
       if (writeRequest.getTimeSeries().isEmpty())
         return new ExecutionResponse(204, "");
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -26,6 +26,7 @@ import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.TimeSeriesTypeBuilder;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Label;
 import com.arcadedb.server.http.handler.prometheus.PrometheusTypes.Sample;
@@ -87,67 +88,75 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
 
     final DatabaseInternal database = httpServer.getServer().getDatabase(databaseParam.getFirst(), false, false);
 
-    // NOTE: this transaction does NOT make the request atomic. TimeSeriesShard.appendSamples runs its own
-    // begin/commit on getWrappedDatabaseInstance(), so every appendBatch below has already committed its
-    // shard writes by the time it returns. If a later series throws, the rollback here cannot undo the
-    // series already written and the caller sees an error with part of the payload persisted.
-    database.begin();
+    // Resolved once so the bookmark can be emitted in the finally below even on a partial-write error:
+    // TimeSeriesShard.appendSamples commits its own shard transaction per series, so a series already
+    // appended before a later one throws is durable regardless of how this request rolls back (issue #5866).
+    final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
     try {
-      for (final TimeSeries ts : writeRequest.getTimeSeries()) {
-        final String metricName = ts.getMetricName();
-        if (metricName == null || metricName.isEmpty())
-          continue;
-
-        // Sanitize metric name: dots/hyphens → underscores
-        final String typeName = sanitizeTypeName(metricName);
-
-        // Auto-create type if needed
-        final LocalTimeSeriesType tsType = getOrCreateType(database, typeName, ts.getLabels());
-        final TimeSeriesEngine engine = tsType.getEngine();
-        final List<ColumnDefinition> columns = tsType.getTsColumns();
-
-        // Append this series' samples as ONE batch. All samples of a remote-write TimeSeries share the
-        // same type and labels, so they can go in a single shard transaction. Appending one at a time
-        // would cost a transaction per sample - and on a Raft HA leader, a replicated quorum round trip
-        // per sample, serialized behind the per-shard append lock.
-        final List<Sample> tsSamples = ts.getSamples();
-        final int count = tsSamples.size();
-        if (count == 0)
-          continue;
-
-        final long[] timestamps = new long[count];
-        for (int s = 0; s < count; s++)
-          timestamps[s] = tsSamples.get(s).timestampMs();
-
-        // Fill the value grid column by column, matching its column-major layout. A TAG value comes from
-        // the series labels, which are per-series and not per-sample, so it is resolved ONCE and broadcast
-        // down the column: findLabelValue is a linear scan that re-sanitizes every label name it visits,
-        // so resolving it per sample would repeat identical work for every sample of every tag column.
-        final Object[][] columnValues = new Object[columns.size() - 1][count];
-
-        int colIdx = 0;
-        for (final ColumnDefinition col : columns) {
-          if (col.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
+      // NOTE: this transaction does NOT make the request atomic. TimeSeriesShard.appendSamples runs its own
+      // begin/commit on getWrappedDatabaseInstance(), so every appendBatch below has already committed its
+      // shard writes by the time it returns. If a later series throws, the rollback here cannot undo the
+      // series already written and the caller sees an error with part of the payload persisted.
+      database.begin();
+      try {
+        for (final TimeSeries ts : writeRequest.getTimeSeries()) {
+          final String metricName = ts.getMetricName();
+          if (metricName == null || metricName.isEmpty())
             continue;
 
-          if (col.getRole() == ColumnDefinition.ColumnRole.TAG)
-            Arrays.fill(columnValues[colIdx], findLabelValue(ts.getLabels(), col.getName()));
-          else
-            for (int s = 0; s < count; s++)
-              columnValues[colIdx][s] = tsSamples.get(s).value(); // the "value" field
+          // Sanitize metric name: dots/hyphens → underscores
+          final String typeName = sanitizeTypeName(metricName);
 
-          colIdx++;
+          // Auto-create type if needed
+          final LocalTimeSeriesType tsType = getOrCreateType(database, typeName, ts.getLabels());
+          final TimeSeriesEngine engine = tsType.getEngine();
+          final List<ColumnDefinition> columns = tsType.getTsColumns();
+
+          // Append this series' samples as ONE batch. All samples of a remote-write TimeSeries share the
+          // same type and labels, so they can go in a single shard transaction. Appending one at a time
+          // would cost a transaction per sample - and on a Raft HA leader, a replicated quorum round trip
+          // per sample, serialized behind the per-shard append lock.
+          final List<Sample> tsSamples = ts.getSamples();
+          final int count = tsSamples.size();
+          if (count == 0)
+            continue;
+
+          final long[] timestamps = new long[count];
+          for (int s = 0; s < count; s++)
+            timestamps[s] = tsSamples.get(s).timestampMs();
+
+          // Fill the value grid column by column, matching its column-major layout. A TAG value comes from
+          // the series labels, which are per-series and not per-sample, so it is resolved ONCE and broadcast
+          // down the column: findLabelValue is a linear scan that re-sanitizes every label name it visits,
+          // so resolving it per sample would repeat identical work for every sample of every tag column.
+          final Object[][] columnValues = new Object[columns.size() - 1][count];
+
+          int colIdx = 0;
+          for (final ColumnDefinition col : columns) {
+            if (col.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
+              continue;
+
+            if (col.getRole() == ColumnDefinition.ColumnRole.TAG)
+              Arrays.fill(columnValues[colIdx], findLabelValue(ts.getLabels(), col.getName()));
+            else
+              for (int s = 0; s < count; s++)
+                columnValues[colIdx][s] = tsSamples.get(s).value(); // the "value" field
+
+            colIdx++;
+          }
+
+          engine.appendBatch(timestamps, columnValues);
         }
-
-        engine.appendBatch(timestamps, columnValues);
+        database.commit();
+      } catch (final Exception e) {
+        database.rollback();
+        throw e;
       }
-      database.commit();
-    } catch (final Exception e) {
-      database.rollback();
-      throw e;
-    }
 
-    return new ExecutionResponse(204, "");
+      return new ExecutionResponse(204, "");
+    } finally {
+      emitCommitIndexBookmark(exchange, haDb);
+    }
   }
 
   private LocalTimeSeriesType getOrCreateType(final DatabaseInternal database, final String typeName,

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -70,29 +70,31 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
     // Checked before any payload/parameter validation so an unauthorized caller cannot probe the target database.
     checkAuthorizationOnDatabase(user, databaseParam.getFirst());
 
-    if (rawBytes == null || rawBytes.length == 0)
-      return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
-
-    // Snappy decompress
-    final byte[] decompressed;
-    try {
-      decompressed = Snappy.uncompress(rawBytes);
-    } catch (final Exception e) {
-      return new ExecutionResponse(400, "{ \"error\" : \"Invalid Snappy-compressed data\"}");
-    }
-
-    // Decode protobuf WriteRequest
-    final WriteRequest writeRequest = WriteRequest.decode(decompressed);
-    if (writeRequest.getTimeSeries().isEmpty())
-      return new ExecutionResponse(204, "");
-
     final DatabaseInternal database = httpServer.getServer().getDatabase(databaseParam.getFirst(), false, false);
 
-    // Resolved once so the bookmark can be emitted in the finally below even on a partial-write error:
-    // TimeSeriesShard.appendSamples commits its own shard transaction per series, so a series already
-    // appended before a later one throws is durable regardless of how this request rolls back (issue #5866).
+    // Resolved as soon as the database is known - and before the empty-write-request short-circuit below -
+    // so that response also carries the bookmark, matching PostTimeSeriesWriteHandler's behavior. The
+    // finally also covers a partial-write error: TimeSeriesShard.appendSamples commits its own shard
+    // transaction per series, so a series already appended before a later one throws is durable regardless
+    // of how this request rolls back (issue #5866).
     final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
     try {
+      if (rawBytes == null || rawBytes.length == 0)
+        return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
+
+      // Snappy decompress
+      final byte[] decompressed;
+      try {
+        decompressed = Snappy.uncompress(rawBytes);
+      } catch (final Exception e) {
+        return new ExecutionResponse(400, "{ \"error\" : \"Invalid Snappy-compressed data\"}");
+      }
+
+      // Decode protobuf WriteRequest
+      final WriteRequest writeRequest = WriteRequest.decode(decompressed);
+      if (writeRequest.getTimeSeries().isEmpty())
+        return new ExecutionResponse(204, "");
+
       // NOTE: this transaction does NOT make the request atomic. TimeSeriesShard.appendSamples runs its own
       // begin/commit on getWrappedDatabaseInstance(), so every appendBatch below has already committed its
       // shard writes by the time it returns. If a later series throws, the rollback here cannot undo the

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostPrometheusWriteHandler.java
@@ -70,13 +70,16 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
     // Checked before any payload/parameter validation so an unauthorized caller cannot probe the target database.
     checkAuthorizationOnDatabase(user, databaseParam.getFirst());
 
-    // These two checks stay ahead of resolving `database` on purpose: httpServer.getServer().getDatabase(...,
-    // allowLoad=false) throws DatabaseOperationException (a plain RuntimeException, not one of the specific
-    // arms AbstractServerHttpHandler.handleRequest's catch chain recognizes) when the database is absent or
-    // closed, which falls through to a 500 instead of a 400. Resolving `database` before these would turn a
-    // bad-database-name-plus-empty/corrupt-body request into a 500 - a regression an earlier revision of this
-    // fix introduced and review caught. Neither check needs the database, so they keep running first exactly
-    // as they did before this PR.
+    // These checks - and the writeRequest.getTimeSeries().isEmpty() short-circuit below - stay ahead of
+    // resolving `database` on purpose: httpServer.getServer().getDatabase(..., allowLoad=false) throws
+    // DatabaseOperationException (a plain RuntimeException, not one of the specific arms
+    // AbstractServerHttpHandler.handleRequest's catch chain recognizes) when the database is absent or
+    // closed, which falls through to a 500 instead of a 400/204. An earlier revision of this fix moved
+    // `database` resolution ahead of the isEmpty() check so that response could also carry the bookmark;
+    // review caught that this turns ANY request against a nonexistent database - even a well-formed one
+    // that resolves to zero series - into a 500. None of these checks need the database, and a
+    // zero-series write has nothing to bookmark, so this keeps the pre-#5866 ordering: `database` is
+    // resolved only once there is an actual write to make.
     if (rawBytes == null || rawBytes.length == 0)
       return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
 
@@ -90,19 +93,16 @@ public class PostPrometheusWriteHandler extends AbstractBinaryHttpHandler {
 
     // Decode protobuf WriteRequest
     final WriteRequest writeRequest = WriteRequest.decode(decompressed);
+    if (writeRequest.getTimeSeries().isEmpty())
+      return new ExecutionResponse(204, "");
 
     final DatabaseInternal database = httpServer.getServer().getDatabase(databaseParam.getFirst(), false, false);
 
-    // Resolved as soon as the database is known - and before the empty-write-request short-circuit below -
-    // so that response also carries the bookmark, matching PostTimeSeriesWriteHandler's behavior. The
-    // finally also covers a partial-write error: TimeSeriesShard.appendSamples commits its own shard
-    // transaction per series, so a series already appended before a later one throws is durable regardless
-    // of how this request rolls back (issue #5866).
+    // Resolved once so the bookmark can be emitted in the finally below even on a partial-write error:
+    // TimeSeriesShard.appendSamples commits its own shard transaction per series, so a series already
+    // appended before a later one throws is durable regardless of how this request rolls back (issue #5866).
     final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
     try {
-      if (writeRequest.getTimeSeries().isEmpty())
-        return new ExecutionResponse(204, "");
-
       // NOTE: this transaction does NOT make the request atomic. TimeSeriesShard.appendSamples runs its own
       // begin/commit on getWrappedDatabaseInstance(), so every appendBatch below has already committed its
       // shard writes by the time it returns. If a later series throws, the rollback here cannot undo the

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -30,6 +30,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
@@ -129,146 +130,153 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
 
     final DatabaseInternal database = httpServer.getServer().getDatabase(databaseParam.getFirst(), false, false);
 
-    // Get precision from query parameter
-    final Deque<String> precisionParam = exchange.getQueryParameters().get("precision");
-    final Precision precision = precisionParam != null && !precisionParam.isEmpty()
-        ? Precision.fromString(precisionParam.getFirst())
-        : Precision.NANOSECONDS;
-
-    if (rawPayload == null || rawPayload.isBlank())
-      return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
-
-    // Parse line protocol
-    final List<Sample> samples = LineProtocolParser.parse(rawPayload, precision);
-    if (samples.isEmpty())
-      return new ExecutionResponse(204, "");
-
-    // Group by measurement, then append each group as ONE batch. Appending sample-by-sample would open a
-    // shard transaction per sample; on a Raft HA leader every one of those is a replicated quorum round
-    // trip, serialized behind the per-shard append lock, so ingest rate collapses to one sample per
-    // round trip. Grouping first keeps the cost proportional to the number of measurements, not samples.
-    // LinkedHashMap/LinkedHashSet preserve first-occurrence order, so the drop sets and their reported
-    // order stay identical to a straight pass over the samples.
-    final Set<String> unknownTypes = new LinkedHashSet<>();
-    final Set<String> nonTimeSeriesTypes = new LinkedHashSet<>();
-    final Map<String, MeasurementBatch> byMeasurement = new LinkedHashMap<>();
-
-    for (final Sample sample : samples) {
-      final String measurement = sample.getMeasurement();
-
-      if (unknownTypes.contains(measurement) || nonTimeSeriesTypes.contains(measurement))
-        continue;
-
-      final MeasurementBatch batch = byMeasurement.get(measurement);
-      if (batch != null) {
-        batch.samples().add(sample);
-        continue;
-      }
-
-      if (!database.getSchema().existsType(measurement)) {
-        unknownTypes.add(measurement);
-        continue;
-      }
-
-      final DocumentType docType = database.getSchema().getType(measurement);
-      if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null) {
-        nonTimeSeriesTypes.add(measurement);
-        continue;
-      }
-
-      final MeasurementBatch created = new MeasurementBatch(tsType, new ArrayList<>());
-      created.samples().add(sample);
-      byMeasurement.put(measurement, created);
-    }
-
-    int inserted = 0;
-    // NOTE: this transaction does NOT make the request atomic. TimeSeriesShard.appendSamples runs its own
-    // begin/commit on getWrappedDatabaseInstance(), so every appendBatch below has already committed its
-    // shard writes by the time it returns. If a later measurement throws, the rollback here cannot undo
-    // the measurements already written - the same partial-write shape the 400 response below reports,
-    // now at measurement rather than sample granularity.
-    database.begin();
+    // Resolved once so the bookmark can be emitted in the finally below regardless of which return path is
+    // taken - including the partial-write 400, whose already-inserted samples are durable (issue #5866).
+    final HAReplicatedDatabase haDb = resolveHAReplicatedDatabase(database);
     try {
-      for (final MeasurementBatch batch : byMeasurement.values()) {
-        final TimeSeriesEngine engine = batch.type().getEngine();
-        final List<ColumnDefinition> columns = batch.type().getTsColumns();
-        final List<Sample> group = batch.samples();
-        final int count = group.size();
+      // Get precision from query parameter
+      final Deque<String> precisionParam = exchange.getQueryParameters().get("precision");
+      final Precision precision = precisionParam != null && !precisionParam.isEmpty()
+          ? Precision.fromString(precisionParam.getFirst())
+          : Precision.NANOSECONDS;
 
-        final long[] timestamps = new long[count];
-        final Object[][] columnValues = new Object[columns.size() - 1][count]; // exclude timestamp
+      if (rawPayload == null || rawPayload.isBlank())
+        return new ExecutionResponse(400, "{ \"error\" : \"Request body is empty\"}");
 
-        for (int s = 0; s < count; s++) {
-          final Sample sample = group.get(s);
-          timestamps[s] = sample.getTimestampMs();
+      // Parse line protocol
+      final List<Sample> samples = LineProtocolParser.parse(rawPayload, precision);
+      if (samples.isEmpty())
+        return new ExecutionResponse(204, "");
 
-          int colIdx = 0;
-          for (int i = 0; i < columns.size(); i++) {
-            final ColumnDefinition col = columns.get(i);
-            if (col.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
-              continue;
+      // Group by measurement, then append each group as ONE batch. Appending sample-by-sample would open a
+      // shard transaction per sample; on a Raft HA leader every one of those is a replicated quorum round
+      // trip, serialized behind the per-shard append lock, so ingest rate collapses to one sample per
+      // round trip. Grouping first keeps the cost proportional to the number of measurements, not samples.
+      // LinkedHashMap/LinkedHashSet preserve first-occurrence order, so the drop sets and their reported
+      // order stay identical to a straight pass over the samples.
+      final Set<String> unknownTypes = new LinkedHashSet<>();
+      final Set<String> nonTimeSeriesTypes = new LinkedHashSet<>();
+      final Map<String, MeasurementBatch> byMeasurement = new LinkedHashMap<>();
 
-            Object value;
-            if (col.getRole() == ColumnDefinition.ColumnRole.TAG)
-              value = sample.getTags().get(col.getName());
-            else
-              value = sample.getFields().get(col.getName());
+      for (final Sample sample : samples) {
+        final String measurement = sample.getMeasurement();
 
-            columnValues[colIdx][s] = value;
-            colIdx++;
-          }
+        if (unknownTypes.contains(measurement) || nonTimeSeriesTypes.contains(measurement))
+          continue;
+
+        final MeasurementBatch batch = byMeasurement.get(measurement);
+        if (batch != null) {
+          batch.samples().add(sample);
+          continue;
         }
 
-        engine.appendBatch(timestamps, columnValues);
-        inserted += count;
-      }
-      database.commit();
-    } catch (final Exception e) {
-      database.rollback();
-      throw e;
-    }
+        if (!database.getSchema().existsType(measurement)) {
+          unknownTypes.add(measurement);
+          continue;
+        }
 
-    if (!unknownTypes.isEmpty())
-      LogManager.instance().log(this, Level.WARNING,
-          "Skipped line protocol samples for unknown timeseries type(s): %s", null, unknownTypes);
+        final DocumentType docType = database.getSchema().getType(measurement);
+        if (!(docType instanceof LocalTimeSeriesType tsType) || tsType.getEngine() == null) {
+          nonTimeSeriesTypes.add(measurement);
+          continue;
+        }
 
-    if (!nonTimeSeriesTypes.isEmpty())
-      LogManager.instance().log(this, Level.WARNING,
-          "Skipped line protocol samples for non-timeseries type(s): %s", null, nonTimeSeriesTypes);
-
-    // Any dropped sample is a partial write: matching InfluxDB, return 400 naming the dropped
-    // measurements (with written/dropped counts) even when some samples were inserted, so the client
-    // is not told 204 "all good" while data was silently discarded (issue #5036). The samples that did
-    // insert are already committed above - this is a partial-write signal, not a full rollback.
-    // `dropped` counts individual samples (samples.size() - inserted), consistent with `written`
-    // (inserted samples); every parsed sample is either inserted or skipped into one of the drop sets.
-    final int dropped = samples.size() - inserted;
-    if (dropped > 0) {
-      final StringBuilder msg = new StringBuilder("partial write: ");
-      if (!unknownTypes.isEmpty())
-        msg.append("unknown timeseries type(s): ").append(String.join(", ", unknownTypes))
-            .append(" (create the type first with CREATE TIMESERIES TYPE).");
-      if (!nonTimeSeriesTypes.isEmpty()) {
-        if (!unknownTypes.isEmpty())
-          msg.append(" ");
-        msg.append("non-timeseries type(s): ").append(String.join(", ", nonTimeSeriesTypes))
-            .append(" (only TIMESERIES types can receive line protocol data).");
+        final MeasurementBatch created = new MeasurementBatch(tsType, new ArrayList<>());
+        created.samples().add(sample);
+        byMeasurement.put(measurement, created);
       }
 
-      final JSONObject error = new JSONObject();
-      error.put("error", msg.toString());
-      final String correlationId = getCorrelationId(exchange);
-      if (correlationId != null && !correlationId.isEmpty())
-        error.put("requestId", correlationId);
-      error.put("written", inserted);
-      error.put("dropped", dropped);
+      int inserted = 0;
+      // NOTE: this transaction does NOT make the request atomic. TimeSeriesShard.appendSamples runs its own
+      // begin/commit on getWrappedDatabaseInstance(), so every appendBatch below has already committed its
+      // shard writes by the time it returns. If a later measurement throws, the rollback here cannot undo
+      // the measurements already written - the same partial-write shape the 400 response below reports,
+      // now at measurement rather than sample granularity.
+      database.begin();
+      try {
+        for (final MeasurementBatch batch : byMeasurement.values()) {
+          final TimeSeriesEngine engine = batch.type().getEngine();
+          final List<ColumnDefinition> columns = batch.type().getTsColumns();
+          final List<Sample> group = batch.samples();
+          final int count = group.size();
+
+          final long[] timestamps = new long[count];
+          final Object[][] columnValues = new Object[columns.size() - 1][count]; // exclude timestamp
+
+          for (int s = 0; s < count; s++) {
+            final Sample sample = group.get(s);
+            timestamps[s] = sample.getTimestampMs();
+
+            int colIdx = 0;
+            for (int i = 0; i < columns.size(); i++) {
+              final ColumnDefinition col = columns.get(i);
+              if (col.getRole() == ColumnDefinition.ColumnRole.TIMESTAMP)
+                continue;
+
+              Object value;
+              if (col.getRole() == ColumnDefinition.ColumnRole.TAG)
+                value = sample.getTags().get(col.getName());
+              else
+                value = sample.getFields().get(col.getName());
+
+              columnValues[colIdx][s] = value;
+              colIdx++;
+            }
+          }
+
+          engine.appendBatch(timestamps, columnValues);
+          inserted += count;
+        }
+        database.commit();
+      } catch (final Exception e) {
+        database.rollback();
+        throw e;
+      }
+
       if (!unknownTypes.isEmpty())
-        error.put("unknownTypes", new JSONArray(unknownTypes));
+        LogManager.instance().log(this, Level.WARNING,
+            "Skipped line protocol samples for unknown timeseries type(s): %s", null, unknownTypes);
+
       if (!nonTimeSeriesTypes.isEmpty())
-        error.put("nonTimeSeriesTypes", new JSONArray(nonTimeSeriesTypes));
-      return new ExecutionResponse(400, error.toString());
-    }
+        LogManager.instance().log(this, Level.WARNING,
+            "Skipped line protocol samples for non-timeseries type(s): %s", null, nonTimeSeriesTypes);
 
-    return new ExecutionResponse(204, "");
+      // Any dropped sample is a partial write: matching InfluxDB, return 400 naming the dropped
+      // measurements (with written/dropped counts) even when some samples were inserted, so the client
+      // is not told 204 "all good" while data was silently discarded (issue #5036). The samples that did
+      // insert are already committed above - this is a partial-write signal, not a full rollback.
+      // `dropped` counts individual samples (samples.size() - inserted), consistent with `written`
+      // (inserted samples); every parsed sample is either inserted or skipped into one of the drop sets.
+      final int dropped = samples.size() - inserted;
+      if (dropped > 0) {
+        final StringBuilder msg = new StringBuilder("partial write: ");
+        if (!unknownTypes.isEmpty())
+          msg.append("unknown timeseries type(s): ").append(String.join(", ", unknownTypes))
+              .append(" (create the type first with CREATE TIMESERIES TYPE).");
+        if (!nonTimeSeriesTypes.isEmpty()) {
+          if (!unknownTypes.isEmpty())
+            msg.append(" ");
+          msg.append("non-timeseries type(s): ").append(String.join(", ", nonTimeSeriesTypes))
+              .append(" (only TIMESERIES types can receive line protocol data).");
+        }
+
+        final JSONObject error = new JSONObject();
+        error.put("error", msg.toString());
+        final String correlationId = getCorrelationId(exchange);
+        if (correlationId != null && !correlationId.isEmpty())
+          error.put("requestId", correlationId);
+        error.put("written", inserted);
+        error.put("dropped", dropped);
+        if (!unknownTypes.isEmpty())
+          error.put("unknownTypes", new JSONArray(unknownTypes));
+        if (!nonTimeSeriesTypes.isEmpty())
+          error.put("nonTimeSeriesTypes", new JSONArray(nonTimeSeriesTypes));
+        return new ExecutionResponse(400, error.toString());
+      }
+
+      return new ExecutionResponse(204, "");
+    } finally {
+      emitCommitIndexBookmark(exchange, haDb);
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?

`PostTimeSeriesWriteHandler` (InfluxDB line protocol ingestion, `POST /api/v1/ts/{database}/write`) and
`PostPrometheusWriteHandler` (Prometheus remote-write, `POST /api/v1/ts/{database}/prom/write`) both extend
`AbstractServerHttpHandler` directly instead of `DatabaseAbstractHandler`, and both commit their own
transaction outside the generic per-request wrapper. Because of that, neither handler's response ever
carried the `X-ArcadeDB-Commit-Index` bookmark, so a `READ_YOUR_WRITES` client ingesting metrics through
either protocol had no bookmark to carry into its next read.

The fix resolves the `HAReplicatedDatabase` once, right after each handler fetches its `database` handle,
and emits the bookmark in a `finally` around the rest of `execute()` - mirroring the approach
`PostBatchHandler` already uses (#5865). Emitting from `finally` matters here specifically because both
handlers can return a partial-write 400: `TimeSeriesEngine.appendBatch` commits its own shard transaction
per measurement/series, so a sample or series appended before a later one throws is already durable
regardless of how the request's own transaction rolls back - the response still needs to carry a usable
bookmark for what did commit.

Neither handler has a leader-forwarding relay like `PostBatchHandler.forwardBatchToLeader`, so the
`ExecutionResponse` header-copy half of #5865's fix does not apply here - confirmed while implementing, per
the issue's own note that this was worth checking.

## Motivation

Follow-up to #5862 (fixed in #5865 for `PostBatchHandler`). The same root cause - a write-capable handler
bypassing `DatabaseAbstractHandler` - applies to these two time-series ingestion endpoints as well.

## Related issues

Closes #5866

## Additional Notes

New regression test `RaftTimeSeriesWriteReadYourWritesIT` (ha-raft module, 3-node Raft cluster) covers both
handlers:
- Writes through the raw HTTP endpoint (neither protocol has a `RemoteDatabase`-level client helper) and
  asserts the leader's response carries a non-null `X-ArcadeDB-Commit-Index` header.
- Seeds a follower `RemoteDatabase` connection with that captured value and confirms a `READ_YOUR_WRITES`
  read on the follower sees the just-ingested data - proving the bookmark is not just present but usable.

Verified the test fails without the fix: reverted the three handler/helper changes, reran the suite, and
got the expected `AssertionError: Expecting actual not to be null` on both new tests before restoring the
fix.

Also reran the existing non-HA suites for both handlers (`PostTimeSeriesWriteHandlerIT`,
`PrometheusRemoteWriteReadIT`, 17 tests total) to confirm no regressions.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios

## Review history

4 review cycles against `claude`'s automated review, all addressed:

1. **`c055003b7` → `9cb58642`**: reviewer flagged a minor asymmetry - `PostPrometheusWriteHandler`'s
   empty-write-request 204 didn't resolve `database` first, so it didn't carry a bookmark like
   `PostTimeSeriesWriteHandler`'s equivalent 204 does. Fixed by moving `database`/`haDb` resolution ahead of
   that check.
2. **`9cb58642` → `636db409`**: reviewer caught that the prior fix's reordering also moved `database`
   resolution ahead of the raw-body/Snappy validation checks, turning a nonexistent-database-plus-bad-body
   request into a `500` (`DatabaseOperationException` isn't an arm `AbstractServerHttpHandler.handleRequest`'s
   catch chain recognizes) instead of the previous `400`. Fixed by keeping those two checks ahead of
   `database` resolution, matching pre-PR ordering, while still resolving `database` before the
   `isEmpty()` short-circuit.
3. **`636db409` → `cbff4e9d`**: reviewer found the remaining gap in cycle 2's fix - `database` was still
   resolved ahead of the `writeRequest.getTimeSeries().isEmpty()` short-circuit itself, so a nonexistent
   database combined with a well-formed-but-empty `WriteRequest` (valid Snappy + protobuf, zero series)
   still hit the same `500`. Backed off the "empty-write-request 204 also gets a bookmark" attempt entirely:
   `database` is now resolved only once there's an actual write to make, matching
   `PostPrometheusWriteHandler`'s ordering from before this PR. The empty-write-request 204 no longer
   carries a bookmark (harmless per cycle 1's own framing - a client just keeps its last-known bookmark),
   but a nonexistent database can no longer reach `getDatabase()` on that path.
4. **`cbff4e9d` → `8e25c861`**: reviewer approved with no blocking items, and one concrete coverage
   suggestion - no test exercised `PostTimeSeriesWriteHandler`'s partial-write 400 path carrying a bookmark,
   despite that being the PR's own stated motivation for emitting from `finally`. Added
   `lineProtocolPartialWrite400EmitsUsableCommitIndexBookmark` covering it end-to-end.

Max review cycles (4) reached per the `resolve-issue-with-review` skill's `--max-cycles=4`. The fourth
review's fix (`8e25c861`) has not yet been re-reviewed by the bot - worth confirming a clean pass before
merge, or re-running `@claude review` on this PR.

