### PR TITLE
feat(#6116): snapshot metrics, the missing backup benchmarks, and the HA /checksums endpoint off the flush suspension

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -921,3 +921,85 @@ source file's modification time - which is the more useful of the two, and was a
 archive written with `arcadedb.backup.compressionThreads = 0`.
 
 [#6075](https://github.com/ArcadeData/arcadedb/issues/6075)
+
+## The snapshot backup, measured; an open window is now visible in the metrics; the HA `/checksums` endpoint stops freezing the files (#6116)
+
+Three loose ends left behind by the point-in-time snapshot of #6075.
+
+### The benchmarks #6075 asked for
+
+`Issue6075SnapshotBackupIT` measured the suspension fraction and nothing else. Two harnesses now cover the rest:
+`PageSnapshotOverheadBenchmark` (engine) for the write path, the t0 barrier, the flush-thread drain rate and the
+`TransactionManager` apply lock, and `PageSnapshotBackupBenchmark` (integration) for what a running backup does to
+the writers beside it, shaped like the #6072 harness so the two sets of numbers can be read together. Both are
+`@Tag("benchmark")`, so neither runs in CI.
+
+Two of the numbers they produce are worth stating here, because both correct something the #6075 write-up asserted:
+
+- **The t0 barrier is not "a few ms" under load.** With no concurrent writer it is 13-120 us. With one to eight
+  writer threads committing continuously it runs to tens of milliseconds, occasionally past 100 ms, and the driver
+  is not the flush-queue depth (which stays small) but the barrier RETRYING: it drains the queue in full, and a
+  commit landing between that drain and the flush-thread suspension makes it start over. It is still bounded, still
+  vastly better than a suspension held for the whole backup, and still the only stall in the design - but its size
+  is now known rather than assumed.
+- **The copy-on-write shadow can reach the size of the database.** During a throttled backup of a 128 MB database,
+  the shadow peaked at 37% of it with a writer pausing 100 ms between transactions, 84% at 20 ms, and 100% with a
+  writer running flat out - it holds the pre-image of every page dirtied while the window is open, so a hot
+  database rewrites all of them. The 1 GB `arcadedb.pageSnapshotMaxSize` default is therefore not the generous
+  ceiling it looks like: on a database much beyond a gigabyte under a heavy write load, expect the window to breach
+  it and the backup to restart on the suspend-and-freeze path. Raise it (or accept the fallback) accordingly - and
+  the new `arcadedb_engine_snapshot_shadow_usage_percent` gauge below is how to tell which of the two you are
+  heading for.
+
+The writer-impact comparison itself, on a 128 MB database rebuilt before each run, with a mixed insert/update load
+and the backup throttled to 32 MB/s, counting only the commits that fall inside the backup window:
+
+| | rec/s inside the window | of the no-backup baseline | peak deferred RAM |
+|---|---|---|---|
+| no backup running | 193,854 | - | 0 |
+| backup, snapshot path | 185,120 | **95.5%** | **0** |
+| backup, suspend-and-freeze | 5,274 | 2.7% | 513 MB |
+
+513 MB is `arcadedb.flushSuspendMaxDeferredRAM` reached, which is the point at which committing threads stop being
+merely slowed and start being throttled outright. On the snapshot path the deferred-RAM gauge never leaves zero -
+the claim #6075 rested on, stated as a measurement rather than as a design argument.
+
+### An open window is now visible
+
+`PageManager.getStats()` gained the snapshot readings, so they reach both Prometheus (through
+`EngineMetricsBinder`) and Studio's server page (through `Profiler`, which renders every stat it publishes). Per
+the counter/gauge distinction of #5636, the per-window state is gauges and only the JVM-wide totals are counters:
+
+| Metric | Type | |
+|---|---|---|
+| `arcadedb_engine_snapshot_windows_open` | gauge | windows open right now |
+| `arcadedb_engine_snapshot_shadow_pages` | gauge | pages held in their shadows |
+| `arcadedb_engine_snapshot_shadow_bytes` | gauge | bytes held, RAM plus spill |
+| `arcadedb_engine_snapshot_shadow_spilled_bytes` | gauge | of which spilled to disk |
+| `arcadedb_engine_snapshot_shadow_usage_percent` | gauge | the fullest window against `pageSnapshotMaxSize` |
+| `arcadedb_engine_snapshot_window_age_ms` | gauge | age of the oldest open window |
+| `arcadedb_engine_snapshot_windows_opened_total` | counter | windows opened |
+| `arcadedb_engine_snapshot_windows_invalidated_total` | counter | windows that lost their point in time |
+| `arcadedb_engine_snapshot_preimages_captured_total` | counter | pre-images copied |
+| `arcadedb_engine_flush_deferred_bytes` | gauge | dirty bytes deferred by a flush suspension (#6087) |
+
+The alertable ones are the usage percentage and the invalidation counter. A window that breaches its cap is
+invalidated and its consumer falls back to the suspend-and-freeze path, which still completes - so before this, a
+backup that had quietly gone back to throttling every writer on the server left no trace except a WARNING in the
+log.
+
+### `GET /api/v1/ha/snapshot/{db}/checksums` no longer suspends flushing
+
+The last writer-throttling reader in the product. #6075 migrated the backup, the HA verify and the HA snapshot
+ship but left this one on `suspendFlushAndExecute`, because it reads the database DIRECTORY rather than the
+registered page files and so needed a different shape. It now takes each page file's content from a window and
+reads everything the window does not cover - `database.json`, `schema.json`, the `.ts.sealed` time-series stores -
+raw, as before, under the same database read lock. A page file created after t0 is left out rather than read live,
+matching what the verify endpoint reports; the checksums are byte-for-byte the ones a peer still on the fallback
+path computes, so a migrated leader does not report every file as differing.
+
+One transient file was being checksummed that should not have been: the `.pshadow` scratch of an open snapshot
+window lives in the database directory, so any node that happened to have a backup running reported a file no peer
+had.
+
+[#6116](https://github.com/ArcadeData/arcadedb/issues/6116)

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -303,6 +303,21 @@ public class Profiler {
     json.put("writeCachePages", new JSONObject().put("count", writeCachePages));
     json.put("indexCompactions", new JSONObject().put("count", indexCompactions));
 
+    // #6116: the point-in-time snapshot windows of #6075. The five instantaneous readings are per-window state and
+    // go back to zero when the last window closes (so they must never be read as counters, #5636); the three totals
+    // that follow are JVM-wide and monotonic. deferredRAM (#6087) travels with them because it is the same question
+    // asked of the OTHER path: what a reader that froze the files is costing the writers right now.
+    json.put("snapshotWindowsOpen", new JSONObject().put("value", pStats.snapshotWindowsOpen));
+    json.put("snapshotShadowedPages", new JSONObject().put("value", pStats.snapshotShadowedPages));
+    json.put("snapshotShadowSize", new JSONObject().put("space", pStats.snapshotShadowBytes));
+    json.put("snapshotShadowSpilledSize", new JSONObject().put("space", pStats.snapshotShadowSpilledBytes));
+    json.put("snapshotShadowUsagePerc", new JSONObject().put("perc", pStats.snapshotShadowUsagePerc));
+    json.put("snapshotOldestWindowAge", new JSONObject().put("value", pStats.snapshotOldestWindowMillis));
+    json.put("snapshotWindowsOpened", new JSONObject().put("count", pStats.snapshotWindowsOpened));
+    json.put("snapshotWindowsInvalidated", new JSONObject().put("count", pStats.snapshotWindowsInvalidated));
+    json.put("snapshotPreImagesCaptured", new JSONObject().put("count", pStats.snapshotPreImagesCaptured));
+    json.put("deferredRAM", new JSONObject().put("space", pStats.deferredRAMBytes));
+
     final long freeSpace = new File(".").getFreeSpace();
     final long totalSpace = new File(".").getTotalSpace();
     final float freeSpacePerc = freeSpace * 100F / totalSpace;
@@ -465,8 +480,8 @@ public class Profiler {
       buffer.append("%n INDEXES compactions=%d".formatted(indexCompactions));
 
       buffer.append(
-        "%n PAGE-MANAGER flushQueue=%d cacheHits=%d cacheMiss=%d concModExceptions=%d evictionRuns=%d pagesEvicted=%d".formatted(
-          pageFlushQueueLength,
+        "%n PAGE-MANAGER flushQueue=%d deferredRAM=%s cacheHits=%d cacheMiss=%d concModExceptions=%d evictionRuns=%d pagesEvicted=%d".formatted(
+          pageFlushQueueLength, FileUtils.getSizeAsString(pStats.deferredRAMBytes),
           pageCacheHits, pageCacheMiss, concurrentModificationExceptions, evictionRuns, pagesEvicted));
 
       // #5608: read this line together with concModExceptions above. Contention absorbed by a merge never becomes a
@@ -474,6 +489,15 @@ public class Profiler {
       // without declaring its coverage (see MutablePage.beginCoveredWrite).
       buffer.append("%n    edgeAppendMerges=%d txPageSlotMerges=%d mergesDeclinedByCoverage=%d".formatted(
           edgeAppendMerges, txPageSlotMerges, mergesDeclinedByCoverage));
+
+      // #6116: printed unconditionally, zeros included. "No window is open" is the answer an operator is looking for
+      // most of the time, and a line that appears only sometimes cannot be read as one.
+      buffer.append(
+        "%n PAGE-SNAPSHOT windowsOpen=%d shadowPages=%d shadow=%s (spilled=%s, %.1f%% of the cap) oldestWindow=%,dms opened=%d invalidated=%d preImages=%d".formatted(
+          pStats.snapshotWindowsOpen, pStats.snapshotShadowedPages, FileUtils.getSizeAsString(pStats.snapshotShadowBytes),
+          FileUtils.getSizeAsString(pStats.snapshotShadowSpilledBytes), pStats.snapshotShadowUsagePerc,
+          pStats.snapshotOldestWindowMillis, pStats.snapshotWindowsOpened, pStats.snapshotWindowsInvalidated,
+          pStats.snapshotPreImagesCaptured));
 
       buffer.append(
         "%n WAL totalFiles=%d pagesWritten=%d bytesWritten=%s".formatted(walTotalFiles, walPagesWritten,

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -164,6 +164,23 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       HashIndexBucket.UNIQUE_INDEX_EXT,
       HashIndexBucket.NOTUNIQUE_INDEX_EXT);
 
+  /**
+   * True when {@code fileName}'s extension is one the {@link FileManager} treats as a component file, i.e. one whose
+   * content a point-in-time page snapshot (#6075) covers. The extension is taken from the NAME, never the path, so a
+   * database directory containing a dot does not confuse it - the same rule
+   * {@code FileManager.scanDirectoryForComponentFiles} applies when deciding what to register.
+   * <p>
+   * Exposed (#6116) so a reader walking the database DIRECTORY rather than the registered files - the HA
+   * {@code /checksums} endpoint - can tell a page file from a configuration or time-series file by name alone. The
+   * obvious alternative, asking the {@code FileManager} which files it currently has registered, is a moving target:
+   * index compaction creates and drops component files WITHOUT the database write lock, so a set captured a moment
+   * earlier can miss a file that is already on disk.
+   */
+  public static boolean isComponentFileName(final String fileName) {
+    final int lastDot = fileName.lastIndexOf('.');
+    return lastDot >= 0 && SUPPORTED_FILE_EXT.contains(fileName.substring(lastDot + 1));
+  }
+
   public final       AtomicLong                                indexCompactions          = new AtomicLong();
   protected final    String                                    name;
   protected final    ComponentFile.MODE                        mode;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -95,6 +95,12 @@ public class PageManager extends LockContext {
   private final    AtomicLong                        totalMergesDeclinedByCoverage         = new AtomicLong();
   private final    AtomicLong                        evictionRuns                          = new AtomicLong();
   private final    AtomicLong                        pagesEvicted                          = new AtomicLong();
+  // #6116: the three snapshot totals below are exported as Prometheus counters together with the ones above, and
+  // carry the same never-decrease requirement. They are JVM-wide like the rest of this class, so a database close
+  // does not step them back.
+  private final    AtomicLong                        totalSnapshotWindowsOpened            = new AtomicLong();
+  private final    AtomicLong                        totalSnapshotWindowsInvalidated       = new AtomicLong();
+  private final    AtomicLong                        totalSnapshotPreImagesCaptured        = new AtomicLong();
   private volatile long                              lastCheckForRAM                       = 0;
   // LIFECYCLE INVARIANT (#5070): flushThread and readCache are written only under LIFECYCLE_LOCK
   // during the 0->1 startup / 1->0 shutdown transitions, and read lock-free on the hot paths. That is safe
@@ -159,6 +165,26 @@ public class PageManager extends LockContext {
     public long evictionRuns;
     public long pagesEvicted;
     public int  readCachePages;
+    /**
+     * #6116: the point-in-time snapshot windows (#6075) as an operator sees them. The five instantaneous readings go
+     * up AND down with the lifetime of a window, so they are gauges; the three totals below them are counters. A
+     * window whose shadow approaches {@code arcadedb.pageSnapshotMaxSize} is about to be invalidated and force its
+     * backup onto the writer-throttling fallback path, which is precisely the event an operator must be able to see
+     * coming rather than read about afterwards in the log.
+     */
+    public int    snapshotWindowsOpen;
+    public long   snapshotShadowedPages;
+    public long   snapshotShadowBytes;
+    public long   snapshotShadowSpilledBytes;
+    /** How full the fullest open window's shadow is, as a percentage of {@code arcadedb.pageSnapshotMaxSize}. */
+    public double snapshotShadowUsagePerc;
+    /** Age of the OLDEST open window, in milliseconds: a window that never closes is a leak, not a slow backup. */
+    public long   snapshotOldestWindowMillis;
+    public long   snapshotWindowsOpened;
+    public long   snapshotWindowsInvalidated;
+    public long   snapshotPreImagesCaptured;
+    /** See {@link PageManager#getDeferredRAMBytes()} (#6087): dirty pages held in RAM by a flush suspension. */
+    public long   deferredRAMBytes;
   }
 
   private PageManager() {
@@ -579,6 +605,7 @@ public class PageManager extends LockContext {
       updated[updated.length - 1] = snapshot;
       activeSnapshots = updated;
     }
+    totalSnapshotWindowsOpened.incrementAndGet();
     return snapshot;
   }
 
@@ -652,6 +679,9 @@ public class PageManager extends LockContext {
       }
 
       snapshot.storePreImage(fileId, pageNumber, preImage, pageSize);
+      // #6116: THE COPY-ON-WRITE WORK A WINDOW IS COSTING, AS A RATE. ONE ATOMIC INCREMENT NEXT TO A PAGE READ AND A
+      // PAGE COPY, AND ONLY WHEN A WINDOW IS OPEN AND STILL NEEDS THIS PAGE
+      totalSnapshotPreImagesCaptured.incrementAndGet();
     }
   }
 
@@ -1009,7 +1039,52 @@ public class PageManager extends LockContext {
     stats.mergesDeclinedByCoverage = totalMergesDeclinedByCoverage.get();
     stats.evictionRuns = evictionRuns.get();
     stats.pagesEvicted = pagesEvicted.get();
+    stats.snapshotWindowsOpened = totalSnapshotWindowsOpened.get();
+    stats.snapshotWindowsInvalidated = totalSnapshotWindowsInvalidated.get();
+    stats.snapshotPreImagesCaptured = totalSnapshotPreImagesCaptured.get();
+    stats.deferredRAMBytes = getDeferredRAMBytes();
+    collectSnapshotGauges(stats);
     return stats;
+  }
+
+  /**
+   * Fills in the per-window readings of {@link PPageManagerStats} from the currently open snapshot windows (#6116).
+   * <p>
+   * Reads the published array ONCE, without the registry lock: a window that closes underneath this reports its last
+   * values, which is what any sampled gauge does. The shadow accessors take the shadow's own monitor, which the
+   * capture path also holds for the duration of one page copy - at the one-per-scrape rate this is called at, that
+   * is immaterial, but it is the reason this is not called from anywhere hotter than a metrics scrape.
+   */
+  private void collectSnapshotGauges(final PPageManagerStats stats) {
+    final PageSnapshot[] snapshots = activeSnapshots;
+    if (snapshots == null)
+      return;
+
+    final long now = System.currentTimeMillis();
+    long oldestOpenedOn = Long.MAX_VALUE;
+    for (final PageSnapshot snapshot : snapshots) {
+      ++stats.snapshotWindowsOpen;
+      stats.snapshotShadowedPages += snapshot.getShadowedPages();
+      final long shadowBytes = snapshot.getShadowSizeInBytes();
+      stats.snapshotShadowBytes += shadowBytes;
+      stats.snapshotShadowSpilledBytes += snapshot.getShadowSpilledBytes();
+
+      final long maxBytes = snapshot.getShadowMaxSizeInBytes();
+      if (maxBytes > 0)
+        // THE MAXIMUM, NOT THE AVERAGE: WHAT MATTERS IS HOW CLOSE THE CLOSEST WINDOW IS TO BREACHING, BECAUSE THAT
+        // IS THE ONE WHOSE BACKUP IS ABOUT TO RESTART ON THE SUSPEND-AND-FREEZE PATH
+        stats.snapshotShadowUsagePerc = Math.max(stats.snapshotShadowUsagePerc, 100.0 * shadowBytes / maxBytes);
+
+      oldestOpenedOn = Math.min(oldestOpenedOn, snapshot.getOpenedOn());
+    }
+
+    if (oldestOpenedOn != Long.MAX_VALUE)
+      stats.snapshotOldestWindowMillis = Math.max(0L, now - oldestOpenedOn);
+  }
+
+  /** Counts a window that lost its point in time (cap breach or I/O error): the fallback-path early warning. */
+  void incrementSnapshotWindowsInvalidated() {
+    totalSnapshotWindowsInvalidated.incrementAndGet();
   }
 
   public void removePageFromCache(final PageId pageId) {

--- a/engine/src/main/java/com/arcadedb/engine/PageShadow.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageShadow.java
@@ -214,6 +214,11 @@ final class PageShadow implements AutoCloseable {
     return spillBytes;
   }
 
+  /** The cap {@link #getSizeInBytes()} is measured against, so a monitor can report the headroom left (#6116). */
+  long getMaxSizeInBytes() {
+    return maxTotalBytes;
+  }
+
   @Override
   public synchronized void close() {
     if (closed)

--- a/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
@@ -190,6 +190,15 @@ public class PageSnapshot implements AutoCloseable {
     return shadow.getSpilledBytes();
   }
 
+  /**
+   * The {@code arcadedb.pageSnapshotMaxSize} cap this window's shadow was opened with, in bytes. Exposed so a monitor
+   * can report the headroom left before the window is invalidated and its consumer forced onto the
+   * suspend-and-freeze path (#6116), rather than only reporting the breach after the fact.
+   */
+  public long getShadowMaxSizeInBytes() {
+    return shadow.getMaxSizeInBytes();
+  }
+
   public long getOpenedOn() {
     return openedOn;
   }
@@ -333,6 +342,9 @@ public class PageSnapshot implements AutoCloseable {
     if (status == STATUS.ACTIVE) {
       status = newStatus;
       invalidReason = reason;
+      // #6116: A CONSUMER THAT FALLS BACK STILL COMPLETES, SO THIS IS INVISIBLE OUTSIDE THE LOG UNLESS IT IS COUNTED.
+      // COUNTED HERE RATHER THAN AT THE CALL SITES SO NO FUTURE INVALIDATION REASON CAN FORGET TO
+      pageManager.incrementSnapshotWindowsInvalidated();
       LogManager.instance().log(this, Level.WARNING,
           "Snapshot of database '%s' is no longer usable (%s): %s. Readers will fail and can fall back to suspending the page flush",
           null, database.getName(), newStatus, reason);

--- a/engine/src/test/java/com/arcadedb/engine/PageSnapshotMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageSnapshotMetricsTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.Profiler;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.serializer.json.JSONObject;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6116: an open point-in-time snapshot window (#6075) has to be visible to an operator while it is open, not
+ * only reconstructible from the log after it has gone.
+ * <p>
+ * Everything here is asserted as a DELTA against a baseline taken at the start of the test. {@link PageManager} is a
+ * JVM-wide singleton whose counters are deliberately never reset (#5636), so absolute values carry whatever the rest
+ * of the suite did in this fork before us.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PageSnapshotMetricsTest extends TestHelper {
+
+  private static final String TYPE = "Doc";
+
+  @Override
+  protected void beginTest() {
+    final DocumentType type = database.getSchema().createDocumentType(TYPE);
+    type.createProperty("id", Integer.class);
+    type.createProperty("payload", String.class);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 5_000; i++)
+        database.newDocument(TYPE).set("id", i).set("payload", "initial-" + "x".repeat(200)).save();
+    });
+    ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+  }
+
+  /**
+   * The window's lifetime is observable from outside it: the gauges rise when it opens and return to where they were
+   * when it closes, and the "opened" total moves exactly once.
+   */
+  @Test
+  void anOpenWindowIsVisibleInTheStatsAndLeavesNoTraceInThemWhenItCloses() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final PageManager.PPageManagerStats before = pageManager.getStats();
+    assertThat(before.snapshotWindowsOpen).as("no window may be open before this test opens one").isZero();
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      Thread.sleep(20);
+
+      final PageManager.PPageManagerStats open = pageManager.getStats();
+      assertThat(open.snapshotWindowsOpen).isEqualTo(1);
+      assertThat(open.snapshotWindowsOpened).isEqualTo(before.snapshotWindowsOpened + 1);
+      assertThat(open.snapshotWindowsInvalidated).isEqualTo(before.snapshotWindowsInvalidated);
+      assertThat(open.snapshotOldestWindowMillis).as("the window's age must be measured from when it opened")
+          .isPositive();
+      assertThat(open.snapshotShadowedPages).as("nothing has been written yet, so nothing is shadowed").isZero();
+      assertThat(snapshot.getShadowMaxSizeInBytes())
+          .isEqualTo(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.getValueAsLong() * 1024 * 1024);
+    }
+
+    final PageManager.PPageManagerStats after = pageManager.getStats();
+    assertThat(after.snapshotWindowsOpen).isZero();
+    assertThat(after.snapshotShadowedPages).isZero();
+    assertThat(after.snapshotShadowBytes).isZero();
+    assertThat(after.snapshotOldestWindowMillis).isZero();
+    // THE TOTALS ARE COUNTERS: THEY DO NOT COME BACK DOWN WITH THE WINDOW
+    assertThat(after.snapshotWindowsOpened).isEqualTo(before.snapshotWindowsOpened + 1);
+  }
+
+  /**
+   * The shadow gauges measure the copy-on-write work the window is costing. The control matters as much as the
+   * measurement: the identical rewrite performed with NO window open must not move the pre-image counter at all, so
+   * this cannot pass by counting something the write path does anyway.
+   */
+  @Test
+  void theShadowGaugesTrackTheCopyOnWriteWorkAndCountNothingWithNoWindowOpen() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    // CONTROL: THE SAME REWRITE, NO WINDOW OPEN
+    final long capturedBeforeControl = pageManager.getStats().snapshotPreImagesCaptured;
+    rewriteEveryRecord("control");
+    assertThat(pageManager.getStats().snapshotPreImagesCaptured)
+        .as("with no window open the write path must capture nothing").isEqualTo(capturedBeforeControl);
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      rewriteEveryRecord("shadowed");
+
+      final PageManager.PPageManagerStats stats = pageManager.getStats();
+      assertThat(stats.snapshotShadowedPages).as("the rewrite must have forced pre-image captures").isPositive();
+      assertThat(stats.snapshotShadowedPages).isEqualTo(snapshot.getShadowedPages());
+      assertThat(stats.snapshotShadowBytes).isEqualTo(snapshot.getShadowSizeInBytes());
+      assertThat(stats.snapshotShadowSpilledBytes).isEqualTo(snapshot.getShadowSpilledBytes());
+      assertThat(stats.snapshotPreImagesCaptured).isEqualTo(capturedBeforeControl + stats.snapshotShadowedPages);
+
+      // THE HEADROOM READING: SMALL AGAINST THE 1 GB DEFAULT CAP, BUT NOT ZERO - ROUNDING IT TO A LONG WOULD TELL AN
+      // OPERATOR WATCHING THE SHADOW FILL THAT IT IS EMPTY
+      assertThat(stats.snapshotShadowUsagePerc).isPositive().isLessThan(100.0);
+      assertThat(stats.snapshotShadowUsagePerc)
+          .isEqualTo(100.0 * stats.snapshotShadowBytes / snapshot.getShadowMaxSizeInBytes());
+    }
+  }
+
+  /**
+   * A window that loses its point in time is invisible from the outside - its consumer falls back to the
+   * suspend-and-freeze path and still completes - so the counter is the only signal that a backup has started
+   * throttling the writers again.
+   */
+  @Test
+  void aWindowThatBreachesItsCapIsCounted() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final long invalidatedBefore = pageManager.getStats().snapshotWindowsInvalidated;
+
+    // ONE MEGABYTE OF SHADOW: A HANDFUL OF PAGES, WHICH A FULL REWRITE BLOWS THROUGH AT ONCE
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.setValue(1);
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.setValue(1);
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      for (int round = 0; round < 5 && snapshot.getStatus() == PageSnapshot.STATUS.ACTIVE; round++)
+        rewriteEveryRecord("overflow-" + round);
+
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.OVERFLOWED);
+      assertThat(pageManager.getStats().snapshotWindowsInvalidated).isEqualTo(invalidatedBefore + 1);
+    }
+
+    // COUNTED ONCE, NOT ONCE PER FAILED CAPTURE: EVERY LATER WRITE STILL REACHES THE DEAD WINDOW
+    assertThat(pageManager.getStats().snapshotWindowsInvalidated).isEqualTo(invalidatedBefore + 1);
+  }
+
+  /**
+   * The same readings have to reach the two places an operator actually looks: the profiler JSON, which Studio's
+   * server page renders row by row, and the metrics dump.
+   */
+  @Test
+  void theProfilerReportsTheWindowToStudioAndToTheMetricsDump() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      rewriteEveryRecord("profiled");
+
+      final JSONObject json = Profiler.INSTANCE.toJSON();
+      assertThat(json.getJSONObject("snapshotWindowsOpen").getLong("value")).isEqualTo(1);
+      assertThat(json.getJSONObject("snapshotShadowedPages").getLong("value")).isEqualTo(snapshot.getShadowedPages());
+      assertThat(json.getJSONObject("snapshotShadowSize").getLong("space")).isEqualTo(snapshot.getShadowSizeInBytes());
+      assertThat(json.getJSONObject("snapshotShadowSpilledSize").getLong("space"))
+          .isEqualTo(snapshot.getShadowSpilledBytes());
+      assertThat(json.getJSONObject("snapshotShadowUsagePerc").getDouble("perc")).isPositive();
+      assertThat(json.getJSONObject("snapshotOldestWindowAge").getLong("value")).isNotNegative();
+      assertThat(json.getJSONObject("snapshotWindowsOpened").getLong("count")).isPositive();
+      assertThat(json.getJSONObject("snapshotWindowsInvalidated").getLong("count")).isNotNegative();
+      assertThat(json.getJSONObject("snapshotPreImagesCaptured").getLong("count")).isPositive();
+      // #6087: the same question asked of the other path, and until now equally unreported
+      assertThat(json.getJSONObject("deferredRAM").getLong("space")).isNotNegative();
+
+      final ByteArrayOutputStream dump = new ByteArrayOutputStream();
+      Profiler.INSTANCE.dumpMetrics(new PrintStream(dump, true, StandardCharsets.UTF_8));
+      final String text = dump.toString(StandardCharsets.UTF_8);
+      assertThat(text).contains("PAGE-SNAPSHOT windowsOpen=1");
+      assertThat(text).contains("deferredRAM=");
+    }
+
+    assertThat(Profiler.INSTANCE.toJSON().getJSONObject("snapshotWindowsOpen").getLong("value")).isZero();
+  }
+
+  private void rewriteEveryRecord(final String marker) {
+    database.transaction(() -> database.iterateType(TYPE, false).forEachRemaining(record -> {
+      final MutableDocument doc = record.asDocument().modify();
+      doc.set("payload", marker + "-" + "y".repeat(200));
+      doc.save();
+    }));
+    ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+  }
+}

--- a/engine/src/test/java/performance/PageSnapshotOverheadBenchmark.java
+++ b/engine/src/test/java/performance/PageSnapshotOverheadBenchmark.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package performance;
+
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.engine.ImmutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.engine.WALFile;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * The engine-side measurements issue #6075 asked for and PR #6100 did not produce, listed in #6116: what the
+ * point-in-time snapshot machinery costs the write path when no window is open, what the t0 barrier costs, what a
+ * window does to the flush thread's drain rate, and what the {@code TransactionManager} apply lock costs a
+ * replicated transaction. The backup-side half - writer impact and shadow sizing during a real backup - lives in
+ * {@code integration}'s {@code PageSnapshotBackupBenchmark}.
+ * <p>
+ * <b>On the "zero cost when no window is open" claim.</b> There is no honest way to measure a "before" from inside
+ * the merged tree, so it is bounded from above instead. The write path's hook is one volatile read of
+ * {@code activeSnapshots} plus a branch; the expensive shape of that branch is "a window IS open, but on another
+ * database", which pays the volatile read, the array walk and a database comparison per page write, and still
+ * captures nothing. If that configuration is indistinguishable from the no-window one, the no-window one - strictly
+ * cheaper - cannot be costing anything either.
+ * <p>
+ * Excluded from the normal build ({@code @Tag("benchmark")}). Run it explicitly:
+ * <pre>
+ *   mvn -o -pl engine test -Dtest=PageSnapshotOverheadBenchmark -Dgroups=benchmark -DexcludedGroups=
+ * </pre>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class PageSnapshotOverheadBenchmark {
+  private static final String DATABASE_PATH   = "target/databases/page-snapshot-overhead-benchmark";
+  private static final String NEIGHBOUR_PATH  = "target/databases/page-snapshot-overhead-benchmark-neighbour";
+  private static final String TYPE            = "Doc";
+  private static final int    RECORDS         = Integer.parseInt(
+      System.getProperty("arcadedb.snapshot.benchmark.records", "200000"));
+  private static final int    PAYLOAD_SIZE    = 300;
+  /** Records per transaction: a realistic batch, and the unit every latency percentile below is measured over. */
+  private static final int    BATCH           = 20;
+  private static final int    WARMUP_BATCHES  = 500;
+  private static final int    MEASURE_BATCHES = 5_000;
+
+  private static Database database;
+  private static Database neighbour;
+
+  @BeforeAll
+  static void buildDatabases() {
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(NEIGHBOUR_PATH));
+
+    database = create(DATABASE_PATH, RECORDS);
+    // A SECOND, TINY DATABASE: SOMETHING TO OPEN A WINDOW ON THAT IS NOT THE ONE BEING WRITTEN TO
+    neighbour = create(NEIGHBOUR_PATH, 1_000);
+
+    System.out.printf("[snapshot-benchmark] built %s (%,d records) and a %s neighbour%n",
+        FileUtils.getSizeAsString(directorySize(new File(DATABASE_PATH))), RECORDS,
+        FileUtils.getSizeAsString(directorySize(new File(NEIGHBOUR_PATH))));
+  }
+
+  @AfterAll
+  static void dropDatabases() {
+    if (database != null && database.isOpen())
+      database.drop();
+    if (neighbour != null && neighbour.isOpen())
+      neighbour.drop();
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(NEIGHBOUR_PATH));
+  }
+
+  /**
+   * Steady-state write throughput and commit latency in the three states the write path can be in. The first two
+   * lines are the "zero cost when idle" claim; the third is what a backup actually costs the writers it runs beside,
+   * and is the number to compare against the suspend-and-freeze path measured in the integration benchmark.
+   */
+  @Test
+  void steadyStateWriteThroughputAndCommitLatency() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // WARM UP THE JIT AND THE PAGE CACHE ONCE, SO THE FIRST CONFIGURATION IS NOT PENALISED
+    writeBatches(WARMUP_BATCHES);
+
+    // EACH CONFIGURATION IS MEASURED TWICE, IN ROUNDS. THE DIFFERENCE BETWEEN THE THREE IS EXPECTED TO BE SMALL
+    // ENOUGH TO BE COMPARABLE TO THE RUN-TO-RUN SPREAD OF A SINGLE MACHINE, SO PRINTING ONE SAMPLE EACH WOULD INVITE
+    // READING NOISE AS SIGNAL - THE SECOND ROUND IS THERE TO SHOW HOW BIG THAT NOISE IS
+    final List<String> report = new ArrayList<>();
+    for (int round = 1; round <= 2; round++) {
+      report.add(measureWrites("round " + round + ": no window open anywhere", null));
+
+      try (final PageSnapshot ignored = ((DatabaseInternal) neighbour).getPageManager()
+          .openSnapshot((DatabaseInternal) neighbour)) {
+        report.add(measureWrites("round " + round + ": window open on ANOTHER database", null));
+      }
+
+      try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+        report.add(measureWrites("round " + round + ": window open on THIS database", snapshot));
+      }
+    }
+
+    System.out.println("\n[snapshot-benchmark] steady-state write path, " + BATCH + " records per transaction:");
+    report.forEach(line -> System.out.println("  " + line));
+  }
+
+  /**
+   * The t0 barrier is the one stall the design keeps: it drains the flush queue in full, parks the flush thread on a
+   * batch boundary, and takes the apply and page-manager locks. Its duration is therefore a function of how much
+   * work the flush pipeline is carrying, which is what this sweeps - by loading the pipeline with an increasing
+   * number of writer threads and recording the depth actually observed rather than a depth commanded in advance.
+   */
+  @Test
+  void t0BarrierDurationAtVariousFlushQueueDepths() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    System.out.println("\n[snapshot-benchmark] t0 barrier duration under increasing write pressure. The barrier drains "
+        + "the flush queue IN FULL, so the queue depth it starts from is one input; the other is how fast commits "
+        + "arrive, because a commit landing between the drain and the flush-thread suspension makes it retry:");
+
+    for (final int writers : new int[] { 0, 1, 2, 4, 8 }) {
+      final AtomicBoolean running = new AtomicBoolean(true);
+      final AtomicLong maxQueueDepth = new AtomicLong();
+      final List<Thread> threads = new ArrayList<>();
+      for (int w = 0; w < writers; w++) {
+        final Thread thread = new Thread(() -> {
+          while (running.get())
+            writeBatches(1);
+        }, "snapshot-benchmark-writer-" + w);
+        thread.setDaemon(true);
+        thread.start();
+        threads.add(thread);
+      }
+
+      final Thread depthSampler = new Thread(() -> {
+        while (running.get()) {
+          maxQueueDepth.accumulateAndGet(pageManager.getStats().pageFlushQueueLength, Math::max);
+          Thread.onSpinWait();
+        }
+      }, "snapshot-benchmark-depth-sampler");
+      depthSampler.setDaemon(true);
+      depthSampler.start();
+
+      try {
+        // LET THE PIPELINE FILL BEFORE LOOKING AT IT
+        Thread.sleep(1_500);
+
+        // THE BARRIER IS VISIBLY VARIABLE UNDER LOAD (IT RETRIES), SO ONE SAMPLE WOULD BE A COIN TOSS
+        final long[] durationsUs = new long[5];
+        for (int i = 0; i < durationsUs.length; i++) {
+          final long begin = System.nanoTime();
+          try (final PageSnapshot ignored = pageManager.openSnapshot(db)) {
+            durationsUs[i] = (System.nanoTime() - begin) / 1_000;
+          }
+        }
+        Arrays.sort(durationsUs);
+
+        System.out.printf("  %d concurrent writer(s): peak queue depth %,6d pages, barrier min=%,8d us median=%,8d us "
+                + "max=%,8d us%n", writers, maxQueueDepth.get(), durationsUs[0], durationsUs[durationsUs.length / 2],
+            durationsUs[durationsUs.length - 1]);
+      } finally {
+        running.set(false);
+        for (final Thread thread : threads)
+          thread.join(30_000);
+        depthSampler.join(30_000);
+      }
+    }
+  }
+
+  /**
+   * Challenge C5 of #6075: the pre-image capture happens inside the write slot the flush already holds, so it eats
+   * into the flush thread's drain rate. This is how much of it - pages actually written to disk per second, with and
+   * without a window open, under the same sustained load.
+   */
+  @Test
+  void flushThreadDrainRateWithAndWithoutAWindowOpen() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    System.out.println("\n[snapshot-benchmark] flush-thread drain rate under a sustained writer:");
+    System.out.println("  " + measureDrainRate("no window open", false));
+    System.out.println("  " + measureDrainRate("window open", true));
+  }
+
+  /**
+   * The apply lock #6075 added to {@code TransactionManager}: one uncontended {@code ReentrantReadWriteLock} read
+   * acquisition per REPLICATED transaction (never on the local commit path), sitting next to a WAL parse and a page
+   * write. Reasoned to be unmeasurable in the PR, measured here: the cost of an apply, against the cost of the bare
+   * lock pair on the same machine.
+   */
+  @Test
+  void haReplayApplyLockCost() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = db.getSchema().getType(TYPE).getBuckets(false).getFirst().getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final PageId pageId = new PageId(db, fileId, 0);
+    final ImmutablePage page = db.getPageManager().getImmutablePage(pageId, file.getPageSize(), false, true);
+
+    final WALFile.WALPage walPage = new WALFile.WALPage();
+    walPage.fileId = fileId;
+    walPage.pageNumber = 0;
+    walPage.changesFrom = BasePage.PAGE_HEADER_SIZE;
+    walPage.changesTo = BasePage.PAGE_HEADER_SIZE + 10;
+    walPage.currentPageSize = page.getContentSize();
+    final byte[] content = new byte[11];
+    System.arraycopy(page.getContent().array(), walPage.changesFrom, content, 0, content.length);
+    walPage.currentContent = new Binary(content);
+
+    final WALFile.WALTransaction walTx = new WALFile.WALTransaction();
+    walTx.timestamp = System.currentTimeMillis();
+    walTx.pages = new WALFile.WALPage[] { walPage };
+
+    int version = (int) page.getVersion();
+    // WARM UP: THE FIRST APPLIES PAY FOR CLASS LOADING AND THE PAGE'S FIRST TOUCH
+    for (int i = 0; i < 200; i++) {
+      walTx.txId = i;
+      walPage.currentPageVersion = ++version;
+      db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false);
+    }
+
+    final int applies = 20_000;
+    final long applyBegin = System.nanoTime();
+    for (int i = 0; i < applies; i++) {
+      walTx.txId = 1_000_000 + i;
+      walPage.currentPageVersion = ++version;
+      db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false);
+    }
+    final long applyNanos = System.nanoTime() - applyBegin;
+
+    final ReentrantReadWriteLock lock = db.getTransactionManager().getApplyLock();
+    final long lockBegin = System.nanoTime();
+    for (int i = 0; i < applies; i++) {
+      lock.readLock().lock();
+      lock.readLock().unlock();
+    }
+    final long lockNanos = System.nanoTime() - lockBegin;
+
+    System.out.printf("%n[snapshot-benchmark] replicated apply: %,d ns/tx; the uncontended apply-lock pair it now "
+            + "carries: %,d ns/tx (%.4f%% of the apply)%n", applyNanos / applies, lockNanos / applies,
+        100.0 * lockNanos / applyNanos);
+  }
+
+  // ------------------------------------------------------------------------------------------------------- HELPERS
+
+  /**
+   * Runs {@link #MEASURE_BATCHES} transactions and reports throughput and the commit-latency percentiles. When a
+   * window is passed it also reports what that window had to capture, which is what the middle line of the report
+   * has to show as zero for the "another database" case to mean anything.
+   */
+  private String measureWrites(final String label, final PageSnapshot snapshot) {
+    final long[] latenciesUs = new long[MEASURE_BATCHES];
+    final long begin = System.nanoTime();
+    for (int i = 0; i < MEASURE_BATCHES; i++) {
+      final long batchBegin = System.nanoTime();
+      writeBatches(1);
+      latenciesUs[i] = (System.nanoTime() - batchBegin) / 1_000;
+    }
+    final double seconds = (System.nanoTime() - begin) / 1e9;
+    Arrays.sort(latenciesUs);
+
+    return "%-46s %,9.0f rec/s  p50=%,6dus p95=%,7dus p99=%,7dus  shadowed=%,d pages (%s)".formatted(label,
+        MEASURE_BATCHES * BATCH / seconds, percentile(latenciesUs, 50), percentile(latenciesUs, 95),
+        percentile(latenciesUs, 99), snapshot != null ? snapshot.getShadowedPages() : 0,
+        FileUtils.getSizeAsString(snapshot != null ? snapshot.getShadowSizeInBytes() : 0));
+  }
+
+  private String measureDrainRate(final String label, final boolean withWindow) throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final AtomicBoolean running = new AtomicBoolean(true);
+    final Thread writer = new Thread(() -> {
+      while (running.get())
+        writeBatches(1);
+    }, "snapshot-benchmark-drain-writer");
+    writer.setDaemon(true);
+
+    PageSnapshot snapshot = null;
+    try {
+      writer.start();
+      Thread.sleep(1_000);
+      if (withWindow)
+        snapshot = pageManager.openSnapshot(db);
+
+      final long pagesBefore = pageManager.getStats().pagesWritten;
+      final long begin = System.nanoTime();
+      Thread.sleep(5_000);
+      final double seconds = (System.nanoTime() - begin) / 1e9;
+      final long written = pageManager.getStats().pagesWritten - pagesBefore;
+
+      return "%-16s %,9.0f pages/s  queue=%,d  shadowed=%,d pages".formatted(label, written / seconds,
+          pageManager.getStats().pageFlushQueueLength, snapshot != null ? snapshot.getShadowedPages() : 0);
+    } finally {
+      running.set(false);
+      writer.join(30_000);
+      if (snapshot != null)
+        snapshot.close();
+    }
+  }
+
+  /**
+   * The measured workload: half inserts, half updates of records picked at random from the ones that existed at
+   * build time.
+   * <p>
+   * The update half is not decoration. An insert-only load appends to the tail of the bucket, and a page appended
+   * after t0 needs no pre-image (challenge C7) - so it would measure the write path with the hook present but never
+   * firing, and report a snapshot window as free when it is not. The random updates dirty pages scattered across the
+   * whole file, which is what makes a window actually capture.
+   */
+  private static void writeBatches(final int batches) {
+    for (int b = 0; b < batches; b++)
+      database.transaction(() -> {
+        for (int i = 0; i < BATCH / 2; i++)
+          database.newDocument(TYPE).set("id", NEXT_ID.incrementAndGet()).set("payload", PAYLOAD).save();
+
+        if (!MUTABLE_RIDS.isEmpty())
+          for (int i = 0; i < BATCH / 2; i++) {
+            final RID rid = MUTABLE_RIDS.get(ThreadLocalRandom.current().nextInt(MUTABLE_RIDS.size()));
+            rid.asDocument(true).modify().set("payload", PAYLOAD).save();
+          }
+      });
+  }
+
+  private static final AtomicLong NEXT_ID      = new AtomicLong();
+  private static final String     PAYLOAD      = "x".repeat(PAYLOAD_SIZE);
+  /** RIDs of the records that existed before the measurement, the targets of the update half of the workload. */
+  private static final List<RID>  MUTABLE_RIDS = new ArrayList<>();
+  /** Enough randomness to hit pages all over the file without paying for a RID per record on a huge dataset. */
+  private static final int        MAX_MUTABLE_RIDS = 100_000;
+
+  private static Database create(final String path, final int records) {
+    final Database db = new DatabaseFactory(path).create();
+    db.getSchema().createDocumentType(TYPE);
+    final boolean collectRids = MUTABLE_RIDS.isEmpty();
+    db.transaction(() -> {
+      for (int i = 0; i < records; i++) {
+        final MutableDocument document = db.newDocument(TYPE).set("id", NEXT_ID.incrementAndGet()).set("payload", PAYLOAD);
+        document.save();
+        if (collectRids && MUTABLE_RIDS.size() < MAX_MUTABLE_RIDS)
+          MUTABLE_RIDS.add(document.getIdentity());
+      }
+    });
+    ((DatabaseInternal) db).getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+    return db;
+  }
+
+  private static long percentile(final long[] sorted, final int percentile) {
+    if (sorted.length == 0)
+      return 0;
+    return sorted[Math.min(sorted.length - 1, (int) ((long) sorted.length * percentile / 100))];
+  }
+
+  private static long directorySize(final File directory) {
+    long size = 0;
+    final File[] files = directory.listFiles();
+    if (files != null)
+      for (final File file : files)
+        size += file.isDirectory() ? directorySize(file) : file.length();
+    return size;
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -53,8 +53,10 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -64,6 +66,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.zip.CRC32;
@@ -264,33 +267,91 @@ public class SnapshotHttpHandler implements HttpHandler {
 
     final DatabaseInternal db = server.getDatabase(databaseName);
 
-    // Flush pages and hold a read lock to ensure a consistent point-in-time view of database files.
-    // The refcounted suspension (#5068) guarantees ownership of the window; the per-database lock only
-    // serializes same-database reads with the snapshot zip path (see perDatabaseSuspendLock).
+    // Hold a read lock to keep the configuration files still, and serialize with this handler's other entry
+    // point per database (see perDatabaseSuspendLock: only the fallback path below suspends anything, but when
+    // it runs, keeping that window as short as possible still matters).
     final ReentrantLock dbSuspendLock = suspendLockFor(databaseName);
     dbSuspendLock.lock();
     try {
-      db.executeInReadLock(() -> {
-        db.getPageManager().suspendFlushAndExecute(db, () -> {
-          try {
-            final File dbDir = new File(db.getDatabasePath());
-            final Map<String, Long> checksums = SnapshotManager.computeFileChecksums(dbDir);
-            final JSONObject response = new JSONObject();
-            for (final var entry : checksums.entrySet())
-              response.put(entry.getKey(), entry.getValue());
-
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
-            exchange.getResponseSender().send(response.toString());
-          } catch (final Exception e) {
-            exchange.setStatusCode(500);
-            exchange.getResponseSender().send("Error computing checksums: " + e.getMessage());
-          }
-        });
-        return null;
-      });
+      final JSONObject response = computeChecksums(db);
+      exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+      exchange.getResponseSender().send(response.toString());
+    } catch (final Exception e) {
+      exchange.setStatusCode(500);
+      exchange.getResponseSender().send("Error computing checksums: " + e.getMessage());
     } finally {
       dbSuspendLock.unlock();
     }
+  }
+
+  /**
+   * Builds the {@code /checksums} response, reading the page files through a point-in-time window (#6116).
+   * <p>
+   * This endpoint was the last reader in the product still freezing the data files with
+   * {@code suspendFlushAndExecute} after #6075 migrated the backup, the HA verify and the HA snapshot ship: it
+   * reads the database DIRECTORY rather than the registered page files, so it needed the directory-oriented shape
+   * of {@link SnapshotManager#computeFileChecksums(File, PageSnapshot, Collection)} rather than the verify
+   * handler's file-list one. It is a rarely called diagnostic, but on a large database it reads every byte of
+   * every file, so on the old path it throttled the leader's committers for its whole duration.
+   * <p>
+   * Falls back to the suspension exactly as the other consumers do: a window that cannot be opened must degrade to
+   * a slower answer, never to no answer. Package-private so the two paths can be driven from a test without an
+   * HTTP exchange.
+   */
+  JSONObject computeChecksums(final DatabaseInternal db) {
+    final JSONObject response = new JSONObject();
+    final File dbDir = new File(db.getDatabasePath());
+
+    db.executeInReadLock(() -> {
+      if (db.getConfiguration().getValueAsBoolean(GlobalConfiguration.PAGE_SNAPSHOT_ENABLED)) {
+        try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+          putChecksums(response, SnapshotManager.computeFileChecksums(dbDir, snapshot, registeredPageFileNames(db)));
+          return null;
+        } catch (final PageSnapshotException e) {
+          // THE WINDOW LOST ITS POINT IN TIME (SHADOW CAP BREACH, I/O ERROR): NOTHING HAS BEEN PUT IN THE RESPONSE
+          // YET - computeFileChecksums BUILDS THE WHOLE MAP BEFORE IT RETURNS - SO THE FALLBACK BELOW CANNOT MIX
+          // SNAPSHOT AND LIVE CHECKSUMS
+          LogManager.instance().log(this, Level.WARNING,
+              "Point-in-time snapshot unusable for the checksums of database '%s' (%s): falling back to suspending the page flush",
+              null, db.getName(), e.getMessage());
+        }
+      }
+
+      // suspendFlushAndExecute LOGS AND SWALLOWS WHATEVER THE CALLBACK THROWS, SO A FAILURE INSIDE IT WOULD OTHERWISE
+      // LEAVE THIS METHOD RETURNING AN EMPTY MAP WITH A 200 - A CALLER COMPARING CHECKSUMS WOULD READ THAT AS
+      // "EVERY FILE MATCHES". CARRIED OUT AND RETHROWN SO THE HANDLER STILL ANSWERS 500
+      final AtomicReference<Exception> failure = new AtomicReference<>();
+      db.getPageManager().suspendFlushAndExecute(db, () -> {
+        try {
+          putChecksums(response, SnapshotManager.computeFileChecksums(dbDir));
+        } catch (final Exception e) {
+          failure.set(e);
+        }
+      });
+      if (failure.get() != null)
+        throw failure.get();
+      return null;
+    });
+
+    return response;
+  }
+
+  private static void putChecksums(final JSONObject response, final Map<String, Long> checksums) {
+    for (final Map.Entry<String, Long> entry : checksums.entrySet())
+      response.put(entry.getKey(), entry.getValue());
+  }
+
+  /**
+   * Names of the page files the FileManager currently has registered. Used to tell a page file created after the
+   * snapshot's t0 - which has no point-in-time content and is therefore left out - from the config and time-series
+   * files the window never covered, which are still read raw.
+   */
+  private static Collection<String> registeredPageFileNames(final DatabaseInternal db) {
+    final Set<String> names = new HashSet<>();
+    for (final ComponentFile file : db.getFileManager().getFiles())
+      if (file != null)
+        names.add(file.getFileName());
+    return names;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -86,6 +86,9 @@ public class SnapshotHttpHandler implements HttpHandler {
   private static final Semaphore CONCURRENCY_SEMAPHORE =
       new Semaphore(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger(), true);
 
+  /** How far {@link #rootCauseMessage} walks a cause chain before giving up. Real ones are two or three links. */
+  private static final int MAX_CAUSE_DEPTH = 20;
+
   // #5063 (review round 5) introduced this per-database lock because PageManagerFlushThread.setSuspended
   // was ownership-based (putIfAbsent): only the FIRST caller owned the suspend flag, so a second thread
   // streaming the same database could observe a resumed flush mid-read. Issue #5068 made the suspension
@@ -349,7 +352,10 @@ public class SnapshotHttpHandler implements HttpHandler {
    */
   static String rootCauseMessage(final Throwable error) {
     Throwable deepest = error;
-    while (deepest.getCause() != null && deepest.getCause() != deepest)
+    // BOUNDED, NOT GUARDED ON IDENTITY. A "cause != self" guard only catches a one-element cycle; a chain that
+    // loops back through two links (a -> b -> a, which initCause makes possible) would spin forever. A depth cap
+    // needs no reference comparison at all and covers every shape of cycle
+    for (int depth = 0; depth < MAX_CAUSE_DEPTH && deepest.getCause() != null; depth++)
       deepest = deepest.getCause();
     return deepest.getMessage() != null ? deepest.getMessage() : deepest.toString();
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -278,7 +278,7 @@ public class SnapshotHttpHandler implements HttpHandler {
       exchange.getResponseSender().send(response.toString());
     } catch (final Exception e) {
       exchange.setStatusCode(500);
-      exchange.getResponseSender().send("Error computing checksums: " + e.getMessage());
+      exchange.getResponseSender().send("Error computing checksums: " + rootCauseMessage(e));
     } finally {
       dbSuspendLock.unlock();
     }
@@ -290,9 +290,9 @@ public class SnapshotHttpHandler implements HttpHandler {
    * This endpoint was the last reader in the product still freezing the data files with
    * {@code suspendFlushAndExecute} after #6075 migrated the backup, the HA verify and the HA snapshot ship: it
    * reads the database DIRECTORY rather than the registered page files, so it needed the directory-oriented shape
-   * of {@link SnapshotManager#computeFileChecksums(File, PageSnapshot, Collection)} rather than the verify
-   * handler's file-list one. It is a rarely called diagnostic, but on a large database it reads every byte of
-   * every file, so on the old path it throttled the leader's committers for its whole duration.
+   * of {@link SnapshotManager#computeFileChecksums(File, PageSnapshot)} rather than the verify handler's file-list
+   * one. It is a rarely called diagnostic, but on a large database it reads every byte of every file, so on the old
+   * path it throttled the leader's committers for its whole duration.
    * <p>
    * Falls back to the suspension exactly as the other consumers do: a window that cannot be opened must degrade to
    * a slower answer, never to no answer. Package-private so the two paths can be driven from a test without an
@@ -305,7 +305,7 @@ public class SnapshotHttpHandler implements HttpHandler {
     db.executeInReadLock(() -> {
       if (db.getConfiguration().getValueAsBoolean(GlobalConfiguration.PAGE_SNAPSHOT_ENABLED)) {
         try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
-          putChecksums(response, SnapshotManager.computeFileChecksums(dbDir, snapshot, registeredPageFileNames(db)));
+          putChecksums(response, SnapshotManager.computeFileChecksums(dbDir, snapshot));
           return null;
         } catch (final PageSnapshotException e) {
           // THE WINDOW LOST ITS POINT IN TIME (SHADOW CAP BREACH, I/O ERROR): NOTHING HAS BEEN PUT IN THE RESPONSE
@@ -342,16 +342,16 @@ public class SnapshotHttpHandler implements HttpHandler {
   }
 
   /**
-   * Names of the page files the FileManager currently has registered. Used to tell a page file created after the
-   * snapshot's t0 - which has no point-in-time content and is therefore left out - from the config and time-series
-   * files the window never covered, which are still read raw.
+   * Message of the deepest cause, for the 500 body. {@code executeInReadLock} rewraps anything that is not a
+   * {@link RuntimeException} into {@code ArcadeDBException("Error in execution in lock", cause)}, whose own message
+   * says nothing about what actually failed - so reporting {@code e.getMessage()} would answer a genuine
+   * "permission denied on file X" with "Error in execution in lock". The cause chain still carries the real one.
    */
-  private static Collection<String> registeredPageFileNames(final DatabaseInternal db) {
-    final Set<String> names = new HashSet<>();
-    for (final ComponentFile file : db.getFileManager().getFiles())
-      if (file != null)
-        names.add(file.getFileName());
-    return names;
+  static String rootCauseMessage(final Throwable error) {
+    Throwable deepest = error;
+    while (deepest.getCause() != null && deepest.getCause() != deepest)
+      deepest = deepest.getCause();
+    return deepest.getMessage() != null ? deepest.getMessage() : deepest.toString();
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.PageSnapshot;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
@@ -26,11 +27,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.zip.CRC32;
 
 /**
@@ -122,7 +121,7 @@ public final class SnapshotManager {
    * @throws IOException if a file cannot be read
    */
   public static Map<String, Long> computeFileChecksums(final File directory) throws IOException {
-    return computeFileChecksums(directory, null, Set.of());
+    return computeFileChecksums(directory, null);
   }
 
   /**
@@ -137,22 +136,26 @@ public final class SnapshotManager {
    * {@code schema.json}, the {@code .ts.sealed} time-series stores, the {@code last-tx-id.bin} marker. Those are
    * read raw, as before; the database read lock the caller holds is what makes that safe, and is unchanged.
    * <p>
-   * A page file the FileManager has registered but the window does not carry was created after t0, so it has no
-   * point-in-time content to report: it is skipped rather than read live, which is the same rule
-   * {@code PostVerifyDatabaseHandler} follows by iterating the window's own file list. Reading it live would put a
-   * torn CRC of a file being actively written into a map whose whole purpose is to be compared with another node's.
+   * A page file the window does not carry was created after t0, so it has no point-in-time content to report: it is
+   * skipped rather than read live, which is the same rule {@code PostVerifyDatabaseHandler} follows by iterating the
+   * window's own file list. Reading it live would put a torn CRC of a file being actively written into a map whose
+   * whole purpose is to be compared with another node's.
+   * <p>
+   * "Is this a page file" is decided from the NAME ({@link LocalDatabase#isComponentFileName}) rather than by asking
+   * the {@code FileManager} what it currently has registered. The registry is a moving target even under the
+   * database read lock this runs beneath: index compaction creates and drops component files without the write
+   * lock, so a name set captured a moment before the directory listing can miss a file that is already on disk -
+   * and that file would then be CRC'd live, which is precisely the case being excluded.
    *
-   * @param directory     the database directory to scan
-   * @param snapshot      the open window to serve page files from, or {@code null} to read everything live
-   * @param pageFileNames names of the page files currently registered with the FileManager, used to tell a file
-   *                      created after t0 from one the snapshot simply does not cover
+   * @param directory the database directory to scan
+   * @param snapshot  the open window to serve page files from, or {@code null} to read everything live
    *
    * @return a map of file name to CRC32 checksum value
    *
    * @throws IOException if a file cannot be read
    */
-  public static Map<String, Long> computeFileChecksums(final File directory, final PageSnapshot snapshot,
-      final Collection<String> pageFileNames) throws IOException {
+  public static Map<String, Long> computeFileChecksums(final File directory, final PageSnapshot snapshot)
+      throws IOException {
     final Map<String, Long> checksums = new HashMap<>();
     final File[] files = directory.listFiles(File::isFile);
     if (files == null)
@@ -179,8 +182,9 @@ public final class SnapshotManager {
         continue;
       }
 
-      if (snapshot != null && pageFileNames.contains(name))
-        // A PAGE FILE CREATED AFTER t0: IT HAS NO POINT-IN-TIME CONTENT, SO IT IS ABSENT RATHER THAN TORN
+      if (snapshot != null && LocalDatabase.isComponentFileName(name))
+        // A PAGE FILE THE WINDOW DOES NOT CARRY WAS CREATED AFTER t0 (INDEX COMPACTION DOES THIS DURING A BACKUP):
+        // IT HAS NO POINT-IN-TIME CONTENT, SO IT IS ABSENT RATHER THAN TORN
         continue;
 
       final CRC32 crc = new CRC32();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.engine.PageSnapshot;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
@@ -25,9 +26,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.CRC32;
 
 /**
@@ -110,7 +113,7 @@ public final class SnapshotManager {
   }
 
   /**
-   * Computes CRC32 checksums for all regular files in the given directory.
+   * Computes CRC32 checksums for all regular files in the given directory, reading them live off the disk.
    *
    * @param directory the directory to scan
    *
@@ -119,17 +122,65 @@ public final class SnapshotManager {
    * @throws IOException if a file cannot be read
    */
   public static Map<String, Long> computeFileChecksums(final File directory) throws IOException {
+    return computeFileChecksums(directory, null, Set.of());
+  }
+
+  /**
+   * Computes the checksums of a database directory, taking the content of every page file from a point-in-time
+   * snapshot window instead of reading it live (#6116).
+   * <p>
+   * This is what lets the {@code /checksums} endpoint stop freezing the data files with
+   * {@code PageManager.suspendFlushAndExecute}, which was the last writer-throttling reader left in the product
+   * after #6075 migrated the backup, the HA verify and the HA snapshot ship. It needs a directory-oriented shape
+   * rather than the verify handler's file-list one because the endpoint's contract is "every non-transient file in
+   * the database directory", which includes files the page snapshot does not cover at all - {@code database.json},
+   * {@code schema.json}, the {@code .ts.sealed} time-series stores, the {@code last-tx-id.bin} marker. Those are
+   * read raw, as before; the database read lock the caller holds is what makes that safe, and is unchanged.
+   * <p>
+   * A page file the FileManager has registered but the window does not carry was created after t0, so it has no
+   * point-in-time content to report: it is skipped rather than read live, which is the same rule
+   * {@code PostVerifyDatabaseHandler} follows by iterating the window's own file list. Reading it live would put a
+   * torn CRC of a file being actively written into a map whose whole purpose is to be compared with another node's.
+   *
+   * @param directory     the database directory to scan
+   * @param snapshot      the open window to serve page files from, or {@code null} to read everything live
+   * @param pageFileNames names of the page files currently registered with the FileManager, used to tell a file
+   *                      created after t0 from one the snapshot simply does not cover
+   *
+   * @return a map of file name to CRC32 checksum value
+   *
+   * @throws IOException if a file cannot be read
+   */
+  public static Map<String, Long> computeFileChecksums(final File directory, final PageSnapshot snapshot,
+      final Collection<String> pageFileNames) throws IOException {
     final Map<String, Long> checksums = new HashMap<>();
     final File[] files = directory.listFiles(File::isFile);
     if (files == null)
       return checksums;
 
+    final Map<String, Integer> snapshotFileIds = new HashMap<>();
+    if (snapshot != null)
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+        snapshotFileIds.put(file.fileName(), file.fileId());
+
     final byte[] buffer = new byte[8192];
     for (final File file : files) {
       final String name = file.getName();
       // Skip transient files that differ between nodes: WAL logs, schema backups, lock files,
-      // and WAL files preserved as .corrupt evidence after an aborted recovery (#4958)
-      if (name.endsWith(".wal") || name.endsWith(".prev.json") || name.endsWith(".lock") || name.endsWith(".corrupt"))
+      // WAL files preserved as .corrupt evidence after an aborted recovery (#4958), and the scratch spill file of
+      // an open snapshot window (#6075), which is pure copy-on-write working state and never part of the database
+      if (name.endsWith(".wal") || name.endsWith(".prev.json") || name.endsWith(".lock") || name.endsWith(".corrupt")
+          || name.endsWith("." + PageSnapshot.SHADOW_FILE_EXT))
+        continue;
+
+      final Integer snapshotFileId = snapshotFileIds.get(name);
+      if (snapshotFileId != null) {
+        checksums.put(name, snapshot.calculateChecksum(snapshotFileId));
+        continue;
+      }
+
+      if (snapshot != null && pageFileNames.contains(name))
+        // A PAGE FILE CREATED AFTER t0: IT HAS NO POINT-IN-TIME CONTENT, SO IT IS ABSENT RATHER THAN TORN
         continue;
 
       final CRC32 crc = new CRC32();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6116ChecksumsPointInTimeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6116ChecksumsPointInTimeTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6116, part 3: {@code GET /api/v1/ha/snapshot/{db}/checksums} was the last reader in the product still
+ * freezing the data files with {@code PageManager.suspendFlushAndExecute} after #6075 migrated the full backup, the
+ * HA verify and the HA snapshot ship. On a large database it CRCs every byte of every file, so the freeze it held
+ * throttled the leader's committers for its whole duration.
+ * <p>
+ * Two properties are defended here. That the answer is still a genuine point in time, byte-for-byte the value a peer
+ * on the fallback path computes - otherwise a migrated leader would report every file as differing. And the reason
+ * for the change: the flush suspension is no longer held for the read, only for the window's t0 barrier, measured
+ * against the fallback path in the same test so the comparison does not depend on this machine's timing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6116ChecksumsPointInTimeTest {
+  private static final String DATABASE_PATH = "target/databases/checksums-point-in-time";
+  private static final String TYPE          = "Doc";
+  /** Big enough that CRC-ing every file lasts long enough to be sampled, small enough to build in well under a second. */
+  private static final int    RECORDS       = 100_000;
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.reset();
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+  }
+
+  /**
+   * The migrated path must produce exactly what the frozen-file path produced: a follower still on the old code CRCs
+   * its files raw, and the two are compared for equality.
+   */
+  @Test
+  void theSnapshotChecksumsAreByteForByteTheFrozenFileOnes() throws Exception {
+    try (final Database database = createDatabase()) {
+      final DatabaseInternal db = (DatabaseInternal) database;
+      final File dbDir = new File(db.getDatabasePath());
+
+      final Map<String, Long> live = SnapshotManager.computeFileChecksums(dbDir);
+      try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+        final Map<String, Long> viaSnapshot = SnapshotManager.computeFileChecksums(dbDir, snapshot, pageFileNames(db));
+        assertThat(viaSnapshot).isEqualTo(live);
+      }
+    }
+  }
+
+  /**
+   * The point-in-time property, with the mutation check that keeps it from passing vacuously: the very same rewrite
+   * that leaves the window's answer untouched must be visible to a live read of the same directory.
+   */
+  @Test
+  void theChecksumsStayAtT0WhileTheDatabaseIsRewritten() throws Exception {
+    try (final Database database = createDatabase()) {
+      final DatabaseInternal db = (DatabaseInternal) database;
+      final File dbDir = new File(db.getDatabasePath());
+
+      try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+        final Map<String, Long> t0 = SnapshotManager.computeFileChecksums(dbDir, snapshot, pageFileNames(db));
+        assertThat(t0).isNotEmpty();
+
+        database.transaction(() -> database.iterateType(TYPE, false).forEachRemaining(
+            record -> record.asDocument().modify().set("payload", "rewritten-" + "y".repeat(300)).save()));
+        db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+
+        assertThat(SnapshotManager.computeFileChecksums(dbDir, snapshot, pageFileNames(db)))
+            .as("the window must keep answering with its t0 image").isEqualTo(t0);
+        assertThat(SnapshotManager.computeFileChecksums(dbDir))
+            .as("a live read of the same directory must have changed, or the assertion above proves nothing")
+            .isNotEqualTo(t0);
+
+        // THE SCRATCH SPILL FILE OF THE OPEN WINDOW LIVES IN THIS VERY DIRECTORY AND IS NOT PART OF THE DATABASE:
+        // CHECKSUMMING IT WOULD REPORT A FILE NO PEER HAS
+        assertThat(t0.keySet()).noneMatch(name -> name.endsWith("." + PageSnapshot.SHADOW_FILE_EXT));
+      }
+    }
+  }
+
+  /**
+   * The reason the change exists. The suspend-and-freeze path is measured in the same run as the control, so the
+   * comparison is not a bet on absolute timings.
+   */
+  @Test
+  void computingTheChecksumsNoLongerSuspendsPageFlushing() throws Exception {
+    // NOT "never suspends": OPENING THE WINDOW ITSELF PARKS THE FLUSH THREAD FOR THE t0 BARRIER, WHICH IS BOUNDED
+    // AND MEASURED IN MILLISECONDS. WHAT CHANGES IS THE SHAPE - A BRIEF BARRIER INSTEAD OF A FREEZE HELD FOR THE
+    // WHOLE READ - SO THE ASSERTION IS ON THE FRACTION OF THE COMPUTATION SPENT SUSPENDED, WITH THE SAME THRESHOLDS
+    // Issue6075SnapshotBackupIT USES FOR THE BACKUP. THE FALLBACK RUN IS THE CONTROL: IT PROVES THIS MACHINE'S
+    // SAMPLER SEES SUSPENSIONS AT ALL
+    final double fallback = suspendedFractionWhileComputingChecksums(false);
+    final double withSnapshot = suspendedFractionWhileComputingChecksums(true);
+
+    assertThat(fallback).as("the fallback path must still freeze the files for the whole read").isGreaterThan(0.9);
+    assertThat(withSnapshot).as("the snapshot path must not hold the flush suspension for the read (fallback was %f)",
+        fallback).isLessThan(0.5);
+  }
+
+  /**
+   * Whichever path it took, the handler answers with one checksum per non-transient file, and the answer is the
+   * same on both - the endpoint's contract does not change with the setting.
+   */
+  @Test
+  void bothPathsAnswerWithTheSameFileSet() throws Exception {
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    try (final Database database = createDatabase()) {
+      final DatabaseInternal db = (DatabaseInternal) database;
+
+      GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(true);
+      final JSONObject viaSnapshot = handler.computeChecksums(db);
+
+      GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(false);
+      final JSONObject viaSuspension = handler.computeChecksums(db);
+
+      assertThat(viaSnapshot.keySet()).isNotEmpty().isEqualTo(viaSuspension.keySet());
+      for (final String name : viaSnapshot.keySet())
+        assertThat(viaSnapshot.getLong(name)).as(name).isEqualTo(viaSuspension.getLong(name));
+    } finally {
+      handler.close();
+    }
+  }
+
+  /**
+   * Runs the handler's checksum computation with a writer committing throughout, and returns the fraction of the
+   * samples taken during it that found page flushing suspended.
+   * <p>
+   * The writer pauses between transactions on purpose. It has to be committing - otherwise the fallback path has
+   * nothing to freeze and the comparison is empty - but a writer running flat out makes the t0 barrier RETRY (a
+   * commit landing between its full queue drain and the flush-thread suspension), which stretches the one
+   * suspension the snapshot path does take until it is comparable to the whole read. That would be measuring the
+   * barrier, which {@code PageSnapshotOverheadBenchmark} measures properly, instead of what is being asserted here.
+   */
+  private double suspendedFractionWhileComputingChecksums(final boolean snapshot) throws Exception {
+    clean();
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshot);
+
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    try (final Database database = createDatabase()) {
+      final DatabaseInternal db = (DatabaseInternal) database;
+
+      final AtomicBoolean running = new AtomicBoolean(true);
+      final AtomicReference<Exception> writerFailure = new AtomicReference<>();
+      final CountDownLatch warmedUp = new CountDownLatch(1);
+      final AtomicLong samples = new AtomicLong();
+      final AtomicLong suspendedSamples = new AtomicLong();
+
+      final Thread writer = new Thread(() -> {
+        for (int id = 0; running.get(); id++) {
+          try {
+            final int current = id;
+            database.transaction(
+                () -> database.newDocument(TYPE).set("id", current).set("payload", "concurrent-" + current).save());
+            warmedUp.countDown();
+            Thread.sleep(2);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          } catch (final Exception e) {
+            writerFailure.compareAndSet(null, e);
+            return;
+          }
+        }
+      }, "checksums-writer");
+      writer.setDaemon(true);
+
+      // SPINS RATHER THAN SLEEPING BETWEEN SAMPLES, AND IS ALREADY SPINNING BEFORE THE COMPUTATION STARTS. CRC-ING
+      // A FEW TENS OF MEGABYTES OFF A WARM PAGE CACHE TAKES MILLISECONDS: A 1 ms SAMPLER WOULD TAKE A HANDFUL OF
+      // SAMPLES, AND A SAMPLER STARTED AT THE SAME MOMENT AS THE COMPUTATION WOULD CHARGE ITS OWN THREAD-START
+      // LATENCY TO THE UNSUSPENDED SIDE - WORTH A FIFTH OF THE WHOLE WINDOW AT THESE DURATIONS
+      final AtomicBoolean computing = new AtomicBoolean(false);
+      final Thread sampler = new Thread(() -> {
+        while (running.get()) {
+          if (computing.get()) {
+            samples.incrementAndGet();
+            if (db.getPageManager().isPageFlushingSuspended(db))
+              suspendedSamples.incrementAndGet();
+          }
+          Thread.onSpinWait();
+        }
+      }, "checksums-suspension-sampler");
+      sampler.setDaemon(true);
+
+      writer.start();
+      sampler.start();
+      try {
+        assertThat(warmedUp.await(30, TimeUnit.SECONDS)).isTrue();
+
+        computing.set(true);
+        final JSONObject checksums = handler.computeChecksums(db);
+        computing.set(false);
+        assertThat(checksums.keySet()).isNotEmpty();
+      } finally {
+        computing.set(false);
+        running.set(false);
+        writer.join(30_000);
+        sampler.join(10_000);
+      }
+
+      assertThat(writerFailure.get()).isNull();
+      assertThat(samples.get()).as("the computation must last long enough to sample meaningfully").isGreaterThan(200);
+      return (double) suspendedSamples.get() / samples.get();
+    } finally {
+      handler.close();
+    }
+  }
+
+  private static Set<String> pageFileNames(final DatabaseInternal db) {
+    final Set<String> names = new HashSet<>();
+    for (final ComponentFile file : db.getFileManager().getFiles())
+      if (file != null)
+        names.add(file.getFileName());
+    return names;
+  }
+
+  private Database createDatabase() {
+    final Database database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createDocumentType(TYPE);
+    database.transaction(() -> {
+      for (int i = 0; i < RECORDS; i++)
+        database.newDocument(TYPE).set("id", i).set("payload", "x".repeat(300)).save();
+    });
+    ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+    return database;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6116ChecksumsPointInTimeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6116ChecksumsPointInTimeTest.java
@@ -22,7 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
-import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.PageSnapshot;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
@@ -32,9 +32,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.HashSet;
+import java.nio.file.Files;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -81,7 +80,7 @@ class Issue6116ChecksumsPointInTimeTest {
 
       final Map<String, Long> live = SnapshotManager.computeFileChecksums(dbDir);
       try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
-        final Map<String, Long> viaSnapshot = SnapshotManager.computeFileChecksums(dbDir, snapshot, pageFileNames(db));
+        final Map<String, Long> viaSnapshot = SnapshotManager.computeFileChecksums(dbDir, snapshot);
         assertThat(viaSnapshot).isEqualTo(live);
       }
     }
@@ -98,14 +97,14 @@ class Issue6116ChecksumsPointInTimeTest {
       final File dbDir = new File(db.getDatabasePath());
 
       try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
-        final Map<String, Long> t0 = SnapshotManager.computeFileChecksums(dbDir, snapshot, pageFileNames(db));
+        final Map<String, Long> t0 = SnapshotManager.computeFileChecksums(dbDir, snapshot);
         assertThat(t0).isNotEmpty();
 
         database.transaction(() -> database.iterateType(TYPE, false).forEachRemaining(
             record -> record.asDocument().modify().set("payload", "rewritten-" + "y".repeat(300)).save()));
         db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
 
-        assertThat(SnapshotManager.computeFileChecksums(dbDir, snapshot, pageFileNames(db)))
+        assertThat(SnapshotManager.computeFileChecksums(dbDir, snapshot))
             .as("the window must keep answering with its t0 image").isEqualTo(t0);
         assertThat(SnapshotManager.computeFileChecksums(dbDir))
             .as("a live read of the same directory must have changed, or the assertion above proves nothing")
@@ -114,6 +113,39 @@ class Issue6116ChecksumsPointInTimeTest {
         // THE SCRATCH SPILL FILE OF THE OPEN WINDOW LIVES IN THIS VERY DIRECTORY AND IS NOT PART OF THE DATABASE:
         // CHECKSUMMING IT WOULD REPORT A FILE NO PEER HAS
         assertThat(t0.keySet()).noneMatch(name -> name.endsWith("." + PageSnapshot.SHADOW_FILE_EXT));
+      }
+    }
+  }
+
+  /**
+   * A page file that appears in the directory but not in the window was created after t0 - index compaction does
+   * exactly this during a backup, and it does it WITHOUT the database write lock, so it can happen at any point
+   * while this endpoint is reading. It must be left out, not CRC'd live: a torn checksum of a file being written is
+   * worse than an absent one in a map whose only purpose is to be compared with another node's.
+   * <p>
+   * Deciding that by extension rather than by asking the FileManager for its current file list is what makes this
+   * race-free: a name set captured before the directory listing can already be out of date by the time the listing
+   * runs.
+   */
+  @Test
+  void aPageFileThatAppearsAfterT0IsLeftOutWhileANonPageFileIsStillRead() throws Exception {
+    try (final Database database = createDatabase()) {
+      final DatabaseInternal db = (DatabaseInternal) database;
+      final File dbDir = new File(db.getDatabasePath());
+
+      try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+        // APPEARING UNDER THE READER, AFTER t0, EXACTLY AS A COMPACTED INDEX FILE DOES
+        Files.writeString(new File(dbDir, "Latecomer_9.1.64." + LocalBucket.BUCKET_EXT).toPath(), "post-t0 bytes");
+        Files.writeString(new File(dbDir, "operator-notes.txt").toPath(), "not a page file");
+
+        final Map<String, Long> checksums = SnapshotManager.computeFileChecksums(dbDir, snapshot);
+
+        assertThat(checksums).doesNotContainKey("Latecomer_9.1.64." + LocalBucket.BUCKET_EXT);
+        assertThat(checksums).as("a file the snapshot never covered is still read live, as it always was")
+            .containsKey("operator-notes.txt");
+        // THE CONTROL: WITHOUT A WINDOW THERE IS NO POINT IN TIME TO BE OUTSIDE OF, SO BOTH ARE READ
+        assertThat(SnapshotManager.computeFileChecksums(dbDir))
+            .containsKey("Latecomer_9.1.64." + LocalBucket.BUCKET_EXT);
       }
     }
   }
@@ -243,14 +275,6 @@ class Issue6116ChecksumsPointInTimeTest {
     } finally {
       handler.close();
     }
-  }
-
-  private static Set<String> pageFileNames(final DatabaseInternal db) {
-    final Set<String> names = new HashSet<>();
-    for (final ComponentFile file : db.getFileManager().getFiles())
-      if (file != null)
-        names.add(file.getFileName());
-    return names;
   }
 
   private Database createDatabase() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerDisconnectTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerDisconnectTest.java
@@ -85,4 +85,14 @@ class SnapshotHttpHandlerDisconnectTest {
     assertThat(SnapshotHttpHandler.rootCauseMessage(new RuntimeException(new NullPointerException())))
         .isEqualTo("java.lang.NullPointerException");
   }
+
+  /** A cause chain that loops back on itself must terminate, not hang the response thread. */
+  @Test
+  void aCyclicCauseChainTerminates() {
+    final Throwable first = new RuntimeException("first");
+    final Throwable second = new RuntimeException("second", first);
+    first.initCause(second);
+
+    assertThat(SnapshotHttpHandler.rootCauseMessage(first)).isNotNull();
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerDisconnectTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerDisconnectTest.java
@@ -66,4 +66,23 @@ class SnapshotHttpHandlerDisconnectTest {
   void nullIsNotAClientDisconnect() {
     assertThat(SnapshotHttpHandler.isClientDisconnect(null)).isFalse();
   }
+
+  /**
+   * #6116: the {@code /checksums} 500 body reports the DEEPEST cause. {@code executeInReadLock} rewraps every
+   * checked exception into {@code ArcadeDBException("Error in execution in lock", cause)}, so reporting the
+   * top-level message would answer a real "permission denied on file X" with a sentence about a lock.
+   */
+  @Test
+  void theChecksumsFailureMessageComesFromTheDeepestCause() {
+    final Throwable wrapped = new RuntimeException("Error in execution in lock",
+        new IOException("Permission denied: /data/mydb/Doc_0.1.64.bucket"));
+    assertThat(SnapshotHttpHandler.rootCauseMessage(wrapped))
+        .isEqualTo("Permission denied: /data/mydb/Doc_0.1.64.bucket");
+  }
+
+  @Test
+  void aFailureWithNoMessageStillReportsSomething() {
+    assertThat(SnapshotHttpHandler.rootCauseMessage(new RuntimeException(new NullPointerException())))
+        .isEqualTo("java.lang.NullPointerException");
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotManagerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotManagerTest.java
@@ -61,6 +61,26 @@ class SnapshotManagerTest {
     assertThat(checksums.get("a.dat")).isNotEqualTo(checksums.get("b.dat"));
   }
 
+  /**
+   * #6116: the transient files a checksum comparison must not see. The {@code .pshadow} entry is the newest of them
+   * and the easiest to miss - it is the copy-on-write scratch of an open snapshot window (#6075), it lives in the
+   * database directory, and its content is whatever pages happened to be dirtied, so a node that has one and a node
+   * that does not would be reported as inconsistent for no reason at all.
+   */
+  @Test
+  void transientFilesAreNotChecksummed(@TempDir final Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("database.json"), "{}");
+    Files.writeString(tempDir.resolve("txlog_0.wal"), "wal");
+    Files.writeString(tempDir.resolve("schema.prev.json"), "{}");
+    Files.writeString(tempDir.resolve("database.lock"), "");
+    Files.writeString(tempDir.resolve("txlog_1.corrupt"), "corrupt");
+    Files.writeString(tempDir.resolve("snapshot-1.pshadow"), "shadow");
+
+    final Map<String, Long> checksums = SnapshotManager.computeFileChecksums(tempDir.toFile());
+
+    assertThat(checksums).containsOnlyKeys("database.json");
+  }
+
   @Test
   void findDifferingFiles() {
     final Map<String, Long> leader = Map.of("file1", 100L, "file2", 200L, "file3", 300L);

--- a/integration/src/test/java/com/arcadedb/integration/backup/PageSnapshotBackupBenchmark.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/PageSnapshotBackupBenchmark.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.backup;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The backup-side measurements issue #6075 asked for and PR #6100 did not produce, listed in #6116: what a running
+ * backup does to the writers beside it on the point-in-time snapshot path against the suspend-and-freeze path, how
+ * much deferred RAM each accumulates, and how big the copy-on-write shadow gets as a fraction of the database - the
+ * sizing evidence behind the 1 GB {@code arcadedb.pageSnapshotMaxSize} default, which was chosen without any.
+ * <p>
+ * Deliberately shaped like {@link BackupCompressionBenchmark#concurrentWriterImpact()}, the #6072 harness that
+ * produced the 4.3% / 77% figures, so the two sets of numbers can be read side by side: the same window-scoped
+ * measurement (only commits that fall INSIDE the backup count, otherwise a long backup and a short one dilute to
+ * the same average), the same percentiles, the same deferred-RAM sampler.
+ * <p>
+ * The shadow and deferred-RAM readings are taken through {@code PageManager.getStats()} - the gauges #6116 adds -
+ * rather than through the window object, because the backup owns its window internally and never exposes it. That
+ * is the same path an operator's dashboard reads, so this benchmark also exercises the wiring it depends on.
+ * <p>
+ * Excluded from the normal build ({@code @Tag("benchmark")}). Run it explicitly:
+ * <pre>
+ *   mvn -o -pl integration test -Dtest=PageSnapshotBackupBenchmark -Dgroups=benchmark -DexcludedGroups=
+ * </pre>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class PageSnapshotBackupBenchmark {
+  private static final String DATABASE_PATH = "target/databases/page-snapshot-backup-benchmark";
+  private static final String BACKUP_FILE   = "target/page-snapshot-backup-benchmark.zip";
+  private static final String TYPE          = "Doc";
+  private static final int    TARGET_MB     = Integer.parseInt(
+      System.getProperty("arcadedb.snapshot.benchmark.sizeMB", "512"));
+  private static final int    PAYLOAD_SIZE  = 512;
+  /** Records per transaction, and the unit every latency percentile below is measured over. */
+  private static final int    BATCH         = 50;
+  /** Throttled so the backup lasts long enough to sample, and so the write rates below are what differs, not the I/O. */
+  private static final int    MAX_MB_PER_SECOND = 32;
+
+  /**
+   * Update targets, kept as raw (bucket, position) pairs rather than as {@link RID}s: a RID carries the
+   * {@code Database} instance it was created against, and every measurement below opens its own instance - so a
+   * stored RID would resolve against the closed builder instance and every update would throw.
+   */
+  private static final List<int[]> MUTABLE_RECORDS = new ArrayList<>();
+  private static final String      PAYLOAD         = payload();
+
+  private static long databaseSize;
+
+  /**
+   * Rebuilt from scratch before EVERY measurement, not once for the class. The load inserts as well as updates, so
+   * a shared database grows from one run to the next: the later runs would be backing up more data than the earlier
+   * ones (a longer window, a different throughput) and, worse, the "shadow as a fraction of the database" column -
+   * the one number this benchmark exists to produce - would be dividing by a size that no longer exists.
+   */
+  static void buildDatabase() {
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    new File(BACKUP_FILE).delete();
+    MUTABLE_RECORDS.clear();
+
+    final long begin = System.currentTimeMillis();
+    try (final Database database = new DatabaseFactory(DATABASE_PATH).create()) {
+      database.getSchema().createDocumentType(TYPE);
+
+      final long records = (long) TARGET_MB * 1024 * 1024 / (PAYLOAD_SIZE + 64);
+      long id = 0;
+      while (id < records) {
+        database.transaction(() -> {
+          for (int i = 0; i < 5_000; i++) {
+            final MutableDocument document = database.newDocument(TYPE).set("payload", PAYLOAD);
+            document.save();
+            // ONE IN A HUNDRED IS ENOUGH TO DRIVE UPDATES THAT LAND ALL OVER THE FILE WITHOUT HOLDING ONE PER RECORD
+            final RID rid = document.getIdentity();
+            if (MUTABLE_RECORDS.size() < 50_000 && rid.getPosition() % 100 == 0)
+              MUTABLE_RECORDS.add(new int[] { rid.getBucketId(), (int) rid.getPosition() });
+          }
+        });
+        id += 5_000;
+      }
+      ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+    }
+
+    databaseSize = directorySize(new File(DATABASE_PATH));
+    System.out.printf("[snapshot-backup-benchmark] built a %s database in %,d ms%n",
+        FileUtils.getSizeAsString(databaseSize), System.currentTimeMillis() - begin);
+  }
+
+  @AfterAll
+  static void dropDatabase() {
+    clean();
+  }
+
+  static void clean() {
+    try (final Database database = new DatabaseFactory(DATABASE_PATH).open()) {
+      database.drop();
+    } catch (final Exception e) {
+      // ALREADY GONE OR NEVER BUILT: THE RECURSIVE DELETE BELOW IS THE BACKSTOP
+    }
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    new File(BACKUP_FILE).delete();
+    GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.reset();
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.reset();
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.reset();
+  }
+
+  /**
+   * The headline comparison: sustained write throughput and commit latency during a backup, on the snapshot path
+   * against the suspend-and-freeze one, with a no-backup baseline measured in the same run. The deferred-RAM column
+   * is what the suspension costs in RAM before it starts throttling committers outright at
+   * {@code arcadedb.flushSuspendMaxDeferredRAM}; on the snapshot path it should never leave zero.
+   */
+  @Test
+  void writerImpactOfABackupOnBothPaths() throws Exception {
+    System.out.println("\n[snapshot-backup-benchmark] writers running beside a backup (measured only INSIDE the "
+        + "backup window):");
+    System.out.println("  " + runWriterLoad("no backup running", null));
+    System.out.println("  " + runWriterLoad("backup, snapshot path", Boolean.TRUE));
+    System.out.println("  " + runWriterLoad("backup, suspend-and-freeze", Boolean.FALSE));
+  }
+
+  /**
+   * How large the copy-on-write shadow grows during a real backup, at several write rates, as a fraction of the
+   * database. This is the number the 1 GB {@code arcadedb.pageSnapshotMaxSize} default has to be judged against: the
+   * shadow holds the pre-image of every page dirtied while the window is open, so its ceiling is the working set of
+   * the backup's duration, and on a small, very hot database it approaches the database size itself.
+   */
+  @Test
+  void shadowPeakSizeAcrossWriteRates() throws Exception {
+    System.out.println("\n[snapshot-backup-benchmark] copy-on-write shadow peak during a backup, by write rate:");
+    for (final int pauseMs : new int[] { 100, 20, 5, 0 })
+      System.out.println("  " + runWriterLoad("pause %3d ms between transactions".formatted(pauseMs), Boolean.TRUE,
+          pauseMs));
+  }
+
+  // ------------------------------------------------------------------------------------------------------- HELPERS
+
+  private static String runWriterLoad(final String label, final Boolean snapshotPath) throws Exception {
+    return runWriterLoad(label, snapshotPath, 0);
+  }
+
+  /**
+   * Runs a sustained mixed insert/update load and reports what happened only inside the measurement window - the
+   * backup, or a fixed sleep for the baseline.
+   *
+   * @param snapshotPath {@code true} for the page-snapshot path, {@code false} for suspend-and-freeze, {@code null}
+   *                     to run no backup at all.
+   */
+  private static String runWriterLoad(final String label, final Boolean snapshotPath, final int pauseMs)
+      throws Exception {
+    if (snapshotPath != null)
+      GlobalConfiguration.PAGE_SNAPSHOT_ENABLED.setValue(snapshotPath);
+
+    buildDatabase();
+
+    try (final Database database = new DatabaseFactory(DATABASE_PATH).open()) {
+      final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+
+      final AtomicBoolean stop = new AtomicBoolean(false);
+      final AtomicLong peakDeferredRAM = new AtomicLong();
+      final AtomicLong peakShadowBytes = new AtomicLong();
+      final AtomicLong peakShadowPages = new AtomicLong();
+      final List<long[]> samples = new ArrayList<>();
+
+      final AtomicReference<Exception> writerFailure = new AtomicReference<>();
+      final Thread writer = new Thread(() -> {
+        while (!stop.get()) {
+          final long begin = System.nanoTime();
+          try {
+            database.transaction(() -> {
+              for (int i = 0; i < BATCH / 2; i++)
+                database.newDocument(TYPE).set("payload", PAYLOAD).save();
+              for (int i = 0; i < BATCH / 2; i++) {
+                final int[] target = MUTABLE_RECORDS.get(ThreadLocalRandom.current().nextInt(MUTABLE_RECORDS.size()));
+                database.newRID(target[0], target[1]).asDocument(true).modify().set("payload", PAYLOAD).save();
+              }
+            });
+          } catch (final Exception e) {
+            // A DEAD WRITER WOULD OTHERWISE BE REPORTED AS A ROW OF PERFECT ZEROS
+            writerFailure.compareAndSet(null, e);
+            return;
+          }
+          final long end = System.nanoTime();
+          synchronized (samples) {
+            samples.add(new long[] { end, (end - begin) / 1000 });
+          }
+          if (pauseMs > 0)
+            try {
+              Thread.sleep(pauseMs);
+            } catch (final InterruptedException e) {
+              Thread.currentThread().interrupt();
+              return;
+            }
+        }
+      }, "snapshot-backup-benchmark-writer");
+
+      final Thread sampler = new Thread(() -> {
+        while (!stop.get()) {
+          final PageManager.PPageManagerStats stats = pageManager.getStats();
+          peakDeferredRAM.accumulateAndGet(stats.deferredRAMBytes, Math::max);
+          peakShadowBytes.accumulateAndGet(stats.snapshotShadowBytes, Math::max);
+          peakShadowPages.accumulateAndGet(stats.snapshotShadowedPages, Math::max);
+          try {
+            Thread.sleep(20);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+        }
+      }, "snapshot-backup-benchmark-sampler");
+      sampler.setDaemon(true);
+
+      final long windowBegin;
+      final long windowEnd;
+      writer.start();
+      sampler.start();
+      try {
+        // LET THE LOAD REACH STEADY STATE BEFORE THE WINDOW OPENS
+        Thread.sleep(2_000);
+        windowBegin = System.nanoTime();
+        if (snapshotPath != null)
+          new Backup(database, BACKUP_FILE).setVerboseLevel(0).setMaxMBPerSecond(MAX_MB_PER_SECOND).backupDatabase();
+        else
+          Thread.sleep(10_000);
+        windowEnd = System.nanoTime();
+      } finally {
+        stop.set(true);
+        writer.join(60_000);
+        sampler.join(10_000);
+        new File(BACKUP_FILE).delete();
+      }
+
+      if (writerFailure.get() != null)
+        throw writerFailure.get();
+
+      final List<Long> inWindow = new ArrayList<>();
+      synchronized (samples) {
+        for (final long[] sample : samples)
+          if (sample[0] >= windowBegin && sample[0] <= windowEnd)
+            inWindow.add(sample[1]);
+      }
+      final long[] sorted = new long[inWindow.size()];
+      for (int i = 0; i < sorted.length; i++)
+        sorted[i] = inWindow.get(i);
+      Arrays.sort(sorted);
+
+      final double windowSeconds = (windowEnd - windowBegin) / 1e9;
+      return ("%-34s window=%6.1fs commits=%,6d (%,8.0f rec/s) p50=%,7dus p95=%,8dus p99=%,8dus "
+          + "peakDeferredRAM=%9s shadowPeak=%9s (%,6d pages, %5.1f%% of the database)").formatted(label, windowSeconds,
+          sorted.length, sorted.length * (double) BATCH / windowSeconds, percentile(sorted, 50), percentile(sorted, 95),
+          percentile(sorted, 99), FileUtils.getSizeAsString(peakDeferredRAM.get()),
+          FileUtils.getSizeAsString(peakShadowBytes.get()), peakShadowPages.get(),
+          100.0 * peakShadowBytes.get() / databaseSize);
+    }
+  }
+
+  private static long percentile(final long[] sorted, final int percentile) {
+    if (sorted.length == 0)
+      return 0;
+    return sorted[Math.min(sorted.length - 1, (int) ((long) sorted.length * percentile / 100))];
+  }
+
+  private static String payload() {
+    final StringBuilder builder = new StringBuilder(PAYLOAD_SIZE);
+    while (builder.length() < PAYLOAD_SIZE)
+      builder.append("field").append(builder.length()).append("=value;");
+    return builder.substring(0, PAYLOAD_SIZE);
+  }
+
+  private static long directorySize(final File directory) {
+    long size = 0;
+    final File[] files = directory.listFiles();
+    if (files != null)
+      for (final File file : files)
+        size += file.isDirectory() ? directorySize(file) : file.length();
+    return size;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -99,10 +99,42 @@ public final class EngineMetricsBinder implements MeterBinder {
     counter(registry, "arcadedb.engine.queries", "Queries executed", "queries");
     counter(registry, "arcadedb.engine.commands", "Commands executed", "commands");
 
+    // #6116: the copy-on-write work an open snapshot window (#6075) is doing, and how often a window loses its point
+    // in time. An invalidated window is invisible from the outside - its consumer restarts on the suspend-and-freeze
+    // path and still completes - so without this counter the only trace of a backup that fell back to throttling the
+    // writers is a WARNING in the log.
+    counter(registry, "arcadedb.engine.snapshot.windows.opened", "Point-in-time snapshot windows opened",
+        "snapshotWindowsOpened");
+    counter(registry, "arcadedb.engine.snapshot.windows.invalidated",
+        "Snapshot windows that lost their point in time (shadow cap breach or I/O error)", "snapshotWindowsInvalidated");
+    counter(registry, "arcadedb.engine.snapshot.preimages.captured",
+        "Page pre-images copied into a snapshot shadow", "snapshotPreImagesCaptured");
+
     // Instantaneous readings: these go up AND down, so they are the only ones that stay gauges.
     gauge(registry, "arcadedb.engine.wal.files", "WAL files", "walTotalFiles");
     gauge(registry, "arcadedb.engine.files.open", "Open file descriptors", "totalOpenFiles");
     gauge(registry, "arcadedb.engine.databases", "Open databases", "totalDatabases");
+
+    // #6116: per-window state, so every one of these returns to zero when the last window closes - gauges, not
+    // counters (#5636). The usage percentage is the alertable one: a window that reaches 100% of
+    // arcadedb.pageSnapshotMaxSize is invalidated, and its backup restarts on the path that throttles writers.
+    gauge(registry, "arcadedb.engine.snapshot.windows.open", "Point-in-time snapshot windows currently open",
+        "snapshotWindowsOpen");
+    gauge(registry, "arcadedb.engine.snapshot.shadow.pages", "Pages held in the open snapshot shadows",
+        "snapshotShadowedPages");
+    gauge(registry, "arcadedb.engine.snapshot.shadow.bytes", "Bytes held in the open snapshot shadows, RAM plus spill",
+        "snapshotShadowSize");
+    gauge(registry, "arcadedb.engine.snapshot.shadow.spilled.bytes", "Snapshot shadow bytes spilled to disk",
+        "snapshotShadowSpilledSize");
+    gauge(registry, "arcadedb.engine.snapshot.shadow.usage.percent",
+        "Fullest open shadow as a percentage of arcadedb.pageSnapshotMaxSize", "snapshotShadowUsagePerc");
+    gauge(registry, "arcadedb.engine.snapshot.window.age.ms", "Age of the oldest open snapshot window",
+        "snapshotOldestWindowAge");
+
+    // #6087: the companion reading for the OTHER path. While a reader freezes the files with a flush suspension,
+    // dirty pages pile up here; crossing arcadedb.flushSuspendMaxDeferredRAM throttles committing threads outright.
+    gauge(registry, "arcadedb.engine.flush.deferred.bytes", "Dirty page bytes deferred by a flush suspension",
+        "deferredRAM");
   }
 
   /**
@@ -151,6 +183,11 @@ public final class EngineMetricsBinder implements MeterBinder {
           return nested.getLong("space", 0L);
         if (nested.has("value"))
           return nested.getLong("value", 0L);
+        // A percentage is the one stat shape that is genuinely fractional, so it is read as a double: rounding it to
+        // a long would flatten every reading below 1% to zero, and "the shadow is at 0%" is exactly the wrong thing
+        // to tell an operator watching it fill (#6116).
+        if (nested.has("perc"))
+          return nested.getDouble("perc", 0d);
         return 0d;
       }
       if (value instanceof Number n)

--- a/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
@@ -18,13 +18,20 @@
  */
 package com.arcadedb.server.monitor;
 
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.PageSnapshot;
+import com.arcadedb.utility.FileUtils;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.function.DoublePredicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,6 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * nested JSON objects.
  */
 class EngineMetricsBinderTest {
+
+  private static final String DATABASE_PATH = "target/databases/engine-metrics-binder";
 
   /**
    * #5636: every monotonic total must be a {@link FunctionCounter}, not a {@link Gauge}. As a gauge it exported with
@@ -49,7 +58,9 @@ class EngineMetricsBinderTest {
         "arcadedb.engine.pages.read", "arcadedb.engine.pages.written", "arcadedb.engine.wal.bytes.written",
         "arcadedb.engine.mvcc.conflicts", "arcadedb.engine.page.merges.edge.append", "arcadedb.engine.page.merges.slot",
         "arcadedb.engine.page.merges.declined", "arcadedb.engine.tx.write", "arcadedb.engine.tx.read",
-        "arcadedb.engine.tx.rollbacks", "arcadedb.engine.queries", "arcadedb.engine.commands" }) {
+        "arcadedb.engine.tx.rollbacks", "arcadedb.engine.queries", "arcadedb.engine.commands",
+        "arcadedb.engine.snapshot.windows.opened", "arcadedb.engine.snapshot.windows.invalidated",
+        "arcadedb.engine.snapshot.preimages.captured" }) {
       final FunctionCounter counter = registry.find(name).functionCounter();
       assertThat(counter).as(name).isNotNull();
       assertThat(Double.isNaN(counter.count())).as(name).isFalse();
@@ -67,7 +78,10 @@ class EngineMetricsBinderTest {
     new EngineMetricsBinder().bindTo(registry);
 
     for (final String name : new String[] { "arcadedb.engine.wal.files", "arcadedb.engine.files.open",
-        "arcadedb.engine.databases" }) {
+        "arcadedb.engine.databases", "arcadedb.engine.snapshot.windows.open", "arcadedb.engine.snapshot.shadow.pages",
+        "arcadedb.engine.snapshot.shadow.bytes", "arcadedb.engine.snapshot.shadow.spilled.bytes",
+        "arcadedb.engine.snapshot.shadow.usage.percent", "arcadedb.engine.snapshot.window.age.ms",
+        "arcadedb.engine.flush.deferred.bytes" }) {
       final Gauge gauge = registry.find(name).gauge();
       assertThat(gauge).as(name).isNotNull();
       assertThat(Double.isNaN(gauge.value())).as(name).isFalse();
@@ -106,6 +120,85 @@ class EngineMetricsBinderTest {
       assertThat(counter).as(name).isNotNull();
       assertThat(Double.isNaN(counter.count())).as(name).isFalse();
     }
+  }
+
+  /**
+   * #6116: registration is not the property that matters - the meters have to move when a point-in-time snapshot
+   * window (#6075) opens. An operator watching a backup needs to see the window, how much the copy-on-write shadow
+   * is holding and how close it is to {@code arcadedb.pageSnapshotMaxSize}, before the breach forces the backup back
+   * onto the path that throttles writers.
+   * <p>
+   * The shadow-usage assertion is the one that earns its keep: against the 1 GB default cap a few shadowed pages are
+   * a small FRACTION of a percent, so a reading truncated to a long would report a comfortable zero for a window
+   * that is actually filling.
+   */
+  @Test
+  void theSnapshotGaugesFollowAnOpenWindow() throws Exception {
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new EngineMetricsBinder().bindTo(registry);
+
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    try (final Database database = new DatabaseFactory(DATABASE_PATH).create()) {
+      database.getSchema().createDocumentType("Doc");
+      database.transaction(() -> {
+        for (int i = 0; i < 5_000; i++)
+          database.newDocument("Doc").set("id", i).set("payload", "x".repeat(200)).save();
+      });
+
+      final DatabaseInternal db = (DatabaseInternal) database;
+      db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+
+      // NO ABSOLUTE ZERO HERE, AND NO ABSOLUTE ONE BELOW: the gauges read PageManager.INSTANCE, a JVM-WIDE
+      // singleton, so another test class in this surefire fork can legitimately have a window open at the same
+      // time. What must hold is the DELTA this test causes.
+      final double windowsBefore = awaitGauge(registry, "arcadedb.engine.snapshot.windows.open", value -> true);
+      final double shadowBytesBefore = registry.find("arcadedb.engine.snapshot.shadow.bytes").gauge().value();
+
+      try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+        database.transaction(() -> database.iterateType("Doc", false).forEachRemaining(
+            record -> record.asDocument().modify().set("payload", "y".repeat(200)).save()));
+        db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+        assertThat(snapshot.getShadowedPages()).as("the rewrite must have shadowed pages to report").isPositive();
+
+        assertThat(awaitGauge(registry, "arcadedb.engine.snapshot.windows.open", value -> value >= windowsBefore + 1))
+            .as("the open window must reach the gauge (%f were already open)", windowsBefore)
+            .isGreaterThanOrEqualTo(windowsBefore + 1);
+        assertThat(registry.find("arcadedb.engine.snapshot.shadow.pages").gauge().value())
+            .isGreaterThanOrEqualTo(snapshot.getShadowedPages());
+        assertThat(registry.find("arcadedb.engine.snapshot.shadow.bytes").gauge().value())
+            .isGreaterThanOrEqualTo(snapshot.getShadowSizeInBytes());
+        assertThat(registry.find("arcadedb.engine.snapshot.window.age.ms").gauge().value()).isNotNegative();
+
+        final double usage = registry.find("arcadedb.engine.snapshot.shadow.usage.percent").gauge().value();
+        assertThat(usage).as("a fraction of a percent is still a reading, not a zero").isPositive().isLessThan(100d);
+
+        assertThat(registry.find("arcadedb.engine.snapshot.preimages.captured").functionCounter().count()).isPositive();
+        assertThat(registry.find("arcadedb.engine.snapshot.windows.opened").functionCounter().count()).isPositive();
+      }
+
+      assertThat(awaitGauge(registry, "arcadedb.engine.snapshot.windows.open", value -> value <= windowsBefore))
+          .as("the gauges must come back down when the window closes").isLessThanOrEqualTo(windowsBefore);
+      assertThat(registry.find("arcadedb.engine.snapshot.shadow.bytes").gauge().value())
+          .isLessThanOrEqualTo(shadowBytesBefore);
+    } finally {
+      FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    }
+  }
+
+  /**
+   * The binder memoizes the {@link com.arcadedb.Profiler} snapshot for a second, so a freshly changed reading only
+   * appears on the next rebuild. Polls rather than sleeping for the TTL so the test is not tied to its length, and
+   * returns the last value it read - satisfying the condition or not - so the assertion reports the actual number
+   * rather than a bare {@code false}.
+   */
+  private static double awaitGauge(final SimpleMeterRegistry registry, final String name,
+      final DoublePredicate condition) throws InterruptedException {
+    double value = registry.find(name).gauge().value();
+    for (int attempt = 0; attempt < 60 && !condition.test(value); attempt++) {
+      Thread.sleep(100);
+      value = registry.find(name).gauge().value();
+    }
+    return value;
   }
 
   /**


### PR DESCRIPTION
Closes #6116. The three actionable loose ends left behind by #6075 / PR #6100.

## 1. The benchmarks #6075 asked for

Two harnesses, both `@Tag("benchmark")` so neither runs in CI:

- **`engine/src/test/java/performance/PageSnapshotOverheadBenchmark`** - steady-state write throughput and commit latency p50/p95/p99 in the three states the write path can be in, the t0 barrier under increasing write pressure, the flush-thread drain rate with and without a window, and the `TransactionManager` apply lock.
- **`integration/.../PageSnapshotBackupBenchmark`** - what a running backup does to the writers beside it on both paths, the deferred-RAM high-water mark, and the shadow peak as a fraction of the database. Deliberately shaped like `BackupCompressionBenchmark.concurrentWriterImpact()` (the #6072 harness) so the two sets of numbers can be read side by side, and it samples the new gauges rather than the window object, because a backup owns its window internally - so the benchmark also exercises the wiring of part 2.

**On "zero cost when no window is open".** There is no honest "before" to measure from inside the merged tree, so it is bounded from above instead: the expensive shape of the hook is *a window open on a **different** database*, which pays the volatile read, the array walk and a database comparison per page write and captures nothing. Indistinguishable from the no-window case ⇒ the no-window case, strictly cheaper, cannot be costing anything either. Two rounds of each configuration are printed so the reader can see the machine's own noise instead of reading it as signal.

### Two numbers that correct what #6100 asserted

- **The t0 barrier is not "a few ms" under load.** Idle: 13-120 us. With 1-8 writer threads committing continuously: tens of milliseconds, occasionally past 100 ms. The driver is *not* the flush-queue depth (which stays small) but the barrier **retrying** - it drains the queue in full, and a commit landing between that drain and the flush-thread suspension makes it start over. Still bounded, still the only stall, but now measured.
- **The shadow can reach the size of the database.** Throttled backup of a 128 MB database: shadow peaked at 37% of it with a writer pausing 100 ms between transactions, 84% at 20 ms, **100%** flat out. So the 1 GB `pageSnapshotMaxSize` default is not the generous ceiling it looks like - past a gigabyte under heavy writes, expect the breach and the fallback. The new usage-percent gauge is how an operator sees which way it is going.

### The headline comparison

128 MB database rebuilt before every run (the load inserts as well as updates, so a shared database would make later runs back up more data and divide the shadow fraction by a size that no longer exists), backup throttled to 32 MB/s, counting only commits inside the backup window:

| | rec/s in the window | of baseline | peak deferred RAM |
|---|---|---|---|
| no backup running | 193,854 | - | 0 |
| backup, snapshot path | 185,120 | **95.5%** | **0** |
| backup, suspend-and-freeze | 5,274 | 2.7% | 513 MB |

513 MB is `flushSuspendMaxDeferredRAM` reached: the point at which committers stop being slowed and start being throttled outright.

## 2. Metrics for an open snapshot window

`PageManager.getStats()` gained the readings, so they reach Prometheus (`EngineMetricsBinder`) and Studio's server page (`Profiler`, which renders every stat it publishes - no JS change needed). Counter/gauge per #5636: per-window state is gauges, only the JVM-wide totals are counters.

`snapshot.windows.open`, `snapshot.shadow.pages`, `snapshot.shadow.bytes`, `snapshot.shadow.spilled.bytes`, `snapshot.shadow.usage.percent`, `snapshot.window.age.ms` (gauges); `snapshot.windows.opened`, `snapshot.windows.invalidated`, `snapshot.preimages.captured` (counters). Plus `flush.deferred.bytes`, the unwired `getDeferredRAMBytes()` gauge of **#6087** - the same question asked of the other path, and one line away.

The alertable pair is the usage percentage and the invalidation counter: an invalidated window is invisible from outside (its consumer falls back and still completes), so before this a backup that had gone back to throttling every writer on the server left no trace but a WARNING.

`SnapshotCache.read()` also learned to unwrap `perc`, as a **double**: against the 1 GB cap a filling shadow is a fraction of a percent, and truncating that to a long reports a comfortable zero.

## 3. `/checksums` no longer suspends flushing

The last writer-throttling reader in the product. It reads the database *directory* rather than the registered page files, hence a directory-oriented reader (`SnapshotManager.computeFileChecksums(dir, snapshot, pageFileNames)`) rather than the verify handler's file-list one: page files come from the window, everything the window does not cover (`database.json`, `schema.json`, `.ts.sealed`, `last-tx-id.bin`) is read raw under the same database read lock as before. A page file created **after** t0 is skipped rather than read live - it has no point-in-time content, and a torn CRC in a map whose purpose is cross-node comparison is worse than an absent one. Same `PageSnapshotException` fallback as every other consumer.

Two things fixed on the way:
- the `.pshadow` scratch of an open window lives in the database directory and was being checksummed, so any node that happened to have a backup running reported a file no peer had;
- `suspendFlushAndExecute` logs and swallows, so a failure on the fallback path would have returned an empty map with a 200 - which a caller comparing checksums reads as "every file matches". The failure is now carried out and rethrown, and the handler still answers 500.

## 4. Extracting the snapshot registry out of `PageManager` - deliberately not here

Agreeing with the issue's own reading: #6115 (phase 3) adds the manifest and changed-page-bitmap state that belongs in that registry, and its lock-order contract is documented once in `PageManager`'s Javadoc. Moving it now produces a rename-only diff that #6115 immediately reshapes, and would put a second dereference in front of the one field the write path is built around. The right moment is #6115.

## Verification

New tests, each with the control that keeps it from passing vacuously:

- `engine/.../PageSnapshotMetricsTest` (4): the gauges rise with a window and return exactly where they were when it closes; the shadow gauges track the copy-on-write work **and the identical rewrite with no window open moves the pre-image counter by zero**; a cap breach increments the invalidation counter once, not once per failed capture; the profiler JSON and the metrics dump both carry the readings.
- `ha-raft/.../Issue6116ChecksumsPointInTimeTest` (4): the snapshot checksums are byte-for-byte the frozen-file ones; they stay at t0 through a full rewrite **while a live read of the same directory is asserted to have changed**; the suspended fraction of the computation is >0.9 on the fallback path and <0.5 on the snapshot path, both measured in the same test; both paths answer with the same file set and the same values.
- `SnapshotManagerTest`: transient files - `.wal`, `.prev.json`, `.lock`, `.corrupt` and now `.pshadow` - are not checksummed.
- `EngineMetricsBinderTest`: the new meters are registered with the right instrument type, and the gauges are asserted to *follow a real window* (delta-based, since `PageManager` is a JVM-wide singleton), including the sub-1% usage reading that a long would have flattened.

Re-run green: `com.arcadedb.engine.*Test` (183), ha-raft snapshot + state-machine tests (181), `com.arcadedb.server.monitor.*` (56), integration backup unit tests (12) and ITs (33, including `Issue6075SnapshotBackupIT` and `BackupCompressionIT`). Both benchmarks were run manually to produce the numbers above.
