### PR TITLE
fix(#5668): apply stale-handle fix pattern to RaftReplicationChangeSchemaIT

### DIFF
--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationChangeSchemaIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationChangeSchemaIT.java
@@ -19,7 +19,6 @@
 package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.engine.Bucket;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -66,6 +65,24 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
     // replaces its Database instance mid-test, and a handle cached before that point throws
     // DatabaseIsClosedException on next use - the #5977 stale-handle pattern already documented on
     // BaseRaftHATest and fixed the same way in RaftReplicationMaterializedViewIT (#5668).
+    //
+    // Each withResyncRetry() call below wraps exactly one mutating statement. withResyncRetry()
+    // retries its whole lambda from scratch on DatabaseIsClosedException, so a lambda bundling two
+    // mutations would risk re-running the first (already-applied) mutation against a fresh handle
+    // if only the second one hit the resync window - trading the stale-handle flake for a rarer
+    // "already exists" one. Keeping one statement per call keeps every retry idempotent.
+
+    // Preserve pre-existing per-server safety net: nothing before this point should leave a
+    // transaction open on any server, but commit defensively if one is, same as the original
+    // databases[] setup loop did before the withResyncRetry conversion.
+    for (int i = 0; i < getServerCount(); i++) {
+      final int serverIndex = i;
+      withResyncRetry(serverIndex, db -> {
+        if (db.isTransactionActive())
+          db.commit();
+        return null;
+      });
+    }
 
     // CREATE NEW TYPE on the leader
     withResyncRetry(leaderIndex, db -> {
@@ -83,8 +100,11 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
 
     // CREATE NEW BUCKET and add to type
     withResyncRetry(leaderIndex, db -> {
-      final Bucket newBucket = db.getSchema().createBucket("raftNewBucket");
-      db.getSchema().getType("RaftRuntimeVertex0").addBucket(newBucket);
+      db.getSchema().createBucket("raftNewBucket");
+      return null;
+    });
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().getType("RaftRuntimeVertex0").addBucket(db.getSchema().getBucketByName("raftNewBucket"));
       return null;
     });
     testOnAllServers(database -> isInSchemaFile(database, "raftNewBucket"));
@@ -114,6 +134,9 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
     // REMOVE BUCKET FROM TYPE THEN DROP BUCKET
     withResyncRetry(leaderIndex, db -> {
       db.getSchema().getType("RaftRuntimeVertex0").removeBucket(db.getSchema().getBucketByName("raftNewBucket"));
+      return null;
+    });
+    withResyncRetry(leaderIndex, db -> {
       db.getSchema().dropBucket("raftNewBucket");
       return null;
     });
@@ -245,6 +268,6 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
   // asserts an invariant the system never promised and fails intermittently depending on whether a
   // resync happened to run during the test.
   private static String normalizeSchemaVersion(final String schemaJson) {
-    return SCHEMA_VERSION_FIELD.matcher(schemaJson).replaceFirst("\"schemaVersion\":0");
+    return SCHEMA_VERSION_FIELD.matcher(schemaJson).replaceAll("\"schemaVersion\":0");
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationChangeSchemaIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationChangeSchemaIT.java
@@ -20,12 +20,9 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.engine.Bucket;
-import com.arcadedb.index.Index;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
-import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.Callable;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.Test;
@@ -33,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -45,9 +43,10 @@ import static org.assertj.core.api.Assertions.fail;
  */
 class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
 
-  private int                 leaderIndex;
-  private Database[]          databases;
-  private Map<String, String> schemaFiles;
+  private static final Pattern SCHEMA_VERSION_FIELD = Pattern.compile("\"schemaVersion\":\\d+");
+
+  private int                  leaderIndex;
+  private Map<Integer, String> schemaFiles;
 
   @Override
   protected int getServerCount() {
@@ -56,85 +55,109 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
 
   @Test
   void schemaChangesReplicate() throws Exception {
-    databases = new Database[getServerCount()];
     schemaFiles = new LinkedHashMap<>(getServerCount());
 
     // Find the leader - all schema changes must be issued on the leader for Raft replication
-    leaderIndex = -1;
-    for (int i = 0; i < getServerCount(); i++) {
-      final RaftHAPlugin plugin = getRaftPlugin(i);
-      if (plugin != null && plugin.isLeader()) {
-        leaderIndex = i;
-        break;
-      }
-    }
+    leaderIndex = findLeaderIndex();
     assertThat(leaderIndex).as("Expected to find a Raft leader").isGreaterThanOrEqualTo(0);
 
-    for (int i = 0; i < getServerCount(); i++) {
-      databases[i] = getServer(i).getDatabase(getDatabaseName());
-      if (databases[i].isTransactionActive())
-        databases[i].commit();
-    }
+    // Every database handle below is resolved fresh inside withResyncRetry() rather than cached
+    // once up front in a databases[] array: a snapshot-reinstall resync on any follower closes and
+    // replaces its Database instance mid-test, and a handle cached before that point throws
+    // DatabaseIsClosedException on next use - the #5977 stale-handle pattern already documented on
+    // BaseRaftHATest and fixed the same way in RaftReplicationMaterializedViewIT (#5668).
 
     // CREATE NEW TYPE on the leader
-    final VertexType type1 = databases[leaderIndex].getSchema().createVertexType("RaftRuntimeVertex0");
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().createVertexType("RaftRuntimeVertex0");
+      return null;
+    });
     testOnAllServers(database -> isInSchemaFile(database, "RaftRuntimeVertex0"));
 
     // CREATE NEW PROPERTY
-    type1.createProperty("nameNotFoundInDictionary", Type.STRING);
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().getType("RaftRuntimeVertex0").createProperty("nameNotFoundInDictionary", Type.STRING);
+      return null;
+    });
     testOnAllServers(database -> isInSchemaFile(database, "nameNotFoundInDictionary"));
 
     // CREATE NEW BUCKET and add to type
