### PR TITLE
fix(#5850): close HAReplicationMetrics on server stop

### DIFF
--- a/docs/5850-hareplicationmetrics-scheduler-leak.md
+++ b/docs/5850-hareplicationmetrics-scheduler-leak.md
@@ -1,0 +1,54 @@
+# Issue #5850: HAReplicationMetrics leaks a ScheduledExecutorService per bindTo()
+
+## Root cause
+
+`HAReplicationMetrics` already carried the fix infrastructure from a prior "chore: fixed flaky
+tests" commit (`ff764e79a`): it implements `Closeable`, holds the per-follower gauge refresh
+scheduler in a `followerMetricsScheduler` field, and `close()` shuts it down. That commit's own
+message says the class was fixed "even though nothing in `src/main` currently binds it" - and
+that was the residual bug. `ArcadeDBServer.startMetrics()` called
+`new HAReplicationMetrics(this).bindTo(Metrics.globalRegistry)` and discarded the instance
+immediately; nothing in production ever called `close()`, so the daemon thread named
+`arcadedb-ha-follower-metrics` (and the `ScheduledExecutorService` behind it) outlived every
+server stop/restart cycle.
+
+## Fix
+
+`server/src/main/java/com/arcadedb/server/ArcadeDBServer.java`:
+- Added a `haReplicationMetrics` field, mirroring the existing `metricsJvmGc` field/lifecycle
+  pattern already used for `JvmGcMetrics`.
+- `startMetrics()` now keeps the `HAReplicationMetrics` instance in that field instead of
+  discarding it.
+- `stopMetrics()` now closes it (guarded with `CodeUtils.executeIgnoringExceptions`, matching how
+  the other metrics binders are torn down) and nulls the field.
+
+This follows the same start/stop symmetry already established for `metricsJvmGc`,
+`metricsRegistry`, and `metricsLoggingRegistry` in the same method pair.
+
+## Regression test
+
+`server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java`:
+added `followerMetricsSchedulerThreadStopsWhenTheServerStops`, which starts a real embedded
+`ArcadeDBServer`, asserts the `arcadedb-ha-follower-metrics` daemon thread is alive after
+`start()`, then asserts (via Awaitility, since `shutdownNow()` interrupts asynchronously) that the
+thread is gone within 5s of `stop()`.
+
+Verified the test fails without the fix (red): `ConditionTimeoutException` - thread still alive 5s
+after `stop()`. Passes with the fix (green).
+
+## Test results
+
+- `ServerMetricsLifecycleTest`: 7/7 passing (new test included).
+- `HAReplicationMetricsTest`, `HAPendingPhase2MetricsTest`, `DefaultServerMetricsTest`,
+  `EngineMetricsBinderTest`, `PoolMetricsTest`: 28/28 passing, no regressions.
+- `mvn -pl server -am install -DskipTests`: BUILD SUCCESS.
+
+## Scope note
+
+The issue's final paragraph mentions two sibling leaks in the same "startService creates it,
+stopService doesn't clean it up" class: `HAReplicationMetrics` (this issue) and
+`PrometheusMetricsPlugin`. Checked `PrometheusMetricsPlugin.java` on this branch: it already
+removes and closes its registry in `stopService()` (added in the same `ff764e79a` commit that
+built `HAReplicationMetrics`'s `close()`), so no further action was needed there. `RaftHAPlugin`
+(the third instance, issue #5890) was already fixed and merged in PR #5981. This PR is scoped to
+`HAReplicationMetrics` only, per issue #5850.

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -162,6 +162,9 @@ public class ArcadeDBServer {
   private              MeterRegistry metricsRegistry;
   private              MeterRegistry metricsLoggingRegistry;
   private              JvmGcMetrics  metricsJvmGc;
+  // Holds the per-follower gauge refresh scheduler open; must be closed on stop or the daemon
+  // thread it starts leaks one instance per restart (issue #5850).
+  private              HAReplicationMetrics haReplicationMetrics;
 //  private             ServerMonitor                         serverMonitor;
 
   static {
@@ -624,8 +627,11 @@ public class ArcadeDBServer {
     // queries) - exposes arcadedb.engine.* gauges read live from the Profiler on each scrape.
     new EngineMetricsBinder().bindTo(Metrics.globalRegistry);
     // HA replication health (heartbeat lag + replication lag) sourced live from the HA plugin -
-    // exposes arcadedb.ha.* gauges; harmless no-op (all -1/0) when HA is disabled.
-    new HAReplicationMetrics(this).bindTo(Metrics.globalRegistry);
+    // exposes arcadedb.ha.* gauges; harmless no-op (all -1/0) when HA is disabled. Kept in a field
+    // and closed in stopMetrics(), or the per-follower gauge refresh scheduler it starts leaks one
+    // daemon thread per restart (issue #5850).
+    haReplicationMetrics = new HAReplicationMetrics(this);
+    haReplicationMetrics.bindTo(Metrics.globalRegistry);
     QueryMetricsRecorder.Holder.register(new MicrometerQueryMetricsRecorder());
 
     if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_LOGGING)) {
@@ -647,6 +653,10 @@ public class ArcadeDBServer {
     if (metricsJvmGc != null) {
       CodeUtils.executeIgnoringExceptions(metricsJvmGc::close, "Error on closing the JVM GC metrics", false);
       metricsJvmGc = null;
+    }
+    if (haReplicationMetrics != null) {
+      CodeUtils.executeIgnoringExceptions(haReplicationMetrics::close, "Error on closing the HA replication metrics", false);
+      haReplicationMetrics = null;
     }
     if (metricsLoggingRegistry != null) {
       removeMeterRegistry(metricsLoggingRegistry);

--- a/server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/ServerMetricsLifecycleTest.java
@@ -29,11 +29,13 @@ import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Regression tests for the lifecycle of the server-side Micrometer subsystem.
@@ -118,6 +120,25 @@ class ServerMetricsLifecycleTest extends StaticBaseServerTest {
   }
 
   @Test
+  void followerMetricsSchedulerThreadStopsWhenTheServerStops() {
+    // HAReplicationMetrics.bindPerFollowerGauges() starts a daemon thread named
+    // "arcadedb-ha-follower-metrics" to refresh the per-follower MultiGauges every 5s (issue #5850).
+    // Nothing in production called close() on the binder, so the thread outlived the server that
+    // started it; a restart therefore leaked one more.
+    final ArcadeDBServer server = startServer(0);
+
+    assertThat(followerMetricsThreadIsAlive())
+        .as("start() must launch the per-follower HA gauge refresh thread").isTrue();
+
+    server.stop();
+
+    await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+        assertThat(followerMetricsThreadIsAlive())
+            .as("stop() must shut down the per-follower HA gauge refresh thread, "
+                + "or it leaks one daemon thread per restart").isFalse());
+  }
+
+  @Test
   void metricsSurviveWhileAnotherServerInTheSameJvmIsRunning() {
     final ArcadeDBServer first = startServer(0);
     final ArcadeDBServer second = startServer(1);
@@ -182,5 +203,10 @@ class ServerMetricsLifecycleTest extends StaticBaseServerTest {
 
   private static List<MeterRegistry> registries() {
     return new ArrayList<>(Metrics.globalRegistry.getRegistries());
+  }
+
+  private static boolean followerMetricsThreadIsAlive() {
+    return Thread.getAllStackTraces().keySet().stream()
+        .anyMatch(t -> "arcadedb-ha-follower-metrics".equals(t.getName()) && t.isAlive());
   }
 }


### PR DESCRIPTION
Closes #5850

## Summary

`HAReplicationMetrics.bindPerFollowerGauges()` starts a `ScheduledExecutorService` (daemon thread `arcadedb-ha-follower-metrics`) that refreshes the per-follower HA gauges every 5 seconds. A prior commit (`ff764e79a`) already gave the class the `Closeable`/`close()` infrastructure to shut that scheduler down - but nothing in `src/main` actually called it: `ArcadeDBServer.startMetrics()` did `new HAReplicationMetrics(this).bindTo(Metrics.globalRegistry)` and discarded the instance immediately. Every server start therefore leaked one more daemon thread that outlived the server (and kept polling the HA plugin and writing into a possibly-discarded registry) for the rest of the JVM's life.

The fix wires `HAReplicationMetrics` into the same start/stop lifecycle `ArcadeDBServer` already uses for `metricsJvmGc` (`JvmGcMetrics`): keep the instance in a field on `startMetrics()`, and close it in `stopMetrics()`.

Also checked the two sibling leaks called out in the issue thread: `PrometheusMetricsPlugin` already removes+closes its registry in `stopService()` (fixed in the same `ff764e79a` commit), and `RaftHAPlugin` (issue #5890) was already fixed and merged in PR #5981. No further action needed on either; this PR is scoped to `HAReplicationMetrics` per issue #5850.

## Test plan

- New regression test `ServerMetricsLifecycleTest.followerMetricsSchedulerThreadStopsWhenTheServerStops`: starts a real embedded `ArcadeDBServer`, asserts the `arcadedb-ha-follower-metrics` daemon thread is alive after `start()`, then asserts (via Awaitility, since `shutdownNow()` interrupts asynchronously) it is gone within 5s of `stop()`.
  - Confirmed it fails without the fix (`ConditionTimeoutException`: thread still alive 5s after `stop()`).
  - Passes with the fix.
- `mvn -pl server test -Dtest=ServerMetricsLifecycleTest`: 7/7 passing.
- `mvn -pl server test -Dtest=HAReplicationMetricsTest,HAPendingPhase2MetricsTest,DefaultServerMetricsTest,EngineMetricsBinderTest,PoolMetricsTest`: 28/28 passing, no regressions.
- `mvn -pl server -am install -DskipTests`: BUILD SUCCESS.