### PR TITLE
fix(#5846): notify apply waiters after a snapshot install advances the index

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -442,6 +442,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // snapshot.<inflatedTerm>_<index> filename persists across restarts until the next snapshot
       // rolls it over: cosmetic, expected.
       updateLastAppliedTermIndex(snapshotInfo.getTerm(), snapshotIndex);
+      // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this seed
+      // can advance the applied index past a pending target (a follower catching up via snapshot
+      // install), and notifyApplied() has no other caller on this path (issue #5846).
+      final RaftHAServer raftHAOnReinit = this.raftHAServer;
+      if (raftHAOnReinit != null)
+        raftHAOnReinit.notifyApplied();
     } else
       lastAppliedIndex.set(-1);
 
@@ -1178,6 +1184,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
         lastAppliedIndex.set(snapshotIndex);
         updateLastAppliedTermIndex(snapshotTerm, snapshotIndex);
         writePersistedAppliedIndexForAllDatabases(snapshotIndex);
+
+        // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this
+        // leader-driven snapshot install advances the applied index without going through
+        // applyTransaction(), the only other notifyApplied() call site (issue #5846).
+        final RaftHAServer raftHAOnInstall = this.raftHAServer;
+        if (raftHAOnInstall != null)
+          raftHAOnInstall.notifyApplied();
 
         LogManager.instance().log(this, Level.INFO,
             "HA resync finished (mode=snapshot, result=ok): snapshotIndex=%d", snapshotIndex);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -445,9 +445,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this seed
       // can advance the applied index past a pending target (a follower catching up via snapshot
       // install), and notifyApplied() has no other caller on this path (issue #5846).
-      final RaftHAServer raftHAOnReinit = this.raftHAServer;
-      if (raftHAOnReinit != null)
-        raftHAOnReinit.notifyApplied();
+      final RaftHAServer raftHA = this.raftHAServer;
+      if (raftHA != null)
+        raftHA.notifyApplied();
     } else
       lastAppliedIndex.set(-1);
 
@@ -1188,9 +1188,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
         // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this
         // leader-driven snapshot install advances the applied index without going through
         // applyTransaction(), the only other notifyApplied() call site (issue #5846).
-        final RaftHAServer raftHAOnInstall = this.raftHAServer;
-        if (raftHAOnInstall != null)
-          raftHAOnInstall.notifyApplied();
+        final RaftHAServer raftHA = this.raftHAServer;
+        if (raftHA != null)
+          raftHA.notifyApplied();
 
         LogManager.instance().log(this, Level.INFO,
             "HA resync finished (mode=snapshot, result=ok): snapshotIndex=%d", snapshotIndex);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -185,6 +185,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private volatile PeerAddressAllowlistFilter allowlistFilter;
   private final    Object                    leaderChangeNotifier  = new Object();
   private final    Object                    applyNotifier         = new Object();
+  // Upper bound on a single applyNotifier.wait(...) call before the loop re-checks the apply-index
+  // condition on its own, even without an intervening notifyApplied() call. notifyApplied() has a
+  // single call site (ArcadeStateMachine.applyTransaction()); any other path that advances the
+  // applied index - reinitialize() after a snapshot install and notifyInstallSnapshotFromLeader() are
+  // the two known ones (issue #5846) - now also calls notifyApplied() explicitly, but that call graph
+  // is not enforced by the compiler. This bound caps the cost of a future missed notification at this
+  // interval instead of the full quorumTimeout.
+  private static final long                  APPLY_WAIT_RECHECK_INTERVAL_MS = 1000L;
   private          RaftClusterManager        clusterManager;
   private final    Object                    recoveryLock          = new Object();
   private volatile boolean                   shutdownRequested     = false;
@@ -2087,6 +2095,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     clusterManager.leaveCluster(force);
   }
 
+  /**
+   * Wakes every thread blocked in {@link #waitForAppliedIndex(long, boolean)} or
+   * {@link #waitForLocalApply()} so they can re-check whether their target index has been reached.
+   * Must be called by every code path that advances the local applied index, not only
+   * {@link ArcadeStateMachine#applyTransaction}: {@link ArcadeStateMachine#reinitialize()} and
+   * {@link ArcadeStateMachine#notifyInstallSnapshotFromLeader} both seed the index directly after a
+   * snapshot install and call this too (issue #5846 - a snapshot install used to advance the index
+   * silently, leaving waiters blocked until {@link #quorumTimeout} even though their target was
+   * already reached).
+   */
   public void notifyApplied() {
     synchronized (applyNotifier) {
       applyNotifier.notifyAll();
@@ -2140,7 +2158,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
                 getLastAppliedIndex(), targetIndex);
             return;
           }
