### PR TITLE
fix: CHECK DATABASE FIX destroyed the index of a document type

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -530,8 +530,14 @@ public class DatabaseChecker {
   }
 
   /**
-   * Removes the records this pass flagged corrupted, counting them into {@code autoFix} exactly as
-   * {@code GraphDatabaseChecker}'s vertex and edge arms count theirs.
+   * Removes the records this pass flagged corrupted, counting them into {@code autoFix}.
+   * <p>
+   * NOT quite what {@code GraphDatabaseChecker}'s vertex and edge arms count, and the difference is deliberate:
+   * they call {@code autoFix.incrementAndGet()} BEFORE attempting the delete, so a record they then fail to remove
+   * is still reported as fixed. This one counts a repair only once the delete and its counter delta have both
+   * succeeded, and counts nothing for a record that was already gone. If the two are ever unified, unify them
+   * towards THIS one: {@code autoFix} is what an operator reads to decide whether the run did anything, and a
+   * number that includes failed deletes cannot answer that.
    * <p>
    * This is not merely tidiness, and it is not optional. A corrupted record's RID goes into
    * {@code corruptedRecords}, which is what {@link #check()} turns into {@code affectedBuckets}, and every index on

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -314,7 +314,8 @@ public class DatabaseChecker {
         // the larger LOCK_POST_DROP_ATTEMPT_MULTIPLIER budget instead of giving up at LOCK_MAX_ATTEMPTS.
         boolean rebuilt = false;
         boolean indexDropped = false;
-        NeedRetryException lastRetryFailure = null;
+        RuntimeException lastFailure = null;
+        boolean lastFailureRetryable = true;
         int attemptsUsed = 0;
         for (int attempt = 1; ; attempt++) {
           attemptsUsed = attempt;
@@ -344,7 +345,8 @@ public class DatabaseChecker {
             rebuilt = true;
             break;
           } catch (final NeedRetryException e) {
-            lastRetryFailure = e;
+            lastFailure = e;
+            lastFailureRetryable = true;
             if (droppedThisAttempt[0])
               indexDropped = true;
 
@@ -359,26 +361,52 @@ public class DatabaseChecker {
               Thread.currentThread().interrupt();
               throw e;
             }
+          } catch (final RuntimeException e) {
+            // NOT retryable, so it gets no attempts: a DuplicatedKeyException from a unique index whose bucket
+            // already holds a violating record, a ReplicatedEntryTooLargeException on an HA leader whose rebuilt
+            // index exceeds arcadedb.ha.appendBufferSize, an IndexException from a record the build cannot read.
+            // Retrying reproduces it exactly.
+            //
+            // Caught at all - rather than left to unwind - for the reason the NeedRetryException arm above already
+            // states and which applies with MORE force here: this loop runs after checkDocuments/checkVertices/
+            // checkEdges have already found and repaired things, and none of that may be thrown away because ONE
+            // index could not be rebuilt. Before this arm existed, any such failure escaped check() with that
+            // attempt's dropIndex() already committed, so the single most destructive outcome (index gone, nothing
+            // reported, remaining indexes never even attempted) was also the one with no handling at all.
+            //
+            // RuntimeException, not a narrower list: the set of ways a rebuild can fail is open (every index type
+            // has its own, and the HA wrapper adds more), and the alternative to catching an unanticipated one is
+            // destroying the run. Nothing is swallowed - the exception's own message is quoted in the warning
+            // below and the index is struck from rebuiltIndexes.
+            lastFailure = e;
+            lastFailureRetryable = false;
+            if (droppedThisAttempt[0])
+              indexDropped = true;
+            break;
           }
         }
 
-        // Isolated per index rather than letting the exhausted retry unwind out of check(): this loop repairs
-        // potentially many indexes plus whatever checkDocuments/checkVertices/checkEdges already found and fixed,
-        // and none of that should be discarded because retrying ONE index ran out of attempts. Report it (this
-        // class's "reported, never silent" convention - see the manual-index warning above) and correct the
-        // rebuiltIndexes claim instead of pretending the rebuild happened.
+        // Isolated per index rather than letting the failure unwind out of check(): this loop repairs potentially
+        // many indexes plus whatever checkDocuments/checkVertices/checkEdges already found and fixed, and none of
+        // that should be discarded because ONE index could not be rebuilt - whether it ran out of retry attempts
+        // or failed outright. Report it (this class's "reported, never silent" convention - see the manual-index
+        // warning above) and correct the rebuiltIndexes claim instead of pretending the rebuild happened.
         //
-        // The warning's phrasing follows indexDropped (#6040): lock-acquisition exhaustion leaves the index
-        // exactly as it was, while post-drop exhaustion means the index is actually gone, not merely unrebuilt -
-        // lastRetryFailure.getMessage() is also surfaced so the operator can see the underlying cause either way.
+        // The warning's phrasing follows indexDropped (#6040) and retryability - see rebuildFailureStatus - and
+        // quotes lastFailure.getMessage() so the operator can see the underlying cause in every case.
         if (!rebuilt) {
           rebuildIndexes.remove(idx.getName());
-          final String status = indexDropped ?
-              "the index was dropped but the rebuild could not complete; it is now missing" :
-              "the index lock could not be acquired; the index itself is unchanged";
-          addWarning("index '" + idx.getName() + "' did not finish rebuilding after " + attemptsUsed + " attempts (" + status
-              + ", error: " + lastRetryFailure.getMessage() + "). Verify with `SELECT FROM schema:indexes WHERE name = '"
-              + idx.getName() + "'` and run CHECK DATABASE FIX again if it is missing");
+          // Named by the OWNING TypeIndex where there is one, because that is the name the operator created and
+          // the only one they can act on: idx.getName() is the internal per-bucket sub-index ("Doc_0_<nanos>"),
+          // which nobody typed and which makes the follow-up query below return nothing. The sub-index name is
+          // still quoted when the two differ, since a multi-bucket type has several and this says which failed.
+          final String reportedName = ownerTypeIndex != null ? ownerTypeIndex.getName() : idx.getName();
+          final String bucketSubIndex = reportedName.equals(idx.getName()) ? "" : " (bucket sub-index '" + idx.getName() + "')";
+          addWarning("index '" + reportedName + "'" + bucketSubIndex + " " + (lastFailureRetryable ?
+              "did not finish rebuilding after " + attemptsUsed + " attempts" :
+              "could not be rebuilt") + " (" + rebuildFailureStatus(indexDropped, lastFailureRetryable)
+              + ", error: " + lastFailure.getMessage() + "). Verify with `SELECT FROM schema:indexes WHERE name = '"
+              + reportedName + "'` and run CHECK DATABASE FIX again if it is missing");
         }
 
         stepTick();
@@ -397,6 +425,24 @@ public class DatabaseChecker {
       LogManager.instance().log(this, Level.INFO, "Result:\n%s", null, new JSONObject(result).toString(2));
 
     return result;
+  }
+
+  /**
+   * What state a failed index rebuild left behind, which is the only part of the warning an operator has to act
+   * on: an index that is MISSING needs recreating, one that is unchanged needs nothing.
+   * <p>
+   * Both dimensions matter and neither implies the other. {@code indexDropped} says whether this attempt's
+   * {@code dropIndex()} had already committed when it failed - #6040's distinction, and the difference between
+   * "gone" and "merely unrebuilt". Retryability says whether it was worth attempting again, which is what decides
+   * between the two ways of not being dropped: exhausting the lock-acquisition budget, or failing outright before
+   * the drop.
+   */
+  private static String rebuildFailureStatus(final boolean indexDropped, final boolean retryable) {
+    if (indexDropped)
+      return "the index was dropped but the rebuild could not complete; it is now missing";
+    return retryable ?
+        "the index lock could not be acquired; the index itself is unchanged" :
+        "the rebuild failed before the index was dropped; the index itself is unchanged";
   }
 
   /** Merges one scan's per-target dangling-reference counts into the cross-scan accumulator. */
