### PR TITLE
fix(#6096): skip record-table holes when computing the RESTORE insertion offset

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1121,16 +1121,32 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * {@link #restoreRecordAtPosition} - the target page is fixed.
    */
   private int findContentInsertionOffset(final BasePage page, final int totalRecordsInPage) throws IOException {
-    int lastRecordPositionInPage = -1;
-    for (int i = 0; i < totalRecordsInPage; i++) {
-      final int recordPositionInPage = getRecordPositionInPage(page, i);
-      if (recordPositionInPage > lastRecordPositionInPage)
-        lastRecordPositionInPage = recordPositionInPage;
-    }
+    return contentEndOffset(page, getLastRecordPositionInPage(page, totalRecordsInPage));
+  }
 
+  /**
+   * Content-byte offset right past the record whose bytes end last in the page, i.e. where the next record's bytes
+   * can start. {@code lastRecordPositionInPage} is what {@link #getLastRecordPositionInPage} returned, so -1 means
+   * the page holds no live slot at all and the content starts right after the header.
+   * <p>
+   * #6096: this used to be duplicated between the allocator ({@link #getFreeSpaceInPage}) and
+   * {@link #findContentInsertionOffset}, and the two copies had already drifted - the restore-side copy took the
+   * max over the record table without skipping the 0 entries a delete leaves behind, so on a page whose every slot
+   * was a hole it read the entry as a record starting at content offset 0 (the record-count header) and placed the
+   * restored record inside the page header, corrupting the slot table it had just written. Both callers now share
+   * the one implementation.
+   */
+  private int contentEndOffset(final BasePage page, final int lastRecordPositionInPage) throws IOException {
     if (lastRecordPositionInPage == -1)
       // EMPTY PAGE (OR EVERY SLOT IS A HOLE): START RIGHT AFTER THE HEADER
       return contentHeaderSize;
+
+    if (lastRecordPositionInPage < contentHeaderSize)
+      // A LIVE SLOT POINTING INSIDE THE PAGE HEADER: THERE IS NO RECORD THERE, THE RECORD TABLE IS CORRUPTED. FAIL
+      // LOUDLY INSTEAD OF DERIVING AN INSERTION OFFSET FROM HEADER BYTES AND OVERWRITING THE SLOT TABLE (#6096).
+      throw new DatabaseOperationException(
+          "Invalid record position " + lastRecordPositionInPage + " in page " + page.getPageId() + " of bucket '" + componentName
+              + "'");
 
     final long[] lastRecordSize = page.readNumberAndSize(lastRecordPositionInPage);
     if (lastRecordSize[0] == 0)
@@ -2918,7 +2934,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     return true;
   }
 
-  private int getLastRecordPositionInPage(final MutablePage page, final int totalRecords) throws IOException {
+  /**
+   * Highest content offset in use in {@code page}, or -1 when no slot below {@code totalRecords} holds one. A 0
+   * entry in the record table is a hole left by a delete, not a record at content offset 0 (the page header lives
+   * there), so it is skipped - see {@link #contentEndOffset}.
+   */
+  private int getLastRecordPositionInPage(final BasePage page, final int totalRecords) throws IOException {
     int lastRecordPositionInPage = -1;
     for (int i = 0; i < totalRecords; i++) {
       final int recordPositionInPage = getRecordPositionInPage(page, i);
@@ -2988,33 +3009,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // USE NEW POSITION
       pageAnalysis.availablePositionIndex = pageAnalysis.totalRecordsInPage;
 
-    if (pageAnalysis.lastRecordPositionInPage == -1) {
-      // TOTALLY EMPTY PAGE AFTER DELETION, GET THE FIRST POSITION
-      pageAnalysis.newRecordPositionInPage = contentHeaderSize;
-    } else {
-      final long[] lastRecordSize = pageAnalysis.page.readNumberAndSize(pageAnalysis.lastRecordPositionInPage);
-      if (lastRecordSize[0] == 0)
-        // DELETED (V<24.1.1)
-        pageAnalysis.newRecordPositionInPage = pageAnalysis.lastRecordPositionInPage + (int) lastRecordSize[1];
-      else if (lastRecordSize[0] > 0)
-        // RECORD PRESENT, CONSIDER THE RECORD SIZE + VARINT SIZE
-        pageAnalysis.newRecordPositionInPage =
-                pageAnalysis.lastRecordPositionInPage + (int) lastRecordSize[0] + (int) lastRecordSize[1];
-      else if (lastRecordSize[0] == RECORD_PLACEHOLDER_POINTER)
-        // PLACEHOLDER, CONSIDER NEXT 9 BYTES
-        pageAnalysis.newRecordPositionInPage =
-                pageAnalysis.lastRecordPositionInPage + LONG_SERIALIZED_SIZE + (int) lastRecordSize[1];
-      else if (lastRecordSize[0] == FIRST_CHUNK || lastRecordSize[0] == NEXT_CHUNK) {
-        // CHUNK
-        final int chunkSize = pageAnalysis.page.readInt((int) (pageAnalysis.lastRecordPositionInPage + lastRecordSize[1]));
-        pageAnalysis.newRecordPositionInPage =
-                pageAnalysis.lastRecordPositionInPage + (int) lastRecordSize[1] + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE
-                        + chunkSize;
-      } else
-        // PLACEHOLDER CONTENT, CONSIDER THE RECORD SIZE (CONVERTED FROM NEGATIVE NUMBER) + VARINT SIZE
-        pageAnalysis.newRecordPositionInPage =
-                pageAnalysis.lastRecordPositionInPage + (int) (-1 * lastRecordSize[0]) + (int) lastRecordSize[1];
-    }
+    pageAnalysis.newRecordPositionInPage = contentEndOffset(pageAnalysis.page, pageAnalysis.lastRecordPositionInPage);
     pageAnalysis.spaceAvailableInCurrentPage = pageAnalysis.page.getMaxContentSize() - pageAnalysis.newRecordPositionInPage;
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/RestoreRecordAtPositionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/RestoreRecordAtPositionTest.java
@@ -101,6 +101,86 @@ class RestoreRecordAtPositionTest extends TestHelper {
   }
 
   @Test
+  void restoresARecordDeletedInTheSameTransaction() {
+    // #6096: same shape as restoresARecordAtItsOriginalRidAfterARawDelete(), but the delete and the restore share
+    // ONE transaction. That is the only way to reach the restore with a page whose record count is still > 0 while
+    // every one of those slots is a hole: on commit compressPage() resets the count to 0, which is why the
+    // separate-transaction case never hit it. The insertion offset was then derived from the 0 entry as if a
+    // record started at content offset 0, and the restored bytes landed on top of the page's own slot table - the
+    // record was written but no scan or lookup could ever find it again.
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final RID[] rid = new RID[1];
+
+    database.transaction(() -> rid[0] = database.newVertex(TYPE).set("name", "original").save().getIdentity());
+
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(rid[0].getBucketId());
+
+    database.transaction(() -> {
+      bucket.deleteRecord(rid[0]);
+      final MutableVertex shell = database.newVertex(TYPE).set("name", "restored-same-tx");
+      assertThat(bucket.restoreRecordAtPosition(rid[0].getPosition(), shell)).isEqualTo(rid[0]);
+    });
+
+    database.transaction(() -> {
+      assertThat(bucket.existsRecord(rid[0])).isTrue();
+      assertThat(database.lookupByRID(rid[0], true).asVertex().getString("name")).isEqualTo("restored-same-tx");
+      assertThat(countByScan(bucket)).isEqualTo(1);
+      assertThat(bucket.count()).isEqualTo(1);
+    });
+
+    reopenDatabase();
+
+    final LocalBucket reopened = (LocalBucket) ((DatabaseInternal) database).getSchema().getBucketById(rid[0].getBucketId());
+    database.transaction(() -> {
+      assertThat(database.lookupByRID(rid[0], true).asVertex().getString("name")).isEqualTo("restored-same-tx");
+      assertThat(countByScan(reopened)).isEqualTo(1);
+      assertThat(reopened.count()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void restoresIntoAPageWhoseEverySlotIsAHole() {
+    // #6096, wider variant: several records deleted in the same transaction so the page keeps a record count of 3
+    // with three holes, then the middle one is restored. The restore must start the content right after the page
+    // header, exactly like an insert into a page emptied by deletes. The type is created with a single bucket so
+    // the three records provably share one page and the all-holes shape is guaranteed rather than incidental.
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final String type = "RestoreSingleBucket";
+    database.transaction(() -> database.getSchema().createDocumentType(type, 1));
+
+    final RID[] rid = new RID[3];
+    database.transaction(() -> {
+      for (int i = 0; i < 3; i++)
+        rid[i] = database.newDocument(type).set("name", "doc" + i).save().getIdentity();
+    });
+
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(rid[1].getBucketId());
+    assertThat(rid[0].getBucketId()).isEqualTo(rid[2].getBucketId());
+
+    database.transaction(() -> {
+      for (int i = 0; i < 3; i++)
+        database.lookupByRID(rid[i], false).asDocument().delete();
+
+      final MutableDocument shell = database.newDocument(type).set("name", "restored-middle");
+      assertThat(bucket.restoreRecordAtPosition(rid[1].getPosition(), shell)).isEqualTo(rid[1]);
+    });
+
+    database.transaction(() -> {
+      assertThat(database.lookupByRID(rid[1], true).asDocument().getString("name")).isEqualTo("restored-middle");
+      assertThat(countByScan(bucket)).isEqualTo(1);
+    });
+  }
+
+  private long countByScan(final LocalBucket bucket) {
+    final long[] scanned = new long[1];
+    bucket.scan((rid, view) -> {
+      scanned[0]++;
+      return true;
+    }, null);
+    return scanned[0];
+  }
+
+  @Test
   void refusesToOverwriteAnOccupiedSlot() {
     final DatabaseInternal db = (DatabaseInternal) database;
     final RID[] rid = new RID[1];

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/RestoreSqlStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/RestoreSqlStatementTest.java
@@ -249,6 +249,53 @@ class RestoreSqlStatementTest extends TestHelper {
     assertThat(countByQuery()).isEqualTo(3);
   }
 
+  @Test
+  void restoreDocumentInTheSameTransactionAsTheDelete() {
+    // #6096: DELETE and RESTORE of the same RID inside ONE transaction. The two folds cancel out (-1 then +1) so
+    // count(*) still reports 1, but the record itself was written at a bogus page offset and a full scan returned
+    // 0 rows. The only live record of the page is the deleted one, so every slot of the page is a hole - the case
+    // findContentInsertionOffset() mistook for "a record starting at offset 0".
+    final RID[] rid = new RID[1];
+    database.transaction(() -> rid[0] = database.newDocument(DOC_TYPE).set("i", 7).save().getIdentity());
+
+    database.transaction(() -> {
+      database.command("sql", "DELETE FROM " + rid[0]);
+      database.command("sql", "RESTORE DOCUMENT " + DOC_TYPE + " RID " + rid[0] + " SET i = 7");
+    });
+
+    assertThat(countByScan()).isEqualTo(1);
+    assertThat(countByQuery()).isEqualTo(1);
+    database.transaction(() -> assertThat(database.lookupByRID(rid[0], true).asDocument().<Integer>get("i")).isEqualTo(7));
+
+    reopenDatabase();
+
+    assertThat(countByScan()).isEqualTo(1);
+    assertThat(countByQuery()).isEqualTo(1);
+  }
+
+  @Test
+  void restoreDocumentWhenEverySlotOfThePageIsAHole() {
+    // #6096, separate-transaction variant of the same page shape: the bucket's only record is deleted and
+    // committed, then restored. The record table is all holes, so the restore must start the content right after
+    // the page header instead of deriving an offset from a hole.
+    final RID[] rid = new RID[1];
+    database.transaction(() -> rid[0] = database.newDocument(DOC_TYPE).set("i", 7).save().getIdentity());
+
+    database.transaction(() -> database.command("sql", "DELETE FROM " + rid[0]));
+    assertThat(countByScan()).isEqualTo(0);
+    assertThat(countByQuery()).isEqualTo(0);
+
+    database.transaction(() -> database.command("sql", "RESTORE DOCUMENT " + DOC_TYPE + " RID " + rid[0] + " SET i = 7"));
+
+    assertThat(countByScan()).isEqualTo(1);
+    assertThat(countByQuery()).isEqualTo(1);
+
+    reopenDatabase();
+
+    assertThat(countByScan()).isEqualTo(1);
+    assertThat(countByQuery()).isEqualTo(1);
+  }
+
   private long countByQuery() {
     try (ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM " + DOC_TYPE)) {
       return rs.next().<Number>getProperty("c").longValue();


### PR DESCRIPTION
Fixes #6096.

## What was wrong

`RESTORE DOCUMENT/VERTEX/EDGE` executed in the **same transaction** as the `DELETE` wrote the restored record on top of the page's own slot table. The record was then unreachable by every scan and lookup, while `count(*)` still reported it as present - the `DELETE`'s `-1` and the `RESTORE`'s `+1` (added by #6082 for #6069) cancel out, so the counter is right about a record that is not there.

## Root cause

`LocalBucket.findContentInsertionOffset()` took the max over the page's record table to find where the last record's bytes end:

```java
if (recordPositionInPage > lastRecordPositionInPage)   // 0 == hole, not a record
  lastRecordPositionInPage = recordPositionInPage;
```

A delete leaves a `0` entry in that table. `0` was treated as *a record starting at content offset 0* instead of as a hole, so on a page whose **every** slot is a hole the max is `0`: the varint read at offset 0 lands on the `recordCountInPage` header short, decodes as size 0 ("deleted, v<24.1.1"), and the computed insertion offset comes out as **1** - inside the 8194-byte page header. The restore wrote the record there, over the slot-table entry it had just written for itself.

Only the same-transaction shape can reach it. On commit, `compressPage()` resets an all-holes page's record count to 0, so a restore in a **later** transaction sees 0 slots and correctly starts at `contentHeaderSize` - which is exactly why the reporter's separate-transaction run worked and the one-transaction run did not.

## The fix

The allocator's `getFreeSpaceInPage()` has always skipped those `0` entries correctly (`if (recordPositionInPage == 0) { ... } else if (... > last)`). `findContentInsertionOffset()` was a **second copy** of the same "offset past the last record" computation, and the two had drifted.

Rather than patching the copy, the shared part is now one method - `contentEndOffset()` - used by both callers, over the existing hole-skipping `getLastRecordPositionInPage()`. Net effect: 34 duplicated lines removed, and the two paths can no longer diverge again.

It also rejects a live slot pointing *inside* the page header outright. That state is a corrupted record table, and failing loudly beats deriving an insertion offset from header bytes - the same guard `getPageOccupiedInBytes()` already applies on the update path.

## Verification

Three regression tests, all confirmed **red** on the pre-fix code and green with it:

- `RestoreRecordAtPositionTest.restoresARecordDeletedInTheSameTransaction` - engine primitive, delete + restore in one transaction, asserts scan, `bucket.count()` and lookup agree before and after a reopen
- `RestoreRecordAtPositionTest.restoresIntoAPageWhoseEverySlotIsAHole` - single-bucket type, all three records deleted in one transaction, middle one restored
- `RestoreSqlStatementTest.restoreDocumentInTheSameTransactionAsTheDelete` - the reporter's exact SQL shape, `count(*)` vs full scan vs `lookupByRID`, before and after reopen

Full `engine` suite: 11709 tests, 1 failure - `Issue5279ConcurrentUpdateTest.growingUpdatesUnderContentionKeepTheDatabaseConsistent`, which fails identically on clean `main` (verified by stashing this change) and is a known pre-existing contention flake. Full project compiles.

## Not in this PR

`RESTORE` does not add index entries for the restored record (the statements call `bucket.restoreRecordAtPosition()` directly, bypassing the `LocalDatabase.createRecord` path that indexes). That is a separate pre-existing gap in the same family - an indexed query and a full scan disagree after a restore - and I will file it separately rather than widen this fix.