### PR TITLE
fix(#5870): renumber vector ids densely during LSM_VECTOR compaction

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -428,8 +428,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   /**
    * Rewrite the index data file keeping only the live entries, and swap it in: this is what a compaction of an
-   * LSM_VECTOR index is. Entries are copied verbatim (the quantized payload is never re-quantized) and keep their
-   * vector id, so no id is reused and the graph ordinals rebuilt right after stay valid.
+   * LSM_VECTOR index is. The quantized payload is never re-quantized, but the vector id IS reissued: every entry is
+   * renumbered densely from 0, in ascending old-id order, so the id space is dense by construction after every
+   * compaction instead of merely bounding the partially drained band trailing the live region (issue #5870). The
+   * graph ordinals rebuilt right after read the reassigned ids off the same {@code liveEntries} objects, so they
+   * stay valid without a second pass.
    * <p>
    * The whole rewrite runs under the index write lock. A compaction is an explicit maintenance operation, its cost
    * is one sequential pass over the live vectors, and blocking writers for it is the price of not having to
@@ -437,9 +440,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * <p>
    * Both old files - the previous data file and the legacy compacted component, if the index still has one - are
    * dropped afterwards, leaving the index with a single data file. That is what actually returns the space to the
-   * filesystem: leaving the old file behind was why compaction used to make the index bigger, not smaller.
+   * filesystem: leaving the old file behind was why compaction used to make the index bigger, not smaller. It is
+   * also what makes the renumbering safe with respect to tombstones: every on-disk tombstone for an id being
+   * discarded or reissued lived only in one of these two files, and {@link #publishLocationIndex} discards the
+   * in-memory {@code DeletedIds} bitset the same way on every rebuild, so no stale "deleted" answer for an old id
+   * survives to be paired with the live vector that now holds the same (reissued) number.
    *
-   * @param liveEntries the live set, re-pointed in place at the new file
+   * @param liveEntries the live set, re-pointed and renumbered in place at the new file
    *
    * @return true when the file was actually rewritten and the location index re-published with it, false when the
    * rewrite was skipped
@@ -493,7 +500,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
           throw new IllegalStateException(
               "Cannot compact vector index '" + indexName + "': cannot lock the new file " + newFileId);
 
-        // Copy the live entries, in vector id order, into freshly built pages of the new file.
+        // Copy the live entries, in vector id order, into freshly built pages of the new file. They are also
+        // RENUMBERED here, densely from 0: this is the one moment in the index's life where reissuing every id
+        // costs nothing extra, since the whole live set is already being walked and rewritten (issue #5870). Ids
+        // are handed out in ascending old-id order, which preserves the relative order #4581's ordinal map depends
+        // on and guarantees newId <= oldId for every entry (N distinct non-negative integers sorted ascending are
+        // each >= their rank), so a renumbered entry is never bigger on disk than the one it replaces.
         final List<VectorEntryForGraphBuild> sorted = new ArrayList<>(liveEntries);
         sorted.sort((a, b) -> Integer.compare(a.vectorId, b.vectorId));
 
@@ -504,18 +516,29 @@ public class LSMVectorIndex implements Index, IndexInternal {
         int pageNum = -1;
         int freeContent = 0;
         int entriesInPage = 0;
+        int denseId = 0;
         final byte[] buffer = new byte[maxEntryLength(sorted)];
 
         for (final VectorEntryForGraphBuild entry : sorted) {
+          final int oldVectorId = entry.vectorId;
+          final int newVectorId = denseId++;
+          // The vector id is the leading varint of the on-disk entry (LSMVectorIndexPageParser), so a renumbering
+          // has to re-encode it - a verbatim byte copy would keep shipping the old id. The rest of the entry (RID,
+          // deleted flag, quantization payload) is untouched and copied as-is.
+          final int oldIdSize = Binary.getNumberSpace(oldVectorId);
+          final int newIdSize = Binary.getNumberSpace(newVectorId);
+          final int restLength = entry.entryLength - oldIdSize;
+          final int newEntryLength = newIdSize + restLength;
+
           // Every entry came off a page of this same size, so it fits in a fresh one. Check it anyway: if a future
           // change ever let the pages shrink under an existing index, the loop below would create a new page and
           // then write straight past its end, and a compaction that silently corrupts is the worst possible one.
-          if (entry.entryLength > pageSizeContent)
+          if (newEntryLength > pageSizeContent)
             throw new IndexException(
-                "Cannot compact vector index '" + indexName + "': entry of vector " + entry.vectorId + " is "
-                    + entry.entryLength + " bytes and does not fit in a " + pageSizeContent + " byte page");
+                "Cannot compact vector index '" + indexName + "': entry of vector " + oldVectorId + " is "
+                    + newEntryLength + " bytes and does not fit in a " + pageSizeContent + " byte page");
 
-          if (page == null || page.getMaxContentSize() - freeContent < entry.entryLength) {
+          if (page == null || page.getMaxContentSize() - freeContent < newEntryLength) {
             if (page != null) {
               // Seal the page just filled: only the last page of the file stays open for new writes.
               page.writeByte(OFFSET_MUTABLE, (byte) 0);
@@ -530,18 +553,26 @@ public class LSMVectorIndex implements Index, IndexInternal {
           }
 
           readRawEntry(entry, buffer);
-          page.writeByteArray(freeContent, buffer, 0, entry.entryLength);
+          page.writeNumber(freeContent, newVectorId);
+          page.writeByteArray(freeContent + newIdSize, buffer, oldIdSize, restLength);
 
-          // Re-point the entry at its new home before anything downstream reads it back.
+          // Re-point the entry at its new home and its new id before anything downstream reads it back.
           entry.absoluteFileOffset = (long) pageNum * pageSize + BasePage.PAGE_HEADER_SIZE + freeContent;
           entry.isCompacted = false;
+          entry.vectorId = newVectorId;
 
-          freeContent += entry.entryLength;
+          freeContent += newEntryLength;
           entriesInPage++;
           page.writeInt(OFFSET_FREE_CONTENT, freeContent);
           page.writeInt(OFFSET_NUM_ENTRIES, entriesInPage);
         }
         newPages.add(page); // the last page stays mutable: new vectors append to it
+
+        // The live set now occupies exactly ids [0, denseId), so the dense count IS the next id to hand out: future
+        // inserts continue the dense sequence instead of resuming from whatever the pre-compaction high-water mark
+        // was, which is what keeps the id space dense rather than merely bounding the partially drained band
+        // (issue #5870). Set before publishLocationIndex(), which reads this field back below.
+        nextId.set(denseId);
 
         final List<MutablePage> versionedPages = new ArrayList<>(newPages.size());
         for (final MutablePage p : newPages) {
@@ -690,6 +721,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
       rebuilt.addOrUpdate(entry.vectorId, entry.isCompacted, entry.absoluteFileOffset, entry.rid, false);
     // The rebuilt index only knows the ids that are still live, so its high-water mark can be lower than the one
     // already handed out. Carry the sequence over, or the next insert would reuse an id a tombstone still refers to.
+    // A renumbering compaction (issue #5870) already reset `nextId` to the dense live count before calling this,
+    // so on that path the two operands are equal and the max is a no-op - the dense count IS the carried sequence.
     rebuilt.setNextId(Math.max(rebuilt.getNextId(), nextId.get()));
     vectorIndex = rebuilt;
   }
@@ -743,7 +776,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Used to avoid race conditions with concurrent VectorLocationIndex modifications.
    */
   private static class VectorEntryForGraphBuild {
-    final int vectorId;
+    // Not final: a compaction renumbers the live set densely from 0 (issue #5870), reassigning this in place so
+    // every reader of the same liveEntries collection - including the caller that fed it in - observes the new id.
+    int       vectorId;
     final RID rid;
     // Not final: a compaction rewrites the data file underneath the live set and re-points these at the new file.
     boolean   isCompacted;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1406,6 +1406,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // This happens when vectors were added after the graph was last built and persisted.
           // On database restart, deltaVectors (volatile) are lost and graphState is set to IMMUTABLE,
           // so rebuildGraphBeforeSearch() never triggers. Search can only find nodes in the stale graph.
+          //
+          // This is a COUNT comparison, not a content one: a persisted graph whose node count merely happens to
+          // match the current live count is treated as up to date even if it was built for a different generation
+          // of the live set. A renumbering compaction (issue #5870) makes that coincidence more likely to matter,
+          // not less - every post-compaction generation's ids are densely [0, N), so two different generations of
+          // the same index are far more likely to independently land on matching lengths than the old sparse,
+          // monotonically-growing ids ever were. Whether a real crash window can pair a stale graph with a live
+          // set of the same size this way is tracked, not confirmed, in issue #6106.
           if (graphSize < rebuiltOrdinalToVectorId.length) {
             LogManager.instance().log(this, Level.INFO,
                 """

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorLocationIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorLocationIndex.java
@@ -72,7 +72,10 @@ import java.util.stream.StreamSupport;
  * {@value #CHUNK_SIZE} ids are live, against ~90 bytes per entry for the map, so the crossover is at about 30 live
  * ids per chunk - <b>roughly 23% density</b>. Monotonic id assignment keeps a real workload far above that; a live
  * set genuinely scattered across a large id space would fall below it. Making the id space dense by construction -
- * renumbering during the data file rewrite - is the structural fix and is tracked separately in issue #5870.
+ * renumbering every entry during the data file rewrite, in {@code LSMVectorIndex.rewriteDataFileWithLiveEntries} -
+ * is the structural fix for the residual partially-drained band, and issue #5870 is where it happens: after every
+ * compaction the live set occupies exactly {@code [0, size())} and this class sees the renumbered ids the same way
+ * it sees any other id, through {@link #addOrUpdate}.
  *
  * <h2>Concurrency</h2>
  * Writers serialize on a single monitor; every read is lock-free and weakly consistent, matching what the
@@ -238,8 +241,11 @@ public class VectorLocationIndex {
    * workload and is enough to know whether a persisted graph carries stale ordinals.
    * <p>
    * The array is sized by the highest id handed out since the last {@link #clear()}, not by the number of live
-   * vectors: ids are preserved across a compaction rather than renumbered. Every graph rebuild (and therefore every
-   * compaction) releases it, so it grows only across the writes between two rebuilds.
+   * vectors. Every graph rebuild (and therefore every compaction) releases it - this class is always rebuilt fresh
+   * by {@code LSMVectorIndex.publishLocationIndex} rather than refilled in place - so it grows only across the
+   * writes between two rebuilds, and a compaction that renumbers the live set (issue #5870) starts the next one
+   * from empty exactly like a compaction that does not: no tombstone bit, and no on-disk tombstone entry, survives
+   * a rebuild to be paired with whatever live vector a reissued id now belongs to.
    * <p>
    * Writes are serialized on this object; reads are lock-free over a volatile array snapshot. Every mutation
    * republishes {@code bits} even when it did not resize the array: setting a bit is a plain array store, and a

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue5870VectorIndexIdRenumberingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue5870VectorIndexIdRenumberingTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5870: {@code LSMVectorIndex.rewriteDataFileWithLiveEntries} renumbers the live set densely from 0 during
+ * a compaction instead of preserving each vector's pre-compaction id, so the id space is dense by construction
+ * after every compaction rather than merely bounding the partially drained band trailing the live region (the
+ * residual weakness issue #5588 left open).
+ * <p>
+ * Both files a compaction replaces - the previous data file and the legacy compacted component - are dropped
+ * afterwards, and {@code publishLocationIndex} always rebuilds {@link VectorLocationIndex} fresh rather than
+ * refilling it in place, so no on-disk tombstone entry and no in-memory {@code DeletedIds} bit for a discarded or
+ * reissued id survives a compaction: that is what makes reissuing ids safe rather than merely convenient.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue5870VectorIndexIdRenumberingTest extends TestHelper {
+
+  private static final int DIMENSIONS = 16;
+  private static final int VERTICES   = 300;
+
+  /**
+   * Acceptance criterion 1: {@code getMaxVectorId() == size() - 1} after a compaction. Acceptance criterion 2: no
+   * partially drained band survives a compaction - {@code chunkCount() == ceil(live / CHUNK_SIZE)}.
+   * <p>
+   * The "before" state is built the way a real re-embedding workload builds it (issue #5516/#5588): one vertex
+   * ({@code doc0}) is updated hundreds of times, so its live id climbs far past the dense block the other
+   * {@value #VERTICES}{@code - 1} vertices still occupy. Every chunk behind it drains and releases wholesale (the
+   * existing #5516 mechanism already handles that), but the chunk holding its current id is a lone straggler - the
+   * one thing only a renumbering compaction removes.
+   */
+  @Test
+  void compactionMakesTheLiveIdSpaceDenseWithNoTrailingStraggler() {
+    createSchema();
+    insertVertices();
+
+    final LSMVectorIndex index = vectorIndex();
+    final int denseChunksForLiveSet =
+        (VERTICES + VectorLocationIndex.CHUNK_SIZE - 1) / VectorLocationIndex.CHUNK_SIZE;
+
+    // Re-embed doc0 enough times that its live id crosses at least one chunk boundary past the dense block the
+    // other vertices still occupy (ids 1..VERTICES-1, i.e. chunks 0..denseChunksForLiveSet-1). One transaction per
+    // update, like a real re-embedding workload issues it: each commit tombstones doc0's current id and mints
+    // exactly one new one.
+    final int updateCycles = VERTICES + 2 * VectorLocationIndex.CHUNK_SIZE;
+    for (int cycle = 0; cycle < updateCycles; cycle++) {
+      final int c = cycle;
+      database.transaction(() -> database.command("sql", "UPDATE Doc SET embedding = ? WHERE id = ?", embedding(0, c + 1), "doc0"));
+    }
+
+    assertThat(index.getVectorIndex().size()).as("re-embedding must not change the live count").isEqualTo(VERTICES);
+    assertThat(index.getVectorIndex().chunkCount())
+        .as("before compaction: the dense block plus one straggler chunk trailing far behind it")
+        .isGreaterThan(denseChunksForLiveSet);
+
+    database.command("sql", "COMPACT INDEX `Doc[embedding]`");
+
+    assertThat(index.getVectorIndex().size()).as("compaction must not lose or gain live vectors").isEqualTo(VERTICES);
+    assertThat(index.getVectorIndex().getMaxVectorId())
+        .as("the live set occupies exactly [0, size()) after a renumbering compaction")
+        .isEqualTo(index.getVectorIndex().size() - 1);
+    assertThat(index.getVectorIndex().chunkCount())
+        .as("no partially drained band survives a renumbering compaction")
+        .isEqualTo(denseChunksForLiveSet);
+
+    assertSearchWorks(0, updateCycles);
+    assertSearchWorks(VERTICES / 2, 0);
+
+    reopenDatabase();
+
+    final LSMVectorIndex reopened = vectorIndex();
+    assertThat(reopened.getVectorIndex().size()).as("density survives a reopen").isEqualTo(VERTICES);
+    assertThat(reopened.getVectorIndex().getMaxVectorId()).isEqualTo(reopened.getVectorIndex().size() - 1);
+    assertSearchWorks(0, updateCycles);
+    assertSearchWorks(VERTICES / 2, 0);
+  }
+
+  /**
+   * Acceptance criterion 4: a tombstone written before a renumbering cannot suppress a vector that inherits its id
+   * afterwards.
+   * <p>
+   * Which document ends up holding vector id 0 after the initial insert is an implementation detail (a single
+   * transaction's queued index operations are not guaranteed to replay in statement order), so this test does not
+   * assume "doc0" got id 0. It reads the id assignment back from the location index instead, and deletes exactly
+   * the documents holding the lowest half of the ids - guaranteeing id 0 itself is tombstoned before the
+   * compaction. Renumbering then reissues id 0 to whichever survivor held the smallest surviving old id: without
+   * the fix that survivor keeps its old (higher) id and id 0 stays absent; with the fix it inherits id 0, the exact
+   * integer a tombstone referred to moments earlier.
+   */
+  @Test
+  void aTombstoneWrittenBeforeRenumberingCannotSuppressAVectorThatInheritsItsId() {
+    createSchema();
+    insertVertices();
+
+    final int deleted = VERTICES / 2;
+    final int[] vertexOfLowestIds = resolveVertexIndicesOfLowestIds(deleted);
+    database.transaction(() -> {
+      for (final int vertex : vertexOfLowestIds)
+        database.command("sql", "DELETE FROM Doc WHERE id = ?", "doc" + vertex);
+    });
+    assertThat(countLive()).isEqualTo(VERTICES - deleted);
+
+    database.command("sql", "COMPACT INDEX `Doc[embedding]`");
+    assertThat(countLive()).as("compaction must not resurrect the deleted half").isEqualTo(VERTICES - deleted);
+
+    final LSMVectorIndex index = vectorIndex();
+    final VectorLocationIndex locations = index.getVectorIndex();
+
+    // Id 0 is reissued to a survivor by a renumbering compaction, and it must NOT read back as deleted even though
+    // a tombstone for id 0 - a different vector entirely - was written moments before the compaction.
+    assertThat(locations.isLive(0)).as("id 0 must be live: it was reissued to a surviving vector").isTrue();
+    assertThat(locations.isDeleted(0)).as("no stale tombstone for the discarded owner of id 0 may survive").isFalse();
+
+    final RID survivorRid = locations.getRid(0);
+    assertThat(survivorRid).as("id 0 must resolve to a document").isNotNull();
+    final int[] survivorVertexHolder = new int[1];
+    database.transaction(() -> {
+      final Document survivor = (Document) database.lookupByRID(survivorRid, true);
+      final String survivorId = survivor.getString("id");
+      survivorVertexHolder[0] = Integer.parseInt(survivorId.substring("doc".length()));
+    });
+    final int survivorVertex = survivorVertexHolder[0];
+    boolean wasDeleted = false;
+    for (final int vertex : vertexOfLowestIds)
+      wasDeleted |= vertex == survivorVertex;
+    assertThat(wasDeleted).as("id 0's owner must be one of the survivors, not one of the deleted vertices").isFalse();
+
+    // And the survivor is not silently buried: it is still found as its own nearest neighbor.
+    assertSearchWorks(survivorVertex, 0);
+
+    reopenDatabase();
+
+    assertThat(countLive()).as("the reissued id must not resurrect a deleted vector after a reopen")
+        .isEqualTo(VERTICES - deleted);
+    assertSearchWorks(survivorVertex, 0);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON Doc (id) UNIQUE");
+
+      // Automatic compaction of vector indexes is disabled (LSMVectorIndex.onAfterCommit): only the explicit
+      // COMPACT INDEX below must trigger the renumbering rewrite this test is about.
+      database.command("sql", """
+          CREATE INDEX ON Doc (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions": %d,
+            "similarity": "COSINE",
+            "quantization": "INT8",
+            "mutationsBeforeRebuild": 100000000,
+            "inactivityRebuildTimeoutMs": 0
+          }""".formatted(DIMENSIONS));
+    });
+  }
+
+  private void insertVertices() {
+    database.transaction(() -> {
+      for (int i = 0; i < VERTICES; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i, 0));
+    });
+  }
+
+  /** Well-separated vectors: the nearest neighbor of vertex i must be vertex i itself. */
+  private static float[] embedding(final int vertex, final int cycle) {
+    final float[] v = new float[DIMENSIONS];
+    for (int j = 0; j < DIMENSIONS; j++)
+      v[j] = (float) Math.sin((vertex + 1) * 0.37 * (j + 1) + cycle * 0.0001);
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return (LSMVectorIndex) ((TypeIndex) database.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+
+  private long countLive() {
+    return vectorIndex().countEntries();
+  }
+
+  /**
+   * The vertex index (the {@code N} in {@code "docN"}) of the {@code count} documents currently holding the
+   * lowest-numbered vector ids, resolved through the location index rather than assumed from insertion order.
+   */
+  private int[] resolveVertexIndicesOfLowestIds(final int count) {
+    final VectorLocationIndex locations = vectorIndex().getVectorIndex();
+    final int[] lowestIds = locations.getAllVectorIds().limit(count).toArray(); // already ascending
+    final int[] vertices = new int[lowestIds.length];
+    database.transaction(() -> {
+      for (int i = 0; i < lowestIds.length; i++) {
+        final Document doc = (Document) database.lookupByRID(locations.getRid(lowestIds[i]), true);
+        vertices[i] = Integer.parseInt(doc.getString("id").substring("doc".length()));
+      }
+    });
+    return vertices;
+  }
+
+  private void assertSearchWorks(final int vertex, final int cycle) {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "SELECT `vector.neighbors`('Doc[embedding]', ?, 3) AS neighbors FROM Doc LIMIT 1",
+          (Object) embedding(vertex, cycle));
+      assertThat(rs.hasNext()).isTrue();
+      final List<Map<String, Object>> neighbors = rs.next().getProperty("neighbors");
+      assertThat(neighbors).as("neighbors of doc%d", vertex).isNotEmpty();
+      assertThat(neighbors.getFirst().get("id")).as("closest vector to doc%d", vertex).isEqualTo("doc" + vertex);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue5870VectorIndexIdRenumberingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue5870VectorIndexIdRenumberingTest.java
@@ -167,6 +167,55 @@ class Issue5870VectorIndexIdRenumberingTest extends TestHelper {
     assertSearchWorks(survivorVertex, 0);
   }
 
+  /**
+   * Exercises the dense sequence from the insert side rather than only observing it through
+   * {@code getMaxVectorId()}: a compaction renumbers the live set to exactly {@code [0, VERTICES)}, and the next
+   * insert must mint id {@code VERTICES} - not collide with the vector that now legitimately holds
+   * {@code VERTICES - 1} (an off-by-one in the reset would do exactly that), and not merely resume from whatever
+   * the pre-compaction high-water mark used to be (which would still be correct but would defeat the point of
+   * renumbering: the id space would grow unboundedly again on the very first write after every compaction).
+   * <p>
+   * The insert runs after a {@link #reopenDatabase()}, not in the same session the compaction ran in: a write
+   * issued immediately after {@code COMPACT INDEX} in the same session does not reach the vector index at all,
+   * independently of this fix (confirmed by reverting it and reproducing the same symptom on unmodified code) -
+   * see issue #6105, filed separately. A reopen forces {@code loadVectorsFromPages} to recompute {@code nextId}
+   * from the (now dense) persisted file, which is the code path a real "compact, then restart, then keep
+   * writing" operational sequence actually takes, and it is what this test pins.
+   */
+  @Test
+  void insertingAfterARenumberingCompactionDoesNotCollideWithAnExistingId() {
+    createSchema();
+    insertVertices();
+
+    database.command("sql", "COMPACT INDEX `Doc[embedding]`");
+    assertThat(vectorIndex().getVectorIndex().getMaxVectorId()).as("the live set is dense after compaction")
+        .isEqualTo(VERTICES - 1);
+
+    reopenDatabase();
+
+    final RID ridHoldingTheHighestId = vectorIndex().getVectorIndex().getRid(VERTICES - 1);
+    assertThat(ridHoldingTheHighestId).isNotNull();
+
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + VERTICES,
+        embedding(VERTICES, 0)));
+
+    final RID[] newRidHolder = new RID[1];
+    database.transaction(() -> newRidHolder[0] = database.query("sql", "SELECT FROM Doc WHERE id = ?", "doc" + VERTICES)
+        .next().getIdentity().get());
+    final int[] newIds = vectorIndex().getVectorIndex().getVectorIdsForRid(newRidHolder[0]);
+    assertThat(newIds).as("exactly one id for the new vector").hasSize(1);
+    assertThat(newIds[0]).as("the next insert after a renumbering compaction must continue the dense sequence")
+        .isEqualTo(VERTICES);
+
+    assertThat(vectorIndex().getVectorIndex().getRid(VERTICES - 1))
+        .as("the new insert must not have overwritten the vector that already held id VERTICES-1")
+        .isEqualTo(ridHoldingTheHighestId);
+    assertThat(countLive()).as("both the pre-existing and the new vector must be live").isEqualTo(VERTICES + 1);
+
+    assertSearchWorks(VERTICES, 0);
+    assertSearchWorks(VERTICES / 2, 0);
+  }
+
   // ------------------------------------------------------------------------------------------------- helpers
 
   private void createSchema() {


### PR DESCRIPTION
Closes #5870

## Summary

`LSMVectorIndex.rewriteDataFileWithLiveEntries` (what a `COMPACT INDEX` on an `LSM_VECTOR` index actually runs) used to copy live entries into the new data file verbatim, keeping each vector's pre-compaction id. That bounds the "partially drained band" `VectorLocationIndex` pays for (issue #5588 - a chunk trailing the live region that holds a single live id retains a whole `CHUNK_RETAINED_BYTES`, ~2.7KB), but never removes it: a live vector whose id has drifted far ahead of the rest of the live set (a document re-embedded many times) still costs a whole straggler chunk after every compaction.

This PR renumbers every live entry densely to `[0, N)` during the same rewrite pass, in ascending old-id order:

- **Why this moment**: the rewrite already walks the entire live set and copies every entry to a fresh file, so reissuing ids costs nothing extra.
- **Why ascending old-id order**: it preserves the relative order the graph's ordinal map (`ordinalToVectorId`, issue #4581) depends on, and it guarantees `newId <= oldId` for every entry (N distinct non-negative integers sorted ascending are each `>= their rank`), so a renumbered entry is never bigger on disk than the one it replaces - the existing page-fits-in-current-page bookkeeping stays a safe upper bound.
- **On-disk re-encoding**: the vector id is the leading variable-length integer of the on-disk entry format (`LSMVectorIndexPageParser`), so a renumbering has to re-encode it - a verbatim byte copy would keep shipping the old id. The rest of the entry (RID, deleted flag, quantization payload) is copied as-is.
- **`nextId`**: `LSMVectorIndex.nextId` is reset to the dense count right after the rewrite, before the location index is republished, so future inserts continue the dense sequence instead of resuming from the pre-compaction high-water mark.

### Why reissuing ids is safe (the three things the issue calls out)

1. **`ordinalToVectorId`** - rebuilt immediately after the rewrite from the very same (now renumbered) entry objects, so it is never out of step with the ids the location index holds.
2. **The persisted tombstone set** - `publishLocationIndex` already rebuilds `VectorLocationIndex` fresh (a new instance, not an in-place refill) on every compaction, so its `DeletedIds` bitset starts empty regardless of renumbering. Both files a compaction replaces (the previous data file and the legacy compacted component) are dropped afterwards, so no on-disk tombstone for a discarded or reissued id survives either. A regression test (`aTombstoneWrittenBeforeRenumberingCannotSuppressAVectorThatInheritsItsId`) proves this: it deletes the documents holding the lowest vector ids (discovered through the location index, not assumed from insertion order), compacts, and asserts that the survivor now holding the reissued id 0 reads back live, not deleted.
3. **`nextId`** - see above; reset in lockstep with the renumbering, inside the same write-locked critical section the file swap runs in, so no concurrent writer can observe an inconsistent pairing.

## Changes

- `engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java`
  - `rewriteDataFileWithLiveEntries`: renumbers every live entry densely from 0, re-encoding the id varint per entry; resets `nextId` to the dense count.
  - `VectorEntryForGraphBuild.vectorId`: no longer `final`, so the renumbering can be applied in place and observed by every caller sharing the same `liveEntries` collection.
  - Updated javadoc on the rewrite method and on `publishLocationIndex`'s `nextId` carry-over.
- `engine/src/main/java/com/arcadedb/index/vector/VectorLocationIndex.java`
  - Updated class-level and `DeletedIds` javadoc: issue #5870 is no longer a forward reference, it is what happens.

No public API changes; no new dependencies.

## Test plan

New test class `engine/src/test/java/com/arcadedb/index/vector/Issue5870VectorIndexIdRenumberingTest.java`:

- `compactionMakesTheLiveIdSpaceDenseWithNoTrailingStraggler` - re-embeds one vertex hundreds of times (each in its own transaction, like a real workload) so its live id drifts into a straggler chunk far past the dense block the rest of the live set occupies; asserts the straggler chunk exists before compaction, and that after compaction `getMaxVectorId() == size() - 1` and `chunkCount() == ceil(live / CHUNK_SIZE)` exactly (both across the compaction and after a reopen).
- `aTombstoneWrittenBeforeRenumberingCannotSuppressAVectorThatInheritsItsId` - deletes the documents holding the lowest vector ids (resolved through the location index, not assumed from insertion order), compacts, and asserts the survivor that inherits the reissued id 0 is live, not deleted, resolves to the correct document, and is still found as its own nearest neighbor - across the compaction and after a reopen.

Both new tests were verified to **fail** against the pre-fix code (`getMaxVectorId()` stayed at the old high-water mark; the reissued id read back as not-live) before the fix, and pass after it.

Also ran and confirmed green against the fix:
- `Issue5588PrimitiveLocationIndexTest` (the `VectorLocationIndex` unit tests this issue's structural fix was deferred from)
- `LSMVectorIndexTombstoneMemoryTest` (the `#5516`/`#5588` tombstone-memory regression suite, including the id-sequence-survives-a-reopen test)
- `LSMVectorIndexCompactionTest` (existing compaction functional tests: space reclaimed, repeated compaction, deletes stay deleted, index identity follows the compacted file)
- The full `com.arcadedb.index.vector.*Test` package

- [x] `mvn -pl engine -am compile`
- [x] `mvn -pl engine test -Dtest=Issue5870VectorIndexIdRenumberingTest` (new tests, fail-before/pass-after verified)
- [x] `mvn -pl engine test -Dtest=Issue5588PrimitiveLocationIndexTest,LSMVectorIndexTombstoneMemoryTest,LSMVectorIndexCompactionTest`
- [x] `mvn -pl engine test -Dtest=com.arcadedb.index.vector.*Test` (full package)
- [ ] `RaftIndexCompactionReplicationIT` (ha-raft multi-node IT) was not run locally - out of scope for a quick verification pass, but the fix only changes the numeric id a live entry is encoded with, not the wire/file format itself, and a follower rebuilds by parsing the file the leader ships rather than re-deriving ids independently, so no follower-side change was needed.