@@ -429,13 +475,18 @@ public class DatabaseChecker {
    *   {@code totalWarnings}/{@code totalCorruptedRecords}, so a corrupt document reported different numbers
    *   depending on which path found it - and, since the totals are what a capped run reports, reported zero once
    *   the sets filled up;</li>
-   *   <li>it called a document a "vertex", and said it was "removing it" when nothing here removes anything -
-   *   {@code corruptedRecords} only drives the index rebuild at the end of {@link #check()};</li>
+   *   <li>it called a document a "vertex", and claimed to be "removing it" while removing nothing;</li>
    *   <li>it kept no cap at all, so a type whose whole bucket is unreadable retained one message per record.</li>
    * </ul>
    * Both paths now go through {@link #addWarning}/{@link #addCorrupted}. The accumulators are also per-type now:
    * they used to be declared outside the loop and re-added to the result after every type, which the sets absorbed
    * but paid for in re-insertions proportional to the square of the type count.
+   * <p>
+   * The second of those was settled the OTHER way round afterwards, so do not restore the old wording from the
+   * bullet above: under {@code FIX} this arm now really does remove the record, via
+   * {@link #deleteCorruptedRecords}, matching the vertex and edge arms. Flagging without removing was not merely a
+   * reporting quirk - {@code corruptedRecords} drives the index rebuild at the end of {@link #check()}, and that
+   * rebuild rescans the bucket, so the record left behind destroyed the very index the flag asked to repair.
    */
   private void checkDocuments(final List<DocumentType> documentTypes) {
     if (verboseLevel > 0)
@@ -443,6 +494,10 @@ public class DatabaseChecker {
 
     for (final DocumentType type : documentTypes) {
       stepBegin("Checking documents '" + type.getName() + "'", database.countType(type.getName(), false));
+
+      // Collected during the scan and deleted after it: LocalBucket.scan is walking the very pages the delete
+      // would rewrite, so removing a record from inside the callback would mutate the structure being iterated.
+      final List<RID> toDelete = new ArrayList<>();
 
       database.begin();
       try {
@@ -456,17 +511,59 @@ public class DatabaseChecker {
             } catch (Exception e) {
               addWarning("document " + rid + " cannot be loaded");
               addCorrupted(rid);
+              if (fix)
+                toDelete.add(rid);
             }
             stepTick();
             return true;
           }, null);
         }
 
+        deleteCorruptedRecords(toDelete);
+
       } finally {
         database.commit();
       }
 
       stepComplete();
+    }
+  }
+
+  /**
+   * Removes the records this pass flagged corrupted, counting them into {@code autoFix} exactly as
+   * {@code GraphDatabaseChecker}'s vertex and edge arms count theirs.
+   * <p>
+   * This is not merely tidiness, and it is not optional. A corrupted record's RID goes into
+   * {@code corruptedRecords}, which is what {@link #check()} turns into {@code affectedBuckets}, and every index on
+   * an affected bucket is then dropped and rebuilt. The rebuild's own bucket scan re-reads every record in it, so a
+   * corrupt record LEFT IN PLACE is met a second time by {@code LSMTreeIndex.build}, whose error callback
+   * propagates rather than logging (deliberately - a swallowed failure would leave the index silently incomplete).
+   * That exception escaped {@link #check()} with the drop already committed, which destroyed the index and
+   * abandoned the rest of the run. The document arms used to flag without deleting and were the only way to reach
+   * that state; {@link #rebuildFailureStatus} now contains the damage if a rebuild fails for some other reason,
+   * but not creating the state in the first place is the actual fix.
+   * <p>
+   * Deletes through the bucket rather than {@code database.deleteRecord}: the record cannot be materialised - that
+   * is what "corrupted" means here - so there is nothing to hand the record-level API, and its index entries are
+   * about to be regenerated from scratch by the rebuild anyway. Same call the graph arms use.
+   */
+  private void deleteCorruptedRecords(final List<RID> toDelete) {
+    for (final RID rid : toDelete) {
+      try {
+        database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid);
+        // Mirror the accounting in LocalDatabase.cascadeDeleteExternalValues (and in checkExternalProperties just
+        // below) so count() stays consistent: LocalBucket.deleteRecord does NOT touch cachedRecordCount, and
+        // count(*) reads that counter rather than scanning. Without this the type keeps reporting the deleted
+        // record until something else recomputes the counter - which a full-scope run happens to do in
+        // checkBuckets, but the RECORD scope deliberately skips, so the same repair would report two different
+        // counts depending on the scope it was asked for.
+        database.getTransaction().updateBucketRecordDelta(rid.getBucketId(), -1);
+        result.put("autoFix", (Long) result.get("autoFix") + 1);
+      } catch (final RecordNotFoundException e) {
+        // ALREADY GONE
+      } catch (final Exception e) {
+        addWarning("document " + rid + " cannot be removed (error: " + e.getMessage() + ")");
+      }
     }
   }
 
@@ -648,6 +745,8 @@ public class DatabaseChecker {
   private void checkScopedDocuments(final DocumentType type, final List<RID> rids) {
     stepBegin("Checking records of '" + type.getName() + "'", rids.size());
 
+    final List<RID> toDelete = new ArrayList<>();
+
     database.begin();
     try {
       for (final RID rid : rids) {
@@ -658,12 +757,18 @@ public class DatabaseChecker {
           // every index on it - see the same guard in GraphDatabaseChecker's scoped arms.
           addWarning("document " + rid + " does not exist");
         } catch (final Exception e) {
-          // NOT "removing it": corruptedRecords only drives the index rebuild, nothing deletes the record here.
           addWarning("document " + rid + " cannot be loaded");
           addCorrupted(rid);
+          if (fix)
+            toDelete.add(rid);
         }
         stepTick();
       }
+
+      // Same removal as the type-wide arm, for the same reason: this scope also feeds affectedBuckets, so a
+      // corrupt record left here would be met again by the rebuild that its own flagging triggers.
+      deleteCorruptedRecords(toDelete);
+
     } finally {
       database.commit();
     }

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -445,6 +445,21 @@ public class DatabaseChecker {
         "the rebuild failed before the index was dropped; the index itself is unchanged";
   }
 
+  /**
+   * Merges the records a sub-check actually deleted into {@code deletedRecordsAfterFix}.
+   * <p>
+   * Absent before, which made the field answer a different question depending on which pass did the removing: the
+   * bucket-wide {@code LocalBucket.check} listed what it deleted, while the vertex and edge arms deleted silently
+   * and reported only an {@code autoFix} count. The distinction was invisible while a broken-chain record was
+   * always removed by the bucket pass; once the arms could remove it first, the same repair stopped listing the
+   * same record. Reported by whichever pass performs it, or the field cannot be read at all.
+   */
+  private void mergeDeletedRecords(final Map<String, Object> stats) {
+    final Collection<RID> deleted = (Collection<RID>) stats.get("deletedRecordsAfterFix");
+    if (deleted != null)
+      ((LinkedHashSet<RID>) result.get("deletedRecordsAfterFix")).addAll(deleted);
+  }
+
   /** Merges one scan's per-target dangling-reference counts into the cross-scan accumulator. */
   private void mergeMissingReferences(final Map<RID, Long> refs, final Map<RID, String> errors) {
     if (refs == null)
@@ -556,7 +571,13 @@ public class DatabaseChecker {
   private void deleteCorruptedRecords(final List<RID> toDelete) {
     for (final RID rid : toDelete) {
       try {
-        database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid);
+        final Bucket bucket = database.getSchema().getBucketById(rid.getBucketId());
+        // See GraphDatabaseChecker.deleteCorruptedRecord: escalates to a force delete for the one failure force
+        // exists to clear, a structurally broken chunk chain, which a plain delete reports as a retry signal.
+        if (bucket instanceof LocalBucket localBucket)
+          localBucket.deleteCorruptedRecord(rid);
+        else
+          bucket.deleteRecord(rid);
         // Mirror the accounting in LocalDatabase.cascadeDeleteExternalValues (and in checkExternalProperties just
         // below) so count() stays consistent: LocalBucket.deleteRecord does NOT touch cachedRecordCount, and
         // count(*) reads that counter rather than scanning. Without this the type keeps reporting the deleted
@@ -565,6 +586,8 @@ public class DatabaseChecker {
         // counts depending on the scope it was asked for.
         database.getTransaction().updateBucketRecordDelta(rid.getBucketId(), -1);
         result.put("autoFix", (Long) result.get("autoFix") + 1);
+        // Same reason as mergeDeletedRecords: a removal nobody lists cannot be audited.
+        ((LinkedHashSet<RID>) result.get("deletedRecordsAfterFix")).add(rid);
       } catch (final RecordNotFoundException e) {
         // ALREADY GONE
       } catch (final Exception e) {
@@ -686,6 +709,7 @@ public class DatabaseChecker {
       updateStats(stats);
       ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
       ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+      mergeDeletedRecords(stats);
       mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
           (Map<RID, String>) stats.get("missingReferenceErrors"));
     }
@@ -800,6 +824,7 @@ public class DatabaseChecker {
 
       ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
       ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+      mergeDeletedRecords(stats);
       mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
           (Map<RID, String>) stats.get("missingReferenceErrors"));
     }
@@ -823,6 +848,7 @@ public class DatabaseChecker {
 
       ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
       ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+      mergeDeletedRecords(stats);
       mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
           (Map<RID, String>) stats.get("missingReferenceErrors"));
     }

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -377,6 +377,38 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     deleteRecordInternal(rid, false, false, force);
   }
 
+  /**
+   * Deletes a record an integrity check has already judged beyond repair, escalating to {@link #deleteRecord(RID,
+   * boolean) force} only for the one failure that force exists to clear: a structurally broken chunk chain.
+   * <p>
+   * The escalation is GATED on {@link #isChunkChainBroken}, not unconditional, and that is the whole point of this
+   * method. A {@link ConcurrentModificationException} from a plain delete does not prove corruption - the same
+   * page-version validation fails when concurrent writes touch OTHER records sharing the chain's pages, so on a
+   * busy bucket it is ordinary contention, and forcing through it would orphan chunks and skip index cleanup for a
+   * healthy record. The version-blind structural probe is what tells the two apart; it is the same discriminator
+   * {@code LocalDatabase.deleteRecord} uses for the tolerant path, and a transient conflict still propagates as
+   * the retry signal it is.
+   * <p>
+   * Deliberately does NOT consult {@code DELETE_TOLERATE_BROKEN_CHAIN}: that setting governs whether an ORDINARY
+   * delete may force through, and its own documentation states that CHECK DATABASE FIX is unaffected by it either
+   * way, so a broken record is never permanently stuck. {@link #check} already force-deletes such a record on the
+   * bucket-wide pass; this is the same guarantee for the callers that reach one record directly, which is what the
+   * RECORD-scoped check does after skipping the bucket-wide passes.
+   * <p>
+   * Note for the caller: like both {@code deleteRecord} overloads, this does NOT maintain {@code cachedRecordCount}
+   * - the counter {@code count(*)} answers from. Pair it with {@code updateBucketRecordDelta(fileId, -1)}.
+   */
+  public void deleteCorruptedRecord(final RID rid) {
+    try {
+      deleteRecord(rid);
+    } catch (final ConcurrentModificationException e) {
+      if (!isChunkChainBroken(rid))
+        // CONTENTION, not corruption: preserve the NeedRetryException semantics so the caller can retry.
+        throw e;
+      deleteRecord(rid, true);
+    }
+  }
+
   @Override
   public void scan(final RawRecordCallback callback, final ErrorRecordCallback errorRecordCallback) {
     database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.READ_RECORD);

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
+import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
@@ -280,7 +281,16 @@ public class GraphDatabaseChecker {
    *                                                        that is worth reporting
    */
   private void deleteCorruptedRecord(final RID rid) {
-    database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid);
+    final Bucket bucket = database.getSchema().getBucketById(rid.getBucketId());
+    // LocalBucket.deleteCorruptedRecord escalates to a force delete for a structurally broken chunk chain, which a
+    // plain delete cannot clear (#4932). Without it the RECORD scope reported "error on delete" and left the record
+    // in place: the bucket-wide pass that force-deletes it (LocalBucket.check) is one of the database-wide passes
+    // that scope skips. The instanceof rather than a cast keeps a non-local Bucket implementation on the plain
+    // delete instead of failing outright, since the escalation is a repair nicety, not a precondition.
+    if (bucket instanceof LocalBucket localBucket)
+      localBucket.deleteCorruptedRecord(rid);
+    else
+      bucket.deleteRecord(rid);
     database.getTransaction().updateBucketRecordDelta(rid.getBucketId(), -1);
   }
 
@@ -451,6 +461,8 @@ public class GraphDatabaseChecker {
     final Set<RID> reconnectInEdges = new HashSet<>();
     final Map<RID, Long> missingReferences = new HashMap<>();
     final Map<RID, String> missingReferenceErrors = new HashMap<>();
+    /** Records this run actually removed, surfaced as {@code deletedRecordsAfterFix}. */
+    final Set<RID> deletedRecords = new LinkedHashSet<>();
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -530,6 +542,11 @@ public class GraphDatabaseChecker {
           autoFix.incrementAndGet();
           try {
             deleteCorruptedRecord(rid);
+            // Reported, not only counted: an operator reads deletedRecordsAfterFix to learn WHICH records a repair
+            // removed, and until this arm populated it the answer depended on which pass happened to do the delete -
+            // a broken-chain record was listed (LocalBucket.check removed it) and every other corrupt record was not.
+            // Bounded by the same cap as report.corruptedRecords, which this iterates.
+            deletedRecords.add(rid);
           } catch (final RecordNotFoundException e) {
             // IGNORE IT
           } catch (final Throwable e) {
@@ -546,6 +563,7 @@ public class GraphDatabaseChecker {
 
     } finally {
       stats.put("autoFix", autoFix.get());
+      stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("duplicateLightEdges", report.duplicateLightEdges);
       stats.put("invalidLinks", report.invalidLinks);
@@ -1175,6 +1193,8 @@ public class GraphDatabaseChecker {
     // Vertices whose edge LIST failed to walk during the back-reference probe: warned once each (a broken
     // super-node chain is referenced by millions of edges), never flagged corrupted - see the probe guards.
     final Set<RID> unreadableListVertices = new HashSet<>();
+    /** Records this run actually removed, surfaced as {@code deletedRecordsAfterFix}. */
+    final Set<RID> deletedRecords = new LinkedHashSet<>();
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -1319,6 +1339,11 @@ public class GraphDatabaseChecker {
           autoFix.incrementAndGet();
           try {
             deleteCorruptedRecord(rid);
+            // Reported, not only counted: an operator reads deletedRecordsAfterFix to learn WHICH records a repair
+            // removed, and until this arm populated it the answer depended on which pass happened to do the delete -
+            // a broken-chain record was listed (LocalBucket.check removed it) and every other corrupt record was not.
+            // Bounded by the same cap as report.corruptedRecords, which this iterates.
+            deletedRecords.add(rid);
           } catch (final RecordNotFoundException e) {
             // IGNORE IT
           } catch (final Throwable e) {
@@ -1335,6 +1360,7 @@ public class GraphDatabaseChecker {
 
     } finally {
       stats.put("autoFix", autoFix.get());
+      stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("invalidLinks", report.invalidLinks);
       stats.put("missingReferenceBack", missingReferenceBack.get());

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -227,7 +227,7 @@ public class GraphDatabaseChecker {
 
         for (final RID orphan : orphansToDelete) {
           try {
-            database.getSchema().getBucketById(orphan.getBucketId()).deleteRecord(orphan);
+            deleteCorruptedRecord(orphan);
             ++reclaimed;
           } catch (final RecordNotFoundException e) {
             // ALREADY GONE
@@ -254,6 +254,34 @@ public class GraphDatabaseChecker {
       stats.put("totalWarnings", report.totalWarnings);
     }
     return stats;
+  }
+
+  /**
+   * Removes one record this checker decided is beyond repair, and pays the bucket-counter debt that comes with it.
+   * <p>
+   * {@code LocalBucket.deleteRecord} does NOT touch {@code cachedRecordCount}, and that counter - not a scan - is
+   * what {@code count(*)} and {@code countType()} answer from. Every caller that deletes through the bucket
+   * therefore owes the matching {@code updateBucketRecordDelta(-1)}, the same accounting
+   * {@code LocalDatabase.cascadeDeleteExternalValues} and {@code DatabaseChecker}'s document arm do.
+   * <p>
+   * Missing it was invisible on a type-wide run, which is why it survived: {@code DatabaseChecker.checkBuckets}
+   * recomputes every bucket counter afterwards and repaired the drift as a side effect. The RECORD scope
+   * deliberately skips the database-wide passes, so there the type simply kept over-reporting the deleted record
+   * for good. Pinned by {@code CheckDatabaseRecordScopeTest#aRecordScopedFixKeepsTheCachedRecordCountConsistent}
+   * and its edge twin.
+   * <p>
+   * Shared by all three delete sites in this class - the vertex arm, the edge arm and the orphan-segment reclaim -
+   * rather than repeated: they were byte-identical copies, and the rule is the thing that must not drift apart
+   * again. The reclaim's edge-list buckets belong to no type, so nothing user-facing reads their counter today;
+   * it goes through here anyway, because "which buckets have a reader" is not a distinction worth encoding in
+   * three places.
+   *
+   * @throws com.arcadedb.exception.RecordNotFoundException if the record is already gone - callers decide whether
+   *                                                        that is worth reporting
+   */
+  private void deleteCorruptedRecord(final RID rid) {
+    database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid);
+    database.getTransaction().updateBucketRecordDelta(rid.getBucketId(), -1);
   }
 
   /**
@@ -501,7 +529,7 @@ public class GraphDatabaseChecker {
 
           autoFix.incrementAndGet();
           try {
-            database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid);
+            deleteCorruptedRecord(rid);
           } catch (final RecordNotFoundException e) {
             // IGNORE IT
           } catch (final Throwable e) {
@@ -1290,7 +1318,7 @@ public class GraphDatabaseChecker {
 
           autoFix.incrementAndGet();
           try {
-            database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid);
+            deleteCorruptedRecord(rid);
           } catch (final RecordNotFoundException e) {
             // IGNORE IT
           } catch (final Throwable e) {

--- a/engine/src/test/java/com/arcadedb/BrokenMultiPageRecordDeleteTest.java
+++ b/engine/src/test/java/com/arcadedb/BrokenMultiPageRecordDeleteTest.java
@@ -90,6 +90,39 @@ class BrokenMultiPageRecordDeleteTest extends TestHelper {
     assertThat(row.<Collection<?>>getProperty("warnings").toString()).doesNotContain("broken multi-page chunk chain");
   }
 
+  /**
+   * The same removal through {@code CHECK DATABASE RECORD <rid> FIX}. The scope matters here in a way it does not
+   * for any other corruption shape: the force-delete that clears a broken chain lives in {@code LocalBucket.check},
+   * reached from {@code DatabaseChecker.checkBuckets} - one of the database-wide passes the RECORD scope
+   * deliberately skips. So the scoped run met the record only through the vertex arm, whose plain
+   * {@code bucket.deleteRecord} raises the #4932 retry signal on the broken link, reported it as "Cannot fix the
+   * record ...: error on delete" and left it in place. It stayed reachable by a full-scope run, so nothing was
+   * permanently stuck, but the operator who reached for the narrow tool was told the repair had failed with no
+   * indication that the wide one would work.
+   * <p>
+   * The scoped arms now force through a chain that {@code isChunkChainBroken} confirms is structurally broken,
+   * which is the same discriminator {@code LocalDatabase.deleteRecord} uses to tell corruption from contention -
+   * and NOT an unconditional force, which would also fire on a healthy record whose page merely lost a version
+   * race, discarding its index cleanup.
+   */
+  @Test
+  void checkDatabaseRecordScopedFixRemovesBrokenMultiPageRecord() {
+    final RID broken = createBrokenMultiPageVertex();
+
+    assertThat(database.getSchema().getBucketById(broken.getBucketId()).existsRecord(broken))
+        .as("precondition: the broken record is there to begin with").isTrue();
+
+    try (final ResultSet rs = database.command("sql", "CHECK DATABASE RECORD " + broken + " FIX")) {
+      final Result row = rs.next();
+      assertThat(row.<Collection<String>>getProperty("warnings").toString())
+          .as("the scoped repair must not report a failed delete: %s", row.toJSON())
+          .doesNotContain("error on delete");
+    }
+
+    assertThat(database.getSchema().getBucketById(broken.getBucketId()).existsRecord(broken))
+        .as("the RECORD scope must remove a broken-chain record, like the full-scope run does").isFalse();
+  }
+
   @Test
   void forceDeleteRemovesBrokenMultiPageRecordWhilePlainDeleteRetries() {
     final RID broken = createBrokenMultiPageVertex();

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixDocumentTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixDocumentTypeTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code CHECK DATABASE FIX} over a plain DOCUMENT type holding an unreadable record.
+ * <p>
+ * The two halves below were one defect in practice: {@code DatabaseChecker.checkDocuments} flagged a corrupted
+ * document through {@code addCorrupted} but - unlike the vertex and edge arms in {@code GraphDatabaseChecker} -
+ * never DELETED it, while the shared tail of {@code check()} still put its bucket into {@code affectedBuckets} and
+ * dropped and rebuilt every index there. The rebuild's own bucket scan then met the same unreadable record,
+ * {@code LSMTreeIndex.build}'s error callback propagated it (deliberately - see its comment), and because the
+ * rebuild loop caught only {@code NeedRetryException} the failure escaped {@code check()} entirely with that
+ * attempt's {@code dropIndex()} already committed. Net effect on a single node, no cluster involved: running
+ * {@code CHECK DATABASE FIX} to repair one corrupt document DESTROYED the type's index and aborted the whole
+ * check, so nothing after it was repaired either.
+ * <p>
+ * Every {@code CHECK DATABASE FIX} index test that existed before this one used {@code CREATE VERTEX TYPE} (see
+ * {@code CheckDatabaseFixPreservesIndexMetadataTest}), where the graph arm deletes the record first and the
+ * rebuild therefore never meets it - which is why the document arm's omission survived.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseFixDocumentTypeTest extends TestHelper {
+
+  /**
+   * The primary half: a corrupted document is removed, so the rebuild that follows has nothing to trip over and
+   * the index survives with the entries of the records that are still readable.
+   */
+  @Test
+  void fixDeletesCorruptedDocumentAndPreservesIndex() {
+    final RID victimRid = createIndexedDocs("myDocIdx", "NOTUNIQUE");
+
+    // PRECONDITION: both records are indexed before anything is broken, so a later count of 1 means the rebuild
+    // dropped exactly the corrupted one rather than the index having been short all along.
+    assertThat(database.getSchema().getIndexByName("myDocIdx").countEntries()).isEqualTo(2L);
+
+    final AtomicReference<RID> victim = new AtomicReference<>(victimRid);
+
+    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
+
+    final Result fix;
+    try (final ResultSet rs = database.command("sql", "check database fix")) {
+      fix = rs.next();
+    }
+
+    assertThat(fix.<Long>getProperty("autoFix"))
+        .as("the corrupted document must be counted as repaired, exactly as the vertex arm counts its own")
+        .isGreaterThan(0L);
+
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("myDocIdx"))
+          .as("the index must survive: the rebuild had nothing left to trip over").isTrue();
+      assertThat(database.getSchema().getIndexByName("myDocIdx").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
+      assertThat(database.getSchema().getIndexByName("myDocIdx").countEntries())
+          .as("the rebuilt index holds the surviving record only").isEqualTo(1L);
+
+      assertThat(database.countType("Doc", false)).as("the corrupted document is gone").isEqualTo(1L);
+    });
+
+    // A follow-up check, WITHOUT fix, must find nothing: a run that reported a repair it did not make would
+    // otherwise pass everything above.
+    try (final ResultSet rs = database.command("sql", "check database")) {
+      final Result verify = rs.next();
+      assertThat(verify.<Long>getProperty("totalCorruptedRecords")).isZero();
+      assertThat(verify.<Long>getProperty("totalWarnings")).isZero();
+    }
+  }
+
+  /** The same repair through the {@code RECORD} scope, which reaches the corrupted document by its own arm. */
+  @Test
+  void recordScopedFixDeletesCorruptedDocumentAndPreservesIndex() {
+    final AtomicReference<RID> victim = new AtomicReference<>(createIndexedDocs("myDocIdx", "NOTUNIQUE"));
+
+    assertThat(database.getSchema().getIndexByName("myDocIdx").countEntries()).isEqualTo(2L);
+
+    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
+
+    try (final ResultSet rs = database.command("sql", "check database record " + victim.get() + " fix")) {
+      assertThat(rs.next().<Long>getProperty("autoFix")).isGreaterThan(0L);
+    }
+
+    database.transaction(() -> {
+      assertThat(database.getSchema().existsIndex("myDocIdx")).isTrue();
+      assertThat(database.getSchema().getIndexByName("myDocIdx").countEntries()).isEqualTo(1L);
+      assertThat(database.countType("Doc", false)).isEqualTo(1L);
+    });
+  }
+
+  /**
+   * The second half, which the first does not cover: a rebuild that fails for a reason the checker cannot remove
+   * first. The retry loop only ever caught {@code NeedRetryException}, so anything else - a
+   * {@code DuplicatedKeyException} here, a {@code ReplicatedEntryTooLargeException} on an HA leader whose index is
+   * bigger than {@code arcadedb.ha.appendBufferSize} - unwound out of {@code check()} with the drop already
+   * committed, discarding every repair the run had made so far and leaving the index missing with no report of it.
+   * <p>
+   * The duplicate is inserted straight into the bucket via {@code LocalBucket.createRecord}, which does not go
+   * through {@code DocumentIndexer}: that is the only way to hold a unique index and a violating record at the same
+   * time, which is exactly the state a rebuild cannot resolve.
+   */
+  @Test
+  void rebuildFailureIsReportedAndDoesNotAbortTheCheck() {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.command("sql", "CREATE DOCUMENT TYPE Doc");
+    database.command("sql", "CREATE PROPERTY Doc.name STRING");
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Doc SET name = 'alpha'");
+      victim.set(database.command("sql", "INSERT INTO Doc SET name = 'gamma'").next().toElement().getIdentity());
+    });
+    database.command("sql", "CREATE INDEX myUniqueDocIdx ON Doc (name) UNIQUE");
+    assertThat(database.getSchema().getIndexByName("myUniqueDocIdx").countEntries()).isEqualTo(2L);
+
+    // A second 'alpha' the unique index knows nothing about. Legal to write, impossible to index.
+    database.transaction(() -> {
+      final MutableDocument duplicate = database.newDocument("Doc").set("name", "alpha");
+      database.getSchema().getBucketById(victim.get().getBucketId()).createRecord(duplicate, false);
+    });
+
+    // The corrupted record is what puts the bucket into affectedBuckets and so triggers the rebuild at all.
+    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
+
+    final Result fix;
+    try (final ResultSet rs = database.command("sql", "check database fix")) {
+      assertThat(rs.hasNext()).as("the check must COMPLETE and return its report, not unwind").isTrue();
+      fix = rs.next();
+    }
+
+    assertThat(fix.<Long>getProperty("autoFix"))
+        .as("the repairs made before the failing index must be kept, not discarded with it").isGreaterThan(0L);
+
+    final Collection<String> rebuilt = fix.getProperty("rebuiltIndexes");
+    assertThat(rebuilt)
+        .as("an index that did not rebuild must not be claimed as rebuilt")
+        .doesNotContain("myUniqueDocIdx");
+
+    final Collection<String> warnings = fix.getProperty("warnings");
+    assertThat(warnings)
+        .as("the failure must be REPORTED, naming the index and saying it is now missing")
+        .anyMatch(w -> w.contains("myUniqueDocIdx") && w.contains("missing"));
+
+    // The honest end state: the index really is gone. Recreating it empty would be worse - queries would silently
+    // return nothing - so the contract is that the operator is told, loudly, and recreates it.
+    assertThat(database.getSchema().existsIndex("myUniqueDocIdx")).isFalse();
+  }
+
+  /**
+   * Two documents plus an index over them. The insert and the {@code CREATE INDEX} are deliberately in SEPARATE
+   * transactions: {@code BucketIndexBuilder.create()} builds in a transaction of its own with
+   * {@code joinCurrentTx = false}, so an index created inside the transaction that inserted the records is built
+   * against committed state and comes out EMPTY - which would make every entry-count assertion below vacuous.
+   *
+   * @return the RID of the record the caller is meant to corrupt
+   */
+  private RID createIndexedDocs(final String indexName, final String uniqueness) {
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    database.command("sql", "CREATE DOCUMENT TYPE Doc");
+    database.command("sql", "CREATE PROPERTY Doc.name STRING");
+    database.transaction(() -> {
+      victim.set(database.command("sql", "INSERT INTO Doc SET name = 'alpha'").next().toElement().getIdentity());
+      database.command("sql", "INSERT INTO Doc SET name = 'beta'");
+    });
+    database.command("sql", "CREATE INDEX " + indexName + " ON Doc (name) " + uniqueness);
+    return victim.get();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixDocumentTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseFixDocumentTypeTest.java
@@ -57,15 +57,13 @@ class CheckDatabaseFixDocumentTypeTest extends TestHelper {
    */
   @Test
   void fixDeletesCorruptedDocumentAndPreservesIndex() {
-    final RID victimRid = createIndexedDocs("myDocIdx", "NOTUNIQUE");
+    final RID victim = createIndexedDocs("myDocIdx", "NOTUNIQUE");
 
     // PRECONDITION: both records are indexed before anything is broken, so a later count of 1 means the rebuild
     // dropped exactly the corrupted one rather than the index having been short all along.
     assertThat(database.getSchema().getIndexByName("myDocIdx").countEntries()).isEqualTo(2L);
 
-    final AtomicReference<RID> victim = new AtomicReference<>(victimRid);
-
-    corruptRecordTypeByte((DatabaseInternal) database, victim.get());
+    corruptRecordTypeByte((DatabaseInternal) database, victim);
 
     final Result fix;
     try (final ResultSet rs = database.command("sql", "check database fix")) {

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRecordScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRecordScopeTest.java
@@ -494,6 +494,79 @@ class CheckDatabaseRecordScopeTest extends TestHelper {
     }
   }
 
+  /**
+   * A scoped FIX that DELETES a corrupted record must leave the bucket's cached record count telling the truth.
+   * <p>
+   * {@code LocalBucket.deleteRecord} does not touch {@code cachedRecordCount} - the counter {@code count(*)} and
+   * {@code countType()} read instead of scanning - so every caller that deletes through it owes the matching
+   * {@code updateBucketRecordDelta(-1)}. The graph arms did not pay it, and the type-wide run hid that: its
+   * {@code checkBuckets} pass recomputes every bucket counter afterwards, which happens to repair the drift. The
+   * RECORD scope deliberately skips the database-wide passes, so nothing repaired it there and the type kept
+   * over-reporting the deleted record for good.
+   * <p>
+   * Asserted against a real scan rather than a literal, so this pins the two ANSWERS AGREEING rather than one
+   * arithmetic result: {@code count(@rid)} scans and is ground truth, {@code countType} reads the counter.
+   */
+  @Test
+  void aRecordScopedFixKeepsTheCachedRecordCountConsistent() {
+    createSchema();
+
+    final RID[] victim = new RID[1];
+    database.transaction(() -> {
+      database.newVertex("Src").set("name", "keep-me").save();
+      final MutableVertex v = database.newVertex("Src").set("name", "corrupt-me");
+      v.save();
+      victim[0] = v.getIdentity();
+    });
+
+    // PRECONDITION: the counter is right BEFORE the repair, so a mismatch afterwards is the repair's doing and not
+    // a counter that was already adrift.
+    assertThat(database.countType("Src", false)).as("baseline cached count").isEqualTo(2L);
+    assertThat(scanCountOf("Src")).as("baseline scan").isEqualTo(2L);
+
+    corruptRecordTypeByte(victim[0]);
+
+    try (final ResultSet rs = database.command("sql", "CHECK DATABASE RECORD " + victim[0] + " FIX")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(longProperty(rs.next(), "autoFix")).as("the corrupted vertex must actually have been removed")
+          .isGreaterThan(0L);
+    }
+
+    assertThat(scanCountOf("Src")).as("the corrupted vertex is really gone").isEqualTo(1L);
+    assertThat(database.countType("Src", false))
+        .as("count(*) reads the cached counter and must agree with the scan after a scoped repair")
+        .isEqualTo(scanCountOf("Src"));
+  }
+
+  /** The edge arm of {@link #aRecordScopedFixKeepsTheCachedRecordCountConsistent}: same deletion, same rule. */
+  @Test
+  void aRecordScopedEdgeFixKeepsTheCachedRecordCountConsistent() {
+    createSchema();
+    final RID hub = createHub();
+    final List<RID> edges = createEdges(hub, 2);
+
+    assertThat(database.countType("LINK", false)).as("baseline cached count").isEqualTo(2L);
+
+    corruptRecordTypeByte(edges.getFirst());
+
+    try (final ResultSet rs = database.command("sql", "CHECK DATABASE RECORD " + edges.getFirst() + " FIX")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(longProperty(rs.next(), "autoFix")).as("the corrupted edge must actually have been removed")
+          .isGreaterThan(0L);
+    }
+
+    assertThat(database.countType("LINK", false))
+        .as("count(*) reads the cached counter and must agree with the scan after a scoped repair")
+        .isEqualTo(scanCountOf("LINK"));
+  }
+
+  /** Ground truth: {@code count(@rid)} scans, unlike {@code count(*)} which reads the cached bucket counter. */
+  private long scanCountOf(final String typeName) {
+    try (final ResultSet rs = database.command("sql", "SELECT count(@rid) AS c FROM `" + typeName + "`")) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
   /** Runs a non-fixing check and returns its corrupted-record total, asserting the record was named in a warning. */
   private long corruptedReportedBy(final String command, final RID rid) {
     try (final ResultSet rs = database.command("sql", command)) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCheckDatabaseFix3NodesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCheckDatabaseFix3NodesIT.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.exception.DatabaseIsClosedException;
+import com.arcadedb.graph.EdgeSegment;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.VertexInternal;
+import com.arcadedb.database.Binary;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * First cluster coverage of {@code CHECK DATABASE ... FIX}. Before this class the statement had none: a grep of
+ * {@code ha-raft/src/test} for "CHECK DATABASE" returned nothing, and the only file named for a checker
+ * ({@code ClusterDatabaseChecker}) is a {@code main()} that diffs three database directories offline.
+ * <p>
+ * The gap matters because the checker's repair path is not an ordinary write. Three things about it are specific
+ * to a replicated database and none of them are exercised by the engine's own {@code CheckDatabase*Test}s:
+ * <ul>
+ *   <li>{@code CheckDatabaseStatement} is not idempotent, so on a follower {@code RaftReplicatedDatabase.command}
+ *   forwards the whole statement to the leader over HTTP - with or without {@code FIX}. The check therefore only
+ *   ever inspects the LEADER's pages, and every repair has to reach the other nodes as replicated WAL rather than
+ *   by each node repairing itself;</li>
+ *   <li>{@code GraphDatabaseChecker.checkVertices} accumulates an entire type's repair in ONE transaction, which
+ *   under Raft becomes ONE log entry - {@code RaftTransactionBroker.replicateTransaction} submits it whole, with
+ *   no equivalent of the schema-entry splitter added for issue #4743;</li>
+ *   <li>the index rebuild at the end of {@code DatabaseChecker.check()} drops and recreates the index, so it runs
+ *   inside {@code recordFileChanges} and its build WAL rides a {@code SCHEMA_ENTRY} instead of replicating batch by
+ *   batch.</li>
+ * </ul>
+ * The corruption is induced THROUGH the Raft wrapper on the leader, so all three nodes carry it identically before
+ * the repair starts. That is the shape an operator actually meets: the damage was replicated when it happened, and
+ * {@code CHECK DATABASE FIX} is being run afterwards to clean it up.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class RaftCheckDatabaseFix3NodesIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE = "CheckNode";
+  private static final String EDGE_TYPE   = "CheckLink";
+  /**
+   * 500 in-edges on one hub. Big enough that the edge list spans several chunks (the first chunk is
+   * {@code GRAPH_EDGE_LIST_INITIAL_CHUNK_SIZE} = 64 bytes and each further one doubles up to 8192), so the head
+   * chunk has a previous to delete; well under {@code GRAPH_SUPERNODE_THRESHOLD} = 4096, so the hub keeps the
+   * classic layout and {@code getInEdgesHeadChunk} means what it says. Same figure as the engine-side
+   * {@code GraphDatabaseCheckerChainRebuildTest}, which pins the single-node behaviour this one extends.
+   */
+  private static final int    DEGREE      = 500;
+
+  private static final String INDEX_TYPE_NAME = "CheckIdxDoc";
+  private static final String INDEX_NAME      = "checkIdxDocName";
+  private static final int    INDEX_RECORDS   = 50;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  /**
+   * The headline case: a mid-chain edge segment is lost on every node, and {@code CHECK DATABASE FIX} run through
+   * the cluster has to rebuild the adjacency from the surviving edge records AND land that rebuild on the two
+   * followers. A regression that commits the repair on the inner {@code LocalDatabase} (the #5492 shape) leaves the
+   * leader clean and the followers broken, which is exactly what the per-node assertions below separate.
+   */
+  @Test
+  void fixRebuildsBrokenEdgeChainOnEveryNode() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+
+    final DatabaseInternal leaderDb = wrapped(leaderIndex);
+    final RID hubRid = createHub(leaderDb);
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitInDegreeOn(i, hubRid, DEGREE))
+          .as("baseline: server %d must see the hub's full adjacency before anything is broken", i)
+          .isEqualTo(DEGREE);
+
+    breakMidChainChunk(leaderDb, hubRid);
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(inDegreeOn(i, hubRid))
+          .as("the corruption itself must have replicated to server %d, otherwise the repair below proves nothing", i)
+          .isNotEqualTo(DEGREE);
+
+    final Result fix = runCheck(leaderIndex, "CHECK DATABASE FIX");
+    assertThat(fix.<String>getProperty("operation")).isEqualTo("check database");
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitInDegreeOn(i, hubRid, DEGREE))
+          .as("server %d must see the rebuilt adjacency: the repair replicates, it is not re-derived per node", i)
+          .isEqualTo(DEGREE);
+
+    // A second check, on the leader, must now find nothing. Run WITHOUT fix so a still-dirty database cannot be
+    // repaired into silence by the very statement that is supposed to report on it.
+    final Result verify = runCheck(leaderIndex, "CHECK DATABASE");
+    assertThat(verify.<Long>getProperty("totalCorruptedRecords"))
+        .as("the database must be clean after the repair").isZero();
+
+    assertClusterConsistency();
+  }
+
+  /**
+   * The same repair, issued on a FOLLOWER. {@code CheckDatabaseStatement} does not override
+   * {@code Statement.isIdempotent()}, so it is classified non-idempotent and
+   * {@code RaftReplicatedDatabase.command} forwards it to the leader rather than running it locally - which is the
+   * only correct outcome, since a follower repairing its own pages outside the Raft log is precisely the
+   * divergence the forwarding exists to prevent.
+   * <p>
+   * Asserted by effect rather than by instrumentation: the follower that ISSUED the statement is not the node the
+   * repair was computed on, so all three converging is the observable consequence of the forward having happened.
+   */
+  @Test
+  void fixIssuedOnFollowerIsForwardedToTheLeaderAndRepairsTheCluster() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = (leaderIndex + 1) % getServerCount();
+
+    final DatabaseInternal leaderDb = wrapped(leaderIndex);
+    final RID hubRid = createHub(leaderDb);
+
+    waitForAllServers();
+    assertThat(awaitInDegreeOn(followerIndex, hubRid, DEGREE)).isEqualTo(DEGREE);
+
+    breakMidChainChunk(leaderDb, hubRid);
+    waitForAllServers();
+    assertThat(inDegreeOn(followerIndex, hubRid)).isNotEqualTo(DEGREE);
+
+    runCheck(followerIndex, "CHECK DATABASE FIX");
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitInDegreeOn(i, hubRid, DEGREE))
+          .as("server %d must be repaired by a FIX issued on the follower", i)
+          .isEqualTo(DEGREE);
+
+    assertClusterConsistency();
+  }
+
+  /**
+   * The index-rebuild arm. A corrupted record puts its bucket into {@code affectedBuckets}, and the tail of
+   * {@code DatabaseChecker.check()} then drops and recreates every index on that bucket. Under Raft the recreate
+   * runs inside {@code recordFileChanges}, so the build's batch commits are buffered into {@code schemaWalBuffer}
+   * and shipped as one {@code SCHEMA_ENTRY} (split across entries by {@code splitSchemaEntry} when it does not
+   * fit) instead of replicating as they happen.
+   * <p>
+   * Two distinct failure modes are separated here, because they need different fixes. The index still EXISTING
+   * cluster-wide covers the drop-committed-then-rebuild-failed hole: {@code DatabaseChecker}'s rebuild loop
+   * catches only {@code NeedRetryException}, so a replication failure raised from inside {@code create()} after
+   * that attempt's {@code dropIndex()} already committed its own schema entry propagates straight out of
+   * {@code check()} and leaves the index gone on every node. The entry COUNT matching on every node covers the
+   * separate question of whether the rebuilt pages actually reached the followers.
+   * <p>
+   * The type is a VERTEX type, matching the engine-side {@code CheckDatabaseFixPreservesIndexMetadataTest}. Writing
+   * this test with a DOCUMENT type is what first surfaced the defect that {@code DatabaseChecker.checkDocuments}
+   * flagged a corrupted document without DELETING it, so the rebuild's own bucket scan met the same unreadable
+   * record and destroyed the index. That is fixed, and its regression test is
+   * {@code CheckDatabaseFixDocumentTypeTest} - single-node, where it belongs: nothing about it needed a cluster.
+   */
+  @Test
+  void fixRebuildsIndexAndKeepsItOnEveryNode() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+
+    final DatabaseInternal leaderDb = wrapped(leaderIndex);
+
+    leaderDb.command("sql", "CREATE VERTEX TYPE " + INDEX_TYPE_NAME);
+    leaderDb.command("sql", "CREATE PROPERTY " + INDEX_TYPE_NAME + ".name STRING");
+
+    final AtomicReference<RID> victim = new AtomicReference<>();
+    leaderDb.transaction(() -> {
+      for (int i = 0; i < INDEX_RECORDS; i++) {
+        final Result inserted = leaderDb.command("sql",
+            "INSERT INTO " + INDEX_TYPE_NAME + " SET name = 'name" + i + "'").next();
+        if (i == 0)
+          victim.set(inserted.toElement().getIdentity());
+      }
+    });
+    leaderDb.command("sql", "CREATE INDEX " + INDEX_NAME + " ON " + INDEX_TYPE_NAME + " (name) NOTUNIQUE");
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitIndexEntriesOn(i, INDEX_RECORDS))
+          .as("baseline: server %d must hold the whole index before the corruption", i)
+          .isEqualTo(INDEX_RECORDS);
+
+    // Corrupt the record's type byte through the wrapper, so every node holds the same unreadable record. This is
+    // what makes the checker flag it, delete it under FIX, and rebuild the bucket's indexes.
+    corruptRecordTypeByte(leaderDb, victim.get());
+    waitForAllServers();
+
+    final Result fix = runCheck(leaderIndex, "CHECK DATABASE TYPE " + INDEX_TYPE_NAME + " FIX");
+    assertThat(fix.<Long>getProperty("autoFix"))
+        .as("the corrupted record must have been detected and removed").isGreaterThan(0L);
+
+    waitForAllServers();
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final int server = i;
+      final boolean indexSurvived = withResyncRetry(server, db -> db.getSchema().existsIndex(INDEX_NAME));
+      assertThat(indexSurvived)
+          .as("server %d must still have index '%s': a rebuild that fails after the drop leaves it missing "
+              + "cluster-wide, not merely unrebuilt", server, INDEX_NAME)
+          .isTrue();
+
+      assertThat(awaitIndexEntriesOn(server, INDEX_RECORDS - 1L))
+          .as("server %d must hold the REBUILT index: its pages ride a SCHEMA_ENTRY, they are not rebuilt locally",
+              server)
+          .isEqualTo(INDEX_RECORDS - 1L);
+    }
+
+    assertClusterConsistency();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * The Raft wrapper for a server's database. {@code getWrappedDatabaseInstance()} returns the wrapper under HA and
+   * the instance itself off it, so resolving it is always correct - and getting it wrong is the #5492 defect, where
+   * a commit on the inner instance publishes pages locally and replicates nothing.
+   */
+  private DatabaseInternal wrapped(final int serverIndex) {
+    return ((DatabaseInternal) getServerDatabase(serverIndex, getDatabaseName())).getWrappedDatabaseInstance();
+  }
+
+  /** Creates the hub and its {@link #DEGREE} in-edges through the cluster, and returns the hub's RID. */
+  private RID createHub(final DatabaseInternal db) {
+    db.command("sql", "CREATE VERTEX TYPE " + VERTEX_TYPE);
+    db.command("sql", "CREATE EDGE TYPE " + EDGE_TYPE);
+
+    final AtomicReference<RID> hub = new AtomicReference<>();
+    db.transaction(() -> hub.set(db.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity()));
+
+    final int batch = 100;
+    for (int from = 0; from < DEGREE; from += batch) {
+      final int start = from;
+      final int end = Math.min(from + batch, DEGREE);
+      db.transaction(() -> {
+        for (int i = start; i < end; i++)
+          db.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, hub.get().asVertex(true));
+      });
+    }
+    return hub.get();
+  }
+
+  /**
+   * Deletes the chunk BEFORE the head of the hub's in-edge list, through the Raft wrapper so the deletion
+   * replicates. The head chunk is the newest, so its previous is genuinely mid-chain: the walk reaches it and
+   * fails there, rather than the vertex simply appearing to have no edges.
+   */
+  private void breakMidChainChunk(final DatabaseInternal db, final RID hubRid) {
+    final AtomicReference<RID> midChunk = new AtomicReference<>();
+    db.transaction(() -> {
+      final RID head = ((VertexInternal) hubRid.asVertex(true)).getInEdgesHeadChunk();
+      assertThat(head).as("the hub must have an in-edge list").isNotNull();
+      final EdgeSegment headChunk = (EdgeSegment) db.lookupByRID(head, true);
+      midChunk.set(headChunk.getPreviousRID());
+      assertThat(midChunk.get()).as("the hub's degree must span more than one chunk").isNotNull();
+    });
+
+    db.transaction(() -> db.getSchema().getBucketById(midChunk.get().getBucketId()).deleteRecord(midChunk.get()));
+  }
+
+  /**
+   * Overwrites the record's type byte with a value no type uses, so loading it throws. Reimplemented here rather
+   * than reused from the engine's {@code TestHelper}: that copy is {@code protected static} on a class this module
+   * does not extend, and {@code ha-raft} does not depend on the engine test-jar.
+   * <p>
+   * Runs through the wrapper, so the damaged page replicates and all three nodes hold the same unreadable record.
+   */
+  private void corruptRecordTypeByte(final DatabaseInternal db, final RID rid) {
+    final int fileId = rid.getBucketId();
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
+
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
+        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
+        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
+        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
+        final long[] recordSize = page.readNumberAndSize(recordOffset);
+        page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /** Runs a CHECK DATABASE statement against one server and returns its single result row. */
+  private Result runCheck(final int serverIndex, final String statement) {
+    try (final ResultSet rs = wrapped(serverIndex).command("sql", statement)) {
+      assertThat(rs.hasNext()).as("'%s' must return a result", statement).isTrue();
+      return rs.next();
+    }
+  }
+
+  /**
+   * The hub's in-degree as seen by one server, or -1 when the edge list cannot be walked at all. Both outcomes are
+   * "not {@link #DEGREE}", which is what the corruption assertions test: whether a broken mid-chain surfaces as a
+   * throw or as a short count is an engine detail this test has no business pinning.
+   */
+  private long inDegreeOn(final int serverIndex, final RID hubRid) {
+    return withResyncRetry(serverIndex, db -> {
+      final AtomicLong degree = new AtomicLong(-1);
+      db.transaction(() -> {
+        try {
+          degree.set(db.lookupByRID(hubRid, true).asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE));
+        } catch (final DatabaseIsClosedException e) {
+          // A snapshot-reinstall resync, not a finding: withResyncRetry retries it with a fresh handle.
+          throw e;
+        } catch (final Exception e) {
+          degree.set(-1);
+        }
+      });
+      return degree.get();
+    });
+  }
+
+  private long awaitInDegreeOn(final int serverIndex, final RID hubRid, final long expected) throws InterruptedException {
+    return awaitValue(expected, () -> inDegreeOn(serverIndex, hubRid));
+  }
+
+  private long indexEntriesOn(final int serverIndex) {
+    final Database db = getServerDatabase(serverIndex, getDatabaseName());
+    return db.getSchema().existsIndex(INDEX_NAME) ? db.getSchema().getIndexByName(INDEX_NAME).countEntries() : -1L;
+  }
+
+  private long awaitIndexEntriesOn(final int serverIndex, final long expected) throws InterruptedException {
+    return awaitValue(expected, () -> indexEntriesOn(serverIndex));
+  }
+}


### PR DESCRIPTION
## Problem

`CHECK DATABASE FIX` over a plain **DOCUMENT** type holding an unreadable record drops the type's index, never recreates it, and aborts the whole check:

```
IndexException: Error on creating index 'Doc_0_2285086433454166'
  caused by: DatabaseMetadataException: Cannot find record type '99'
```

The index is gone afterwards, and every repair the run had already made is lost with it. This is a single-node defect - no cluster involved.

`DatabaseChecker.checkDocuments` flagged a corrupted document through `addCorrupted` but, unlike the vertex and edge arms in `GraphDatabaseChecker`, never DELETED it. The shared tail of `check()` still put its bucket into `affectedBuckets` and dropped and rebuilt every index there, so the rebuild's own bucket scan met the same unreadable record and `LSMTreeIndex.build`'s error callback propagated it (deliberately - a swallowed failure would leave the index silently incomplete). Because the rebuild loop caught only `NeedRetryException`, that escaped `check()` with the attempt's `dropIndex()` already committed.

Every pre-existing FIX index test uses `CREATE VERTEX TYPE`, where the graph arm deletes the record first and the rebuild never meets it. That is why the document arm's omission survived.

## Fix

- `checkDocuments` and `checkScopedDocuments` delete corrupted documents under `FIX`, through a new `deleteCorruptedRecords`, matching the graph arms. Collected during the scan and deleted after it, since `LocalBucket.scan` is walking the pages the delete rewrites.
- That delete also does the `updateBucketRecordDelta(-1)` that `LocalBucket.deleteRecord` does not, so `count(*)` no longer depends on whether the run was full-scope (which happens to recompute in `checkBuckets`) or `RECORD`-scoped (which deliberately skips it).
- The rebuild loop gained a non-retryable catch arm. One index that cannot be rebuilt is now reported and struck from `rebuiltIndexes` instead of discarding the rest of the run - the same rationale the existing retry arm already states. This also contains the HA case, where an oversized index rebuild raises `ReplicatedEntryTooLargeException`.
- The failure warning names the owning `TypeIndex` instead of the internal `<bucket>_<nanos>` sub-index, which nobody typed and which made the `SELECT FROM schema:indexes` the message suggests return nothing.

## Tests

`CheckDatabaseFixDocumentTypeTest` - written first and confirmed red on the real defect before the fix:

- the type-wide arm;
- the `RECORD` scope, which reaches the same record by its own path;
- a rebuild that fails for a reason the checker cannot remove first. It gets its unremovable failure by inserting a duplicate straight into the bucket via `LocalBucket.createRecord`, which bypasses `DocumentIndexer` - the only way to hold a unique index and a violating record at once. It asserts the check completes, keeps the repairs already made, does not claim the index as rebuilt, and reports it as missing by name.

`RaftCheckDatabaseFix3NodesIT` is the first cluster coverage `CHECK DATABASE` has had. A grep of `ha-raft/src/test` for "CHECK DATABASE" previously returned nothing; the only file named for a checker is a `main()` that diffs three database directories offline. Three cases on a 3-node Raft cluster, with the corruption induced through the Raft wrapper so all three nodes carry it identically before the repair starts:

- a lost mid-chain edge segment is rebuilt on every node;
- the same FIX issued on a **follower** is forwarded to the leader and converges all three;
- a rebuilt index still exists and holds the rebuilt entry count on every node.

This one was written first, and writing it with a document type is what surfaced the defect above.

## Verification

- The 3 new document-type tests: red before the fix, green after.
- 136 tests across every suite that touches the FIX path, including `DatabaseCheckerIndexRebuildLockContentionTest` and `RebuildIndexLockExhaustionTest`, which exercise the retry arm this restructures.
- 562 tests across the `database`, `graph` and `engine` packages. The one failure, `Issue5279ConcurrentUpdateTest`, reproduces identically on a clean tree with these changes stashed.
- `RaftCheckDatabaseFix3NodesIT`, 3/3 green. Its mutation check - handing `DatabaseChecker` the inner instance in `CheckDatabaseStatement.createChecker`, the #5492 shape - fails all three with the right signatures: followers stuck at in-degree `-1`, and `Page PageId(graph/28/0) has different versions on databases. DB1 3 <> DB2 2` from the page comparator.

## Operator impact

Anyone with document types and suspected record corruption should not run `CHECK DATABASE FIX` on a build without this fix: it can destroy indexes. After a failed FIX, check `SELECT FROM schema:indexes` before reading the error.

## Follow-up commit: the same drift in the graph arms

`LocalBucket.deleteRecord` does not touch `cachedRecordCount`, and that counter - not a scan - is what `count(*)` and `countType()` answer from. The document arm above pays the matching `updateBucketRecordDelta(-1)`; `GraphDatabaseChecker` did not, at any of its three delete sites.

A type-wide run hides it, because `checkBuckets` recomputes every counter afterwards. The `RECORD` scope skips the database-wide passes, so `CHECK DATABASE RECORD <rid> FIX` on a corrupted vertex or edge left the type over-reporting the deleted record permanently:

| Scope | cached `countType` | `count(@rid)` scan |
| --- | --- | --- |
| RECORD | 2 | 1 |
| type-wide | 1 | 1 |

The vertex arm, the edge arm and the orphan-segment reclaim were byte-identical copies, so they now share a `deleteCorruptedRecord()` helper. `CheckDatabaseRecordScopeTest` gains a vertex case and an edge case, both asserting the cached counter against a real scan rather than a literal.
