### PR TITLE
fix(#6063): report file-id identity collisions instead of silently dropping the new component

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.WALVersionGapException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
@@ -1673,15 +1674,37 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * Creates new database files for each entry in {@code filesToAdd} that does not already exist.
    * Skips files that are already registered in the file manager or already present on disk with
    * non-zero content (idempotent re-apply after a crash before the applied-index was persisted).
+   * <p>
+   * A file id already registered under a DIFFERENT name is not that same idempotent case: the two
+   * names cannot both be legitimate replays of this entry, so it means this node's file-id space has
+   * diverged from the leader's (issue #6063) - for example, a first-formation bootstrap peer whose
+   * local copy of a database was locally fresher than the cluster's chosen baseline and was therefore
+   * left alone by {@link #applyBootstrapFingerprintEntry} rather than reinstalled, but whose file ids
+   * were assigned by an independent history and can collide with a later, ordinary replicated schema
+   * change (e.g. the bucket a brand new type creates). Silently skipping such a collision would leave
+   * the new component never actually created on this node while the schema entry is merged anyway,
+   * so the type is later dropped from the schema silently on load ("Cannot find bucket ..., removing
+   * it from type configuration") - the type count divergence {@code DatabaseComparator} reports.
+   * Throwing here instead routes through {@link #applyWithRetry}'s generic {@code RuntimeException}
+   * handling straight to {@link #handleUnexpectedApplyError}, which quarantines the database and
+   * triggers a full snapshot resync - replacing this node's whole file-id space rather than trying to
+   * reconcile it entry by entry.
    */
   private void createNewFiles(final DatabaseInternal db, final Map<Integer, String> filesToAdd) throws IOException {
     final String databasePath = db.getDatabasePath();
     for (final Map.Entry<Integer, String> fileEntry : filesToAdd.entrySet()) {
       final int fileId = fileEntry.getKey();
       final String fileName = fileEntry.getValue();
-      // Skip if already registered in memory (idempotent)
-      if (db.getFileManager().existsFile(fileId))
+      // Skip if already registered in memory (idempotent) - but only when it is truly the same file
+      if (db.getFileManager().existsFile(fileId)) {
+        final String existingName = db.getFileManager().getFile(fileId).getFileName();
+        if (!existingName.equals(fileName))
+          throw new SchemaException(
+              "File id " + fileId + " for database '" + db.getName() + "' already names '" + existingName
+                  + "' locally but a committed schema change expects it to name '" + fileName
+                  + "' - this node's file-id space has diverged from the leader's");
         continue;
+      }
       // Skip if the file already exists on disk with data (crash-safe: the prior run created it)
       final File osFile = new File(databasePath + File.separator + fileName);
       if (osFile.exists() && osFile.length() > 0)

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineCreateFilesTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineCreateFilesTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,11 +28,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.RandomAccessFile;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests idempotency of createNewFiles() in ArcadeStateMachine.
@@ -143,5 +146,54 @@ class ArcadeStateMachineCreateFilesTest {
     // File should now exist and be registered
     assertThat(new File(filePath).exists()).isTrue();
     assertThat(db.getFileManager().existsFile(fileId)).isTrue();
+  }
+
+  /**
+   * Issue #6063 regression: a file id already registered under a name DIFFERENT from what a committed
+   * schema entry expects is not the safe idempotent-replay case the other tests above cover - the two
+   * names cannot both be legitimate replays of the same entry, so it means this node's file-id space has
+   * diverged from the leader's (e.g. left behind by the first-formation bootstrap "local data is fresher,
+   * keep it" guard in {@code applyBootstrapFingerprintEntry}). Silently skipping the collision, as the
+   * pre-fix code did, left the new component (e.g. a freshly created type's bucket) never actually
+   * created on this node while the schema JSON was still merged, so the type was later dropped from the
+   * schema on load ("Cannot find bucket ..., removing it from type configuration") - the exact "Types:
+   * DB1 6 <> DB2 5" divergence the issue's CI log shows. It must now be reported loudly instead.
+   */
+  @Test
+  void createNewFilesThrowsOnFileIdCollisionWithDifferentName() throws Exception {
+    final int fileId = 9003;
+    final String existingFileName = "unrelated_bucket.9003.65536.v0.pcf";
+    final String expectedFileName = "new_type_bucket.9003.65536.v0.pcf";
+    final String existingFilePath = db.getDatabasePath() + File.separator + existingFileName;
+
+    // Plant the divergence directly, rather than racing for it: this node already has an unrelated file
+    // registered under fileId 9003 from its own independent history.
+    db.getFileManager().getOrCreateFile(fileId, existingFilePath);
+    assertThat(db.getFileManager().existsFile(fileId)).isTrue();
+
+    final ArcadeStateMachine stateMachine = new ArcadeStateMachine();
+    final Method createNewFiles = ArcadeStateMachine.class.getDeclaredMethod(
+        "createNewFiles", DatabaseInternal.class, Map.class);
+    createNewFiles.setAccessible(true);
+
+    // A committed schema change now expects the SAME fileId to name a DIFFERENT (brand new) file.
+    final Map<Integer, String> filesToAdd = new HashMap<>();
+    filesToAdd.put(fileId, expectedFileName);
+
+    assertThatThrownBy(() -> {
+      try {
+        createNewFiles.invoke(stateMachine, db, filesToAdd);
+      } catch (final InvocationTargetException e) {
+        throw e.getCause();
+      }
+    }).isInstanceOf(SchemaException.class)
+        .hasMessageContaining(String.valueOf(fileId))
+        .hasMessageContaining(existingFileName)
+        .hasMessageContaining(expectedFileName);
+
+    // The collision must not silently fabricate the new file: the existing registration is untouched
+    // and the new one was never created.
+    assertThat(db.getFileManager().getFile(fileId).getFileName()).isEqualTo(existingFileName);
+    assertThat(new File(db.getDatabasePath() + File.separator + expectedFileName)).doesNotExist();
   }
 }


### PR DESCRIPTION
Closes #6063

## Root cause

`Bolt5002RoutingTableIT.neo4jSchemeRoutesReadsAndWrites` failed on `integration-tests` with `Types: DB1 6 <> DB2 5` after an implicit type creation via Cypher-over-Bolt - the same divergence shape as #5728, but the CI log's surrounding context (a "third leader election... reinstalling from leader-shipped full snapshot") ruled out a recurrence of #5728's own fix path.

The CI log also shows this line, which is the real clue:

```
SEVER [ArcadeStateMachine] Database 'graph': local lastTxId=8 is GREATER than cluster bootstrap lastTxId=7.
This peer's data is fresher than the cluster's chosen baseline... Refusing to overwrite local data.
```

At first-formation, `BootstrapElection` picks ONE node as the authoritative baseline for the whole cluster based on aggregate freshness across *all* databases - not per-database. It is entirely possible (and, for independently-booted nodes whose own internal schema/security init is non-deterministic, routine) for a *different*, non-elected node to have a locally higher `lastTxId` for one specific database. `ArcadeStateMachine.applyBootstrapFingerprintEntry`'s "local is fresher, refuse to overwrite" guard then leaves that node's copy of the database alone rather than reinstalling it from the leader - correct as a data-safety measure (it exists to protect an operator's genuinely fresher backup), but it leaves that node's internal file-id counter permanently out of step with the rest of the cluster, with no reconciliation.

`ArcadeStateMachine.createNewFiles()` - which materializes the files a later, ordinary replicated `SCHEMA_ENTRY` names (e.g. the bucket a brand-new vertex type creates) - only checked `FileManager.existsFile(fileId)` before skipping creation, treating "a file already exists at this id" as always the safe idempotent-replay case (crash-restart re-applying an entry it already handled). On a node whose file-id space has diverged as above, that assumption is wrong: the id is already in use for something *else*. The skip fired, the new bucket was never created on that node, and `applySchemaEntry` merged the schema JSON anyway (unconditionally). `LocalSchema.readConfiguration()` then failed to resolve the type's declared bucket and silently dropped it ("Cannot find bucket ..., removing it from type configuration") - producing exactly the observed type-count divergence.

## Fix

`createNewFiles()` now checks that an already-registered file id actually names the same file before treating it as an idempotent skip. A mismatch throws `SchemaException`, which propagates through `applyWithRetry`'s existing generic `RuntimeException` handling straight to `handleUnexpectedApplyError` (issue #4797) - the same machinery that already quarantines a database and triggers a full snapshot resync for `WALVersionGapException` (page-level divergence). This is the minimal, narrowly-scoped fix: it does not touch the "refuse to overwrite" bootstrap safety guard's philosophy at all, it only closes the silent-data-loss gap in how a later replicated change interacts with a node already left divergent by that guard.

## Testing

- New regression test `ArcadeStateMachineCreateFilesTest#createNewFilesThrowsOnFileIdCollisionWithDifferentName` plants the divergence directly (a file id registered under an unrelated name, then a schema entry expecting the same id to name something new) rather than racing for it - the same technique #5728's own regression test used. Verified it fails on the pre-fix code and passes with the fix.
- Full `ha-raft` unit suite (90 test classes) green with the fix.
- `bolt` module compiles and test-compiles cleanly against the change.
- Ran `Bolt5002RoutingTableIT` locally multiple times (clean passes); the underlying race is load/timing-sensitive on a shared CI runner and not reliably reproducible in isolation, consistent with the issue's own framing - this fix targets the concrete, statically-verified defect the CI log's "refusing to overwrite" line points to, not a re-creation of the exact CI timing.

## Test plan

- [x] New unit test fails on unfixed code, passes fixed
- [x] Full `ha-raft` surefire suite green
- [x] `bolt` module builds against the change