### PR TITLE
fix(#5871): remove SimpleNode's vestigial int constructor parameter

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
@@ -87,7 +87,7 @@ public class SQLQueryEngine implements QueryEngine {
     if (!statement.isIdempotent())
       throw new QueryNotIdempotentException("Query '" + query + "' is not idempotent");
 
-    statement.setLimit(new Limit(-1).setValue((int) database.getResultSetLimit()));
+    statement.setLimit(new Limit().setValue((int) database.getResultSetLimit()));
     return statement.execute(database, parameters);
   }
 
@@ -97,14 +97,14 @@ public class SQLQueryEngine implements QueryEngine {
     if (!statement.isIdempotent())
       throw new QueryNotIdempotentException("Query '" + query + "' is not idempotent");
 
-    statement.setLimit(new Limit(-1).setValue((int) database.getResultSetLimit()));
+    statement.setLimit(new Limit().setValue((int) database.getResultSetLimit()));
     return statement.execute(database, parameters);
   }
 
   @Override
   public ResultSet command(final String query, final ContextConfiguration configuration, final Map<String, Object> parameters) {
     final Statement statement = parse(query, database);
-    statement.setLimit(new Limit(-1).setValue((int) database.getResultSetLimit()));
+    statement.setLimit(new Limit().setValue((int) database.getResultSetLimit()));
 
     final CommandContext context = new BasicCommandContext();
     context.setInputParameters(parameters);
@@ -116,7 +116,7 @@ public class SQLQueryEngine implements QueryEngine {
   @Override
   public ResultSet command(final String query, ContextConfiguration configuration, final Object... parameters) {
     final Statement statement = parse(query, database);
-    statement.setLimit(new Limit(-1).setValue((int) database.getResultSetLimit()));
+    statement.setLimit(new Limit().setValue((int) database.getResultSetLimit()));
     final CommandContext context = new BasicCommandContext();
     context.setConfiguration(configuration);
     return statement.execute(executionDatabase(), parameters, context);
@@ -175,7 +175,7 @@ public class SQLQueryEngine implements QueryEngine {
       public ResultSet execute(final Map<String, Object> parameters) {
         final long resultSetLimit = database.getResultSetLimit();
         if (resultSetLimit > 0)
-          statement.setLimit(new Limit(-1).setValue((int) resultSetLimit));
+          statement.setLimit(new Limit().setValue((int) resultSetLimit));
         // Same resolution as command(): this is a third execution entry point, not an analysis-only one.
         // The MCP command tool runs SQL exclusively through here (analyze() once, then execute(); the
         // database.command() fallback is only reached by engines whose execute() returns null), so leaving

--- a/engine/src/main/java/com/arcadedb/query/sql/SQLScriptQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLScriptQueryEngine.java
@@ -150,7 +150,7 @@ public class SQLScriptQueryEngine extends SQLQueryEngine {
 
     for (final Statement stm : statements) {
       stm.setOriginalStatement(stm);
-      stm.setLimit(new Limit(-1).setValue((int) database.getResultSetLimit()));
+      stm.setLimit(new Limit().setValue((int) database.getResultSetLimit()));
 
       if (stm instanceof BeginStatement)
         nestedTxLevel++;

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -115,7 +115,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public SelectStatement visitSelectStatement(final SQLParser.SelectStatementContext ctx) {
-    final SelectStatement stmt = new SelectStatement(-1);
+    final SelectStatement stmt = new SelectStatement();
 
     // Projection
     if (ctx.projection() != null) {
@@ -174,7 +174,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public SelectStatement visitSelectStmt(final SQLParser.SelectStmtContext ctx) {
-    final SelectStatement stmt = new SelectStatement(-1);
+    final SelectStatement stmt = new SelectStatement();
 
     // Get the selectStatement context from the labeled alternative
     final SQLParser.SelectStatementContext selectCtx = ctx.selectStatement();
@@ -238,7 +238,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchStatement visitMatchStatement(final SQLParser.MatchStatementContext ctx) {
-    final MatchStatement stmt = new MatchStatement(-1);
+    final MatchStatement stmt = new MatchStatement();
 
     // Parse match expressions (both positive and negative patterns)
     final List<MatchExpression> matchExpressions = new ArrayList<>();
@@ -329,7 +329,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchStatement visitMatchStmt(final SQLParser.MatchStmtContext ctx) {
-    final MatchStatement stmt = new MatchStatement(-1);
+    final MatchStatement stmt = new MatchStatement();
 
     // Get the matchStatement context from the labeled alternative
     final SQLParser.MatchStatementContext matchCtx = ctx.matchStatement();
@@ -424,7 +424,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchExpression visitMatchExpression(final SQLParser.MatchExpressionContext ctx) {
-    final MatchExpression matchExpr = new MatchExpression(-1);
+    final MatchExpression matchExpr = new MatchExpression();
     final List<MatchPathItem> items = new ArrayList<>();
 
     // Parse match path items
@@ -450,10 +450,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
                   for (final MatchPathItem subItem : multiItem.getItems()) {
                     // For MatchPathItemFirst, convert to regular MatchPathItem
                     if (subItem instanceof final MatchPathItemFirst firstSubItem) {
-                      final MatchPathItem regularItem = new MatchPathItem(-1);
+                      final MatchPathItem regularItem = new MatchPathItem();
                       // Convert function to method
                       if (firstSubItem.getFunction() != null) {
-                        final MethodCall method = new MethodCall(-1);
+                        final MethodCall method = new MethodCall();
                         method.methodName = firstSubItem.getFunction().name;
                         method.params = new ArrayList<>(firstSubItem.getFunction().params);
                         regularItem.setMethod(method);
@@ -483,7 +483,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
         // Each path item can have a filter and methods
         if (itemCtx.matchFilter() != null) {
-          final MatchPathItem pathItem = new MatchPathItem(-1);
+          final MatchPathItem pathItem = new MatchPathItem();
           pathItem.setFilter((MatchFilter) visit(itemCtx.matchFilter()));
           items.add(pathItem);
         }
@@ -500,10 +500,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
                   for (final MatchPathItem subItem : multiItem.getItems()) {
                     // For MatchPathItemFirst, convert to regular MatchPathItem
                     if (subItem instanceof final MatchPathItemFirst firstSubItem) {
-                      final MatchPathItem regularItem = new MatchPathItem(-1);
+                      final MatchPathItem regularItem = new MatchPathItem();
                       // Convert function to method
                       if (firstSubItem.getFunction() != null) {
-                        final MethodCall method = new MethodCall(-1);
+                        final MethodCall method = new MethodCall();
                         method.methodName = firstSubItem.getFunction().name;
                         method.params = new ArrayList<>(firstSubItem.getFunction().params);
                         regularItem.setMethod(method);
@@ -544,7 +544,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       if (ctx.nestedMatchPath() != null) {
         // This is .(methodChain) - a nested sequence of match methods
         // Create a MultiMatchPathItem to hold the nested method chain
-        final MultiMatchPathItem multiPathItem = new MultiMatchPathItem(-1);
+        final MultiMatchPathItem multiPathItem = new MultiMatchPathItem();
         multiPathItem.setNestedPath(true); // Mark as nested path - should NOT be flattened
         final SQLParser.NestedMatchPathContext nestedCtx = ctx.nestedMatchPath();
 
@@ -557,12 +557,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
           if (pathItem != null) {
             if (i == 0) {
               // First item should be MatchPathItemFirst
-              final MatchPathItemFirst firstItem = new MatchPathItemFirst(-1);
+              final MatchPathItemFirst firstItem = new MatchPathItemFirst();
               // Copy method and filter from the pathItem
               firstItem.setFilter(pathItem.getFilter());
               if (pathItem.getMethod() != null) {
                 // Convert MethodCall to FunctionCall for first item
-                final FunctionCall funcCall = new FunctionCall(-1);
+                final FunctionCall funcCall = new FunctionCall();
                 funcCall.name = pathItem.getMethod().methodName;
                 if (pathItem.getMethod().params != null) {
                   funcCall.params = new ArrayList<>(pathItem.getMethod().params);
@@ -594,10 +594,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final SQLParser.FunctionCallContext funcCtx = ctx.matchMethodCall().functionCall();
         if (CollectionUtils.isNotEmpty(funcCtx.methodCall())) {
           // We have chained method calls - create MultiMatchPathItem
-          final MultiMatchPathItem multiPathItem = new MultiMatchPathItem(-1);
+          final MultiMatchPathItem multiPathItem = new MultiMatchPathItem();
 
           // First item from the function call
-          final MatchPathItemFirst firstItem = new MatchPathItemFirst(-1);
+          final MatchPathItemFirst firstItem = new MatchPathItemFirst();
           if (methodObj instanceof FunctionCall) {
             firstItem.setFunction((FunctionCall) methodObj);
           }
@@ -605,12 +605,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
           // Additional items from methodCall chains
           for (final SQLParser.MethodCallContext methodCallCtx : funcCtx.methodCall()) {
-            final MatchPathItem item = new MatchPathItem(-1);
+            final MatchPathItem item = new MatchPathItem();
 
             // Extract method name and params from methodCall
             // methodCall: DOT identifier LPAREN (expression (COMMA expression)*)? RPAREN
             final Identifier methodName = (Identifier) visit(methodCallCtx.identifier());
-            final MethodCall method = new MethodCall(-1);
+            final MethodCall method = new MethodCall();
             method.methodName = methodName;
 
             if (CollectionUtils.isNotEmpty(methodCallCtx.expression())) {
@@ -634,7 +634,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       // Check if this is a field access (.identifier) or a method call (.method())
       if (methodObj instanceof Identifier) {
         // This is .identifier (field access) - create FieldMatchPathItem
-        final FieldMatchPathItem fieldPathItem = new FieldMatchPathItem(-1);
+        final FieldMatchPathItem fieldPathItem = new FieldMatchPathItem();
         fieldPathItem.field = (Identifier) methodObj;
 
         // Add properties if present: {as:x, where:...}
@@ -645,14 +645,14 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
 
       // This is a method call (.method() or .function(...))
-      final MatchPathItem pathItem = new MatchPathItem(-1);
+      final MatchPathItem pathItem = new MatchPathItem();
       final MethodCall method;
 
       if (methodObj instanceof MethodCall) {
         method = (MethodCall) methodObj;
       } else if (methodObj instanceof final FunctionCall funcCall) {
         // Convert FunctionCall to MethodCall (they have the same structure)
-        method = new MethodCall(-1);
+        method = new MethodCall();
         method.methodName = funcCall.name;
         method.params.addAll(funcCall.params);
       } else {
@@ -671,7 +671,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // Handle anonymous arrow syntax: --> <-- --
     if (ctx.DECR() != null || (ctx.ARROW_LEFT() != null && ctx.identifier() == null)) {
-      final MatchPathItem pathItem = new MatchPathItem(-1);
+      final MatchPathItem pathItem = new MatchPathItem();
       String methodName;
       if (ctx.GT() != null || (ctx.MINUS() != null && ctx.ARROW_LEFT() == null)) {
         // DECR GT = --> = outgoing
@@ -684,7 +684,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         methodName = "both";
       }
 
-      final MethodCall method = new MethodCall(-1);
+      final MethodCall method = new MethodCall();
       method.methodName = new Identifier(methodName);
       pathItem.setMethod(method);
 
@@ -698,7 +698,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // Arrow syntax with identifier: -EdgeType-> <-EdgeType- -EdgeType-
     // Determine direction based on arrow combination
-    final MatchPathItem pathItem = new MatchPathItem(-1);
+    final MatchPathItem pathItem = new MatchPathItem();
     final boolean leftIsArrow = ctx.ARROW_LEFT() != null;
     final boolean rightIsArrow = ctx.ARROW_RIGHT() != null;
 
@@ -715,15 +715,15 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     }
 
     // Create a MethodCall with the edge type as parameter
-    final MethodCall method = new MethodCall(-1);
+    final MethodCall method = new MethodCall();
     method.methodName = new Identifier(methodName);
 
     // Edge type becomes the parameter (as a string literal Expression)
     final Identifier edgeLabel = (Identifier) visit(ctx.identifier());
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
     baseExpr.string = "'" + edgeLabel.getStringValue() + "'";
 
-    final Expression edgeTypeParam = new Expression(-1);
+    final Expression edgeTypeParam = new Expression();
     edgeTypeParam.mathExpression = baseExpr;
     method.params.add(edgeTypeParam);
 
@@ -751,12 +751,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchPathItem visitNestedMatchMethod(final SQLParser.NestedMatchMethodContext ctx) {
-    final MatchPathItem pathItem = new MatchPathItem(-1);
+    final MatchPathItem pathItem = new MatchPathItem();
 
     // Check for function call syntax: identifier(...) or .identifier(...)
     if (ctx.LPAREN() != null) {
       final Identifier methodName = (Identifier) visit(ctx.identifier());
-      final MethodCall method = new MethodCall(-1);
+      final MethodCall method = new MethodCall();
       method.methodName = methodName;
 
       // Add parameters if present
@@ -802,16 +802,16 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
 
       // Create a MethodCall
-      final MethodCall method = new MethodCall(-1);
+      final MethodCall method = new MethodCall();
       method.methodName = new Identifier(methodName);
 
       // Edge type becomes the parameter if identifier is present
       if (ctx.identifier() != null) {
         final Identifier edgeLabel = (Identifier) visit(ctx.identifier());
-        final BaseExpression baseExpr = new BaseExpression(-1);
+        final BaseExpression baseExpr = new BaseExpression();
         baseExpr.string = "'" + edgeLabel.getStringValue() + "'";
 
-        final Expression edgeTypeParam = new Expression(-1);
+        final Expression edgeTypeParam = new Expression();
         edgeTypeParam.mathExpression = baseExpr;
         method.params.add(edgeTypeParam);
       }
@@ -825,7 +825,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     } else if (ctx.identifier() != null) {
       // Simple identifier without parentheses: methodName{...}
       final Identifier methodName = (Identifier) visit(ctx.identifier());
-      final MethodCall method = new MethodCall(-1);
+      final MethodCall method = new MethodCall();
       method.methodName = methodName;
       pathItem.setMethod(method);
 
@@ -859,7 +859,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchFilter visitMatchProperties(final SQLParser.MatchPropertiesContext ctx) {
-    final MatchFilter filter = new MatchFilter(-1);
+    final MatchFilter filter = new MatchFilter();
 
     // Handle filter items in braces: {type: Person, as: p, where: (name='John')}
     if (CollectionUtils.isNotEmpty(ctx.matchFilterItem())) {
@@ -878,7 +878,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchFilter visitMatchFilter(final SQLParser.MatchFilterContext ctx) {
-    final MatchFilter filter = new MatchFilter(-1);
+    final MatchFilter filter = new MatchFilter();
 
     // Handle function call (e.g., out(), in(), both())
     if (ctx.functionCall() != null) {
@@ -947,7 +947,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MatchFilterItem visitMatchFilterItem(final SQLParser.MatchFilterItemContext ctx) {
-    final MatchFilterItem item = new MatchFilterItem(-1);
+    final MatchFilterItem item = new MatchFilterItem();
 
     // Handle special case for BUCKET_IDENTIFIER (bucket:name) and BUCKET_NUMBER_IDENTIFIER (bucket:123)
     if (ctx.BUCKET_IDENTIFIER() != null) {
@@ -967,7 +967,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       // Extract the bucket number from the token (after the colon)
       final String tokenText = ctx.BUCKET_NUMBER_IDENTIFIER().getText();
       final String bucketNumStr = tokenText.substring(7); // Remove "bucket:" prefix
-      item.bucketId = new PInteger(-1).setValue(Integer.parseInt(bucketNumStr));
+      item.bucketId = new PInteger().setValue(Integer.parseInt(bucketNumStr));
       return item;
     }
 
@@ -1025,7 +1025,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
           } else {
             // Parameterized or computed RID such as :rid - keep the expression and resolve it against
             // the command context at plan time (Rid.toRecordId)
-            final Rid computed = new Rid(-1);
+            final Rid computed = new Rid();
             computed.expression = expr;
             item.rid = computed;
           }
@@ -1057,7 +1057,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         if (valueObj instanceof WhereClause) {
           item.filter = (WhereClause) valueObj;
         } else if (valueObj instanceof BooleanExpression) {
-          final WhereClause whereClause = new WhereClause(-1);
+          final WhereClause whereClause = new WhereClause();
           whereClause.baseExpression = (BooleanExpression) valueObj;
           item.filter = whereClause;
         } else if (valueObj instanceof final Expression expr) {
@@ -1066,7 +1066,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
           if (expr.mathExpression instanceof final BaseExpression baseExpr) {
             if (baseExpr.expression != null && baseExpr.expression.booleanValue != null) {
               // Handle boolean literals wrapped in BaseExpression: where: (true)
-              final WhereClause whereClause = new WhereClause(-1);
+              final WhereClause whereClause = new WhereClause();
               final BooleanExpression boolExpr = createBooleanLiteral(baseExpr.expression.booleanValue);
               whereClause.baseExpression = boolExpr;
               item.filter = whereClause;
@@ -1079,7 +1079,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
               item.filter = parenExpr.expression.whereCondition;
             } else if (parenExpr.expression != null && parenExpr.expression.booleanValue != null) {
               // Handle boolean literals like (true) or (false)
-              final WhereClause whereClause = new WhereClause(-1);
+              final WhereClause whereClause = new WhereClause();
               final BooleanExpression boolExpr = createBooleanLiteral(parenExpr.expression.booleanValue);
               whereClause.baseExpression = boolExpr;
               item.filter = whereClause;
@@ -1089,7 +1089,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
             item.filter = expr.whereCondition;
           } else if (expr.booleanValue != null) {
             // Direct boolean literal
-            final WhereClause whereClause = new WhereClause(-1);
+            final WhereClause whereClause = new WhereClause();
             final BooleanExpression boolExpr = createBooleanLiteral(expr.booleanValue);
             whereClause.baseExpression = boolExpr;
             item.filter = whereClause;
@@ -1100,7 +1100,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         if (valueObj instanceof WhereClause) {
           item.whileCondition = (WhereClause) valueObj;
         } else if (valueObj instanceof BooleanExpression) {
-          final WhereClause whereClause = new WhereClause(-1);
+          final WhereClause whereClause = new WhereClause();
           whereClause.baseExpression = (BooleanExpression) valueObj;
           item.whileCondition = whereClause;
         } else if (valueObj instanceof final Expression expr) {
@@ -1109,7 +1109,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
           if (expr.mathExpression instanceof final BaseExpression baseExpr) {
             if (baseExpr.expression != null && baseExpr.expression.booleanValue != null) {
               // Handle boolean literals wrapped in BaseExpression: while: (true)
-              final WhereClause whereClause = new WhereClause(-1);
+              final WhereClause whereClause = new WhereClause();
               final BooleanExpression boolExpr = createBooleanLiteral(baseExpr.expression.booleanValue);
               whereClause.baseExpression = boolExpr;
               item.whileCondition = whereClause;
@@ -1122,7 +1122,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
               item.whileCondition = parenExpr.expression.whereCondition;
             } else if (parenExpr.expression != null && parenExpr.expression.booleanValue != null) {
               // Handle boolean literals like (true) or (false)
-              final WhereClause whereClause = new WhereClause(-1);
+              final WhereClause whereClause = new WhereClause();
               final BooleanExpression boolExpr = createBooleanLiteral(parenExpr.expression.booleanValue);
               whereClause.baseExpression = boolExpr;
               item.whileCondition = whereClause;
@@ -1132,7 +1132,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
             item.whileCondition = expr.whereCondition;
           } else if (expr.booleanValue != null) {
             // Direct boolean literal
-            final WhereClause whereClause = new WhereClause(-1);
+            final WhereClause whereClause = new WhereClause();
             final BooleanExpression boolExpr = createBooleanLiteral(expr.booleanValue);
             whereClause.baseExpression = boolExpr;
             item.whileCondition = whereClause;
@@ -1224,7 +1224,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public TraverseStatement visitTraverseStmt(final SQLParser.TraverseStmtContext ctx) {
-    final TraverseStatement stmt = new TraverseStatement(-1);
+    final TraverseStatement stmt = new TraverseStatement();
 
     // Get the traverseStatement context from the labeled alternative
     final SQLParser.TraverseStatementContext traverseCtx = ctx.traverseStatement();
@@ -1275,7 +1275,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public TraverseProjectionItem visitTraverseProjectionItem(final SQLParser.TraverseProjectionItemContext ctx) {
-    final TraverseProjectionItem item = new TraverseProjectionItem(-1);
+    final TraverseProjectionItem item = new TraverseProjectionItem();
 
     // Expression (required) - convert to BaseIdentifier
     if (ctx.expression() != null) {
@@ -1301,7 +1301,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
       // If we still don't have a base, create a simple one
       if (item.base == null) {
-        item.base = new BaseIdentifier(-1);
+        item.base = new BaseIdentifier();
       }
     }
 
@@ -1312,7 +1312,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   }
 
   public Projection visitProjection(final SQLParser.ProjectionContext ctx) {
-    final Projection projection = new Projection(-1);
+    final Projection projection = new Projection();
 
     // DISTINCT flag
     final boolean distinct = ctx.DISTINCT() != null;
@@ -1323,7 +1323,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Handle * wildcard
     if (ctx.STAR() != null) {
       // Add wildcard projection item
-      final ProjectionItem item = new ProjectionItem(-1);
+      final ProjectionItem item = new ProjectionItem();
       item.setAll(true);
       items.add(item);
     }
@@ -1348,7 +1348,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ProjectionItem visitProjectionItem(final SQLParser.ProjectionItemContext ctx) {
-    final ProjectionItem item = new ProjectionItem(-1);
+    final ProjectionItem item = new ProjectionItem();
 
     // BANG (exclude flag) - e.g., !surname
     if (ctx.BANG() != null)
@@ -1472,7 +1472,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public NestedProjection visitNestedProjection(final SQLParser.NestedProjectionContext ctx) {
-    final NestedProjection nestedProjection = new NestedProjection(-1);
+    final NestedProjection nestedProjection = new NestedProjection();
 
     @SuppressWarnings("unchecked") final List<NestedProjectionItem> includeItems =
         nestedProjection.includeItems;
@@ -1500,7 +1500,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public NestedProjectionItem visitNestedProjectionItem(final SQLParser.NestedProjectionItemContext ctx) {
-    final NestedProjectionItem item = new NestedProjectionItem(-1);
+    final NestedProjectionItem item = new NestedProjectionItem();
 
     // STAR
     if (ctx.STAR() != null && ctx.expression() == null)
@@ -1534,7 +1534,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromClause visitFromClause(final SQLParser.FromClauseContext ctx) {
-    final FromClause fromClause = new FromClause(-1);
+    final FromClause fromClause = new FromClause();
 
     // FROM item - get the first one (JavaCC uses single item)
     if (ctx.fromItem() != null) {
@@ -1549,7 +1549,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromIdentifier(final SQLParser.FromIdentifierContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
 
     // Identifier is the main FROM target (alias, if present, is the second identifier and ignored in execution)
     if (ctx.identifier() != null && !ctx.identifier().isEmpty()) {
@@ -1584,7 +1584,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromRids(final SQLParser.FromRidsContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.rids = new ArrayList<>();
 
     for (final SQLParser.RidContext ridCtx : ctx.rid()) {
@@ -1599,7 +1599,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromRidArray(final SQLParser.FromRidArrayContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.rids = new ArrayList<>();
 
     for (final SQLParser.RidContext ridCtx : ctx.rid()) {
@@ -1615,7 +1615,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromEmptyArray(final SQLParser.FromEmptyArrayContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.rids = new ArrayList<>();
     return fromItem;
   }
@@ -1625,7 +1625,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromParamArray(final SQLParser.FromParamArrayContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.inputParams = new ArrayList<>();
 
     for (final SQLParser.InputParameterContext paramCtx : ctx.inputParameter()) {
@@ -1640,7 +1640,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromParam(final SQLParser.FromParamContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     // Use inputParam (singular) for single parameter - this is what TraverseExecutionPlanner expects
     fromItem.inputParam = (InputParameter) visit(ctx.inputParameter());
     return fromItem;
@@ -1652,8 +1652,8 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromBucket(final SQLParser.FromBucketContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
-    final Bucket bucket = new Bucket(-1);
+    final FromItem fromItem = new FromItem();
+    final Bucket bucket = new Bucket();
 
     if (ctx.BUCKET_IDENTIFIER() != null) {
       // BUCKET:name format
@@ -1676,21 +1676,21 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromBucketParameter(final SQLParser.FromBucketParameterContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
-    final Bucket bucket = new Bucket(-1);
+    final FromItem fromItem = new FromItem();
+    final Bucket bucket = new Bucket();
 
     // Extract the parameter from the token
     if (ctx.BUCKET_NAMED_PARAM() != null) {
       // bucket::paramName - extract the parameter name after "bucket::"
       final String text = ctx.BUCKET_NAMED_PARAM().getText();
       final String paramName = text.substring("bucket::".length());
-      final NamedParameter param = new NamedParameter(-1);
+      final NamedParameter param = new NamedParameter();
       param.paramName = paramName;
       param.paramNumber = positionalParamCounter++;
       bucket.inputParam = param;
     } else if (ctx.BUCKET_POSITIONAL_PARAM() != null) {
       // bucket:? - create a positional parameter
-      final PositionalParameter param = new PositionalParameter(-1);
+      final PositionalParameter param = new PositionalParameter();
       param.paramNumber = positionalParamCounter++;
       bucket.inputParam = param;
     }
@@ -1704,7 +1704,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromBucketList(final SQLParser.FromBucketListContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.bucketList = (BucketList) visit(ctx.bucketList());
     return fromItem;
   }
@@ -1714,7 +1714,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromIndex(final SQLParser.FromIndexContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.index = (IndexIdentifier) visit(ctx.indexIdentifier());
     return fromItem;
   }
@@ -1724,7 +1724,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromSchema(final SQLParser.FromSchemaContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.schema = (SchemaIdentifier) visit(ctx.schemaIdentifier());
     return fromItem;
   }
@@ -1734,7 +1734,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromSubquery(final SQLParser.FromSubqueryContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.statement = (Statement) visit(ctx.statement());
 
     // Handle modifiers if present - chain them using modifier.next
@@ -1771,7 +1771,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FromItem visitFromFunctionCall(final SQLParser.FromFunctionCallContext ctx) {
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
     fromItem.functionCall = (FunctionCall) visit(ctx.functionCall());
 
     if (ctx.identifier() != null)
@@ -1786,7 +1786,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public WhereClause visitWhereClause(final SQLParser.WhereClauseContext ctx) {
-    final WhereClause whereClause = new WhereClause(-1);
+    final WhereClause whereClause = new WhereClause();
 
     // The orBlock is the root of the boolean expression tree
     whereClause.baseExpression = (BooleanExpression) visit(ctx.orBlock());
@@ -1808,7 +1808,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     }
 
     // Multiple AND blocks connected with OR
-    final OrBlock orBlock = new OrBlock(-1);
+    final OrBlock orBlock = new OrBlock();
     final List<BooleanExpression> subBlocks = new ArrayList<>();
     for (final SQLParser.AndBlockContext andCtx : andBlocks) {
       subBlocks.add((BooleanExpression) visit(andCtx));
@@ -1832,7 +1832,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     }
 
     // Multiple NOT blocks connected with AND
-    final AndBlock andBlock = new AndBlock(-1);
+    final AndBlock andBlock = new AndBlock();
     for (final SQLParser.NotBlockContext notCtx : notBlocks) {
       andBlock.subBlocks.add((BooleanExpression) visit(notCtx));
     }
@@ -1849,7 +1849,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     if (ctx.NOT() != null) {
       // Apply NOT operator
-      final NotBlock notBlock = new NotBlock(-1);
+      final NotBlock notBlock = new NotBlock();
       notBlock.sub = condition;
       notBlock.negate = true;
       return notBlock;
@@ -1863,7 +1863,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BinaryCondition visitComparisonCondition(final SQLParser.ComparisonConditionContext ctx) {
-    final BinaryCondition condition = new BinaryCondition(-1);
+    final BinaryCondition condition = new BinaryCondition();
 
     // Left expression
     condition.left = (Expression) visit(ctx.expression(0));
@@ -1887,27 +1887,27 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BinaryCondition visitFunctionCallCondition(final SQLParser.FunctionCallConditionContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
 
     final FunctionCall funcCall = (FunctionCall) visit(ctx.functionCall());
 
-    final LevelZeroIdentifier levelZero = new LevelZeroIdentifier(-1);
+    final LevelZeroIdentifier levelZero = new LevelZeroIdentifier();
     levelZero.functionCall = funcCall;
 
-    final BaseIdentifier baseId = new BaseIdentifier(-1);
+    final BaseIdentifier baseId = new BaseIdentifier();
     baseId.levelZero = levelZero;
 
     baseExpr.identifier = baseId;
 
-    final Expression left = new Expression(-1);
+    final Expression left = new Expression();
     left.mathExpression = baseExpr;
 
-    final Expression right = new Expression(-1);
+    final Expression right = new Expression();
     right.booleanValue = Boolean.TRUE;
 
-    final BinaryCondition condition = new BinaryCondition(-1);
+    final BinaryCondition condition = new BinaryCondition();
     condition.left = left;
-    condition.operator = new EqualsCompareOperator(-1);
+    condition.operator = new EqualsCompareOperator();
     condition.right = right;
     return condition;
   }
@@ -1923,12 +1923,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     try {
       if (ctx.NOT() != null) {
         // IS NOT NULL
-        final IsNotNullCondition condition = new IsNotNullCondition(-1);
+        final IsNotNullCondition condition = new IsNotNullCondition();
         condition.expression = expr;
         return condition;
       } else {
         // IS NULL
-        final IsNullCondition condition = new IsNullCondition(-1);
+        final IsNullCondition condition = new IsNullCondition();
         condition.expression = expr;
         return condition;
       }
@@ -1942,7 +1942,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BooleanExpression visitInCondition(final SQLParser.InConditionContext ctx) {
-    final InCondition condition = new InCondition(-1);
+    final InCondition condition = new InCondition();
 
     // Check if left side is a parenthesized statement (subquery): (SELECT ...) IN tags
     final SQLParser.ExpressionContext leftExprCtx = ctx.expression(0);
@@ -2105,7 +2105,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Expression third = (Expression) visit(ctx.expression(2));
 
     try {
-      final BetweenCondition condition = new BetweenCondition(-1);
+      final BetweenCondition condition = new BetweenCondition();
       condition.first = first;
 
       condition.second = second;
@@ -2114,7 +2114,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
       // Handle NOT BETWEEN
       if (ctx.NOT() != null) {
-        final NotBlock notBlock = new NotBlock(-1);
+        final NotBlock notBlock = new NotBlock();
         notBlock.sub = condition;
         notBlock.negate = true;
         return notBlock;
@@ -2135,7 +2135,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Expression left = (Expression) visit(ctx.expression(0));
 
     try {
-      final ContainsCondition condition = new ContainsCondition(-1);
+      final ContainsCondition condition = new ContainsCondition();
       condition.left = left;
 
       if (ctx.whereClause() != null) {
@@ -2189,7 +2189,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Expression left = (Expression) visit(ctx.expression(0));
 
     try {
-      final ContainsAllCondition condition = new ContainsAllCondition(-1);
+      final ContainsAllCondition condition = new ContainsAllCondition();
       condition.left = left;
 
       if (ctx.whereClause() != null) {
@@ -2217,7 +2217,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Expression left = (Expression) visit(ctx.expression(0));
 
     try {
-      final ContainsAnyCondition condition = new ContainsAnyCondition(-1);
+      final ContainsAnyCondition condition = new ContainsAnyCondition();
       condition.left = left;
 
       if (ctx.whereClause() != null) {
@@ -2242,10 +2242,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public BooleanExpression visitContainsKeyCondition(final SQLParser.ContainsKeyConditionContext ctx) {
     // Use CONTAINS operator for key checking
-    final BinaryCondition condition = new BinaryCondition(-1);
+    final BinaryCondition condition = new BinaryCondition();
     condition.left = (Expression) visit(ctx.expression(0));
     condition.right = (Expression) visit(ctx.expression(1));
-    condition.operator = new ContainsKeyOperator(-1);
+    condition.operator = new ContainsKeyOperator();
     return condition;
   }
 
@@ -2258,7 +2258,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Expression right = (Expression) visit(ctx.expression(1));
 
     try {
-      final ContainsValueCondition condition = new ContainsValueCondition(-1);
+      final ContainsValueCondition condition = new ContainsValueCondition();
       condition.left = left;
 
       condition.expression = right;
@@ -2278,7 +2278,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Expression right = (Expression) visit(ctx.expression(1));
 
     try {
-      final ContainsTextCondition condition = new ContainsTextCondition(-1);
+      final ContainsTextCondition condition = new ContainsTextCondition();
       condition.left = left;
 
       condition.right = right;
@@ -2296,14 +2296,14 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BooleanExpression visitLikeCondition(final SQLParser.LikeConditionContext ctx) {
-    final BinaryCondition condition = new BinaryCondition(-1);
+    final BinaryCondition condition = new BinaryCondition();
     condition.left = (Expression) visit(ctx.expression(0));
     condition.right = (Expression) visit(ctx.expression(1));
-    condition.operator = new LikeOperator(-1);
+    condition.operator = new LikeOperator();
 
     // Handle NOT LIKE
     if (ctx.NOT() != null) {
-      final NotBlock notBlock = new NotBlock(-1);
+      final NotBlock notBlock = new NotBlock();
       notBlock.sub = condition;
       notBlock.negate = true;
       return notBlock;
@@ -2319,14 +2319,14 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BooleanExpression visitIlikeCondition(final SQLParser.IlikeConditionContext ctx) {
-    final BinaryCondition condition = new BinaryCondition(-1);
+    final BinaryCondition condition = new BinaryCondition();
     condition.left = (Expression) visit(ctx.expression(0));
     condition.right = (Expression) visit(ctx.expression(1));
-    condition.operator = new ILikeOperator(-1);
+    condition.operator = new ILikeOperator();
 
     // Handle NOT ILIKE
     if (ctx.NOT() != null) {
-      final NotBlock notBlock = new NotBlock(-1);
+      final NotBlock notBlock = new NotBlock();
       notBlock.sub = condition;
       notBlock.negate = true;
       return notBlock;
@@ -2345,7 +2345,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Expression rightExpr = (Expression) visit(ctx.expression(1));
 
     try {
-      final MatchesCondition condition = new MatchesCondition(-1);
+      final MatchesCondition condition = new MatchesCondition();
       condition.expression = leftExpr;
 
       // Set rightExpression (the regex pattern)
@@ -2364,7 +2364,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public BooleanExpression visitInstanceofCondition(final SQLParser.InstanceofConditionContext ctx) {
     final Expression left = (Expression) visit(ctx.expression());
-    final InstanceofCondition condition = new InstanceofCondition(-1);
+    final InstanceofCondition condition = new InstanceofCondition();
 
     try {
       condition.left = left;
@@ -2396,12 +2396,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     try {
       if (ctx.NOT() != null) {
         // IS NOT DEFINED
-        final IsNotDefinedCondition condition = new IsNotDefinedCondition(-1);
+        final IsNotDefinedCondition condition = new IsNotDefinedCondition();
         condition.expression = expr;
         return condition;
       } else {
         // IS DEFINED
-        final IsDefinedCondition condition = new IsDefinedCondition(-1);
+        final IsDefinedCondition condition = new IsDefinedCondition();
         condition.expression = expr;
         return condition;
       }
@@ -2428,7 +2428,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitArrayConcat(final SQLParser.ArrayConcatContext ctx) {
-    final ArrayConcatExpression concatExpr = new ArrayConcatExpression(-1);
+    final ArrayConcatExpression concatExpr = new ArrayConcatExpression();
 
     // Visit left side
     final Expression leftExpr = (Expression) visit(ctx.expression(0));
@@ -2436,7 +2436,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (leftExpr.arrayConcatExpression != null)
       concatExpr.getChildExpressions().addAll(leftExpr.arrayConcatExpression.getChildExpressions());
     else {
-      final ArrayConcatExpressionElement leftElement = new ArrayConcatExpressionElement(-1);
+      final ArrayConcatExpressionElement leftElement = new ArrayConcatExpressionElement();
       copyExpressionFields(leftExpr, leftElement);
       leftElement.nestedProjection = extractNestedProjectionFromBaseExpression(leftExpr);
       concatExpr.getChildExpressions().add(leftElement);
@@ -2444,13 +2444,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // Visit right side
     final Expression rightExpr = (Expression) visit(ctx.expression(1));
-    final ArrayConcatExpressionElement rightElement = new ArrayConcatExpressionElement(-1);
+    final ArrayConcatExpressionElement rightElement = new ArrayConcatExpressionElement();
     copyExpressionFields(rightExpr, rightElement);
     rightElement.nestedProjection = extractNestedProjectionFromBaseExpression(rightExpr);
     concatExpr.getChildExpressions().add(rightElement);
 
     // Wrap in Expression
-    final Expression result = new Expression(-1);
+    final Expression result = new Expression();
     result.arrayConcatExpression = concatExpr;
     return result;
   }
@@ -2472,7 +2472,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitMathExpr(final SQLParser.MathExprContext ctx) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.mathExpression = (MathExpression) visit(ctx.mathExpression());
     return expr;
   }
@@ -2482,7 +2482,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitNullLiteral(final SQLParser.NullLiteralContext ctx) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.isNull = true;
     return expr;
   }
@@ -2492,7 +2492,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitTrueLiteral(final SQLParser.TrueLiteralContext ctx) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.booleanValue = Boolean.TRUE;
     return expr;
   }
@@ -2502,7 +2502,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitFalseLiteral(final SQLParser.FalseLiteralContext ctx) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.booleanValue = Boolean.FALSE;
     return expr;
   }
@@ -2512,7 +2512,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitRidLiteral(final SQLParser.RidLiteralContext ctx) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.rid = (Rid) visit(ctx.rid());
     return expr;
   }
@@ -2523,7 +2523,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitParenthesizedWhereExpr(final SQLParser.ParenthesizedWhereExprContext ctx) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.whereCondition = (WhereClause) visit(ctx.whereClause());
     return expr;
   }
@@ -2533,7 +2533,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Expression visitJsonLiteral(final SQLParser.JsonLiteralContext ctx) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.json = (Json) visit(ctx.json());
     return expr;
   }
@@ -2556,7 +2556,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public JsonArray visitJsonArray(final SQLParser.JsonArrayContext ctx) {
-    final JsonArray jsonArray = new JsonArray(-1);
+    final JsonArray jsonArray = new JsonArray();
 
     if (ctx.json() != null) {
       for (final SQLParser.JsonContext jsonCtx : ctx.json()) {
@@ -2576,11 +2576,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final Json json = (Json) visit(ctx.mapLiteral());
 
     // Wrap in Expression
-    final Expression expression = new Expression(-1);
+    final Expression expression = new Expression();
     expression.json = json;
 
     // Wrap in BaseExpression
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
     try {
       baseExpr.expression = expression;
     } catch (final Exception e) {
@@ -2614,7 +2614,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public Json visitMapLiteral(final SQLParser.MapLiteralContext ctx) {
     try {
-      final Json json = new Json(-1);
+      final Json json = new Json();
 
       if (ctx.mapEntry() != null) {
         for (final SQLParser.MapEntryContext entryCtx : ctx.mapEntry()) {
@@ -2695,12 +2695,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     } else if (ctx.MINUS() != null) {
       // Unary minus: create 0 - expression
       // Create a MathExpression with zero and the MINUS operator
-      final MathExpression result = new MathExpression(-1);
+      final MathExpression result = new MathExpression();
 
       // Create zero expression (BaseExpression with PInteger(0))
-      final MathExpression zeroExpr = new MathExpression(-1);
-      final BaseExpression baseZero = new BaseExpression(-1);
-      final PInteger zero = new PInteger(-1);
+      final MathExpression zeroExpr = new MathExpression();
+      final BaseExpression baseZero = new BaseExpression();
+      final PInteger zero = new PInteger();
       zero.setValue(0);
       baseZero.number = zero;
       zeroExpr.childExpressions.add(baseZero);
@@ -2724,7 +2724,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final MathExpression left = (MathExpression) visit(ctx.mathExpression(0));
     final MathExpression right = (MathExpression) visit(ctx.mathExpression(1));
 
-    final MathExpression result = new MathExpression(-1);
+    final MathExpression result = new MathExpression();
     result.childExpressions.add(left);
     result.childExpressions.add(right);
 
@@ -2747,7 +2747,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final MathExpression left = (MathExpression) visit(ctx.mathExpression(0));
     final MathExpression right = (MathExpression) visit(ctx.mathExpression(1));
 
-    final MathExpression result = new MathExpression(-1);
+    final MathExpression result = new MathExpression();
     result.childExpressions.add(left);
     result.childExpressions.add(right);
 
@@ -2768,7 +2768,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final MathExpression left = (MathExpression) visit(ctx.mathExpression(0));
     final MathExpression right = (MathExpression) visit(ctx.mathExpression(1));
 
-    final MathExpression result = new MathExpression(-1);
+    final MathExpression result = new MathExpression();
     result.childExpressions.add(left);
     result.childExpressions.add(right);
 
@@ -2791,7 +2791,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final MathExpression left = (MathExpression) visit(ctx.mathExpression(0));
     final MathExpression right = (MathExpression) visit(ctx.mathExpression(1));
 
-    final MathExpression result = new MathExpression(-1);
+    final MathExpression result = new MathExpression();
     result.childExpressions.add(left);
     result.childExpressions.add(right);
     result.operators.add(MathExpression.Operator.BIT_AND);
@@ -2807,7 +2807,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final MathExpression left = (MathExpression) visit(ctx.mathExpression(0));
     final MathExpression right = (MathExpression) visit(ctx.mathExpression(1));
 
-    final MathExpression result = new MathExpression(-1);
+    final MathExpression result = new MathExpression();
     result.childExpressions.add(left);
     result.childExpressions.add(right);
     result.operators.add(MathExpression.Operator.XOR);
@@ -2823,7 +2823,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final MathExpression left = (MathExpression) visit(ctx.mathExpression(0));
     final MathExpression right = (MathExpression) visit(ctx.mathExpression(1));
 
-    final MathExpression result = new MathExpression(-1);
+    final MathExpression result = new MathExpression();
     result.childExpressions.add(left);
     result.childExpressions.add(right);
     result.operators.add(MathExpression.Operator.BIT_OR);
@@ -2847,9 +2847,9 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitIntegerLiteral(final SQLParser.IntegerLiteralContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
 
-    final PInteger number = new PInteger(-1);
+    final PInteger number = new PInteger();
     final String text = ctx.INTEGER_LITERAL().getText();
     try {
       if (text.endsWith("L") || text.endsWith("l")) {
@@ -2875,9 +2875,9 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitFloatLiteral(final SQLParser.FloatLiteralContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
 
-    final PNumber number = new PNumber(-1);
+    final PNumber number = new PNumber();
     final String text = ctx.FLOATING_POINT_LITERAL().getText();
     try {
       if (text.endsWith("F") || text.endsWith("f")) {
@@ -2901,7 +2901,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitStringLiteral(final SQLParser.StringLiteralContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
 
     // STRING_LITERAL or RID_STRING ("@rid") — store as-is including quotes
     // BaseExpression.execute() will handle unquoting and escape sequence decoding
@@ -2935,7 +2935,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitNullBaseExpr(final SQLParser.NullBaseExprContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
     baseExpr.isNull = true;
     return baseExpr;
   }
@@ -2945,8 +2945,8 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitThisLiteral(final SQLParser.ThisLiteralContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
-    final RecordAttribute attr = new RecordAttribute(-1);
+    final BaseExpression baseExpr = new BaseExpression();
+    final RecordAttribute attr = new RecordAttribute();
     attr.setName("@this");
     final BaseIdentifier baseId = new BaseIdentifier(attr);
     baseExpr.identifier = baseId;
@@ -2958,7 +2958,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitInputParam(final SQLParser.InputParamContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
     baseExpr.inputParam = (InputParameter) visit(ctx.inputParameter());
     return baseExpr;
   }
@@ -2968,16 +2968,16 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitFunctionCallExpr(final SQLParser.FunctionCallExprContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
 
     try {
       // Create the AST structure: BaseExpression -> BaseIdentifier -> LevelZeroIdentifier -> FunctionCall
       final FunctionCall funcCall = (FunctionCall) visit(ctx.functionCall());
 
-      final LevelZeroIdentifier levelZero = new LevelZeroIdentifier(-1);
+      final LevelZeroIdentifier levelZero = new LevelZeroIdentifier();
       levelZero.functionCall = funcCall;
 
-      final BaseIdentifier baseId = new BaseIdentifier(-1);
+      final BaseIdentifier baseId = new BaseIdentifier();
       baseId.levelZero = levelZero;
 
       baseExpr.identifier = baseId;
@@ -2994,7 +2994,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         for (final SQLParser.NestedProjectionContext projCtx : funcCtx.nestedProjection()) {
           final NestedProjection nestedProj = (NestedProjection) visit(projCtx);
           // Convert to a Modifier for the AST structure
-          final Modifier modifier = new Modifier(-1);
+          final Modifier modifier = new Modifier();
           modifier.nestedProjection = nestedProj;
           if (firstModifier == null) {
             firstModifier = modifier;
@@ -3065,7 +3065,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitArrayLit(final SQLParser.ArrayLitContext ctx) {
-    final ArrayLiteralExpression arrayLiteral = new ArrayLiteralExpression(-1);
+    final ArrayLiteralExpression arrayLiteral = new ArrayLiteralExpression();
 
     // Visit each expression in the array literal
     if (ctx.arrayLiteral().expression() != null) {
@@ -3076,7 +3076,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final Expression expr;
         if (visited instanceof Json json) {
           // Wrap Json in Expression
-          expr = new Expression(-1);
+          expr = new Expression();
           expr.json = json;
         } else {
           expr = (Expression) visited;
@@ -3087,10 +3087,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     }
 
     // Wrap in BaseExpression with mathExpression set to our array literal
-    final Expression expression = new Expression(-1);
+    final Expression expression = new Expression();
     expression.mathExpression = arrayLiteral;
 
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
     baseExpr.expression = expression;
 
     // Process modifiers (method calls like .keys(), .values(), etc.)
@@ -3119,7 +3119,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FunctionCall visitFunctionCall(final SQLParser.FunctionCallContext ctx) {
-    final FunctionCall funcCall = new FunctionCall(-1);
+    final FunctionCall funcCall = new FunctionCall();
 
     try {
       // Function name
@@ -3130,12 +3130,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       if (ctx.STAR() != null) {
         // Handle COUNT(*), SUM(*), etc. - create a parameter representing *
         final List<Expression> params = new ArrayList<>();
-        final Expression starExpr = new Expression(-1);
-        final BaseExpression baseExpr = new BaseExpression(-1);
+        final Expression starExpr = new Expression();
+        final BaseExpression baseExpr = new BaseExpression();
 
         // Create a special identifier for * using SuffixIdentifier with star flag
-        final BaseIdentifier starId = new BaseIdentifier(-1);
-        final SuffixIdentifier suffix = new SuffixIdentifier(-1);
+        final BaseIdentifier starId = new BaseIdentifier();
+        final SuffixIdentifier suffix = new SuffixIdentifier();
         suffix.star = true;
         starId.suffix = suffix;
 
@@ -3164,7 +3164,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BaseExpression visitIdentifierChain(final SQLParser.IdentifierChainContext ctx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
 
     // Build identifier chain
     if (ctx.identifier() != null) {
@@ -3185,7 +3185,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       // Check if the first identifier is a record attribute (@rid, @type, @in, @out, @this),
       // including backtick-quoted variants like `@rid`
       final SuffixIdentifier firstSuffix = buildSuffixForIdentifier(firstIdCtx);
-      final BaseIdentifier baseId = new BaseIdentifier(-1);
+      final BaseIdentifier baseId = new BaseIdentifier();
       baseId.suffix = firstSuffix;
       baseExpr.identifier = baseId;
 
@@ -3201,17 +3201,17 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
           final SQLParser.MethodCallContext methodCtx = ctx.methodCall(0);
           final String qualifiedName = baseIdName + "." + methodCtx.identifier().getText();
 
-          final FunctionCall funcCall = new FunctionCall(-1);
+          final FunctionCall funcCall = new FunctionCall();
           funcCall.name = new Identifier(qualifiedName);
           funcCall.params = new ArrayList<>();
           if (methodCtx.expression() != null)
             for (final SQLParser.ExpressionContext exprCtx : methodCtx.expression())
               funcCall.params.add((Expression) visit(exprCtx));
 
-          final LevelZeroIdentifier levelZero = new LevelZeroIdentifier(-1);
+          final LevelZeroIdentifier levelZero = new LevelZeroIdentifier();
           levelZero.functionCall = funcCall;
 
-          final BaseIdentifier baseId2 = new BaseIdentifier(-1);
+          final BaseIdentifier baseId2 = new BaseIdentifier();
           baseId2.levelZero = levelZero;
 
           baseExpr.identifier = baseId2;
@@ -3228,7 +3228,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         // Process additional property names (DOT propertyName)* - e.g., "custom.label"
         if (!ctx.propertyName().isEmpty()) {
           for (final SQLParser.PropertyNameContext propCtx : ctx.propertyName()) {
-            final Modifier modifier = new Modifier(-1);
+            final Modifier modifier = new Modifier();
 
             // Check if this identifier is a record attribute (@rid, @type, @in, @out, @this)
             modifier.suffix = buildSuffixForPropertyName(propCtx);
@@ -3310,12 +3310,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   private BaseExpression buildNamespaceQualifiedFunctionCall(final String namespace,
       final SQLParser.MethodCallContext methodCtx, final SQLParser.IdentifierChainContext chainCtx) {
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
 
     try {
       // Build the combined function name: "geo.point", "geo.within", etc.
       final Identifier methodName = (Identifier) visit(methodCtx.identifier());
-      final FunctionCall funcCall = new FunctionCall(-1);
+      final FunctionCall funcCall = new FunctionCall();
       funcCall.name = new Identifier(namespace + "." + methodName.getStringValue());
 
       // Collect arguments from the method call
@@ -3328,9 +3328,9 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
 
       // Wrap the FunctionCall in the standard BaseExpression structure
-      final LevelZeroIdentifier levelZero = new LevelZeroIdentifier(-1);
+      final LevelZeroIdentifier levelZero = new LevelZeroIdentifier();
       levelZero.functionCall = funcCall;
-      final BaseIdentifier baseId = new BaseIdentifier(-1);
+      final BaseIdentifier baseId = new BaseIdentifier();
       baseId.levelZero = levelZero;
       baseExpr.identifier = baseId;
 
@@ -3390,7 +3390,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     }
 
     // Otherwise, create a Modifier and wrap the selector
-    final Modifier modifier = new Modifier(-1);
+    final Modifier modifier = new Modifier();
 
     try {
       // Set squareBrackets flag
@@ -3404,7 +3404,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         modifier.arraySingleValues = (ArraySingleValuesSelector) selector;
       } else if (selector instanceof ArraySelector) {
         // Single selector - wrap in ArraySingleValuesSelector
-        final ArraySingleValuesSelector singleValues = new ArraySingleValuesSelector(-1);
+        final ArraySingleValuesSelector singleValues = new ArraySingleValuesSelector();
         singleValues.items.add((ArraySelector) selector);
 
         modifier.arraySingleValues = singleValues;
@@ -3428,11 +3428,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * Example: type.substring(0,1) creates a Modifier with a MethodCall
    */
   private Modifier createModifierForMethodCall(final SQLParser.MethodCallContext methodCtx) {
-    final Modifier modifier = new Modifier(-1);
+    final Modifier modifier = new Modifier();
 
     try {
       // Create MethodCall object
-      final MethodCall methodCall = new MethodCall(-1);
+      final MethodCall methodCall = new MethodCall();
 
       // Set method name
       methodCall.methodName = (Identifier) visit(methodCtx.identifier());
@@ -3466,14 +3466,14 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         idCtx.IN_ATTR() != null || idCtx.OUT_ATTR() != null ||
         idCtx.THIS() != null || idCtx.RID_ID_ATTR() != null ||
         idCtx.RID_POS_ATTR() != null || idCtx.PROPS_ATTR() != null) {
-      final RecordAttribute attr = new RecordAttribute(-1);
+      final RecordAttribute attr = new RecordAttribute();
       attr.setName(idCtx.getText());
       return new SuffixIdentifier(attr);
     }
     // Quoted identifiers (e.g. `@rid`) or plain identifiers whose value matches a record attribute
     final Identifier id = (Identifier) visit(idCtx);
     if (isRecordAttributeName(id.getStringValue())) {
-      final RecordAttribute attr = new RecordAttribute(-1);
+      final RecordAttribute attr = new RecordAttribute();
       attr.setName(id.getStringValue());
       return new SuffixIdentifier(attr);
     }
@@ -3515,19 +3515,19 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Modifier visitModifier(final SQLParser.ModifierContext ctx) {
-    final Modifier modifier = new Modifier(-1);
+    final Modifier modifier = new Modifier();
 
     try {
       if (ctx.STAR() != null) {
         // Wildcard suffix: .*
-        final SuffixIdentifier suffix = new SuffixIdentifier(-1);
+        final SuffixIdentifier suffix = new SuffixIdentifier();
         suffix.star = true;
         modifier.suffix = suffix;
       } else if (ctx.propertyName() != null) {
         // Check if this is a method call (has parentheses) or property access (no parentheses)
         if (ctx.LPAREN() != null) {
           // Method call: .identifier(args)
-          final MethodCall methodCall = new MethodCall(-1);
+          final MethodCall methodCall = new MethodCall();
           methodCall.methodName = (Identifier) visit(ctx.propertyName());
 
           // Add parameters if present
@@ -3604,7 +3604,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public BaseExpression visitParenthesizedExpr(final SQLParser.ParenthesizedExprContext ctx) {
     // Regular parenthesized expression
-    final BaseExpression baseExpr = new BaseExpression(-1);
+    final BaseExpression baseExpr = new BaseExpression();
     baseExpr.expression = (Expression) visit(ctx.expression());
 
     // Process modifiers if present
@@ -3659,10 +3659,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final CaseExpression caseExpression = new CaseExpression(alternatives, elseExpression);
 
     // Wrap in Expression, then in BaseExpression
-    final Expression wrapperExpression = new Expression(-1);
+    final Expression wrapperExpression = new Expression();
     wrapperExpression.mathExpression = caseExpression;
 
-    final BaseExpression result = new BaseExpression(-1);
+    final BaseExpression result = new BaseExpression();
     result.expression = wrapperExpression;
 
     // Process modifiers if any
@@ -3717,10 +3717,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     final CaseExpression caseExpression = new CaseExpression(testExpression, alternatives, elseExpression);
 
     // Wrap in Expression, then in BaseExpression
-    final Expression wrapperExpression = new Expression(-1);
+    final Expression wrapperExpression = new Expression();
     wrapperExpression.mathExpression = caseExpression;
 
-    final BaseExpression result = new BaseExpression(-1);
+    final BaseExpression result = new BaseExpression();
     result.expression = wrapperExpression;
 
     // Process modifiers if any
@@ -3751,7 +3751,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * For (SELECT ...) IN collection, we need to extract values from Results and check if ANY match.
    */
   private Expression createStatementExpression(final SelectStatement statement) {
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.mathExpression = new SubqueryExpression(statement);
     return expr;
   }
@@ -3810,25 +3810,25 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   private BinaryCompareOperator mapComparisonOperator(final SQLParser.ComparisonOperatorContext ctx) {
     if (ctx.EQ() != null || ctx.EQEQ() != null) {
-      return new EqualsCompareOperator(-1);
+      return new EqualsCompareOperator();
     } else if (ctx.NE() != null) {
-      return new NeOperator(-1);
+      return new NeOperator();
     } else if (ctx.NEQ() != null) {
-      return new NeqOperator(-1);
+      return new NeqOperator();
     } else if (ctx.LT() != null) {
-      return new LtOperator(-1);
+      return new LtOperator();
     } else if (ctx.GT() != null) {
-      return new GtOperator(-1);
+      return new GtOperator();
     } else if (ctx.LE() != null) {
-      return new LeOperator(-1);
+      return new LeOperator();
     } else if (ctx.GE() != null) {
-      return new GeOperator(-1);
+      return new GeOperator();
     } else if (ctx.NSEQ() != null) {
-      return new NullSafeEqualsCompareOperator(-1);
+      return new NullSafeEqualsCompareOperator();
     } else if (ctx.NEAR() != null) {
-      return new NearOperator(-1);
+      return new NearOperator();
     } else if (ctx.WITHIN() != null) {
-      return new WithinOperator(-1);
+      return new WithinOperator();
     }
 
     throw new CommandSQLParsingException("Unknown comparison operator: " + ctx.getText());
@@ -3868,7 +3868,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Rid visitRid(final SQLParser.RidContext ctx) {
-    final Rid rid = new Rid(-1);
+    final Rid rid = new Rid();
 
     // Check if it's an expression-based RID: {rid: expr} or {"@rid": expr}
     if (ctx.expression() != null) {
@@ -3895,7 +3895,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (ctx.HOOK() != null) {
       // Positional parameter: ?
       // Increment counter to assign sequential parameter numbers
-      final PositionalParameter param = new PositionalParameter(-1);
+      final PositionalParameter param = new PositionalParameter();
       param.paramNumber = positionalParamCounter;
       positionalParamCounter++;
       return param;
@@ -3908,7 +3908,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       } else {
         paramName = ctx.FROM().getText().toLowerCase();
       }
-      final NamedParameter param = new NamedParameter(-1);
+      final NamedParameter param = new NamedParameter();
       param.paramName = paramName;
       param.paramNumber = positionalParamCounter;
       positionalParamCounter++;
@@ -3916,13 +3916,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     } else if (ctx.INTEGER_LITERAL() != null) {
       // Positional parameter: $1, $2, etc.
       final int paramNum = Integer.parseInt(ctx.INTEGER_LITERAL().getText());
-      final PositionalParameter param = new PositionalParameter(-1);
+      final PositionalParameter param = new PositionalParameter();
       param.paramNumber = paramNum;
       return param;
     } else if (ctx.COLON() != null && ctx.INTEGER_LITERAL() != null) {
       // Named parameter: :1, :2, etc. (numeric named params)
       final int paramNum = Integer.parseInt(ctx.INTEGER_LITERAL().getText());
-      final NamedParameter param = new NamedParameter(-1);
+      final NamedParameter param = new NamedParameter();
       param.paramName = String.valueOf(paramNum);
       param.paramNumber = paramNum;
       return param;
@@ -3936,7 +3936,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BucketList visitBucketList(final SQLParser.BucketListContext ctx) {
-    final BucketList bucketList = new BucketList(-1);
+    final BucketList bucketList = new BucketList();
 
     for (final SQLParser.IdentifierContext idCtx : ctx.identifier()) {
       final Identifier id = (Identifier) visit(idCtx);
@@ -3951,7 +3951,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public IndexIdentifier visitIndexIdentifier(final SQLParser.IndexIdentifierContext ctx) {
-    final IndexIdentifier indexId = new IndexIdentifier(-1);
+    final IndexIdentifier indexId = new IndexIdentifier();
 
     if (ctx.identifier() != null) {
       // index:name format
@@ -3978,7 +3978,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public SchemaIdentifier visitSchemaIdentifier(final SQLParser.SchemaIdentifierContext ctx) {
-    final SchemaIdentifier schemaId = new SchemaIdentifier(-1);
+    final SchemaIdentifier schemaId = new SchemaIdentifier();
 
     if (ctx.SCHEMA_IDENTIFIER() != null) {
       final String text = ctx.SCHEMA_IDENTIFIER().getText().substring("schema:".length());
@@ -3998,7 +3998,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public PInteger visitPInteger(final SQLParser.PIntegerContext ctx) {
-    final PInteger pInt = new PInteger(-1);
+    final PInteger pInt = new PInteger();
     final String text = ctx.INTEGER_LITERAL().getText();
 
     try {
@@ -4016,7 +4016,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public PInteger visitInteger(final SQLParser.IntegerContext ctx) {
-    final PInteger pInt = new PInteger(-1);
+    final PInteger pInt = new PInteger();
     final String text = ctx.getText();  // Includes optional MINUS sign
 
     try {
@@ -4034,7 +4034,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Limit visitLimit(final SQLParser.LimitContext ctx) {
-    final Limit limit = new Limit(-1);
+    final Limit limit = new Limit();
 
     // The limit expression can be a number or an input parameter
     final Expression expr = (Expression) visit(ctx.expression());
@@ -4074,7 +4074,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Skip visitSkip(final SQLParser.SkipContext ctx) {
-    final Skip skip = new Skip(-1);
+    final Skip skip = new Skip();
 
     // The skip expression can be a number or an input parameter
     final Expression expr = (Expression) visit(ctx.expression());
@@ -4095,7 +4095,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         try {
           final Object value = expr.execute((Result) null, null);
           if (value instanceof Number number) {
-            skip.num = new PInteger(-1).setValue(number.intValue());
+            skip.num = new PInteger().setValue(number.intValue());
           } else {
             // Can't evaluate as constant, store expression for runtime evaluation
             skip.expression = expr;
@@ -4117,7 +4117,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Timeout visitTimeout(final SQLParser.TimeoutContext ctx) {
-    final Timeout timeout = new Timeout(-1);
+    final Timeout timeout = new Timeout();
 
     // The timeout expression can be a number or an input parameter
     final Expression expr = (Expression) visit(ctx.expression());
@@ -4144,7 +4144,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public GroupBy visitGroupBy(final SQLParser.GroupByContext ctx) {
-    final GroupBy groupBy = new GroupBy(-1);
+    final GroupBy groupBy = new GroupBy();
 
     // GROUP BY has a list of expressions
     try {
@@ -4164,7 +4164,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public OrderBy visitOrderBy(final SQLParser.OrderByContext ctx) {
-    final OrderBy orderBy = new OrderBy(-1);
+    final OrderBy orderBy = new OrderBy();
 
     // ORDER BY has a list of orderByItem
     final List<OrderByItem> items = new ArrayList<>();
@@ -4275,7 +4275,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public Unwind visitUnwind(final SQLParser.UnwindContext ctx) {
-    final Unwind unwind = new Unwind(-1);
+    final Unwind unwind = new Unwind();
 
     try {
       // Iterate over all comma-separated expressions: UNWIND expr1, expr2, ...
@@ -4309,7 +4309,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public LetClause visitLetClause(final SQLParser.LetClauseContext ctx) {
-    final LetClause letClause = new LetClause(-1);
+    final LetClause letClause = new LetClause();
 
     try {
       for (final SQLParser.LetItemContext itemCtx : ctx.letItem()) {
@@ -4328,7 +4328,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public LetItem visitLetItem(final SQLParser.LetItemContext ctx) {
-    final LetItem item = new LetItem(-1);
+    final LetItem item = new LetItem();
 
     // Set the variable name
     final Identifier varName = (Identifier) visit(ctx.identifier());
@@ -4379,7 +4379,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public InsertStatement visitInsertStmt(final SQLParser.InsertStmtContext ctx) {
-    final InsertStatement stmt = new InsertStatement(-1);
+    final InsertStatement stmt = new InsertStatement();
     final SQLParser.InsertStatementContext insertCtx = ctx.insertStatement();
 
     // Target: identifier (BUCKET identifier)? | bucketIdentifier
@@ -4392,7 +4392,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     } else if (insertCtx.bucketIdentifier() != null) {
       // Convert BucketIdentifier to Bucket
       final BucketIdentifier bucketId = (BucketIdentifier) visit(insertCtx.bucketIdentifier());
-      final Bucket bucket = new Bucket(-1);
+      final Bucket bucket = new Bucket();
       if (bucketId.bucketName != null) {
         bucket.bucketName = bucketId.bucketName.getStringValue();
       } else if (bucketId.bucketId != null) {
@@ -4420,7 +4420,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         stmt.selectStatement = (SelectStatement) visitResult;
       } else if (visitResult instanceof FromClause) {
         // Handle case where parser returns FromClause - wrap it in a SELECT
-        final SelectStatement select = new SelectStatement(-1);
+        final SelectStatement select = new SelectStatement();
         select.target = (FromClause) visitResult;
         stmt.selectStatement = select;
       } else {
@@ -4447,7 +4447,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public InsertBody visitInsertBody(final SQLParser.InsertBodyContext ctx) {
-    final InsertBody body = new InsertBody(-1);
+    final InsertBody body = new InsertBody();
 
     // VALUES clause: (field1, field2) VALUES (val1, val2), (val3, val4)
     if (ctx.VALUES() != null) {
@@ -4504,7 +4504,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public InsertSetExpression visitInsertSetItem(final SQLParser.InsertSetItemContext ctx) {
-    final InsertSetExpression setExpr = new InsertSetExpression(-1);
+    final InsertSetExpression setExpr = new InsertSetExpression();
     setExpr.left = (Identifier) visit(ctx.propertyName());
     setExpr.right = (Expression) visit(ctx.expression());
     return setExpr;
@@ -4515,7 +4515,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public UpdateStatement visitUpdateStmt(final SQLParser.UpdateStmtContext ctx) {
-    final UpdateStatement stmt = new UpdateStatement(-1);
+    final UpdateStatement stmt = new UpdateStatement();
     final SQLParser.UpdateStatementContext updateCtx = ctx.updateStatement();
 
     // Target
@@ -4555,7 +4555,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // BATCH clause
     if (updateCtx.BATCH() != null) {
-      final Batch batch = new Batch(-1);
+      final Batch batch = new Batch();
       final Expression expr = (Expression) visit(updateCtx.expression());
       if (expr.mathExpression instanceof BaseExpression baseExpr) {
         if (baseExpr.number instanceof PInteger)
@@ -4583,7 +4583,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public UpdateOperations visitUpdateOperation(final SQLParser.UpdateOperationContext ctx) {
-    final UpdateOperations ops = new UpdateOperations(-1);
+    final UpdateOperations ops = new UpdateOperations();
 
     if (ctx.SET() != null) {
       ops.type = UpdateOperations.TYPE_SET;
@@ -4649,7 +4649,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public UpdateItem visitUpdateItem(final SQLParser.UpdateItemContext ctx) {
-    final UpdateItem item = new UpdateItem(-1);
+    final UpdateItem item = new UpdateItem();
 
     // Left side: property name
     item.left = (Identifier) visit(ctx.propertyName());
@@ -4684,7 +4684,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public UpdateRemoveItem visitUpdateRemoveItem(final SQLParser.UpdateRemoveItemContext ctx) {
-    final UpdateRemoveItem item = new UpdateRemoveItem(-1);
+    final UpdateRemoveItem item = new UpdateRemoveItem();
 
     // Left side: expression
     item.left = (Expression) visit(ctx.expression(0));
@@ -4699,7 +4699,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
   @Override
   public UpdatePutItem visitUpdatePutItem(final SQLParser.UpdatePutItemContext ctx) {
-    final UpdatePutItem item = new UpdatePutItem(-1);
+    final UpdatePutItem item = new UpdatePutItem();
     item.setLeft((Identifier) visit(ctx.propertyName()));
     item.setKey((Expression) visit(ctx.expression(0)));
     item.setValue((Expression) visit(ctx.expression(1)));
@@ -4708,7 +4708,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
   @Override
   public UpdateIncrementItem visitUpdateIncrementItem(final SQLParser.UpdateIncrementItemContext ctx) {
-    final UpdateIncrementItem item = new UpdateIncrementItem(-1);
+    final UpdateIncrementItem item = new UpdateIncrementItem();
     item.setLeft((Identifier) visit(ctx.propertyName()));
     if (ctx.modifier() != null) {
       item.setLeftModifier((Modifier) visit(ctx.modifier()));
@@ -4722,7 +4722,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DeleteStatement visitDeleteStmt(final SQLParser.DeleteStmtContext ctx) {
-    final DeleteStatement stmt = new DeleteStatement(-1);
+    final DeleteStatement stmt = new DeleteStatement();
     final SQLParser.DeleteStatementContext deleteCtx = ctx.deleteStatement();
 
     // FROM clause
@@ -4743,7 +4743,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // BATCH clause
     if (deleteCtx.BATCH() != null) {
-      final Batch batch = new Batch(-1);
+      final Batch batch = new Batch();
       final Expression expr = (Expression) visit(deleteCtx.expression());
       if (expr.mathExpression instanceof BaseExpression baseExpr) {
         if (baseExpr.number instanceof PInteger)
@@ -4770,12 +4770,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public MoveVertexStatement visitMoveVertexStmt(final SQLParser.MoveVertexStmtContext ctx) {
-    final MoveVertexStatement stmt = new MoveVertexStatement(-1);
+    final MoveVertexStatement stmt = new MoveVertexStatement();
     final SQLParser.MoveVertexStatementContext moveCtx = ctx.moveVertexStatement();
 
     // Source: expression (typically a subquery like "(SELECT FROM ...)")
     final Object sourceObj = visit(moveCtx.expression(0));
-    final FromItem fromItem = new FromItem(-1);
+    final FromItem fromItem = new FromItem();
 
     // The expression could be a subquery (SELECT statement) or other expression
     if (sourceObj instanceof SelectStatement) {
@@ -4813,7 +4813,9 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     } else if (moveCtx.BUCKET_NUMBER_IDENTIFIER() != null) {
       // TO bucket:123 (lexed as a single BUCKET_NUMBER_IDENTIFIER token)
       final String text = moveCtx.BUCKET_NUMBER_IDENTIFIER().getText();
-      stmt.targetBucket = new Bucket(Integer.parseInt(text.substring("bucket:".length())));
+      final Bucket bucket = new Bucket();
+      bucket.bucketNumber = Integer.parseInt(text.substring("bucket:".length()));
+      stmt.targetBucket = bucket;
     } else if (moveCtx.BUCKET() != null) {
       // TO BUCKET : bucketname (separated tokens, e.g. with spaces around the colon)
       final Identifier bucketId = (Identifier) visit(moveCtx.identifier());
@@ -4830,7 +4832,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // BATCH clause
     if (moveCtx.BATCH() != null) {
-      final Batch batch = new Batch(-1);
+      final Batch batch = new Batch();
       // BATCH expression - get the last expression (index 1 if there was a source expression)
       final int batchExprIndex = moveCtx.expression().size() - 1;
       batch.value = visit(moveCtx.expression(batchExprIndex));
@@ -4849,11 +4851,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BucketIdentifier visitBucketIdentifier(final SQLParser.BucketIdentifierContext ctx) {
-    final BucketIdentifier bucketId = new BucketIdentifier(-1);
+    final BucketIdentifier bucketId = new BucketIdentifier();
 
     if (ctx.INTEGER_LITERAL() != null) {
       // Bucket ID (integer)
-      final PInteger pInt = new PInteger(-1);
+      final PInteger pInt = new PInteger();
       pInt.setValue(Integer.parseInt(ctx.INTEGER_LITERAL().getText()));
       bucketId.bucketId = pInt;
     } else if (ctx.identifier() != null) {
@@ -4868,20 +4870,20 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       // BUCKET:123 format
       final String text = ctx.BUCKET_NUMBER_IDENTIFIER().getText();
       final String bucketNumberStr = text.substring("bucket:".length());
-      final PInteger pInt = new PInteger(-1);
+      final PInteger pInt = new PInteger();
       pInt.setValue(Integer.parseInt(bucketNumberStr));
       bucketId.bucketId = pInt;
     } else if (ctx.BUCKET_NAMED_PARAM() != null) {
       // bucket::paramName format
       final String text = ctx.BUCKET_NAMED_PARAM().getText();
       final String paramName = text.substring("bucket::".length());
-      final NamedParameter param = new NamedParameter(-1);
+      final NamedParameter param = new NamedParameter();
       param.paramName = paramName;
       param.paramNumber = positionalParamCounter++;
       bucketId.inputParam = param;
     } else if (ctx.BUCKET_POSITIONAL_PARAM() != null) {
       // bucket:? format
-      final PositionalParameter param = new PositionalParameter(-1);
+      final PositionalParameter param = new PositionalParameter();
       param.paramNumber = positionalParamCounter++;
       bucketId.inputParam = param;
     }
@@ -4894,7 +4896,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateDocumentTypeStatement visitCreateDocumentTypeStmt(final SQLParser.CreateDocumentTypeStmtContext ctx) {
-    final CreateDocumentTypeStatement stmt = new CreateDocumentTypeStatement(-1);
+    final CreateDocumentTypeStatement stmt = new CreateDocumentTypeStatement();
     final SQLParser.CreateTypeBodyContext bodyCtx = ctx.createTypeBody();
 
     // Type name
@@ -4928,7 +4930,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final ParseTree child = bodyCtx.getChild(i);
         if (foundBuckets && child instanceof final TerminalNode termNode) {
           if (termNode.getSymbol().getType() == SQLParser.INTEGER_LITERAL) {
-            final PInteger pInt = new PInteger(-1);
+            final PInteger pInt = new PInteger();
             pInt.setValue(Integer.parseInt(termNode.getText()));
             stmt.totalBucketNo = pInt;
             break;
@@ -4950,7 +4952,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final ParseTree child = bodyCtx.getChild(i);
         if (foundPageSize && child instanceof final TerminalNode termNode) {
           if (termNode.getSymbol().getType() == SQLParser.INTEGER_LITERAL) {
-            final PInteger pInt = new PInteger(-1);
+            final PInteger pInt = new PInteger();
             pInt.setValue(Integer.parseInt(termNode.getText()));
             stmt.pageSize = pInt;
             break;
@@ -4974,7 +4976,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateVertexTypeStatement visitCreateVertexTypeStmt(final SQLParser.CreateVertexTypeStmtContext ctx) {
-    final CreateVertexTypeStatement stmt = new CreateVertexTypeStatement(-1);
+    final CreateVertexTypeStatement stmt = new CreateVertexTypeStatement();
     final SQLParser.CreateTypeBodyContext bodyCtx = ctx.createTypeBody();
 
     // Type name
@@ -5008,7 +5010,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final ParseTree child = bodyCtx.getChild(i);
         if (foundBuckets && child instanceof final TerminalNode termNode) {
           if (termNode.getSymbol().getType() == SQLParser.INTEGER_LITERAL) {
-            final PInteger pInt = new PInteger(-1);
+            final PInteger pInt = new PInteger();
             pInt.setValue(Integer.parseInt(termNode.getText()));
             stmt.totalBucketNo = pInt;
             break;
@@ -5030,7 +5032,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final ParseTree child = bodyCtx.getChild(i);
         if (foundPageSize && child instanceof final TerminalNode termNode) {
           if (termNode.getSymbol().getType() == SQLParser.INTEGER_LITERAL) {
-            final PInteger pInt = new PInteger(-1);
+            final PInteger pInt = new PInteger();
             pInt.setValue(Integer.parseInt(termNode.getText()));
             stmt.pageSize = pInt;
             break;
@@ -5054,7 +5056,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateEdgeTypeStatement visitCreateEdgeTypeStmt(final SQLParser.CreateEdgeTypeStmtContext ctx) {
-    final CreateEdgeTypeStatement stmt = new CreateEdgeTypeStatement(-1);
+    final CreateEdgeTypeStatement stmt = new CreateEdgeTypeStatement();
     final SQLParser.CreateEdgeTypeBodyContext bodyCtx = ctx.createEdgeTypeBody();
 
     // Type name
@@ -5095,7 +5097,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final ParseTree child = bodyCtx.getChild(i);
         if (foundBuckets && child instanceof final TerminalNode termNode) {
           if (termNode.getSymbol().getType() == SQLParser.INTEGER_LITERAL) {
-            final PInteger pInt = new PInteger(-1);
+            final PInteger pInt = new PInteger();
             pInt.setValue(Integer.parseInt(termNode.getText()));
             stmt.totalBucketNo = pInt;
             break;
@@ -5117,7 +5119,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         final ParseTree child = bodyCtx.getChild(i);
         if (foundPageSize && child instanceof final TerminalNode termNode) {
           if (termNode.getSymbol().getType() == SQLParser.INTEGER_LITERAL) {
-            final PInteger pInt = new PInteger(-1);
+            final PInteger pInt = new PInteger();
             pInt.setValue(Integer.parseInt(termNode.getText()));
             stmt.pageSize = pInt;
             break;
@@ -5156,7 +5158,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateVertexStatement visitCreateVertexStmt(final SQLParser.CreateVertexStmtContext ctx) {
-    final CreateVertexStatement stmt = new CreateVertexStatement(-1);
+    final CreateVertexStatement stmt = new CreateVertexStatement();
     final SQLParser.CreateVertexBodyContext bodyCtx = ctx.createVertexBody();
 
     try {
@@ -5165,14 +5167,14 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         // bucket:name format — no type, just bucket
         final String text = bodyCtx.BUCKET_IDENTIFIER().getText(); // "bucket:name"
         final String bucketName = text.substring(text.indexOf(':') + 1);
-        final Bucket bucket = new Bucket(-1);
+        final Bucket bucket = new Bucket();
         bucket.bucketName = bucketName;
         stmt.targetBucket = bucket;
       } else if (bodyCtx.BUCKET_NUMBER_IDENTIFIER() != null) {
         // bucket:123 format — no type, just bucket number
         final String text = bodyCtx.BUCKET_NUMBER_IDENTIFIER().getText();
         final String bucketNum = text.substring(text.indexOf(':') + 1);
-        final Bucket bucket = new Bucket(-1);
+        final Bucket bucket = new Bucket();
         bucket.bucketNumber = Integer.parseInt(bucketNum);
         stmt.targetBucket = bucket;
       } else if (bodyCtx.identifier() != null && !bodyCtx.identifier().isEmpty()) {
@@ -5186,7 +5188,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
       // Create InsertBody if we have VALUES, SET, or CONTENT clauses
       if (bodyCtx.VALUES() != null || bodyCtx.SET() != null || bodyCtx.CONTENT() != null) {
-        final InsertBody body = new InsertBody(-1);
+        final InsertBody body = new InsertBody();
 
         // Handle VALUES clause - (field1, field2) VALUES (val1, val2), (val3, val4)
         if (bodyCtx.VALUES() != null) {
@@ -5256,7 +5258,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateEdgeStatement visitCreateEdgeStmt(final SQLParser.CreateEdgeStmtContext ctx) {
-    final CreateEdgeStatement stmt = new CreateEdgeStatement(-1);
+    final CreateEdgeStatement stmt = new CreateEdgeStatement();
     final SQLParser.CreateEdgeBodyContext bodyCtx = ctx.createEdgeBody();
 
     try {
@@ -5274,10 +5276,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       if (bodyCtx.fromItem() != null && bodyCtx.fromItem().size() > 0) {
         final FromItem fromItem = (FromItem) visit(bodyCtx.fromItem(0));
         // Convert FromItem to Expression
-        final Expression leftExpr = new Expression(-1);
+        final Expression leftExpr = new Expression();
         if (fromItem.statement != null) {
           // Handle subquery (e.g., CREATE EDGE FROM (SELECT ...) TO ...)
-          final ParenthesisExpression parenExpr = new ParenthesisExpression(-1);
+          final ParenthesisExpression parenExpr = new ParenthesisExpression();
           parenExpr.setStatement(fromItem.statement);
           leftExpr.mathExpression = parenExpr;
         } else if (fromItem.identifier != null) {
@@ -5285,7 +5287,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         } else if (fromItem.rids != null) {
           // Handle RID, array of RIDs, or empty array
           if (fromItem.rids.isEmpty()) {
-            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression(-1);
+            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression();
             arrayLit.items = new ArrayList<>();
             leftExpr.mathExpression = arrayLit;
           } else if (fromItem.rids.size() == 1) {
@@ -5294,30 +5296,30 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
             // Multiple RIDs - create array literal
             final List<Expression> ridExprs = new ArrayList<>();
             for (final Rid rid : fromItem.rids) {
-              final Expression ridExpr = new Expression(-1);
+              final Expression ridExpr = new Expression();
               ridExpr.rid = rid;
               ridExprs.add(ridExpr);
             }
-            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression(-1);
+            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression();
             arrayLit.items = ridExprs;
             leftExpr.mathExpression = arrayLit;
           }
         } else if (fromItem.inputParam != null) {
           // Handle single input parameter (e.g., CREATE EDGE FROM :rid TO ...)
-          final BaseExpression baseExpr = new BaseExpression(-1);
+          final BaseExpression baseExpr = new BaseExpression();
           baseExpr.inputParam = fromItem.inputParam;
           leftExpr.mathExpression = baseExpr;
         } else if (CollectionUtils.isNotEmpty(fromItem.inputParams)) {
           // Handle input parameters list (e.g., CREATE EDGE FROM [?, ?] TO ?)
           final List<Expression> paramExprs = new ArrayList<>();
           for (final InputParameter param : fromItem.inputParams) {
-            final Expression paramExpr = new Expression(-1);
-            final BaseExpression baseExpr = new BaseExpression(-1);
+            final Expression paramExpr = new Expression();
+            final BaseExpression baseExpr = new BaseExpression();
             baseExpr.inputParam = param;
             paramExpr.mathExpression = baseExpr;
             paramExprs.add(paramExpr);
           }
-          final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression(-1);
+          final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression();
           arrayLit.items = paramExprs;
           leftExpr.mathExpression = arrayLit;
         }
@@ -5328,10 +5330,10 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       if (bodyCtx.fromItem() != null && bodyCtx.fromItem().size() > 1) {
         final FromItem toItem = (FromItem) visit(bodyCtx.fromItem(1));
         // Convert FromItem to Expression
-        final Expression rightExpr = new Expression(-1);
+        final Expression rightExpr = new Expression();
         if (toItem.statement != null) {
           // Handle subquery (e.g., CREATE EDGE FROM ... TO (SELECT ...))
-          final ParenthesisExpression parenExpr = new ParenthesisExpression(-1);
+          final ParenthesisExpression parenExpr = new ParenthesisExpression();
           parenExpr.setStatement(toItem.statement);
           rightExpr.mathExpression = parenExpr;
         } else if (toItem.identifier != null) {
@@ -5339,7 +5341,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         } else if (toItem.rids != null) {
           // Handle RID, array of RIDs, or empty array
           if (toItem.rids.isEmpty()) {
-            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression(-1);
+            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression();
             arrayLit.items = new ArrayList<>();
             rightExpr.mathExpression = arrayLit;
           } else if (toItem.rids.size() == 1) {
@@ -5348,30 +5350,30 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
             // Multiple RIDs - create array literal
             final List<Expression> ridExprs = new ArrayList<>();
             for (final Rid rid : toItem.rids) {
-              final Expression ridExpr = new Expression(-1);
+              final Expression ridExpr = new Expression();
               ridExpr.rid = rid;
               ridExprs.add(ridExpr);
             }
-            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression(-1);
+            final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression();
             arrayLit.items = ridExprs;
             rightExpr.mathExpression = arrayLit;
           }
         } else if (toItem.inputParam != null) {
           // Handle single input parameter (e.g., CREATE EDGE FROM ... TO :rid)
-          final BaseExpression baseExpr = new BaseExpression(-1);
+          final BaseExpression baseExpr = new BaseExpression();
           baseExpr.inputParam = toItem.inputParam;
           rightExpr.mathExpression = baseExpr;
         } else if (CollectionUtils.isNotEmpty(toItem.inputParams)) {
           // Handle input parameters list (e.g., CREATE EDGE FROM ? TO [?, ?])
           final List<Expression> paramExprs = new ArrayList<>();
           for (final InputParameter param : toItem.inputParams) {
-            final Expression paramExpr = new Expression(-1);
-            final BaseExpression baseExpr = new BaseExpression(-1);
+            final Expression paramExpr = new Expression();
+            final BaseExpression baseExpr = new BaseExpression();
             baseExpr.inputParam = param;
             paramExpr.mathExpression = baseExpr;
             paramExprs.add(paramExpr);
           }
-          final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression(-1);
+          final ArrayLiteralExpression arrayLit = new ArrayLiteralExpression();
           arrayLit.items = paramExprs;
           rightExpr.mathExpression = arrayLit;
         }
@@ -5380,7 +5382,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
       // Set body (SET clause) if present
       if (bodyCtx.SET() != null && bodyCtx.updateItem() != null) {
-        final InsertBody body = new InsertBody(-1);
+        final InsertBody body = new InsertBody();
         body.setExpressions = new ArrayList<>();
         for (final SQLParser.UpdateItemContext updateItemCtx : bodyCtx.updateItem()) {
           // Manually create InsertSetExpression from updateItem
@@ -5396,7 +5398,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       // Note: CREATE EDGE CONTENT takes an expression (unlike INSERT/CREATE VERTEX which take json|jsonArray directly)
       // The expression is typically an array literal like [{'x':0}] or a map literal like {'x':0}
       if (bodyCtx.CONTENT() != null && bodyCtx.expression() != null) {
-        final InsertBody body = stmt.body != null ? stmt.body : new InsertBody(-1);
+        final InsertBody body = stmt.body != null ? stmt.body : new InsertBody();
         final Expression contentExpr = (Expression) visit(bodyCtx.expression());
 
         // Try to extract json or jsonArray from the expression
@@ -5432,7 +5434,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
               }
             } else {
               // Multiple elements or non-json items - convert to JsonArray
-              final JsonArray jsonArray = new JsonArray(-1);
+              final JsonArray jsonArray = new JsonArray();
               for (final Expression itemExpr : arrayLit.items) {
                 Json itemJson = itemExpr.json;
                 // If json is null, try unwrapping from BaseExpression
@@ -5455,7 +5457,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
           if (arrayLit.items.size() == 1 && arrayLit.items.get(0).json != null) {
             body.contentJson = arrayLit.items.get(0).json;
           } else {
-            final JsonArray jsonArray = new JsonArray(-1);
+            final JsonArray jsonArray = new JsonArray();
             for (final Expression itemExpr : arrayLit.items) {
               if (itemExpr.json != null) {
                 jsonArray.items.add(itemExpr.json);
@@ -5488,7 +5490,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreatePropertyStatement visitCreatePropertyStmt(final SQLParser.CreatePropertyStmtContext ctx) {
-    final CreatePropertyStatement stmt = new CreatePropertyStatement(-1);
+    final CreatePropertyStatement stmt = new CreatePropertyStatement();
     final SQLParser.CreatePropertyBodyContext bodyCtx = ctx.createPropertyBody();
 
     // Type.property names (identifier DOT propertyName)
@@ -5528,7 +5530,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreatePropertyAttributeStatement visitPropertyAttribute(final SQLParser.PropertyAttributeContext ctx) {
-    final CreatePropertyAttributeStatement attr = new CreatePropertyAttributeStatement(-1);
+    final CreatePropertyAttributeStatement attr = new CreatePropertyAttributeStatement();
 
     // Attribute name
     attr.settingName = (Identifier) visit(ctx.identifier());
@@ -5547,7 +5549,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateIndexStatement visitCreateIndexStmt(final SQLParser.CreateIndexStmtContext ctx) {
-    final CreateIndexStatement stmt = new CreateIndexStatement(-1);
+    final CreateIndexStatement stmt = new CreateIndexStatement();
     final SQLParser.CreateIndexBodyContext bodyCtx = ctx.createIndexBody();
 
     // IF NOT EXISTS flag
@@ -5692,7 +5694,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateBucketStatement visitCreateBucketStmt(final SQLParser.CreateBucketStmtContext ctx) {
-    final CreateBucketStatement stmt = new CreateBucketStatement(-1);
+    final CreateBucketStatement stmt = new CreateBucketStatement();
     final SQLParser.CreateBucketBodyContext bodyCtx = ctx.createBucketBody();
 
     // Bucket name
@@ -5711,7 +5713,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DefineFunctionStatement visitDefineFunctionStatement(final SQLParser.DefineFunctionStatementContext ctx) {
-    final DefineFunctionStatement stmt = new DefineFunctionStatement(-1);
+    final DefineFunctionStatement stmt = new DefineFunctionStatement();
 
     // Library name (first identifier)
     stmt.libraryName = (Identifier) visit(ctx.identifier(0));
@@ -5755,7 +5757,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DeleteFunctionStatement visitDeleteFunctionStmt(final SQLParser.DeleteFunctionStmtContext ctx) {
-    final DeleteFunctionStatement stmt = new DeleteFunctionStatement(-1);
+    final DeleteFunctionStatement stmt = new DeleteFunctionStatement();
     final SQLParser.DeleteFunctionStatementContext bodyCtx = ctx.deleteFunctionStatement();
 
     // Library name (first identifier)
@@ -5773,7 +5775,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public RebuildIndexStatement visitRebuildIndexStatement(final SQLParser.RebuildIndexStatementContext ctx) {
-    final RebuildIndexStatement stmt = new RebuildIndexStatement(-1);
+    final RebuildIndexStatement stmt = new RebuildIndexStatement();
 
     if (ctx.STAR() != null) {
       // REBUILD INDEX * - rebuild all indexes
@@ -5812,7 +5814,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public CompactIndexStatement visitCompactIndexStmt(final SQLParser.CompactIndexStmtContext ctx) {
     final SQLParser.CompactIndexStatementContext body = ctx.compactIndexStatement();
-    final CompactIndexStatement stmt = new CompactIndexStatement(-1);
+    final CompactIndexStatement stmt = new CompactIndexStatement();
     if (body.STAR() != null)
       stmt.all = true;
     else
@@ -5826,7 +5828,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public RebuildTypeStatement visitRebuildTypeStmt(final SQLParser.RebuildTypeStmtContext ctx) {
-    final RebuildTypeStatement stmt = new RebuildTypeStatement(-1);
+    final RebuildTypeStatement stmt = new RebuildTypeStatement();
     final SQLParser.RebuildTypeBodyContext bodyCtx = ctx.rebuildTypeBody();
     // Grammar uses explicit labels (typeName=, settingKey+=, settingValue+=) so a future grammar tweak that
     // introduces another identifier slot won't silently shift index-based bindings here.
@@ -5858,7 +5860,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public AlterTypeStatement visitAlterTypeStmt(final SQLParser.AlterTypeStmtContext ctx) {
-    final AlterTypeStatement stmt = new AlterTypeStatement(-1);
+    final AlterTypeStatement stmt = new AlterTypeStatement();
     final SQLParser.AlterTypeBodyContext bodyCtx = ctx.alterTypeBody();
 
     // Type name
@@ -5950,7 +5952,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public AlterPropertyStatement visitAlterPropertyStmt(final SQLParser.AlterPropertyStmtContext ctx) {
-    final AlterPropertyStatement stmt = new AlterPropertyStatement(-1);
+    final AlterPropertyStatement stmt = new AlterPropertyStatement();
     final SQLParser.AlterPropertyBodyContext bodyCtx = ctx.alterPropertyBody();
 
     // Type.property
@@ -5962,18 +5964,18 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       if (itemCtx.NAME() != null) {
         stmt.settingName = new Identifier("name");
         final Identifier nameId = (Identifier) visit(itemCtx.identifier());
-        final BaseExpression nameBaseExpr = new BaseExpression(-1);
+        final BaseExpression nameBaseExpr = new BaseExpression();
         nameBaseExpr.identifier = new BaseIdentifier(nameId);
-        final Expression nameExpr = new Expression(-1);
+        final Expression nameExpr = new Expression();
         nameExpr.mathExpression = nameBaseExpr;
         stmt.settingValue = nameExpr;
       } else if (itemCtx.TYPE() != null) {
         stmt.settingName = new Identifier("type");
         // Property type as expression
         final Identifier typeId = new Identifier(itemCtx.propertyType().getText());
-        final BaseExpression baseExpr = new BaseExpression(-1);
+        final BaseExpression baseExpr = new BaseExpression();
         baseExpr.identifier = new BaseIdentifier(typeId);
-        final Expression expr = new Expression(-1);
+        final Expression expr = new Expression();
         expr.mathExpression = baseExpr;
         stmt.settingValue = expr;
       } else if (itemCtx.CUSTOM() != null) {
@@ -5996,7 +5998,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public AlterBucketStatement visitAlterBucketStmt(final SQLParser.AlterBucketStmtContext ctx) {
-    final AlterBucketStatement stmt = new AlterBucketStatement(-1);
+    final AlterBucketStatement stmt = new AlterBucketStatement();
     final SQLParser.AlterBucketBodyContext bodyCtx = ctx.alterBucketBody();
 
     // Bucket name (possibly with wildcard *)
@@ -6008,9 +6010,9 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       if (itemCtx.NAME() != null) {
         stmt.attributeName = new Identifier("name");
         final Identifier attrNameId = (Identifier) visit(itemCtx.identifier());
-        final BaseExpression attrNameBaseExpr = new BaseExpression(-1);
+        final BaseExpression attrNameBaseExpr = new BaseExpression();
         attrNameBaseExpr.identifier = new BaseIdentifier(attrNameId);
-        final Expression attrNameExpr = new Expression(-1);
+        final Expression attrNameExpr = new Expression();
         attrNameExpr.mathExpression = attrNameBaseExpr;
         stmt.attributeValue = attrNameExpr;
       } else if (itemCtx.CUSTOM() != null) {
@@ -6027,7 +6029,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public AlterDatabaseStatement visitAlterDatabaseStmt(final SQLParser.AlterDatabaseStmtContext ctx) {
-    final AlterDatabaseStatement stmt = new AlterDatabaseStatement(-1);
+    final AlterDatabaseStatement stmt = new AlterDatabaseStatement();
     final SQLParser.AlterDatabaseBodyContext bodyCtx = ctx.alterDatabaseBody();
 
     // Process all alter database items
@@ -6048,7 +6050,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DropTypeStatement visitDropTypeStmt(final SQLParser.DropTypeStmtContext ctx) {
-    final DropTypeStatement stmt = new DropTypeStatement(-1);
+    final DropTypeStatement stmt = new DropTypeStatement();
     final SQLParser.DropTypeBodyContext bodyCtx = ctx.dropTypeBody();
 
     // Type name - can be either identifier or input parameter
@@ -6072,7 +6074,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DropTypeStatement visitDropTimeSeriesTypeStmt(final SQLParser.DropTimeSeriesTypeStmtContext ctx) {
-    final DropTypeStatement stmt = new DropTypeStatement(-1);
+    final DropTypeStatement stmt = new DropTypeStatement();
     final SQLParser.DropTypeBodyContext bodyCtx = ctx.dropTypeBody();
 
     if (bodyCtx.identifier() != null)
@@ -6091,7 +6093,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DropPropertyStatement visitDropPropertyStmt(final SQLParser.DropPropertyStmtContext ctx) {
-    final DropPropertyStatement stmt = new DropPropertyStatement(-1);
+    final DropPropertyStatement stmt = new DropPropertyStatement();
     final SQLParser.DropPropertyBodyContext bodyCtx = ctx.dropPropertyBody();
 
     // Type.property
@@ -6112,7 +6114,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DropIndexStatement visitDropIndexStmt(final SQLParser.DropIndexStmtContext ctx) {
-    final DropIndexStatement stmt = new DropIndexStatement(-1);
+    final DropIndexStatement stmt = new DropIndexStatement();
     final SQLParser.DropIndexBodyContext bodyCtx = ctx.dropIndexBody();
 
     // Index name or STAR (*)
@@ -6133,12 +6135,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DropBucketStatement visitDropBucketStmt(final SQLParser.DropBucketStmtContext ctx) {
-    final DropBucketStatement stmt = new DropBucketStatement(-1);
+    final DropBucketStatement stmt = new DropBucketStatement();
     final SQLParser.DropBucketBodyContext bodyCtx = ctx.dropBucketBody();
 
     // Bucket name or numeric ID
     if (bodyCtx.INTEGER_LITERAL() != null) {
-      stmt.id = new PInteger(-1);
+      stmt.id = new PInteger();
       stmt.id.setValue(Integer.parseInt(bodyCtx.INTEGER_LITERAL().getText()));
     } else {
       stmt.name = (Identifier) visit(bodyCtx.identifier());
@@ -6157,7 +6159,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CreateTriggerStatement visitCreateTriggerStmt(final SQLParser.CreateTriggerStmtContext ctx) {
-    final CreateTriggerStatement stmt = new CreateTriggerStatement(-1);
+    final CreateTriggerStatement stmt = new CreateTriggerStatement();
     final SQLParser.CreateTriggerBodyContext bodyCtx = ctx.createTriggerBody();
 
     // IF NOT EXISTS flag
@@ -6192,7 +6194,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public DropTriggerStatement visitDropTriggerStmt(final SQLParser.DropTriggerStmtContext ctx) {
-    final DropTriggerStatement stmt = new DropTriggerStatement(-1);
+    final DropTriggerStatement stmt = new DropTriggerStatement();
     final SQLParser.DropTriggerBodyContext bodyCtx = ctx.dropTriggerBody();
 
     // Trigger name
@@ -6211,7 +6213,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public CreateMaterializedViewStatement visitCreateMaterializedViewStmt(
       final SQLParser.CreateMaterializedViewStmtContext ctx) {
-    final CreateMaterializedViewStatement stmt = new CreateMaterializedViewStatement(-1);
+    final CreateMaterializedViewStatement stmt = new CreateMaterializedViewStatement();
     final SQLParser.CreateMaterializedViewBodyContext bodyCtx = ctx.createMaterializedViewBody();
 
     stmt.ifNotExists = bodyCtx.IF() != null && bodyCtx.NOT() != null && bodyCtx.EXISTS() != null;
@@ -6248,7 +6250,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public CreateTimeSeriesTypeStatement visitCreateTimeSeriesTypeStmt(
       final SQLParser.CreateTimeSeriesTypeStmtContext ctx) {
-    final CreateTimeSeriesTypeStatement stmt = new CreateTimeSeriesTypeStatement(-1);
+    final CreateTimeSeriesTypeStatement stmt = new CreateTimeSeriesTypeStatement();
     final SQLParser.CreateTimeSeriesTypeBodyContext bodyCtx = ctx.createTimeSeriesTypeBody();
 
     stmt.name = (Identifier) visit(bodyCtx.identifier(0));
@@ -6288,7 +6290,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
           for (int j = i + 1; j < bodyCtx.children.size(); j++) {
             if (bodyCtx.children.get(j) instanceof TerminalNode tn2
                 && tn2.getSymbol().getType() == SQLParser.INTEGER_LITERAL) {
-              stmt.shards = new PInteger(-1);
+              stmt.shards = new PInteger();
               stmt.shards.setValue(Integer.parseInt(tn2.getText()));
               break;
             }
@@ -6350,7 +6352,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public AlterTimeSeriesTypeStatement visitAlterTimeSeriesTypeStmt(
       final SQLParser.AlterTimeSeriesTypeStmtContext ctx) {
-    final AlterTimeSeriesTypeStatement stmt = new AlterTimeSeriesTypeStatement(-1);
+    final AlterTimeSeriesTypeStatement stmt = new AlterTimeSeriesTypeStatement();
     final SQLParser.AlterTimeSeriesTypeBodyContext bodyCtx = ctx.alterTimeSeriesTypeBody();
 
     stmt.name = (Identifier) visit(bodyCtx.identifier());
@@ -6421,7 +6423,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public DropMaterializedViewStatement visitDropMaterializedViewStmt(
       final SQLParser.DropMaterializedViewStmtContext ctx) {
-    final DropMaterializedViewStatement stmt = new DropMaterializedViewStatement(-1);
+    final DropMaterializedViewStatement stmt = new DropMaterializedViewStatement();
     final SQLParser.DropMaterializedViewBodyContext bodyCtx = ctx.dropMaterializedViewBody();
     stmt.name = (Identifier) visit(bodyCtx.identifier());
     stmt.ifExists = bodyCtx.IF() != null && bodyCtx.EXISTS() != null;
@@ -6431,7 +6433,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public RefreshMaterializedViewStatement visitRefreshMaterializedViewStmt(
       final SQLParser.RefreshMaterializedViewStmtContext ctx) {
-    final RefreshMaterializedViewStatement stmt = new RefreshMaterializedViewStatement(-1);
+    final RefreshMaterializedViewStatement stmt = new RefreshMaterializedViewStatement();
     stmt.name = (Identifier) visit(ctx.refreshMaterializedViewBody().identifier());
     return stmt;
   }
@@ -6439,7 +6441,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public AlterMaterializedViewStatement visitAlterMaterializedViewStmt(
       final SQLParser.AlterMaterializedViewStmtContext ctx) {
-    final AlterMaterializedViewStatement stmt = new AlterMaterializedViewStatement(-1);
+    final AlterMaterializedViewStatement stmt = new AlterMaterializedViewStatement();
     final SQLParser.AlterMaterializedViewBodyContext bodyCtx = ctx.alterMaterializedViewBody();
     stmt.name = (Identifier) visit(bodyCtx.identifier());
 
@@ -6472,7 +6474,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public CreateContinuousAggregateStatement visitCreateContinuousAggregateStmt(
       final SQLParser.CreateContinuousAggregateStmtContext ctx) {
-    final CreateContinuousAggregateStatement stmt = new CreateContinuousAggregateStatement(-1);
+    final CreateContinuousAggregateStatement stmt = new CreateContinuousAggregateStatement();
     final SQLParser.CreateContinuousAggregateBodyContext bodyCtx = ctx.createContinuousAggregateBody();
 
     stmt.ifNotExists = bodyCtx.IF() != null && bodyCtx.NOT() != null && bodyCtx.EXISTS() != null;
@@ -6485,7 +6487,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public DropContinuousAggregateStatement visitDropContinuousAggregateStmt(
       final SQLParser.DropContinuousAggregateStmtContext ctx) {
-    final DropContinuousAggregateStatement stmt = new DropContinuousAggregateStatement(-1);
+    final DropContinuousAggregateStatement stmt = new DropContinuousAggregateStatement();
     final SQLParser.DropContinuousAggregateBodyContext bodyCtx = ctx.dropContinuousAggregateBody();
     stmt.name = (Identifier) visit(bodyCtx.identifier());
     stmt.ifExists = bodyCtx.IF() != null && bodyCtx.EXISTS() != null;
@@ -6495,7 +6497,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public RefreshContinuousAggregateStatement visitRefreshContinuousAggregateStmt(
       final SQLParser.RefreshContinuousAggregateStmtContext ctx) {
-    final RefreshContinuousAggregateStatement stmt = new RefreshContinuousAggregateStatement(-1);
+    final RefreshContinuousAggregateStatement stmt = new RefreshContinuousAggregateStatement();
     stmt.name = (Identifier) visit(ctx.refreshContinuousAggregateBody().identifier());
     return stmt;
   }
@@ -6505,7 +6507,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public CreateGraphAnalyticalViewStatement visitCreateGraphAnalyticalViewStmt(
       final SQLParser.CreateGraphAnalyticalViewStmtContext ctx) {
-    final CreateGraphAnalyticalViewStatement stmt = new CreateGraphAnalyticalViewStatement(-1);
+    final CreateGraphAnalyticalViewStatement stmt = new CreateGraphAnalyticalViewStatement();
     final SQLParser.CreateGraphAnalyticalViewBodyContext bodyCtx = ctx.createGraphAnalyticalViewBody();
 
     stmt.ifNotExists = bodyCtx.IF() != null && bodyCtx.NOT() != null && bodyCtx.EXISTS() != null;
@@ -6542,7 +6544,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public DropGraphAnalyticalViewStatement visitDropGraphAnalyticalViewStmt(
       final SQLParser.DropGraphAnalyticalViewStmtContext ctx) {
-    final DropGraphAnalyticalViewStatement stmt = new DropGraphAnalyticalViewStatement(-1);
+    final DropGraphAnalyticalViewStatement stmt = new DropGraphAnalyticalViewStatement();
     final SQLParser.DropGraphAnalyticalViewBodyContext bodyCtx = ctx.dropGraphAnalyticalViewBody();
     stmt.name = (Identifier) visit(bodyCtx.identifier());
     stmt.ifExists = bodyCtx.IF() != null && bodyCtx.EXISTS() != null;
@@ -6552,7 +6554,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public AlterGraphAnalyticalViewStatement visitAlterGraphAnalyticalViewStmt(
       final SQLParser.AlterGraphAnalyticalViewStmtContext ctx) {
-    final AlterGraphAnalyticalViewStatement stmt = new AlterGraphAnalyticalViewStatement(-1);
+    final AlterGraphAnalyticalViewStatement stmt = new AlterGraphAnalyticalViewStatement();
     final SQLParser.AlterGraphAnalyticalViewBodyContext bodyCtx = ctx.alterGraphAnalyticalViewBody();
     final var identifiers = bodyCtx.identifier();
     stmt.name = (Identifier) visit(identifiers.get(0));
@@ -6566,7 +6568,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public RebuildGraphAnalyticalViewStatement visitRebuildGraphAnalyticalViewStmt(
       final SQLParser.RebuildGraphAnalyticalViewStmtContext ctx) {
-    final RebuildGraphAnalyticalViewStatement stmt = new RebuildGraphAnalyticalViewStatement(-1);
+    final RebuildGraphAnalyticalViewStatement stmt = new RebuildGraphAnalyticalViewStatement();
     final SQLParser.RebuildGraphAnalyticalViewBodyContext bodyCtx = ctx.rebuildGraphAnalyticalViewBody();
     stmt.name = (Identifier) visit(bodyCtx.identifier());
     return stmt;
@@ -6609,7 +6611,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public TruncateTypeStatement visitTruncateTypeStmt(final SQLParser.TruncateTypeStmtContext ctx) {
-    final TruncateTypeStatement stmt = new TruncateTypeStatement(-1);
+    final TruncateTypeStatement stmt = new TruncateTypeStatement();
     final SQLParser.TruncateTypeBodyContext bodyCtx = ctx.truncateTypeBody();
 
     // Type name
@@ -6630,12 +6632,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public TruncateBucketStatement visitTruncateBucketStmt(final SQLParser.TruncateBucketStmtContext ctx) {
-    final TruncateBucketStatement stmt = new TruncateBucketStatement(-1);
+    final TruncateBucketStatement stmt = new TruncateBucketStatement();
     final SQLParser.TruncateBucketBodyContext bodyCtx = ctx.truncateBucketBody();
 
     // Bucket name or numeric ID
     if (bodyCtx.INTEGER_LITERAL() != null) {
-      stmt.bucketNumber = new PInteger(-1);
+      stmt.bucketNumber = new PInteger();
       stmt.bucketNumber.setValue(Integer.parseInt(bodyCtx.INTEGER_LITERAL().getText()));
     } else {
       stmt.bucketName = (Identifier) visit(bodyCtx.identifier());
@@ -6652,7 +6654,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public TruncateRecordStatement visitTruncateRecordStmt(final SQLParser.TruncateRecordStmtContext ctx) {
-    final TruncateRecordStatement stmt = new TruncateRecordStatement(-1);
+    final TruncateRecordStatement stmt = new TruncateRecordStatement();
     final SQLParser.TruncateRecordBodyContext bodyCtx = ctx.truncateRecordBody();
 
     // Record RIDs (one or more)
@@ -6675,7 +6677,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public FindReferencesStatement visitFindReferencesStmt(final SQLParser.FindReferencesStmtContext ctx) {
-    final FindReferencesStatement stmt = new FindReferencesStatement(-1);
+    final FindReferencesStatement stmt = new FindReferencesStatement();
     final SQLParser.FindReferencesBodyContext bodyCtx = ctx.findReferencesBody();
 
     final SQLParser.FindReferencesTargetContext target = bodyCtx.findReferencesTarget();
@@ -6708,7 +6710,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public LetStatement visitLetStmt(final SQLParser.LetStmtContext ctx) {
-    final LetStatement stmt = new LetStatement(-1);
+    final LetStatement stmt = new LetStatement();
     final SQLParser.LetStatementContext letCtx = ctx.letStatement();
 
     // Process the first let item
@@ -6733,7 +6735,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public SetGlobalStatement visitSetGlobalStmt(final SQLParser.SetGlobalStmtContext ctx) {
-    final SetGlobalStatement stmt = new SetGlobalStatement(-1);
+    final SetGlobalStatement stmt = new SetGlobalStatement();
     final SQLParser.SetGlobalStatementContext setGlobalCtx = ctx.setGlobalStatement();
 
     stmt.variableName = (Identifier) visit(setGlobalCtx.identifier());
@@ -6747,7 +6749,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ReturnStatement visitReturnStmt(final SQLParser.ReturnStmtContext ctx) {
-    final ReturnStatement stmt = new ReturnStatement(-1);
+    final ReturnStatement stmt = new ReturnStatement();
     final SQLParser.ReturnStatementContext returnCtx = ctx.returnStatement();
 
     if (returnCtx.expression() != null) {
@@ -6772,7 +6774,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ForEachBlock visitForeachStmt(final SQLParser.ForeachStmtContext ctx) {
-    final ForEachBlock block = new ForEachBlock(-1);
+    final ForEachBlock block = new ForEachBlock();
     final SQLParser.ForeachStatementContext foreachCtx = ctx.foreachStatement();
 
     // Loop variable (the identifier after FOREACH and before IN)
@@ -6795,7 +6797,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public WhileBlock visitWhileStmt(final SQLParser.WhileStmtContext ctx) {
-    final WhileBlock block = new WhileBlock(-1);
+    final WhileBlock block = new WhileBlock();
     final SQLParser.WhileStatementContext whileCtx = ctx.whileStatement();
 
     // Condition (the orBlock produces a BooleanExpression)
@@ -6815,7 +6817,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BreakStatement visitBreakStmt(final SQLParser.BreakStmtContext ctx) {
-    return new BreakStatement(-1);
+    return new BreakStatement();
   }
 
   /**
@@ -6825,20 +6827,20 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ExpressionStatement visitFunctionStmt(final SQLParser.FunctionStmtContext ctx) {
-    final ExpressionStatement stmt = new ExpressionStatement(-1);
+    final ExpressionStatement stmt = new ExpressionStatement();
 
     // Get the function call
     final FunctionCall funcCall = (FunctionCall) visit(ctx.functionCall());
 
     // Wrap it in an Expression (like visitFunctionCallExpr does)
-    final BaseExpression baseExpr = new BaseExpression(-1);
-    final LevelZeroIdentifier levelZero = new LevelZeroIdentifier(-1);
+    final BaseExpression baseExpr = new BaseExpression();
+    final LevelZeroIdentifier levelZero = new LevelZeroIdentifier();
     levelZero.functionCall = funcCall;
-    final BaseIdentifier baseId = new BaseIdentifier(-1);
+    final BaseIdentifier baseId = new BaseIdentifier();
     baseId.levelZero = levelZero;
     baseExpr.identifier = baseId;
 
-    final Expression expr = new Expression(-1);
+    final Expression expr = new Expression();
     expr.mathExpression = baseExpr;
 
     stmt.expression = expr;
@@ -6852,7 +6854,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public IfStatement visitIfStmt(final SQLParser.IfStmtContext ctx) {
-    final IfStatement stmt = new IfStatement(-1);
+    final IfStatement stmt = new IfStatement();
     final SQLParser.IfStatementContext ifCtx = ctx.ifStatement();
 
     // Condition (the orBlock produces a BooleanExpression)
@@ -6904,7 +6906,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ExplainStatement visitExplainStmt(final SQLParser.ExplainStmtContext ctx) {
-    final ExplainStatement stmt = new ExplainStatement(-1);
+    final ExplainStatement stmt = new ExplainStatement();
     final SQLParser.ExplainStatementContext explainCtx = ctx.explainStatement();
 
     stmt.statement = (Statement) visit(explainCtx.statement());
@@ -6917,7 +6919,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ProfileStatement visitProfileStmt(final SQLParser.ProfileStmtContext ctx) {
-    final ProfileStatement stmt = new ProfileStatement(-1);
+    final ProfileStatement stmt = new ProfileStatement();
     final SQLParser.ProfileStatementContext profileCtx = ctx.profileStatement();
 
     stmt.statement = (Statement) visit(profileCtx.statement());
@@ -6931,7 +6933,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public SleepStatement visitSleepStmt(final SQLParser.SleepStmtContext ctx) {
-    final SleepStatement stmt = new SleepStatement(-1);
+    final SleepStatement stmt = new SleepStatement();
     final SQLParser.SleepStatementContext sleepCtx = ctx.sleepStatement();
 
     // EXPRESSION: duration in milliseconds
@@ -6946,7 +6948,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ConsoleStatement visitConsoleStmt(final SQLParser.ConsoleStmtContext ctx) {
-    final ConsoleStatement stmt = new ConsoleStatement(-1);
+    final ConsoleStatement stmt = new ConsoleStatement();
     final SQLParser.ConsoleStatementContext consoleCtx = ctx.consoleStatement();
 
     // LOG LEVEL: log, output, error, warn, debug
@@ -6964,7 +6966,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public LockStatement visitLockStmt(final SQLParser.LockStmtContext ctx) {
-    final LockStatement stmt = new LockStatement(-1);
+    final LockStatement stmt = new LockStatement();
     final SQLParser.LockStatementContext lockCtx = ctx.lockStatement();
 
     // MODE: TYPE or BUCKET
@@ -6990,7 +6992,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BeginStatement visitBeginStmt(final SQLParser.BeginStmtContext ctx) {
-    final BeginStatement stmt = new BeginStatement(-1);
+    final BeginStatement stmt = new BeginStatement();
     final SQLParser.BeginStatementContext beginCtx = ctx.beginStatement();
 
     // ISOLATION clause
@@ -7006,12 +7008,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CommitStatement visitCommitStmt(final SQLParser.CommitStmtContext ctx) {
-    final CommitStatement stmt = new CommitStatement(-1);
+    final CommitStatement stmt = new CommitStatement();
     final SQLParser.CommitStatementContext commitCtx = ctx.commitStatement();
 
     // RETRY clause
     if (commitCtx.INTEGER_LITERAL() != null) {
-      final PInteger retry = new PInteger(-1);
+      final PInteger retry = new PInteger();
       retry.value = Integer.parseInt(commitCtx.INTEGER_LITERAL().getText());
       stmt.retry = retry;
 
@@ -7042,7 +7044,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public RollbackStatement visitRollbackStmt(final SQLParser.RollbackStmtContext ctx) {
-    final RollbackStatement stmt = new RollbackStatement(-1);
+    final RollbackStatement stmt = new RollbackStatement();
     // ROLLBACK has no parameters - just need to reference the rollbackStatement context
     return stmt;
   }
@@ -7056,7 +7058,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public CheckDatabaseStatement visitCheckDatabaseStmt(final SQLParser.CheckDatabaseStmtContext ctx) {
-    final CheckDatabaseStatement stmt = new CheckDatabaseStatement(-1);
+    final CheckDatabaseStatement stmt = new CheckDatabaseStatement();
     final SQLParser.CheckDatabaseStatementContext checkCtx = ctx.checkDatabaseStatement();
 
     // Parse TYPE clause - list of type identifiers
@@ -7075,8 +7077,8 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       // If we have INTEGER_LITERAL tokens, use them
       if (checkCtx.INTEGER_LITERAL() != null && !checkCtx.INTEGER_LITERAL().isEmpty()) {
         for (final TerminalNode intNode : checkCtx.INTEGER_LITERAL()) {
-          final BucketIdentifier bucketId = new BucketIdentifier(-1);
-          final PInteger pInt = new PInteger(-1);
+          final BucketIdentifier bucketId = new BucketIdentifier();
+          final PInteger pInt = new PInteger();
           pInt.setValue(Integer.parseInt(intNode.getText()));
           bucketId.bucketId = pInt;
           stmt.buckets.add(bucketId);
@@ -7088,7 +7090,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       final List<SQLParser.IdentifierContext> allIdents = checkCtx.identifier();
       if (allIdents != null && allIdents.size() > typeIdentCount) {
         for (int i = typeIdentCount; i < allIdents.size(); i++) {
-          final BucketIdentifier bucketId = new BucketIdentifier(-1);
+          final BucketIdentifier bucketId = new BucketIdentifier();
           bucketId.bucketName = (Identifier) visit(allIdents.get(i));
           stmt.buckets.add(bucketId);
         }
@@ -7121,7 +7123,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public RestoreDocumentStatement visitRestoreDocumentStmt(final SQLParser.RestoreDocumentStmtContext ctx) {
-    final RestoreDocumentStatement stmt = new RestoreDocumentStatement(-1);
+    final RestoreDocumentStatement stmt = new RestoreDocumentStatement();
     final SQLParser.RestoreDocumentStatementContext bodyCtx = ctx.restoreDocumentStatement();
 
     stmt.targetType = (Identifier) visit(bodyCtx.identifier());
@@ -7138,7 +7140,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public RestoreVertexStatement visitRestoreVertexStmt(final SQLParser.RestoreVertexStmtContext ctx) {
-    final RestoreVertexStatement stmt = new RestoreVertexStatement(-1);
+    final RestoreVertexStatement stmt = new RestoreVertexStatement();
     final SQLParser.RestoreVertexStatementContext bodyCtx = ctx.restoreVertexStatement();
 
     stmt.targetType = (Identifier) visit(bodyCtx.identifier());
@@ -7155,7 +7157,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public RestoreEdgeStatement visitRestoreEdgeStmt(final SQLParser.RestoreEdgeStmtContext ctx) {
-    final RestoreEdgeStatement stmt = new RestoreEdgeStatement(-1);
+    final RestoreEdgeStatement stmt = new RestoreEdgeStatement();
     final SQLParser.RestoreEdgeStatementContext bodyCtx = ctx.restoreEdgeStatement();
 
     stmt.targetType = (Identifier) visit(bodyCtx.identifier());
@@ -7179,7 +7181,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     if (setToken == null && jsonCtx == null && jsonArrayCtx == null && inputParameterCtx == null)
       return null;
 
-    final InsertBody body = new InsertBody(-1);
+    final InsertBody body = new InsertBody();
 
     if (setToken != null && updateItemCtxList != null && !updateItemCtxList.isEmpty()) {
       body.setExpressions = new ArrayList<>();
@@ -7206,7 +7208,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public AlignDatabaseStatement visitAlignDatabaseStmt(final SQLParser.AlignDatabaseStmtContext ctx) {
-    return new AlignDatabaseStatement(-1);
+    return new AlignDatabaseStatement();
   }
 
   /**
@@ -7215,7 +7217,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ImportDatabaseStatement visitImportDatabaseStmt(final SQLParser.ImportDatabaseStmtContext ctx) {
-    final ImportDatabaseStatement stmt = new ImportDatabaseStatement(-1);
+    final ImportDatabaseStatement stmt = new ImportDatabaseStatement();
     final SQLParser.ImportDatabaseStatementContext importCtx = ctx.importDatabaseStatement();
 
     // Parse URL (optional)
@@ -7233,7 +7235,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
         // Store as Expression with key/value
         // ImportDatabaseStatement uses .execute() on the value Expression
-        final Expression keyExpr = new Expression(-1);
+        final Expression keyExpr = new Expression();
         keyExpr.value = key.getStringValue();
 
         stmt.settings.put(keyExpr, value);
@@ -7249,7 +7251,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ExportDatabaseStatement visitExportDatabaseStmt(final SQLParser.ExportDatabaseStmtContext ctx) {
-    final ExportDatabaseStatement stmt = new ExportDatabaseStatement(-1);
+    final ExportDatabaseStatement stmt = new ExportDatabaseStatement();
     final SQLParser.ExportDatabaseStatementContext exportCtx = ctx.exportDatabaseStatement();
 
     // Parse URL
@@ -7266,7 +7268,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
         // Store as Expression with key/value
         // ExportDatabaseStatement uses .execute() on the value Expression
-        final Expression keyExpr = new Expression(-1);
+        final Expression keyExpr = new Expression();
         keyExpr.value = key.getStringValue();
 
         stmt.settings.put(keyExpr, value);
@@ -7305,7 +7307,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public BackupDatabaseStatement visitBackupDatabaseStmt(final SQLParser.BackupDatabaseStmtContext ctx) {
-    final BackupDatabaseStatement stmt = new BackupDatabaseStatement(-1);
+    final BackupDatabaseStatement stmt = new BackupDatabaseStatement();
     final SQLParser.BackupDatabaseStatementContext backupCtx = ctx.backupDatabaseStatement();
 
     // Parse URL
@@ -7322,7 +7324,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
         // Store as Expression with key/value
         // BackupDatabaseStatement uses .execute() on the value Expression, so no need to extract .value
-        final Expression keyExpr = new Expression(-1);
+        final Expression keyExpr = new Expression();
         keyExpr.value = key.getStringValue();
 
         stmt.settings.put(keyExpr, value);
@@ -7343,13 +7345,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     try {
       if (ctx.rid() != null) {
         // RID selector like [#10:5]
-        final ArraySelector selector = new ArraySelector(-1);
+        final ArraySelector selector = new ArraySelector();
         selector.rid = (Rid) visit(ctx.rid());
         return selector;
 
       } else if (ctx.inputParameter() != null) {
         // Parameter selector like [?] or [:name] or [$1]
-        final ArraySelector selector = new ArraySelector(-1);
+        final ArraySelector selector = new ArraySelector();
         selector.inputParam = (InputParameter) visit(ctx.inputParameter());
         return selector;
 
@@ -7377,7 +7379,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         }
 
         // Regular expression selector like [i+1]
-        final ArraySelector selector = new ArraySelector(-1);
+        final ArraySelector selector = new ArraySelector();
         selector.expression = (Expression) visit(ctx.expression());
         return selector;
       }
@@ -7385,7 +7387,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       throw new CommandSQLParsingException("Failed to build array selector: " + e.getMessage(), e);
     }
 
-    return new ArraySelector(-1);
+    return new ArraySelector();
   }
 
   /**
@@ -7395,11 +7397,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public ArraySingleValuesSelector visitArrayMultiSelector(final SQLParser.ArrayMultiSelectorContext ctx) {
     try {
-      final ArraySingleValuesSelector multiSelector = new ArraySingleValuesSelector(-1);
+      final ArraySingleValuesSelector multiSelector = new ArraySingleValuesSelector();
 
       // Add all selectors (first one plus the ones after commas)
       for (int i = 0; i < ctx.expression().size(); i++) {
-        final ArraySelector selector = new ArraySelector(-1);
+        final ArraySelector selector = new ArraySelector();
 
         if (ctx.expression(i) != null) {
           selector.expression = (Expression) visit(ctx.expression(i));
@@ -7428,15 +7430,15 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       final WhereClause whereClause = (WhereClause) visit(ctx.whereClause());
 
       // Convert whereClause to OrBlock for the condition field
-      final OrBlock orBlock = new OrBlock(-1);
+      final OrBlock orBlock = new OrBlock();
       if (whereClause.baseExpression != null) {
-        final AndBlock andBlock = new AndBlock(-1);
+        final AndBlock andBlock = new AndBlock();
         andBlock.subBlocks.add(whereClause.baseExpression);
         orBlock.subBlocks.add(andBlock);
       }
 
       // Create Modifier with the condition
-      final Modifier modifier = new Modifier(-1);
+      final Modifier modifier = new Modifier();
       modifier.squareBrackets = true;
       modifier.condition = orBlock;
 
@@ -7454,7 +7456,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   public Modifier visitArrayFilterSelector(final SQLParser.ArrayFilterSelectorContext ctx) {
     try {
       // Create RightBinaryCondition for filtering
-      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition(-1);
+      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition();
 
       // Get and set the comparison operator
       rightBinaryCondition.operator = mapComparisonOperator(ctx.comparisonOperator());
@@ -7463,7 +7465,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       rightBinaryCondition.right = (Expression) visit(ctx.expression());
 
       // Create Modifier with the filter condition
-      final Modifier modifier = new Modifier(-1);
+      final Modifier modifier = new Modifier();
       modifier.squareBrackets = true;
 
       modifier.rightBinaryCondition = rightBinaryCondition;
@@ -7485,7 +7487,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   public Modifier visitArrayBinaryCondSelector(final SQLParser.ArrayBinaryCondSelectorContext ctx) {
     try {
       // Create a binary condition to filter elements
-      final BinaryCondition condition = new BinaryCondition(-1);
+      final BinaryCondition condition = new BinaryCondition();
 
       // Set left side - use special placeholder for "current element"
       // In array filter context, the left side will be substituted with each element
@@ -7498,16 +7500,16 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       condition.right = (Expression) visit(ctx.expression(1));
 
       // Wrap in WhereClause, then OrBlock for the condition field
-      final WhereClause whereClause = new WhereClause(-1);
+      final WhereClause whereClause = new WhereClause();
       try {
         whereClause.baseExpression = condition;
       } catch (final Exception e) {
         throw new CommandSQLParsingException("Failed to set baseExpression: " + e.getMessage(), e);
       }
 
-      final OrBlock orBlock = new OrBlock(-1);
+      final OrBlock orBlock = new OrBlock();
       try {
-        final AndBlock andBlock = new AndBlock(-1);
+        final AndBlock andBlock = new AndBlock();
         andBlock.subBlocks.add(condition);
         orBlock.subBlocks.add(andBlock);
       } catch (final Exception e) {
@@ -7515,7 +7517,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       }
 
       // Create Modifier with the condition
-      final Modifier modifier = new Modifier(-1);
+      final Modifier modifier = new Modifier();
       modifier.squareBrackets = true;
 
       modifier.condition = orBlock;
@@ -7533,13 +7535,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public Modifier visitArrayLikeSelector(final SQLParser.ArrayLikeSelectorContext ctx) {
     try {
-      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition(-1);
+      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition();
 
-      rightBinaryCondition.operator = new LikeOperator(-1);
+      rightBinaryCondition.operator = new LikeOperator();
 
       rightBinaryCondition.right = (Expression) visit(ctx.expression());
 
-      final Modifier modifier = new Modifier(-1);
+      final Modifier modifier = new Modifier();
       modifier.squareBrackets = true;
 
       modifier.rightBinaryCondition = rightBinaryCondition;
@@ -7557,13 +7559,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public Modifier visitArrayIlikeSelector(final SQLParser.ArrayIlikeSelectorContext ctx) {
     try {
-      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition(-1);
+      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition();
 
-      rightBinaryCondition.operator = new ILikeOperator(-1);
+      rightBinaryCondition.operator = new ILikeOperator();
 
       rightBinaryCondition.right = (Expression) visit(ctx.expression());
 
-      final Modifier modifier = new Modifier(-1);
+      final Modifier modifier = new Modifier();
       modifier.squareBrackets = true;
 
       modifier.rightBinaryCondition = rightBinaryCondition;
@@ -7581,13 +7583,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public Modifier visitArrayInSelector(final SQLParser.ArrayInSelectorContext ctx) {
     try {
-      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition(-1);
+      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition();
 
-      rightBinaryCondition.inOperator = new InOperator(-1);
+      rightBinaryCondition.inOperator = new InOperator();
 
       rightBinaryCondition.right = (Expression) visit(ctx.expression());
 
-      final Modifier modifier = new Modifier(-1);
+      final Modifier modifier = new Modifier();
       modifier.squareBrackets = true;
 
       modifier.rightBinaryCondition = rightBinaryCondition;
@@ -7601,12 +7603,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   @Override
   public Modifier visitArrayNotInSelector(final SQLParser.ArrayNotInSelectorContext ctx) {
     try {
-      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition(-1);
-      rightBinaryCondition.inOperator = new InOperator(-1);
+      final RightBinaryCondition rightBinaryCondition = new RightBinaryCondition();
+      rightBinaryCondition.inOperator = new InOperator();
       rightBinaryCondition.not = true;
       rightBinaryCondition.right = (Expression) visit(ctx.expression());
 
-      final Modifier modifier = new Modifier(-1);
+      final Modifier modifier = new Modifier();
       modifier.squareBrackets = true;
       modifier.rightBinaryCondition = rightBinaryCondition;
 
@@ -7621,7 +7623,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * Splits the token text on ".." or "..." to extract from and to integers.
    */
   private ArrayRangeSelector createRangeSelectorFromToken(final String tokenText, final boolean inclusive) {
-    final ArrayRangeSelector selector = new ArrayRangeSelector(-1);
+    final ArrayRangeSelector selector = new ArrayRangeSelector();
 
     try {
       // Split on ".." or "..."
@@ -7654,7 +7656,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ArrayRangeSelector visitArrayRangeSelector(final SQLParser.ArrayRangeSelectorContext ctx) {
-    final ArrayRangeSelector selector = new ArrayRangeSelector(-1);
+    final ArrayRangeSelector selector = new ArrayRangeSelector();
 
     try {
       // Set newRange flag (true for .. syntax)
@@ -7702,7 +7704,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    */
   @Override
   public ArrayRangeSelector visitArrayEllipsisSelector(final SQLParser.ArrayEllipsisSelectorContext ctx) {
-    final ArrayRangeSelector selector = new ArrayRangeSelector(-1);
+    final ArrayRangeSelector selector = new ArrayRangeSelector();
 
     try {
       // Set newRange flag (true for ... syntax)
@@ -7775,7 +7777,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * Handles input parameters, simple integers, and complex expressions.
    */
   private ArrayNumberSelector createArrayNumberSelectorFromExpression(final Expression expr) {
-    final ArrayNumberSelector selector = new ArrayNumberSelector(-1);
+    final ArrayNumberSelector selector = new ArrayNumberSelector();
 
     try {
       // Check if the expression is an input parameter
@@ -7821,7 +7823,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   private BooleanExpression createBooleanLiteral(final Boolean boolValue) {
     // Create an anonymous BooleanExpression that returns the literal value
     final boolean val = boolValue != null && boolValue;  // Convert to primitive to avoid closure issues
-    return new BooleanExpression(-1) {
+    return new BooleanExpression() {
       @Override
       public Boolean evaluate(final Identifiable currentRecord, final CommandContext ctx) {
         return val;

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/StatementExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/StatementExpression.java
@@ -40,7 +40,6 @@ public class StatementExpression extends BaseExpression {
   private Statement statement;
 
   public StatementExpression(final Statement statement) {
-    super(-1);
     this.statement = statement;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SubqueryExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SubqueryExpression.java
@@ -37,7 +37,6 @@ public class SubqueryExpression extends BaseExpression {
   private final SelectStatement statement;
 
   public SubqueryExpression(final SelectStatement statement) {
-    super(-1);
     this.statement = statement;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgeExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgeExecutionPlanner.java
@@ -148,7 +148,7 @@ public class CreateEdgeExecutionPlanner {
     } else if (insertBody.getSetExpressions() != null) {
       final List<UpdateItem> items = new ArrayList<>();
       for (final InsertSetExpression exp : insertBody.getSetExpressions()) {
-        final UpdateItem item = new UpdateItem(-1);
+        final UpdateItem item = new UpdateItem();
         item.setOperator(UpdateItem.OPERATOR_EQ);
         item.setLeft(exp.getLeft().copy());
         item.setRight(exp.getRight().copy());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteExecutionPlanner.java
@@ -125,7 +125,7 @@ public class DeleteExecutionPlanner {
       }
       result.chain(new DeleteFromIndexStep(index, keyCondition, null, ridCondition, context));
       if (ridCondition != null) {
-        final WhereClause where = new WhereClause(-1);
+        final WhereClause where = new WhereClause();
         where.setBaseExpression(ridCondition);
         result.chain(new FilterStep(where, context));
       }
@@ -180,7 +180,7 @@ public class DeleteExecutionPlanner {
       final CommandContext context,
       final FromClause fromClause,
       final WhereClause whereClause) {
-    final SelectStatement sourceStatement = new SelectStatement(-1);
+    final SelectStatement sourceStatement = new SelectStatement();
     sourceStatement.setTarget(fromClause);
     sourceStatement.setWhereClause(whereClause);
     final SelectExecutionPlanner planner = new SelectExecutionPlanner(sourceStatement);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -288,7 +288,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       throw new CommandExecutionException("search for index for " + condition + " is not supported yet");
     }
     final Object rightValue = inCondition.evaluateRight((Result) null, context);
-    final EqualsCompareOperator equals = new EqualsCompareOperator(-1);
+    final EqualsCompareOperator equals = new EqualsCompareOperator();
     if (MultiValue.isMultiValue(rightValue)) {
       customIterator = new MultiIterator<>();
       for (final Object item : MultiValue.getMultiValueIterable(rightValue)) {
@@ -435,7 +435,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
   }
 
   private List<PCollection> cartesianProduct(final PCollection key) {
-    return cartesianProduct(new PCollection(-1), key);//TODO
+    return cartesianProduct(new PCollection(), key);//TODO
   }
 
   private List<PCollection> cartesianProduct(final PCollection head, final PCollection key) {
@@ -450,7 +450,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     if (!(value instanceof Identifiable) && MultiValue.isMultiValue(value)) {
       final List<PCollection> result = new ArrayList<>();
       for (final Object elemInKey : MultiValue.getMultiValueIterable(value)) {
-        final PCollection newHead = new PCollection(-1);
+        final PCollection newHead = new PCollection();
         for (final Expression exp : head.getExpressions())
           newHead.add(exp.copy());
 
@@ -461,7 +461,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       }
       return result;
     } else {
-      final PCollection newHead = new PCollection(-1);
+      final PCollection newHead = new PCollection();
       for (final Expression exp : head.getExpressions())
         newHead.add(exp.copy());
 
@@ -657,7 +657,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
   }
 
   private static PCollection indexKeyFrom(final AndBlock keyCondition, final BinaryCondition additional) {
-    PCollection result = new PCollection(-1);
+    PCollection result = new PCollection();
     for (BooleanExpression exp : keyCondition.getSubBlocks()) {
       Expression res = exp.resolveKeyFrom(additional);
       if (res != null) {
@@ -668,7 +668,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
   }
 
   private static PCollection indexKeyTo(final AndBlock keyCondition, final BinaryCondition additional) {
-    PCollection result = new PCollection(-1);
+    PCollection result = new PCollection();
     for (BooleanExpression exp : keyCondition.getSubBlocks()) {
       Expression res = exp.resolveKeyTo(additional);
       if (res != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
@@ -110,7 +110,7 @@ public class InsertExecutionPlanner {
     } else if (insertBody.getSetExpressions() != null) {
       final List<UpdateItem> items = new ArrayList<>();
       for (final InsertSetExpression exp : insertBody.getSetExpressions()) {
-        final UpdateItem item = new UpdateItem(-1);
+        final UpdateItem item = new UpdateItem();
         item.setOperator(UpdateItem.OPERATOR_EQ);
         item.setLeft(exp.getLeft().copy());
         item.setRight(exp.getRight().copy());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchExecutionPlanner.java
@@ -244,10 +244,10 @@ public class MatchExecutionPlanner {
     } else if (returnPathElements) {
       result.chain(new ReturnMatchPathElementsStep(context));
     } else {
-      final Projection projection = new Projection(-1);
+      final Projection projection = new Projection();
       projection.setItems(new ArrayList<>());
       for (int i = 0; i < returnAliases.size(); i++) {
-        final ProjectionItem item = new ProjectionItem(-1);
+        final ProjectionItem item = new ProjectionItem();
         item.setExpression(returnItems.get(i));
         item.setAlias(returnAliases.get(i));
         item.setNestedProjection(returnNestedProjections.get(i));
@@ -599,9 +599,9 @@ public class MatchExecutionPlanner {
       final String bucket = this.aliasBuckets.get(patternNode.alias);
       final Rid rid = this.aliasRids.get(patternNode.alias);
       final WhereClause where = aliasFilters.get(patternNode.alias);
-      final SelectStatement select = new SelectStatement(-1);
-      select.setTarget(new FromClause(-1));
-      select.getTarget().setItem(new FromItem(-1));
+      final SelectStatement select = new SelectStatement();
+      select.setTarget(new FromClause());
+      select.getTarget().setItem(new FromItem());
       if (typez != null) {
         select.getTarget().getItem().setIdentifier(new Identifier(typez));
       } else if (bucket != null) {
@@ -640,10 +640,10 @@ public class MatchExecutionPlanner {
 
   private SelectStatement createSelectStatement(final String targetClass, final String targetCluster, final Rid targetRid,
       final WhereClause filter) {
-    final SelectStatement prefetchStm = new SelectStatement(-1);
+    final SelectStatement prefetchStm = new SelectStatement();
     prefetchStm.setWhereClause(filter);
-    final FromClause from = new FromClause(-1);
-    final FromItem fromItem = new FromItem(-1);
+    final FromClause from = new FromClause();
+    final FromItem fromItem = new FromItem();
     if (targetRid != null) {
       fromItem.setRids(List.of(targetRid));
     } else if (targetClass != null) {
@@ -714,8 +714,8 @@ public class MatchExecutionPlanner {
       if (filter != null && filter.getBaseExpression() != null) {
         WhereClause previousFilter = aliasFilters.get(alias);
         if (previousFilter == null) {
-          previousFilter = new WhereClause(-1);
-          previousFilter.setBaseExpression(new AndBlock(-1));
+          previousFilter = new WhereClause();
+          previousFilter.setBaseExpression(new AndBlock());
           aliasFilters.put(alias, previousFilter);
         }
         final AndBlock filterBlock = (AndBlock) previousFilter.getBaseExpression();
@@ -787,7 +787,7 @@ public class MatchExecutionPlanner {
 
       for (final MatchPathItem item : expression.getItems()) {
         if (item.getFilter() == null) {
-          item.setFilter(new MatchFilter(-1));
+          item.setFilter(new MatchFilter());
         }
         if (item.getFilter().getAlias() == null) {
           item.getFilter().setAlias(DEFAULT_ALIAS_PREFIX + (counter++));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MoveVertexExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MoveVertexExecutionPlanner.java
@@ -114,8 +114,8 @@ public class MoveVertexExecutionPlanner {
   }
 
   private void handleSource(final UpdateExecutionPlan result, final CommandContext ctx, final FromItem source) {
-    final SelectStatement sourceStatement = new SelectStatement(-1);
-    sourceStatement.setTarget(new FromClause(-1));
+    final SelectStatement sourceStatement = new SelectStatement();
+    sourceStatement.setTarget(new FromClause());
     sourceStatement.getTarget().setItem(source);
     final SelectExecutionPlanner planner = new SelectExecutionPlanner(sourceStatement);
     result.chain(new SubQueryStep(planner.createExecutionPlan(ctx, false), ctx, ctx));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -149,7 +149,7 @@ public class SelectExecutionPlanner {
     info.limit = this.statement.getLimit();
     info.timeout = this.statement.getTimeout() == null ? null : this.statement.getTimeout().copy();
     if (info.timeout == null && context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_TIMEOUT) > 0) {
-      info.timeout = new Timeout(-1);
+      info.timeout = new Timeout();
       info.timeout.setValue(context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_TIMEOUT));
     }
 
@@ -353,10 +353,10 @@ public class SelectExecutionPlanner {
         final FunctionCall function = ((BaseExpression) item.getExpression().getMathExpression()).getIdentifier().getLevelZero()
             .getFunctionCall();
         final Expression exp = function.getParams().getFirst();
-        final ProjectionItem resultItem = new ProjectionItem(-1);
+        final ProjectionItem resultItem = new ProjectionItem();
         resultItem.setAlias(item.getAlias());
         resultItem.setExpression(exp.copy());
-        final Projection result = new Projection(-1);
+        final Projection result = new Projection();
         result.setItems(new ArrayList<>());
         result.setDistinct(true);
         result.getItems().add(resultItem);
@@ -810,7 +810,7 @@ public class SelectExecutionPlanner {
       info.orderBy = newOrderBy;//the ORDER BY has changed
     }
     if (additionalOrderByProjections.size() > 0) {
-      info.projectionAfterOrderBy = new Projection(-1);
+      info.projectionAfterOrderBy = new Projection();
       info.projectionAfterOrderBy.setItems(new ArrayList<>());
       for (final String alias : info.projection.getAllAliases()) {
         info.projectionAfterOrderBy.getItems().add(projectionFromAlias(new Identifier(alias)));
@@ -845,7 +845,7 @@ public class SelectExecutionPlanner {
     for (final Identifier unwindItem : info.unwind.getItems()) {
       final String unwindFieldName = unwindItem.getStringValue();
       if (!allAliases.contains(unwindFieldName)) {
-        final ProjectionItem newProj = new ProjectionItem(-1);
+        final ProjectionItem newProj = new ProjectionItem();
         newProj.setExpression(new Expression(unwindItem));
         // Keep the original field name so UNWIND can find it
         newProj.setAlias(unwindItem);
@@ -855,7 +855,7 @@ public class SelectExecutionPlanner {
 
     if (!additionalUnwindProjections.isEmpty()) {
       // Save the original projection to restore after UNWIND
-      info.projectionAfterUnwind = new Projection(-1);
+      info.projectionAfterUnwind = new Projection();
       info.projectionAfterUnwind.setItems(new ArrayList<>());
       for (final String alias : allAliases) {
         info.projectionAfterUnwind.getItems().add(projectionFromAlias(new Identifier(alias)));
@@ -890,14 +890,14 @@ public class SelectExecutionPlanner {
     if (orderBy != null && orderBy.getItems() != null && !orderBy.getItems().isEmpty()) {
       for (final OrderByItem item : orderBy.getItems()) {
         if (!allAliases.contains(item.getName())) {
-          final ProjectionItem newProj = new ProjectionItem(-1);
+          final ProjectionItem newProj = new ProjectionItem();
           if (item.expression != null) {
             // Complex expression (e.g., CASE WHEN) - use the stored expression directly
             newProj.setExpression(item.expression);
           } else if (item.getAlias() != null) {
             newProj.setExpression(new Expression(new Identifier(item.getAlias()), item.getModifier()));
           } else if (item.getRecordAttr() != null) {
-            final RecordAttribute attr = new RecordAttribute(-1);
+            final RecordAttribute attr = new RecordAttribute();
             attr.setName(item.getRecordAttr());
             newProj.setExpression(new Expression(attr, item.getModifier()));
           } else {
@@ -922,11 +922,11 @@ public class SelectExecutionPlanner {
     if (info.projection == null)
       return;
 
-    final Projection preAggregate = new Projection(-1);
+    final Projection preAggregate = new Projection();
     preAggregate.setItems(new ArrayList<>());
-    final Projection aggregate = new Projection(-1);
+    final Projection aggregate = new Projection();
     aggregate.setItems(new ArrayList<>());
-    final Projection postAggregate = new Projection(-1);
+    final Projection postAggregate = new Projection();
     postAggregate.setItems(new ArrayList<>());
 
     boolean isSplitted = false;
@@ -947,7 +947,7 @@ public class SelectExecutionPlanner {
       } else {
         preAggregate.getItems().add(item);
         //also push the alias forward in the chain
-        final ProjectionItem aggItem = new ProjectionItem(-1);
+        final ProjectionItem aggItem = new ProjectionItem();
         aggItem.setExpression(new Expression(item.getProjectionAlias()));
         aggregate.getItems().add(aggItem);
         postAggregate.getItems().add(aggItem);
@@ -979,10 +979,10 @@ public class SelectExecutionPlanner {
       if (exp.isAggregate(context))
         throw new CommandExecutionException("Cannot group by an aggregate function");
 
-      final ProjectionItem newItem = new ProjectionItem(-1);
+      final ProjectionItem newItem = new ProjectionItem();
       newItem.setExpression(exp);
       if (info.aggregateProjection == null)
-        info.aggregateProjection = new Projection(-1);
+        info.aggregateProjection = new Projection();
 
       if (info.aggregateProjection.getItems() == null)
         info.aggregateProjection.setItems(new ArrayList<>());
@@ -996,7 +996,7 @@ public class SelectExecutionPlanner {
   }
 
   private static ProjectionItem projectionFromAlias(final Identifier oIdentifier) {
-    final ProjectionItem result = new ProjectionItem(-1);
+    final ProjectionItem result = new ProjectionItem();
     result.setExpression(new Expression(oIdentifier));
     return result;
   }
@@ -1009,7 +1009,7 @@ public class SelectExecutionPlanner {
     if (info.groupBy == null || info.groupBy.getItems() == null || info.groupBy.getItems().size() == 0) {
       return;
     }
-    final GroupBy newGroupBy = new GroupBy(-1);
+    final GroupBy newGroupBy = new GroupBy();
     final int i = 0;
     for (final Expression exp : info.groupBy.getItems()) {
       if (exp.isAggregate(context)) {
@@ -1028,12 +1028,12 @@ public class SelectExecutionPlanner {
         }
       }
       if (!found) {
-        final ProjectionItem newItem = new ProjectionItem(-1);
+        final ProjectionItem newItem = new ProjectionItem();
         newItem.setExpression(exp);
         final Identifier groupByAlias = new Identifier("_$$$GROUP_BY_ALIAS$$$_" + i);
         newItem.setAlias(groupByAlias);
         if (info.preAggregateProjection == null) {
-          info.preAggregateProjection = new Projection(-1);
+          info.preAggregateProjection = new Projection();
         }
         if (info.preAggregateProjection.getItems() == null) {
           info.preAggregateProjection.setItems(new ArrayList<>());
@@ -1092,9 +1092,9 @@ public class SelectExecutionPlanner {
 
   private static void addGlobalLet(final QueryPlanningInfo info, final Identifier alias, final Expression exp) {
     if (info.globalLetClause == null)
-      info.globalLetClause = new LetClause(-1);
+      info.globalLetClause = new LetClause();
 
-    final LetItem item = new LetItem(-1);
+    final LetItem item = new LetItem();
     item.setVarName(alias);
     item.setExpression(exp);
     info.globalLetClause.addItem(item);
@@ -1102,9 +1102,9 @@ public class SelectExecutionPlanner {
 
   private static void addGlobalLet(final QueryPlanningInfo info, final Identifier alias, final Statement stm, final int pos) {
     if (info.globalLetClause == null)
-      info.globalLetClause = new LetClause(-1);
+      info.globalLetClause = new LetClause();
 
-    final LetItem item = new LetItem(-1);
+    final LetItem item = new LetItem();
     item.setVarName(alias);
     item.setQuery(stm);
     if (pos > -1)
@@ -1115,9 +1115,9 @@ public class SelectExecutionPlanner {
 
   private static void addRecordLevelLet(final QueryPlanningInfo info, final Identifier alias, final Statement stm, final int pos) {
     if (info.perRecordLetClause == null)
-      info.perRecordLetClause = new LetClause(-1);
+      info.perRecordLetClause = new LetClause();
 
-    final LetItem item = new LetItem(-1);
+    final LetItem item = new LetItem();
     item.setVarName(alias);
     item.setQuery(stm);
     if (pos > -1)
@@ -1358,7 +1358,7 @@ public class SelectExecutionPlanner {
   }
 
   private AndBlock extractRidRanges(final List<AndBlock> flattenedWhereClause, final CommandContext context) {
-    final AndBlock result = new AndBlock(-1);
+    final AndBlock result = new AndBlock();
 
     if (flattenedWhereClause == null || flattenedWhereClause.size() != 1)
       return result;
@@ -1404,25 +1404,25 @@ public class SelectExecutionPlanner {
     if (paramValue == null) {
       result.chain(new EmptyStep(context));//nothing to return
     } else if (paramValue instanceof LocalDocumentType type) {
-      final FromClause from = new FromClause(-1);
-      final FromItem item = new FromItem(-1);
+      final FromClause from = new FromClause();
+      final FromItem item = new FromItem();
       from.setItem(item);
       item.setIdentifier(new Identifier(type.getName()));
       handleTypeAsTarget(result, filterClusters, from, info, context);
     } else if (paramValue instanceof String string) {
       //strings are treated as classes
-      final FromClause from = new FromClause(-1);
-      final FromItem item = new FromItem(-1);
+      final FromClause from = new FromClause();
+      final FromItem item = new FromItem();
       from.setItem(item);
       item.setIdentifier(new Identifier(string));
       handleTypeAsTarget(result, filterClusters, from, info, context);
     } else if (paramValue instanceof Identifiable identifiable) {
       final RID orid = identifiable.getIdentity();
 
-      final Rid rid = new Rid(-1);
-      final PInteger bucket = new PInteger(-1);
+      final Rid rid = new Rid();
+      final PInteger bucket = new PInteger();
       bucket.setValue(orid.getBucketId());
-      final PInteger position = new PInteger(-1);
+      final PInteger position = new PInteger();
       position.setValue(orid.getPosition());
       rid.setLegacy(true);
       rid.setBucket(bucket);
@@ -1442,10 +1442,10 @@ public class SelectExecutionPlanner {
           throw new CommandExecutionException("Cannot use collection as target: " + paramValue);
         }
         final RID orid = ((Identifiable) x).getIdentity();
-        final Rid rid = new Rid(-1);
-        final PInteger bucket = new PInteger(-1);
+        final Rid rid = new Rid();
+        final PInteger bucket = new PInteger();
         bucket.setValue(orid.getBucketId());
-        final PInteger position = new PInteger(-1);
+        final PInteger position = new PInteger();
         position.setValue(orid.getPosition());
         rid.setLegacy(true);
         rid.setBucket(bucket);
@@ -1535,7 +1535,7 @@ public class SelectExecutionPlanner {
       }
       result.chain(new FetchFromIndexStep(index, keyCondition, null, context));
       if (ridCondition != null) {
-        final WhereClause where = new WhereClause(-1);
+        final WhereClause where = new WhereClause();
         where.setBaseExpression(ridCondition);
         result.chain(new FilterStep(where, context));
       }
@@ -1967,9 +1967,9 @@ public class SelectExecutionPlanner {
       final List<BooleanExpression> remaining = new ArrayList<>(andBlock.getSubBlocks());
       remaining.remove(i);
       if (!remaining.isEmpty()) {
-        final AndBlock remainingBlock = new AndBlock(-1);
+        final AndBlock remainingBlock = new AndBlock();
         remainingBlock.getSubBlocks().addAll(remaining);
-        final WhereClause remainingWhere = new WhereClause(-1);
+        final WhereClause remainingWhere = new WhereClause();
         remainingWhere.setBaseExpression(remainingBlock);
         plan.chain(new FilterStep(remainingWhere, context));
       }
@@ -2045,9 +2045,9 @@ public class SelectExecutionPlanner {
       final List<BooleanExpression> remaining = new ArrayList<>(andBlock.getSubBlocks());
       remaining.remove(i);
       if (!remaining.isEmpty()) {
-        final AndBlock remainingBlock = new AndBlock(-1);
+        final AndBlock remainingBlock = new AndBlock();
         remainingBlock.getSubBlocks().addAll(remaining);
-        final WhereClause remainingWhere = new WhereClause(-1);
+        final WhereClause remainingWhere = new WhereClause();
         remainingWhere.setBaseExpression(remainingBlock);
         plan.chain(new FilterStep(remainingWhere, context));
       }
@@ -3155,10 +3155,10 @@ public class SelectExecutionPlanner {
 
           // Create IS NULL filter for the first indexed property
           final String propertyName = indexFields.getFirst();
-          final IsNullCondition isNullCondition = new IsNullCondition(-1);
+          final IsNullCondition isNullCondition = new IsNullCondition();
           final Expression expr = new Expression(new Identifier(propertyName));
           isNullCondition.setExpression(expr);
-          final WhereClause nullWhereClause = new WhereClause(-1);
+          final WhereClause nullWhereClause = new WhereClause();
           nullWhereClause.setBaseExpression(isNullCondition);
           nullPlan.chain(new FilterStep(nullWhereClause, context));
 
@@ -3470,7 +3470,7 @@ public class SelectExecutionPlanner {
   }
 
   private WhereClause createWhereFrom(final BooleanExpression remainingCondition) {
-    final WhereClause result = new WhereClause(-1);
+    final WhereClause result = new WhereClause();
     result.setBaseExpression(remainingCondition);
     return result;
   }
@@ -3728,7 +3728,7 @@ public class SelectExecutionPlanner {
   private IndexSearchDescriptor buildIndexSearchDescriptorForFulltext(final CommandContext context, final Index index,
       final AndBlock block, final DocumentType clazz) {
     final List<String> indexFields = index.getPropertyNames();
-    final BinaryCondition keyCondition = new BinaryCondition(-1);
+    final BinaryCondition keyCondition = new BinaryCondition();
     final Identifier key = new Identifier("key");
     keyCondition.setLeft(new Expression(key));
     boolean found = false;
@@ -3736,7 +3736,7 @@ public class SelectExecutionPlanner {
     final AndBlock blockCopy = block.copy();
     Iterator<BooleanExpression> blockIterator;
 
-    final AndBlock indexKeyValue = new AndBlock(-1);
+    final AndBlock indexKeyValue = new AndBlock();
     final IndexSearchDescriptor result = new IndexSearchDescriptor();
     result.index = (RangeIndex) index;
     result.keyCondition = indexKeyValue;
@@ -3763,7 +3763,7 @@ public class SelectExecutionPlanner {
           if (baseFieldName.equals(fieldName)) {
             found = true;
             indexFieldFound = true;
-            final ContainsTextCondition condition = new ContainsTextCondition(-1);
+            final ContainsTextCondition condition = new ContainsTextCondition();
             condition.setLeft(left);
             condition.setRight(textCondition.getRight().copy());
             indexKeyValue.getSubBlocks().add(condition);
@@ -3805,7 +3805,7 @@ public class SelectExecutionPlanner {
     AndBlock blockCopy = block.copy();
     Iterator<BooleanExpression> blockIterator;
 
-    AndBlock indexKeyValue = new AndBlock(-1);
+    AndBlock indexKeyValue = new AndBlock();
     BinaryCondition additionalRangeCondition = null;
 
     for (String indexField : indexFields) {
@@ -3949,7 +3949,7 @@ public class SelectExecutionPlanner {
 
       OrBlock existingAdditionalConditions = filtersForIndex.get(extendedCond);
       if (existingAdditionalConditions == null) {
-        existingAdditionalConditions = new OrBlock(-1);
+        existingAdditionalConditions = new OrBlock();
         filtersForIndex.put(extendedCond, existingAdditionalConditions);
       }
       existingAdditionalConditions.getSubBlocks().add(item.remainingCondition);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/TraverseExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/TraverseExecutionPlanner.java
@@ -128,24 +128,24 @@ public class TraverseExecutionPlanner {
     if (paramValue == null) {
       result.chain(new EmptyStep(context));//nothing to return
     } else if (paramValue instanceof LocalDocumentType type) {
-      final FromClause from = new FromClause(-1);
-      final FromItem item = new FromItem(-1);
+      final FromClause from = new FromClause();
+      final FromItem item = new FromItem();
       from.setItem(item);
       item.setIdentifier(new Identifier(type.getName()));
       handleClassAsTarget(result, from, context);
     } else if (paramValue instanceof String string) {
       //strings are treated as classes
-      final FromClause from = new FromClause(-1);
-      final FromItem item = new FromItem(-1);
+      final FromClause from = new FromClause();
+      final FromItem item = new FromItem();
       from.setItem(item);
       item.setIdentifier(new Identifier(string));
       handleClassAsTarget(result, from, context);
     } else if (paramValue instanceof Identifiable identifiable) {
       final RID orid = identifiable.getIdentity();
-      final Rid rid = new Rid(-1);
-      final PInteger bucket = new PInteger(-1);
+      final Rid rid = new Rid();
+      final PInteger bucket = new PInteger();
       bucket.setValue(orid.getBucketId());
-      final PInteger position = new PInteger(-1);
+      final PInteger position = new PInteger();
       position.setValue(orid.getPosition());
       rid.setLegacy(true);
       rid.setBucket(bucket);
@@ -161,10 +161,10 @@ public class TraverseExecutionPlanner {
         }
         final RID orid = ((Identifiable) x).getIdentity();
 
-        final Rid rid = new Rid(-1);
-        final PInteger bucket = new PInteger(-1);
+        final Rid rid = new Rid();
+        final PInteger bucket = new PInteger();
         bucket.setValue(orid.getBucketId());
-        final PInteger position = new PInteger(-1);
+        final PInteger position = new PInteger();
         position.setValue(orid.getPosition());
         rid.setLegacy(true);
         rid.setBucket(bucket);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/UpdateExecutionPlanner.java
@@ -216,7 +216,7 @@ public class UpdateExecutionPlanner {
 
   private void handleTarget(final UpdateExecutionPlan result, final CommandContext context, final FromClause target,
       final WhereClause whereClause, final Timeout timeout) {
-    final SelectStatement sourceStatement = new SelectStatement(-1);
+    final SelectStatement sourceStatement = new SelectStatement();
     sourceStatement.setTarget(target);
     sourceStatement.setWhereClause(whereClause);
     if (timeout != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Alias.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Alias.java
@@ -23,8 +23,7 @@ package com.arcadedb.query.sql.parser;
 import java.util.Map;
 
 public class Alias extends SimpleNode {
-  public Alias(final int id) {
-    super(id);
+  public Alias() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlignDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlignDatabaseStatement.java
@@ -29,8 +29,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import java.util.Map;
 
 public class AlignDatabaseStatement extends SimpleExecStatement {
-  public AlignDatabaseStatement(final int id) {
-    super(id);
+  public AlignDatabaseStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterBucketStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterBucketStatement.java
@@ -32,8 +32,7 @@ public class AlterBucketStatement extends DDLStatement {
   public Identifier attributeName;
   public Expression attributeValue;
 
-  public AlterBucketStatement(final int id) {
-    super(id);
+  public AlterBucketStatement() {
   }
 
   @Override
@@ -51,7 +50,7 @@ public class AlterBucketStatement extends DDLStatement {
 
   @Override
   public AlterBucketStatement copy() {
-    final AlterBucketStatement result = new AlterBucketStatement(-1);
+    final AlterBucketStatement result = new AlterBucketStatement();
     result.name = name == null ? null : name.copy();
     result.attributeName = attributeName == null ? null : attributeName.copy();
     result.starred = starred;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
@@ -42,8 +42,7 @@ public class AlterDatabaseStatement extends DDLStatement {
   public Identifier settingName;
   public Expression settingValue;
 
-  public AlterDatabaseStatement(final int id) {
-    super(id);
+  public AlterDatabaseStatement() {
   }
 
   @Override
@@ -125,7 +124,7 @@ public class AlterDatabaseStatement extends DDLStatement {
 
   @Override
   public AlterDatabaseStatement copy() {
-    final AlterDatabaseStatement result = new AlterDatabaseStatement(-1);
+    final AlterDatabaseStatement result = new AlterDatabaseStatement();
     result.settingName = settingName == null ? null : settingName.copy();
     result.settingValue = settingValue == null ? null : settingValue.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterGraphAnalyticalViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterGraphAnalyticalViewStatement.java
@@ -35,8 +35,7 @@ public class AlterGraphAnalyticalViewStatement extends DDLStatement {
   public String     updateModeStr;
   public int        compactionThreshold = -1; // -1 means not set
 
-  public AlterGraphAnalyticalViewStatement(final int id) {
-    super(id);
+  public AlterGraphAnalyticalViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterMaterializedViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterMaterializedViewStatement.java
@@ -31,8 +31,7 @@ public class AlterMaterializedViewStatement extends DDLStatement {
   public int refreshInterval;
   public String refreshUnit;
 
-  public AlterMaterializedViewStatement(final int id) {
-    super(id);
+  public AlterMaterializedViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
@@ -41,8 +41,7 @@ public class AlterPropertyStatement extends DDLStatement {
   public Expression customPropertyValue;
   public Identifier settingName;
 
-  public AlterPropertyStatement(final int id) {
-    super(id);
+  public AlterPropertyStatement() {
   }
 
   @Override
@@ -144,7 +143,7 @@ public class AlterPropertyStatement extends DDLStatement {
 
   @Override
   public AlterPropertyStatement copy() {
-    final AlterPropertyStatement result = new AlterPropertyStatement(-1);
+    final AlterPropertyStatement result = new AlterPropertyStatement();
     result.typeName = typeName == null ? null : typeName.copy();
     result.propertyName = propertyName == null ? null : propertyName.copy();
     result.customPropertyName = customPropertyName == null ? null : customPropertyName.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTimeSeriesTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTimeSeriesTypeStatement.java
@@ -42,8 +42,7 @@ public class AlterTimeSeriesTypeStatement extends DDLStatement {
   public boolean                 addPolicy;
   public List<DownsamplingTier>  tiers = new ArrayList<>();
 
-  public AlterTimeSeriesTypeStatement(final int id) {
-    super(id);
+  public AlterTimeSeriesTypeStatement() {
   }
 
   @Override
@@ -82,7 +81,7 @@ public class AlterTimeSeriesTypeStatement extends DDLStatement {
 
   @Override
   public AlterTimeSeriesTypeStatement copy() {
-    final AlterTimeSeriesTypeStatement result = new AlterTimeSeriesTypeStatement(-1);
+    final AlterTimeSeriesTypeStatement result = new AlterTimeSeriesTypeStatement();
     result.name = name == null ? null : name.copy();
     result.addPolicy = addPolicy;
     result.tiers = new ArrayList<>(tiers);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
@@ -58,8 +58,7 @@ public class AlterTypeStatement extends DDLStatement {
   // invalidating ALTER (issue #4087); generic so future settings drop in cleanly.
   public final Map<Identifier, Expression> settings = new LinkedHashMap<>();
 
-  public AlterTypeStatement(final int id) {
-    super(id);
+  public AlterTypeStatement() {
   }
 
   @Override
@@ -91,7 +90,7 @@ public class AlterTypeStatement extends DDLStatement {
   }
 
   public Statement copy() {
-    final AlterTypeStatement result = new AlterTypeStatement(-1);
+    final AlterTypeStatement result = new AlterTypeStatement();
     result.name = name == null ? null : name.copy();
     result.property = property;
     result.identifierListValue = identifierListValue.stream().map(x -> x.copy()).collect(Collectors.toList());
@@ -287,7 +286,7 @@ public class AlterTypeStatement extends DDLStatement {
       // {@code REBUILD TYPE <name> WITH repartition = true} as a standalone command (which takes
       // the {@code implicitTx == true} branch and commits in {@code DEFAULT_BATCH_SIZE} chunks),
       // and then issue the bare {@code ALTER TYPE ...} without {@code WITH repartition = true}.
-      final RebuildTypeStatement rebuild = new RebuildTypeStatement(-1);
+      final RebuildTypeStatement rebuild = new RebuildTypeStatement();
       rebuild.typeName = name.copy();
       rebuild.polymorphic = false;
       // try-with-resources: any throw between the open and the explicit close would leak the

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AndBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AndBlock.java
@@ -32,13 +32,12 @@ import java.util.Map;
 public class AndBlock extends BooleanExpression {
   public final List<BooleanExpression> subBlocks;
 
-  public AndBlock(final int id) {
-    super(id);
+  public AndBlock() {
     this.subBlocks = new ArrayList<>();
   }
 
   public AndBlock(final List<BooleanExpression>... expressions) {
-    this(-1);
+    this();
 
     for (List<BooleanExpression> expression : expressions)
       subBlocks.addAll(expression);
@@ -144,7 +143,7 @@ public class AndBlock extends BooleanExpression {
           result.add(subAndItem);
         } else {
           for (final AndBlock oldResultItem : oldResult) {
-            final AndBlock block = new AndBlock(-1);
+            final AndBlock block = new AndBlock();
             block.subBlocks.addAll(oldResultItem.subBlocks);
             for (final BooleanExpression resultItem : subAndItem.subBlocks) {
               block.subBlocks.add(resultItem);
@@ -162,13 +161,13 @@ public class AndBlock extends BooleanExpression {
     if (item instanceof AndBlock block) {
       return block;
     }
-    final AndBlock result = new AndBlock(-1);
+    final AndBlock result = new AndBlock();
     result.subBlocks.add(item);
     return result;
   }
 
   public AndBlock copy() {
-    final AndBlock result = new AndBlock(-1);
+    final AndBlock result = new AndBlock();
     for (final BooleanExpression exp : subBlocks) {
       result.subBlocks.add(exp.copy());
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayConcatExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayConcatExpression.java
@@ -35,8 +35,7 @@ public class ArrayConcatExpression extends SimpleNode {
 
   List<ArrayConcatExpressionElement> childExpressions = new ArrayList<>();
 
-  public ArrayConcatExpression(final int id) {
-    super(id);
+  public ArrayConcatExpression() {
   }
 
   public List<ArrayConcatExpressionElement> getChildExpressions() {
@@ -127,7 +126,7 @@ public class ArrayConcatExpression extends SimpleNode {
 
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateSplit, final CommandContext context) {
     if (isAggregate(context)) {
-      final ArrayConcatExpression result = new ArrayConcatExpression(-1);
+      final ArrayConcatExpression result = new ArrayConcatExpression();
       for (final ArrayConcatExpressionElement expr : this.childExpressions) {
         if (expr.isAggregate(context)) {
           // Split the aggregate expression, passing the aggregateSplit context
@@ -136,7 +135,7 @@ public class ArrayConcatExpression extends SimpleNode {
             result.childExpressions.add(element);
           } else {
             // Convert Expression to ArrayConcatExpressionElement
-            final ArrayConcatExpressionElement element = new ArrayConcatExpressionElement(-1);
+            final ArrayConcatExpressionElement element = new ArrayConcatExpressionElement();
             element.mathExpression = splitResult.mathExpression;
             element.json = splitResult.json;
             element.rid = splitResult.rid;
@@ -161,7 +160,7 @@ public class ArrayConcatExpression extends SimpleNode {
   }
 
   public ArrayConcatExpression copy() {
-    final ArrayConcatExpression result = new ArrayConcatExpression(-1);
+    final ArrayConcatExpression result = new ArrayConcatExpression();
     this.childExpressions.forEach(x -> result.childExpressions.add(x.copy()));
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayConcatExpressionElement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayConcatExpressionElement.java
@@ -27,8 +27,7 @@ import com.arcadedb.query.sql.executor.Result;
 public class ArrayConcatExpressionElement extends Expression {
   public NestedProjection nestedProjection;
 
-  public ArrayConcatExpressionElement(final int id) {
-    super(id);
+  public ArrayConcatExpressionElement() {
   }
 
   @Override
@@ -52,7 +51,7 @@ public class ArrayConcatExpressionElement extends Expression {
   @Override
   public Expression splitForAggregation(final AggregateProjectionSplit aggregateSplit, final CommandContext context) {
     if (isAggregate(context)) {
-      final ArrayConcatExpressionElement result = new ArrayConcatExpressionElement(-1);
+      final ArrayConcatExpressionElement result = new ArrayConcatExpressionElement();
 
       // If there's a nested projection, we need to track the number of aggregates before and after
       // the split so we can attach the nested projection to the newly created aggregate item
@@ -89,7 +88,7 @@ public class ArrayConcatExpressionElement extends Expression {
 
   @Override
   public ArrayConcatExpressionElement copy() {
-    final ArrayConcatExpressionElement result = new ArrayConcatExpressionElement(-1);
+    final ArrayConcatExpressionElement result = new ArrayConcatExpressionElement();
     result.singleQuotes = singleQuotes;
     result.doubleQuotes = doubleQuotes;
     result.isNull = isNull;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayLiteralExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayLiteralExpression.java
@@ -35,8 +35,7 @@ public class ArrayLiteralExpression extends MathExpression {
 
   public List<Expression> items = new ArrayList<>();
 
-  public ArrayLiteralExpression(final int id) {
-    super(id);
+  public ArrayLiteralExpression() {
   }
 
   public void addItem(final Expression item) {
@@ -113,7 +112,7 @@ public class ArrayLiteralExpression extends MathExpression {
 
   @Override
   public MathExpression copy() {
-    final ArrayLiteralExpression result = new ArrayLiteralExpression(-1);
+    final ArrayLiteralExpression result = new ArrayLiteralExpression();
     for (final Expression item : items) {
       result.items.add(item.copy());
     }
@@ -148,7 +147,7 @@ public class ArrayLiteralExpression extends MathExpression {
   @Override
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final ArrayLiteralExpression result = new ArrayLiteralExpression(-1);
+      final ArrayLiteralExpression result = new ArrayLiteralExpression();
 
       for (final Expression item : items) {
         final SimpleNode splitResult = item.splitForAggregation(aggregateProj, context);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayNumberSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayNumberSelector.java
@@ -31,8 +31,7 @@ public class ArrayNumberSelector extends SimpleNode {
   public MathExpression expressionValue;
   public Integer        integer;
 
-  public ArrayNumberSelector(final int id) {
-    super(id);
+  public ArrayNumberSelector() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -84,7 +83,7 @@ public class ArrayNumberSelector extends SimpleNode {
   }
 
   public ArrayNumberSelector copy() {
-    final ArrayNumberSelector result = new ArrayNumberSelector(-1);
+    final ArrayNumberSelector result = new ArrayNumberSelector();
     result.inputValue = inputValue == null ? null : inputValue.copy();
     result.expressionValue = expressionValue == null ? null : expressionValue.copy();
     result.integer = integer;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayRangeSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayRangeSelector.java
@@ -39,8 +39,7 @@ public class ArrayRangeSelector extends SimpleNode {
   public ArrayNumberSelector fromSelector;
   public ArrayNumberSelector toSelector;
 
-  public ArrayRangeSelector(final int id) {
-    super(id);
+  public ArrayRangeSelector() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -144,7 +143,7 @@ public class ArrayRangeSelector extends SimpleNode {
   }
 
   public ArrayRangeSelector copy() {
-    final ArrayRangeSelector result = new ArrayRangeSelector(-1);
+    final ArrayRangeSelector result = new ArrayRangeSelector();
     result.from = from;
     result.to = to;
     result.newRange = newRange;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySelector.java
@@ -34,8 +34,7 @@ public class ArraySelector extends SimpleNode {
   public Expression     expression;
   protected PInteger       integer;
 
-  public ArraySelector(final int id) {
-    super(id);
+  public ArraySelector() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -89,7 +88,7 @@ public class ArraySelector extends SimpleNode {
   }
 
   public ArraySelector copy() {
-    final ArraySelector result = new ArraySelector(-1);
+    final ArraySelector result = new ArraySelector();
     result.rid = rid == null ? null : rid.copy();
     result.inputParam = inputParam == null ? null : inputParam.copy();
     result.expression = expression == null ? null : expression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySingleValuesSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySingleValuesSelector.java
@@ -38,8 +38,7 @@ public class ArraySingleValuesSelector extends SimpleNode {
 
   public List<ArraySelector> items = new ArrayList<>();
 
-  public ArraySingleValuesSelector(final int id) {
-    super(id);
+  public ArraySingleValuesSelector() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -137,7 +136,7 @@ public class ArraySingleValuesSelector extends SimpleNode {
   }
 
   public ArraySingleValuesSelector copy() {
-    final ArraySingleValuesSelector result = new ArraySingleValuesSelector(-1);
+    final ArraySingleValuesSelector result = new ArraySingleValuesSelector();
     result.items = items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
@@ -45,8 +45,7 @@ public class BackupDatabaseStatement extends SimpleExecStatement {
   protected       Expression                  value;
   public final    Map<Expression, Expression> settings = new HashMap<>();
 
-  public BackupDatabaseStatement(final int id) {
-    super(id);
+  public BackupDatabaseStatement() {
   }
 
   @Override
@@ -198,7 +197,7 @@ public class BackupDatabaseStatement extends SimpleExecStatement {
 
   @Override
   public Statement copy() {
-    final BackupDatabaseStatement result = new BackupDatabaseStatement(-1);
+    final BackupDatabaseStatement result = new BackupDatabaseStatement();
     result.url = this.url;
     // WITHOUT THIS, A COPY TAKEN FROM THE STATEMENT CACHE SILENTLY DROPS EVERY 'WITH ...' SETTING
     result.settings.putAll(this.settings);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -45,17 +45,14 @@ public class BaseExpression extends MathExpression {
   public Modifier       modifier;
   public boolean        isNull = false;
 
-  public BaseExpression(final int id) {
-    super(id);
+  public BaseExpression() {
   }
 
   public BaseExpression(final Identifier identifier) {
-    super(-1);
     this.identifier = new BaseIdentifier(identifier);
   }
 
   public BaseExpression(final String string) {
-    super(-1);
     this.string = "\"" + encode(string) + "\"";
   }
 
@@ -67,7 +64,6 @@ public class BaseExpression extends MathExpression {
   }
 
   public BaseExpression(final RecordAttribute attr, final Modifier modifier) {
-    super(-1);
     this.identifier = new BaseIdentifier(attr);
     if (modifier != null) {
       this.modifier = modifier;
@@ -246,7 +242,7 @@ public class BaseExpression extends MathExpression {
     if (!registered)
       return null;
 
-    final FunctionCall fc = new FunctionCall(-1);
+    final FunctionCall fc = new FunctionCall();
     final Identifier name = new Identifier(combined);
     fc.name = name;
     fc.params = mc.params;
@@ -255,7 +251,7 @@ public class BaseExpression extends MathExpression {
   }
 
   private transient FunctionCall cachedNamespacedCall;
-  private static final FunctionCall NAMESPACED_CALL_NONE = new FunctionCall(-1);
+  private static final FunctionCall NAMESPACED_CALL_NONE = new FunctionCall();
 
   @Override
   public boolean isIndexedFunctionCall(final CommandContext context) {
@@ -394,7 +390,7 @@ public class BaseExpression extends MathExpression {
 
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final BaseExpression result = new BaseExpression(-1);
+      final BaseExpression result = new BaseExpression();
 
       // Handle case where identifier is set
       if (identifier != null) {
@@ -412,7 +408,7 @@ public class BaseExpression extends MathExpression {
           result.expression = expr;
         } else if (splitResult instanceof MathExpression mathExpr) {
           // Wrap the MathExpression back in an Expression
-          final Expression wrapperExpr = new Expression(-1);
+          final Expression wrapperExpr = new Expression();
           wrapperExpr.mathExpression = mathExpr;
           result.expression = wrapperExpr;
         }
@@ -438,7 +434,7 @@ public class BaseExpression extends MathExpression {
 
   @Override
   public BaseExpression copy() {
-    final BaseExpression result = new BaseExpression(-1);
+    final BaseExpression result = new BaseExpression();
     result.isNull = isNull;
     result.number = number == null ? null : number.copy();
     result.identifier = identifier == null ? null : identifier.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
@@ -34,8 +34,7 @@ public class BaseIdentifier extends SimpleNode {
   public LevelZeroIdentifier levelZero;
   public SuffixIdentifier    suffix;
 
-  public BaseIdentifier(final int id) {
-    super(id);
+  public BaseIdentifier() {
   }
 
   public BaseIdentifier(final Identifier identifier) {
@@ -181,7 +180,7 @@ public class BaseIdentifier extends SimpleNode {
 
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final BaseIdentifier result = new BaseIdentifier(-1);
+      final BaseIdentifier result = new BaseIdentifier();
       if (levelZero != null) {
         final SimpleNode splitResult = levelZero.splitForAggregation(aggregateProj, context);
         if (splitResult instanceof LevelZeroIdentifier identifier) {
@@ -218,7 +217,7 @@ public class BaseIdentifier extends SimpleNode {
   }
 
   public BaseIdentifier copy() {
-    final BaseIdentifier result = new BaseIdentifier(-1);
+    final BaseIdentifier result = new BaseIdentifier();
     result.levelZero = levelZero == null ? null : levelZero.copy();
     result.suffix = suffix == null ? null : suffix.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Batch.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Batch.java
@@ -16,8 +16,7 @@ public class Batch extends SimpleNode {
   public InputParameter inputParam;
   public Expression     expression;
 
-  public Batch(final int id) {
-    super(id);
+  public Batch() {
   }
 
   public int evaluate(final CommandContext ctx) {
@@ -55,7 +54,7 @@ public class Batch extends SimpleNode {
   }
 
   public Batch copy() {
-    final Batch result = new Batch(-1);
+    final Batch result = new Batch();
     result.num = num == null ? null : num.copy();
     result.inputParam = inputParam == null ? null : inputParam.copy();
     result.expression = expression == null ? null : expression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BeginStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BeginStatement.java
@@ -33,8 +33,7 @@ import java.util.Map;
 public class BeginStatement extends SimpleExecStatement {
   public Identifier isolation;
 
-  public BeginStatement(final int id) {
-    super(id);
+  public BeginStatement() {
   }
 
   @Override
@@ -65,7 +64,7 @@ public class BeginStatement extends SimpleExecStatement {
 
   @Override
   public BeginStatement copy() {
-    final BeginStatement result = new BeginStatement(-1);
+    final BeginStatement result = new BeginStatement();
     result.isolation = isolation == null ? null : isolation.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BetweenCondition.java
@@ -36,8 +36,7 @@ public class BetweenCondition extends BooleanExpression {
   public Expression second;
   public Expression third;
 
-  public BetweenCondition(final int id) {
-    super(id);
+  public BetweenCondition() {
   }
 
   @Override
@@ -130,7 +129,7 @@ public class BetweenCondition extends BooleanExpression {
 
   @Override
   public BooleanExpression copy() {
-    final BetweenCondition result = new BetweenCondition(-1);
+    final BetweenCondition result = new BetweenCondition();
     result.first = first.copy();
     result.second = second.copy();
     result.third = third.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
@@ -34,8 +34,7 @@ public class BinaryCondition extends BooleanExpression {
   public BinaryCompareOperator operator;
   public Expression            right;
 
-  public BinaryCondition(final int id) {
-    super(id);
+  public BinaryCondition() {
   }
 
   @Override
@@ -122,7 +121,7 @@ public class BinaryCondition extends BooleanExpression {
 
   @Override
   public BinaryCondition copy() {
-    final BinaryCondition result = new BinaryCondition(-1);
+    final BinaryCondition result = new BinaryCondition();
     result.left = left.copy();
     result.operator = operator.copy();
     result.right = right.copy();
@@ -141,7 +140,7 @@ public class BinaryCondition extends BooleanExpression {
       return Optional.empty();
     }
     if (operator instanceof EqualsCompareOperator) {
-      final UpdateItem result = new UpdateItem(-1);
+      final UpdateItem result = new UpdateItem();
       result.operator = UpdateItem.OPERATOR_EQ;
       final BaseExpression baseExp = (BaseExpression) left.mathExpression;
       result.left = baseExp.identifier.suffix.identifier.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BooleanExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BooleanExpression.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  */
 public abstract class BooleanExpression extends SimpleNode {
 
-  public static final BooleanExpression TRUE = new BooleanExpression(0) {
+  public static final BooleanExpression TRUE = new BooleanExpression() {
     @Override
     public Boolean evaluate(final Identifiable currentRecord, final CommandContext context) {
       return true;
@@ -84,7 +84,7 @@ public abstract class BooleanExpression extends SimpleNode {
     }
   };
 
-  public static final BooleanExpression FALSE = new BooleanExpression(0) {
+  public static final BooleanExpression FALSE = new BooleanExpression() {
     @Override
     public Boolean evaluate(final Identifiable currentRecord, final CommandContext context) {
       return false;
@@ -135,7 +135,7 @@ public abstract class BooleanExpression extends SimpleNode {
     }
   };
 
-  public static final BooleanExpression NULL = new BooleanExpression(0) {
+  public static final BooleanExpression NULL = new BooleanExpression() {
     @Override
     public Boolean evaluate(final Identifiable currentRecord, final CommandContext context) {
       return null;
@@ -186,8 +186,7 @@ public abstract class BooleanExpression extends SimpleNode {
     }
   };
 
-  public BooleanExpression(final int id) {
-    super(id);
+  public BooleanExpression() {
   }
 
   public abstract Boolean evaluate(final Identifiable currentRecord, final CommandContext context);
@@ -218,7 +217,7 @@ public abstract class BooleanExpression extends SimpleNode {
     if (item instanceof AndBlock block)
       return block;
 
-    final AndBlock result = new AndBlock(-1);
+    final AndBlock result = new AndBlock();
     result.subBlocks.add(item);
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BothPathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BothPathItem.java
@@ -25,8 +25,7 @@ import com.arcadedb.query.sql.executor.Result;
 import java.util.Map;
 
 public class BothPathItem extends MatchPathItem {
-  public BothPathItem(final int id) {
-    super(id);
+  public BothPathItem() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BothPathItemOpt.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BothPathItemOpt.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class BothPathItemOpt extends BothPathItem {
-  public BothPathItemOpt(final int id) {
-    super(id);
+  public BothPathItemOpt() {
   }
 }
 /* JavaCC - OriginalChecksum=96af673f114382e530f23ae7937cb201 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BreakStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BreakStatement.java
@@ -21,8 +21,7 @@ public class BreakStatement extends SimpleExecStatement {
     }
   };
 
-  public BreakStatement(int id) {
-    super(id);
+  public BreakStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Bucket.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Bucket.java
@@ -28,12 +28,10 @@ public class Bucket extends SimpleNode {
   public InputParameter inputParam;
 
   public Bucket(final String bucketName) {
-    super(-1);
     this.bucketName = bucketName;
   }
 
-  public Bucket(final int id) {
-    super(id);
+  public Bucket() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -60,7 +58,7 @@ public class Bucket extends SimpleNode {
   }
 
   public Bucket copy() {
-    final Bucket result = new Bucket(-1);
+    final Bucket result = new Bucket();
     result.bucketName = bucketName;
     result.bucketNumber = bucketNumber;
     result.inputParam = inputParam != null ? inputParam.copy() : null;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BucketIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BucketIdentifier.java
@@ -27,8 +27,7 @@ public class BucketIdentifier extends SimpleNode {
   public Identifier     bucketName;
   public InputParameter inputParam;
 
-  public BucketIdentifier(final int id) {
-    super(id);
+  public BucketIdentifier() {
   }
 
   public Object getValue() {
@@ -75,7 +74,7 @@ public class BucketIdentifier extends SimpleNode {
 
   @Override
   public BucketIdentifier copy() {
-    final BucketIdentifier copy = new BucketIdentifier(-1);
+    final BucketIdentifier copy = new BucketIdentifier();
     copy.bucketName = bucketName != null ? bucketName.copy() : null;
     copy.bucketId = bucketId != null ? bucketId.copy() : null;
     copy.inputParam = inputParam != null ? inputParam.copy() : null;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BucketList.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BucketList.java
@@ -29,8 +29,7 @@ public class BucketList extends SimpleNode {
 
   public List<Identifier> buckets = new ArrayList<>();
 
-  public BucketList(final int id) {
-    super(id);
+  public BucketList() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -49,7 +48,7 @@ public class BucketList extends SimpleNode {
   public List<Bucket> toListOfClusters() {
     final List<Bucket> result = new ArrayList<>();
     for (final Identifier id : buckets) {
-      final Bucket bucket = new Bucket(-1);
+      final Bucket bucket = new Bucket();
       bucket.bucketName = id.getStringValue();
       result.add(bucket);
     }
@@ -57,7 +56,7 @@ public class BucketList extends SimpleNode {
   }
 
   public BucketList copy() {
-    final BucketList result = new BucketList(-1);
+    final BucketList result = new BucketList();
     result.buckets = buckets.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
@@ -55,7 +55,6 @@ public class CaseExpression extends MathExpression {
    * Constructor for simple CASE form (no case expression).
    */
   public CaseExpression(final List<CaseAlternative> alternatives, final Expression elseExpression) {
-    super(-1);
     this.caseExpression = null;
     this.alternatives = alternatives;
     this.elseExpression = elseExpression;
@@ -76,7 +75,6 @@ public class CaseExpression extends MathExpression {
    */
   public CaseExpression(final Expression caseExpression, final List<CaseAlternative> alternatives,
                         final Expression elseExpression) {
-    super(-1);
     this.caseExpression = caseExpression;
     this.alternatives = alternatives;
     this.elseExpression = elseExpression;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
@@ -52,8 +52,7 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
   public       boolean               fix      = false;
   public       boolean               compress = false;
 
-  public CheckDatabaseStatement(final int id) {
-    super(id);
+  public CheckDatabaseStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CommitStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CommitStatement.java
@@ -35,8 +35,7 @@ public class CommitStatement extends SimpleExecStatement {
   public List<Statement> elseStatements;
   public Boolean         elseFail;
 
-  public CommitStatement(final int id) {
-    super(id);
+  public CommitStatement() {
   }
 
   public void addElse(final Statement statement) {
@@ -88,7 +87,7 @@ public class CommitStatement extends SimpleExecStatement {
 
   @Override
   public CommitStatement copy() {
-    CommitStatement result = new CommitStatement(-1);
+    CommitStatement result = new CommitStatement();
     result.retry = retry == null ? null : retry.copy();
     if (this.elseStatements != null) {
       result.elseStatements = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CompactIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CompactIndexStatement.java
@@ -52,8 +52,7 @@ public class CompactIndexStatement extends DDLStatement {
   public boolean    all = false;
   public Identifier name;
 
-  public CompactIndexStatement(final int id) {
-    super(id);
+  public CompactIndexStatement() {
   }
 
   @Override
@@ -149,7 +148,7 @@ public class CompactIndexStatement extends DDLStatement {
 
   @Override
   public CompactIndexStatement copy() {
-    final CompactIndexStatement result = new CompactIndexStatement(-1);
+    final CompactIndexStatement result = new CompactIndexStatement();
     result.all = all;
     result.name = name == null ? null : name.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CompareOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CompareOperator.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class CompareOperator extends SimpleNode {
-  public CompareOperator(final int id) {
-    super(id);
+  public CompareOperator() {
   }
 
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ConditionBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ConditionBlock.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class ConditionBlock extends SimpleNode {
-  public ConditionBlock(final int id) {
-    super(id);
+  public ConditionBlock() {
   }
 }
 /* JavaCC - OriginalChecksum=d3e0589119a7b64cf9891d6baaf9e449 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ConsoleStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ConsoleStatement.java
@@ -36,8 +36,7 @@ public class ConsoleStatement extends SimpleExecStatement {
   public Identifier logLevel;
   public Expression message;
 
-  public ConsoleStatement(final int id) {
-    super(id);
+  public ConsoleStatement() {
   }
 
   @Override
@@ -80,7 +79,7 @@ public class ConsoleStatement extends SimpleExecStatement {
 
   @Override
   public ConsoleStatement copy() {
-    final ConsoleStatement result = new ConsoleStatement(-1);
+    final ConsoleStatement result = new ConsoleStatement();
     result.logLevel = logLevel == null ? null : logLevel.copy();
     result.message = message == null ? null : message.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAllCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAllCondition.java
@@ -35,8 +35,7 @@ public class ContainsAllCondition extends BooleanExpression {
   public Expression right;
   public OrBlock    rightBlock;
 
-  public ContainsAllCondition(final int id) {
-    super(id);
+  public ContainsAllCondition() {
   }
 
   public boolean execute(Object left, Object right) {
@@ -165,7 +164,7 @@ public class ContainsAllCondition extends BooleanExpression {
 
   @Override
   public ContainsAllCondition copy() {
-    final ContainsAllCondition result = new ContainsAllCondition(-1);
+    final ContainsAllCondition result = new ContainsAllCondition();
     result.left = left.copy();
     result.right = right == null ? null : right.copy();
     result.rightBlock = rightBlock == null ? null : rightBlock.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
@@ -34,8 +34,7 @@ public class ContainsAnyCondition extends BooleanExpression {
   public Expression right;
   public OrBlock    rightBlock;
 
-  public ContainsAnyCondition(final int id) {
-    super(id);
+  public ContainsAnyCondition() {
   }
 
   public boolean execute(Object left, Object right) {
@@ -160,7 +159,7 @@ public class ContainsAnyCondition extends BooleanExpression {
 
   @Override
   public ContainsAnyCondition copy() {
-    final ContainsAnyCondition result = new ContainsAnyCondition(-1);
+    final ContainsAnyCondition result = new ContainsAnyCondition();
     result.left = left.copy();
     result.right = right == null ? null : right.copy();
     result.rightBlock = rightBlock == null ? null : rightBlock.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -36,8 +36,7 @@ public class ContainsCondition extends BooleanExpression {
   public Expression        right;
   public BooleanExpression condition;
 
-  public ContainsCondition(final int id) {
-    super(id);
+  public ContainsCondition() {
   }
 
   public boolean execute(final Object left, Object right) {
@@ -201,7 +200,7 @@ public class ContainsCondition extends BooleanExpression {
 
   @Override
   public ContainsCondition copy() {
-    final ContainsCondition result = new ContainsCondition(-1);
+    final ContainsCondition result = new ContainsCondition();
     result.left = left == null ? null : left.copy();
     result.right = right == null ? null : right.copy();
     result.condition = condition == null ? null : condition.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsKeyOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsKeyOperator.java
@@ -25,8 +25,7 @@ import com.arcadedb.database.DatabaseInternal;
 import java.util.Map;
 
 public class ContainsKeyOperator extends SimpleNode implements BinaryCompareOperator {
-  public ContainsKeyOperator(final int id) {
-    super(id);
+  public ContainsKeyOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
@@ -33,8 +33,7 @@ public class ContainsTextCondition extends BooleanExpression {
   public Expression left;
   public Expression right;
 
-  public ContainsTextCondition(final int id) {
-    super(id);
+  public ContainsTextCondition() {
   }
 
   @Override
@@ -71,7 +70,7 @@ public class ContainsTextCondition extends BooleanExpression {
 
   @Override
   public ContainsTextCondition copy() {
-    final ContainsTextCondition result = new ContainsTextCondition(-1);
+    final ContainsTextCondition result = new ContainsTextCondition();
     result.left = left.copy();
     result.right = right.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsValueCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsValueCondition.java
@@ -35,8 +35,7 @@ public class ContainsValueCondition extends BooleanExpression {
   protected OrBlock               condition;
   public Expression            expression;
 
-  public ContainsValueCondition(final int id) {
-    super(id);
+  public ContainsValueCondition() {
   }
 
   @Override
@@ -93,7 +92,7 @@ public class ContainsValueCondition extends BooleanExpression {
 
   @Override
   public ContainsValueCondition copy() {
-    final ContainsValueCondition result = new ContainsValueCondition(-1);
+    final ContainsValueCondition result = new ContainsValueCondition();
     result.left = left.copy();
     result.operator = operator;
     result.condition = condition == null ? null : condition.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsValueOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsValueOperator.java
@@ -25,8 +25,7 @@ import com.arcadedb.database.DatabaseInternal;
 import java.util.Map;
 
 public class ContainsValueOperator extends SimpleNode implements BinaryCompareOperator {
-  public ContainsValueOperator(final int id) {
-    super(id);
+  public ContainsValueOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateBucketStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateBucketStatement.java
@@ -35,8 +35,7 @@ public class CreateBucketStatement extends DDLStatement {
   public boolean    ifNotExists = false;
   public boolean    blob        = false;
 
-  public CreateBucketStatement(final int id) {
-    super(id);
+  public CreateBucketStatement() {
   }
 
   @Override
@@ -74,7 +73,7 @@ public class CreateBucketStatement extends DDLStatement {
 
   @Override
   public CreateBucketStatement copy() {
-    final CreateBucketStatement result = new CreateBucketStatement(-1);
+    final CreateBucketStatement result = new CreateBucketStatement();
     result.name = name == null ? null : name.copy();
     result.ifNotExists = this.ifNotExists;
     result.blob = blob;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateContinuousAggregateStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateContinuousAggregateStatement.java
@@ -29,8 +29,7 @@ public class CreateContinuousAggregateStatement extends DDLStatement {
   public SelectStatement selectStatement;
   public boolean ifNotExists = false;
 
-  public CreateContinuousAggregateStatement(final int id) {
-    super(id);
+  public CreateContinuousAggregateStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateDocumentTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateDocumentTypeStatement.java
@@ -25,8 +25,7 @@ import com.arcadedb.schema.Schema;
 
 public class CreateDocumentTypeStatement extends CreateTypeAbstractStatement {
 
-  public CreateDocumentTypeStatement(final int id) {
-    super(id);
+  public CreateDocumentTypeStatement() {
   }
 
   @Override
@@ -61,7 +60,7 @@ public class CreateDocumentTypeStatement extends CreateTypeAbstractStatement {
 
   @Override
   public CreateDocumentTypeStatement copy() {
-    return (CreateDocumentTypeStatement) super.copy(new CreateDocumentTypeStatement(-1));
+    return (CreateDocumentTypeStatement) super.copy(new CreateDocumentTypeStatement());
   }
 }
 /* JavaCC - OriginalChecksum=4043013624f55fdf0ea8fee6d4f211b0 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeStatement.java
@@ -43,8 +43,7 @@ public class CreateEdgeStatement extends Statement {
   public boolean    ifNotExists;
   public boolean    unidirectional = false;
 
-  public CreateEdgeStatement(final int id) {
-    super(id);
+  public CreateEdgeStatement() {
   }
 
   @Override
@@ -124,7 +123,7 @@ public class CreateEdgeStatement extends Statement {
 
   @Override
   public CreateEdgeStatement copy() {
-    final CreateEdgeStatement result = new CreateEdgeStatement(-1);
+    final CreateEdgeStatement result = new CreateEdgeStatement();
     result.targetType = targetType == null ? null : targetType.copy();
     result.targetBucketName = targetBucketName == null ? null : targetBucketName.copy();
     result.leftExpression = leftExpression == null ? null : leftExpression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeTypeStatement.java
@@ -30,8 +30,7 @@ public class CreateEdgeTypeStatement extends CreateTypeAbstractStatement {
   public boolean lightweight    = false;
   public boolean unique         = false;
 
-  public CreateEdgeTypeStatement(final int id) {
-    super(id);
+  public CreateEdgeTypeStatement() {
   }
 
   @Override
@@ -76,7 +75,7 @@ public class CreateEdgeTypeStatement extends CreateTypeAbstractStatement {
 
   @Override
   public CreateEdgeTypeStatement copy() {
-    final CreateEdgeTypeStatement copy = (CreateEdgeTypeStatement) super.copy(new CreateEdgeTypeStatement(-1));
+    final CreateEdgeTypeStatement copy = (CreateEdgeTypeStatement) super.copy(new CreateEdgeTypeStatement());
     copy.unidirectional = unidirectional;
     copy.lightweight = lightweight;
     copy.unique = unique;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateGraphAnalyticalViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateGraphAnalyticalViewStatement.java
@@ -40,8 +40,7 @@ public class CreateGraphAnalyticalViewStatement extends DDLStatement {
   public int          compactionThreshold = -1; // -1 means not set (use default)
   public boolean      ifNotExists  = false;
 
-  public CreateGraphAnalyticalViewStatement(final int id) {
-    super(id);
+  public CreateGraphAnalyticalViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -89,8 +89,7 @@ public class CreateIndexStatement extends DDLStatement {
   public LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP;
   public List<Identifier>                   keyTypes     = new ArrayList<Identifier>();
 
-  public CreateIndexStatement(final int id) {
-    super(id);
+  public CreateIndexStatement() {
   }
 
   @Override
@@ -510,7 +509,7 @@ public class CreateIndexStatement extends DDLStatement {
 
   @Override
   public CreateIndexStatement copy() {
-    final CreateIndexStatement result = new CreateIndexStatement(-1);
+    final CreateIndexStatement result = new CreateIndexStatement();
     result.name = name == null ? null : name.copy();
     result.typeName = typeName == null ? null : typeName.copy();
     result.propertyList = propertyList == null ? null : propertyList.stream().map(x -> x.copy()).collect(Collectors.toList());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateMaterializedViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateMaterializedViewStatement.java
@@ -34,8 +34,7 @@ public class CreateMaterializedViewStatement extends DDLStatement {
   public int buckets;
   public boolean ifNotExists = false;
 
-  public CreateMaterializedViewStatement(final int id) {
-    super(id);
+  public CreateMaterializedViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
@@ -32,8 +32,7 @@ public class CreatePropertyAttributeStatement extends SimpleNode {
   public Identifier settingName;
   public Expression settingValue;
 
-  public CreatePropertyAttributeStatement(final int id) {
-    super(id);
+  public CreatePropertyAttributeStatement() {
   }
 
   @Override
@@ -46,7 +45,7 @@ public class CreatePropertyAttributeStatement extends SimpleNode {
   }
 
   public CreatePropertyAttributeStatement copy() {
-    final CreatePropertyAttributeStatement result = new CreatePropertyAttributeStatement(-1);
+    final CreatePropertyAttributeStatement result = new CreatePropertyAttributeStatement();
     result.settingName = settingName == null ? null : settingName.copy();
     result.settingValue = settingValue == null ? null : settingValue.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java
@@ -48,8 +48,7 @@ public class CreatePropertyStatement extends DDLStatement {
    */
   public final Map<Identifier, Expression> customProperties = new LinkedHashMap<>();
 
-  public CreatePropertyStatement(final int id) {
-    super(id);
+  public CreatePropertyStatement() {
   }
 
   @Override
@@ -154,7 +153,7 @@ public class CreatePropertyStatement extends DDLStatement {
 
   @Override
   public CreatePropertyStatement copy() {
-    final CreatePropertyStatement result = new CreatePropertyStatement(-1);
+    final CreatePropertyStatement result = new CreatePropertyStatement();
     result.typeName = typeName == null ? null : typeName.copy();
     result.propertyName = propertyName == null ? null : propertyName.copy();
     result.ifNotExists = ifNotExists;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTimeSeriesTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTimeSeriesTypeStatement.java
@@ -50,8 +50,7 @@ public class CreateTimeSeriesTypeStatement extends DDLStatement {
   public List<ColumnDef> tags   = new ArrayList<>();
   public List<ColumnDef> fields = new ArrayList<>();
 
-  public CreateTimeSeriesTypeStatement(final int id) {
-    super(id);
+  public CreateTimeSeriesTypeStatement() {
   }
 
   @Override
@@ -153,7 +152,7 @@ public class CreateTimeSeriesTypeStatement extends DDLStatement {
 
   @Override
   public CreateTimeSeriesTypeStatement copy() {
-    final CreateTimeSeriesTypeStatement result = new CreateTimeSeriesTypeStatement(-1);
+    final CreateTimeSeriesTypeStatement result = new CreateTimeSeriesTypeStatement();
     result.name = name == null ? null : name.copy();
     result.ifNotExists = ifNotExists;
     result.timestampColumn = timestampColumn == null ? null : timestampColumn.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTriggerStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTriggerStatement.java
@@ -45,8 +45,7 @@ public class CreateTriggerStatement extends DDLStatement {
   public String actionCode;
   public boolean ifNotExists = false;
 
-  public CreateTriggerStatement(final int id) {
-    super(id);
+  public CreateTriggerStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTypeAbstractStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTypeAbstractStatement.java
@@ -74,8 +74,7 @@ public abstract class CreateTypeAbstractStatement extends DDLStatement {
    */
   public final Map<Identifier, Expression> customProperties = new LinkedHashMap<>();
 
-  public CreateTypeAbstractStatement(final int id) {
-    super(id);
+  public CreateTypeAbstractStatement() {
   }
 
   protected abstract String commandType();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatement.java
@@ -44,8 +44,7 @@ public class CreateVertexStatement extends Statement {
   public Projection returnStatement;
   public InsertBody insertBody;
 
-  public CreateVertexStatement(final int id) {
-    super(id);
+  public CreateVertexStatement() {
   }
 
   @Override
@@ -126,7 +125,7 @@ public class CreateVertexStatement extends Statement {
   public CreateVertexStatement copy() {
     CreateVertexStatement result;
     try {
-      result = getClass().getConstructor(Integer.TYPE).newInstance(-1);
+      result = getClass().getConstructor().newInstance();
     } catch (final Exception e) {
       throw new ArcadeDBException(e);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatementEmpty.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatementEmpty.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class CreateVertexStatementEmpty extends CreateVertexStatement {
-  public CreateVertexStatementEmpty(final int id) {
-    super(id);
+  public CreateVertexStatementEmpty() {
   }
 
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatementEmptyNoTarget.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatementEmptyNoTarget.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class CreateVertexStatementEmptyNoTarget extends CreateVertexStatement {
-  public CreateVertexStatementEmptyNoTarget(final int id) {
-    super(id);
+  public CreateVertexStatementEmptyNoTarget() {
   }
 
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatementNoTarget.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexStatementNoTarget.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class CreateVertexStatementNoTarget extends CreateVertexStatement {
-  public CreateVertexStatementNoTarget(final int id) {
-    super(id);
+  public CreateVertexStatementNoTarget() {
   }
 
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexTypeStatement.java
@@ -25,8 +25,7 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 
 public class CreateVertexTypeStatement extends CreateTypeAbstractStatement {
-  public CreateVertexTypeStatement(final int id) {
-    super(id);
+  public CreateVertexTypeStatement() {
   }
 
   @Override
@@ -60,7 +59,7 @@ public class CreateVertexTypeStatement extends CreateTypeAbstractStatement {
 
   @Override
   public CreateVertexTypeStatement copy() {
-    return (CreateVertexTypeStatement) super.copy(new CreateVertexTypeStatement(-1));
+    return (CreateVertexTypeStatement) super.copy(new CreateVertexTypeStatement());
   }
 }
 /* JavaCC - OriginalChecksum=4043013624f55fdf0ea8fee6d4f211b0 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
@@ -33,8 +33,7 @@ import java.util.Map;
  */
 public abstract class DDLStatement extends Statement {
 
-  public DDLStatement(final int id) {
-    super(id);
+  public DDLStatement() {
   }
 
   public abstract ResultSet executeDDL(CommandContext context);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DefineFunctionStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DefineFunctionStatement.java
@@ -27,8 +27,7 @@ public class DefineFunctionStatement extends SimpleExecStatement {
   public List<Identifier> parameters;
   public Identifier       language;
 
-  public DefineFunctionStatement(final int id) {
-    super(id);
+  public DefineFunctionStatement() {
   }
 
   @Override
@@ -118,7 +117,7 @@ public class DefineFunctionStatement extends SimpleExecStatement {
 
   @Override
   public DefineFunctionStatement copy() {
-    final DefineFunctionStatement result = new DefineFunctionStatement(-1);
+    final DefineFunctionStatement result = new DefineFunctionStatement();
     result.libraryName = libraryName == null ? null : libraryName.copy();
     result.functionName = functionName == null ? null : functionName.copy();
     result.codeQuoted = codeQuoted;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DeleteFunctionStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DeleteFunctionStatement.java
@@ -17,8 +17,7 @@ public class DeleteFunctionStatement extends SimpleExecStatement {
   public Identifier libraryName;
   public Identifier functionName;
 
-  public DeleteFunctionStatement(final int id) {
-    super(id);
+  public DeleteFunctionStatement() {
   }
 
   @Override
@@ -50,7 +49,7 @@ public class DeleteFunctionStatement extends SimpleExecStatement {
 
   @Override
   public DefineFunctionStatement copy() {
-    final DefineFunctionStatement result = new DefineFunctionStatement(-1);
+    final DefineFunctionStatement result = new DefineFunctionStatement();
     result.libraryName = libraryName == null ? null : libraryName.copy();
     result.functionName = functionName == null ? null : functionName.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DeleteStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DeleteStatement.java
@@ -41,8 +41,7 @@ public class DeleteStatement extends Statement {
   public Batch       batch;
   public boolean     unsafe       = false;
 
-  public DeleteStatement(final int id) {
-    super(id);
+  public DeleteStatement() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -68,7 +67,7 @@ public class DeleteStatement extends Statement {
 
   @Override
   public DeleteStatement copy() {
-    final DeleteStatement result = new DeleteStatement(-1);
+    final DeleteStatement result = new DeleteStatement();
     result.fromClause = fromClause == null ? null : fromClause.copy();
     result.whereClause = whereClause == null ? null : whereClause.copy();
     result.returnBefore = returnBefore;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropBucketStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropBucketStatement.java
@@ -37,8 +37,7 @@ public class DropBucketStatement extends DDLStatement {
   public PInteger   id;
   public boolean    ifExists = false;
 
-  public DropBucketStatement(final int id) {
-    super(id);
+  public DropBucketStatement() {
   }
 
   @Override
@@ -93,7 +92,7 @@ public class DropBucketStatement extends DDLStatement {
 
   @Override
   public DropBucketStatement copy() {
-    final DropBucketStatement result = new DropBucketStatement(-1);
+    final DropBucketStatement result = new DropBucketStatement();
     result.name = name == null ? null : name.copy();
     result.id = id == null ? null : id.copy();
     result.ifExists = this.ifExists;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropContinuousAggregateStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropContinuousAggregateStatement.java
@@ -29,8 +29,7 @@ public class DropContinuousAggregateStatement extends DDLStatement {
   public Identifier name;
   public boolean ifExists = false;
 
-  public DropContinuousAggregateStatement(final int id) {
-    super(id);
+  public DropContinuousAggregateStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropGraphAnalyticalViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropGraphAnalyticalViewStatement.java
@@ -36,8 +36,7 @@ public class DropGraphAnalyticalViewStatement extends DDLStatement {
   public Identifier name;
   public boolean    ifExists = false;
 
-  public DropGraphAnalyticalViewStatement(final int id) {
-    super(id);
+  public DropGraphAnalyticalViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropIndexStatement.java
@@ -37,8 +37,7 @@ public class DropIndexStatement extends DDLStatement {
   public Identifier name;
   public boolean    ifExists = false;
 
-  public DropIndexStatement(final int id) {
-    super(id);
+  public DropIndexStatement() {
   }
 
   @Override
@@ -87,7 +86,7 @@ public class DropIndexStatement extends DDLStatement {
 
   @Override
   public DropIndexStatement copy() {
-    final DropIndexStatement result = new DropIndexStatement(-1);
+    final DropIndexStatement result = new DropIndexStatement();
     result.all = all;
     result.name = name == null ? null : name.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropMaterializedViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropMaterializedViewStatement.java
@@ -29,8 +29,7 @@ public class DropMaterializedViewStatement extends DDLStatement {
   public Identifier name;
   public boolean ifExists = false;
 
-  public DropMaterializedViewStatement(final int id) {
-    super(id);
+  public DropMaterializedViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropPropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropPropertyStatement.java
@@ -41,8 +41,7 @@ public class DropPropertyStatement extends DDLStatement {
   public boolean    ifExists = false;
   public boolean    force    = false;
 
-  public DropPropertyStatement(final int id) {
-    super(id);
+  public DropPropertyStatement() {
   }
 
   @Override
@@ -115,7 +114,7 @@ public class DropPropertyStatement extends DDLStatement {
 
   @Override
   public DropPropertyStatement copy() {
-    final DropPropertyStatement result = new DropPropertyStatement(-1);
+    final DropPropertyStatement result = new DropPropertyStatement();
     result.typeName = typeName == null ? null : typeName.copy();
     result.propertyName = propertyName == null ? null : propertyName.copy();
     result.force = force;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropTriggerStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropTriggerStatement.java
@@ -39,8 +39,7 @@ public class DropTriggerStatement extends DDLStatement {
   public Identifier name;
   public boolean ifExists = false;
 
-  public DropTriggerStatement(final int id) {
-    super(id);
+  public DropTriggerStatement() {
   }
 
   @Override
@@ -82,7 +81,7 @@ public class DropTriggerStatement extends DDLStatement {
 
   @Override
   public DropTriggerStatement copy() {
-    final DropTriggerStatement result = new DropTriggerStatement(-1);
+    final DropTriggerStatement result = new DropTriggerStatement();
     result.name = name == null ? null : name.copy();
     result.ifExists = ifExists;
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DropTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DropTypeStatement.java
@@ -39,8 +39,7 @@ public class DropTypeStatement extends DDLStatement {
   public boolean        ifExists = false;
   public boolean        unsafe   = false;
 
-  public DropTypeStatement(final int id) {
-    super(id);
+  public DropTypeStatement() {
   }
 
   @Override
@@ -105,7 +104,7 @@ public class DropTypeStatement extends DDLStatement {
 
   @Override
   public DropTypeStatement copy() {
-    final DropTypeStatement result = new DropTypeStatement(-1);
+    final DropTypeStatement result = new DropTypeStatement();
     result.name = name == null ? null : name.copy();
     result.nameParam = nameParam == null ? null : nameParam.copy();
     result.ifExists = ifExists;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/EqualsCompareOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/EqualsCompareOperator.java
@@ -26,8 +26,7 @@ import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 public class EqualsCompareOperator extends SimpleNode implements BinaryCompareOperator {
   boolean doubleEquals = false;
 
-  public EqualsCompareOperator(final int id) {
-    super(id);
+  public EqualsCompareOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
@@ -34,8 +34,7 @@ public class ExplainStatement extends Statement {
 
   public Statement statement;
 
-  public ExplainStatement(final int id) {
-    super(id);
+  public ExplainStatement() {
   }
 
   @Override
@@ -83,7 +82,7 @@ public class ExplainStatement extends Statement {
 
   @Override
   public ExplainStatement copy() {
-    final ExplainStatement result = new ExplainStatement(-1);
+    final ExplainStatement result = new ExplainStatement();
     result.statement = statement == null ? null : statement.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
@@ -45,8 +45,7 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
   protected       Expression                  value;
   public final    Map<Expression, Expression> settings  = new HashMap<>();
 
-  public ExportDatabaseStatement(final int id) {
-    super(id);
+  public ExportDatabaseStatement() {
   }
 
   @Override
@@ -132,7 +131,7 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
 
   @Override
   public Statement copy() {
-    final ExportDatabaseStatement result = new ExportDatabaseStatement(-1);
+    final ExportDatabaseStatement result = new ExportDatabaseStatement();
     result.url = this.url;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
@@ -43,8 +43,7 @@ public class Expression extends SimpleNode {
   public Boolean               booleanValue;
   public WhereClause           whereCondition;
 
-  public Expression(final int id) {
-    super(id);
+  public Expression() {
   }
 
   public Expression(final Identifier identifier) {
@@ -342,7 +341,7 @@ public class Expression extends SimpleNode {
 
   public Expression splitForAggregation(final AggregateProjectionSplit aggregateSplit, final CommandContext context) {
     if (isAggregate(context)) {
-      final Expression result = new Expression(-1);
+      final Expression result = new Expression();
       if (mathExpression != null) {
         final SimpleNode splitResult = mathExpression.splitForAggregation(aggregateSplit, context);
         if (splitResult instanceof MathExpression expression) {
@@ -383,7 +382,7 @@ public class Expression extends SimpleNode {
   }
 
   public Expression copy() {
-    final Expression result = new Expression(-1);
+    final Expression result = new Expression();
     result.singleQuotes = singleQuotes;
     result.doubleQuotes = doubleQuotes;
     result.isNull = isNull;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExpressionStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExpressionStatement.java
@@ -14,8 +14,7 @@ public class ExpressionStatement extends SimpleExecStatement {
 
   public Expression expression;
 
-  public ExpressionStatement(int id) {
-    super(id);
+  public ExpressionStatement() {
   }
 
   @Override
@@ -30,7 +29,7 @@ public class ExpressionStatement extends SimpleExecStatement {
 
   @Override
   public Statement copy() {
-    final ExpressionStatement result = new ExpressionStatement(-1);
+    final ExpressionStatement result = new ExpressionStatement();
     result.expression = expression.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FieldMatchPathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FieldMatchPathItem.java
@@ -33,8 +33,7 @@ public class FieldMatchPathItem extends MatchPathItem {
   public    Identifier       field;
   private   SuffixIdentifier exp;
 
-  public FieldMatchPathItem(final int id) {
-    super(id);
+  public FieldMatchPathItem() {
   }
 
   /**
@@ -98,7 +97,7 @@ public class FieldMatchPathItem extends MatchPathItem {
   public MatchPathItem copy() {
     FieldMatchPathItem result = null;
     try {
-      result = getClass().getConstructor(Integer.TYPE).newInstance(-1);
+      result = getClass().getConstructor().newInstance();
     } catch (final Exception e) {
       throw new ArcadeDBException(e);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FindReferencesStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FindReferencesStatement.java
@@ -64,8 +64,7 @@ public class FindReferencesStatement extends SimpleExecStatement {
   protected List<Identifier> classes = new ArrayList<>();
   protected List<Identifier> buckets = new ArrayList<>();
 
-  public FindReferencesStatement(final int id) {
-    super(id);
+  public FindReferencesStatement() {
   }
 
   @Override
@@ -276,7 +275,7 @@ public class FindReferencesStatement extends SimpleExecStatement {
 
   @Override
   public FindReferencesStatement copy() {
-    final FindReferencesStatement out = new FindReferencesStatement(-1);
+    final FindReferencesStatement out = new FindReferencesStatement();
     out.rid = rid == null ? null : rid.copy();
     out.subQuery = subQuery == null ? null : subQuery.copy();
     out.classes = new ArrayList<>(classes);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FirstLevelExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FirstLevelExpression.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class FirstLevelExpression extends MathExpression {
-  public FirstLevelExpression(final int id) {
-    super(id);
+  public FirstLevelExpression() {
   }
 
   //never used, this class is never returned by the parser!

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FloatingPoint.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FloatingPoint.java
@@ -27,8 +27,7 @@ public class FloatingPoint extends PNumber {
   protected String stringValue = null;
   Number finalValue = null;
 
-  public FloatingPoint(final int id) {
-    super(id);
+  public FloatingPoint() {
   }
 
   @Override
@@ -88,7 +87,7 @@ public class FloatingPoint extends PNumber {
 
   @Override
   public FloatingPoint copy() {
-    final FloatingPoint result = new FloatingPoint(-1);
+    final FloatingPoint result = new FloatingPoint();
     result.sign = sign;
     result.stringValue = stringValue;
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ForEachBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ForEachBlock.java
@@ -45,8 +45,7 @@ public class ForEachBlock extends Statement {
   public                 Expression      loopValues;
   public                 List<Statement> statements             = new ArrayList<>();
 
-  public ForEachBlock(final int id) {
-    super(id);
+  public ForEachBlock() {
   }
 
   @Override
@@ -91,7 +90,7 @@ public class ForEachBlock extends Statement {
 
   @Override
   public Statement copy() {
-    final ForEachBlock result = new ForEachBlock(-1);
+    final ForEachBlock result = new ForEachBlock();
     result.loopVariable = loopVariable.copy();
     result.loopValues = loopValues.copy();
     result.statements = statements.stream().map(x -> x.copy()).collect(Collectors.toList());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FromClause.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FromClause.java
@@ -25,8 +25,7 @@ import java.util.Map;
 public class FromClause extends SimpleNode {
   public FromItem item;
 
-  public FromClause(final int id) {
-    super(id);
+  public FromClause() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -44,7 +43,7 @@ public class FromClause extends SimpleNode {
   }
 
   public FromClause copy() {
-    final FromClause result = new FromClause(-1);
+    final FromClause result = new FromClause();
     result.item = item.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FromItem.java
@@ -44,8 +44,7 @@ public class FromItem extends SimpleNode {
   public Modifier             modifier;
   public Identifier           alias;
 
-  public FromItem(final int id) {
-    super(id);
+  public FromItem() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -173,7 +172,7 @@ public class FromItem extends SimpleNode {
   }
 
   public FromItem copy() {
-    final FromItem result = new FromItem(-1);
+    final FromItem result = new FromItem();
     if (rids != null) {
       result.rids = rids.stream().map(r -> r.copy()).collect(Collectors.toList());
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -42,8 +42,7 @@ public class FunctionCall extends SimpleNode {
   public List<Expression> params = new ArrayList<>();
   private   SQLFunction      cachedFunction;
 
-  public FunctionCall(final int id) {
-    super(id);
+  public FunctionCall() {
   }
 
   public boolean isStar() {
@@ -272,7 +271,7 @@ public class FunctionCall extends SimpleNode {
 
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final FunctionCall newFunct = new FunctionCall(-1);
+      final FunctionCall newFunct = new FunctionCall();
       newFunct.name = this.name;
       final Identifier functionResultAlias = aggregateProj.getNextAlias();
 
@@ -287,7 +286,7 @@ public class FunctionCall extends SimpleNode {
               throw new CommandExecutionException("Cannot calculate an aggregate function of another aggregate function " + this);
             }
             final Identifier nextAlias = aggregateProj.getNextAlias();
-            final ProjectionItem paramItem = new ProjectionItem(-1);
+            final ProjectionItem paramItem = new ProjectionItem();
             paramItem.alias = nextAlias;
             paramItem.expression = param;
             aggregateProj.getPreAggregate().add(paramItem);
@@ -318,15 +317,15 @@ public class FunctionCall extends SimpleNode {
   }
 
   private ProjectionItem createProjection(final FunctionCall newFunct, final Identifier alias) {
-    final LevelZeroIdentifier l0 = new LevelZeroIdentifier(-1);
+    final LevelZeroIdentifier l0 = new LevelZeroIdentifier();
     l0.functionCall = newFunct;
-    final BaseIdentifier l1 = new BaseIdentifier(-1);
+    final BaseIdentifier l1 = new BaseIdentifier();
     l1.levelZero = l0;
-    final BaseExpression l2 = new BaseExpression(-1);
+    final BaseExpression l2 = new BaseExpression();
     l2.identifier = l1;
-    final Expression l3 = new Expression(-1);
+    final Expression l3 = new Expression();
     l3.mathExpression = l2;
-    final ProjectionItem item = new ProjectionItem(-1);
+    final ProjectionItem item = new ProjectionItem();
     item.alias = alias;
     item.expression = l3;
     return item;
@@ -357,7 +356,7 @@ public class FunctionCall extends SimpleNode {
   }
 
   public FunctionCall copy() {
-    final FunctionCall result = new FunctionCall(-1);
+    final FunctionCall result = new FunctionCall();
     result.name = name;
     result.params = params.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
@@ -385,7 +384,7 @@ public class FunctionCall extends SimpleNode {
   }
 
   public MethodCall toMethod() {
-    final MethodCall result = new MethodCall(-1);
+    final MethodCall result = new MethodCall();
     result.methodName = name.copy();
     result.params = params.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
@@ -26,8 +26,7 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryComparator;
 
 public class GeOperator extends SimpleNode implements BinaryCompareOperator {
-  public GeOperator(final int id) {
-    super(id);
+  public GeOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GroupBy.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GroupBy.java
@@ -28,8 +28,7 @@ import java.util.stream.Collectors;
 public class GroupBy extends SimpleNode {
   public List<Expression> items = new ArrayList<Expression>();
 
-  public GroupBy(final int id) {
-    super(id);
+  public GroupBy() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -47,7 +46,7 @@ public class GroupBy extends SimpleNode {
   }
 
   public GroupBy copy() {
-    final GroupBy result = new GroupBy(-1);
+    final GroupBy result = new GroupBy();
     result.items = items.stream().map(Expression::copy).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
@@ -26,8 +26,7 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryComparator;
 
 public class GtOperator extends SimpleNode implements BinaryCompareOperator {
-  public GtOperator(final int id) {
-    super(id);
+  public GtOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
@@ -30,8 +30,7 @@ import java.util.Iterator;
 import java.util.Locale;
 
 public class ILikeOperator extends SimpleNode implements BinaryCompareOperator {
-  public ILikeOperator(final int id) {
-    super(id);
+  public ILikeOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Identifier.java
@@ -41,18 +41,15 @@ public class Identifier extends SimpleNode {
   protected boolean internalAlias = false;
 
   public Identifier(final Identifier copyFrom, final boolean quoted) {
-    this(-1);
     this.value = copyFrom.value;
     this.quoted = quoted;
   }
 
   public Identifier(final String content) {
-    this(-1);
     setStringValue(content);
   }
 
-  protected Identifier(final int id) {
-    super(id);
+  protected Identifier() {
   }
 
   /**
@@ -61,7 +58,7 @@ public class Identifier extends SimpleNode {
    * result on the following {@link #setQuotedStringValue(String)}.
    */
   public static Identifier quoted(final String spelling) {
-    final Identifier identifier = new Identifier(-1);
+    final Identifier identifier = new Identifier();
     identifier.setQuotedStringValue(spelling);
     return identifier;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IfNotExists.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IfNotExists.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class IfNotExists extends SimpleNode {
-  public IfNotExists(final int id) {
-    super(id);
+  public IfNotExists() {
   }
 }
 /* JavaCC - OriginalChecksum=5990db905ac7259f864fa5c62f123bcc (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IfStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IfStatement.java
@@ -41,8 +41,7 @@ public class IfStatement extends Statement {
   public List<Statement>   statements     = new ArrayList<Statement>();
   public List<Statement>   elseStatements = new ArrayList<Statement>();//TODO support ELSE in the SQL syntax
 
-  public IfStatement(final int id) {
-    super(id);
+  public IfStatement() {
   }
 
   @Override
@@ -158,7 +157,7 @@ public class IfStatement extends Statement {
 
   @Override
   public IfStatement copy() {
-    final IfStatement result = new IfStatement(-1);
+    final IfStatement result = new IfStatement();
     result.expression = expression == null ? null : expression.copy();
     result.statements = statements == null ? null : statements.stream().map(Statement::copy).collect(Collectors.toList());
     result.elseStatements =

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -44,8 +44,7 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
   protected       Expression                  value;
   public final    Map<Expression, Expression> settings = new HashMap<>();
 
-  public ImportDatabaseStatement(final int id) {
-    super(id);
+  public ImportDatabaseStatement() {
   }
 
   @Override
@@ -148,7 +147,7 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
 
   @Override
   public Statement copy() {
-    final ImportDatabaseStatement result = new ImportDatabaseStatement(-1);
+    final ImportDatabaseStatement result = new ImportDatabaseStatement();
     result.url = this.url;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -50,8 +50,7 @@ public class InCondition extends BooleanExpression {
       Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*");
   private final        Object inputFinalValue = UNSET;
 
-  public InCondition(final int id) {
-    super(id);
+  public InCondition() {
   }
 
   @Override
@@ -271,7 +270,7 @@ public class InCondition extends BooleanExpression {
 
   @Override
   public InCondition copy() {
-    final InCondition result = new InCondition(-1);
+    final InCondition result = new InCondition();
     result.operator = operator == null ? null : operator.copy();
     result.left = left == null ? null : left.copy();
     result.rightMathExpression = rightMathExpression == null ? null : rightMathExpression.copy();
@@ -416,12 +415,12 @@ public class InCondition extends BooleanExpression {
     }
 
     // Normal syntax: field IN [values]
-    Expression item = new Expression(-1);
+    Expression item = new Expression();
     if (getRightMathExpression() != null) {
       item.setMathExpression(getRightMathExpression());
       return item;
     } else if (getRightParam() != null) {
-      BaseExpression e = new BaseExpression(-1);
+      BaseExpression e = new BaseExpression();
       e.setInputParam(getRightParam().copy());
       item.setMathExpression(e);
       return item;
@@ -440,12 +439,12 @@ public class InCondition extends BooleanExpression {
     }
 
     // Normal syntax: field IN [values]
-    Expression item = new Expression(-1);
+    Expression item = new Expression();
     if (getRightMathExpression() != null) {
       item.setMathExpression(getRightMathExpression());
       return item;
     } else if (getRightParam() != null) {
-      BaseExpression e = new BaseExpression(-1);
+      BaseExpression e = new BaseExpression();
       e.setInputParam(getRightParam().copy());
       item.setMathExpression(e);
       return item;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InOperator.java
@@ -26,8 +26,7 @@ import java.util.Collection;
 import java.util.Iterator;
 
 public class InOperator extends SimpleNode implements BinaryCompareOperator {
-  public InOperator(final int id) {
-    super(id);
+  public InOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InPathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InPathItem.java
@@ -25,8 +25,7 @@ import com.arcadedb.query.sql.executor.Result;
 import java.util.Map;
 
 public class InPathItem extends MatchPathItem {
-  public InPathItem(final int id) {
-    super(id);
+  public InPathItem() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InPathItemOpt.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InPathItemOpt.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class InPathItemOpt extends InPathItem {
-  public InPathItemOpt(final int id) {
-    super(id);
+  public InPathItemOpt() {
   }
 }
 /* JavaCC - OriginalChecksum=ef282589054869578c47f554474b5c3b (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IndexIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IndexIdentifier.java
@@ -33,8 +33,7 @@ public class IndexIdentifier extends SimpleNode {
   public String     indexNameString;
   public Identifier indexName;
 
-  public IndexIdentifier(final int id) {
-    super(id);
+  public IndexIdentifier() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -72,7 +71,7 @@ public class IndexIdentifier extends SimpleNode {
   }
 
   public IndexIdentifier copy() {
-    final IndexIdentifier result = new IndexIdentifier(-1);
+    final IndexIdentifier result = new IndexIdentifier();
     result.type = type;
     result.indexNameString = indexNameString;
     result.indexName = indexName.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IndexMatchCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IndexMatchCondition.java
@@ -38,8 +38,7 @@ public class IndexMatchCondition extends BooleanExpression {
   protected List<Expression> leftExpressions;
   protected List<Expression> rightExpressions;
 
-  public IndexMatchCondition(final int id) {
-    super(id);
+  public IndexMatchCondition() {
   }
 
   @Override
@@ -91,7 +90,7 @@ public class IndexMatchCondition extends BooleanExpression {
 
   @Override
   public IndexMatchCondition copy() {
-    final IndexMatchCondition result = new IndexMatchCondition(-1);
+    final IndexMatchCondition result = new IndexMatchCondition();
     result.operator = operator == null ? null : operator.copy();
     result.between = between;
     result.leftExpressions = leftExpressions == null ? null : leftExpressions.stream().map(x -> x.copy()).collect(Collectors.toList());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InputParameter.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InputParameter.java
@@ -31,8 +31,7 @@ public class InputParameter extends SimpleNode {
 
   protected static final String dateFormatString = "yyyy-MM-dd HH:mm:ss.SSS";
 
-  public InputParameter(final int id) {
-    super(id);
+  public InputParameter() {
   }
 
   public Object bindFromInputParams(final Map<String, Object> params) {
@@ -45,36 +44,36 @@ public class InputParameter extends SimpleNode {
 
   protected Object toParsedTree(final Object value) {
     if (value == null) {
-      final Expression result = new Expression(-1);
+      final Expression result = new Expression();
       result.isNull = true;
       return result;
     }
     if (value instanceof Boolean boolean1) {
-      final Expression result = new Expression(-1);
+      final Expression result = new Expression();
       result.booleanValue = boolean1;
       return result;
     }
     if (value instanceof Integer integer) {
-      final PInteger result = new PInteger(-1);
+      final PInteger result = new PInteger();
       result.setValue(integer);
       return result;
     }
     if (value instanceof BigDecimal decimal) {
-      final Expression result = new Expression(-1);
-      final FunctionCall funct = new FunctionCall(-1);
-      result.mathExpression = new BaseExpression(-1);
-      ((BaseExpression) result.mathExpression).identifier = new BaseIdentifier(-1);
-      ((BaseExpression) result.mathExpression).identifier.levelZero = new LevelZeroIdentifier(-1);
+      final Expression result = new Expression();
+      final FunctionCall funct = new FunctionCall();
+      result.mathExpression = new BaseExpression();
+      ((BaseExpression) result.mathExpression).identifier = new BaseIdentifier();
+      ((BaseExpression) result.mathExpression).identifier.levelZero = new LevelZeroIdentifier();
       ((BaseExpression) result.mathExpression).identifier.levelZero.functionCall = funct;
       funct.name = new Identifier("decimal");
-      final Expression stringExp = new Expression(-1);
+      final Expression stringExp = new Expression();
       stringExp.mathExpression = new BaseExpression(decimal.toPlainString());
       funct.getParams().add(stringExp);
       return result;
     }
 
     if (value instanceof Number number) {
-      final FloatingPoint result = new FloatingPoint(-1);
+      final FloatingPoint result = new FloatingPoint();
       result.sign = number.doubleValue() >= 0 ? 1 : -1;
       result.stringValue = value.toString();
       if (result.stringValue.startsWith("-")) {
@@ -91,24 +90,24 @@ public class InputParameter extends SimpleNode {
       return value;
     }
     if (MultiValue.isMultiValue(value)) {
-      final PCollection coll = new PCollection(-1);
+      final PCollection coll = new PCollection();
       coll.expressions = new ArrayList<Expression>();
       final Iterator iterator = MultiValue.getMultiValueIterator(value);
       while (iterator.hasNext()) {
         final Object o = iterator.next();
-        final Expression exp = new Expression(-1);
+        final Expression exp = new Expression();
         exp.value = toParsedTree(o);
         coll.expressions.add(exp);
       }
       return coll;
     }
     if (value instanceof Map map) {
-      final Json json = new Json(-1);
+      final Json json = new Json();
       json.items = new ArrayList<JsonItem>();
       for (final Object entry : map.entrySet()) {
         final JsonItem item = new JsonItem();
         item.leftString = "" + ((Map.Entry) entry).getKey();
-        final Expression exp = new Expression(-1);
+        final Expression exp = new Expression();
         exp.value = toParsedTree(((Map.Entry) entry).getValue());
         item.right = exp;
         json.items.add(item);
@@ -117,30 +116,30 @@ public class InputParameter extends SimpleNode {
     }
     if (value instanceof Identifiable identifiable) {
       // TODO if invalid build a JSON
-      final Rid rid = new Rid(-1);
+      final Rid rid = new Rid();
       final String stringVal = identifiable.getIdentity().toString().substring(1);
       final String[] splitted = stringVal.split(":");
-      final PInteger c = new PInteger(-1);
+      final PInteger c = new PInteger();
       c.setValue(Integer.parseInt(splitted[0]));
       rid.bucket = c;
-      final PInteger p = new PInteger(-1);
+      final PInteger p = new PInteger();
       p.setValue(Integer.parseInt(splitted[1]));
       rid.position = p;
       rid.setLegacy(true);
       return rid;
     }
     if (value instanceof Date) {
-      final FunctionCall function = new FunctionCall(-1);
+      final FunctionCall function = new FunctionCall();
       function.name = new Identifier("date");
 
-      final Expression dateExpr = new Expression(-1);
+      final Expression dateExpr = new Expression();
       dateExpr.singleQuotes = true;
       dateExpr.doubleQuotes = false;
       final SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
       dateExpr.value = dateFormat.format(value);
       function.getParams().add(dateExpr);
 
-      final Expression dateFormatExpr = new Expression(-1);
+      final Expression dateFormatExpr = new Expression();
       dateFormatExpr.singleQuotes = true;
       dateFormatExpr.doubleQuotes = false;
       dateFormatExpr.value = dateFormatString;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InsertBody.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InsertBody.java
@@ -32,8 +32,7 @@ public class InsertBody extends SimpleNode {
   public JsonArray                 contentArray;
   public InputParameter            contentInputParam;
 
-  public InsertBody(final int id) {
-    super(id);
+  public InsertBody() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -96,7 +95,7 @@ public class InsertBody extends SimpleNode {
   }
 
   public InsertBody copy() {
-    final InsertBody result = new InsertBody(-1);
+    final InsertBody result = new InsertBody();
     result.identifierList = identifierList == null ? null : identifierList.stream().map(x -> x.copy()).collect(Collectors.toList());
     result.valueExpressions = valueExpressions == null ?
         null :

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InsertSetExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InsertSetExpression.java
@@ -31,10 +31,6 @@ public class InsertSetExpression {
   public InsertSetExpression() {
   }
 
-  public InsertSetExpression(final int id) {
-    // Constructor for compatibility with visitor pattern
-  }
-
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
     left.toString(params, builder);
     builder.append(" = ");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InsertStatement.java
@@ -46,8 +46,7 @@ public class InsertStatement extends Statement {
   public boolean         selectWithFrom      = false;
   public boolean         unsafe              = false;
 
-  public InsertStatement(final int id) {
-    super(id);
+  public InsertStatement() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -96,7 +95,7 @@ public class InsertStatement extends Statement {
 
   @Override
   public InsertStatement copy() {
-    final InsertStatement result = new InsertStatement(-1);
+    final InsertStatement result = new InsertStatement();
     result.targetType = targetType == null ? null : targetType.copy();
     result.targetBucketName = targetBucketName == null ? null : targetBucketName.copy();
     result.targetBucket = targetBucket == null ? null : targetBucket.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InstanceofCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InstanceofCondition.java
@@ -36,8 +36,7 @@ public class InstanceofCondition extends BooleanExpression {
   public Identifier right;
   public String     rightString;
 
-  public InstanceofCondition(final int id) {
-    super(id);
+  public InstanceofCondition() {
   }
 
   @Override
@@ -109,7 +108,7 @@ public class InstanceofCondition extends BooleanExpression {
 
   @Override
   public InstanceofCondition copy() {
-    final InstanceofCondition result = new InstanceofCondition(-1);
+    final InstanceofCondition result = new InstanceofCondition();
     result.left = left.copy();
     result.right = right == null ? null : right.copy();
     result.rightString = rightString;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IsDefinedCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IsDefinedCondition.java
@@ -30,8 +30,7 @@ import java.util.Map;
 public class IsDefinedCondition extends BooleanExpression implements SimpleBooleanExpression {
   public Expression expression;
 
-  public IsDefinedCondition(final int id) {
-    super(id);
+  public IsDefinedCondition() {
   }
 
   @Override
@@ -51,7 +50,7 @@ public class IsDefinedCondition extends BooleanExpression implements SimpleBoole
 
   @Override
   public IsDefinedCondition copy() {
-    final IsDefinedCondition result = new IsDefinedCondition(-1);
+    final IsDefinedCondition result = new IsDefinedCondition();
     result.expression = expression.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IsNotDefinedCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IsNotDefinedCondition.java
@@ -30,8 +30,7 @@ import java.util.Map;
 public class IsNotDefinedCondition extends BooleanExpression {
   public Expression expression;
 
-  public IsNotDefinedCondition(final int id) {
-    super(id);
+  public IsNotDefinedCondition() {
   }
 
   @Override
@@ -46,7 +45,7 @@ public class IsNotDefinedCondition extends BooleanExpression {
 
   @Override
   public IsNotDefinedCondition copy() {
-    final IsNotDefinedCondition result = new IsNotDefinedCondition(-1);
+    final IsNotDefinedCondition result = new IsNotDefinedCondition();
     result.expression = expression.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IsNotNullCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IsNotNullCondition.java
@@ -30,8 +30,7 @@ import java.util.Map;
 public class IsNotNullCondition extends BooleanExpression {
   public Expression expression;
 
-  public IsNotNullCondition(final int id) {
-    super(id);
+  public IsNotNullCondition() {
   }
 
   @Override
@@ -51,7 +50,7 @@ public class IsNotNullCondition extends BooleanExpression {
 
   @Override
   public BooleanExpression copy() {
-    final IsNotNullCondition result = new IsNotNullCondition(-1);
+    final IsNotNullCondition result = new IsNotNullCondition();
     result.expression = expression.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/IsNullCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/IsNullCondition.java
@@ -32,8 +32,7 @@ public class IsNullCondition extends BooleanExpression {
 
   public Expression expression;
 
-  public IsNullCondition(final int id) {
-    super(id);
+  public IsNullCondition() {
   }
 
   @Override
@@ -61,7 +60,7 @@ public class IsNullCondition extends BooleanExpression {
 
   @Override
   public IsNullCondition copy() {
-    final IsNullCondition result = new IsNullCondition(-1);
+    final IsNullCondition result = new IsNullCondition();
     result.expression = expression.copy();
     return result;
   }
@@ -98,14 +97,14 @@ public class IsNullCondition extends BooleanExpression {
 
   @Override
   public Expression resolveKeyFrom(final BinaryCondition additional) {
-    final Expression exp = new Expression(-1);
+    final Expression exp = new Expression();
     exp.setNull(true);
     return exp;
   }
 
   @Override
   public Expression resolveKeyTo(final BinaryCondition additional) {
-    Expression exp = new Expression(-1);
+    Expression exp = new Expression();
     exp.setNull(true);
     return exp;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Json.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Json.java
@@ -34,8 +34,7 @@ public class Json extends SimpleNode {
 
   public List<JsonItem> items = new ArrayList<>();
 
-  public Json(final int id) {
-    super(id);
+  public Json() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -133,7 +132,7 @@ public class Json extends SimpleNode {
 
   public Json splitForAggregation(final AggregateProjectionSplit aggregateSplit, final CommandContext context) {
     if (isAggregate(context)) {
-      final Json result = new Json(-1);
+      final Json result = new Json();
       for (final JsonItem item : items) {
         result.items.add(item.splitForAggregation(aggregateSplit, context));
       }
@@ -144,7 +143,7 @@ public class Json extends SimpleNode {
   }
 
   public Json copy() {
-    final Json result = new Json(-1);
+    final Json result = new Json();
     result.items = items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/JsonArray.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/JsonArray.java
@@ -10,8 +10,7 @@ import java.util.stream.Collectors;
 public class JsonArray extends SimpleNode {
   public List<Json> items = new ArrayList<>();
 
-  public JsonArray(int id) {
-    super(id);
+  public JsonArray() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -29,7 +28,7 @@ public class JsonArray extends SimpleNode {
   }
 
   public JsonArray copy() {
-    final JsonArray result = new JsonArray(-1);
+    final JsonArray result = new JsonArray();
     result.items = items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
@@ -25,8 +25,7 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryComparator;
 
 public class LeOperator extends SimpleNode implements BinaryCompareOperator {
-  public LeOperator(final int id) {
-    super(id);
+  public LeOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LetClause.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LetClause.java
@@ -29,8 +29,7 @@ public class LetClause extends SimpleNode {
 
   public List<LetItem> items = new ArrayList<LetItem>();
 
-  public LetClause(final int id) {
-    super(id);
+  public LetClause() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -50,7 +49,7 @@ public class LetClause extends SimpleNode {
   }
 
   public LetClause copy() {
-    final LetClause result = new LetClause(-1);
+    final LetClause result = new LetClause();
     result.items = items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LetItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LetItem.java
@@ -27,8 +27,7 @@ public class LetItem extends SimpleNode {
   Expression expression;
   Statement  query;
 
-  public LetItem(final int id) {
-    super(id);
+  public LetItem() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -44,7 +43,7 @@ public class LetItem extends SimpleNode {
   }
 
   public LetItem copy() {
-    final LetItem result = new LetItem(-1);
+    final LetItem result = new LetItem();
     result.varName = varName.copy();
     result.expression = expression == null ? null : expression.copy();
     result.query = query == null ? null : query.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LetStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LetStatement.java
@@ -36,8 +36,7 @@ public class LetStatement extends SimpleExecStatement {
   public Statement  statement;
   public Expression expression;
 
-  public LetStatement(final int id) {
-    super(id);
+  public LetStatement() {
   }
 
   @Override
@@ -83,7 +82,7 @@ public class LetStatement extends SimpleExecStatement {
 
   @Override
   public LetStatement copy() {
-    final LetStatement result = new LetStatement(-1);
+    final LetStatement result = new LetStatement();
     result.variableName = variableName == null ? null : variableName.copy();
     result.statement = statement == null ? null : statement.copy();
     result.expression = expression == null ? null : expression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
@@ -34,8 +34,7 @@ public class LevelZeroIdentifier extends SimpleNode {
   protected Boolean      self;
   protected PCollection  collection;
 
-  public LevelZeroIdentifier(final int id) {
-    super(id);
+  public LevelZeroIdentifier() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -194,7 +193,7 @@ public class LevelZeroIdentifier extends SimpleNode {
 
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final LevelZeroIdentifier result = new LevelZeroIdentifier(-1);
+      final LevelZeroIdentifier result = new LevelZeroIdentifier();
       if (functionCall != null) {
         final SimpleNode node = functionCall.splitForAggregation(aggregateProj, context);
         if (node instanceof FunctionCall call) {
@@ -224,7 +223,7 @@ public class LevelZeroIdentifier extends SimpleNode {
   }
 
   public LevelZeroIdentifier copy() {
-    final LevelZeroIdentifier result = new LevelZeroIdentifier(-1);
+    final LevelZeroIdentifier result = new LevelZeroIdentifier();
     result.functionCall = functionCall == null ? null : functionCall.copy();
     result.self = self;
     result.collection = collection == null ? null : collection.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LikeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LikeOperator.java
@@ -29,8 +29,7 @@ import com.arcadedb.utility.TimeBoundRegex;
 import java.util.Iterator;
 
 public class LikeOperator extends SimpleNode implements BinaryCompareOperator {
-  public LikeOperator(final int id) {
-    super(id);
+  public LikeOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
@@ -33,8 +33,7 @@ public class Limit extends SimpleNode {
   public InputParameter inputParam;
   public Expression     expression;
 
-  public Limit(final int id) {
-    super(id);
+  public Limit() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -81,12 +80,12 @@ public class Limit extends SimpleNode {
   }
 
   public Limit setValue(final int value) {
-    num = new PInteger(-1).setValue(value);
+    num = new PInteger().setValue(value);
     return this;
   }
 
   public Limit copy() {
-    final Limit result = new Limit(-1);
+    final Limit result = new Limit();
     result.num = num == null ? null : num.copy();
     result.inputParam = inputParam == null ? null : inputParam.copy();
     result.expression = expression == null ? null : expression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LockStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LockStatement.java
@@ -17,8 +17,7 @@ public class LockStatement extends SimpleExecStatement {
   public String           mode;
   public List<Identifier> identifiers;
 
-  public LockStatement(final int id) {
-    super(id);
+  public LockStatement() {
   }
 
   @Override
@@ -61,7 +60,7 @@ public class LockStatement extends SimpleExecStatement {
 
   @Override
   public LockStatement copy() {
-    final LockStatement result = new LockStatement(-1);
+    final LockStatement result = new LockStatement();
     result.mode = mode;
     result.identifiers = identifiers == null ? null : new ArrayList<>(identifiers);
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
@@ -25,8 +25,7 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryComparator;
 
 public class LtOperator extends SimpleNode implements BinaryCompareOperator {
-  public LtOperator(final int id) {
-    super(id);
+  public LtOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchExpression.java
@@ -27,8 +27,7 @@ public class MatchExpression extends SimpleNode {
   protected MatchFilter         origin;
   protected List<MatchPathItem> items = new ArrayList<MatchPathItem>();
 
-  public MatchExpression(final int id) {
-    super(id);
+  public MatchExpression() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -40,7 +39,7 @@ public class MatchExpression extends SimpleNode {
 
   @Override
   public MatchExpression copy() {
-    final MatchExpression result = new MatchExpression(-1);
+    final MatchExpression result = new MatchExpression();
     result.origin = origin == null ? null : origin.copy();
     result.items = items == null ? null : items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchFilter.java
@@ -29,8 +29,7 @@ public class MatchFilter extends SimpleNode {
   // TODO transform in a map
   public List<MatchFilterItem> items = new ArrayList<MatchFilterItem>();
 
-  public MatchFilter(final int id) {
-    super(id);
+  public MatchFilter() {
   }
 
   public String getAlias() {
@@ -52,7 +51,7 @@ public class MatchFilter extends SimpleNode {
       }
     }
     if (!found) {
-      final MatchFilterItem newItem = new MatchFilterItem(-1);
+      final MatchFilterItem newItem = new MatchFilterItem();
       newItem.alias = new Identifier(alias);
       items.add(newItem);
     }
@@ -77,7 +76,7 @@ public class MatchFilter extends SimpleNode {
       }
     }
     if (!found) {
-      final MatchFilterItem newItem = new MatchFilterItem(-1);
+      final MatchFilterItem newItem = new MatchFilterItem();
       newItem.filter = filter;
       items.add(newItem);
     }
@@ -186,7 +185,7 @@ public class MatchFilter extends SimpleNode {
 
   @Override
   public MatchFilter copy() {
-    final MatchFilter result = new MatchFilter(-1);
+    final MatchFilter result = new MatchFilter();
     result.items = items == null ? null : items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchFilterItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchFilterItem.java
@@ -39,8 +39,7 @@ public class MatchFilterItem extends SimpleNode {
   public Identifier         depthAlias;
   public Identifier         pathAlias;
 
-  public MatchFilterItem(final int id) {
-    super(id);
+  public MatchFilterItem() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -117,7 +116,7 @@ public class MatchFilterItem extends SimpleNode {
 
   @Override
   public MatchFilterItem copy() {
-    final MatchFilterItem result = new MatchFilterItem(-1);
+    final MatchFilterItem result = new MatchFilterItem();
     result.typeName = typeName == null ? null : typeName.copy();
     result.typeNames = typeNames == null ? null : typeNames.copy();
     result.bucketName = bucketName == null ? null : bucketName.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchPathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchPathItem.java
@@ -33,8 +33,7 @@ public class MatchPathItem extends SimpleNode {
   protected MethodCall  method;
   protected MatchFilter filter;
 
-  public MatchPathItem(final int id) {
-    super(id);
+  public MatchPathItem() {
   }
 
   public boolean isBidirectional() {
@@ -177,7 +176,7 @@ public class MatchPathItem extends SimpleNode {
   public MatchPathItem copy() {
     final MatchPathItem result;
     try {
-      result = getClass().getConstructor(Integer.TYPE).newInstance(-1);
+      result = getClass().getConstructor().newInstance();
     } catch (final Exception e) {
       throw new ArcadeDBException(e);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchPathItemFirst.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchPathItemFirst.java
@@ -33,8 +33,7 @@ public class MatchPathItemFirst extends MatchPathItem {
   protected          FunctionCall function;
   protected volatile MethodCall   methodWrapper;
 
-  public MatchPathItemFirst(final int id) {
-    super(id);
+  public MatchPathItemFirst() {
   }
 
   public boolean isBidirectional() {
@@ -89,7 +88,7 @@ public class MatchPathItemFirst extends MatchPathItem {
     if (methodWrapper == null) {
       synchronized (this) {
         if (methodWrapper == null) {
-          final MethodCall m = new MethodCall(-1);
+          final MethodCall m = new MethodCall();
           m.params = function.params;
           m.methodName = function.name;
           methodWrapper = m;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchStatement.java
@@ -107,11 +107,6 @@ public class MatchStatement extends Statement {
   }
 
   public MatchStatement() {
-    super(-1);
-  }
-
-  public MatchStatement(final int id) {
-    super(id);
   }
 
   @Override
@@ -201,7 +196,7 @@ public class MatchStatement extends Statement {
 
       for (final MatchPathItem item : expression.items) {
         if (item.filter == null) {
-          item.filter = new MatchFilter(-1);
+          item.filter = new MatchFilter();
         }
         if (item.filter.getAlias() == null) {
           item.filter.setAlias(DEFAULT_ALIAS_PREFIX + (counter++));
@@ -267,8 +262,8 @@ public class MatchStatement extends Statement {
       if (filter != null && filter.baseExpression != null) {
         WhereClause previousFilter = aliasFilters.get(alias);
         if (previousFilter == null) {
-          previousFilter = new WhereClause(-1);
-          previousFilter.baseExpression = new AndBlock(-1);
+          previousFilter = new WhereClause();
+          previousFilter.baseExpression = new AndBlock();
           aliasFilters.put(alias, previousFilter);
         }
         final AndBlock filterBlock = (AndBlock) previousFilter.baseExpression;
@@ -374,7 +369,7 @@ public class MatchStatement extends Statement {
 
   @Override
   public MatchStatement copy() {
-    final MatchStatement result = new MatchStatement(-1);
+    final MatchStatement result = new MatchStatement();
     result.database = database;
     result.matchExpressions =
         matchExpressions == null ? null : matchExpressions.stream().map(x -> x.copy()).collect(Collectors.toList());
@@ -526,11 +521,11 @@ public class MatchStatement extends Statement {
   private void setProfilingConstraints(final DatabaseInternal db) {
     final long profiledLimit = db.getResultSetLimit();
     if (profiledLimit > -1 && (limit == null || limit.num.value.longValue() > profiledLimit))
-      setLimit(new Limit(-1).setValue((int) profiledLimit));
+      setLimit(new Limit().setValue((int) profiledLimit));
 
     final long profiledTimeout = db.getReadTimeout();
     if (profiledTimeout > -1 && (timeout == null || timeout.val.longValue() > profiledTimeout))
-      setTimeout(new Timeout(-1).setValue((int) profiledTimeout));
+      setTimeout(new Timeout().setValue((int) profiledTimeout));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchesCondition.java
@@ -38,8 +38,7 @@ public class MatchesCondition extends BooleanExpression {
   public    Expression     rightExpression;
   protected InputParameter rightParam;
 
-  public MatchesCondition(final int id) {
-    super(id);
+  public MatchesCondition() {
   }
 
   @Override
@@ -150,7 +149,7 @@ public class MatchesCondition extends BooleanExpression {
 
   @Override
   public MatchesCondition copy() {
-    final MatchesCondition result = new MatchesCondition(-1);
+    final MatchesCondition result = new MatchesCondition();
     result.expression = expression == null ? null : expression.copy();
     result.right = right;
     result.rightParam = rightParam == null ? null : rightParam.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -769,8 +769,7 @@ public class MathExpression extends SimpleNode {
     }
   }
 
-  public MathExpression(final int id) {
-    super(id);
+  public MathExpression() {
   }
 
   @Override
@@ -1114,7 +1113,7 @@ public class MathExpression extends SimpleNode {
 
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final MathExpression result = new MathExpression(-1);
+      final MathExpression result = new MathExpression();
       int i = 0;
       for (final MathExpression expr : this.childExpressions) {
         if (i > 0)
@@ -1144,7 +1143,7 @@ public class MathExpression extends SimpleNode {
   public MathExpression copy() {
     MathExpression result = null;
     try {
-      result = getClass().getConstructor(Integer.TYPE).newInstance(-1);
+      result = getClass().getConstructor().newInstance();
     } catch (final Exception e) {
       throw new ArcadeDBException(e);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
@@ -50,8 +50,7 @@ public class MethodCall extends SimpleNode {
 
   private Boolean calculatedIsGraph = null;
 
-  public MethodCall(final int id) {
-    super(id);
+  public MethodCall() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -167,7 +166,7 @@ public class MethodCall extends SimpleNode {
   }
 
   public MethodCall copy() {
-    final MethodCall result = new MethodCall(-1);
+    final MethodCall result = new MethodCall();
     result.methodName = methodName.copy();
     result.params = params.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Modifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Modifier.java
@@ -41,8 +41,7 @@ public class Modifier extends SimpleNode {
   public NestedProjection          nestedProjection;
   public Modifier                  next;
 
-  public Modifier(final int id) {
-    super(id);
+  public Modifier() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -145,7 +144,7 @@ public class Modifier extends SimpleNode {
   }
 
   public Modifier copy() {
-    final Modifier result = new Modifier(-1);
+    final Modifier result = new Modifier();
     result.squareBrackets = squareBrackets;
     result.arrayRange = arrayRange == null ? null : arrayRange.copy();
     result.condition = condition == null ? null : condition.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MoveVertexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MoveVertexStatement.java
@@ -22,8 +22,7 @@ public class MoveVertexStatement extends Statement {
   public UpdateOperations updateOperations;
   public Batch            batch;
 
-  public MoveVertexStatement(int id) {
-    super(id);
+  public MoveVertexStatement() {
   }
 
   @Override
@@ -100,7 +99,7 @@ public class MoveVertexStatement extends Statement {
 
   @Override
   public MoveVertexStatement copy() {
-    MoveVertexStatement result = new MoveVertexStatement(-1);
+    MoveVertexStatement result = new MoveVertexStatement();
     result.source = source.copy();
     result.targetType = targetType == null ? null : targetType.copy();
     result.targetBucket = targetBucket == null ? null : targetBucket.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MultiMatchPathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MultiMatchPathItem.java
@@ -32,8 +32,7 @@ public class MultiMatchPathItem extends MatchPathItem {
   // Flag to indicate if this is from .(nested) syntax (true) or chained function calls (false)
   protected boolean isNestedPath = false;
 
-  public MultiMatchPathItem(final int id) {
-    super(id);
+  public MultiMatchPathItem() {
   }
 
   public void validate() throws CommandParsingException {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MultiMatchPathItemArrows.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MultiMatchPathItemArrows.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class MultiMatchPathItemArrows extends MultiMatchPathItem {
-  public MultiMatchPathItemArrows(final int id) {
-    super(id);
+  public MultiMatchPathItemArrows() {
   }
 }
 /* JavaCC - OriginalChecksum=75506ca75aab9f66ab24c9f1b1cfe3ac (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NamedParameter.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NamedParameter.java
@@ -28,8 +28,7 @@ public class NamedParameter extends InputParameter {
   public int    paramNumber;
   public String paramName;
 
-  public NamedParameter(final int id) {
-    super(id);
+  public NamedParameter() {
   }
 
   @Override
@@ -80,7 +79,7 @@ public class NamedParameter extends InputParameter {
 
   @Override
   public NamedParameter copy() {
-    final NamedParameter result = new NamedParameter(-1);
+    final NamedParameter result = new NamedParameter();
     result.paramName = paramName;
     result.paramNumber = paramNumber;
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NeOperator.java
@@ -24,8 +24,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 
 public class NeOperator extends SimpleNode implements BinaryCompareOperator {
-  public NeOperator(final int id) {
-    super(id);
+  public NeOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NearOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NearOperator.java
@@ -23,8 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.DatabaseInternal;
 
 public class NearOperator extends SimpleNode implements BinaryCompareOperator {
-  public NearOperator(final int id) {
-    super(id);
+  public NearOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NeqOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NeqOperator.java
@@ -24,8 +24,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 
 public class NeqOperator extends SimpleNode implements BinaryCompareOperator {
-  public NeqOperator(final int id) {
-    super(id);
+  public NeqOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NestedProjection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NestedProjection.java
@@ -39,8 +39,7 @@ public class NestedProjection extends SimpleNode {
   public NestedProjectionItem       starItem;
   private   PInteger                   recursion; //not used for now
 
-  public NestedProjection(final int id) {
-    super(id);
+  public NestedProjection() {
   }
 
   /**
@@ -212,7 +211,7 @@ public class NestedProjection extends SimpleNode {
   }
 
   public NestedProjection copy() {
-    final NestedProjection result = new NestedProjection(-1);
+    final NestedProjection result = new NestedProjection();
     result.includeItems = includeItems.stream().map(NestedProjectionItem::copy).toList();
     result.excludeItems = excludeItems.stream().map(NestedProjectionItem::copy).toList();
     result.starItem = starItem == null ? null : starItem.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NestedProjectionItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NestedProjectionItem.java
@@ -33,13 +33,12 @@ public class NestedProjectionItem extends SimpleNode {
   public NestedProjection expansion;
   public Identifier       alias;
 
-  public NestedProjectionItem(final int id) {
-    super(id);
+  public NestedProjectionItem() {
   }
 
   @Override
   public NestedProjectionItem copy() {
-    final NestedProjectionItem result = new NestedProjectionItem(-1);
+    final NestedProjectionItem result = new NestedProjectionItem();
     result.exclude = exclude;
     result.star = star;
     result.expression = expression == null ? null : expression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NotBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NotBlock.java
@@ -33,8 +33,7 @@ public class NotBlock extends BooleanExpression {
 
   public boolean negate = false;
 
-  public NotBlock(final int id) {
-    super(id);
+  public NotBlock() {
   }
 
   @Override
@@ -109,7 +108,7 @@ public class NotBlock extends BooleanExpression {
 
   @Override
   public NotBlock copy() {
-    final NotBlock result = new NotBlock(-1);
+    final NotBlock result = new NotBlock();
     result.sub = sub != null ? sub.copy() : null;
     result.negate = negate;
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NotInCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NotInCondition.java
@@ -41,8 +41,7 @@ public class NotInCondition extends BooleanExpression {
   private static final Object UNSET           = new Object();
   private final        Object inputFinalValue = UNSET;
 
-  public NotInCondition(final int id) {
-    super(id);
+  public NotInCondition() {
   }
 
   @Override
@@ -105,7 +104,7 @@ public class NotInCondition extends BooleanExpression {
 
   @Override
   public NotInCondition copy() {
-    final NotInCondition result = new NotInCondition(-1);
+    final NotInCondition result = new NotInCondition();
     result.operator = operator == null ? null : operator.copy();
     result.left = left == null ? null : left.copy();
     result.rightMathExpression = rightMathExpression == null ? null : rightMathExpression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NullSafeEqualsCompareOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NullSafeEqualsCompareOperator.java
@@ -27,8 +27,7 @@ import com.arcadedb.query.sql.executor.QueryOperatorEquals;
 import java.util.Iterator;
 
 public class NullSafeEqualsCompareOperator extends SimpleNode implements BinaryCompareOperator {
-  public NullSafeEqualsCompareOperator(final int id) {
-    super(id);
+  public NullSafeEqualsCompareOperator() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
@@ -34,8 +34,7 @@ import java.util.stream.Collectors;
 public class OrBlock extends BooleanExpression {
   public List<BooleanExpression> subBlocks = new ArrayList<BooleanExpression>();
 
-  public OrBlock(final int id) {
-    super(id);
+  public OrBlock() {
   }
 
   @Override
@@ -144,7 +143,7 @@ public class OrBlock extends BooleanExpression {
 
   @Override
   public OrBlock copy() {
-    final OrBlock result = new OrBlock(-1);
+    final OrBlock result = new OrBlock();
     result.subBlocks = subBlocks.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OrderBy.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OrderBy.java
@@ -31,11 +31,6 @@ public class OrderBy extends SimpleNode {
   protected List<OrderByItem> items;
 
   public OrderBy() {
-    super(-1);
-  }
-
-  public OrderBy(final int id) {
-    super(id);
   }
 
   public List<OrderByItem> getItems() {
@@ -69,7 +64,7 @@ public class OrderBy extends SimpleNode {
   }
 
   public OrderBy copy() {
-    final OrderBy result = new OrderBy(-1);
+    final OrderBy result = new OrderBy();
     result.items = items == null ? null : items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OutPathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OutPathItem.java
@@ -25,8 +25,7 @@ import com.arcadedb.query.sql.executor.Result;
 import java.util.Map;
 
 public class OutPathItem extends MatchPathItem {
-  public OutPathItem(final int id) {
-    super(id);
+  public OutPathItem() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OutPathItemOpt.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OutPathItemOpt.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class OutPathItemOpt extends OutPathItem {
-  public OutPathItemOpt(final int id) {
-    super(id);
+  public OutPathItemOpt() {
   }
 }
 /* JavaCC - OriginalChecksum=03ffaa23b3d039235588ad2fb032c273 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/PCollection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/PCollection.java
@@ -33,8 +33,7 @@ import java.util.stream.Collectors;
 public class PCollection extends SimpleNode {
   protected List<Expression> expressions = new ArrayList<>();
 
-  public PCollection(final int id) {
-    super(id);
+  public PCollection() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -81,7 +80,7 @@ public class PCollection extends SimpleNode {
 
   public PCollection splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final PCollection result = new PCollection(-1);
+      final PCollection result = new PCollection();
       for (final Expression exp : this.expressions) {
         if (exp.isAggregate(context) || exp.isEarlyCalculated(context)) {
           result.expressions.add(exp.splitForAggregation(aggregateProj, context));
@@ -105,7 +104,7 @@ public class PCollection extends SimpleNode {
   }
 
   public PCollection copy() {
-    final PCollection result = new PCollection(-1);
+    final PCollection result = new PCollection();
     result.expressions = expressions == null ? null : expressions.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/PInteger.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/PInteger.java
@@ -26,8 +26,7 @@ public class PInteger extends PNumber {
 
   public Number value;
 
-  public PInteger(final int id) {
-    super(id);
+  public PInteger() {
   }
 
   public Number getValue() {
@@ -84,7 +83,7 @@ public class PInteger extends PNumber {
   }
 
   public PInteger copy() {
-    final PInteger result = new PInteger(-1);
+    final PInteger result = new PInteger();
     result.value = value;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/PNumber.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/PNumber.java
@@ -23,8 +23,7 @@ package com.arcadedb.query.sql.parser;
 import java.util.Map;
 
 public class PNumber extends SimpleNode {
-  public PNumber(final int id) {
-    super(id);
+  public PNumber() {
   }
 
   public Number getValue() {
@@ -36,7 +35,7 @@ public class PNumber extends SimpleNode {
   }
 
   public PNumber copy() {
-    final PNumber result = new PNumber(-1);
+    final PNumber result = new PNumber();
     result.value = value;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/PString.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/PString.java
@@ -21,12 +21,11 @@
 package com.arcadedb.query.sql.parser;
 
 public class PString extends SimpleNode {
-  public PString(final int id) {
-    super(id);
+  public PString() {
   }
 
   public PString copy() {
-    final PString result = new PString(-1);
+    final PString result = new PString();
     result.value = value;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisBlock.java
@@ -30,8 +30,7 @@ import java.util.Map;
 public class ParenthesisBlock extends BooleanExpression {
   BooleanExpression subElement;
 
-  public ParenthesisBlock(final int id) {
-    super(id);
+  public ParenthesisBlock() {
   }
 
   @Override
@@ -57,7 +56,7 @@ public class ParenthesisBlock extends BooleanExpression {
 
   @Override
   public ParenthesisBlock copy() {
-    final ParenthesisBlock result = new ParenthesisBlock(-1);
+    final ParenthesisBlock result = new ParenthesisBlock();
     result.subElement = subElement.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisExpression.java
@@ -39,12 +39,10 @@ public class ParenthesisExpression extends MathExpression {
   protected Statement             statement;
   private   InternalExecutionPlan executionPlan;
 
-  public ParenthesisExpression(final int id) {
-    super(id);
+  public ParenthesisExpression() {
   }
 
   public ParenthesisExpression(final Expression exp) {
-    super(-1);
     this.expression = exp;
   }
 
@@ -140,7 +138,7 @@ public class ParenthesisExpression extends MathExpression {
 
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
-      final ParenthesisExpression result = new ParenthesisExpression(-1);
+      final ParenthesisExpression result = new ParenthesisExpression();
       result.expression = expression.splitForAggregation(aggregateProj, context);
       return result;
     } else {
@@ -150,7 +148,7 @@ public class ParenthesisExpression extends MathExpression {
 
   @Override
   public ParenthesisExpression copy() {
-    final ParenthesisExpression result = new ParenthesisExpression(-1);
+    final ParenthesisExpression result = new ParenthesisExpression();
     result.expression = expression == null ? null : expression.copy();
     result.statement = statement == null ? null : statement.copy();
     result.cachedStringForm = cachedStringForm;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Parse.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Parse.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class Parse extends SimpleNode {
-  public Parse(final int id) {
-    super(id);
+  public Parse() {
   }
 }
 /* JavaCC - OriginalChecksum=d5bdbb7024b5ee7edd4f794c6b8860d0 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParseCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParseCondition.java
@@ -3,8 +3,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class ParseCondition extends SimpleNode {
-  public ParseCondition(int id) {
-    super(id);
+  public ParseCondition() {
   }
 }
 /* JavaCC - OriginalChecksum=d64078cc644dc1fcfdb94e69af064395 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParseExpression.java
@@ -3,8 +3,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class ParseExpression extends SimpleNode {
-  public ParseExpression(int id) {
-    super(id);
+  public ParseExpression() {
   }
 }
 /* JavaCC - OriginalChecksum=05ab3488725894e5e4e7400a75f98dfa (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParseScript.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParseScript.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class ParseScript extends SimpleNode {
-  public ParseScript(final int id) {
-    super(id);
+  public ParseScript() {
   }
 }
 /* JavaCC - OriginalChecksum=c4b5a47c139799464ac46d2f482dc3ac (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/PositionalParameter.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/PositionalParameter.java
@@ -26,8 +26,7 @@ public class PositionalParameter extends InputParameter {
 
   public int paramNumber;
 
-  public PositionalParameter(final int id) {
-    super(id);
+  public PositionalParameter() {
   }
 
   @Override
@@ -69,7 +68,7 @@ public class PositionalParameter extends InputParameter {
 
   @Override
   public PositionalParameter copy() {
-    final PositionalParameter result = new PositionalParameter(-1);
+    final PositionalParameter result = new PositionalParameter();
     result.paramNumber = paramNumber;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ProfileStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ProfileStatement.java
@@ -36,8 +36,7 @@ public class ProfileStatement extends Statement {
 
   public Statement statement;
 
-  public ProfileStatement(final int id) {
-    super(id);
+  public ProfileStatement() {
   }
 
   @Override
@@ -100,7 +99,7 @@ public class ProfileStatement extends Statement {
 
   @Override
   public ProfileStatement copy() {
-    final ProfileStatement result = new ProfileStatement(-1);
+    final ProfileStatement result = new ProfileStatement();
     result.statement = statement == null ? null : statement.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
@@ -46,14 +46,12 @@ public class Projection extends SimpleNode {
   private Set<String> excludes;
 
   public Projection(final List<ProjectionItem> items, final boolean distinct) {
-    super(-1);
     this.items = items;
     this.distinct = distinct;
     //TODO make the whole class immutable!
   }
 
-  public Projection(final int id) {
-    super(id);
+  public Projection() {
   }
 
   public List<ProjectionItem> getItems() {
@@ -184,7 +182,7 @@ public class Projection extends SimpleNode {
   }
 
   public Projection getExpandContent() {
-    final Projection result = new Projection(-1);
+    final Projection result = new Projection();
     result.setItems(new ArrayList<>());
     result.getItems().add(this.getItems().getFirst().getExpandContent());
     return result;
@@ -195,7 +193,7 @@ public class Projection extends SimpleNode {
   }
 
   public Projection copy() {
-    final Projection result = new Projection(-1);
+    final Projection result = new Projection();
     if (items != null)
       result.items = items.stream().map(ProjectionItem::copy).collect(Collectors.toList());
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ProjectionItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ProjectionItem.java
@@ -41,14 +41,12 @@ public class ProjectionItem extends SimpleNode {
   public NestedProjection nestedProjection;
 
   public ProjectionItem(final Expression expression, final Identifier alias, final NestedProjection nestedProjection) {
-    super(-1);
     this.expression = expression;
     this.alias = alias;
     this.nestedProjection = nestedProjection;
   }
 
-  public ProjectionItem(final int id) {
-    super(id);
+  public ProjectionItem() {
   }
 
   public boolean isAll() {
@@ -166,7 +164,7 @@ public class ProjectionItem extends SimpleNode {
   }
 
   public ProjectionItem getExpandContent() {
-    final ProjectionItem result = new ProjectionItem(-1);
+    final ProjectionItem result = new ProjectionItem();
     result.setExpression(expression.getExpandContent());
     // Ad-hoc support for issue #2965: preserve nested projection when expanding
     result.nestedProjection = this.nestedProjection;
@@ -196,7 +194,7 @@ public class ProjectionItem extends SimpleNode {
    */
   public ProjectionItem splitForAggregation(final AggregateProjectionSplit aggregateSplit, final CommandContext context) {
     if (isAggregate(context)) {
-      final ProjectionItem result = new ProjectionItem(-1);
+      final ProjectionItem result = new ProjectionItem();
       result.alias = getProjectionAlias();
       result.expression = expression.splitForAggregation(aggregateSplit, context);
       result.nestedProjection = nestedProjection;
@@ -214,7 +212,7 @@ public class ProjectionItem extends SimpleNode {
   }
 
   public ProjectionItem copy() {
-    final ProjectionItem result = new ProjectionItem(-1);
+    final ProjectionItem result = new ProjectionItem();
     result.exclude = this.exclude;
     result.all = all;
     result.alias = alias == null ? null : alias.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/QueryStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/QueryStatement.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class QueryStatement extends SimpleNode {
-  public QueryStatement(final int id) {
-    super(id);
+  public QueryStatement() {
   }
 }
 /* JavaCC - OriginalChecksum=f78d23e607a64459efb18502e47359c1 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildGraphAnalyticalViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildGraphAnalyticalViewStatement.java
@@ -31,8 +31,7 @@ import com.arcadedb.security.SecurityDatabaseUser;
 public class RebuildGraphAnalyticalViewStatement extends DDLStatement {
   public Identifier name;
 
-  public RebuildGraphAnalyticalViewStatement(final int id) {
-    super(id);
+  public RebuildGraphAnalyticalViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -68,8 +68,7 @@ public class RebuildIndexStatement extends DDLStatement {
   public               Expression                  value;
   public final         Map<Expression, Expression> settings     = new HashMap<>();
 
-  public RebuildIndexStatement(final int id) {
-    super(id);
+  public RebuildIndexStatement() {
   }
 
   @Override
@@ -463,7 +462,7 @@ public class RebuildIndexStatement extends DDLStatement {
 
   @Override
   public RebuildIndexStatement copy() {
-    final RebuildIndexStatement result = new RebuildIndexStatement(-1);
+    final RebuildIndexStatement result = new RebuildIndexStatement();
     result.all = all;
     result.name = name == null ? null : name.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
@@ -74,8 +74,7 @@ public class RebuildTypeStatement extends DDLStatement {
   public boolean                     polymorphic = false;
   public final Map<Expression, Expression> settings = new HashMap<>();
 
-  public RebuildTypeStatement(final int id) {
-    super(id);
+  public RebuildTypeStatement() {
   }
 
   @Override
@@ -387,7 +386,7 @@ public class RebuildTypeStatement extends DDLStatement {
 
   @Override
   public RebuildTypeStatement copy() {
-    final RebuildTypeStatement result = new RebuildTypeStatement(-1);
+    final RebuildTypeStatement result = new RebuildTypeStatement();
     result.typeName = typeName == null ? null : typeName.copy();
     result.polymorphic = polymorphic;
     for (final Map.Entry<Expression, Expression> e : settings.entrySet())

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RecordAttribute.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RecordAttribute.java
@@ -35,8 +35,7 @@ import static com.arcadedb.schema.Property.*;
 public class RecordAttribute extends SimpleNode {
   protected String name;
 
-  public RecordAttribute(final int id) {
-    super(id);
+  public RecordAttribute() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -44,7 +43,7 @@ public class RecordAttribute extends SimpleNode {
   }
 
   public RecordAttribute copy() {
-    final RecordAttribute result = new RecordAttribute(-1);
+    final RecordAttribute result = new RecordAttribute();
     result.name = name;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RefreshContinuousAggregateStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RefreshContinuousAggregateStatement.java
@@ -27,8 +27,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 public class RefreshContinuousAggregateStatement extends DDLStatement {
   public Identifier name;
 
-  public RefreshContinuousAggregateStatement(final int id) {
-    super(id);
+  public RefreshContinuousAggregateStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RefreshMaterializedViewStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RefreshMaterializedViewStatement.java
@@ -27,8 +27,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 public class RefreshMaterializedViewStatement extends DDLStatement {
   public Identifier name;
 
-  public RefreshMaterializedViewStatement(final int id) {
-    super(id);
+  public RefreshMaterializedViewStatement() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ResourcePathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ResourcePathItem.java
@@ -28,8 +28,7 @@ public class ResourcePathItem extends SimpleNode {
   protected Identifier identifier;
   protected String     name;
 
-  public ResourcePathItem(final int id) {
-    super(id);
+  public ResourcePathItem() {
   }
 
   @Override
@@ -45,7 +44,7 @@ public class ResourcePathItem extends SimpleNode {
 
   @Override
   public ResourcePathItem copy() {
-    final ResourcePathItem result = new ResourcePathItem(-1);
+    final ResourcePathItem result = new ResourcePathItem();
     result.star = star;
     result.identifier = identifier == null ? null : identifier.copy();
     result.name = name;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreDocumentStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreDocumentStatement.java
@@ -44,8 +44,7 @@ public class RestoreDocumentStatement extends SimpleExecStatement {
   public Rid        targetRid;
   public InsertBody insertBody;
 
-  public RestoreDocumentStatement(final int id) {
-    super(id);
+  public RestoreDocumentStatement() {
   }
 
   @Override
@@ -89,7 +88,7 @@ public class RestoreDocumentStatement extends SimpleExecStatement {
 
   @Override
   public RestoreDocumentStatement copy() {
-    final RestoreDocumentStatement result = new RestoreDocumentStatement(-1);
+    final RestoreDocumentStatement result = new RestoreDocumentStatement();
     result.targetType = targetType == null ? null : targetType.copy();
     result.targetRid = targetRid == null ? null : targetRid.copy();
     result.insertBody = insertBody == null ? null : insertBody.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreEdgeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreEdgeStatement.java
@@ -50,8 +50,7 @@ public class RestoreEdgeStatement extends SimpleExecStatement {
   public Rid        toRid;
   public InsertBody insertBody;
 
-  public RestoreEdgeStatement(final int id) {
-    super(id);
+  public RestoreEdgeStatement() {
   }
 
   @Override
@@ -119,7 +118,7 @@ public class RestoreEdgeStatement extends SimpleExecStatement {
 
   @Override
   public RestoreEdgeStatement copy() {
-    final RestoreEdgeStatement result = new RestoreEdgeStatement(-1);
+    final RestoreEdgeStatement result = new RestoreEdgeStatement();
     result.targetType = targetType == null ? null : targetType.copy();
     result.targetRid = targetRid == null ? null : targetRid.copy();
     result.fromRid = fromRid == null ? null : fromRid.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreVertexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RestoreVertexStatement.java
@@ -50,8 +50,7 @@ public class RestoreVertexStatement extends SimpleExecStatement {
   public Rid        targetRid;
   public InsertBody insertBody;
 
-  public RestoreVertexStatement(final int id) {
-    super(id);
+  public RestoreVertexStatement() {
   }
 
   @Override
@@ -103,7 +102,7 @@ public class RestoreVertexStatement extends SimpleExecStatement {
 
   @Override
   public RestoreVertexStatement copy() {
-    final RestoreVertexStatement result = new RestoreVertexStatement(-1);
+    final RestoreVertexStatement result = new RestoreVertexStatement();
     result.targetType = targetType == null ? null : targetType.copy();
     result.targetRid = targetRid == null ? null : targetRid.copy();
     result.insertBody = insertBody == null ? null : insertBody.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Retry.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Retry.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class Retry extends SimpleNode {
-  public Retry(final int id) {
-    super(id);
+  public Retry() {
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ReturnStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ReturnStatement.java
@@ -34,8 +34,7 @@ import java.util.Objects;
 public class ReturnStatement extends SimpleExecStatement {
   public Expression expression;
 
-  public ReturnStatement(final int id) {
-    super(id);
+  public ReturnStatement() {
   }
 
   @Override
@@ -97,7 +96,7 @@ public class ReturnStatement extends SimpleExecStatement {
 
   @Override
   public ReturnStatement copy() {
-    final ReturnStatement result = new ReturnStatement(-1);
+    final ReturnStatement result = new ReturnStatement();
     result.expression = expression == null ? null : expression.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Rid.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Rid.java
@@ -38,14 +38,12 @@ public class Rid extends SimpleNode {
   public Expression expression;
   public boolean    legacy;
 
-  public Rid(final int id) {
-    super(id);
+  public Rid() {
   }
 
   public Rid(final RID rid) {
-    super(-1);
-    bucket = new PInteger(-1).setValue(rid.getBucketId());
-    position = new PInteger(-1).setValue(rid.getPosition());
+    bucket = new PInteger().setValue(rid.getBucketId());
+    position = new PInteger().setValue(rid.getPosition());
     legacy = true;
   }
 
@@ -112,7 +110,7 @@ public class Rid extends SimpleNode {
   }
 
   public Rid copy() {
-    final Rid result = new Rid(-1);
+    final Rid result = new Rid();
     result.bucket = bucket == null ? null : bucket.copy();
     result.position = position == null ? null : position.copy();
     result.expression = expression == null ? null : expression.copy();
@@ -162,7 +160,7 @@ public class Rid extends SimpleNode {
     if (expression != null) {
       final RID rid = toRecordId((Result) null, new BasicCommandContext());
       if (rid != null) {
-        final PInteger result = new PInteger(-1);
+        final PInteger result = new PInteger();
         result.setValue(rid.getBucketId());
         return result;
       }
@@ -174,7 +172,7 @@ public class Rid extends SimpleNode {
     if (expression != null) {
       final RID rid = toRecordId((Result) null, new BasicCommandContext());
       if (rid != null) {
-        final PInteger result = new PInteger(-1);
+        final PInteger result = new PInteger();
         result.setValue(rid.getPosition());
         return result;
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RightBinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RightBinaryCondition.java
@@ -32,13 +32,12 @@ public class RightBinaryCondition extends SimpleNode {
   public InOperator            inOperator;
   public Expression            right;
 
-  public RightBinaryCondition(final int id) {
-    super(id);
+  public RightBinaryCondition() {
   }
 
   @Override
   public RightBinaryCondition copy() {
-    final RightBinaryCondition result = new RightBinaryCondition(-1);
+    final RightBinaryCondition result = new RightBinaryCondition();
     result.operator = operator == null ? null : operator.copy();
     result.not = not;
     result.inOperator = inOperator == null ? null : inOperator.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RollbackStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RollbackStatement.java
@@ -28,8 +28,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import java.util.Map;
 
 public class RollbackStatement extends SimpleExecStatement {
-  public RollbackStatement(final int id) {
-    super(id);
+  public RollbackStatement() {
   }
 
   @Override
@@ -49,7 +48,7 @@ public class RollbackStatement extends SimpleExecStatement {
 
   @Override
   public RollbackStatement copy() {
-    final RollbackStatement result = new RollbackStatement(-1);
+    final RollbackStatement result = new RollbackStatement();
     return result;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SchemaIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SchemaIdentifier.java
@@ -26,8 +26,7 @@ import java.util.Objects;
 public class SchemaIdentifier extends SimpleNode {
   public String name;
 
-  public SchemaIdentifier(final int id) {
-    super(id);
+  public SchemaIdentifier() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -73,7 +72,7 @@ public class SchemaIdentifier extends SimpleNode {
   }
 
   public SchemaIdentifier copy() {
-    final SchemaIdentifier result = new SchemaIdentifier(-1);
+    final SchemaIdentifier result = new SchemaIdentifier();
     result.name = name;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SelectStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SelectStatement.java
@@ -47,8 +47,7 @@ public class SelectStatement extends Statement {
   public Skip        skip;
   public LetClause   letClause;
 
-  public SelectStatement(final int id) {
-    super(id);
+  public SelectStatement() {
   }
 
   public Projection getProjection() {
@@ -229,7 +228,7 @@ public class SelectStatement extends Statement {
   @Override
   public SelectStatement copy() {
     try {
-      final SelectStatement result = getClass().getConstructor(Integer.TYPE).newInstance(-1);
+      final SelectStatement result = getClass().getConstructor().newInstance();
       result.originalStatement = originalStatement;
       result.target = target == null ? null : target.copy();
       result.projection = projection == null ? null : projection.copy();
@@ -306,11 +305,11 @@ public class SelectStatement extends Statement {
   private void setProfilingConstraints(final DatabaseInternal db) {
     final long profiledLimit = db.getResultSetLimit();
     if (profiledLimit > -1 && (limit == null || limit.num.value.longValue() > profiledLimit))
-      setLimit(new Limit(-1).setValue((int) profiledLimit));
+      setLimit(new Limit().setValue((int) profiledLimit));
 
     final long profiledTimeout = db.getReadTimeout();
     if (profiledTimeout > -1 && (timeout == null || timeout.val.longValue() > profiledTimeout))
-      setTimeout(new Timeout(-1).setValue((int) profiledTimeout));
+      setTimeout(new Timeout().setValue((int) profiledTimeout));
   }
 }
 /* JavaCC - OriginalChecksum=b26959b9726a8cf35d6283eca931da6b (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SelectWithoutTargetStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SelectWithoutTargetStatement.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class SelectWithoutTargetStatement extends SelectStatement {
-  public SelectWithoutTargetStatement(final int id) {
-    super(id);
+  public SelectWithoutTargetStatement() {
   }
 }
 /* JavaCC - OriginalChecksum=2b0c73e32d84e559188b75251a4d262c (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SetGlobalStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SetGlobalStatement.java
@@ -39,8 +39,7 @@ public class SetGlobalStatement extends SimpleExecStatement {
   public Identifier variableName;
   public Expression expression;
 
-  public SetGlobalStatement(final int id) {
-    super(id);
+  public SetGlobalStatement() {
   }
 
   @Override
@@ -64,7 +63,7 @@ public class SetGlobalStatement extends SimpleExecStatement {
 
   @Override
   public SetGlobalStatement copy() {
-    final SetGlobalStatement result = new SetGlobalStatement(-1);
+    final SetGlobalStatement result = new SetGlobalStatement();
     result.variableName = variableName == null ? null : variableName.copy();
     result.expression = expression == null ? null : expression.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleExecStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleExecStatement.java
@@ -35,8 +35,7 @@ import java.util.Map;
  */
 public abstract class SimpleExecStatement extends Statement {
 
-  public SimpleExecStatement(final int id) {
-    super(id);
+  public SimpleExecStatement() {
   }
 
   public abstract ResultSet executeSimple(CommandContext context);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
@@ -32,9 +32,6 @@ public abstract class SimpleNode implements Node {
   public SimpleNode() {
   }
 
-  public SimpleNode(final int i) {
-  }
-
   public void jjtOpen() {
     // NO ACTIONS
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Skip.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Skip.java
@@ -32,8 +32,7 @@ public class Skip extends SimpleNode {
   public InputParameter inputParam;
   public Expression     expression;
 
-  public Skip(final int id) {
-    super(id);
+  public Skip() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -78,7 +77,7 @@ public class Skip extends SimpleNode {
   }
 
   public Skip copy() {
-    final Skip result = new Skip(-1);
+    final Skip result = new Skip();
     result.num = num == null ? null : num.copy();
     result.inputParam = inputParam == null ? null : inputParam.copy();
     result.expression = expression == null ? null : expression.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SleepStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SleepStatement.java
@@ -32,8 +32,7 @@ import java.util.Objects;
 public class SleepStatement extends SimpleExecStatement {
   public Expression expression;
 
-  public SleepStatement(final int id) {
-    super(id);
+  public SleepStatement() {
   }
 
   @Override
@@ -67,7 +66,7 @@ public class SleepStatement extends SimpleExecStatement {
 
   @Override
   public SleepStatement copy() {
-    final SleepStatement result = new SleepStatement(-1);
+    final SleepStatement result = new SleepStatement();
     result.expression = expression == null ? null : expression.copy();
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
@@ -39,8 +39,7 @@ public class Statement extends SimpleNode {
   public Limit     limit   = null;
   public Timeout   timeout = null;
 
-  public Statement(final int id) {
-    super(id);
+  public Statement() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/StatementInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/StatementInternal.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class StatementInternal extends SimpleNode {
-  public StatementInternal(final int id) {
-    super(id);
+  public StatementInternal() {
   }
 }
 /* JavaCC - OriginalChecksum=441892d4d3a90ef763379175fb756b22 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/StatementSemicolon.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/StatementSemicolon.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class StatementSemicolon extends SimpleNode {
-  public StatementSemicolon(final int id) {
-    super(id);
+  public StatementSemicolon() {
   }
 }
 /* JavaCC - OriginalChecksum=dd666171278492fc7540b6aed7c08733 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
@@ -51,8 +51,7 @@ public class SuffixIdentifier extends SimpleNode {
   protected RecordAttribute recordAttribute;
   public boolean         star = false;
 
-  public SuffixIdentifier(final int id) {
-    super(id);
+  public SuffixIdentifier() {
   }
 
   public SuffixIdentifier(final Identifier identifier) {
@@ -301,7 +300,7 @@ public class SuffixIdentifier extends SimpleNode {
   }
 
   public SuffixIdentifier copy() {
-    final SuffixIdentifier result = new SuffixIdentifier(-1);
+    final SuffixIdentifier result = new SuffixIdentifier();
     result.identifier = identifier == null ? null : identifier.copy();
     result.recordAttribute = recordAttribute == null ? null : recordAttribute.copy();
     result.star = star;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Timeout.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Timeout.java
@@ -30,8 +30,7 @@ public class Timeout extends SimpleNode {
   protected Number val;
   protected String failureStrategy;
 
-  public Timeout(final int id) {
-    super(id);
+  public Timeout() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -43,7 +42,7 @@ public class Timeout extends SimpleNode {
   }
 
   public Timeout copy() {
-    final Timeout result = new Timeout(-1);
+    final Timeout result = new Timeout();
     result.val = val;
     result.failureStrategy = failureStrategy;
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TraverseProjectionItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TraverseProjectionItem.java
@@ -31,8 +31,7 @@ public class TraverseProjectionItem extends SimpleNode {
   public BaseIdentifier base;
   public Modifier       modifier;
 
-  public TraverseProjectionItem(final int id) {
-    super(id);
+  public TraverseProjectionItem() {
   }
 
   public Object execute(final Result currentRecord, final CommandContext context) {
@@ -95,7 +94,7 @@ public class TraverseProjectionItem extends SimpleNode {
   }
 
   public TraverseProjectionItem copy() {
-    final TraverseProjectionItem result = new TraverseProjectionItem(-1);
+    final TraverseProjectionItem result = new TraverseProjectionItem();
     result.base = base == null ? null : base.copy();
     result.modifier = modifier == null ? null : modifier.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TraverseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TraverseStatement.java
@@ -49,8 +49,7 @@ public class TraverseStatement extends Statement {
   // before emission only: non-matching vertices still drive expansion, they are just not returned as results. Not exposed in grammar.
   protected WhereClause                  postFilter;
 
-  public TraverseStatement(final int id) {
-    super(id);
+  public TraverseStatement() {
   }
 
   public void validate() throws CommandSQLParsingException {
@@ -158,7 +157,7 @@ public class TraverseStatement extends Statement {
 
   @Override
   public Statement copy() {
-    final TraverseStatement result = new TraverseStatement(-1);
+    final TraverseStatement result = new TraverseStatement();
     result.projections = projections == null ? null : projections.stream().map(x -> x.copy()).collect(Collectors.toList());
     result.target = target == null ? null : target.copy();
     result.whileClause = whileClause == null ? null : whileClause.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateBucketStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateBucketStatement.java
@@ -42,8 +42,7 @@ public class TruncateBucketStatement extends DDLStatement {
   public PInteger   bucketNumber;
   public boolean    unsafe = false;
 
-  public TruncateBucketStatement(final int id) {
-    super(id);
+  public TruncateBucketStatement() {
   }
 
   @Override
@@ -152,7 +151,7 @@ public class TruncateBucketStatement extends DDLStatement {
 
   @Override
   public TruncateBucketStatement copy() {
-    final TruncateBucketStatement result = new TruncateBucketStatement(-1);
+    final TruncateBucketStatement result = new TruncateBucketStatement();
     result.bucketName = bucketName == null ? null : bucketName.copy();
     result.bucketNumber = bucketNumber == null ? null : bucketNumber.copy();
     result.unsafe = unsafe;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateRecordStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateRecordStatement.java
@@ -32,8 +32,7 @@ public class TruncateRecordStatement extends SimpleExecStatement {
   public Rid       record;
   public List<Rid> records;
 
-  public TruncateRecordStatement(final int id) {
-    super(id);
+  public TruncateRecordStatement() {
   }
 
   @Override
@@ -89,7 +88,7 @@ public class TruncateRecordStatement extends SimpleExecStatement {
 
   @Override
   public TruncateRecordStatement copy() {
-    final TruncateRecordStatement result = new TruncateRecordStatement(-1);
+    final TruncateRecordStatement result = new TruncateRecordStatement();
     result.record = record == null ? null : record.copy();
     result.records = records == null ? null : records.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
@@ -43,8 +43,7 @@ public class TruncateTypeStatement extends DDLStatement {
   public boolean    polymorphic = false;
   public boolean    unsafe      = false;
 
-  public TruncateTypeStatement(final int id) {
-    super(id);
+  public TruncateTypeStatement() {
   }
 
   @Override
@@ -237,7 +236,7 @@ public class TruncateTypeStatement extends DDLStatement {
 
   @Override
   public TruncateTypeStatement copy() {
-    final TruncateTypeStatement result = new TruncateTypeStatement(-1);
+    final TruncateTypeStatement result = new TruncateTypeStatement();
     result.typeName = typeName == null ? null : typeName.copy();
     result.polymorphic = polymorphic;
     result.unsafe = unsafe;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Unwind.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Unwind.java
@@ -29,8 +29,7 @@ import java.util.stream.Collectors;
 public class Unwind extends SimpleNode {
   public List<Identifier> items = new ArrayList<Identifier>();
 
-  public Unwind(final int id) {
-    super(id);
+  public Unwind() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -44,7 +43,7 @@ public class Unwind extends SimpleNode {
   }
 
   public Unwind copy() {
-    final Unwind result = new Unwind(-1);
+    final Unwind result = new Unwind();
     result.items = items.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateAddItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateAddItem.java
@@ -27,8 +27,7 @@ public class UpdateAddItem extends SimpleNode {
   protected Identifier left;
   protected Expression right;
 
-  public UpdateAddItem(final int id) {
-    super(id);
+  public UpdateAddItem() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateIncrementItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateIncrementItem.java
@@ -28,8 +28,7 @@ public class UpdateIncrementItem extends SimpleNode {
   protected Modifier   leftModifier;
   protected Expression right;
 
-  public UpdateIncrementItem(final int id) {
-    super(id);
+  public UpdateIncrementItem() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -57,7 +56,7 @@ public class UpdateIncrementItem extends SimpleNode {
   }
 
   public UpdateIncrementItem copy() {
-    final UpdateIncrementItem result = new UpdateIncrementItem(-1);
+    final UpdateIncrementItem result = new UpdateIncrementItem();
     result.left = left == null ? null : left.copy();
     result.leftModifier = leftModifier == null ? null : leftModifier.copy();
     result.right = right == null ? null : right.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateItem.java
@@ -45,8 +45,7 @@ public class UpdateItem extends SimpleNode {
   public int        operator;
   public Expression right;
 
-  public UpdateItem(final int id) {
-    super(id);
+  public UpdateItem() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -77,7 +76,7 @@ public class UpdateItem extends SimpleNode {
   }
 
   public UpdateItem copy() {
-    final UpdateItem result = new UpdateItem(-1);
+    final UpdateItem result = new UpdateItem();
     result.left = left == null ? null : left.copy();
     result.leftModifier = leftModifier == null ? null : leftModifier.copy();
     result.operator = operator;
@@ -220,7 +219,7 @@ public class UpdateItem extends SimpleNode {
     if (leftModifier != null)
       ((BaseExpression) leftEx.mathExpression).modifier = leftModifier.copy();
 
-    final MathExpression mathExp = new MathExpression(-1);
+    final MathExpression mathExp = new MathExpression();
     mathExp.getChildExpressions().add(leftEx.getMathExpression());
     mathExp.getChildExpressions().add(new ParenthesisExpression(right.copy()));
     mathExp.getOperators().add(explicitOperator);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateOperations.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateOperations.java
@@ -48,8 +48,7 @@ public class UpdateOperations extends SimpleNode {
   public List<UpdateIncrementItem> updateIncrementItems = new ArrayList<UpdateIncrementItem>();
   public List<UpdateRemoveItem>    updateRemoveItems    = new ArrayList<UpdateRemoveItem>();
 
-  public UpdateOperations(final int id) {
-    super(id);
+  public UpdateOperations() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -128,7 +127,7 @@ public class UpdateOperations extends SimpleNode {
   }
 
   public UpdateOperations copy() {
-    final UpdateOperations result = new UpdateOperations(-1);
+    final UpdateOperations result = new UpdateOperations();
     result.type = type;
     result.updateItems = updateItems == null ? null : updateItems.stream().map(x -> x.copy()).collect(Collectors.toList());
     result.updatePutItems = updatePutItems == null ? null : updatePutItems.stream().map(x -> x.copy()).collect(Collectors.toList());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdatePutItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdatePutItem.java
@@ -29,8 +29,7 @@ public class UpdatePutItem extends SimpleNode {
   protected Expression key;
   protected Expression value;
 
-  public UpdatePutItem(final int id) {
-    super(id);
+  public UpdatePutItem() {
   }
 
   public UpdatePutItem setLeft(final Identifier left) {
@@ -57,7 +56,7 @@ public class UpdatePutItem extends SimpleNode {
   }
 
   public UpdatePutItem copy() {
-    final UpdatePutItem result = new UpdatePutItem(-1);
+    final UpdatePutItem result = new UpdatePutItem();
     result.left = left == null ? null : left.copy();
     result.key = key == null ? null : key.copy();
     result.value = value == null ? null : value.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateRemoveItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateRemoveItem.java
@@ -33,8 +33,7 @@ public class UpdateRemoveItem extends SimpleNode {
   public Expression left;
   public Expression right;
 
-  public UpdateRemoveItem(final int id) {
-    super(id);
+  public UpdateRemoveItem() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -46,7 +45,7 @@ public class UpdateRemoveItem extends SimpleNode {
   }
 
   public UpdateRemoveItem copy() {
-    final UpdateRemoveItem result = new UpdateRemoveItem(-1);
+    final UpdateRemoveItem result = new UpdateRemoveItem();
     result.left = left == null ? null : left.copy();
     result.right = right == null ? null : right.copy();
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/UpdateStatement.java
@@ -45,8 +45,7 @@ public class UpdateStatement extends Statement {
   public WhereClause            whereClause;
   public Batch                  batch;
 
-  public UpdateStatement(final int id) {
-    super(id);
+  public UpdateStatement() {
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
@@ -99,7 +98,7 @@ public class UpdateStatement extends Statement {
 
   @Override
   public UpdateStatement copy() {
-    final UpdateStatement result = new UpdateStatement(-1);
+    final UpdateStatement result = new UpdateStatement();
     result.target = target == null ? null : target.copy();
     result.operations = operations == null ? null : operations.stream().map(x -> x.copy()).collect(Collectors.toList());
     result.upsert = upsert;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Url.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Url.java
@@ -26,12 +26,10 @@ import java.util.Objects;
 public class Url extends SimpleNode {
   protected String urlString;
 
-  public Url(final int id) {
-    super(id);
+  public Url() {
   }
 
   public Url(final String url) {
-    super(-1);
     this.urlString = url;
   }
 
@@ -57,7 +55,7 @@ public class Url extends SimpleNode {
 
   @Override
   public SimpleNode copy() {
-    final Url result = new Url(-1);
+    final Url result = new Url();
     result.urlString = urlString;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ValueExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ValueExpression.java
@@ -37,7 +37,6 @@ import java.util.Map;
  */
 public class ValueExpression extends Expression {
   public ValueExpression(final Object val) {
-    super(-1);
     this.value = val;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ValueExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ValueExpression.java
@@ -108,7 +108,7 @@ public class ValueExpression extends Expression {
   }
 
   public ValueExpression copy() {
-    final ValueExpression result = new ValueExpression(-1);
+    final ValueExpression result = new ValueExpression(null);
     result.value = value;
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Wait.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Wait.java
@@ -21,8 +21,7 @@
 package com.arcadedb.query.sql.parser;
 
 public class Wait extends SimpleNode {
-  public Wait(final int id) {
-    super(id);
+  public Wait() {
   }
 }
 /* JavaCC - OriginalChecksum=e77b1496216c4d2b2f8ad564da0c3dac (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
@@ -38,8 +38,7 @@ public class WhereClause extends SimpleNode {
   public BooleanExpression baseExpression;
   protected List<AndBlock>    flattened;
 
-  public WhereClause(final int id) {
-    super(id);
+  public WhereClause() {
   }
 
   public Boolean matchesFilters(final Identifiable currentRecord, final CommandContext context) {
@@ -117,8 +116,8 @@ public class WhereClause extends SimpleNode {
 
       if (indexedFunctConditions != null) {
         for (final BinaryCondition cond : indexedFunctConditions) {
-          final FromClause from = new FromClause(-1);
-          from.item = new FromItem(-1);
+          final FromClause from = new FromClause();
+          from.item = new FromItem();
           from.item.setIdentifier(new Identifier(oClass.getName()));
           final long newCount = cond.estimateIndexed(from, context);
           if (newCount < conditionEstimation) {
@@ -207,7 +206,7 @@ public class WhereClause extends SimpleNode {
   }
 
   public WhereClause copy() {
-    final WhereClause result = new WhereClause(-1);
+    final WhereClause result = new WhereClause();
     result.baseExpression = baseExpression.copy();
     result.flattened = flattened == null ? null : flattened.stream()
         .map(x -> x.copy()).collect(Collectors.toList());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WhileBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WhileBlock.java
@@ -37,8 +37,7 @@ public class WhileBlock extends Statement {
   public BooleanExpression condition;
   public List<Statement>   statements = new ArrayList<>();
 
-  public WhileBlock(final int id) {
-    super(id);
+  public WhileBlock() {
   }
 
   @Override
@@ -86,7 +85,7 @@ public class WhileBlock extends Statement {
 
   @Override
   public Statement copy() {
-    final WhileBlock result = new WhileBlock(-1);
+    final WhileBlock result = new WhileBlock();
     result.condition = condition.copy();
     result.statements = statements.stream().map(x -> x.copy()).collect(Collectors.toList());
     return result;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WithinOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WithinOperator.java
@@ -23,8 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.DatabaseInternal;
 
 public class WithinOperator extends SimpleNode implements BinaryCompareOperator {
-  public WithinOperator(final int id) {
-    super(id);
+  public WithinOperator() {
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromIndexStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromIndexStepTest.java
@@ -67,7 +67,7 @@ public class CountFromIndexStepTest {
 
       className = TestHelper.createRandomType(db).getName();
       final Identifier name = new Identifier(indexName);
-      final IndexIdentifier identifier = new IndexIdentifier(-1);
+      final IndexIdentifier identifier = new IndexIdentifier();
       identifier.setIndexName(name);
       identifier.setIndexNameString(name.getValue());
       identifier.setType(identifierType);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DeleteFromIndexStepTest.java
@@ -417,7 +417,7 @@ class DeleteFromIndexStepTest extends TestHelper {
       final BasicCommandContext context = new BasicCommandContext();
       context.setDatabase(database);
 
-      final DeleteFromIndexStep step = new DeleteFromIndexStep(index, new AndBlock(-1), null, null, context);
+      final DeleteFromIndexStep step = new DeleteFromIndexStep(index, new AndBlock(), null, null, context);
 
       assertThatThrownBy(() -> step.syncPull(context, 1))
           .isInstanceOf(CommandExecutionException.class)

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
@@ -89,7 +89,7 @@ public class InsertStatementExecutionTest extends TestHelper {
 
   private void assertInsertExecutionPlanRunsOnce(final Function<InsertStatement, ResultSet> executeStatement) {
     final AtomicInteger executions = new AtomicInteger();
-    final InsertStatement statement = new InsertStatement(-1) {
+    final InsertStatement statement = new InsertStatement() {
       @Override
       public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
         return countingExecutionPlan(context, executions);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
@@ -288,6 +288,28 @@ class MoveVertexStatementExecutionTest extends TestHelper {
   }
 
   /**
+   * Regression test for issue #5871: MOVE VERTEX ... TO bucket:&lt;number&gt; (the numeric bucket form) must move the
+   * vertex to the target bucket. This form is parsed via {@code Bucket.bucketNumber} rather than {@code bucketName},
+   * a path that was silently discarding the parsed bucket id before this fix (the AST builder was constructing the
+   * {@link com.arcadedb.query.sql.parser.Bucket} through a constructor that never wired the number into the field).
+   */
+  @Test
+  void moveVertexToBucketNumber() {
+    final String typeA = "testMoveBucketNumA";
+    final int extraBucketId = database.getSchema().createBucket("testMoveBucketNum_extra").getFileId();
+    database.getSchema().createVertexType(typeA).addBucket(database.getSchema().getBucketById(extraBucketId));
+    database.setAutoTransaction(true);
+
+    final String rid = database.command("sql", "create vertex " + typeA).next().getIdentity().get().toString();
+    try (final ResultSet rs = database.command("sql", "MOVE VERTEX " + rid + " TO bucket:" + extraBucketId)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result moved = rs.next();
+      assertThat(moved.getElement().get().getIdentity().getBucketId()).isEqualTo(extraBucketId);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
    * Regression test for issue #4461: the SET/REMOVE/MERGE/CONTENT operations must be applied to the moved (re-created)
    * vertex. Previously they were silently applied to the stale source record and lost.
    */

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionPlanCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionPlanCloseTest.java
@@ -90,7 +90,7 @@ public class ScriptExecutionPlanCloseTest {
 
     final ScriptExecutionPlan plan = new ScriptExecutionPlan(context);
     plan.chain(new RecordingPlan("line0", closed, false));
-    plan.chain(new SingleOpExecutionPlan(context, new ReturnStatement(-1)));
+    plan.chain(new SingleOpExecutionPlan(context, new ReturnStatement()));
     plan.chain(new RecordingPlan("line2", closed, false));
 
     assertThat(plan.executeUntilReturn()).isInstanceOf(ReturnStep.class);
@@ -127,7 +127,7 @@ public class ScriptExecutionPlanCloseTest {
     final List<String> closed = new ArrayList<>();
 
     final ScriptExecutionPlan plan = new ScriptExecutionPlan(context);
-    plan.chain(new SingleOpExecutionPlan(context, new ReturnStatement(-1)));
+    plan.chain(new SingleOpExecutionPlan(context, new ReturnStatement()));
     for (int i = 0; i < LINES; i++)
       plan.chain(new RecordingPlan("line" + i, closed, false));
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/CheckDatabaseStatementProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/CheckDatabaseStatementProgressTest.java
@@ -45,7 +45,7 @@ class CheckDatabaseStatementProgressTest extends TestHelper {
     final CommandContext context = new BasicCommandContext();
     ((BasicCommandContext) context).setDatabase(database);
 
-    final CheckDatabaseStatement statement = new CheckDatabaseStatement(-1) {
+    final CheckDatabaseStatement statement = new CheckDatabaseStatement() {
       @Override
       DatabaseChecker createChecker(final CommandContext ctx) {
         return new DatabaseChecker(ctx.getDatabase().getWrappedDatabaseInstance()) {

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/InputParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/InputParameterTest.java
@@ -33,7 +33,7 @@ class InputParameterTest {
   void floatArrayNotConvertedToPCollection() {
     // Given: A float array parameter (common for vector operations)
     final float[] floatArray = new float[]{1.0f, 2.0f, 3.0f};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(floatArray);
@@ -47,7 +47,7 @@ class InputParameterTest {
   void intArrayNotConvertedToPCollection() {
     // Given: An int array parameter
     final int[] intArray = new int[]{1, 2, 3};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(intArray);
@@ -61,7 +61,7 @@ class InputParameterTest {
   void doubleArrayNotConvertedToPCollection() {
     // Given: A double array parameter
     final double[] doubleArray = new double[]{1.0, 2.0, 3.0};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(doubleArray);
@@ -75,7 +75,7 @@ class InputParameterTest {
   void longArrayNotConvertedToPCollection() {
     // Given: A long array parameter
     final long[] longArray = new long[]{1L, 2L, 3L};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(longArray);
@@ -89,7 +89,7 @@ class InputParameterTest {
   void shortArrayNotConvertedToPCollection() {
     // Given: A short array parameter
     final short[] shortArray = new short[]{1, 2, 3};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(shortArray);
@@ -103,7 +103,7 @@ class InputParameterTest {
   void byteArrayNotConvertedToPCollection() {
     // Existing behavior should still work
     final byte[] byteArray = new byte[]{1, 2, 3};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(byteArray);
@@ -117,7 +117,7 @@ class InputParameterTest {
   void booleanArrayNotConvertedToPCollection() {
     // Given: A boolean array parameter
     final boolean[] booleanArray = new boolean[]{true, false, true};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(booleanArray);
@@ -131,7 +131,7 @@ class InputParameterTest {
   void charArrayNotConvertedToPCollection() {
     // Given: A char array parameter
     final char[] charArray = new char[]{'a', 'b', 'c'};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(charArray);
@@ -145,7 +145,7 @@ class InputParameterTest {
   void wrapperFloatArrayNotConvertedToPCollection() {
     // Float[] (boxed) should also be excluded for consistency
     final Float[] floatWrapperArray = new Float[]{1.0f, 2.0f, 3.0f};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(floatWrapperArray);
@@ -159,7 +159,7 @@ class InputParameterTest {
   void wrapperIntegerArrayNotConvertedToPCollection() {
     // Integer[] (boxed) should also be excluded for consistency
     final Integer[] integerWrapperArray = new Integer[]{1, 2, 3};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(integerWrapperArray);
@@ -173,7 +173,7 @@ class InputParameterTest {
   void wrapperDoubleArrayNotConvertedToPCollection() {
     // Double[] (boxed) should also be excluded for consistency
     final Double[] doubleWrapperArray = new Double[]{1.0, 2.0, 3.0};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(doubleWrapperArray);
@@ -187,7 +187,7 @@ class InputParameterTest {
   void wrapperByteArrayNotConvertedToPCollection() {
     // Byte[] (boxed) should also be excluded (was already excluded before)
     final Byte[] byteWrapperArray = new Byte[]{1, 2, 3};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(byteWrapperArray);
@@ -201,7 +201,7 @@ class InputParameterTest {
   void objectArrayStillConvertedToPCollection() {
     // String[] should still be converted to PCollection (existing behavior for object arrays)
     final String[] stringArray = new String[]{"a", "b", "c"};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(stringArray);
@@ -215,7 +215,7 @@ class InputParameterTest {
   void emptyFloatArrayNotConvertedToPCollection() {
     // Edge case: Empty float array
     final float[] emptyArray = new float[0];
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(emptyArray);
@@ -229,7 +229,7 @@ class InputParameterTest {
   void singleElementFloatArrayNotConvertedToPCollection() {
     // Edge case: Single element float array
     final float[] singleElementArray = new float[]{42.0f};
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(singleElementArray);
@@ -246,7 +246,7 @@ class InputParameterTest {
     for (int i = 0; i < 128; i++) {
       largeArray[i] = i * 1.0f;
     }
-    final InputParameter param = new InputParameter(-1);
+    final InputParameter param = new InputParameter();
 
     // When: Converting to parsed tree
     final Object result = param.toParsedTree(largeArray);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/MathExpressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/MathExpressionTest.java
@@ -34,7 +34,7 @@ class MathExpressionTest {
   @Test
   void types() {
 
-    final MathExpression expr = new MathExpression(-1);
+    final MathExpression expr = new MathExpression();
 
     final MathExpression.Operator[] basicOps = new MathExpression.Operator[] { MathExpression.Operator.PLUS, MathExpression.Operator.MINUS,
         MathExpression.Operator.STAR, MathExpression.Operator.SLASH, MathExpression.Operator.REM };
@@ -66,7 +66,7 @@ class MathExpressionTest {
 
   @Test
   void priority() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(10));
     exp.operators.add(MathExpression.Operator.PLUS);
     exp.childExpressions.add(integer(5));
@@ -86,7 +86,7 @@ class MathExpressionTest {
 
   @Test
   void priority2() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(1));
     exp.operators.add(MathExpression.Operator.PLUS);
     exp.childExpressions.add(integer(2));
@@ -112,7 +112,7 @@ class MathExpressionTest {
 
   @Test
   void priority3() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(3));
     exp.operators.add(MathExpression.Operator.RSHIFT);
     exp.childExpressions.add(integer(1));
@@ -126,7 +126,7 @@ class MathExpressionTest {
 
   @Test
   void priority4() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(3));
     exp.operators.add(MathExpression.Operator.LSHIFT);
     exp.childExpressions.add(integer(1));
@@ -140,7 +140,7 @@ class MathExpressionTest {
 
   @Test
   void and() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(5));
     exp.operators.add(MathExpression.Operator.BIT_AND);
     exp.childExpressions.add(integer(1));
@@ -152,7 +152,7 @@ class MathExpressionTest {
 
   @Test
   void and2() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(5));
     exp.operators.add(MathExpression.Operator.BIT_AND);
     exp.childExpressions.add(integer(4));
@@ -164,7 +164,7 @@ class MathExpressionTest {
 
   @Test
   void divide() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(20));
     exp.operators.add(MathExpression.Operator.SLASH);
     exp.childExpressions.add(integer(4));
@@ -176,7 +176,7 @@ class MathExpressionTest {
 
   @Test
   void divideByNull() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(20));
     exp.operators.add(MathExpression.Operator.SLASH);
     exp.childExpressions.add(nullValue());
@@ -187,7 +187,7 @@ class MathExpressionTest {
 
   @Test
   void or() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(integer(4));
     exp.operators.add(MathExpression.Operator.BIT_OR);
     exp.childExpressions.add(integer(1));
@@ -208,7 +208,7 @@ class MathExpressionTest {
 
   @Test
   void addListOfNumbers() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(list(1, 2, 3));
     exp.operators.add(MathExpression.Operator.PLUS);
     exp.childExpressions.add(integer(5));
@@ -220,7 +220,7 @@ class MathExpressionTest {
 
   @Test
   void addListOfStrings() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(list("this", "is", "a"));
     exp.operators.add(MathExpression.Operator.PLUS);
     exp.childExpressions.add(str("test"));
@@ -232,7 +232,7 @@ class MathExpressionTest {
 
   @Test
   void removeListOfStrings() {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(list("this", "is", "a", "test"));
     exp.operators.add(MathExpression.Operator.MINUS);
     exp.childExpressions.add(str("a"));
@@ -244,7 +244,7 @@ class MathExpressionTest {
   }
 
   private void testNullCoalescingGeneric(final MathExpression left, final MathExpression right, final Object expected) {
-    final MathExpression exp = new MathExpression(-1);
+    final MathExpression exp = new MathExpression();
     exp.childExpressions.add(left);
     exp.operators.add(MathExpression.Operator.NULL_COALESCING);
     exp.childExpressions.add(right);
@@ -255,38 +255,38 @@ class MathExpressionTest {
   }
 
   private MathExpression integer(final Number i) {
-    final BaseExpression exp = new BaseExpression(-1);
-    final PInteger integer = new PInteger(-1);
+    final BaseExpression exp = new BaseExpression();
+    final PInteger integer = new PInteger();
     integer.setValue(i);
     exp.number = integer;
     return exp;
   }
 
   private BaseExpression nullValue() {
-    final BaseExpression exp = new BaseExpression(-1);
+    final BaseExpression exp = new BaseExpression();
     exp.isNull = true;
     return exp;
   }
 
   private MathExpression str(final String value) {
-    final BaseExpression exp = new BaseExpression(-1);
+    final BaseExpression exp = new BaseExpression();
     exp.string = "'" + value + "'";
     return exp;
   }
 
   private MathExpression nullExpr() {
-    return new BaseExpression(-1);
+    return new BaseExpression();
   }
 
   private MathExpression list(final Number... values) {
-    final BaseExpression exp = new BaseExpression(-1);
-    exp.identifier = new BaseIdentifier(-1);
-    exp.identifier.levelZero = new LevelZeroIdentifier(-1);
-    final PCollection coll = new PCollection(-1);
+    final BaseExpression exp = new BaseExpression();
+    exp.identifier = new BaseIdentifier();
+    exp.identifier.levelZero = new LevelZeroIdentifier();
+    final PCollection coll = new PCollection();
     exp.identifier.levelZero.collection = coll;
 
     for (final Number val : values) {
-      final Expression sub = new Expression(-1);
+      final Expression sub = new Expression();
       sub.mathExpression = integer(val);
       coll.expressions.add(sub);
     }
@@ -294,14 +294,14 @@ class MathExpressionTest {
   }
 
   private MathExpression list(final String... values) {
-    final BaseExpression exp = new BaseExpression(-1);
-    exp.identifier = new BaseIdentifier(-1);
-    exp.identifier.levelZero = new LevelZeroIdentifier(-1);
-    final PCollection coll = new PCollection(-1);
+    final BaseExpression exp = new BaseExpression();
+    exp.identifier = new BaseIdentifier();
+    exp.identifier.levelZero = new LevelZeroIdentifier();
+    final PCollection coll = new PCollection();
     exp.identifier.levelZero.collection = coll;
 
     for (final String val : values) {
-      final Expression sub = new Expression(-1);
+      final Expression sub = new Expression();
       sub.mathExpression = str(val);
       coll.expressions.add(sub);
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/QuotedIdentifierEscapingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/QuotedIdentifierEscapingTest.java
@@ -42,7 +42,7 @@ class QuotedIdentifierEscapingTest {
   @Test
   void quotedInputIsNotEscapedTwice() {
     // `a\`b` is the SQL spelling of the name a`b - the inner text arrives already escaped and must not be escaped again
-    final Identifier identifier = new Identifier(-1);
+    final Identifier identifier = new Identifier();
     identifier.setQuotedStringValue("`a\\`b`");
 
     assertThat(identifier.getStringValue()).isEqualTo("a`b");

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAllConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAllConditionTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContainsAllConditionTest {
   @Test
   void test() {
-    final ContainsAllCondition op = new ContainsAllCondition(-1);
+    final ContainsAllCondition op = new ContainsAllCondition();
 
     assertThat(op.execute(null, null)).isFalse();
     assertThat(op.execute(null, "foo")).isFalse();
@@ -89,7 +89,7 @@ class ContainsAllConditionTest {
       }
     };
 
-    final ContainsAllCondition op = new ContainsAllCondition(-1);
+    final ContainsAllCondition op = new ContainsAllCondition();
     // [3, 1, 2] contains all of [2, 3]
     assertThat(op.execute(left, right)).isTrue();
     // [3, 1, 2] does not contain 99
@@ -98,7 +98,7 @@ class ContainsAllConditionTest {
 
   @Test
   void issue1785() {
-    final ContainsAllCondition op = new ContainsAllCondition(-1);
+    final ContainsAllCondition op = new ContainsAllCondition();
 
     final List<Object> nullList = new ArrayList<>();
     nullList.add(null);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAnyConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAnyConditionTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContainsAnyConditionTest {
   @Test
   void test() {
-    final ContainsAnyCondition op = new ContainsAnyCondition(-1);
+    final ContainsAnyCondition op = new ContainsAnyCondition();
 
     assertThat(op.execute(null, null)).isFalse();
     assertThat(op.execute(null, "foo")).isFalse();
@@ -74,13 +74,13 @@ class ContainsAnyConditionTest {
       }
     };
 
-    final ContainsAnyCondition op = new ContainsAnyCondition(-1);
+    final ContainsAnyCondition op = new ContainsAnyCondition();
     assertThat(op.execute(left, right)).isTrue();
   }
 
   @Test
   void issue1785() {
-    final ContainsAnyCondition op = new ContainsAnyCondition(-1);
+    final ContainsAnyCondition op = new ContainsAnyCondition();
 
     final List<Object> nullList = new ArrayList<>();
     nullList.add(null);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContainsConditionTest {
   @Test
   void test() {
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsCondition op = new ContainsCondition();
 
     assertThat(op.execute(null, null)).isFalse();
     assertThat(op.execute(null, "foo")).isFalse();
@@ -74,13 +74,13 @@ class ContainsConditionTest {
       }
     };
 
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsCondition op = new ContainsCondition();
     assertThat(op.execute(left, right)).isTrue();
   }
 
   @Test
   void issue1785() {
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsCondition op = new ContainsCondition();
 
     final List<Object> nullList = new ArrayList<>();
     nullList.add(null);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsKeyOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsKeyOperatorTest.java
@@ -33,7 +33,7 @@ class ContainsKeyOperatorTest {
 
   @Test
   void test() {
-        final ContainsKeyOperator op = new ContainsKeyOperator(-1);
+        final ContainsKeyOperator op = new ContainsKeyOperator();
 
       assertThat(op.execute(null, null, null)).isFalse();
       assertThat(op.execute(null, null, "foo")).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsValueOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsValueOperatorTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContainsValueOperatorTest {
   @Test
   void test() {
-    final ContainsValueOperator op = new ContainsValueOperator(-1);
+    final ContainsValueOperator op = new ContainsValueOperator();
 
     assertThat(op.execute(null, null, null)).isFalse();
     assertThat(op.execute(null, null, "foo")).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/EqualsCompareOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/EqualsCompareOperatorTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EqualsCompareOperatorTest {
   @Test
   void test() {
-    final EqualsCompareOperator op = new EqualsCompareOperator(-1);
+    final EqualsCompareOperator op = new EqualsCompareOperator();
 
     assertThat(op.execute(null, null, 1)).isFalse();
     assertThat(op.execute(null, 1, null)).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GeOperatorTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.fail;
 class GeOperatorTest {
   @Test
   void test() {
-    final GeOperator op = new GeOperator(-1);
+    final GeOperator op = new GeOperator();
     assertThat(op.execute(null, 1, 1)).isTrue();
     assertThat(op.execute(null, 1, 0)).isTrue();
     assertThat(op.execute(null, 0, 1)).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GtOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GtOperatorTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GtOperatorTest {
   @Test
   void test() {
-    final GtOperator op = new GtOperator(-1);
+    final GtOperator op = new GtOperator();
     assertThat(op.execute(null, 1, 1)).isFalse();
     assertThat(op.execute(null, 1, 0)).isTrue();
     assertThat(op.execute(null, 0, 1)).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ILikeOperatorTest {
   @Test
   void test() {
-    final ILikeOperator op = new ILikeOperator(-1);
+    final ILikeOperator op = new ILikeOperator();
     assertThat(op.execute(null, "FOOBAR", "%ooba%")).isTrue();
     assertThat(op.execute(null, "FOOBAR", "%oo%")).isTrue();
     assertThat(op.execute(null, "FOOBAR", "oo%")).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/InOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/InOperatorTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class InOperatorTest {
   @Test
   void test() {
-    final InOperator op = new InOperator(-1);
+    final InOperator op = new InOperator();
 
     assertThat(op.execute(null, null, null)).isFalse();
     assertThat(op.execute(null, null, "foo")).isFalse();
@@ -54,7 +54,7 @@ class InOperatorTest {
 
   @Test
   void issue1785() {
-    final InOperator op = new InOperator(-1);
+    final InOperator op = new InOperator();
 
     final List<Object> nullList = new ArrayList<>();
     nullList.add(null);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LeOperatorTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.fail;
 class LeOperatorTest {
   @Test
   void test() {
-    final LeOperator op = new LeOperator(-1);
+    final LeOperator op = new LeOperator();
     assertThat(op.execute(null, 1, 1)).isTrue();
     assertThat(op.execute(null, 1, 0)).isFalse();
     assertThat(op.execute(null, 0, 1)).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class LikeOperatorTest {
   @Test
   void test() {
-    final LikeOperator op = new LikeOperator(-1);
+    final LikeOperator op = new LikeOperator();
     assertThat(op.execute(null, "foobar", "%ooba%")).isTrue();
     assertThat(op.execute(null, "foobar", "%oo%")).isTrue();
     assertThat(op.execute(null, "foobar", "oo%")).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LtOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LtOperatorTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.fail;
 class LtOperatorTest {
   @Test
   void test() {
-    final LtOperator op = new LtOperator(-1);
+    final LtOperator op = new LtOperator();
     assertThat(op.execute(null, 1, 1)).isFalse();
     assertThat(op.execute(null, 1, 0)).isFalse();
     assertThat(op.execute(null, 0, 1)).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeOperatorTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NeOperatorTest {
   @Test
   void test() {
-    final NeOperator op = new NeOperator(-1);
+    final NeOperator op = new NeOperator();
 
     assertThat(op.execute(null, null, 1)).isTrue();
     assertThat(op.execute(null, 1, null)).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeqOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeqOperatorTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NeqOperatorTest {
   @Test
   void test() {
-    final NeqOperator op = new NeqOperator(-1);
+    final NeqOperator op = new NeqOperator();
     assertThat(op.execute(null, null, 1)).isTrue();
     assertThat(op.execute(null, 1, null)).isTrue();
     assertThat(op.execute(null, null, null)).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NullSafeEqualsCompareOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NullSafeEqualsCompareOperatorTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NullSafeEqualsCompareOperatorTest {
   @Test
   void test() {
-    final NullSafeEqualsCompareOperator op = new NullSafeEqualsCompareOperator(-1);
+    final NullSafeEqualsCompareOperator op = new NullSafeEqualsCompareOperator();
 
     assertThat(op.execute(null, null, 1)).isFalse();
     assertThat(op.execute(null, 1, null)).isFalse();


### PR DESCRIPTION
Closes #5871

## Context

`SimpleNode(int)` took a parser node id that was only ever meaningful to the JJTree-generated tree
walker removed by #5868. After that removal, the `int` parameter was dead: every call site passed
`-1` and the field it fed was never read. This PR removes the constructor, leaving only the no-arg
one, and mechanically converts every dependent constructor and call site to match.

## Change

- Removed `SimpleNode(int)`, leaving only the no-arg constructor.
- Converted 206 subclass/related constructors across `com.arcadedb.query.sql.parser` (200 in the
  parser package plus `BreakStatement`, `ExpressionStatement`, `Identifier`, `JsonArray`,
  `MoveVertexStatement`, `ParseCondition`, `ParseExpression`) from `ClassName(int id) { super(id); }`
  / `super(-1)` chains to no-arg constructors.
- Updated ~750 `new ClassName(-1)` call sites repo-wide, including 3 anonymous
  `new BooleanExpression(0){...}` sites.

## Two real bugs fixed as a necessary consequence

Removing the constructor is not purely mechanical - it surfaced two latent bugs that would have
thrown/misbehaved at runtime once the vestigial constructor was gone. Both are fixed here, not out
of scope creep but because the removal doesn't compile/pass tests without them:

1. **`MOVE VERTEX ... TO bucket:<number>` silently broken (NPE at runtime).**
   `SQLASTBuilder`'s bucket-target path constructed `Bucket` via the vestigial int constructor,
   which never actually set `bucketNumber`. Fixed by setting the field directly. Covered by a new
   regression test `moveVertexToBucketNumber` in `MoveVertexStatementExecutionTest`.

2. **Five `copy()` methods relied on reflecting into the vestigial constructor.**
   `MathExpression`, `FieldMatchPathItem`, `SelectStatement`, `CreateVertexStatement`, and
   `MatchPathItem` all called `getClass().getConstructor(Integer.TYPE).newInstance(-1)` to build
   their copy. This compiled fine but would throw `NoSuchMethodException` at runtime once the
   constructor was removed - only caught by actually running the test suite, not by a static
   compile check. Switched all five to `getClass().getConstructor().newInstance()`.

## Test plan

- `mvn -pl engine -am clean compile` / `test-compile`: pass.
- Full `-DskipTests -DskipITs clean install` across the whole reactor: `BUILD SUCCESS`, confirming
  no other module references the removed constructors.
- `com.arcadedb.query.sql.parser.**`, `com.arcadedb.query.sql.executor.**`, and
  `com.arcadedb.query.sql.antlr.**` (1875 tests, the packages touched by this change plus their
  direct dependents): 0 failures, 0 errors - including the reflection-based `copy()` paths this
  change touches, and the new `moveVertexToBucketNumber` regression test.