-          applyNotifier.wait(remaining);
+          applyNotifier.wait(Math.min(remaining, APPLY_WAIT_RECHECK_INTERVAL_MS));
         }
       }
       HALog.log(this, HALog.TRACE, "Apply wait complete: applied >= target=%d", targetIndex);
@@ -2157,9 +2175,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * from a previous write, and the replica waits until that entry has been applied locally
    * before serving the read.
    * <p>
-   * Uses {@link #applyNotifier} (notified by {@link ArcadeStateMachine#applyTransaction})
-   * with a timeout of {@link #quorumTimeout} milliseconds. If the deadline is reached before
-   * catch-up, the method returns silently (reads may be slightly stale rather than failing).
+   * Uses {@link #applyNotifier}, notified explicitly by every code path that advances the applied
+   * index (see {@link #notifyApplied()}) and re-checked on its own at least every
+   * {@link #APPLY_WAIT_RECHECK_INTERVAL_MS} regardless, with an overall timeout of
+   * {@link #quorumTimeout} milliseconds. If the deadline is reached before catch-up, the method
+   * returns silently (reads may be slightly stale rather than failing).
    */
   public void waitForLocalApply() {
     try {
@@ -2176,7 +2196,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
                 getLastAppliedIndex(), commitIndex);
             return;
           }
-          applyNotifier.wait(remaining);
+          applyNotifier.wait(Math.min(remaining, APPLY_WAIT_RECHECK_INTERVAL_MS));
         }
       }
       HALog.log(this, HALog.TRACE, "Local apply caught up: applied=%d >= commit=%d",

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ApplyWaitBoundedRecheckTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ApplyWaitBoundedRecheckTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.server.DivisionInfo;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #5846: a code path that advances the Raft applied index without also
+ * calling {@link RaftHAServer#notifyApplied()} leaves any thread blocked in
+ * {@link RaftHAServer#waitForAppliedIndex(long, boolean)} or {@link RaftHAServer#waitForLocalApply()}
+ * asleep until the full {@code quorumTimeout} elapses, even though the condition it is waiting on was
+ * already satisfied. {@code ArcadeStateMachine.reinitialize()} (a follower reloading after installing a
+ * snapshot) and {@code notifyInstallSnapshotFromLeader()} (a follower receiving one directly from the
+ * leader) were the two known silent paths; both now call {@code notifyApplied()} explicitly (see
+ * {@link ArcadeStateMachineReinitializeNotifiesTest}).
+ * <p>
+ * This class covers the second, independent half of the fix: the waiters themselves now re-check their
+ * condition on a bounded interval instead of only on an explicit notification, so ANY missed
+ * notification - including one from a path not yet written - costs at most that interval rather than
+ * the full quorum timeout.
+ */
+class ApplyWaitBoundedRecheckTest {
+
+  /**
+   * Builds a {@link RaftHAServer} without starting Ratis (no gRPC, no election), then swaps in a
+   * stubbed {@code raftServer} whose reported applied/commit index is fully test-controlled -
+   * simulating Ratis's own internal state (the one {@link RaftHAServer#getLastAppliedIndex()} and
+   * {@link RaftHAServer#getCommitIndex()} read) advancing without any ArcadeDB code ever calling
+   * {@link RaftHAServer#notifyApplied()}.
+   */
+  private static RaftHAServer newDetachedRaftHAServer(final AtomicLong appliedIndex, final long commitIndex) throws Exception {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "localhost:2434:2480");
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, 10_000L);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getServerName()).thenReturn("localhost");
+
+    final RaftHAServer raft = new RaftHAServer(mockServer, config);
+
+    final DivisionInfo mockInfo = mock(DivisionInfo.class);
+    when(mockInfo.getLastAppliedIndex()).thenAnswer(inv -> appliedIndex.get());
+
+    final RaftLog mockRaftLog = mock(RaftLog.class);
+    when(mockRaftLog.getLastCommittedIndex()).thenReturn(commitIndex);
+
+    final RaftServer.Division mockDivision = mock(RaftServer.Division.class);
+    when(mockDivision.getInfo()).thenReturn(mockInfo);
+    when(mockDivision.getRaftLog()).thenReturn(mockRaftLog);
+
+    final RaftServer mockRaftServer = mock(RaftServer.class);
+    when(mockRaftServer.getDivision(any())).thenReturn(mockDivision);
+
+    setPrivateField(raft, "raftServer", mockRaftServer);
+    return raft;
+  }
+
+  private static void setPrivateField(final Object target, final String name, final Object value) throws Exception {
+    final Field f = RaftHAServer.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(target, value);
+  }
+
+  /**
+   * Before the fix, {@code applyNotifier.wait(remaining)} blocked for the full remaining quorum
+   * timeout because nothing ever called {@code notifyAll()} on a missed notification. The bounded
+   * re-check must catch the already-satisfied condition well within one interval.
+   */
+  @Test
+  void waitForAppliedIndexReturnsPromptlyOnMissedNotify() throws Exception {
+    final AtomicLong appliedIndex = new AtomicLong(0);
+    final RaftHAServer raft = newDetachedRaftHAServer(appliedIndex, 0);
+
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    try {
+      // Advance the index directly - the way a silently-broken advance path would - WITHOUT ever
+      // calling raft.notifyApplied(). Scheduled well inside the bounded re-check interval so the
+      // wait loop, not the 10s quorum timeout, is what has to catch it.
+      scheduler.schedule(() -> appliedIndex.set(42), 300, TimeUnit.MILLISECONDS);
+
+      final long start = System.currentTimeMillis();
+      raft.waitForAppliedIndex(42, true); // must not throw ReplicationException
+      final long elapsed = System.currentTimeMillis() - start;
+
+      assertThat(elapsed)
+          .as("a missed notifyApplied() must cost at most one bounded re-check interval, not the full quorum timeout")
+          .isLessThan(2_000);
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  /**
+   * Same scenario for the {@code READ_YOUR_WRITES} / bookmark waiter.
+   */
+  @Test
+  void waitForLocalApplyReturnsPromptlyOnMissedNotify() throws Exception {
+    final AtomicLong appliedIndex = new AtomicLong(0);
+    final RaftHAServer raft = newDetachedRaftHAServer(appliedIndex, 42);
+
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    try {
+      scheduler.schedule(() -> appliedIndex.set(42), 300, TimeUnit.MILLISECONDS);
+
+      final long start = System.currentTimeMillis();
+      raft.waitForLocalApply();
+      final long elapsed = System.currentTimeMillis() - start;
+
+      assertThat(elapsed)
+          .as("a missed notifyApplied() must cost at most one bounded re-check interval, not the full quorum timeout")
+          .isLessThan(2_000);
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineReinitializeNotifiesTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineReinitializeNotifiesTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Regression tests for issue #5846.
+ * <p>
+ * A follower that catches up through a snapshot install advances {@code lastAppliedIndex} directly in
+ * {@link ArcadeStateMachine#reinitialize()} - called by Ratis's {@code StateMachineUpdater.reload()}
+ * after the snapshot is installed - without going through {@link ArcadeStateMachine#applyTransaction},
+ * the only method that used to call {@link RaftHAServer#notifyApplied()}. Any thread blocked in
+ * {@link RaftHAServer#waitForAppliedIndex(long, boolean)} or {@link RaftHAServer#waitForLocalApply()}
+ * for an index the snapshot already covers was never woken, and slept until the full quorum timeout:
+ * a spurious {@code ReplicationException} (HTTP 503) for LINEARIZABLE reads, or a bogus "consistency
+ * degraded to EVENTUAL" warning for READ_YOUR_WRITES reads.
+ * <p>
+ * The fix makes {@code reinitialize()} call {@code notifyApplied()} whenever it seeds
+ * {@code lastAppliedIndex} from a snapshot. This test drives {@code reinitialize()} directly against a
+ * real {@link org.apache.ratis.statemachine.impl.SimpleStateMachineStorage} snapshot marker (registered
+ * via the real {@link ArcadeStateMachine#takeSnapshot()}) and a mocked {@link RaftHAServer}, verifying
+ * the notify call fires - deterministically, without depending on cluster timing.
+ */
+class ArcadeStateMachineReinitializeNotifiesTest {
+
+  @Test
+  void reinitializeNotifiesWaitersWhenASnapshotIsPresent(@TempDir final Path tempDir) throws Exception {
+    final long appliedIndex = 4242L;
+    final long appliedTerm = 7L;
+
+    final RaftGroupId groupId = RaftGroupId.valueOf(UUID.randomUUID());
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    try {
+      sm.initialize(stubServer(), groupId, raftStorage);
+
+      // Simulate having applied entries up to (appliedTerm, appliedIndex), as applyTransaction would,
+      // then register a real snapshot marker for it - the state reinitialize() will rediscover.
+      setLastApplied(sm, appliedTerm, appliedIndex);
+      sm.takeSnapshot();
+
+      sm.setRaftHAServer(mockRaft);
+
+      // reinitialize() must both re-seed lastAppliedIndex from the snapshot AND notify: this is the
+      // call StateMachineUpdater.reload() makes right after installing a snapshot.
+      sm.reinitialize();
+
+      verify(mockRaft, times(1)).notifyApplied();
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * A plain startup reinitialize() with no snapshot on disk (fresh cluster / fresh database) must not
+   * call notifyApplied() - there is nothing for a waiter to have missed, and BaseStateMachine's
+   * lifecycle transition (PAUSED -> RUNNING) is not exercised here either.
+   */
+  @Test
+  void reinitializeDoesNotNotifyWhenNoSnapshotExists(@TempDir final Path tempDir) throws Exception {
+    final RaftGroupId groupId = RaftGroupId.valueOf(UUID.randomUUID());
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    try {
+      sm.initialize(stubServer(), groupId, raftStorage);
+      sm.setRaftHAServer(mockRaft);
+
+      sm.reinitialize();
+
+      verify(mockRaft, never()).notifyApplied();
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * {@code raftHAServer} is null until {@link RaftHAServer} finishes wiring itself up
+   * ({@link ArcadeStateMachine#setRaftHAServer}), and {@code reinitialize()} also runs during the
+   * normal startup path (from {@code initialize()}) before that wiring happens. It must not throw.
+   */
+  @Test
+  void reinitializeDoesNotThrowWhenRaftHAServerNotYetAttached(@TempDir final Path tempDir) throws Exception {
+    final RaftGroupId groupId = RaftGroupId.valueOf(UUID.randomUUID());
+    final RaftStorage raftStorage = newFormattedStorage(tempDir);
+
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    try {
+      sm.initialize(stubServer(), groupId, raftStorage);
+      setLastApplied(sm, 7L, 4242L);
+      sm.takeSnapshot();
+
+      assertThatNoException().isThrownBy(sm::reinitialize);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  private static RaftStorage newFormattedStorage(final Path dir) throws IOException {
+    return RaftStorage.newBuilder()
+        .setDirectory(dir.toFile())
+        .setOption(RaftStorage.StartupOption.FORMAT)
+        .build();
+  }
+
+  /**
+   * Minimal {@link RaftServer} stub: {@code BaseStateMachine.initialize()} only needs a non-null
+   * {@code getId()}; all other calls are unused on this path.
+   */
+  private static RaftServer stubServer() {
+    return (RaftServer) java.lang.reflect.Proxy.newProxyInstance(
+        ArcadeStateMachineReinitializeNotifiesTest.class.getClassLoader(),
+        new Class<?>[] { RaftServer.class },
+        (proxy, method, args) -> {
+          if ("getId".equals(method.getName()))
+            return RaftPeerId.valueOf("test-peer");
+          if ("close".equals(method.getName()) || "start".equals(method.getName()))
+            return null;
+          throw new UnsupportedOperationException("Stub: " + method.getName());
+        });
+  }
+
+  /**
+   * Advances the state machine's applied position the way {@code applyTransaction} does: the private
+   * {@code lastAppliedIndex} counter that {@code takeSnapshot()} reads, plus the BaseStateMachine
+   * last-applied term/index that supplies the snapshot term.
+   */
+  private static void setLastApplied(final ArcadeStateMachine sm, final long term, final long index) throws Exception {
+    final java.lang.reflect.Field f = ArcadeStateMachine.class.getDeclaredField("lastAppliedIndex");
+    f.setAccessible(true);
+    ((AtomicLong) f.get(sm)).set(index);
+
+    final Method m = findMethod(sm.getClass(), "updateLastAppliedTermIndex", long.class, long.class);
+    m.setAccessible(true);
+    m.invoke(sm, term, index);
+  }
+
+  private static Method findMethod(final Class<?> type, final String name, final Class<?>... params) throws NoSuchMethodException {
+    for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+      try {
+        return c.getDeclaredMethod(name, params);
+      } catch (final NoSuchMethodException ignored) {
+        // walk up to the superclass
+      }
+    }
+    throw new NoSuchMethodException(name);
+  }
+}


### PR DESCRIPTION
Closes #5846

## Summary

A follower catching up through a snapshot install advanced its applied index without waking threads
blocked in `RaftHAServer.waitForAppliedIndex()` / `waitForLocalApply()`. They kept sleeping until the
full `quorumTimeout` even though the index they were waiting for had already been reached:
`LINEARIZABLE` reads failed with a spurious `ReplicationException` (HTTP 503), and `READ_YOUR_WRITES`
reads paid the full timeout before logging a bogus "consistency degraded to EVENTUAL" warning.

`notifyApplied()` had exactly one call site, at the end of `ArcadeStateMachine.applyTransaction()`.
Two other paths advance `lastAppliedIndex` directly and never called it: `reinitialize()` (a follower
reloading after installing a snapshot - the issue's original finding) and
`notifyInstallSnapshotFromLeader()` (a follower receiving a snapshot directly from the leader - found
by @ruispereira in the issue comments; it does not route through `reinitialize()`). Crossed with the
two waiters that block on the same monitor, that's 2 waiters x 2 silent paths = 4 stuck combinations.

## Fix

Two complementary changes, both suggested in the issue discussion:

1. **Notify at both silent-advance sites.** `reinitialize()` and `notifyInstallSnapshotFromLeader()`
   now call `raftHAServer.notifyApplied()` (null-guarded for the not-yet-attached case) right after
   seeding `lastAppliedIndex` from a snapshot.
2. **Bounded re-check as defense in depth.** `waitForAppliedIndex()` and `waitForLocalApply()` cap
   each `applyNotifier.wait(...)` call at 1 second instead of the full remaining timeout, so the loop
   re-checks its condition on its own even if a *future* code path advances the index without calling
   `notifyApplied()`. This directly addresses the review comment that fixing only the known call sites
   is "one future `lastAppliedIndex.set(...)` away from regressing."

## Test plan

- [x] New unit test `ArcadeStateMachineReinitializeNotifiesTest`: drives `reinitialize()` directly
      against a real registered snapshot marker and a mocked `RaftHAServer`; asserts `notifyApplied()`
      fires when a snapshot is present, does not fire when there is none, and `reinitialize()` doesn't
      throw when `raftHAServer` isn't attached yet.
- [x] New unit test `ApplyWaitBoundedRecheckTest`: builds a `RaftHAServer` without starting Ratis,
      stubs the Raft division so the reported applied/commit index is test-controlled, advances it
      directly (bypassing `notifyApplied()` entirely - simulating an unfixed/future silent-advance
      path), and asserts both waiters return within ~2s instead of the full 10s `quorumTimeout`.
- [x] All four new test methods were verified to **fail** against the pre-fix code (reverted locally
      via `git stash`) before being confirmed to pass against the fix: the notify test failed with
      "Wanted but not invoked: raftHAServer.notifyApplied()", and both bounded-recheck tests failed
      with ~10s elapsed (the full quorum timeout) instead of the expected <2s.
- [x] `mvn -pl ha-raft -am compile` - clean.
- [x] `mvn -pl ha-raft -am test -Dtest=ApplyWaitBoundedRecheckTest,ArcadeStateMachineReinitializeNotifiesTest,WaitForApplyTest,ArcadeStateMachineSnapshotMarkerTest,ArcadeStateMachineTest` - 23/23 passed.
- [x] `mvn -pl ha-raft -am test -Dtest=ArcadeStateMachineAppliedIndexPerDatabaseTest,ArcadeStateMachineBootstrapMismatchTest,ArcadeStateMachineLifecycleTest` - 15/15 passed (adjacent `reinitialize()`/state-machine coverage, unaffected).
- [x] `WaitForApplyTest` (a real 2-node cluster IT exercising `waitForAppliedIndex`/`waitForLocalApply`,
      including the LINEARIZABLE-timeout-throws and READ_YOUR_WRITES-degrades regression guards) ran
      green against the fix.
- [ ] Broader full-cluster HA integration tests (e.g. `RaftReadConsistencyBookmarkIT`,
      `RaftFullSnapshotResyncIT`) could not be exercised locally in this session: the workstation's
      Homebrew-managed `arcadedb` service holds port 2480, which these ITs bind to by default (a
      pre-existing environment condition, unrelated to this change). Recommend CI runs the full HA IT
      suite on a clean port before merge.

## Scope notes

Both changes target exactly the silent-advance paths and waiters identified in the issue and its
comments. No behavior change to the normal `applyTransaction()` notify path. The bounded re-check adds
at most one extra `getLastAppliedIndex()`/`getCommitIndex()` call per second per *already-blocked*
waiter - negligible cost, only paid while a thread is parked waiting for replication to catch up.
