### PR TITLE
fix(#5855): re-enable plan cache for parameterized @rid filters

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
@@ -22,32 +22,55 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.query.sql.parser.BooleanExpression;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
  * Created by luigidellaquila on 22/07/16.
  */
 public class FetchFromRidsStep extends AbstractExecutionStep {
-  private final Iterable<RID> rids;
-  private       Iterator<RID> iterator;
-  private       Result        nextResult = null;
+  private       Iterable<RID>     rids;
+  // Set only by the cache-friendly constructor used by SelectExecutionPlanner.handleTypeWithRidFilter
+  // (WHERE @rid = ? / @rid IN ?, see issue #5855). When non-null, `rids` above is re-resolved lazily
+  // against the live CommandContext on the first pull of every execution instead of being baked in
+  // at plan-build time, mirroring how FetchFromTypeWithFilterStep re-evaluates its WhereClause. This
+  // is what makes the step - and therefore the whole plan - safely reusable from the execution plan
+  // cache across executions bound to different RIDs.
+  private final BooleanExpression ridCondition;
+  private       Iterator<RID>     iterator;
+  private       Result            nextResult = null;
 
   public FetchFromRidsStep(final Iterable<RID> rids, final CommandContext context) {
     super(context);
     this.rids = rids;
+    this.ridCondition = null;
     reset();
   }
 
+  FetchFromRidsStep(final BooleanExpression ridCondition, final CommandContext context) {
+    super(context);
+    this.ridCondition = ridCondition;
+  }
+
   public void reset() {
-    iterator = rids.iterator();
+    // With a ridCondition, defer re-resolution to the first pull of the (re)started execution, so it
+    // uses that execution's own live CommandContext/bound parameters rather than whichever context
+    // reset() happens to be called without.
+    iterator = ridCondition == null ? rids.iterator() : null;
     nextResult = null;
   }
 
   @Override
   public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
     pullPrevious(context, nRecords);
+    if (ridCondition != null && iterator == null) {
+      final List<RID> resolved = SelectExecutionPlanner.extractRidEqualityOrInList(ridCondition, context);
+      this.rids = resolved == null ? List.of() : resolved;
+      iterator = this.rids.iterator();
+    }
     return new ResultSet() {
       int internalNext = 0;
 
@@ -106,6 +129,19 @@ public class FetchFromRidsStep extends AbstractExecutionStep {
 
   @Override
   public String prettyPrint(final int depth, final int indent) {
-    return ExecutionStepInternal.getIndent(depth, indent) + "+ FETCH FROM RIDs\n" + ExecutionStepInternal.getIndent(depth, indent) + "  " + rids;
+    return ExecutionStepInternal.getIndent(depth, indent) + "+ FETCH FROM RIDs\n" + ExecutionStepInternal.getIndent(depth, indent) + "  "
+        + (ridCondition != null ? ridCondition : rids);
+  }
+
+  @Override
+  public boolean canBeCached() {
+    return ridCondition != null;
+  }
+
+  @Override
+  public ExecutionStep copy(final CommandContext context) {
+    if (ridCondition == null)
+      throw new UnsupportedOperationException();
+    return new FetchFromRidsStep(ridCondition, context);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
@@ -25,7 +25,6 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.parser.BooleanExpression;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
@@ -67,8 +67,7 @@ public class FetchFromRidsStep extends AbstractExecutionStep {
   public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
     pullPrevious(context, nRecords);
     if (ridCondition != null && iterator == null) {
-      final List<RID> resolved = SelectExecutionPlanner.extractRidEqualityOrInList(ridCondition, context);
-      this.rids = resolved == null ? List.of() : resolved;
+      this.rids = SelectExecutionPlanner.resolveRidEqualityOrInListAtRuntime(ridCondition, context);
       iterator = this.rids.iterator();
     }
     return new ResultSet() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2060,20 +2060,21 @@ public class SelectExecutionPlanner {
   }
 
   /**
-   * Recognizes {@code @rid = <RID>} and {@code @rid IN [<RID list>]} (also {@code IN (<RID list>)}
-   * and {@code IN <bind parameter>}) and resolves the RID(s) against {@code context}. Returns
-   * {@code null} if {@code expr} isn't one of these shapes, or if any element can't be resolved to a
-   * RID given {@code context} (e.g. it's computed from a per-record field). Returns an empty list if
-   * the condition can never match any record (empty IN-list, or a bind parameter bound to null).
-   * {@code @rid NOT IN [...]} is deliberately not handled here: excluding a RID set still requires
-   * scanning every other record of the type, which this optimization cannot help with.
+   * Build-time-only: recognizes {@code @rid = <RID>} and {@code @rid IN [<RID list>]} (also
+   * {@code IN (<RID list>)} and {@code IN <bind parameter>}) and resolves the RID(s) against
+   * {@code context}, purely to decide whether {@code expr} is one of these shapes at all. Returns
+   * {@code null} if {@code expr} isn't one of these shapes, or if ANY element can't be resolved to a
+   * RID given this particular build's {@code context} (e.g. a per-record field, or one bad element
+   * mixed into an otherwise-valid list) - the caller ({@link #handleTypeWithRidFilter}) then falls
+   * back to a normal scan, which evaluates the {@code IN}/{@code =} condition itself and handles a
+   * partially-resolvable list correctly on its own. Returns an empty list if the condition can never
+   * match any record (empty IN-list, or a bind parameter bound to null). {@code @rid NOT IN [...]}
+   * is deliberately not handled here: excluding a RID set still requires scanning every other record
+   * of the type, which this optimization cannot help with.
    * <p>
-   * Called from two places: {@link #handleTypeWithRidFilter} at plan-build time, only to decide
-   * whether {@code expr} is one of these shapes at all (the caller falls back to the normal scan
-   * path if not, which still evaluates correctly); and {@link FetchFromRidsStep#syncPull} on every
-   * pull of the resulting step's execution, re-resolving against that execution's own live
-   * {@code context} so the step - and the whole plan - stays safe to reuse from
-   * {@code db.getExecutionPlanCache()} with different bound parameters (issue #5855).
+   * Do NOT call this from {@link FetchFromRidsStep#syncPull} - once the plan has committed to a
+   * {@code FetchFromRidsStep}, there is no scan fallback left, so "abort the whole list to null on
+   * one bad element" is wrong there. Use {@link #resolveRidEqualityOrInListAtRuntime} instead.
    */
   static List<RID> extractRidEqualityOrInList(final BooleanExpression expr, final CommandContext context) {
     if (expr instanceof BinaryCondition bc && bc.getOperator() instanceof EqualsCompareOperator
@@ -2120,6 +2121,64 @@ public class SelectExecutionPlanner {
       if (rid == null)
         return null;
       rids.add(rid);
+    }
+    return new ArrayList<>(rids);
+  }
+
+  /**
+   * Runtime counterpart of {@link #extractRidEqualityOrInList}, called from
+   * {@link FetchFromRidsStep#syncPull} on every pull of a {@code FetchFromRidsStep} built from a
+   * {@code @rid = ?} / {@code @rid IN ?} condition, re-resolving against that execution's own live
+   * {@code context} so the step - and the whole plan - stays safe to reuse from
+   * {@code db.getExecutionPlanCache()} with different bound parameters (issue #5855).
+   * <p>
+   * Unlike the build-time method, there is no scan fallback left once a plan has committed to this
+   * step, so an {@code IN}-list element that fails to resolve to a RID is skipped rather than
+   * aborting the whole result to empty - mirroring what a normal per-record {@code IN} scan does
+   * with a non-RID element (it simply never matches). An exception thrown while evaluating the
+   * right-hand expression is a genuine execution-time error at this point (not "unknowable at plan
+   * time" the way it is in the build-time method) and is left to propagate.
+   */
+  static List<RID> resolveRidEqualityOrInListAtRuntime(final BooleanExpression expr, final CommandContext context) {
+    if (expr instanceof BinaryCondition bc && bc.getOperator() instanceof EqualsCompareOperator
+        && RID_PROPERTY.equalsIgnoreCase(bc.getLeft().toString())) {
+      final RID rid = extractRidValue(bc.getRight(), context);
+      return rid == null ? List.of() : List.of(rid);
+    }
+
+    if (!(expr instanceof InCondition in) || in.not || !RID_PROPERTY.equalsIgnoreCase(in.getLeft().toString()))
+      return List.of();
+
+    final Object rawValue;
+    if (in.right instanceof List<?> list) {
+      final List<Object> values = new ArrayList<>(list.size());
+      for (final Object item : list)
+        values.add(item instanceof Expression itemExpr ? extractRidValue(itemExpr, context) : item);
+      rawValue = values;
+    } else if (in.getRightMathExpression() != null) {
+      rawValue = in.getRightMathExpression().execute((Result) null, context);
+    } else if (in.getRightParam() != null) {
+      rawValue = in.getRightParam().getValue(context.getInputParameters());
+    } else
+      return List.of();
+
+    if (rawValue == null)
+      return List.of(); // WHERE @rid IN <null> matches nothing
+
+    // Same dedup rationale as extractRidEqualityOrInList; unresolvable elements are skipped instead
+    // of aborting the whole list, matching how a normal IN scan treats a non-RID element (no match
+    // for that element, not a failure of the whole condition).
+    final Set<RID> rids = new LinkedHashSet<>();
+    if (rawValue instanceof Iterable<?> iterable) {
+      for (final Object item : iterable) {
+        final RID rid = toRid(item, context);
+        if (rid != null)
+          rids.add(rid);
+      }
+    } else {
+      final RID rid = toRid(rawValue, context);
+      if (rid != null)
+        rids.add(rid);
     }
     return new ArrayList<>(rids);
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2029,6 +2029,14 @@ public class SelectExecutionPlanner {
       if (extractRidEqualityOrInList(expr, context) == null)
         continue; // not one of the @rid = <RID> / @rid IN [<RID list>] shapes
 
+      // Known tradeoff: this shape check runs against THIS build's bound value, and its true/false
+      // outcome (not the resolved RIDs themselves, which are re-resolved per execution below) is
+      // what the cached plan commits to. An atypical first bind that fails to resolve here (e.g. a
+      // null @rid, or one bad element in an IN-list) permanently locks that statement text into the
+      // scan fallback until the next cache invalidation, even though later executions bind good
+      // RIDs. Not a correctness issue - the scan still evaluates the condition correctly - just a
+      // missed optimization for that call pattern.
+
       // Deliberately do NOT bake the RID(s) resolved above into the fetch step: this build may run
       // once per statement text and get reused later, with different bound parameters, straight from
       // db.getExecutionPlanCache() (see ExecutionPlanCache.get()'s InternalExecutionPlan.copy(context)).
@@ -2087,22 +2095,13 @@ public class SelectExecutionPlanner {
       return null;
 
     final Object rawValue;
-    if (in.right instanceof List<?> list) {
-      final List<Object> values = new ArrayList<>(list.size());
-      for (final Object item : list)
-        values.add(item instanceof Expression itemExpr ? extractRidValue(itemExpr, context) : item);
-      rawValue = values;
-    } else if (in.getRightMathExpression() != null) {
-      try {
-        rawValue = in.getRightMathExpression().execute((Result) null, context);
-      } catch (final Exception e) {
-        return null; // not resolvable at plan time (e.g. references a per-record field)
-      }
-    } else if (in.getRightParam() != null) {
-      rawValue = in.getRightParam().getValue(context.getInputParameters());
-    } else
+    try {
+      rawValue = resolveInRightHandRawValue(in, context);
+    } catch (final Exception e) {
+      return null; // not resolvable at plan time (e.g. references a per-record field)
+    }
+    if (rawValue == NOT_A_RESOLVABLE_RID_SHAPE)
       return null; // subquery on the right: not a plan-time-resolvable RID list
-
     if (rawValue == null)
       return List.of(); // WHERE @rid IN <null> matches nothing
 
@@ -2125,6 +2124,32 @@ public class SelectExecutionPlanner {
     return new ArrayList<>(rids);
   }
 
+  /** Sentinel returned by {@link #resolveInRightHandRawValue} for an {@code IN} shape this optimization can't handle at all (a subquery). */
+  private static final Object NOT_A_RESOLVABLE_RID_SHAPE = new Object();
+
+  /**
+   * Shared by {@link #extractRidEqualityOrInList} and {@link #resolveRidEqualityOrInListAtRuntime}:
+   * turns the right-hand side of an {@code @rid IN <right>} condition into the raw bound value,
+   * before it's walked into individual {@link RID}s. Evaluating
+   * {@code in.getRightMathExpression()} can throw (e.g. it references a per-record field, which is
+   * meaningless outside a scan) - deliberately left uncaught here so each caller can apply its own
+   * policy: the build-time caller treats it as "not resolvable at plan time" (falls back to a scan),
+   * the runtime caller lets it propagate as a genuine execution error.
+   */
+  private static Object resolveInRightHandRawValue(final InCondition in, final CommandContext context) {
+    if (in.right instanceof List<?> list) {
+      final List<Object> values = new ArrayList<>(list.size());
+      for (final Object item : list)
+        values.add(item instanceof Expression itemExpr ? extractRidValue(itemExpr, context) : item);
+      return values;
+    }
+    if (in.getRightMathExpression() != null)
+      return in.getRightMathExpression().execute((Result) null, context);
+    if (in.getRightParam() != null)
+      return in.getRightParam().getValue(context.getInputParameters());
+    return NOT_A_RESOLVABLE_RID_SHAPE;
+  }
+
   /**
    * Runtime counterpart of {@link #extractRidEqualityOrInList}, called from
    * {@link FetchFromRidsStep#syncPull} on every pull of a {@code FetchFromRidsStep} built from a
@@ -2135,9 +2160,12 @@ public class SelectExecutionPlanner {
    * Unlike the build-time method, there is no scan fallback left once a plan has committed to this
    * step, so an {@code IN}-list element that fails to resolve to a RID is skipped rather than
    * aborting the whole result to empty - mirroring what a normal per-record {@code IN} scan does
-   * with a non-RID element (it simply never matches). An exception thrown while evaluating the
-   * right-hand expression is a genuine execution-time error at this point (not "unknowable at plan
-   * time" the way it is in the build-time method) and is left to propagate.
+   * with a non-RID element (it simply never matches). An exception thrown while evaluating
+   * {@code in.getRightMathExpression()} - the only right-hand shape that can throw here - is a
+   * genuine execution-time error at this point (not "unknowable at plan time" the way it is in the
+   * build-time method) and is left to propagate. {@link #extractRidValue}, used for the equality
+   * operand and each list-literal item, still fails safe to "no match" on any exception in both
+   * this method and the build-time one - unchanged from before this split.
    */
   static List<RID> resolveRidEqualityOrInListAtRuntime(final BooleanExpression expr, final CommandContext context) {
     if (expr instanceof BinaryCondition bc && bc.getOperator() instanceof EqualsCompareOperator
@@ -2149,21 +2177,9 @@ public class SelectExecutionPlanner {
     if (!(expr instanceof InCondition in) || in.not || !RID_PROPERTY.equalsIgnoreCase(in.getLeft().toString()))
       return List.of();
 
-    final Object rawValue;
-    if (in.right instanceof List<?> list) {
-      final List<Object> values = new ArrayList<>(list.size());
-      for (final Object item : list)
-        values.add(item instanceof Expression itemExpr ? extractRidValue(itemExpr, context) : item);
-      rawValue = values;
-    } else if (in.getRightMathExpression() != null) {
-      rawValue = in.getRightMathExpression().execute((Result) null, context);
-    } else if (in.getRightParam() != null) {
-      rawValue = in.getRightParam().getValue(context.getInputParameters());
-    } else
-      return List.of();
-
-    if (rawValue == null)
-      return List.of(); // WHERE @rid IN <null> matches nothing
+    final Object rawValue = resolveInRightHandRawValue(in, context);
+    if (rawValue == NOT_A_RESOLVABLE_RID_SHAPE || rawValue == null)
+      return List.of(); // subquery on the right, or WHERE @rid IN <null>: matches nothing
 
     // Same dedup rationale as extractRidEqualityOrInList; unresolvable elements are skipped instead
     // of aborting the whole list, matching how a normal IN scan treats a non-RID element (no match

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2026,20 +2026,19 @@ public class SelectExecutionPlanner {
 
     for (int i = 0; i < andBlock.getSubBlocks().size(); i++) {
       final BooleanExpression expr = andBlock.getSubBlocks().get(i);
-      final List<RID> rids = extractRidEqualityOrInList(expr, context);
-      if (rids == null)
-        continue;
+      if (extractRidEqualityOrInList(expr, context) == null)
+        continue; // not one of the @rid = <RID> / @rid IN [<RID list>] shapes
 
-      if (rids.isEmpty()) {
-        // The RID list is definitely empty (e.g. an empty IN-list or a null bind parameter):
-        // no record can match, whatever the remaining conditions are.
-        plan.chain(new EmptyStep(context));
-        info.whereClause = null;
-        info.flattenedWhereClause = null;
-        return true;
-      }
-
-      plan.chain(new FetchFromRidsStep(rids, context));
+      // Deliberately do NOT bake the RID(s) resolved above into the fetch step: this build may run
+      // once per statement text and get reused later, with different bound parameters, straight from
+      // db.getExecutionPlanCache() (see ExecutionPlanCache.get()'s InternalExecutionPlan.copy(context)).
+      // FetchFromRidsStep(BooleanExpression, CommandContext) re-resolves ridCondition lazily against
+      // each execution's own live context instead, keeping this whole plan cacheable. That includes
+      // whatever this particular build's RIDs resolved to being empty (e.g. a null-bound parameter):
+      // baking THAT into a cached plan would be just as wrong for a later, differently-bound
+      // execution - see EmptyStep.canBeCached()'s "DON'T TOUCH" comment for exactly this hazard, and
+      // issue #5855.
+      plan.chain(new FetchFromRidsStep(expr, context));
       plan.chain(new FilterByTypeStep(identifier, context));
 
       final List<BooleanExpression> remaining = new ArrayList<>(andBlock.getSubBlocks());
@@ -2062,16 +2061,21 @@ public class SelectExecutionPlanner {
 
   /**
    * Recognizes {@code @rid = <RID>} and {@code @rid IN [<RID list>]} (also {@code IN (<RID list>)}
-   * and {@code IN <bind parameter>}) and resolves the RID(s) at plan time. Returns {@code null} if
-   * {@code expr} isn't one of these shapes, or if any element can't be resolved to a RID at plan
-   * time (e.g. it's computed from a per-record field) - the caller falls back to the normal scan
-   * in that case, which still evaluates correctly. Returns an empty list if the condition can
-   * never match any record (empty IN-list, or a bind parameter bound to null) so the caller can
-   * short-circuit to no results. {@code @rid NOT IN [...]} is deliberately not handled here:
-   * excluding a RID set still requires scanning every other record of the type, which this
-   * optimization cannot help with.
+   * and {@code IN <bind parameter>}) and resolves the RID(s) against {@code context}. Returns
+   * {@code null} if {@code expr} isn't one of these shapes, or if any element can't be resolved to a
+   * RID given {@code context} (e.g. it's computed from a per-record field). Returns an empty list if
+   * the condition can never match any record (empty IN-list, or a bind parameter bound to null).
+   * {@code @rid NOT IN [...]} is deliberately not handled here: excluding a RID set still requires
+   * scanning every other record of the type, which this optimization cannot help with.
+   * <p>
+   * Called from two places: {@link #handleTypeWithRidFilter} at plan-build time, only to decide
+   * whether {@code expr} is one of these shapes at all (the caller falls back to the normal scan
+   * path if not, which still evaluates correctly); and {@link FetchFromRidsStep#syncPull} on every
+   * pull of the resulting step's execution, re-resolving against that execution's own live
+   * {@code context} so the step - and the whole plan - stays safe to reuse from
+   * {@code db.getExecutionPlanCache()} with different bound parameters (issue #5855).
    */
-  private static List<RID> extractRidEqualityOrInList(final BooleanExpression expr, final CommandContext context) {
+  static List<RID> extractRidEqualityOrInList(final BooleanExpression expr, final CommandContext context) {
     if (expr instanceof BinaryCondition bc && bc.getOperator() instanceof EqualsCompareOperator
         && RID_PROPERTY.equalsIgnoreCase(bc.getLeft().toString())) {
       final RID rid = extractRidValue(bc.getRight(), context);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.partitioning.PartitioningTestFixture;
@@ -60,6 +61,17 @@ class RidInScanOptimizationTest extends TestHelper {
 
       otherTypeRid = database.newDocument("Other").set("name", "other0").save().getIdentity();
     });
+
+    // The type creations above invalidate the execution plan cache, stamping
+    // ExecutionPlanCache.lastInvalidation with System.currentTimeMillis(). SelectExecutionPlanner's
+    // cache-put guard (createExecutionPlan) rejects a plan whose own planningStart timestamp isn't
+    // strictly greater than that invalidation stamp. On a fast/warmed-up JVM the setup above and a
+    // test's first query can land in the same millisecond tick, so a plan that is legitimately built
+    // after the invalidation gets skipped anyway - this only matters here because #5855 is what makes
+    // these @rid plans cacheable in the first place. Not a bug in the fix; just avoid racing the clock.
+    final long setupMillis = System.currentTimeMillis();
+    while (System.currentTimeMillis() == setupMillis)
+      Thread.onSpinWait();
   }
 
   @Test
@@ -214,6 +226,85 @@ class RidInScanOptimizationTest extends TestHelper {
     }
     rs.close();
     assertThat(count).isEqualTo(4);
+  }
+
+  @Test
+  void ridEqualityBoundParameterPlanIsCacheableAndReresolvesOnReuse() {
+    // Issue #5855: before this fix, FetchFromRidsStep baked the resolved RID into the step at
+    // plan-build time and never overrode canBeCached()/copy(), so the whole plan was never put in
+    // db.getExecutionPlanCache(). A "get by id" query executed repeatedly with different bound
+    // RIDs must re-plan from scratch every time it happened.
+    final String sql = "SELECT FROM Doc WHERE @rid = ?";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final ResultSet rs1 = database.query("sql", sql, doc0Rid);
+    final ExecutionPlan plan1 = rs1.getExecutionPlan().orElseThrow();
+    assertThat(findStep(plan1, FetchFromRidsStep.class)).isNotNull();
+    assertThat(((InternalExecutionPlan) plan1).canBeCached()).as("plan built for @rid = ? must now be cacheable").isTrue();
+    assertThat(collectNames(rs1)).containsExactly("doc0");
+
+    assertThat(db.getExecutionPlanCache().contains(sql)).as("plan must actually be in the execution plan cache").isTrue();
+
+    // Same statement text, a DIFFERENT bound RID: a stale cached plan would either return doc0
+    // again (the RID baked in from the first build) or nothing at all.
+    final ResultSet rs2 = database.query("sql", sql, doc1Rid);
+    assertThat(collectNames(rs2)).containsExactly("doc1");
+
+    final ResultSet rs3 = database.query("sql", sql, doc2Rid);
+    assertThat(collectNames(rs3)).containsExactly("doc2");
+  }
+
+  @Test
+  void ridInListBoundParameterPlanIsCacheableAndReresolvesOnReuse() {
+    final String sql = "SELECT FROM Doc WHERE @rid IN ?";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final ResultSet rs1 = database.query("sql", sql, List.of(doc0Rid, doc1Rid));
+    final ExecutionPlan plan1 = rs1.getExecutionPlan().orElseThrow();
+    assertThat(findStep(plan1, FetchFromRidsStep.class)).isNotNull();
+    assertThat(((InternalExecutionPlan) plan1).canBeCached()).isTrue();
+    assertThat(collectNames(rs1)).containsExactlyInAnyOrder("doc0", "doc1");
+
+    assertThat(db.getExecutionPlanCache().contains(sql)).isTrue();
+
+    // Reused plan, bound to a completely different RID list.
+    final ResultSet rs2 = database.query("sql", sql, List.of(doc2Rid));
+    assertThat(collectNames(rs2)).containsExactly("doc2");
+  }
+
+  @Test
+  void ridInListEmptyThenNonEmptyBoundParameterAcrossCachedReuseStaysCorrect() {
+    // Pins the EmptyStep-caching hazard: the old code short-circuited an empty resolved RID list to
+    // a non-cacheable EmptyStep at build time. The new code must never bake "this execution's RIDs
+    // happen to be empty" into a plan that a later, differently-bound execution can reuse.
+    final String sql = "SELECT FROM Doc WHERE @rid IN ?";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final ResultSet rs1 = database.query("sql", sql, List.of());
+    assertThat(rs1.hasNext()).isFalse();
+    rs1.close();
+
+    assertThat(db.getExecutionPlanCache().contains(sql)).as("even a build that resolves to zero RIDs must be cacheable").isTrue();
+
+    final ResultSet rs2 = database.query("sql", sql, List.of(doc0Rid));
+    assertThat(collectNames(rs2)).containsExactly("doc0");
+  }
+
+  @Test
+  void ridEqualityBoundParameterCombinesWithRemainingFilterAcrossCachedReuse() {
+    final String sql = "SELECT FROM Doc WHERE @rid = ? AND active = true";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // doc0 is active: matches.
+    final ResultSet rs1 = database.query("sql", sql, doc0Rid);
+    assertThat(collectNames(rs1)).containsExactly("doc0");
+    assertThat(db.getExecutionPlanCache().contains(sql)).isTrue();
+
+    // doc1 is NOT active: the remaining filter chained after the reused, cached FetchFromRidsStep
+    // must still be re-evaluated correctly.
+    final ResultSet rs2 = database.query("sql", sql, doc1Rid);
+    assertThat(rs2.hasNext()).isFalse();
+    rs2.close();
   }
 
   private static List<String> collectNames(final ResultSet rs) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
@@ -273,6 +273,27 @@ class RidInScanOptimizationTest extends TestHelper {
   }
 
   @Test
+  void ridInListWithOneUnresolvableElementStillMatchesTheResolvableOnesOnCacheReuse() {
+    // A cache-hit re-execution has no scan fallback left (unlike the build-time shape check in
+    // SelectExecutionPlanner.extractRidEqualityOrInList): one bad element in an otherwise-valid list
+    // must not silently drop the matches that ARE real RIDs.
+    final String sql = "SELECT FROM Doc WHERE @rid IN ?";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // First execution: every element resolves, so the plan is built AND cached as FetchFromRidsStep.
+    final ResultSet rs1 = database.query("sql", sql, List.of(doc0Rid, doc1Rid));
+    final ExecutionPlan plan1 = rs1.getExecutionPlan().orElseThrow();
+    assertThat(findStep(plan1, FetchFromRidsStep.class)).isNotNull();
+    assertThat(collectNames(rs1)).containsExactlyInAnyOrder("doc0", "doc1");
+    assertThat(db.getExecutionPlanCache().contains(sql)).isTrue();
+
+    // Second execution: cache hit, reuses the exact same FetchFromRidsStep - one element is not a
+    // RID at all. The record matching the other, valid element must still come back.
+    final ResultSet rs2 = database.query("sql", sql, java.util.Arrays.asList(doc2Rid, "not-a-rid"));
+    assertThat(collectNames(rs2)).containsExactly("doc2");
+  }
+
+  @Test
   void ridInListEmptyThenNonEmptyBoundParameterAcrossCachedReuseStaysCorrect() {
     // Pins the EmptyStep-caching hazard: the old code short-circuited an empty resolved RID list to
     // a non-cacheable EmptyStep at build time. The new code must never bake "this execution's RIDs

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RidInScanOptimizationTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.partitioning.PartitioningTestFixture;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -289,7 +290,7 @@ class RidInScanOptimizationTest extends TestHelper {
 
     // Second execution: cache hit, reuses the exact same FetchFromRidsStep - one element is not a
     // RID at all. The record matching the other, valid element must still come back.
-    final ResultSet rs2 = database.query("sql", sql, java.util.Arrays.asList(doc2Rid, "not-a-rid"));
+    final ResultSet rs2 = database.query("sql", sql, Arrays.asList(doc2Rid, "not-a-rid"));
     assertThat(collectNames(rs2)).containsExactly("doc2");
   }
 


### PR DESCRIPTION
Closes #5855

## Context

PR #5854 (fixing #5824) rewrites `WHERE @rid = <RID>` / `WHERE @rid IN [<RID list>]` on a type
target into a direct `FetchFromRidsStep` fetch instead of a full type scan. That step resolves the
bound RID(s) at plan-construction time and bakes them into the step. `FetchFromRidsStep` doesn't
override `canBeCached()`/`copy()`, so it defaults to `canBeCached() == false`
(`ExecutionStepInternal.java`), making the whole plan non-cacheable. A "get by id" query executed
repeatedly with different bound RIDs re-plans from scratch every execution instead of hitting
`db.getExecutionPlanCache()`.

Before PR #5854 the same query fell through to `FetchFromTypeWithFilterStep`, which is cacheable:
it stores the `WhereClause` AST and re-evaluates it fresh against bound parameters on every
execution.

## Fix

Mirror `FetchFromTypeWithFilterStep`'s pattern: instead of baking resolved `RID` values into
`FetchFromRidsStep` at plan-build time, add a variant that stores the original `BooleanExpression`
(the `@rid = ?` / `@rid IN ?` condition) and re-resolves it lazily against the live
`CommandContext` on the first pull of every execution, including a cache-hit re-execution with
different bound parameters. That step overrides `canBeCached()` to return `true` and `copy()` to
carry the (immutable) condition forward into the copy handed out by
`ExecutionPlanCache.get()`/`put()`.

The legacy `FetchFromRidsStep(Iterable<RID>, CommandContext)` constructor (used by every other
call site: `FROM [#1:0, #1:1]`, a bind-parameter/variable RID target, a function-call target,
`FetchEdgesFromVertexStep`'s sibling paths, etc.) is untouched and stays non-cacheable, matching
the issue's own scoping note that those call sites were already non-cacheable before PR #5854.

`SelectExecutionPlanner.handleTypeWithRidFilter` now always chains the deferred-resolution step
once the condition is confirmed *resolvable in shape* (`extractRidEqualityOrInList(...) != null`)
rather than short-circuiting to `EmptyStep` when the *value* the condition resolves to at this
particular build happens to be empty (e.g. an `IN`-list bound to `null` on the very first
execution). Baking that build-time "this execution's RIDs happen to be empty" fact into a cached,
reused plan would be wrong for a later execution bound to a non-empty list - `EmptyStep` itself
carries the comment "DON'T TOUCH! ... this execution plan cannot be cached" for exactly this
reason. Resolving to an empty RID set inside `FetchFromRidsStep.syncPull` produces the same
zero-row result without that hazard, on every execution.

`extractRidEqualityOrInList` moved from `private` to package-private static so
`FetchFromRidsStep` (same package) can call it during lazy resolution.

## A test-only race found and fixed along the way

Running the new tests as part of the wider `com.arcadedb.query.sql.**` suite (not the isolated
class) surfaced one flaky failure in `ridInListBoundParameterPlanIsCacheableAndReresolvesOnReuse`:
`assertThat(db.getExecutionPlanCache().contains(sql)).isTrue()` occasionally failed.

Root cause: `RidInScanOptimizationTest.beginTest()` creates types, which calls
`ExecutionPlanCache.invalidate()` (stamps `lastInvalidation` via `System.currentTimeMillis()`).
`SelectExecutionPlanner.createExecutionPlan`'s cache-put guard requires
`getLastInvalidation() < planningStart` before it will cache a freshly-built plan. On a hot/warmed
JVM, `beginTest()`'s schema setup and the test's first query can land in the same millisecond tick,
so a plan legitimately built *after* the invalidation gets skipped by the guard anyway - a
pre-existing, unrelated millisecond-resolution artifact in `SelectExecutionPlanner`/
`ExecutionPlanCache` (predates this PR). It only became reachable here because this PR is what
makes `@rid` plans cacheable in the first place, so this is the first test to exercise the guard
for this step type.

Not fixing the production guard (shared, out of scope, and the actual functional correctness of
query results is unaffected either way - only the caching optimization is occasionally skipped).
Instead, `beginTest()` now waits for the millisecond clock to tick forward before returning, so the
setup and the first query can never land in the same tick. Verified: re-ran the exact suite that
exposed the race (`mvn -pl engine test -Dtest='com.arcadedb.query.sql.**'`) after the fix - clean,
2485/2485, 0 failures.

## Test plan

- `planUsesFetchFromRidsStepForEquality` / `...ForBracketInList` / etc. (pre-existing #5824 tests):
  keep passing unchanged - the rewrite's plan shape and results are untouched.
- New: a bound-parameter `@rid = ?` plan reports `canBeCached() == true` and is actually present in
  `db.getExecutionPlanCache()` after one execution.
- New: the same query text executed twice with two *different* bound RIDs returns the record
  matching each execution's own bound value, not a stale RID baked in from the first (cached) plan
  build - this is the actual regression the issue describes.
- New: same for `@rid IN ?` bound to two different lists across two executions.
- New: an `IN ?` bound to an empty list on the first execution, then to a non-empty list on the
  second (same cached plan reused), returns zero rows the first time and the matching rows the
  second time - pins the `EmptyStep`-caching hazard called out above.
- Full `com.arcadedb.query.sql.**` suite (2485 tests) run clean after the fix.