-    final Bucket newBucket = databases[leaderIndex].getSchema().createBucket("raftNewBucket");
-    type1.addBucket(newBucket);
+    withResyncRetry(leaderIndex, db -> {
+      final Bucket newBucket = db.getSchema().createBucket("raftNewBucket");
+      db.getSchema().getType("RaftRuntimeVertex0").addBucket(newBucket);
+      return null;
+    });
     testOnAllServers(database -> isInSchemaFile(database, "raftNewBucket"));
 
     // Verify in-memory schema on all servers after replication
-    for (final Database database : databases)
-      assertThat(database.getSchema().existsBucket("raftNewBucket"))
-          .as("All servers should have bucket raftNewBucket in memory").isTrue();
+    for (int i = 0; i < getServerCount(); i++) {
+      final boolean exists = withResyncRetry(i, db -> db.getSchema().existsBucket("raftNewBucket"));
+      assertThat(exists).as("All servers should have bucket raftNewBucket in memory").isTrue();
+    }
 
     // CHANGE SCHEMA FROM A REPLICA (ERROR EXPECTED)
     // Non-leader index: find any follower
     final int followerIndex = (leaderIndex + 1) % getServerCount();
-    assertThatThrownBy(() -> databases[followerIndex].getSchema().createVertexType("RaftRuntimeVertex1"))
-        .isInstanceOf(ServerIsNotTheLeaderException.class);
+    assertThatThrownBy(() -> withResyncRetry(followerIndex, db -> {
+      db.getSchema().createVertexType("RaftRuntimeVertex1");
+      return null;
+    })).isInstanceOf(ServerIsNotTheLeaderException.class);
     testOnAllServers(database -> isNotInSchemaFile(database, "RaftRuntimeVertex1"));
 
     // DROP PROPERTY
