### PR TITLE
fix(#5848): RaftGroupCommitter applies quorumTimeout per batch, not per entry

### DIFF
--- a/docs/5848-raftgroupcommitter-per-batch-quorum-timeout.md
+++ b/docs/5848-raftgroupcommitter-per-batch-quorum-timeout.md
@@ -1,0 +1,99 @@
+# Issue #5848: RaftGroupCommitter applies quorumTimeout per entry instead of per batch
+
+## Root cause
+
+`RaftGroupCommitter.flushBatch()` dispatches a whole batch of entries to Ratis concurrently
+(`raftClient.async().send(msg)` for every entry first), then waits on each resulting future
+**sequentially**, each with the **full** `quorumTimeout`:
+
+```java
+for (int i = 0; i < batch.size(); i++) {
+  ...
+  final RaftClientReply reply = futures[i].get(quorumTimeout, TimeUnit.MILLISECONDS);
+```
+
+Since every future was already in flight before the wait loop starts, `quorumTimeout` is clearly
+meant as a deadline for the whole batch. As written it was a fresh budget re-applied to every
+entry, so a batch where N entries never reply (stalled/partitioned quorum) wedges the single
+flusher thread (`arcadedb-raft-group-committer`) for `N x quorumTimeout` instead of
+`quorumTimeout`. At the shipped defaults (`quorumTimeout=10000`, `groupCommitBatchSize=500`) the
+worst case is 500 x 10s = 5000s (~83 minutes) with the replication queue filling up and every
+client seeing `ReplicationQueueFullException` in the meantime.
+
+A follow-up comment on the issue additionally points out a correctness consequence: entries later
+in the batch can have their outcome resolved (by `flushBatch`) after the *caller's own*
+`submitAndWait` budget (`3 x quorumTimeout`) has already expired. Those callers see a
+`ReplicationDispatchedTimeoutException` (retry) for a write that may have actually committed
+cluster-wide, risking a duplicate on client retry. Fixing the per-entry-vs-per-batch timeout also
+narrows that window (an entry can only be reported "indeterminate" once, not after redundant waits
+on preceding stalled entries burn through the caller's own budget).
+
+## Fix
+
+Compute a single deadline before the per-entry wait loop and derive each `Future#get` timeout from
+what remains of it, mirroring the fix suggested in the issue:
+
+```java
+final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(quorumTimeout);
+for (int i = 0; i < batch.size(); i++) {
+  ...
+  final long remainingNanos = deadlineNanos - System.nanoTime();
+  final RaftClientReply reply = futures[i].get(remainingNanos, TimeUnit.NANOSECONDS);
+```
+
+Negative/zero `remainingNanos` is passed straight through rather than special-cased: `CompletableFuture#get(timeout, unit)`
+checks completion **before** looking at the timeout value, so an entry that already has a reply
+by the time we reach it still completes instantly - it is not punished for sharing a batch with
+earlier, slower/stalled entries. Only a not-yet-done future turns a non-positive remaining budget
+into an immediate `TimeoutException`, which is exactly the existing "entry dispatched to Raft;
+outcome unknown" classification the code already used for a real timeout (issue #4790).
+
+No new imports were required (`TimeoutException` was already imported and used elsewhere in the
+class).
+
+## Test
+
+Added `RaftGroupCommitterTest.stalledEntriesInOneBatchDoNotWedgeTheFlusherForTheNextEntry`:
+
+- Mocks `RaftClient.async().send()` so the first 5 dispatched entries never reply (simulated
+  stalled quorum) and any entry dispatched after that replies successfully and immediately.
+- Submits 5 entries concurrently (fire-and-forget background threads) so they land in one batch
+  with a stalled quorum, waits briefly for them to enqueue, then submits one more entry from the
+  main thread.
+- Asserts the extra entry's `submitAndWait` call **succeeds** and returns the expected log index.
+
+This is deterministic regardless of exactly how the 5 stalling submissions split across
+`drainTo()` calls: on the buggy code the flusher pays a full `quorumTimeout` per stalled entry
+before it can loop back to the queue, *regardless* of how those entries were grouped into
+batches, so the extra entry sits `PENDING` long enough that its own submitter-side
+`2 x quorumTimeout` budget expires first and it gets cancelled
+(`QuorumNotReachedException: ... cancelled before dispatch`) - reproducing the "queue fills up,
+clients see errors" symptom from the issue. On the fixed code the flusher frees up within about
+one `quorumTimeout` regardless of batch size, so the extra entry is dispatched normally and
+completes.
+
+Confirmed the test fails against the pre-fix code with exactly that cancellation error, then
+passes after the fix.
+
+### Test results
+
+- `mvn -pl ha-raft test -Dtest=RaftGroupCommitterTest` - 20/20 passed (including the new
+  regression test).
+- `mvn -pl ha-raft test` (full module) - 615/615 passed before the run was interrupted by an
+  unrelated, pre-existing environmental collision: a concurrently-running agent building the same
+  `ha-raft` module in a sibling worktree on this shared machine held the fixed port `WaitForApplyTest`
+  binds, producing `java.net.BindException: Address already in use`. Confirmed via `ps aux` that
+  another `mvn ... -pl ha-raft ... -Dtest=...,WaitForApplyTest` process was running concurrently
+  from a different worktree at the time. Not related to this change (`WaitForApplyTest` does not
+  reference `RaftGroupCommitter`).
+
+## Impact
+
+- Bounds the group-committer flusher's stall on a stuck/partitioned quorum to `quorumTimeout`
+  instead of `batchSize x quorumTimeout`, restoring throughput as soon as the cluster recovers
+  instead of minutes to hours later.
+- Reduces (does not eliminate - `submitAndWait`'s own `3 x quorumTimeout` budget is unchanged and
+  intentionally so) the window in which a write that actually committed cluster-wide is reported to
+  the client as indeterminate/retryable purely because of its position in a stalled batch.
+- No behavioral change for the healthy-quorum path: every entry's real wait time is unchanged when
+  replies arrive promptly.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
@@ -487,12 +487,24 @@ class RaftGroupCommitter {
     // ReplicationDispatchedTimeoutException (indeterminate outcome, issue #4790): the originator then
     // marks the transaction for local apply instead of rolling back and origin-skipping a write the
     // rest of the cluster keeps - the silent leader divergence behind issue #4743's bulk-load churn.
+    //
+    // quorumTimeout is a deadline for the WHOLE batch, not a fresh budget per entry: every future was
+    // already dispatched above, concurrently, before this loop starts. Awaiting each one with its own
+    // full quorumTimeout turns a stalled quorum into a batch.size() x quorumTimeout stall on this
+    // single flusher thread instead of the intended quorumTimeout (issue #5848). Take one deadline
+    // before the loop and derive each wait from what remains of it. A negative/zero remaining budget
+    // is safe to pass straight through: CompletableFuture#get(timeout, unit) checks completion BEFORE
+    // looking at the timeout, so an already-replied entry still completes instantly instead of being
+    // punished for sharing a batch with slower entries; only a not-yet-done future turns that into an
+    // immediate TimeoutException.
+    final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(quorumTimeout);
     for (int i = 0; i < batch.size(); i++) {
       if (futures[i] == null)
         continue;
 
       try {
-        final RaftClientReply reply = futures[i].get(quorumTimeout, TimeUnit.MILLISECONDS);
+        final long remainingNanos = deadlineNanos - System.nanoTime();
+        final RaftClientReply reply = futures[i].get(remainingNanos, TimeUnit.NANOSECONDS);
         if (!reply.isSuccess()) {
           final String err = reply.getException() != null ? reply.getException().getMessage() : "replication failed";
           if (isClientClosed(reply.getException()))

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
@@ -29,10 +29,14 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -486,6 +490,70 @@ class RaftGroupCommitterTest {
       assertThatThrownBy(() -> committer.submitAndWait(new byte[] { 1, 2, 3 }))
           .isInstanceOf(QuorumNotReachedException.class);
     } finally {
+      committer.stop();
+    }
+  }
+
+  /**
+   * Regression for issue #5848: {@code flushBatch} dispatches a whole batch concurrently but then
+   * awaits each reply SEQUENTIALLY with the FULL {@code quorumTimeout}, on the single flusher thread.
+   * A batch where several entries never reply (a stalled quorum) therefore wedges the flusher for
+   * {@code batch.size() x quorumTimeout} instead of the intended {@code quorumTimeout} batch deadline.
+   * <p>
+   * This test fills one batch with entries whose quorum never replies, then submits one more entry
+   * right after. With the bug, the flusher is still sequentially waiting out the stalled batch when
+   * that extra entry's OWN submitter-side {@code 2 x quorumTimeout} budget expires, so it gets
+   * cancelled while still sitting {@code PENDING} in the queue - it never even gets dispatched. With
+   * the fix, the flusher frees up within about one {@code quorumTimeout} of the stalled batch's
+   * dispatch (regardless of how many entries stalled), dispatches the extra entry normally, and it
+   * completes successfully. This holds regardless of how the racing stalled submissions happen to
+   * split across drainTo() calls, because either way the buggy code pays a full quorumTimeout per
+   * stalled entry before the flusher can loop back to the queue.
+   */
+  @Test
+  void stalledEntriesInOneBatchDoNotWedgeTheFlusherForTheNextEntry() throws Exception {
+    final long quorumTimeout = 250; // ms
+    final int stallCount = 5;
+
+    final RaftClientReply okReply = mock(RaftClientReply.class);
+    when(okReply.isSuccess()).thenReturn(true);
+    when(okReply.getLogIndex()).thenReturn(999L);
+
+    final AtomicInteger sendCount = new AtomicInteger();
+    final RaftClient client = mock(RaftClient.class, RETURNS_DEEP_STUBS);
+    when(client.async().send(any(Message.class))).thenAnswer(inv -> {
+      if (sendCount.incrementAndGet() <= stallCount)
+        return new CompletableFuture<RaftClientReply>(); // never completes: simulates a stalled quorum
+      return CompletableFuture.completedFuture(okReply);
+    });
+
+    final RaftGroupCommitter committer = new RaftGroupCommitter(client, Quorum.MAJORITY, quorumTimeout,
+        stallCount + 5, 1_000, 100, RaftGroupCommitter.DEFAULT_MESSAGE_SIZE_MAX, null);
+    final ExecutorService stallers = Executors.newFixedThreadPool(stallCount);
+    try {
+      // Fill (at least) one batch with entries whose quorum will never reply. Fire-and-forget: their
+      // own eventual outcome (indeterminate or cancelled) is not the focus of this test.
+      for (int i = 0; i < stallCount; i++)
+        stallers.submit(() -> {
+          try {
+            committer.submitAndWait(new byte[] { 1, 2, 3 });
+          } catch (final Exception ignored) {
+            // expected eventually
+          }
+        });
+
+      // Give the stalling entries time to enqueue. offer() is near-instant, so this margin is
+      // generous; it is well under the quorumTimeout the assertion below relies on.
+      Thread.sleep(150);
+
+      final AtomicLong index = new AtomicLong(-1);
+      assertThatCode(() -> index.set(committer.submitAndWait(new byte[] { 9, 9, 9 })))
+          .as("the flusher must free up within roughly one quorumTimeout - not stallCount x "
+              + "quorumTimeout - so this entry must be dispatched instead of cancelled while PENDING")
+          .doesNotThrowAnyException();
+      assertThat(index.get()).isEqualTo(999L);
+    } finally {
+      stallers.shutdownNow();
       committer.stop();
     }
   }


### PR DESCRIPTION
Closes #5848

## Summary

`RaftGroupCommitter.flushBatch()` dispatches a whole batch of entries to Ratis concurrently, then waits on each resulting future **sequentially**, each with the **full** `quorumTimeout`. Since every future was already in flight before the wait loop starts, `quorumTimeout` is clearly meant as a deadline for the whole batch. As written it was a fresh budget re-applied to every entry, so a batch where several entries never reply (a stalled/partitioned quorum) wedges the single flusher thread (`arcadedb-raft-group-committer`) for `batch.size() x quorumTimeout` instead of the intended `quorumTimeout`. At the shipped defaults (`quorumTimeout=10000`, `groupCommitBatchSize=500`) the worst case is 500 x 10s = 5000s (~83 minutes), with the replication queue filling up and every client seeing `ReplicationQueueFullException` in the meantime, long after the cluster may have already recovered.

As noted in a follow-up comment on the issue, this also has a correctness dimension: entries later in a stalled batch can have their outcome resolved by `flushBatch` after the *caller's own* `submitAndWait` budget (`3 x quorumTimeout`) already expired, so a write that actually committed cluster-wide can surface to the client as indeterminate/retryable, risking a duplicate on retry. Fixing the per-entry-vs-per-batch timeout narrows that window.

## Fix

Compute a single deadline before the per-entry wait loop and derive each `Future#get` timeout from what remains of it (as suggested in the issue). A negative/zero remaining budget is passed straight through rather than special-cased: `CompletableFuture#get(timeout, unit)` checks completion **before** consulting the timeout, so an entry that already has a reply by the time the loop reaches it still completes instantly instead of being punished for sharing a batch with earlier, stalled entries. Only a not-yet-done future turns an expired batch deadline into an immediate `TimeoutException`, which the code already classifies as "dispatched to Raft; outcome unknown" (issue #4790) - the correct classification, since the entry may still commit on the followers.

The single-entry path (`submitAndWait`'s own two-stage `2 x quorumTimeout` + `quorumTimeout` grace budget) is unaffected; it was already correct per the issue.

## Test plan

- [x] Added `RaftGroupCommitterTest.stalledEntriesInOneBatchDoNotWedgeTheFlusherForTheNextEntry`: mocks `RaftClient.async().send()` so the first 5 dispatched entries never reply (simulated stalled quorum), submits them concurrently so they land in one batch, then submits one more entry afterward that should be dispatched and reply successfully. Confirmed this test fails against the pre-fix code with `QuorumNotReachedException: ... cancelled before dispatch` (the extra entry starved behind the wedged flusher, reproducing the issue's "queue fills up, clients get errors" symptom), and passes after the fix.
- [x] `mvn -pl ha-raft test -Dtest=RaftGroupCommitterTest` - 20/20 passed.
- [x] `mvn -pl ha-raft test` (full module) - 615/615 passed before the run was interrupted by an unrelated, pre-existing environmental port collision from a concurrently-running build of the same module in a sibling worktree on the build machine (`WaitForApplyTest`, which does not reference `RaftGroupCommitter`); not a regression from this change.