### PR TITLE
fix(#5852): parse the Long.MIN_VALUE SQL literal

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -2723,22 +2723,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   }
 
   /**
-   * Folds a directly-negated integer literal whose bare magnitude cannot be represented as a {@code long} on its
-   * own into a single {@code Long.MIN_VALUE} literal, or returns {@code null} when the ordinary {@code 0 - X}
-   * handling in {@link #visitUnary} should run instead.
-   * <p>
-   * {@code 9223372036854775808} (one past {@code Long.MAX_VALUE}) is the only positive magnitude that overflows
-   * both {@code Integer.parseInt} and {@code Long.parseLong}, yet has a valid {@code long} value once negated
-   * ({@code Long.MIN_VALUE}). {@link #visitIntegerLiteral} converts the magnitude before any enclosing unary minus
-   * is applied, so without this fold that one value can never be parsed as a literal - the standard
-   * two's-complement-minimum hazard. Java's own lexer solves it the same way: the magnitude is accepted only when
-   * directly preceded by a unary minus, with the sign folded in before conversion.
-   * <p>
-   * Ordinary literals (the bare magnitude already fits in a {@code long}) fall through untouched, so this only
-   * changes behaviour for the single value that used to fail to parse. An explicit {@code L}/{@code l} suffix
-   * (e.g. {@code -9223372036854775808L}) is stripped before the digit check and folded the same way: the suffix
-   * only ever forces {@link #visitIntegerLiteral} to prefer the {@code long} conversion, which is already what
-   * happens here.
+   * Folds a directly-negated integer literal (optionally {@code L}/{@code l}-suffixed) whose bare magnitude
+   * overflows {@code long} on its own into a single {@code Long.MIN_VALUE} literal - the standard
+   * two's-complement-minimum hazard, since {@link #visitIntegerLiteral} otherwise converts the magnitude before
+   * the enclosing unary minus is applied. Returns {@code null} for every other shape, letting the ordinary
+   * {@code 0 - X} handling in {@link #visitUnary} run instead.
    */
   private BaseExpression tryFoldLongMinValueLiteral(final SQLParser.UnaryContext ctx) {
     if (!(ctx.mathExpression() instanceof final SQLParser.BaseContext baseCtx))

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -2735,7 +2735,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * directly preceded by a unary minus, with the sign folded in before conversion.
    * <p>
    * Ordinary literals (the bare magnitude already fits in a {@code long}) fall through untouched, so this only
-   * changes behaviour for the single value that used to fail to parse.
+   * changes behaviour for the single value that used to fail to parse. An explicit {@code L}/{@code l} suffix
+   * (e.g. {@code -9223372036854775808L}) is stripped before the digit check and folded the same way: the suffix
+   * only ever forces {@link #visitIntegerLiteral} to prefer the {@code long} conversion, which is already what
+   * happens here.
    */
   private BaseExpression tryFoldLongMinValueLiteral(final SQLParser.UnaryContext ctx) {
     if (!(ctx.mathExpression() instanceof final SQLParser.BaseContext baseCtx))
@@ -2743,10 +2746,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (!(baseCtx.baseExpression() instanceof final SQLParser.IntegerLiteralContext intCtx))
       return null;
 
-    final String text = intCtx.INTEGER_LITERAL().getText();
+    final String originalText = intCtx.INTEGER_LITERAL().getText();
+    final String text = (originalText.endsWith("L") || originalText.endsWith("l"))
+        ? originalText.substring(0, originalText.length() - 1) : originalText;
+
     for (int i = 0; i < text.length(); i++)
       if (!Character.isDigit(text.charAt(i)))
-        return null; // has an L/l suffix, or is hex/octal: not the plain-decimal shape we fold here
+        return null; // hex/octal-shaped: not the plain-decimal shape we fold here
 
     try {
       Long.parseLong(text);
@@ -2759,7 +2765,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         baseExpr.number = new PInteger(-1).setValue(Long.parseLong("-" + text));
         return baseExpr;
       } catch (final NumberFormatException stillInvalid) {
-        throw new CommandSQLParsingException("Invalid integer: " + text);
+        throw new CommandSQLParsingException("Invalid integer: " + originalText);
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -2687,6 +2687,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MathExpression visitUnary(final SQLParser.UnaryContext ctx) {
+    if (ctx.MINUS() != null) {
+      final BaseExpression longMinValue = tryFoldLongMinValueLiteral(ctx);
+      if (longMinValue != null)
+        return longMinValue;
+    }
+
     final MathExpression innerExpr = (MathExpression) visit(ctx.mathExpression());
 
     if (ctx.PLUS() != null) {
@@ -2714,6 +2720,48 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     }
 
     throw new CommandSQLParsingException("Unknown unary operator");
+  }
+
+  /**
+   * Folds a directly-negated integer literal whose bare magnitude cannot be represented as a {@code long} on its
+   * own into a single {@code Long.MIN_VALUE} literal, or returns {@code null} when the ordinary {@code 0 - X}
+   * handling in {@link #visitUnary} should run instead.
+   * <p>
+   * {@code 9223372036854775808} (one past {@code Long.MAX_VALUE}) is the only positive magnitude that overflows
+   * both {@code Integer.parseInt} and {@code Long.parseLong}, yet has a valid {@code long} value once negated
+   * ({@code Long.MIN_VALUE}). {@link #visitIntegerLiteral} converts the magnitude before any enclosing unary minus
+   * is applied, so without this fold that one value can never be parsed as a literal - the standard
+   * two's-complement-minimum hazard. Java's own lexer solves it the same way: the magnitude is accepted only when
+   * directly preceded by a unary minus, with the sign folded in before conversion.
+   * <p>
+   * Ordinary literals (the bare magnitude already fits in a {@code long}) fall through untouched, so this only
+   * changes behaviour for the single value that used to fail to parse.
+   */
+  private BaseExpression tryFoldLongMinValueLiteral(final SQLParser.UnaryContext ctx) {
+    if (!(ctx.mathExpression() instanceof final SQLParser.BaseContext baseCtx))
+      return null;
+    if (!(baseCtx.baseExpression() instanceof final SQLParser.IntegerLiteralContext intCtx))
+      return null;
+
+    final String text = intCtx.INTEGER_LITERAL().getText();
+    for (int i = 0; i < text.length(); i++)
+      if (!Character.isDigit(text.charAt(i)))
+        return null; // has an L/l suffix, or is hex/octal: not the plain-decimal shape we fold here
+
+    try {
+      Long.parseLong(text);
+      return null; // magnitude fits on its own: let the existing 0 - X handling run as before
+    } catch (final NumberFormatException magnitudeOverflow) {
+      // only Long.MIN_VALUE's magnitude can still be represented once the sign is folded in;
+      // anything larger is a genuine overflow and keeps raising the original error
+      try {
+        final BaseExpression baseExpr = new BaseExpression(-1);
+        baseExpr.number = new PInteger(-1).setValue(Long.parseLong("-" + text));
+        return baseExpr;
+      } catch (final NumberFormatException stillInvalid) {
+        throw new CommandSQLParsingException("Invalid integer: " + text);
+      }
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5852SqlLongMinValueLiteralTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5852SqlLongMinValueLiteralTest.java
@@ -69,6 +69,24 @@ class Issue5852SqlLongMinValueLiteralTest {
   }
 
   /**
+   * The explicit {@code L}/{@code l}-suffixed spelling must fold the same way as the bare literal: the suffix only
+   * ever forces the {@code long} conversion, which is already what the fold produces.
+   */
+  @Test
+  void longSuffixedLongMinValueLiteralParsesToTheCorrectValue() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5852LiteralSuffixSelect", db -> {
+      try (final ResultSet rs = db.query("sql", "SELECT -9223372036854775808L AS r")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Long>getProperty("r")).isEqualTo(Long.MIN_VALUE);
+      }
+      try (final ResultSet rs = db.query("sql", "SELECT -9223372036854775808l AS r")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Long>getProperty("r")).isEqualTo(Long.MIN_VALUE);
+      }
+    });
+  }
+
+  /**
    * A magnitude that overflows even after the sign is folded in (more digits than {@code Long.MIN_VALUE}'s) must
    * still be rejected with the original error, not silently accepted.
    */

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5852SqlLongMinValueLiteralTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5852SqlLongMinValueLiteralTest.java
@@ -19,11 +19,14 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #5852: {@code Long.MIN_VALUE} (-9223372036854775808) could not be written as a SQL
@@ -93,8 +96,8 @@ class Issue5852SqlLongMinValueLiteralTest {
   @Test
   void largerOverflowIsStillRejected() throws Exception {
     TestHelper.executeInNewDatabase("./target/databases/testIssue5852StillInvalid", db -> {
-      org.assertj.core.api.Assertions.assertThatThrownBy(() -> db.query("sql", "SELECT -99223372036854775808 AS r").close())
-          .isInstanceOf(com.arcadedb.exception.CommandSQLParsingException.class)
+      assertThatThrownBy(() -> db.query("sql", "SELECT -99223372036854775808 AS r").close())
+          .isInstanceOf(CommandSQLParsingException.class)
           .hasMessageContaining("Invalid integer");
     });
   }
@@ -108,7 +111,7 @@ class Issue5852SqlLongMinValueLiteralTest {
     TestHelper.executeInNewDatabase("./target/databases/testIssue5852IndexLookup", db -> {
       db.getSchema().createVertexType("V");
       db.getSchema().getType("V").createProperty("k", Type.LONG);
-      db.getSchema().getType("V").createTypeIndex(com.arcadedb.schema.Schema.INDEX_TYPE.LSM_TREE, true, "k");
+      db.getSchema().getType("V").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "k");
 
       db.transaction(() -> db.command("sql", "INSERT INTO V SET k = 0 - 9223372036854775807 - 1"));
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5852SqlLongMinValueLiteralTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue5852SqlLongMinValueLiteralTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5852: {@code Long.MIN_VALUE} (-9223372036854775808) could not be written as a SQL
+ * literal.
+ * <p>
+ * The positive magnitude {@code 9223372036854775808} is one past {@code Long.MAX_VALUE}, so it overflows both
+ * {@code Integer.parseInt} and {@code Long.parseLong} on its own - the standard two's-complement-minimum hazard.
+ * {@link SQLASTBuilder#visitIntegerLiteral} parsed that bare magnitude before the enclosing unary minus was ever
+ * applied ({@code -X} was rewritten to {@code 0 - X}), so the conversion failed before the sign could rescue it.
+ * Every other {@code long} value, including {@code Long.MIN_VALUE + 1} and {@code Long.MAX_VALUE}, parsed fine, and
+ * the same value was reachable through arithmetic ({@code 0 - 9223372036854775807 - 1}) or through a bound
+ * parameter - only the direct literal spelling failed.
+ */
+class Issue5852SqlLongMinValueLiteralTest {
+
+  @Test
+  void longMinValueLiteralParsesToTheCorrectValue() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5852LiteralSelect", db -> {
+      try (final ResultSet rs = db.query("sql", "SELECT -9223372036854775808 AS r")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Long>getProperty("r")).isEqualTo(Long.MIN_VALUE);
+      }
+    });
+  }
+
+  /**
+   * The boundary just above {@code Long.MIN_VALUE} must keep working exactly as before: it is a normal literal
+   * (its bare magnitude fits in a long), so it still goes through the pre-existing {@code 0 - X} path.
+   */
+  @Test
+  void adjacentLongValuesStillParseCorrectly() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5852Adjacent", db -> {
+      try (final ResultSet rs = db.query("sql", "SELECT -9223372036854775807 AS r")) {
+        assertThat(rs.next().<Long>getProperty("r")).isEqualTo(-9223372036854775807L);
+      }
+      try (final ResultSet rs = db.query("sql", "SELECT 9223372036854775807 AS r")) {
+        assertThat(rs.next().<Long>getProperty("r")).isEqualTo(Long.MAX_VALUE);
+      }
+      try (final ResultSet rs = db.query("sql", "SELECT -2147483648 AS r")) {
+        assertThat(rs.next().<Long>getProperty("r")).isEqualTo(-2147483648L);
+      }
+    });
+  }
+
+  /**
+   * A magnitude that overflows even after the sign is folded in (more digits than {@code Long.MIN_VALUE}'s) must
+   * still be rejected with the original error, not silently accepted.
+   */
+  @Test
+  void largerOverflowIsStillRejected() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5852StillInvalid", db -> {
+      org.assertj.core.api.Assertions.assertThatThrownBy(() -> db.query("sql", "SELECT -99223372036854775808 AS r").close())
+          .isInstanceOf(com.arcadedb.exception.CommandSQLParsingException.class)
+          .hasMessageContaining("Invalid integer");
+    });
+  }
+
+  /**
+   * The end-to-end scenario from the issue: a stored {@code Long.MIN_VALUE} row, unreachable by its own literal
+   * value in a {@code WHERE} predicate before the fix - including through a {@code UNIQUE} index.
+   */
+  @Test
+  void storedLongMinValueIsReachableByItsOwnLiteral() throws Exception {
+    TestHelper.executeInNewDatabase("./target/databases/testIssue5852IndexLookup", db -> {
+      db.getSchema().createVertexType("V");
+      db.getSchema().getType("V").createProperty("k", Type.LONG);
+      db.getSchema().getType("V").createTypeIndex(com.arcadedb.schema.Schema.INDEX_TYPE.LSM_TREE, true, "k");
+
+      db.transaction(() -> db.command("sql", "INSERT INTO V SET k = 0 - 9223372036854775807 - 1"));
+
+      try (final ResultSet rs = db.query("sql", "SELECT FROM V WHERE k = -9223372036854775808")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<Long>getProperty("k")).isEqualTo(Long.MIN_VALUE);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes SQL literal parsing so `Long.MIN_VALUE` (`-9223372036854775808`) can be written directly as a literal.

`-X` is rewritten internally by `SQLASTBuilder.visitUnary` as `0 - X`, so the positive magnitude `X` is converted to a number *before* the unary minus is applied. `9223372036854775808` (one past `Long.MAX_VALUE`) is the one magnitude that overflows both `Integer.parseInt` and `Long.parseLong` on its own, even though its negation is a perfectly valid `long` - the standard two's-complement-minimum hazard. The parser threw `Invalid integer: 9223372036854775808` before the sign was ever considered, even though the engine stores and returns the value fine when it arrives through arithmetic or a bound parameter.

`visitUnary` now checks, before visiting the operand, whether the negated node is a plain-decimal integer literal whose bare magnitude does not fit in a `long`. If so, it folds the sign into the token and converts `-9223372036854775808` directly (mirroring how Java's own lexer treats this one magnitude), producing `Long.MIN_VALUE`. Every other literal - including all the values that already worked - falls through unchanged to the existing `0 - X` handling, so ordinary literals keep their existing type behavior (e.g. `-5` still evaluates as a subtraction, not a direct literal).

A magnitude that overflows even after folding the sign in (more digits than `Long.MIN_VALUE`'s) still raises the original `CommandSQLParsingException`.

## Motivation

Closes #5852

`Long.MIN_VALUE` is a legitimate value to use as an open-ended range sentinel or to round-trip a value read back from storage or a log. Before this fix:

- `SELECT -9223372036854775808 AS r` failed to parse, while `SELECT -9223372036854775807 AS r` and `SELECT 9223372036854775807 AS r` worked.
- A row stored with `k = Long.MIN_VALUE` (reachable via arithmetic or a bound parameter) could not be looked up by its own literal value in a `WHERE`/`DELETE`/`UPDATE` predicate, including through a `UNIQUE` index - the row existed and a range scan found it, but the natural point lookup by its own value threw a parse error.
- Parameters were unaffected (`SELECT :v` bound to `Long.MIN_VALUE` worked), so the only workaround was to avoid the literal spelling entirely.

I also checked whether the openCypher front end has the same defect (per the issue's suggestion): it does not. `CypherExpressionBuilder`'s literal-parsing path folds the sign into the raw token text *before* calling `Long.parseLong`, rather than splitting the sign out as a separate arithmetic node the way the SQL grammar's `unary` rule does, so `Long.parseLong("-9223372036854775808")` already succeeds there. Gremlin numeric-literal parsing comes from the upstream Apache TinkerPop grammar/library rather than code in this repo, so there was nothing to change there either.

## Related issues

Closes #5852

## Additional Notes

- The fix is scoped to `SQLASTBuilder.visitUnary` / a new private helper `tryFoldLongMinValueLiteral`; no grammar (`.g4`) changes were needed.
- New regression test: `engine/src/test/java/com/arcadedb/query/sql/parser/Issue5852SqlLongMinValueLiteralTest.java`, covering: the literal itself, the adjacent boundary values that must keep working exactly as before, a magnitude that still legitimately overflows, and the end-to-end stored-row/unique-index lookup scenario from the issue's follow-up comment.
- Verified the new test fails with the original `CommandSQLParsingException: Invalid integer: 9223372036854775808` when the fix is reverted, and passes with it applied.
- Ran the broader SQL parser/AST/grammar regression suites (`MathExpressionTest`, `Issue5647SqlIntegerArithmeticTest`, `SQLAntlrParserTest`, `SQLGrammarRegressionTest`, `SQLASTBuilderTest`, `SqlExpressionDepthGuardIssue5851FollowupTest`, plus the full `com.arcadedb.query.sql.parser.**` / `com.arcadedb.query.sql.antlr.**` packages) - all green, no regressions.

## Test plan

- [x] `mvn -pl engine -am test -Dtest=Issue5852SqlLongMinValueLiteralTest` - new regression test passes
- [x] Confirmed the new test fails (reproducing the original bug) when the fix is reverted
- [x] `mvn -pl engine -am test -Dtest=Issue5647SqlIntegerArithmeticTest,MathExpressionTest` - no regression in adjacent long-arithmetic/overflow handling
- [x] `mvn -pl engine -am test -Dtest=SQLAntlrParserTest,SQLGrammarRegressionTest,SQLASTBuilderTest,SqlExpressionDepthGuardIssue5851FollowupTest` - no regression in the ANTLR SQL parser/AST builder suites
- [x] `mvn -pl engine -am test -Dtest="com.arcadedb.query.sql.parser.**,com.arcadedb.query.sql.antlr.**"` - full package sweep green

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