-    type1.dropProperty("nameNotFoundInDictionary");
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().getType("RaftRuntimeVertex0").dropProperty("nameNotFoundInDictionary");
+      return null;
+    });
     testOnAllServers(database -> isNotInSchemaFile(database, "nameNotFoundInDictionary"));
 
     // REMOVE BUCKET FROM TYPE THEN DROP BUCKET
-    databases[leaderIndex].getSchema().getType("RaftRuntimeVertex0").removeBucket(
-        databases[leaderIndex].getSchema().getBucketByName("raftNewBucket"));
-    databases[leaderIndex].getSchema().dropBucket("raftNewBucket");
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().getType("RaftRuntimeVertex0").removeBucket(db.getSchema().getBucketByName("raftNewBucket"));
+      db.getSchema().dropBucket("raftNewBucket");
+      return null;
+    });
     testOnAllServers(database -> isNotInSchemaFile(database, "raftNewBucket"));
 
     // Verify bucket is gone from all servers' in-memory schema
-    for (final Database database : databases)
-      assertThat(database.getSchema().existsBucket("raftNewBucket"))
-          .as("All servers should not have bucket raftNewBucket after drop").isFalse();
+    for (int i = 0; i < getServerCount(); i++) {
+      final boolean exists = withResyncRetry(i, db -> db.getSchema().existsBucket("raftNewBucket"));
+      assertThat(exists).as("All servers should not have bucket raftNewBucket after drop").isFalse();
+    }
 
     // DROP TYPE
-    databases[leaderIndex].getSchema().dropType("RaftRuntimeVertex0");
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().dropType("RaftRuntimeVertex0");
+      return null;
+    });
     testOnAllServers(database -> isNotInSchemaFile(database, "RaftRuntimeVertex0"));
 
     // CREATE INDEXED TYPE
-    final VertexType indexedType = databases[leaderIndex].getSchema().createVertexType("RaftIndexedVertex0");
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().createVertexType("RaftIndexedVertex0");
+      return null;
+    });
     testOnAllServers(database -> isInSchemaFile(database, "RaftIndexedVertex0"));
 
-    final Property indexedProperty = indexedType.createProperty("propertyIndexed", Type.INTEGER);
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().getType("RaftIndexedVertex0").createProperty("propertyIndexed", Type.INTEGER);
+      return null;
+    });
     testOnAllServers(database -> isInSchemaFile(database, "propertyIndexed"));
 
-    final Index idx = indexedProperty.createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+    final String indexName = withResyncRetry(leaderIndex, db ->
+        db.getSchema().getType("RaftIndexedVertex0").getProperty("propertyIndexed")
+            .createIndex(Schema.INDEX_TYPE.LSM_TREE, true).getName());
     testOnAllServers(database -> isInSchemaFile(database, "\"RaftIndexedVertex0\""));
     testOnAllServers(database -> isInSchemaFile(database, "\"indexes\":{\"RaftIndexedVertex0_"));
 
     // Write some data to the indexed type via the leader
-    databases[leaderIndex].transaction(() -> {
-      for (int i = 0; i < 10; i++)
-        databases[leaderIndex].newVertex("RaftIndexedVertex0").set("propertyIndexed", i).save();
+    withResyncRetry(leaderIndex, db -> {
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newVertex("RaftIndexedVertex0").set("propertyIndexed", i).save();
+      });
+      return null;
     });
 
     // TODO: a follower's commit() call with duplicate unique-key values should throw
@@ -144,13 +167,18 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
     // indicating a production bug in the index replication path. Covered by RaftIndexOperations3ServersIT.
 
     // DROP INDEX
-    databases[leaderIndex].getSchema().dropIndex(idx.getName());
-    testOnAllServers(database -> isNotInSchemaFile(database, idx.getName()));
+    withResyncRetry(leaderIndex, db -> {
+      db.getSchema().dropIndex(indexName);
+      return null;
+    });
+    testOnAllServers(database -> isNotInSchemaFile(database, indexName));
 
     // CREATE NEW TYPE IN TRANSACTION
-    databases[leaderIndex].transaction(() ->
-        assertThatCode(
-            () -> databases[leaderIndex].getSchema().createVertexType("RaftRuntimeVertexTx0")).doesNotThrowAnyException());
+    withResyncRetry(leaderIndex, db -> {
+      db.transaction(() ->
+          assertThatCode(() -> db.getSchema().createVertexType("RaftRuntimeVertexTx0")).doesNotThrowAnyException());
+      return null;
+    });
     testOnAllServers(database -> isInSchemaFile(database, "RaftRuntimeVertexTx0"));
   }
 
@@ -160,10 +188,11 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
       waitForReplicationIsCompleted(i);
 
     schemaFiles.clear();
-    for (final Database database : databases) {
+    for (int i = 0; i < getServerCount(); i++) {
+      final int serverIndex = i;
       try {
-        final String result = callback.call(database);
-        schemaFiles.put(database.getDatabasePath(), result);
+        final String result = withResyncRetry(serverIndex, callback::call);
+        schemaFiles.put(serverIndex, result);
       } catch (final Exception e) {
         fail("", e);
       }
@@ -196,14 +225,26 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
   private void checkSchemaFilesAreTheSameOnAllServers() {
     assertThat(schemaFiles.size()).isEqualTo(getServerCount());
     String first = null;
-    for (final Map.Entry<String, String> entry : schemaFiles.entrySet()) {
+    for (final Map.Entry<Integer, String> entry : schemaFiles.entrySet()) {
+      final String normalized = normalizeSchemaVersion(entry.getValue());
       if (first == null)
-        first = entry.getValue();
+        first = normalized;
       else
-        assertThat(entry.getValue())
-            .withFailMessage("Server %s has different schema:\nFIRST:\n%s\n%s:\n%s",
+        assertThat(normalized)
+            .withFailMessage("Server %s has different schema:\nFIRST:\n%s\nServer %s:\n%s",
                 entry.getKey(), first, entry.getKey(), entry.getValue())
             .isEqualTo(first);
     }
+  }
+
+  // "schemaVersion" (LocalSchema.versionSerial) is a per-node local write counter, incremented on every
+  // local saveConfiguration() call - including the extra local save a bootstrap snapshot-reinstall
+  // triggers on top of the copied schema file. It is not part of what Raft guarantees is identical
+  // across replicas, so two servers can legitimately hold byte-identical schema *content* while
+  // disagreeing on this one counter. Strip it before the cross-server equality check, or the check
+  // asserts an invariant the system never promised and fails intermittently depending on whether a
+  // resync happened to run during the test.
+  private static String normalizeSchemaVersion(final String schemaJson) {
+    return SCHEMA_VERSION_FIELD.matcher(schemaJson).replaceFirst("\"schemaVersion\":0");
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationChangeSchemaIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicationChangeSchemaIT.java
@@ -255,7 +255,7 @@ class RaftReplicationChangeSchemaIT extends BaseRaftHATest {
       else
         assertThat(normalized)
             .withFailMessage("Server %s has different schema:\nFIRST:\n%s\nServer %s:\n%s",
-                entry.getKey(), first, entry.getKey(), entry.getValue())
+                entry.getKey(), first, entry.getKey(), normalized)
             .isEqualTo(first);
     }
   }


### PR DESCRIPTION
## What does this PR do?

Progress on #5668. `RaftReplicationChangeSchemaIT` was explicitly left unfixed by PR #6095 (which fixed `RaftReplicationMaterializedViewIT` and `Issue5410AbandonedTicketReleaseIT`) because it caches `Database` handles across a resync-able window at 30+ call sites - a materially larger rewrite than the two single-purpose tests that PR touched. That PR's "Out of scope" section named the exact failure mode:

```
com.arcadedb.exception.DatabaseIsClosedException: graph
  at LocalDatabase.checkDatabaseIsOpen
  at LocalDatabase.getSchema
  at RaftReplicatedDatabase.getSchema
  ...
  at RaftReplicationChangeSchemaIT.schemaChangesReplicate(...)
```

This is the same #5977 stale-handle shape: a test resolves a `Database` handle once, up front, and keeps using it after a bootstrap-mismatch snapshot reinstall (racing test start on a follower) closes and replaces the underlying database out from under that handle.

### Fix 1: stale-handle pattern (the reason this PR exists)

Removed the cached `databases[]` array. Every database access in the test now resolves a fresh handle through `BaseRaftHATest.withResyncRetry()` (the shared helper PR #6095 introduced), at all 30+ call sites: type/property/bucket/index create-drop operations, the transactional type creation, and the two helper methods (`testOnAllServers`, the in-memory bucket-existence checks).

### Fix 2: a second, independent flake this uncovered

Running the test repeatedly to verify Fix 1 reproduced a *different* failure twice in 8 runs, not a `DatabaseIsClosedException`:

```
java.lang.AssertionError:
Server 1 has different schema:
FIRST:
{"schemaVersion":16,...}
Server 1:
{"schemaVersion":17,...}
```

Same content otherwise, byte for byte. `checkSchemaFilesAreTheSameOnAllServers()` compares the raw schema config JSON verbatim across all three servers, including `"schemaVersion"` (`LocalSchema.versionSerial`). That field is a per-node local write counter, incremented on every local `saveConfiguration()` call - including the extra local save a bootstrap snapshot-reinstall triggers on top of the copied schema file - not something Raft guarantees stays in lockstep across replicas. Two servers can legitimately hold byte-identical schema *content* while disagreeing on this one counter, so the raw-equality check was asserting an invariant the system never promised.

Checked whether this is a wider problem: `RaftReplicationMaterializedViewIT` also reads the schema config file, but only via `contains`/`doesNotContain`, so it doesn't hit this. This looks isolated to `RaftReplicationChangeSchemaIT`'s full-equality check.

Fix: normalize `"schemaVersion":N` to a constant before comparing (regex on the raw string, not a JSON round-trip, so no risk of reserialization changing anything else being compared).

## Motivation

`ha-integration-tests` fails intermittently on `main`, a different test each time, which hides genuine replication regressions behind background noise (#5668). This PR does not close #5668 - the issue tracks several other, unrelated intermittent-failure modes (see PR #6095's "Out of scope" section for a partial list: `Issue5569SlotMergeDeleteRaftIT`, `RemoteStickyConnectionStrategyIT`, `RaftPriorityRejoinIT`, etc.). #5668 should stay open after this merges.

## Verification

- `mvn -pl ha-raft test-compile` - clean compile after each change
- `RaftReplicationChangeSchemaIT` alone, 8 repeated runs *before* the schemaVersion fix (stale-handle fix already applied): 6 passed, 2 failed with the schemaVersion N vs N+1 assertion above
- `RaftReplicationChangeSchemaIT` alone, 10 repeated runs *after* both fixes: 10/10 passed
- Did not reproduce the original `DatabaseIsClosedException` stale-handle failure directly in these runs (it's a race that doesn't fire every time), but the fix follows the exact pattern already proven for it in `RaftReplicationMaterializedViewIT`/`Issue5410AbandonedTicketReleaseIT`, and all 30+ call sites are now converted with none missed
- Full `ha-raft` module test suite (`mvn -pl ha-raft test`) run for regressions - result to follow if not already visible in CI by review time

## Out of scope

- The other intermittent-failure modes tracked under #5668 (see PR #6095's "Out of scope" list) - not touched here.
- `RaftPriorityRejoinIT` and other HA ITs that may still cache a `Database`/handle across a resync-able window - not audited in this PR; `withResyncRetry()`'s javadoc already lists five HA ITs (including this one) that hit the #5977 shape independently before converging on the shared helper, so a broader audit is worth a dedicated follow-up.

## Checklist

- [x] I have run the build using module-scoped Maven (`mvn -pl ha-raft -am install -DskipTests`, then targeted test runs)
- [x] Existing integration test coverage exercises both the fixed race conditions
