### PR TITLE
feat(#6125): self-sizing snapshot shadow cap, a retry-free t0 barrier, and two loose ends

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1003,3 +1003,95 @@ window lives in the database directory, so any node that happened to have a back
 had.
 
 [#6116](https://github.com/ArcadeData/arcadedb/issues/6116)
+
+## The snapshot shadow cap sizes itself, the t0 barrier stops retrying, and two smaller loose ends (#6125)
+
+Four items the benchmarks of #6116 turned up. None was a correctness bug; two of them contradict an assumption
+#6075 shipped on, and could only be stated once there were measurements.
+
+### `arcadedb.pageSnapshotMaxSize` is no longer a flat number
+
+The measurement first: on a 128 MB database with the backup throttled to 32 MB/s, the copy-on-write shadow peaked
+at 37% of the database with a writer pausing 100 ms between transactions, 84% at 20 ms, and **100%** with a writer
+running flat out. The shadow holds the pre-image of every page dirtied while the window is open, so its ceiling is
+the working set of the backup's duration, and a hot database rewrites all of it.
+
+That makes any fixed default simply the database size above which backups silently start falling back to the
+suspend-and-freeze path - the very writer throttling #6075 set out to remove. The 1 GB default only reliably
+covered databases up to about a gigabyte under sustained writes.
+
+The cap is now sized when the window opens. `arcadedb.pageSnapshotMaxSize` defaults to **-1**, meaning automatic:
+
+```
+cap = min( sum(pageCount * pageSize) at t0,   // the ceiling the shadow provably cannot exceed
+           usableSpace(spill volume) / 2 )    // so a window can never be why the disk filled
+```
+
+The first term is exact rather than a heuristic: the shadow holds one pre-image per page that existed at t0, and
+pages appended after t0 need none, so it cannot grow past the t0 size of the page files. A positive value still
+means an absolute number of MB and `0` still means uncapped, so no existing configuration changes meaning.
+
+Related, and the reason for the second term: the spill file lands in the database directory, where a breach-sized
+shadow competes for disk with the data it is protecting. The new **`arcadedb.pageSnapshotSpillPath`** moves it to
+another volume, and the automatic cap is then measured against the free space there.
+
+The two ways a window can lose its point in time are also counted apart now, because they send an operator to
+different places: `arcadedb_engine_snapshot_windows_overflowed_total` is a tuning problem (raise the cap, or give
+the spill volume room), `arcadedb_engine_snapshot_windows_failed_total` is a disk problem. Their sum remains
+`arcadedb_engine_snapshot_windows_invalidated_total`.
+
+### The t0 barrier is single-pass, exact, and measured
+
+#6116 measured the barrier at tens of milliseconds under load against 13 us idle, and found the driver was not the
+flush-queue depth - which stays near zero on an SSD - but the barrier **retrying**: it drained the flush queue in
+full, and a commit landing between that drain and the flush-thread suspension made it start over. After three
+attempts it stopped retrying and stamped a t0 that could sit slightly behind the last committed transaction.
+
+The gap is now closed by construction. `PageManager.publishPages` already holds the global page-manager lock across
+*both* halves of publication - the synchronous page write and the flush-queue enqueue - so the barrier takes that
+lock (after the apply lock, in the order it already used) and repeats the drain underneath it. Nothing can feed the
+pipeline while the lock is held, so that second drain is guaranteed to converge, and it is normally instant because
+a first, lock-free drain has already emptied the pipeline. The retry loop and `SNAPSHOT_BARRIER_ATTEMPTS` are gone.
+
+Exactness matters beyond tidiness: the HA snapshot ship writes `lastTxId` into the `last-tx-id.bin` recency marker
+a follower is judged by at cold bootstrap, and a marker naming a transaction whose pages were still queued claims
+data the archive does not contain.
+
+The obvious inversion still does not work and is now documented as such: suspending the flush thread before the
+drain makes the drain unable to ever complete, because a suspended thread defers batches instead of writing them.
+
+The barrier is also reported now, the way a Prometheus timer is - a count and a summed duration, so
+`rate(seconds)/rate(count)` is the average - plus the high-water mark a scalar snapshot cannot otherwise carry:
+
+| Metric | Type | |
+|---|---|---|
+| `arcadedb_engine_snapshot_barrier_count_total` | counter | t0 barriers executed |
+| `arcadedb_engine_snapshot_barrier_seconds_total` | counter | total time spent in them |
+| `arcadedb_engine_snapshot_barrier_max_seconds` | gauge | the longest one observed |
+| `arcadedb_engine_snapshot_barrier_inexact_total` | counter | barriers that could not prove the pipeline was empty |
+
+The last one should stay at zero: no commit can cause it any more, so a non-zero value means index compaction was
+feeding the flush pipeline throughout the barrier - harmless for consistency, since those writes go to pages beyond
+the t0 page count of a file being built, but worth being able to see.
+
+### `/checksums` validates the database name before taking its branch
+
+`SnapshotHttpHandler` dispatched the `/checksums` sub-path *before* the block that rejects `..`, separators, NUL
+and non-ASCII. It was not exploitable - the checksums path gates on an exact-match lookup over the already-open
+databases, so a traversal string 404'd and the database was never resolved - but the guarantee lived two calls away
+from the handler that needed it. The sub-path is now stripped, the name validated, and only then is a branch
+chosen. A malformed name on the checksums route answers 400 instead of 404, which the OpenAPI spec now documents.
+
+### The unused checksum diff is gone
+
+`SnapshotManager.findDifferingFiles()` was called from nothing but its own unit test, while its presence - and the
+`/checksums` description - suggested resync could ship only what changed. It has been removed rather than wired in,
+for two reasons. Granularity: an ArcadeDB database is usually dominated by one bucket file, so a whole-file
+comparison saves nothing the moment a single byte of it changes. Consistency: the checksums come from one
+point-in-time window and the ZIP from another, so a file that matched when it was compared can be rewritten before
+the transfer starts, and a follower that kept its local copy on the strength of that match would hold a database
+torn across two instants. Incremental resync belongs at the **page** level, on the page-version manifest of phase 3
+(#6115), where both halves come from the same window. `/checksums` is documented as what it actually is: an
+operator diagnostic.
+
+[#6125](https://github.com/ArcadeData/arcadedb/issues/6125)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1053,6 +1053,15 @@ lock (after the apply lock, in the order it already used) and repeats the drain 
 pipeline while the lock is held, so that second drain is guaranteed to converge, and it is normally instant because
 a first, lock-free drain has already emptied the pipeline. The retry loop and `SNAPSHOT_BARRIER_ATTEMPTS` are gone.
 
+Everything the barrier does under that lock shares one hard 5 s budget, because the lock is JVM-wide and the waits
+those steps use elsewhere are either uncapped (the wait for the in-flight flush batch polls until a synchronous
+`file.write` returns) or capped only by the 60 s progress-based `arcadedb.flushAllPagesTimeout` - either of which
+would let one sick disk stall every committer in the process. Exhausting it is handled per step according to what it
+costs: a pipeline that has not drained only means t0 may sit slightly behind the last commit, which is logged and
+accepted, while a suspension that cannot be acquired or an in-flight batch that has not landed abandons the window
+outright and the consumer falls back to the suspend-and-freeze path - slower for one database rather than briefly
+fatal for all of them.
+
 Exactness matters beyond tidiness: the HA snapshot ship writes `lastTxId` into the `last-tx-id.bin` recency marker
 a follower is judged by at cold bootstrap, and a marker naming a transaction whose pages were still queued claims
 data the archive does not contain.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -472,12 +472,25 @@ public enum GlobalConfiguration {
   PAGE_SNAPSHOT_MAX_SIZE("arcadedb.pageSnapshotMaxSize", SCOPE.DATABASE,
       """
       Hard cap (in MB, RAM plus spill file) on the size a single snapshot shadow may reach before the window is \
-      declared overflowed (issue #6075, challenge C4). Worst case the shadow grows to the working set dirtied while \
-      the window is open, which on a small very hot database approaches the database size, so an uncapped shadow \
-      would reproduce the 'snapshot full' failure mode of sparse-file snapshots. On breach the window stops \
-      capturing and every reader fails loudly, so the consumer can fall back to the suspend-and-freeze path - never \
-      a silently truncated or torn snapshot. Set to 0 for no cap.""",
-      Long.class, 1024),
+      declared overflowed (issue #6075, challenge C4). On breach the window stops capturing and every reader fails \
+      loudly, so the consumer can fall back to the suspend-and-freeze path - never a silently truncated or torn \
+      snapshot. The default -1 sizes the cap AUTOMATICALLY when the window opens (issue #6125), as the smaller of \
+      the ceiling the shadow provably cannot exceed - one pre-image per page that existed at t0, so the t0 size of \
+      the page files - and half the space still usable on the volume holding the spill file. A flat number cannot \
+      do that: measurements on a 128 MB database show the shadow reaching 100% of the database under a flat-out \
+      writer, so any fixed default is simply the database size above which backups silently start falling back to \
+      throttling the writers. Set a positive value to pin an absolute cap in MB, or 0 for no cap at all.""",
+      Long.class, -1),
+
+  PAGE_SNAPSHOT_SPILL_PATH("arcadedb.pageSnapshotSpillPath", SCOPE.DATABASE,
+      """
+      Directory holding the scratch spill file of a snapshot shadow, empty (the default) to keep it in the database \
+      directory (issue #6125). A shadow can grow to the size of the database, so on a volume sized for the data \
+      alone it competes for space with the very files it is protecting; pointing this at another volume removes \
+      that coupling, and the automatic PAGE_SNAPSHOT_MAX_SIZE is then measured against the free space THERE. The \
+      file is pure scratch - it is created when the RAM budget is exhausted, deleted when the window closes, and \
+      never read by recovery.""",
+      String.class, ""),
 
   EXPLICIT_LOCK_TIMEOUT("arcadedb.explicitLockTimeout", SCOPE.DATABASE, "Timeout in ms to lock resources on explicit lock",
       Long.class, 5000),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -479,7 +479,8 @@ public enum GlobalConfiguration {
       the page files - and half the space still usable on the volume holding the spill file. A flat number cannot \
       do that: measurements on a 128 MB database show the shadow reaching 100% of the database under a flat-out \
       writer, so any fixed default is simply the database size above which backups silently start falling back to \
-      throttling the writers. Set a positive value to pin an absolute cap in MB, or 0 for no cap at all.""",
+      throttling the writers. Set a positive value to pin an absolute cap in MB, or 0 for no cap at all; any \
+      negative value means automatic, so -1 is the spelling to use rather than the only one accepted.""",
       Long.class, -1),
 
   PAGE_SNAPSHOT_SPILL_PATH("arcadedb.pageSnapshotSpillPath", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -315,7 +315,16 @@ public class Profiler {
     json.put("snapshotOldestWindowAge", new JSONObject().put("value", pStats.snapshotOldestWindowMillis));
     json.put("snapshotWindowsOpened", new JSONObject().put("count", pStats.snapshotWindowsOpened));
     json.put("snapshotWindowsInvalidated", new JSONObject().put("count", pStats.snapshotWindowsInvalidated));
+    // #6125: the split of the line above, because the two reasons take an operator to different places, plus the
+    // timer over the t0 barrier - the one stall the snapshot path still has, and until now the only thing about it
+    // that was reported was a WARNING when it gave up.
+    json.put("snapshotWindowsOverflowed", new JSONObject().put("count", pStats.snapshotWindowsOverflowed));
+    json.put("snapshotWindowsFailed", new JSONObject().put("count", pStats.snapshotWindowsFailed));
     json.put("snapshotPreImagesCaptured", new JSONObject().put("count", pStats.snapshotPreImagesCaptured));
+    json.put("snapshotBarriers", new JSONObject().put("count", pStats.snapshotBarriers));
+    json.put("snapshotBarrierTime", new JSONObject().put("count", pStats.snapshotBarrierMillis));
+    json.put("snapshotBarrierMaxTime", new JSONObject().put("value", pStats.snapshotBarrierMaxMillis));
+    json.put("snapshotBarriersInexact", new JSONObject().put("count", pStats.snapshotBarriersInexact));
     json.put("deferredRAM", new JSONObject().put("space", pStats.deferredRAMBytes));
 
     final long freeSpace = new File(".").getFreeSpace();
@@ -498,6 +507,15 @@ public class Profiler {
           FileUtils.getSizeAsString(pStats.snapshotShadowSpilledBytes), pStats.snapshotShadowUsagePerc,
           pStats.snapshotOldestWindowMillis, pStats.snapshotWindowsOpened, pStats.snapshotWindowsInvalidated,
           pStats.snapshotPreImagesCaptured));
+
+      // #6125: the t0 barrier on its own line. The average is what an operator compares against their write-latency
+      // budget; the max is what a single unlucky backup actually cost, and averaging it away hides exactly the
+      // outlier worth chasing.
+      buffer.append("%n    barriers=%d avg=%,dms max=%,dms inexact=%d overflowed=%d failed=%d".formatted(
+          pStats.snapshotBarriers,
+          pStats.snapshotBarriers > 0 ? pStats.snapshotBarrierMillis / pStats.snapshotBarriers : 0L,
+          pStats.snapshotBarrierMaxMillis, pStats.snapshotBarriersInexact, pStats.snapshotWindowsOverflowed,
+          pStats.snapshotWindowsFailed));
 
       buffer.append(
         "%n WAL totalFiles=%d pagesWritten=%d bytesWritten=%s".formatted(walTotalFiles, walPagesWritten,

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -95,12 +95,24 @@ public class PageManager extends LockContext {
   private final    AtomicLong                        totalMergesDeclinedByCoverage         = new AtomicLong();
   private final    AtomicLong                        evictionRuns                          = new AtomicLong();
   private final    AtomicLong                        pagesEvicted                          = new AtomicLong();
-  // #6116: the three snapshot totals below are exported as Prometheus counters together with the ones above, and
+  // #6116: the snapshot totals below are exported as Prometheus counters together with the ones above, and
   // carry the same never-decrease requirement. They are JVM-wide like the rest of this class, so a database close
   // does not step them back.
   private final    AtomicLong                        totalSnapshotWindowsOpened            = new AtomicLong();
   private final    AtomicLong                        totalSnapshotWindowsInvalidated       = new AtomicLong();
   private final    AtomicLong                        totalSnapshotPreImagesCaptured        = new AtomicLong();
+  // #6125: the two halves of totalSnapshotWindowsInvalidated. A cap breach is a TUNING problem (raise
+  // PAGE_SNAPSHOT_MAX_SIZE, or give the spill volume room); a capture failure is a DISK problem. Both force the
+  // consumer onto the writer-throttling fallback, so one summed counter cannot tell an operator which lever to pull.
+  private final    AtomicLong                        totalSnapshotWindowsOverflowed        = new AtomicLong();
+  private final    AtomicLong                        totalSnapshotWindowsFailed            = new AtomicLong();
+  // #6125: the t0 barrier is the one stall this design still has, so it is measured like a Micrometer timer - a
+  // count and a summed duration, whose ratio is the average, plus the high-water mark a percentile cannot be
+  // reconstructed from a scalar snapshot.
+  private final    AtomicLong                        totalSnapshotBarriers                 = new AtomicLong();
+  private final    AtomicLong                        totalSnapshotBarrierMillis            = new AtomicLong();
+  private final    AtomicLong                        maxSnapshotBarrierMillis              = new AtomicLong();
+  private final    AtomicLong                        totalSnapshotBarriersInexact          = new AtomicLong();
   private volatile long                              lastCheckForRAM                       = 0;
   // LIFECYCLE INVARIANT (#5070): flushThread and readCache are written only under LIFECYCLE_LOCK
   // during the 0->1 startup / 1->0 shutdown transitions, and read lock-free on the hot paths. That is safe
@@ -139,8 +151,21 @@ public class PageManager extends LockContext {
    */
   private static final ThreadLocal<byte[]> PRE_IMAGE_BUFFER = ThreadLocal.withInitial(() -> new byte[0]);
 
-  /** How many times the t0 barrier retries when commits slip in between the full drain and the suspension. */
-  private static final int SNAPSHOT_BARRIER_ATTEMPTS = 3;
+  /**
+   * Hard wall-clock budget of the t0 barrier's second drain (#6125). That drain runs with the JVM-wide page-manager
+   * lock held and normally has nothing to do - the first, lock-free drain already emptied the pipeline - so this is
+   * not a wait it is expected to use. It is a ceiling on how long a wedged flush thread can hold the global lock,
+   * which the progress-based {@code arcadedb.flushAllPagesTimeout} (60 s by default) would not bound acceptably
+   * here: every committer of every database in the JVM waits behind it.
+   */
+  private static final long SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS = 2_000;
+
+  /**
+   * Fraction of the space still usable on the spill volume that the automatically sized shadow cap may claim
+   * (#6125). Half, so a window can never be the reason a database runs out of disk: what remains still covers the
+   * archive the backup is writing and the ordinary growth of the database while the window is open.
+   */
+  private static final int SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR = 2;
 
   @ExcludeFromJacocoGeneratedReport
   public interface ConcurrentPageAccessCallback {
@@ -182,7 +207,31 @@ public class PageManager extends LockContext {
     public long   snapshotOldestWindowMillis;
     public long   snapshotWindowsOpened;
     public long   snapshotWindowsInvalidated;
+    /**
+     * #6125: the two halves of {@link #snapshotWindowsInvalidated}. Overflowed means the shadow hit
+     * {@code arcadedb.pageSnapshotMaxSize} and is answered by raising it (or by giving the spill volume room, since
+     * the automatic sizing measures against the free space there); failed means a pre-image could not be read or
+     * written and is answered by looking at the disk. Both end in the same fallback, so the summed counter alone
+     * tells an operator that a backup started throttling the writers but not which lever to pull.
+     */
+    public long   snapshotWindowsOverflowed;
+    public long   snapshotWindowsFailed;
     public long   snapshotPreImagesCaptured;
+    /**
+     * #6125: the t0 barrier, measured the way a Micrometer timer is - a count and a summed duration, so
+     * {@code rate(millis)/rate(count)} is the average - plus the high-water mark, which a scalar snapshot cannot
+     * otherwise carry. The barrier is the ONLY stall left in the snapshot path, so it is the one reading that says
+     * whether opening a window is costing a writer anything.
+     */
+    public long   snapshotBarriers;
+    public long   snapshotBarrierMillis;
+    public long   snapshotBarrierMaxMillis;
+    /**
+     * Barriers that could not prove the flush pipeline was empty at t0, so the snapshot point may sit slightly
+     * behind the last committed transaction. Since #6125 no commit can cause this - the drain runs with the
+     * publication locks held - so a non-zero value means index compaction was feeding the pipeline throughout.
+     */
+    public long   snapshotBarriersInexact;
     /** See {@link PageManager#getDeferredRAMBytes()} (#6087): dirty pages held in RAM by a flush suspension. */
     public long   deferredRAMBytes;
   }
@@ -377,21 +426,37 @@ public class PageManager extends LockContext {
    * each by the mechanism that already serializes it:
    * <ol>
    * <li>{@link #waitAllPagesOfDatabaseAreFlushed} drains the flush queue COMPLETELY - not just the in-flight batch
-   * the way {@code waitForCurrentFlushToComplete} does - so every committed transaction is materialised. This is
-   * what makes t0 a genuine, recent transaction boundary and closes the recency gap the suspension left (a restored
-   * backup could be a few hundred transactions behind backup start).</li>
-   * <li>The flush thread is then suspended and its in-flight batch awaited, so the asynchronous path is parked on a
-   * BATCH boundary. That granularity matters: a batch is one transaction's pages, so a snapshot taken between
-   * batches can never hold half a transaction. If commits slipped in between the drain and the suspension, the
-   * suspension is released (which flushes what it deferred) and the barrier retries.</li>
+   * the way {@code waitForCurrentFlushToComplete} does. This first drain takes no lock: it is the bulk of the work
+   * and there is no reason to make anyone wait for it.</li>
    * <li>The transaction manager's apply lock is taken exclusively, which excludes Raft and crash-recovery replay -
    * the one writer that goes to the files outside the flush pipeline ({@code writePageWithLock}). Applies are
    * serialised on the state machine thread, so this is a single bounded wait.</li>
-   * <li>The global page-manager lock is taken, which excludes synchronous commits: they publish their pages from
-   * {@link #publishPages}, which holds it for the whole write.</li>
+   * <li>The global page-manager lock is taken. {@link #publishPages} holds it across BOTH halves of publication -
+   * the synchronous page write and the {@code scheduleFlushOfPages} enqueue - so from here on no committer can put
+   * a page on disk OR into the flush pipeline.</li>
+   * <li>The drain is repeated, now under those locks. It is guaranteed to converge because nothing can feed the
+   * pipeline any more, and it is normally instant because step 1 already emptied it; what it covers is exactly the
+   * commits that landed between step 1 and step 2. It is nevertheless bounded by a hard
+   * {@link #SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS} deadline rather than by the progress-based flush timeout, because the
+   * lock it holds is JVM-wide. The flush thread is then suspended and its in-flight batch awaited, parking the
+   * asynchronous path on a BATCH boundary - a batch is one transaction's pages, so a snapshot taken between batches
+   * can never hold half a transaction.</li>
    * </ol>
    * Only then are the per-file page counts and {@code lastTxId} recorded and the window published. Doing these in
    * the other order produces subtly torn snapshots that pass tests and fail in production.
+   * <p>
+   * <b>Why the drain moved inside the locks</b> (#6125). It used to run entirely outside them, which left a gap
+   * between "the pipeline is empty" and "the flush thread is suspended" that a commit could land in; the barrier
+   * coped by re-checking and retrying up to three times, and gave up after that with a t0 that could sit behind the
+   * last committed transaction. Measured, that retry - not the flush-queue depth, which stays near zero on an SSD -
+   * was the whole cost of the barrier: tens of milliseconds under sustained writes against 13 us idle. Holding the
+   * publication lock across the residual drain removes the gap by construction, so the barrier is single-pass and
+   * {@code lastTxId} is exact. Exactness matters beyond tidiness: the HA snapshot ship writes it into the
+   * {@code last-tx-id.bin} recency marker the follower is judged by, and a marker naming a transaction whose pages
+   * were still queued claims data the archive does not contain.
+   * <p>
+   * The obvious inversion does NOT work and must not be reintroduced: suspending the flush thread before the drain
+   * makes the drain unable to ever complete, because a suspended thread defers batches instead of writing them.
    * <p>
    * The tempting alternative - a shared read lock on the write path so the flip can take the exclusive side - is
    * correct but adds a permanent cost to the hot path that no flag can turn off. Do not.
@@ -410,6 +475,7 @@ public class PageManager extends LockContext {
    *     was deferred for it are released there.
    */
   public PageSnapshot openSnapshot(final DatabaseInternal database) {
+    final long beginTime = System.currentTimeMillis();
     try {
       return openSnapshotInternal(database);
     } catch (final PageSnapshotException e) {
@@ -419,7 +485,18 @@ public class PageManager extends LockContext {
       throw new PageSnapshotException("Interrupted while opening a snapshot of database '" + database.getName() + "'", e);
     } catch (final Exception e) {
       throw new PageSnapshotException("Cannot open a snapshot of database '" + database.getName() + "'", e);
+    } finally {
+      // #6125: TIMED EVEN WHEN THE BARRIER THROWS - A BARRIER THAT FAILS SLOWLY IS EXACTLY AS MUCH OF A STALL AS ONE
+      // THAT SUCCEEDS SLOWLY, AND ITS CONSUMER STILL FALLS BACK TO THE PATH THAT THROTTLES WRITERS
+      recordSnapshotBarrier(System.currentTimeMillis() - beginTime);
     }
+  }
+
+  /** Feeds the timer over the t0 barrier: a count, a summed duration and the high-water mark (#6125). */
+  private void recordSnapshotBarrier(final long elapsedMillis) {
+    totalSnapshotBarriers.incrementAndGet();
+    totalSnapshotBarrierMillis.addAndGet(elapsedMillis);
+    maxSnapshotBarrierMillis.accumulateAndGet(elapsedMillis, Math::max);
   }
 
   private PageSnapshot openSnapshotInternal(final DatabaseInternal database) throws IOException, InterruptedException {
@@ -431,44 +508,43 @@ public class PageManager extends LockContext {
     synchronized (snapshotBarrierLock(database)) {
       boolean suspended = false;
       try {
-        for (int attempt = 1; ; ++attempt) {
-          if (!waitAllPagesOfDatabaseAreFlushed(database))
-            LogManager.instance().log(this, Level.WARNING,
-                "Snapshot of database '%s': the flush queue did not drain within the timeout, the snapshot point may be behind the last committed transaction",
-                null, database.getName());
-
-          thread.setSuspended(database, true);
-          suspended = true;
-          thread.waitForCurrentFlushToComplete(database);
-
-          if (!thread.hasPendingPagesOfDatabase(database))
-            // CLEAN: THE QUEUE DRAINED AND STAYED DRAINED ACROSS THE SUSPENSION, SO t0 IS A GENUINE, CURRENT
-            // TRANSACTION BOUNDARY
-            break;
-
-          if (attempt >= SNAPSHOT_BARRIER_ATTEMPTS) {
-            // GAVE UP: SUSTAINED WRITE PRESSURE KEPT LANDING COMMITS BETWEEN THE DRAIN AND THE SUSPENSION. THE
-            // SNAPSHOT IS STILL CONSISTENT - IT IS TAKEN ON A BATCH BOUNDARY EITHER WAY - JUST AS SLIGHTLY BEHIND
-            // THE LAST COMMIT AS THE SUSPEND-AND-FREEZE PATH ALWAYS WAS. LOGGED BECAUSE "t0 IS A REAL TRANSACTION
-            // BOUNDARY" IS ONE OF THIS DESIGN'S CLAIMS, AND THE DEGRADED CASE MUST BE OBSERVABLE RATHER THAN ONLY
-            // INFERABLE FROM BEHAVIOUR
-            LogManager.instance().log(this, Level.WARNING,
-                "Snapshot of database '%s': the flush pipeline still had pending pages after %d barrier attempts, so the snapshot point may be slightly behind the last committed transaction. Sustained write pressure, not an error",
-                null, database.getName(), attempt);
-            break;
-          }
-
-          // COMMITS LANDED BETWEEN THE DRAIN AND THE SUSPENSION. RELEASING THE SUSPENSION FLUSHES WHAT IT DEFERRED,
-          // SO THE RETRY STARTS FROM A CLEANER PIPELINE
-          thread.setSuspended(database, false);
-          suspended = false;
-        }
+        // STEP 1: THE BULK DRAIN, DELIBERATELY OUTSIDE EVERY LOCK. IT IS THE LONG PART, AND MAKING COMMITTERS WAIT
+        // FOR IT WOULD BE THE STALL THIS DESIGN EXISTS TO REMOVE
+        if (!waitAllPagesOfDatabaseAreFlushed(database))
+          LogManager.instance().log(this, Level.WARNING,
+              "Snapshot of database '%s': the flush queue did not drain within the timeout, the snapshot point may be behind the last committed transaction",
+              null, database.getName());
 
         final ReentrantReadWriteLock applyLock = database.getTransactionManager().getApplyLock();
         applyLock.writeLock().lock();
         try {
           lock();
           try {
+            // STEP 2: THE RESIDUAL DRAIN, WITH PUBLICATION EXCLUDED. publishPages HOLDS THIS SAME LOCK ACROSS BOTH
+            // THE SYNCHRONOUS PAGE WRITE AND THE FLUSH ENQUEUE, SO NOTHING CAN FEED THE PIPELINE WHILE WE HOLD IT
+            // AND THIS CONVERGES BY CONSTRUCTION. IT COVERS EXACTLY THE COMMITS THAT LANDED SINCE STEP 1, WHICH IS
+            // WHY THE RETRY LOOP OF #6075 IS GONE (#6125)
+            if (!thread.waitPendingPagesOfDatabaseUntil(database, SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS))
+              LogManager.instance().log(this, Level.WARNING,
+                  "Snapshot of database '%s': the flush pipeline did not settle within %d ms under the publication lock, the snapshot point may be behind the last committed transaction",
+                  null, database.getName(), SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS);
+
+            thread.setSuspended(database, true);
+            suspended = true;
+            thread.waitForCurrentFlushToComplete(database);
+
+            if (thread.hasPendingPagesOfDatabase(database)) {
+              // NO COMMIT CAN CAUSE THIS ANY MORE, SO THE ONLY REMAINING FEEDER IS INDEX COMPACTION, WHICH SCHEDULES
+              // ASYNCHRONOUS WRITES WITHOUT GOING THROUGH publishPages. THOSE ARE HARMLESS FOR CONSISTENCY - THEY GO
+              // TO PAGES BEYOND THE t0 PAGE COUNT OF A FILE BEING BUILT, AND ANY THAT DID NOT WOULD BE SHADOWED LIKE
+              // ANY OTHER WRITE - BUT THEY DO MEAN THE PIPELINE IS NOT PROVABLY EMPTY, SO SAY SO RATHER THAN LET AN
+              // OPERATOR INFER IT FROM BEHAVIOUR
+              totalSnapshotBarriersInexact.incrementAndGet();
+              LogManager.instance().log(this, Level.FINE,
+                  "Snapshot of database '%s': the flush pipeline still holds pages no committer can have queued (index compaction), so the snapshot point may be slightly behind the last committed transaction",
+                  null, database.getName());
+            }
+
             // LIST THE FILES AND PUBLISH THE WINDOW AS ONE ATOMIC STEP AGAINST FileManager.dropFile. Without this a
             // file dropped in the gap - which index compaction can do at any moment, taking no database lock - would
             // be physically deleted, because deferFileDrop only protects windows that are already published, and the
@@ -590,12 +666,65 @@ public class PageManager extends LockContext {
 
     final ContextConfiguration configuration = database.getConfiguration();
     final long maxRAM = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM) * 1024 * 1024;
-    final long maxSize = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE) * 1024 * 1024;
-    final File spillFile = new File(database.getDatabasePath(),
+    final File spillFile = new File(snapshotSpillDirectory(database),
         "snapshot-" + snapshotCounter.incrementAndGet() + "." + PageSnapshot.SHADOW_FILE_EXT);
+    final long maxSize = snapshotMaxShadowSize(configuration, files, spillFile.getParentFile());
 
     return new PageSnapshot(database, this, database.getTransactionManager().getLastTransactionId(), files,
         new PageShadow(spillFile, maxRAM, maxSize));
+  }
+
+  /**
+   * Where this window's shadow spills once its RAM budget is exhausted: {@code arcadedb.pageSnapshotSpillPath} when
+   * set, the database directory otherwise (#6125). A shadow can grow to the size of the database, so on a volume
+   * sized for the data alone it competes for space with the very files it is protecting.
+   */
+  private File snapshotSpillDirectory(final DatabaseInternal database) {
+    final String configured = database.getConfiguration().getValueAsString(GlobalConfiguration.PAGE_SNAPSHOT_SPILL_PATH);
+    if (configured == null || configured.isBlank())
+      return new File(database.getDatabasePath());
+
+    final File directory = new File(configured.trim());
+    if (!directory.isDirectory() && !directory.mkdirs()) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot use '%s' as the snapshot shadow spill directory (%s): falling back to the database directory", null,
+          directory, GlobalConfiguration.PAGE_SNAPSHOT_SPILL_PATH.getKey());
+      return new File(database.getDatabasePath());
+    }
+    return directory;
+  }
+
+  /**
+   * The cap on this window's shadow, in bytes (#6125).
+   * <p>
+   * A positive {@code arcadedb.pageSnapshotMaxSize} is an absolute number of MB and 0 means uncapped, both unchanged.
+   * The default -1 sizes it here instead, from the two quantities that actually bound the shadow:
+   * <ul>
+   * <li>the t0 size of the page files, which the shadow provably cannot exceed - it holds ONE pre-image per page that
+   * existed at t0, and pages appended after t0 need none (challenge C7);</li>
+   * <li>half the space still usable on the spill volume, so a window can never be the reason the disk fills.</li>
+   * </ul>
+   * The flat 1 GB default this replaces was measured to be undersized for what it protects: on a 128 MB database
+   * under a flat-out writer the shadow reached 100% of the database size, so ANY fixed number is simply the database
+   * size above which backups silently start falling back to throttling the writers.
+   */
+  private static long snapshotMaxShadowSize(final ContextConfiguration configuration,
+      final List<PageSnapshot.SnapshotFile> files, final File spillDirectory) {
+    final long configured = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE);
+    if (configured >= 0)
+      return configured * 1024 * 1024;
+
+    long databaseSize = 0;
+    for (final PageSnapshot.SnapshotFile file : files)
+      databaseSize += file.size();
+
+    final long usable = spillDirectory.getUsableSpace();
+    // getUsableSpace() answers 0 when the path cannot be interrogated (it is not an error signal, and a 0 cap would
+    // mean "uncapped" here): fall back to the provable ceiling alone rather than to no cap at all
+    if (usable <= 0)
+      return databaseSize;
+
+    return Math.min(databaseSize, usable / SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR);
   }
 
   private PageSnapshot registerSnapshot(final PageSnapshot snapshot) {
@@ -1041,7 +1170,13 @@ public class PageManager extends LockContext {
     stats.pagesEvicted = pagesEvicted.get();
     stats.snapshotWindowsOpened = totalSnapshotWindowsOpened.get();
     stats.snapshotWindowsInvalidated = totalSnapshotWindowsInvalidated.get();
+    stats.snapshotWindowsOverflowed = totalSnapshotWindowsOverflowed.get();
+    stats.snapshotWindowsFailed = totalSnapshotWindowsFailed.get();
     stats.snapshotPreImagesCaptured = totalSnapshotPreImagesCaptured.get();
+    stats.snapshotBarriers = totalSnapshotBarriers.get();
+    stats.snapshotBarrierMillis = totalSnapshotBarrierMillis.get();
+    stats.snapshotBarrierMaxMillis = maxSnapshotBarrierMillis.get();
+    stats.snapshotBarriersInexact = totalSnapshotBarriersInexact.get();
     stats.deferredRAMBytes = getDeferredRAMBytes();
     collectSnapshotGauges(stats);
     return stats;
@@ -1082,9 +1217,17 @@ public class PageManager extends LockContext {
       stats.snapshotOldestWindowMillis = Math.max(0L, now - oldestOpenedOn);
   }
 
-  /** Counts a window that lost its point in time (cap breach or I/O error): the fallback-path early warning. */
-  void incrementSnapshotWindowsInvalidated() {
+  /**
+   * Counts a window that lost its point in time: the fallback-path early warning. The total is kept alongside the
+   * per-reason split (#6125) rather than derived from it, so a future invalidation reason that forgets to extend the
+   * split still shows up in the total an operator alerts on.
+   */
+  void incrementSnapshotWindowsInvalidated(final PageSnapshot.STATUS reason) {
     totalSnapshotWindowsInvalidated.incrementAndGet();
+    if (reason == PageSnapshot.STATUS.OVERFLOWED)
+      totalSnapshotWindowsOverflowed.incrementAndGet();
+    else if (reason == PageSnapshot.STATUS.FAILED)
+      totalSnapshotWindowsFailed.incrementAndGet();
   }
 
   public void removePageFromCache(final PageId pageId) {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -445,6 +445,12 @@ public class PageManager extends LockContext {
    * awaited, parking the asynchronous path on a BATCH boundary - a batch is one transaction's pages, so a snapshot
    * taken between batches can never hold half a transaction.</li>
    * </ol>
+   * <b>Nothing inside those locks may block on the filesystem</b>, for the same reason - which is why the shadow's
+   * spill directory is resolved, and the room on that volume read, back in step 1: {@code mkdirs} and
+   * {@code getUsableSpace} are unbounded blocking calls, and {@code arcadedb.pageSnapshotSpillPath} exists precisely
+   * to name a volume that is not the database's own. What is left inside is arithmetic over the t0 file list, plus
+   * the one {@code channel.size()} per file that is definitionally part of t0.
+   * <p>
    * <b>Everything in step 4 shares one hard {@link #SNAPSHOT_BARRIER_MAX_MILLIS} deadline</b>, because the lock it
    * holds is JVM-wide: the waits those three steps use elsewhere are uncapped (the in-flight batch wait polls until
    * a synchronous {@code file.write} returns) or capped only by the 60 s progress-based flush timeout, and either
@@ -526,6 +532,14 @@ public class PageManager extends LockContext {
               "Snapshot of database '%s': the flush queue did not drain within the timeout, the snapshot point may be behind the last committed transaction",
               null, database.getName());
 
+        // RESOLVE THE SHADOW'S SPILL LOCATION AND THE ROOM ON THAT VOLUME HERE, WHILE NOTHING IS LOCKED. BOTH ARE
+        // BLOCKING FILESYSTEM CALLS - isDirectory/mkdirs AND getUsableSpace - AND arcadedb.pageSnapshotSpillPath IS
+        // MEANT TO POINT AT ANOTHER VOLUME, WHICH IN A REAL DEPLOYMENT MAY WELL BE NETWORK-ATTACHED. NEITHER CAN BE
+        // BOUNDED BY A DEADLINE, SO RUNNING THEM UNDER THE JVM-WIDE LOCK WOULD REINTRODUCE EXACTLY THE STALL THE
+        // REST OF THIS BARRIER EXISTS TO REMOVE. WHAT STAYS INSIDE THE LOCK IS PURE ARITHMETIC OVER THE t0 FILE LIST
+        final File spillDirectory = snapshotSpillDirectory(database);
+        final long spillVolumeUsableSpace = spillDirectory.getUsableSpace();
+
         // ONE BUDGET FOR THE WHOLE LOCKED SECTION BELOW, NOT ONE PER STEP: WHAT HAS TO BE BOUNDED IS THE TOTAL TIME
         // THE JVM-WIDE LOCK IS HELD, AND THREE INDEPENDENT CEILINGS WOULD MULTIPLY IT
         final long deadline = System.currentTimeMillis() + SNAPSHOT_BARRIER_MAX_MILLIS;
@@ -577,8 +591,8 @@ public class PageManager extends LockContext {
             // file dropped in the gap - which index compaction can do at any moment, taking no database lock - would
             // be physically deleted, because deferFileDrop only protects windows that are already published, and the
             // snapshot would then be holding a closed channel
-            return database.getFileManager()
-                .executeWithFileSetLocked(() -> registerSnapshot(buildSnapshot(database)));
+            return database.getFileManager().executeWithFileSetLocked(
+                () -> registerSnapshot(buildSnapshot(database, spillDirectory, spillVolumeUsableSpace)));
           } finally {
             unlock();
           }
@@ -668,7 +682,14 @@ public class PageManager extends LockContext {
     }
   }
 
-  private PageSnapshot buildSnapshot(final DatabaseInternal database) throws IOException {
+  /**
+   * @param spillDirectory          resolved by {@link #snapshotSpillDirectory}, and the usable space on it read,
+   *                                BEFORE the barrier took its locks: both are unbounded blocking filesystem calls
+   *                                on a volume the operator may have pointed elsewhere (#6125).
+   * @param spillVolumeUsableSpace  bytes still usable there at that moment, {@code <= 0} when it could not be read.
+   */
+  private PageSnapshot buildSnapshot(final DatabaseInternal database, final File spillDirectory,
+      final long spillVolumeUsableSpace) throws IOException {
     final List<PageSnapshot.SnapshotFile> files = new ArrayList<>();
     for (final ComponentFile file : database.getFileManager().getFiles()) {
       // A null slot is a dropped file id and a not-yet-opened one is the reserved slot of a file id that has been
@@ -694,9 +715,9 @@ public class PageManager extends LockContext {
 
     final ContextConfiguration configuration = database.getConfiguration();
     final long maxRAM = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM) * 1024 * 1024;
-    final File spillFile = new File(snapshotSpillDirectory(database),
+    final File spillFile = new File(spillDirectory,
         "snapshot-" + snapshotCounter.incrementAndGet() + "." + PageSnapshot.SHADOW_FILE_EXT);
-    final long maxSize = snapshotMaxShadowSize(configuration, files, spillFile.getParentFile());
+    final long maxSize = snapshotMaxShadowSize(configuration, files, spillVolumeUsableSpace);
 
     return new PageSnapshot(database, this, database.getTransactionManager().getLastTransactionId(), files,
         new PageShadow(spillFile, maxRAM, maxSize));
@@ -706,6 +727,10 @@ public class PageManager extends LockContext {
    * Where this window's shadow spills once its RAM budget is exhausted: {@code arcadedb.pageSnapshotSpillPath} when
    * set, the database directory otherwise (#6125). A shadow can grow to the size of the database, so on a volume
    * sized for the data alone it competes for space with the very files it is protecting.
+   * <p>
+   * Called from OUTSIDE the barrier's locks on purpose: {@code isDirectory} and {@code mkdirs} are blocking
+   * filesystem calls that no deadline can bound, and the whole point of this setting is to name a volume that is not
+   * the database's own - plausibly a network-attached one.
    */
   private File snapshotSpillDirectory(final DatabaseInternal database) {
     final String configured = database.getConfiguration().getValueAsString(GlobalConfiguration.PAGE_SNAPSHOT_SPILL_PATH);
@@ -713,7 +738,10 @@ public class PageManager extends LockContext {
       return new File(database.getDatabasePath());
 
     final File directory = new File(configured.trim());
-    if (!directory.isDirectory() && !directory.mkdirs()) {
+    // THE isDirectory RE-CHECK IS NOT REDUNDANT: TWO WINDOWS OPENING AT ONCE AGAINST A NOT-YET-EXISTING DIRECTORY
+    // BOTH CALL mkdirs, AND THE LOSER GETS false FOR A DIRECTORY THAT NOW EXISTS. WITHOUT IT THAT WINDOW WOULD
+    // SPILL INTO THE DATABASE DIRECTORY INSTEAD, WHICH IS THE ONE THING THIS SETTING EXISTS TO AVOID
+    if (!directory.isDirectory() && !directory.mkdirs() && !directory.isDirectory()) {
       LogManager.instance().log(this, Level.WARNING,
           "Cannot use '%s' as the snapshot shadow spill directory (%s): falling back to the database directory", null,
           directory, GlobalConfiguration.PAGE_SNAPSHOT_SPILL_PATH.getKey());
@@ -735,9 +763,16 @@ public class PageManager extends LockContext {
    * The flat 1 GB default this replaces was measured to be undersized for what it protects: on a 128 MB database
    * under a flat-out writer the shadow reached 100% of the database size, so ANY fixed number is simply the database
    * size above which backups silently start falling back to throttling the writers.
+   * <p>
+   * Pure arithmetic, deliberately: the free space it works from was read before the barrier took its locks, because
+   * {@code getUsableSpace()} is a blocking filesystem call and this runs inside them.
+   *
+   * @param spillVolumeUsableSpace bytes usable on the spill volume, {@code <= 0} when it could not be read - which
+   *                               {@code File.getUsableSpace()} also answers for a path it cannot interrogate, so it
+   *                               is not an error signal and must not be read as "no room"
    */
   private static long snapshotMaxShadowSize(final ContextConfiguration configuration,
-      final List<PageSnapshot.SnapshotFile> files, final File spillDirectory) {
+      final List<PageSnapshot.SnapshotFile> files, final long spillVolumeUsableSpace) {
     final long configured = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE);
     if (configured >= 0)
       return configured * 1024 * 1024;
@@ -746,13 +781,12 @@ public class PageManager extends LockContext {
     for (final PageSnapshot.SnapshotFile file : files)
       databaseSize += file.size();
 
-    final long usable = spillDirectory.getUsableSpace();
-    // getUsableSpace() answers 0 when the path cannot be interrogated (it is not an error signal, and a 0 cap would
-    // mean "uncapped" here): fall back to the provable ceiling alone rather than to no cap at all
-    if (usable <= 0)
+    // WITH NO USABLE READING, FALL BACK TO THE PROVABLE CEILING ALONE RATHER THAN TO NO CAP AT ALL - A 0 CAP MEANS
+    // "UNCAPPED" TO THE SHADOW
+    if (spillVolumeUsableSpace <= 0)
       return databaseSize;
 
-    return Math.min(databaseSize, usable / SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR);
+    return Math.min(databaseSize, spillVolumeUsableSpace / SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR);
   }
 
   private PageSnapshot registerSnapshot(final PageSnapshot snapshot) {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -542,15 +542,17 @@ public class PageManager extends LockContext {
         final File spillDirectory = snapshotSpillDirectory(database);
         final long spillVolumeUsableSpace = spillDirectory.getUsableSpace();
 
-        // ONE BUDGET FOR THE WHOLE LOCKED SECTION BELOW, NOT ONE PER STEP: WHAT HAS TO BE BOUNDED IS THE TOTAL TIME
-        // THE JVM-WIDE LOCK IS HELD, AND THREE INDEPENDENT CEILINGS WOULD MULTIPLY IT
-        final long deadline = System.currentTimeMillis() + SNAPSHOT_BARRIER_MAX_MILLIS;
-
         final ReentrantReadWriteLock applyLock = database.getTransactionManager().getApplyLock();
         applyLock.writeLock().lock();
         try {
           lock();
           try {
+            // ONE BUDGET FOR EVERYTHING BELOW, NOT ONE PER STEP: WHAT HAS TO BE BOUNDED IS THE TOTAL TIME THE
+            // JVM-WIDE LOCK IS HELD, AND THREE INDEPENDENT CEILINGS WOULD MULTIPLY IT. STARTED ONLY NOW, AFTER BOTH
+            // LOCKS ARE IN HAND: TIME SPENT WAITING TO ACQUIRE THEM IS QUEUEING, NOT HOLDING - CHARGING IT TO THE
+            // BUDGET WOULD SHRINK THE REAL WAITS UNDER CONTENTION AND MAKE A TIMEOUT BLAME THE WRONG THING
+            final long deadline = System.currentTimeMillis() + SNAPSHOT_BARRIER_MAX_MILLIS;
+
             // STEP 2: THE RESIDUAL DRAIN, WITH PUBLICATION EXCLUDED. publishPages HOLDS THIS SAME LOCK ACROSS BOTH
             // THE SYNCHRONOUS PAGE WRITE AND THE FLUSH ENQUEUE, SO NOTHING CAN FEED THE PIPELINE WHILE WE HOLD IT
             // AND THIS CONVERGES BY CONSTRUCTION. IT COVERS EXACTLY THE COMMITS THAT LANDED SINCE STEP 1, WHICH IS
@@ -771,13 +773,18 @@ public class PageManager extends LockContext {
    * size above which backups silently start falling back to throttling the writers.
    * <p>
    * Pure arithmetic, deliberately: the free space it works from was read before the barrier took its locks, because
-   * {@code getUsableSpace()} is a blocking filesystem call and this runs inside them.
+   * {@code getUsableSpace()} is a blocking filesystem call and this runs inside them. Package-private for the same
+   * reason - being pure, the edge cases around {@code PageShadow}'s "0 means uncapped" sentinel are worth asserting
+   * directly rather than through a volume a test cannot fill.
    *
    * @param spillVolumeUsableSpace bytes usable on the spill volume, {@code <= 0} when it could not be read - which
    *                               {@code File.getUsableSpace()} also answers for a path it cannot interrogate, so it
    *                               is not an error signal and must not be read as "no room"
+   *
+   * @return the cap in bytes, {@code 0} meaning uncapped - which this only ever returns for an explicitly configured
+   *     {@code 0} or a t0 page set that is empty, never as a rounding artifact
    */
-  private static long snapshotMaxShadowSize(final ContextConfiguration configuration,
+  static long snapshotMaxShadowSize(final ContextConfiguration configuration,
       final List<PageSnapshot.SnapshotFile> files, final long spillVolumeUsableSpace) {
     final long configured = configuration.getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE);
     if (configured >= 0)
@@ -787,12 +794,21 @@ public class PageManager extends LockContext {
     for (final PageSnapshot.SnapshotFile file : files)
       databaseSize += file.size();
 
+    // NOTHING TO CAP: NO PAGE EXISTED AT t0, SO NO PRE-IMAGE CAN EVER BE NEEDED AND THE VALUE IS MOOT
+    if (databaseSize == 0)
+      return 0;
+
     // WITH NO USABLE READING, FALL BACK TO THE PROVABLE CEILING ALONE RATHER THAN TO NO CAP AT ALL - A 0 CAP MEANS
-    // "UNCAPPED" TO THE SHADOW
+    // "UNCAPPED" TO THE SHADOW. File.getUsableSpace() ALSO ANSWERS 0 FOR A PATH IT CANNOT INTERROGATE, WHICH IS WHY
+    // THIS IS NOT READ AS "NO ROOM"
     if (spillVolumeUsableSpace <= 0)
       return databaseSize;
 
-    return Math.min(databaseSize, spillVolumeUsableSpace / SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR);
+    // CLAMPED TO AT LEAST ONE BYTE: THE DIVISION IS INTEGER, SO A VOLUME DOWN TO ITS LAST BYTE COMPUTES 1/2 == 0 AND
+    // WOULD HAND THE SHADOW THE SAME "UNCAPPED" SENTINEL THE BRANCH ABOVE EXISTS TO AVOID - INVERTING THIS CAP
+    // PRECISELY IN THE DISK-ALMOST-FULL CASE IT IS FOR. A ONE-BYTE CAP INSTEAD BREACHES ON THE FIRST CAPTURE, WHICH
+    // IS THE CORRECT ANSWER: THE WINDOW IS ABANDONED AND ITS CONSUMER FALLS BACK
+    return Math.max(1L, Math.min(databaseSize, spillVolumeUsableSpace / SNAPSHOT_MAX_SIZE_FREE_SPACE_DIVISOR));
   }
 
   private PageSnapshot registerSnapshot(final PageSnapshot snapshot) {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -152,13 +152,18 @@ public class PageManager extends LockContext {
   private static final ThreadLocal<byte[]> PRE_IMAGE_BUFFER = ThreadLocal.withInitial(() -> new byte[0]);
 
   /**
-   * Hard wall-clock budget of the t0 barrier's second drain (#6125). That drain runs with the JVM-wide page-manager
-   * lock held and normally has nothing to do - the first, lock-free drain already emptied the pipeline - so this is
-   * not a wait it is expected to use. It is a ceiling on how long a wedged flush thread can hold the global lock,
-   * which the progress-based {@code arcadedb.flushAllPagesTimeout} (60 s by default) would not bound acceptably
-   * here: every committer of every database in the JVM waits behind it.
+   * Hard wall-clock budget for EVERYTHING the t0 barrier does with the JVM-wide page-manager lock held (#6125): the
+   * residual drain, the suspension acquisition and the wait for the in-flight flush batch. It is a ceiling on how
+   * long a wedged flush thread or a concurrent resume can stall every committer of every database in the JVM, which
+   * neither the progress-based {@code arcadedb.flushAllPagesTimeout} (60 s) nor the uncapped waits those steps use
+   * elsewhere would bound acceptably here.
+   * <p>
+   * It is not a wait the barrier is expected to use: the first, lock-free drain has already emptied the pipeline, so
+   * all three steps normally return on their first check. Sized with a hundredfold margin over the one legitimately
+   * slow case - a single large transaction's batch reaching the disk - so that exhausting it means something is
+   * genuinely wrong rather than merely busy.
    */
-  private static final long SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS = 2_000;
+  private static final long SNAPSHOT_BARRIER_MAX_MILLIS = 5_000;
 
   /**
    * Fraction of the space still usable on the spill volume that the automatically sized shadow cap may claim
@@ -436,12 +441,18 @@ public class PageManager extends LockContext {
    * a page on disk OR into the flush pipeline.</li>
    * <li>The drain is repeated, now under those locks. It is guaranteed to converge because nothing can feed the
    * pipeline any more, and it is normally instant because step 1 already emptied it; what it covers is exactly the
-   * commits that landed between step 1 and step 2. It is nevertheless bounded by a hard
-   * {@link #SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS} deadline rather than by the progress-based flush timeout, because the
-   * lock it holds is JVM-wide. The flush thread is then suspended and its in-flight batch awaited, parking the
-   * asynchronous path on a BATCH boundary - a batch is one transaction's pages, so a snapshot taken between batches
-   * can never hold half a transaction.</li>
+   * commits that landed between step 1 and step 2. The flush thread is then suspended and its in-flight batch
+   * awaited, parking the asynchronous path on a BATCH boundary - a batch is one transaction's pages, so a snapshot
+   * taken between batches can never hold half a transaction.</li>
    * </ol>
+   * <b>Everything in step 4 shares one hard {@link #SNAPSHOT_BARRIER_MAX_MILLIS} deadline</b>, because the lock it
+   * holds is JVM-wide: the waits those three steps use elsewhere are uncapped (the in-flight batch wait polls until
+   * a synchronous {@code file.write} returns) or capped only by the 60 s progress-based flush timeout, and either
+   * would let one sick disk stall every committer of every database in the process. Exhausting the budget is handled
+   * per step according to what it costs: a pipeline that has not drained only means t0 may sit slightly behind the
+   * last commit, which is logged and accepted, while a suspension that cannot be acquired or an in-flight batch that
+   * has not landed abandons the window outright - the batch is half-written by definition - and the consumer falls
+   * back to the suspend-and-freeze path, which is slower for one database rather than briefly fatal for all of them.
    * Only then are the per-file page counts and {@code lastTxId} recorded and the window published. Doing these in
    * the other order produces subtly torn snapshots that pass tests and fail in production.
    * <p>
@@ -515,6 +526,10 @@ public class PageManager extends LockContext {
               "Snapshot of database '%s': the flush queue did not drain within the timeout, the snapshot point may be behind the last committed transaction",
               null, database.getName());
 
+        // ONE BUDGET FOR THE WHOLE LOCKED SECTION BELOW, NOT ONE PER STEP: WHAT HAS TO BE BOUNDED IS THE TOTAL TIME
+        // THE JVM-WIDE LOCK IS HELD, AND THREE INDEPENDENT CEILINGS WOULD MULTIPLY IT
+        final long deadline = System.currentTimeMillis() + SNAPSHOT_BARRIER_MAX_MILLIS;
+
         final ReentrantReadWriteLock applyLock = database.getTransactionManager().getApplyLock();
         applyLock.writeLock().lock();
         try {
@@ -524,14 +539,27 @@ public class PageManager extends LockContext {
             // THE SYNCHRONOUS PAGE WRITE AND THE FLUSH ENQUEUE, SO NOTHING CAN FEED THE PIPELINE WHILE WE HOLD IT
             // AND THIS CONVERGES BY CONSTRUCTION. IT COVERS EXACTLY THE COMMITS THAT LANDED SINCE STEP 1, WHICH IS
             // WHY THE RETRY LOOP OF #6075 IS GONE (#6125)
-            if (!thread.waitPendingPagesOfDatabaseUntil(database, SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS))
+            if (!thread.waitPendingPagesOfDatabaseUntil(database, deadline))
+              // NOT FATAL: A SNAPSHOT TAKEN OVER A STILL-QUEUED BATCH IS CONSISTENT, JUST POSSIBLY BEHIND - THE
+              // BATCH BOUNDARY IS GUARANTEED BY THE SUSPENSION BELOW, NOT BY THIS DRAIN
               LogManager.instance().log(this, Level.WARNING,
                   "Snapshot of database '%s': the flush pipeline did not settle within %d ms under the publication lock, the snapshot point may be behind the last committed transaction",
-                  null, database.getName(), SNAPSHOT_BARRIER_DRAIN_MAX_MILLIS);
+                  null, database.getName(), SNAPSHOT_BARRIER_MAX_MILLIS);
 
-            thread.setSuspended(database, true);
+            if (!thread.trySuspendUntil(database, deadline))
+              // A CONCURRENT RESUME IS FLUSHING ITS DEFERRED BACKLOG (UP TO flushSuspendMaxDeferredRAM) AND WOULD
+              // KEEP EVERY COMMITTER IN THE JVM WAITING BEHIND THIS LOCK. GIVE THE WINDOW UP INSTEAD: THE CONSUMER
+              // FALLS BACK TO SUSPEND-AND-FREEZE, WHICH IS SLOWER FOR ONE DATABASE RATHER THAN BRIEFLY FATAL FOR ALL
+              throw new PageSnapshotException("Cannot open a snapshot of database '" + database.getName()
+                  + "': the page flush could not be suspended within " + SNAPSHOT_BARRIER_MAX_MILLIS
+                  + " ms because another suspender is still resuming");
             suspended = true;
-            thread.waitForCurrentFlushToComplete(database);
+
+            if (!thread.waitForCurrentFlushToCompleteUntil(database, deadline))
+              // FATAL, UNLIKE THE DRAIN ABOVE: THE IN-FLIGHT BATCH IS HALF-WRITTEN BY DEFINITION, SO t0 WOULD HOLD
+              // HALF A TRANSACTION. A WRITE THAT HAS NOT RETURNED IN THIS LONG IS A SICK DISK, NOT A BUSY ONE
+              throw new PageSnapshotException("Cannot open a snapshot of database '" + database.getName()
+                  + "': the in-flight page flush did not complete within " + SNAPSHOT_BARRIER_MAX_MILLIS + " ms");
 
             if (thread.hasPendingPagesOfDatabase(database)) {
               // NO COMMIT CAN CAUSE THIS ANY MORE, SO THE ONLY REMAINING FEEDER IS INDEX COMPACTION, WHICH SCHEDULES

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -492,7 +492,6 @@ public class PageManager extends LockContext {
    *     was deferred for it are released there.
    */
   public PageSnapshot openSnapshot(final DatabaseInternal database) {
-    final long beginTime = System.currentTimeMillis();
     try {
       return openSnapshotInternal(database);
     } catch (final PageSnapshotException e) {
@@ -502,10 +501,6 @@ public class PageManager extends LockContext {
       throw new PageSnapshotException("Interrupted while opening a snapshot of database '" + database.getName() + "'", e);
     } catch (final Exception e) {
       throw new PageSnapshotException("Cannot open a snapshot of database '" + database.getName() + "'", e);
-    } finally {
-      // #6125: TIMED EVEN WHEN THE BARRIER THROWS - A BARRIER THAT FAILS SLOWLY IS EXACTLY AS MUCH OF A STALL AS ONE
-      // THAT SUCCEEDS SLOWLY, AND ITS CONSUMER STILL FALLS BACK TO THE PATH THAT THROTTLES WRITERS
-      recordSnapshotBarrier(System.currentTimeMillis() - beginTime);
     }
   }
 
@@ -519,10 +514,17 @@ public class PageManager extends LockContext {
   private PageSnapshot openSnapshotInternal(final DatabaseInternal database) throws IOException, InterruptedException {
     final PageManagerFlushThread thread = flushThread;
     if (thread == null)
+      // NOT TIMED AND NOT COUNTED: NOTHING OF THE BARRIER RAN, AND A CALL THAT REFUSED INSTANTLY WOULD OTHERWISE PULL
+      // THE AVERAGE THIS METRIC EXISTS TO REPORT TOWARDS ZERO
       throw new PageSnapshotException(
           "Cannot open a snapshot of database '" + database.getName() + "': the page manager is not running");
 
     synchronized (snapshotBarrierLock(database)) {
+      // THE CLOCK STARTS HERE, NOT AT THE PUBLIC ENTRY POINT: THIS MONITOR ONLY SERIALIZES BARRIERS ON THE SAME
+      // DATABASE, AND A SECOND CALLER'S WAIT ON IT IS QUEUEING FOR THE BARRIER RATHER THAN THE BARRIER ITSELF. THE
+      // SUSPENSION RELEASE IN THE OUTER finally IS DELIBERATELY INSIDE THE MEASUREMENT - IT FLUSHES WHAT THE
+      // SUSPENSION DEFERRED, WHICH IS PART OF WHAT OPENING THE WINDOW COSTS
+      final long beginTime = System.currentTimeMillis();
       boolean suspended = false;
       try {
         // STEP 1: THE BULK DRAIN, DELIBERATELY OUTSIDE EVERY LOCK. IT IS THE LONG PART, AND MAKING COMMITTERS WAIT
@@ -602,6 +604,9 @@ public class PageManager extends LockContext {
       } finally {
         if (suspended)
           thread.setSuspended(database, false);
+        // #6125: TIMED EVEN WHEN THE BARRIER THROWS - A BARRIER THAT FAILS SLOWLY IS EXACTLY AS MUCH OF A STALL AS
+        // ONE THAT SUCCEEDS SLOWLY, AND ITS CONSUMER STILL FALLS BACK TO THE PATH THAT THROTTLES WRITERS
+        recordSnapshotBarrier(System.currentTimeMillis() - beginTime);
       }
     }
   }
@@ -754,7 +759,8 @@ public class PageManager extends LockContext {
    * The cap on this window's shadow, in bytes (#6125).
    * <p>
    * A positive {@code arcadedb.pageSnapshotMaxSize} is an absolute number of MB and 0 means uncapped, both unchanged.
-   * The default -1 sizes it here instead, from the two quantities that actually bound the shadow:
+   * ANY negative value - -1 is merely the spelling the default and the documentation use - sizes it here instead,
+   * from the two quantities that actually bound the shadow:
    * <ul>
    * <li>the t0 size of the page files, which the shadow provably cannot exceed - it holds ONE pre-image per page that
    * existed at t0, and pages appended after t0 need none (challenge C7);</li>

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -60,6 +60,8 @@ public class PageManagerFlushThread extends Thread {
   // its suspension window can never overlap the resume's page writes (issue #5068).
   private final        Set<Database>                                            resumingDatabases   = ConcurrentHashMap.newKeySet();
   private final static PagesToFlush                                             SHUTDOWN_THREAD     = new PagesToFlush(null);
+  /** Poll interval of {@link #waitAllPagesOfDatabaseAreFlushed(Database)} for callers that expect to wait. */
+  private final static long                                                     DEFAULT_FLUSH_WAIT_POLL_MILLIS = 10;
   // Package-private so the white-box regression test for issue #5068 can fabricate an in-flight batch and
   // deterministically exercise an interrupt during waitForCurrentFlushToComplete.
   final                AtomicReference<PagesToFlush>                            nextPagesToFlush    = new AtomicReference<>();
@@ -183,21 +185,6 @@ public class PageManagerFlushThread extends Thread {
     }
   }
 
-  /**
-   * Waits until all the pages of a database are flushed to disk.
-   * <p>
-   * Uses the {@link #pageIndex} as the authoritative source of truth for pending pages.
-   * Entries are added to pageIndex BEFORE enqueueing and removed AFTER flushing each page,
-   * so checking pageIndex is race-free unlike checking queue + nextPagesToFlush separately.
-   */
-  /**
-   * @return {@code true} when every page of the database reached the disk, {@code false} when the wait gave
-   *     up: either interrupted, or no flush PROGRESS was observed for {@code arcadedb.flushAllPagesTimeout}
-   *     milliseconds (#4928 - a wedged flush thread or unwritable disk used to hang close()/rename()/backup
-   *     forever here). The window resets whenever the pending-page count decreases, so a healthy but slow
-   *     backlog never trips it. Callers on the close path treat {@code false} as a crash-equivalent close:
-   *     the WAL files and the lock file are preserved so the next open replays the unflushed pages.
-   */
   /** Records that a page of the database LEFT the flush pipeline: the per-database progress signal (#4928). */
   private void bumpFlushProgress(final MutablePage page) {
     final AtomicLong counter = flushedPagesPerDatabase.get(page.getPageId().getDatabase());
@@ -205,6 +192,20 @@ public class PageManagerFlushThread extends Thread {
       counter.incrementAndGet();
   }
 
+  /**
+   * Waits until all the pages of a database are flushed to disk.
+   * <p>
+   * Uses the {@link #pageIndex} as the authoritative source of truth for pending pages. Entries are added to
+   * pageIndex BEFORE enqueueing and removed AFTER flushing each page, so checking pageIndex is race-free unlike
+   * checking queue + nextPagesToFlush separately.
+   *
+   * @return {@code true} when every page of the database reached the disk, {@code false} when the wait gave
+   *     up: either interrupted, or no flush PROGRESS was observed for {@code arcadedb.flushAllPagesTimeout}
+   *     milliseconds (#4928 - a wedged flush thread or unwritable disk used to hang close()/rename()/backup
+   *     forever here). The window resets whenever the pending-page count decreases, so a healthy but slow
+   *     backlog never trips it. Callers on the close path treat {@code false} as a crash-equivalent close:
+   *     the WAL files and the lock file are preserved so the next open replays the unflushed pages.
+   */
   protected boolean waitAllPagesOfDatabaseAreFlushed(final Database database) {
     final long timeoutMs = database.getConfiguration().getValueAsLong(GlobalConfiguration.FLUSH_ALL_PAGES_TIMEOUT);
     int lastPending = Integer.MAX_VALUE;
@@ -236,7 +237,7 @@ public class PageManagerFlushThread extends Thread {
       }
 
       try {
-        Thread.sleep(10);
+        Thread.sleep(DEFAULT_FLUSH_WAIT_POLL_MILLIS);
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         return false;
@@ -366,11 +367,40 @@ public class PageManagerFlushThread extends Thread {
 
   /**
    * Whether any page of the database is still anywhere in the flush pipeline. Used by the snapshot t0 barrier
-   * (#6075) to tell "the queue drained and stayed drained" from "commits landed between the drain and the
-   * suspension", in which case the barrier retries instead of stamping a t0 that is already behind.
+   * (#6075) to tell "the pipeline drained and stayed drained" from "something is still feeding it", which since
+   * #6125 can only be index compaction: the barrier's second drain runs with the publication lock held, so no
+   * committer can queue a page.
    */
   boolean hasPendingPagesOfDatabase(final Database database) {
     return countPendingPagesOfDatabase(database, true) > 0;
+  }
+
+  /**
+   * Waits for the flush pipeline of a database to empty, bounded by a HARD wall-clock deadline rather than by the
+   * progress-based {@code arcadedb.flushAllPagesTimeout} (#6125).
+   * <p>
+   * This exists for exactly one caller: the snapshot t0 barrier's second drain, which runs with the JVM-wide
+   * page-manager lock held. There it has to absorb only the handful of pages that were queued between the barrier's
+   * first, lock-free drain and its acquisition of that lock, so it normally returns on the first check - but a
+   * flush thread wedged on a dead disk must not be able to hold the global lock for the 60 s the progress-based
+   * timeout allows, which would stall every committer of every database in the JVM. Spins before it sleeps, for the
+   * same reason: the expected wait is sub-millisecond.
+   *
+   * @return {@code true} when the pipeline emptied, {@code false} when the deadline expired first (the caller
+   *     proceeds with a t0 that may sit slightly behind the last committed transaction, and says so).
+   */
+  boolean waitPendingPagesOfDatabaseUntil(final Database database, final long maxWaitMillis)
+      throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + maxWaitMillis;
+    for (int spins = 0; hasPendingPagesOfDatabase(database); spins++) {
+      if (System.currentTimeMillis() >= deadline)
+        return false;
+      if (spins < 1_000)
+        Thread.onSpinWait();
+      else
+        Thread.sleep(1);
+    }
+    return true;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -381,26 +381,64 @@ public class PageManagerFlushThread extends Thread {
    * <p>
    * This exists for exactly one caller: the snapshot t0 barrier's second drain, which runs with the JVM-wide
    * page-manager lock held. There it has to absorb only the handful of pages that were queued between the barrier's
-   * first, lock-free drain and its acquisition of that lock, so it normally returns on the first check - but a
+   * first, lock-free drain and its acquisition of that lock, so it normally returns on the FIRST check - but a
    * flush thread wedged on a dead disk must not be able to hold the global lock for the 60 s the progress-based
-   * timeout allows, which would stall every committer of every database in the JVM. Spins before it sleeps, for the
-   * same reason: the expected wait is sub-millisecond.
+   * timeout allows, which would stall every committer of every database in the JVM.
+   * <p>
+   * Polls at 1 ms rather than spinning, deliberately: {@link #countPendingPagesOfDatabase} walks the JVM-WIDE
+   * {@link #pageIndex}, so a spin loop would turn one cheap check into hundreds of O(n) scans of a map whose size
+   * grows with exactly the backlog that makes this wait non-trivial in the first place - and all of them under the
+   * global lock. One extra millisecond in the rare case where a page IS in flight is the better trade.
    *
    * @return {@code true} when the pipeline emptied, {@code false} when the deadline expired first (the caller
    *     proceeds with a t0 that may sit slightly behind the last committed transaction, and says so).
    */
-  boolean waitPendingPagesOfDatabaseUntil(final Database database, final long maxWaitMillis)
+  boolean waitPendingPagesOfDatabaseUntil(final Database database, final long deadlineMillis)
       throws InterruptedException {
-    final long deadline = System.currentTimeMillis() + maxWaitMillis;
-    for (int spins = 0; hasPendingPagesOfDatabase(database); spins++) {
-      if (System.currentTimeMillis() >= deadline)
+    while (hasPendingPagesOfDatabase(database)) {
+      if (System.currentTimeMillis() >= deadlineMillis)
         return false;
-      if (spins < 1_000)
-        Thread.onSpinWait();
-      else
-        Thread.sleep(1);
+      Thread.sleep(1);
     }
     return true;
+  }
+
+  /**
+   * Bounded {@link #setSuspended(Database, boolean)} acquisition for the snapshot t0 barrier (#6125).
+   * <p>
+   * The unbounded version parks on {@code suspendLock} for as long as another suspender's resume is in flight, and
+   * that resume synchronously writes up to {@code arcadedb.flushSuspendMaxDeferredRAM} (512 MB by default) of
+   * deferred pages. The barrier calls this with the JVM-wide page-manager lock held, so an unbounded park there
+   * would put every committer of every database behind that write. Giving up instead lets the barrier fail cleanly
+   * and its consumer fall back to the suspend-and-freeze path, which is slower for the writers of ONE database
+   * rather than briefly fatal for all of them.
+   *
+   * @return {@code true} when a suspender reference was acquired - and the caller must release it exactly once with
+   *     {@code setSuspended(database, false)} - or {@code false} when the deadline expired first, in which case
+   *     nothing was acquired.
+   */
+  boolean trySuspendUntil(final Database database, final long deadlineMillis) {
+    final Object lock = suspendLock(database);
+    synchronized (lock) {
+      boolean interrupted = false;
+      try {
+        while (resumingDatabases.contains(database)) {
+          final long remaining = deadlineMillis - System.currentTimeMillis();
+          if (remaining <= 0)
+            return false;
+          try {
+            lock.wait(Math.min(remaining, 100));
+          } catch (final InterruptedException e) {
+            interrupted = true;
+          }
+        }
+        suspended.merge(database, 1, Integer::sum);
+        return true;
+      } finally {
+        if (interrupted)
+          Thread.currentThread().interrupt();
+      }
+    }
   }
 
   /**
@@ -420,9 +458,29 @@ public class PageManagerFlushThread extends Thread {
   }
 
   public void waitForCurrentFlushToComplete(final Database database) throws InterruptedException {
+    waitForCurrentFlushToCompleteUntil(database, Long.MAX_VALUE);
+  }
+
+  /**
+   * Bounded {@link #waitForCurrentFlushToComplete(Database)} for the snapshot t0 barrier (#6125).
+   * <p>
+   * The unbounded version waits for the in-flight batch to reach the disk with no ceiling at all - it polls until
+   * {@code PageManager.flushPage}'s synchronous {@code file.write} returns, and a write to a dead disk never does.
+   * The barrier calls this with the JVM-wide page-manager lock held, so that wait has to be bounded like every other
+   * step it performs there; a timeout is treated as a failure to establish t0, not as permission to proceed, because
+   * the batch is half-written by definition and a snapshot taken over it would hold half a transaction.
+   *
+   * @return {@code true} when the pipeline is no longer writing this database's pages, {@code false} on deadline.
+   */
+  boolean waitForCurrentFlushToCompleteUntil(final Database database, final long deadlineMillis)
+      throws InterruptedException {
     PagesToFlush current;
-    while ((current = nextPagesToFlush.get()) != null && database.equals(current.database))
+    while ((current = nextPagesToFlush.get()) != null && database.equals(current.database)) {
+      if (System.currentTimeMillis() >= deadlineMillis)
+        return false;
       Thread.sleep(1);
+    }
+    return true;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/PageShadow.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageShadow.java
@@ -143,8 +143,17 @@ final class PageShadow implements AutoCloseable {
     // INVALIDATES THE WHOLE WINDOW - WHICH IS CORRECT, SINCE THAT PAGE'S PRE-IMAGE IS GONE
     final ByteBuffer buffer = ByteBuffer.wrap(content, 0, length);
     long pos = offset;
-    while (buffer.hasRemaining())
-      pos += channel.write(buffer, pos);
+    try {
+      while (buffer.hasRemaining())
+        pos += channel.write(buffer, pos);
+    } catch (final IOException e) {
+      // #6125: NAME THE FILE AND HOW BIG IT HAD GROWN. THE CAP BREACH ABOVE AND A FULL FILESYSTEM BOTH END THE
+      // WINDOW, BUT ONLY THE FIRST IS A TUNING PROBLEM - THE STATUS ALREADY SEPARATES THEM (OVERFLOWED vs FAILED),
+      // AND THIS MAKES THE MESSAGE OF THE SECOND ONE ACTIONABLE INSTEAD OF A BARE "No space left on device"
+      throw new IOException(
+          "Cannot write the snapshot shadow file '" + spillFile + "' (" + (offset + length) + " bytes spilled so far): "
+              + e.getMessage(), e);
+    }
 
     synchronized (this) {
       // UNREACHABLE IN PRACTICE - PageSnapshot.close() DRAINS THE IN-FLIGHT CAPTURES BEFORE CLOSING THE SHADOW - AND

--- a/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageSnapshot.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.FileUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -191,9 +192,11 @@ public class PageSnapshot implements AutoCloseable {
   }
 
   /**
-   * The {@code arcadedb.pageSnapshotMaxSize} cap this window's shadow was opened with, in bytes. Exposed so a monitor
-   * can report the headroom left before the window is invalidated and its consumer forced onto the
-   * suspend-and-freeze path (#6116), rather than only reporting the breach after the fact.
+   * The EFFECTIVE cap this window's shadow was opened with, in bytes: since #6125 the default
+   * {@code arcadedb.pageSnapshotMaxSize} of -1 is resolved at t0 rather than read as a number of MB, so this is the
+   * only place the number a breach will be measured against can be read. Exposed so a monitor can report the
+   * headroom left before the window is invalidated and its consumer forced onto the suspend-and-freeze path (#6116),
+   * rather than only reporting the breach after the fact. {@code 0} means uncapped.
    */
   public long getShadowMaxSizeInBytes() {
     return shadow.getMaxSizeInBytes();
@@ -314,9 +317,12 @@ public class PageSnapshot implements AutoCloseable {
         return;
 
       if (!shadow.store(PageShadow.key(fileId, pageNumber), content, length))
+        // THE EFFECTIVE CAP, NOT THE CONFIGURED ONE: SINCE #6125 THE DEFAULT IS SIZED AT t0 FROM THE DATABASE SIZE
+        // AND THE FREE SPACE ON THE SPILL VOLUME, SO ECHOING THE SETTING WOULD PRINT "-1 MB"
         invalidate(STATUS.OVERFLOWED,
-            "the copy-on-write shadow reached the " + GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.getKey() + " cap of "
-                + database.getConfiguration().getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE) + " MB");
+            "the copy-on-write shadow reached its " + FileUtils.getSizeAsString(shadow.getMaxSizeInBytes()) + " cap ("
+                + GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.getKey() + "="
+                + database.getConfiguration().getValueAsLong(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE) + ")");
     } catch (final IOException e) {
       invalidate(STATUS.FAILED, "error capturing the pre-image of page " + fileId + "/" + pageNumber + ": " + e);
     } finally {
@@ -343,8 +349,10 @@ public class PageSnapshot implements AutoCloseable {
       status = newStatus;
       invalidReason = reason;
       // #6116: A CONSUMER THAT FALLS BACK STILL COMPLETES, SO THIS IS INVISIBLE OUTSIDE THE LOG UNLESS IT IS COUNTED.
-      // COUNTED HERE RATHER THAN AT THE CALL SITES SO NO FUTURE INVALIDATION REASON CAN FORGET TO
-      pageManager.incrementSnapshotWindowsInvalidated();
+      // COUNTED HERE RATHER THAN AT THE CALL SITES SO NO FUTURE INVALIDATION REASON CAN FORGET TO.
+      // #6125: PASSED THE STATUS TOO, BECAUSE THE TWO REASONS TAKE AN OPERATOR TO DIFFERENT PLACES - OVERFLOWED IS A
+      // TUNING PROBLEM (arcadedb.pageSnapshotMaxSize, OR ROOM ON THE SPILL VOLUME), FAILED IS A DISK PROBLEM
+      pageManager.incrementSnapshotWindowsInvalidated(newStatus);
       LogManager.instance().log(this, Level.WARNING,
           "Snapshot of database '%s' is no longer usable (%s): %s. Readers will fail and can fall back to suspending the page flush",
           null, database.getName(), newStatus, reason);

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.schema.DocumentType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6125, items 1 and 2: the shadow cap sizes itself from the thing it actually bounds, and the t0 barrier is
+ * single-pass, exact and measured.
+ * <p>
+ * The two properties are tested together because they come from the same measurement: the benchmarks #6116 asked for
+ * showed the shadow reaching 100% of the database size under a flat-out writer (so no flat cap can be right), and
+ * the barrier costing tens of milliseconds because it RETRIED when a commit landed between the flush-queue drain and
+ * the flush-thread suspension (so t0 could end up behind the last commit).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
+
+  private static final String TYPE          = "Doc";
+  private static final long   ONE_MEGABYTE  = 1024L * 1024L;
+  private static final int    WRITER_THREADS = 4;
+  private static final int    BARRIER_ROUNDS = 12;
+
+  @Override
+  protected void beginTest() {
+    final DocumentType type = database.getSchema().createDocumentType(TYPE);
+    type.createProperty("id", Integer.class);
+    type.createProperty("payload", String.class);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 4_000; i++)
+        database.newDocument(TYPE).set("id", i).set("payload", "initial-" + "x".repeat(200)).save();
+    });
+    ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+  }
+
+  /**
+   * The default cap is no longer a number of megabytes at all: it is resolved when the window opens, to the size the
+   * page files actually occupy at t0 - which is the ceiling the shadow provably cannot exceed, since it holds one
+   * pre-image per page that existed at t0 and pages appended later need none.
+   */
+  @Test
+  void theAutomaticCapIsTheSizeThePagesOccupyAtT0() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    assertThat(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.getValueAsLong())
+        .as("the default must be the automatic marker, not a number of MB").isEqualTo(-1L);
+
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      long t0Size = 0;
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+        t0Size += file.size();
+
+      assertThat(t0Size).as("the fixture has to have written something for this to mean anything").isPositive();
+      assertThat(snapshot.getShadowMaxSizeInBytes()).isEqualTo(t0Size);
+      // THE POINT OF THE CHANGE: THE CAP TRACKS THE DATABASE, IT IS NOT THE OLD FLAT 1 GB THAT HAPPENS TO BE BIG
+      // ENOUGH FOR A TEST FIXTURE AND TOO SMALL FOR A REAL DATABASE
+      assertThat(snapshot.getShadowMaxSizeInBytes()).isNotEqualTo(1024L * ONE_MEGABYTE);
+    }
+  }
+
+  /** A number set by hand still means exactly what it used to, and 0 still means "do not cap at all". */
+  @Test
+  void anExplicitCapIsStillAbsoluteMegabytesAndZeroIsStillUncapped() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.setValue(7);
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      assertThat(snapshot.getShadowMaxSizeInBytes()).isEqualTo(7 * ONE_MEGABYTE);
+    }
+
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.setValue(0);
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      assertThat(snapshot.getShadowMaxSizeInBytes()).isZero();
+    }
+  }
+
+  /**
+   * The shadow spills where it is told to, not necessarily next to the database it is protecting: a shadow can grow
+   * to the size of the database, so on a volume sized for the data alone the two compete for space.
+   */
+  @Test
+  void theShadowSpillsIntoTheConfiguredDirectoryAndCleansUpAfterItself(@TempDir final Path spillDir) throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // NO RAM BUDGET AT ALL, SO THE FIRST CAPTURED PRE-IMAGE GOES STRAIGHT TO THE SPILL FILE
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.setValue(0);
+    GlobalConfiguration.PAGE_SNAPSHOT_SPILL_PATH.setValue(spillDir.toString());
+
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      rewriteEveryRecord("spilled");
+
+      assertThat(snapshot.getShadowSpilledBytes()).as("the whole shadow must have gone to disk").isPositive();
+      assertThat(shadowFilesIn(spillDir.toFile())).as("the spill file must live in the configured directory")
+          .isNotEmpty();
+      assertThat(shadowFilesIn(new File(db.getDatabasePath())))
+          .as("nothing may be left in the database directory").isEmpty();
+    }
+
+    assertThat(shadowFilesIn(spillDir.toFile())).as("the spill file is scratch and is removed with the window")
+        .isEmpty();
+  }
+
+  /**
+   * The property the whole barrier exists for, asserted end to end and on CONTENT rather than on a counter: a record
+   * committed immediately before the window opens, while four threads commit continuously around it, must be
+   * findable in the point-in-time image of the page files, and no barrier may report itself unable to prove the
+   * pipeline was empty.
+   * <p>
+   * This is the integration guard, not the proof - the microsecond-wide race the retry loop used to lose cannot be
+   * provoked on demand, and the mechanism that closes it is pinned deterministically by
+   * {@link #publicationCannotReachTheFlushPipelineWhileThePageManagerLockIsHeld()}.
+   */
+  @Test
+  void theLastCommitBeforeTheBarrierIsAlwaysInThePointInTimeImage() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final AtomicBoolean stop = new AtomicBoolean();
+    final AtomicReference<Throwable> writerFailure = new AtomicReference<>();
+    final List<Thread> writers = startWriters(stop, writerFailure);
+
+    try {
+      final long inexactBefore = pageManager.getStats().snapshotBarriersInexact;
+
+      for (int round = 0; round < BARRIER_ROUNDS; round++) {
+        final String marker = "BARRIER-MARKER-" + round + "-" + System.nanoTime();
+
+        // COMMITTED FROM THIS THREAD, THEN THE WINDOW IS OPENED WITH NO PAUSE IN BETWEEN: THE WRITERS ARE STILL
+        // COMMITTING THROUGHOUT, SO THIS IS THE EXACT RACE THE RETRY LOOP USED TO LOSE
+        database.transaction(() -> database.newDocument(TYPE).set("id", -1).set("payload", marker).save());
+
+        try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+          assertThat(containsMarker(snapshot, marker))
+              .as("round %d: the transaction committed just before t0 must be in the point-in-time image", round)
+              .isTrue();
+        }
+      }
+
+      assertThat(pageManager.getStats().snapshotBarriersInexact)
+          .as("no commit can leave the pipeline non-empty at t0 any more, so no barrier may report itself inexact")
+          .isEqualTo(inexactBefore);
+    } finally {
+      stop.set(true);
+      for (final Thread writer : writers)
+        writer.join(30_000);
+    }
+
+    // A WRITER THAT DIED WOULD HAVE MADE THE ASSERTIONS ABOVE PASS AGAINST AN IDLE DATABASE, WHICH IS THE ONE
+    // CONDITION UNDER WHICH THE OLD BARRIER ALSO PASSED
+    assertThat(writerFailure.get()).isNull();
+  }
+
+  /**
+   * The premise the retry-free barrier rests on, pinned deterministically: {@link PageManager#publishPages} holds
+   * the global page-manager lock across BOTH halves of publication - the synchronous page write and the
+   * {@code scheduleFlushOfPages} enqueue - so while the barrier holds that lock no committer can put a page on disk
+   * or into the flush pipeline, and the drain it performs there is guaranteed to converge.
+   * <p>
+   * This is the assertion to keep: the end-to-end race the retry loop used to lose is a microsecond-wide window that
+   * cannot be provoked on demand, whereas a refactor that moved the enqueue out from under this lock would silently
+   * bring it back and is caught here every run.
+   */
+  @Test
+  void publicationCannotReachTheFlushPipelineWhileThePageManagerLockIsHeld() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+
+    // A REAL PAGE OF A REAL BUCKET, PUBLISHED THE WAY A COMMIT'S SECOND PHASE PUBLISHES ITS PAGES. NOT A WHOLE
+    // TRANSACTION: THAT WOULD ALSO BLOCK ON THE VALIDATION HALF OF updatePages, WHICH TAKES THE SAME LOCK, AND THE
+    // TEST WOULD PASS EVEN IF THE ENQUEUE HAD BEEN MOVED OUT FROM UNDER IT - WHICH IS THE ONE REGRESSION IT EXISTS
+    // TO CATCH
+    final int fileId = db.getSchema().getType(TYPE).getBuckets(false).getFirst().getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final PageId pageId = new PageId(db, fileId, 0);
+    final MutablePage page = pageManager.getImmutablePage(pageId, file.getPageSize(), false, true).modify();
+
+    final AtomicBoolean published = new AtomicBoolean();
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread publisher = new Thread(() -> {
+      try {
+        pageManager.publishPages(List.of(page), null, true);
+        published.set(true);
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "issue6125-blocked-publisher");
+    publisher.setDaemon(true);
+
+    pageManager.executeInLock(() -> {
+      publisher.start();
+      // LONG ENOUGH THAT A PUBLICATION THAT COULD RUN WOULD HAVE FINISHED MANY TIMES OVER
+      Thread.sleep(500);
+      assertThat(published.get()).as("publication must not complete while the page-manager lock is held").isFalse();
+      assertThat(pageManager.getFlushThread().hasPendingPagesOfDatabase(db))
+          .as("and no page of it may have reached the flush pipeline either - that is what lets the t0 barrier's "
+              + "drain converge with this lock held, instead of retrying").isFalse();
+      return null;
+    });
+
+    publisher.join(30_000);
+    assertThat(failure.get()).isNull();
+    // THE PAIRED ASSERTION: THE PUBLICATION WAS BLOCKED, NOT BROKEN, SO THIS CANNOT PASS BY NOTHING EVER HAPPENING
+    assertThat(published.get()).as("releasing the lock must let the very same publication through").isTrue();
+  }
+
+  /** The one stall the snapshot path still has is now reported rather than only logged when it goes wrong. */
+  @Test
+  void theBarrierIsTimed() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    final PageManager.PPageManagerStats before = pageManager.getStats();
+
+    for (int i = 0; i < 3; i++)
+      pageManager.openSnapshot(db).close();
+
+    final PageManager.PPageManagerStats after = pageManager.getStats();
+    assertThat(after.snapshotBarriers).isEqualTo(before.snapshotBarriers + 3);
+    assertThat(after.snapshotBarrierMillis).isGreaterThanOrEqualTo(before.snapshotBarrierMillis);
+    assertThat(after.snapshotBarrierMaxMillis).isGreaterThanOrEqualTo(before.snapshotBarrierMaxMillis);
+  }
+
+  /**
+   * A cap breach and a disk failure both end a window and both push its consumer onto the path that throttles
+   * writers, but one is answered by tuning and the other by looking at the disk, so they are counted apart.
+   */
+  @Test
+  void aCapBreachIsCountedAsAnOverflowAndNotAsAFailure() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+
+    // ENOUGH RECORDS TO SPREAD OVER FAR MORE PAGES THAN THE 1 MB CAP BELOW CAN HOLD PRE-IMAGES FOR
+    database.transaction(() -> {
+      for (int i = 0; i < 20_000; i++)
+        database.newDocument(TYPE).set("id", 500_000 + i).set("payload", "z".repeat(500)).save();
+    });
+    pageManager.waitAllPagesOfDatabaseAreFlushed(db);
+
+    final PageManager.PPageManagerStats before = pageManager.getStats();
+
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.setValue(1);
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.setValue(1);
+
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      for (int round = 0; round < 5 && snapshot.getStatus() == PageSnapshot.STATUS.ACTIVE; round++)
+        rewriteEveryRecord("overflow-" + round);
+
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.OVERFLOWED);
+    }
+
+    final PageManager.PPageManagerStats after = pageManager.getStats();
+    assertThat(after.snapshotWindowsOverflowed).isEqualTo(before.snapshotWindowsOverflowed + 1);
+    assertThat(after.snapshotWindowsFailed).as("nothing about the disk went wrong here")
+        .isEqualTo(before.snapshotWindowsFailed);
+    assertThat(after.snapshotWindowsInvalidated).as("the total stays the sum of the two reasons")
+        .isEqualTo(before.snapshotWindowsInvalidated + 1);
+  }
+
+  // ------------------------------------------------------------------------------------------------------ HELPERS
+
+  private List<Thread> startWriters(final AtomicBoolean stop, final AtomicReference<Throwable> failure) {
+    final List<Thread> writers = new ArrayList<>(WRITER_THREADS);
+    for (int t = 0; t < WRITER_THREADS; t++) {
+      final int writerId = t;
+      final Thread writer = new Thread(() -> {
+        try {
+          for (int i = 0; !stop.get(); i++) {
+            final int id = writerId * 1_000_000 + i;
+            // RETRIES: CONCURRENT WRITERS PACK INTO THE SAME PAGES, AND A LOST MVCC RACE IS NOISE HERE, NOT THE
+            // FAILURE THE TEST IS LOOKING FOR
+            database.transaction(() -> database.newDocument(TYPE).set("id", id).set("payload", "load-" + id).save(),
+                false, 10);
+          }
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6125-writer-" + t);
+      writer.setDaemon(true);
+      writer.start();
+      writers.add(writer);
+    }
+    return writers;
+  }
+
+  /** Streams the whole point-in-time image of every page file, looking for the marker's UTF-8 bytes. */
+  private boolean containsMarker(final PageSnapshot snapshot, final String marker) throws Exception {
+    final byte[] needle = marker.getBytes(StandardCharsets.UTF_8);
+    for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+      if (streamContains(snapshot, file.fileId(), needle))
+        return true;
+    return false;
+  }
+
+  private boolean streamContains(final PageSnapshot snapshot, final int fileId, final byte[] needle) throws Exception {
+    // THE WINDOW BEFORE THE BUFFER IS CARRIED OVER SO A MARKER STRADDLING TWO READS IS STILL FOUND
+    final byte[] buffer = new byte[64 * 1024 + needle.length];
+    int carried = 0;
+    try (final InputStream in = snapshot.newInputStream(fileId)) {
+      for (int read = in.read(buffer, carried, buffer.length - carried); read > 0;
+          read = in.read(buffer, carried, buffer.length - carried)) {
+        final int available = carried + read;
+        if (indexOf(buffer, available, needle) >= 0)
+          return true;
+        carried = Math.min(available, needle.length - 1);
+        System.arraycopy(buffer, available - carried, buffer, 0, carried);
+      }
+    }
+    return false;
+  }
+
+  private static int indexOf(final byte[] haystack, final int length, final byte[] needle) {
+    outer:
+    for (int i = 0; i <= length - needle.length; i++) {
+      for (int j = 0; j < needle.length; j++)
+        if (haystack[i + j] != needle[j])
+          continue outer;
+      return i;
+    }
+    return -1;
+  }
+
+  private static File[] shadowFilesIn(final File directory) {
+    final File[] found = directory.listFiles((d, name) -> name.endsWith("." + PageSnapshot.SHADOW_FILE_EXT));
+    return found != null ? found : new File[0];
+  }
+
+  private void rewriteEveryRecord(final String marker) {
+    database.transaction(() -> database.iterateType(TYPE, false).forEachRemaining(record -> {
+      final MutableDocument doc = record.asDocument().modify();
+      doc.set("payload", marker + "-" + "y".repeat(200));
+      doc.save();
+    }));
+    ((DatabaseInternal) database).getPageManager().waitAllPagesOfDatabaseAreFlushed(database);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -342,7 +342,15 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
     }
   }
 
-  /** The one stall the snapshot path still has is now reported rather than only logged when it goes wrong. */
+  /**
+   * The one stall the snapshot path still has is now reported rather than only logged when it goes wrong.
+   * <p>
+   * The timer measures the barrier itself: it starts inside the per-database monitor, so a second caller queueing
+   * behind a barrier on the same database is not charged for the wait, and a call refused before the barrier is
+   * entered at all is neither timed nor counted. Neither of those is asserted here - the first needs two threads
+   * racing on one database and the second needs a page manager that is not running, which no test can arrange
+   * without breaking the JVM-wide singleton this and every other test class shares.
+   */
   @Test
   void theBarrierIsTimed() {
     final DatabaseInternal db = (DatabaseInternal) database;

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
@@ -94,6 +95,37 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
       // ENOUGH FOR A TEST FIXTURE AND TOO SMALL FOR A REAL DATABASE
       assertThat(snapshot.getShadowMaxSizeInBytes()).isNotEqualTo(1024L * ONE_MEGABYTE);
     }
+  }
+
+  /**
+   * The automatic cap must never resolve to {@link PageShadow}'s "0 means uncapped" sentinel by accident. The free
+   * space is halved with integer division, so a volume down to its last byte computes {@code 1 / 2 == 0} - which
+   * would disable the cap outright in exactly the disk-almost-full case it exists for, the inverse of its purpose.
+   * <p>
+   * Asserted against the arithmetic directly rather than through a real volume: no test can fill a disk, and the
+   * method is pure precisely so this edge is reachable.
+   */
+  @Test
+  void theAutomaticCapNeverDegeneratesIntoTheUncappedSentinel() {
+    final ContextConfiguration configuration = database.getConfiguration();
+    // 64 KB OF PAGES AT t0, SO THE PROVABLE CEILING IS NOT ITSELF ZERO
+    final List<PageSnapshot.SnapshotFile> files = List.of(
+        new PageSnapshot.SnapshotFile(0, null, 65_536, 1, "one.bucket"));
+
+    for (final long usable : new long[] { 1L, 2L, 3L })
+      assertThat(PageManager.snapshotMaxShadowSize(configuration, files, usable))
+          .as("a nearly-full spill volume (%d usable bytes) must still cap the shadow", usable).isPositive();
+
+    // AND THE ORDINARY CASES STILL COMPUTE WHAT THEY SHOULD
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, Long.MAX_VALUE))
+        .as("with room to spare the cap is the provable ceiling").isEqualTo(65_536L);
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 40_000L))
+        .as("with less room than the database the cap is half the free space").isEqualTo(20_000L);
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, files, 0L))
+        .as("an unreadable free-space figure is not 'no room': fall back to the provable ceiling")
+        .isEqualTo(65_536L);
+    assertThat(PageManager.snapshotMaxShadowSize(configuration, List.of(), Long.MAX_VALUE))
+        .as("an empty t0 page set can never need a pre-image, so uncapped is the honest answer").isZero();
   }
 
   /** A number set by hand still means exactly what it used to, and 0 still means "do not cap at all". */

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -139,6 +139,43 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
   }
 
   /**
+   * The spill directory is created if it is not there yet, and a path that cannot be one degrades to the database
+   * directory instead of failing the backup. Both branches run BEFORE the barrier takes its locks (they are
+   * unbounded blocking filesystem calls), so they are also the reason the cap arithmetic that consumes them is pure.
+   */
+  @Test
+  void theSpillDirectoryIsCreatedOnDemandAndAnUnusableOneDegradesToTheDatabaseDirectory(@TempDir final Path tempDir)
+      throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    GlobalConfiguration.PAGE_SNAPSHOT_MAX_RAM.setValue(0);
+
+    final File notYetThere = tempDir.resolve("nested/spill").toFile();
+    assertThat(notYetThere).doesNotExist();
+    GlobalConfiguration.PAGE_SNAPSHOT_SPILL_PATH.setValue(notYetThere.getAbsolutePath());
+
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      rewriteEveryRecord("created-on-demand");
+      assertThat(snapshot.getShadowSpilledBytes()).isPositive();
+      assertThat(shadowFilesIn(notYetThere)).as("the directory must have been created and used").isNotEmpty();
+    }
+
+    // A PLAIN FILE CANNOT BE A DIRECTORY, SO THIS EXERCISES THE FALLBACK. A MISCONFIGURED SPILL PATH MUST COST A
+    // WARNING AND THE OLD LOCATION, NEVER THE BACKUP ITSELF
+    final File notADirectory = tempDir.resolve("this-is-a-file").toFile();
+    assertThat(notADirectory.createNewFile()).isTrue();
+    GlobalConfiguration.PAGE_SNAPSHOT_SPILL_PATH.setValue(notADirectory.getAbsolutePath());
+
+    try (final PageSnapshot snapshot = db.getPageManager().openSnapshot(db)) {
+      rewriteEveryRecord("fallen-back");
+      assertThat(snapshot.getStatus()).as("a misconfigured spill path must not break the window")
+          .isEqualTo(PageSnapshot.STATUS.ACTIVE);
+      assertThat(snapshot.getShadowSpilledBytes()).isPositive();
+      assertThat(shadowFilesIn(new File(db.getDatabasePath())))
+          .as("the shadow must have fallen back to the database directory").isNotEmpty();
+    }
+  }
+
+  /**
    * The property the whole barrier exists for, asserted end to end and on CONTENT rather than on a counter: a record
    * committed immediately before the window opens, while four threads commit continuously around it, must be
    * findable in the point-in-time image of the page files, and no barrier may report itself unable to prove the

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.schema.DocumentType;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6125, items 1 and 2: the shadow cap sizes itself from the thing it actually bounds, and the t0 barrier is
@@ -238,6 +240,69 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
     assertThat(failure.get()).isNull();
     // THE PAIRED ASSERTION: THE PUBLICATION WAS BLOCKED, NOT BROKEN, SO THIS CANNOT PASS BY NOTHING EVER HAPPENING
     assertThat(published.get()).as("releasing the lock must let the very same publication through").isTrue();
+  }
+
+  /**
+   * The other half of holding the JVM-wide lock across the barrier: everything done under it has to be BOUNDED, or
+   * the lock that makes the drain converge becomes a way for one sick disk to stall every committer in the process.
+   * <p>
+   * The review of #6126 caught exactly this: the residual drain was capped but the wait for the in-flight flush
+   * batch was not, and that wait polls until a synchronous {@code file.write} returns. Here an in-flight batch is
+   * fabricated and never completes - the shape a wedged disk presents - and the barrier has to give the window up
+   * within its budget and let go of the lock, rather than hold it until the write lands.
+   */
+  @Test
+  void aFlushThatNeverCompletesFailsTheBarrierInsteadOfHoldingTheGlobalLockForever() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+    final PageManagerFlushThread flushThread = pageManager.getFlushThread();
+    assertThat(pageManager.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+
+    final int fileId = db.getSchema().getType(TYPE).getBuckets(false).getFirst().getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final MutablePage page = pageManager.getImmutablePage(new PageId(db, fileId, 0), file.getPageSize(), false, true)
+        .modify();
+
+    // AN IN-FLIGHT BATCH OF THIS DATABASE THAT NEVER FINISHES. NOT IN pageIndex, SO BOTH DRAINS STILL SEE AN EMPTY
+    // PIPELINE AND THE BARRIER REACHES THE WAIT UNDER TEST. THE FLUSH THREAD ONLY TOUCHES nextPagesToFlush WHEN IT
+    // POLLS A REAL BATCH, AND THIS DATABASE IS QUIET, SO THE FABRICATED VALUE STANDS
+    flushThread.nextPagesToFlush.set(new PageManagerFlushThread.PagesToFlush(new ArrayList<>(List.of(page))));
+    try {
+      final long begin = System.currentTimeMillis();
+      assertThatThrownBy(() -> pageManager.openSnapshot(db))
+          .as("the barrier must abandon the window rather than wait out a flush that never lands")
+          .isInstanceOf(PageSnapshotException.class);
+      final long elapsed = System.currentTimeMillis() - begin;
+
+      // BOTH ENDS MATTER. The upper bound is the property under test - generous enough for a loaded CI runner, far
+      // below the forever the unbounded wait would have taken. The lower one keeps the test honest: it proves the
+      // barrier really did block on the fabricated batch and time out, rather than failing instantly for some
+      // unrelated reason that would make the ceiling assertion pass vacuously
+      assertThat(elapsed).as("the barrier must block on the in-flight batch and then give up within its budget")
+          .isBetween(1_000L, 60_000L);
+
+      // AND IT MUST HAVE LET GO: A FAILED BARRIER THAT KEPT THE GLOBAL LOCK WOULD BE WORSE THAN THE HANG IT REPLACES
+      final AtomicBoolean acquired = new AtomicBoolean();
+      final Thread other = new Thread(() -> pageManager.executeInLock(() -> {
+        acquired.set(true);
+        return null;
+      }), "issue6125-lock-probe");
+      other.setDaemon(true);
+      other.start();
+      other.join(10_000);
+      assertThat(acquired.get()).as("the page-manager lock must be free again after a failed barrier").isTrue();
+
+      // THE SUSPENSION IT TOOK ON THE WAY IN MUST BE RELEASED TOO, OR THE DATABASE STAYS FROZEN FOR EVERY WRITER
+      assertThat(pageManager.isPageFlushingSuspended(db)).isFalse();
+    } finally {
+      flushThread.nextPagesToFlush.set(null);
+    }
+
+    // THE PAIRED ASSERTION: WITH THE FABRICATED BATCH GONE, THE VERY SAME CALL SUCCEEDS - SO THE FAILURE ABOVE WAS
+    // THE WAIT UNDER TEST AND NOT A DATABASE LEFT BROKEN BY THE FIXTURE
+    try (final PageSnapshot snapshot = pageManager.openSnapshot(db)) {
+      assertThat(snapshot.getStatus()).isEqualTo(PageSnapshot.STATUS.ACTIVE);
+    }
   }
 
   /** The one stall the snapshot path still has is now reported rather than only logged when it goes wrong. */

--- a/engine/src/test/java/com/arcadedb/engine/PageSnapshotMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageSnapshotMetricsTest.java
@@ -83,8 +83,11 @@ class PageSnapshotMetricsTest extends TestHelper {
       assertThat(open.snapshotOldestWindowMillis).as("the window's age must be measured from when it opened")
           .isPositive();
       assertThat(open.snapshotShadowedPages).as("nothing has been written yet, so nothing is shadowed").isZero();
-      assertThat(snapshot.getShadowMaxSizeInBytes())
-          .isEqualTo(GlobalConfiguration.PAGE_SNAPSHOT_MAX_SIZE.getValueAsLong() * 1024 * 1024);
+      // #6125: THE DEFAULT CAP IS RESOLVED AT t0 FROM THE SIZE THE PAGE FILES OCCUPY, NOT READ AS A NUMBER OF MB
+      long t0Size = 0;
+      for (final PageSnapshot.SnapshotFile file : snapshot.getFiles())
+        t0Size += file.size();
+      assertThat(snapshot.getShadowMaxSizeInBytes()).isEqualTo(t0Size);
     }
 
     final PageManager.PPageManagerStats after = pageManager.getStats();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -86,6 +86,17 @@ public class SnapshotHttpHandler implements HttpHandler {
   private static final Semaphore CONCURRENCY_SEMAPHORE =
       new Semaphore(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger(), true);
 
+  /** Sub-path selecting the checksums view of a database instead of its snapshot ZIP. */
+  static final String CHECKSUMS_SUFFIX = "/checksums";
+
+  /**
+   * What a request path resolves to: a validated database name plus which of the two views is being asked for, or -
+   * when {@code error} is set - the message of the 400 that answers it instead. Exactly one of {@code error} and
+   * {@code databaseName} is meaningful.
+   */
+  record Route(String databaseName, boolean checksums, String error) {
+  }
+
   /** How far {@link #rootCauseMessage} walks a cause chain before giving up. Real ones are two or three links. */
   private static final int MAX_CAUSE_DEPTH = 20;
 
@@ -131,6 +142,38 @@ public class SnapshotHttpHandler implements HttpHandler {
     watchdogExecutor.shutdownNow();
   }
 
+  /**
+   * Turns {@code /api/v1/ha/snapshot/{database}[/checksums]} into a {@link Route} (#6125).
+   * <p>
+   * The ORDER here is the fix: strip the sub-path, then validate what is left, then decide which branch to take.
+   * The checksums branch used to be taken BEFORE the validation, which was safe only because
+   * {@link #handleChecksums} gates on {@code existsDatabase} - an exact-match lookup over the already-open databases,
+   * so a traversal string 404s and {@code getDatabase} is never reached. That is a property of an implementation
+   * detail two calls away, not of this handler. Validating first makes the guarantee local, at the cost of a
+   * malformed name answering 400 instead of 404 on the checksums route.
+   * <p>
+   * The name rule is deliberately stricter than the engine's own {@code checkDatabaseNameIsValid}: this reads a name
+   * straight out of a URL, so anything that could escape the databases directory or smuggle a control character is
+   * refused before a name is ever resolved. Package-private and static so the whole decision is testable without an
+   * HTTP exchange.
+   */
+  static Route resolveRoute(final String relativePath) {
+    final String path = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
+
+    final boolean checksums = path.endsWith(CHECKSUMS_SUFFIX);
+    final String databaseName = checksums ? path.substring(0, path.length() - CHECKSUMS_SUFFIX.length()) : path;
+
+    if (databaseName.isEmpty())
+      return new Route(null, checksums, "Missing database name in path");
+
+    if (databaseName.contains("/") || databaseName.contains("\\")
+        || databaseName.contains("..") || databaseName.contains("\0")
+        || !databaseName.chars().allMatch(c -> c >= 0x20 && c < 0x7F))
+      return new Route(null, checksums, "Invalid database name");
+
+    return new Route(databaseName, checksums, null);
+  }
+
   @Override
   public void handleRequest(final HttpServerExchange exchange) throws Exception {
     if (exchange.isInIoThread()) {
@@ -168,28 +211,16 @@ public class SnapshotHttpHandler implements HttpHandler {
       return;
     }
     try {
-      // Extract database name from the path: /api/v1/ha/snapshot/{database}
-      final String relativePath = exchange.getRelativePath();
-      final String databaseName = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
-
-      // Check for checksums sub-path: /api/v1/ha/snapshot/{database}/checksums
-      if (databaseName.endsWith("/checksums")) {
-        final String dbName = databaseName.substring(0, databaseName.length() - "/checksums".length());
-        handleChecksums(exchange, dbName);
+      final Route route = resolveRoute(exchange.getRelativePath());
+      if (route.error() != null) {
+        exchange.setStatusCode(400);
+        exchange.getResponseSender().send(route.error());
         return;
       }
 
-      if (databaseName.isEmpty()) {
-        exchange.setStatusCode(400);
-        exchange.getResponseSender().send("Missing database name in path");
-        return;
-      }
-
-      if (databaseName.contains("/") || databaseName.contains("\\")
-          || databaseName.contains("..") || databaseName.contains("\0")
-          || !databaseName.chars().allMatch(c -> c >= 0x20 && c < 0x7F)) {
-        exchange.setStatusCode(400);
-        exchange.getResponseSender().send("Invalid database name");
+      final String databaseName = route.databaseName();
+      if (route.checksums()) {
+        handleChecksums(exchange, databaseName);
         return;
       }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
@@ -33,12 +33,22 @@ import java.util.Map;
 import java.util.zip.CRC32;
 
 /**
- * Utility methods for snapshot-based resync in Raft HA.
+ * Manifest and checksum helpers for snapshot-based resync in Raft HA.
  * <p>
- * Currently provides checksum computation and file-diffing helpers. Full
- * {@code installSnapshot()} integration with Ratis is not yet wired - replicas
- * that fall behind past log compaction require a manual data copy from the leader.
- * These utilities are the building blocks for the future automatic resync.
+ * A follower that falls behind the compacted Raft log downloads the WHOLE database as a ZIP from
+ * {@code SnapshotHttpHandler} and installs it through {@code SnapshotInstaller}; this class carries the manifest
+ * that transfer is verified with, and the checksum computation behind the {@code /checksums} endpoint.
+ * <p>
+ * <b>There is deliberately no file-level diff here</b> (#6125). One used to be - a {@code findDifferingFiles}
+ * helper, called from nothing but its own unit test, whose presence suggested resync could ship only what changed.
+ * It was removed rather than wired in, for two reasons. Granularity: an ArcadeDB database is usually dominated by
+ * one bucket file, so a whole-file comparison saves nothing the moment a single byte of it changes. Consistency:
+ * the checksums come from one point-in-time window and the ZIP from another, so a file that matched when it was
+ * compared can be rewritten before the transfer starts, and a follower that kept its local copy on the strength of
+ * that match would hold a database torn across two instants. Incremental resync therefore belongs at the PAGE
+ * level, on the page-version manifest of phase 3 (#6115), where both halves come from the same window. Until then
+ * {@code /checksums} is an operator diagnostic - "do these two nodes hold the same bytes?" without moving a
+ * database - and nothing more.
  */
 public final class SnapshotManager {
 
@@ -199,26 +209,4 @@ public final class SnapshotManager {
     return checksums;
   }
 
-  /**
-   * Identifies files that differ between leader and replica based on checksums.
-   * A file is considered differing if it exists on the leader but not on the replica,
-   * or if its checksum does not match.
-   *
-   * @param leaderChecksums  checksums from the leader node
-   * @param replicaChecksums checksums from the replica node
-   *
-   * @return list of file names that need to be transferred
-   */
-  public static List<String> findDifferingFiles(final Map<String, Long> leaderChecksums,
-      final Map<String, Long> replicaChecksums) {
-    final List<String> differing = new ArrayList<>();
-
-    for (final Map.Entry<String, Long> entry : leaderChecksums.entrySet()) {
-      final Long replicaChecksum = replicaChecksums.get(entry.getKey());
-      if (replicaChecksum == null || !replicaChecksum.equals(entry.getValue()))
-        differing.add(entry.getKey());
-    }
-
-    return differing;
-  }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
@@ -208,5 +208,4 @@ public final class SnapshotManager {
 
     return checksums;
   }
-
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6125SnapshotRouteValidationTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6125SnapshotRouteValidationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6125 item 3: {@code SnapshotHttpHandler} used to take its {@code /checksums} branch BEFORE the block that
+ * rejects {@code ..}, separators, NUL and non-ASCII in the database name. It was not exploitable - the checksums
+ * path gates on {@code existsDatabase}, an exact-match lookup over the already-open databases, so a traversal string
+ * simply 404'd and the database was never resolved - but the guarantee lived two calls away from the handler that
+ * needed it.
+ * <p>
+ * These tests pin the ORDER: the sub-path is stripped, the name is validated, and only then is a branch chosen, so
+ * both routes refuse a malformed name identically instead of one of them relying on a downstream lookup.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6125SnapshotRouteValidationTest {
+
+  @Test
+  void aPlainDatabaseNameRoutesToTheSnapshotDownload() {
+    final SnapshotHttpHandler.Route route = SnapshotHttpHandler.resolveRoute("/mydb");
+    assertThat(route.error()).isNull();
+    assertThat(route.databaseName()).isEqualTo("mydb");
+    assertThat(route.checksums()).isFalse();
+  }
+
+  @Test
+  void theChecksumsSuffixSelectsTheChecksumsViewOfTheSameName() {
+    final SnapshotHttpHandler.Route route = SnapshotHttpHandler.resolveRoute("/mydb/checksums");
+    assertThat(route.error()).isNull();
+    assertThat(route.databaseName()).isEqualTo("mydb");
+    assertThat(route.checksums()).isTrue();
+  }
+
+  @Test
+  void aLeadingSlashIsOptional() {
+    assertThat(SnapshotHttpHandler.resolveRoute("mydb").databaseName()).isEqualTo("mydb");
+    assertThat(SnapshotHttpHandler.resolveRoute("mydb/checksums").databaseName()).isEqualTo("mydb");
+  }
+
+  /**
+   * The regression itself: every one of these was refused on the download route and waved through the validation on
+   * the checksums route.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "../../etc/passwd", "..", "a/b", "a\\b", "sub/dir/db", "db\u0000x", "caf\u00e9",
+      "bell\u0007" })
+  void aMalformedNameIsRefusedOnTheChecksumsRouteToo(final String malformed) {
+    assertThat(SnapshotHttpHandler.resolveRoute("/" + malformed + "/checksums").error())
+        .as("checksums route must refuse '%s'", malformed).isEqualTo("Invalid database name");
+    assertThat(SnapshotHttpHandler.resolveRoute("/" + malformed).error())
+        .as("download route must refuse '%s' as it always did", malformed).isEqualTo("Invalid database name");
+  }
+
+  @Test
+  void anEmptyNameIsRefusedOnBothRoutes() {
+    assertThat(SnapshotHttpHandler.resolveRoute("/").error()).isEqualTo("Missing database name in path");
+    // "/checksums" IS A DATABASE CALLED "checksums", NOT AN EMPTY NAME ON THE CHECKSUMS ROUTE - THE SUFFIX ONLY
+    // MATCHES WITH ITS SEPARATOR, WHICH IS WHY THE EMPTY CASE NEEDS THE DOUBLE SLASH
+    assertThat(SnapshotHttpHandler.resolveRoute("//checksums").error()).isEqualTo("Missing database name in path");
+    assertThat(SnapshotHttpHandler.resolveRoute("/checksums").databaseName()).isEqualTo("checksums");
+  }
+
+  /**
+   * A refused route carries no database name at all, so no caller can accidentally use one that failed validation.
+   */
+  @Test
+  void aRefusedRouteExposesNoDatabaseName() {
+    assertThat(SnapshotHttpHandler.resolveRoute("/../secret/checksums").databaseName()).isNull();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotManagerTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotManagerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,22 +82,16 @@ class SnapshotManagerTest {
     assertThat(checksums).containsOnlyKeys("database.json");
   }
 
+  /**
+   * #6125: {@code findDifferingFiles} was removed rather than wired into the resync path, and these two tests -
+   * its only callers - went with it. What replaces them is the guarantee that nothing has quietly grown a
+   * file-level diff back: resync ships the whole database, and an incremental one belongs at the page level
+   * (#6115), where the manifest and the page image come from the same window.
+   */
   @Test
-  void findDifferingFiles() {
-    final Map<String, Long> leader = Map.of("file1", 100L, "file2", 200L, "file3", 300L);
-    final Map<String, Long> replica = Map.of("file1", 100L, "file2", 999L);
-
-    final var differing = SnapshotManager.findDifferingFiles(leader, replica);
-
-    assertThat(differing).containsExactlyInAnyOrder("file2", "file3");
-  }
-
-  @Test
-  void noDifferencesWhenIdentical() {
-    final Map<String, Long> checksums = Map.of("a", 1L, "b", 2L);
-
-    final var differing = SnapshotManager.findDifferingFiles(checksums, checksums);
-
-    assertThat(differing).isEmpty();
+  void noFileLevelDiffHelperIsExposed() {
+    assertThat(SnapshotManager.class.getDeclaredMethods())
+        .as("a whole-file diff cannot be the basis of resync: see the class comment")
+        .noneMatch(method -> method.getName().toLowerCase(Locale.ROOT).contains("differing"));
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/PluginApiSpec.java
@@ -319,19 +319,26 @@ public class PluginApiSpec implements OpenApiContributor {
     final Operation get = SpecBuilders.operation("getDatabaseSnapshotChecksums", "Cluster",
         "Read the checksums of a snapshot's files",
         """
-            Returns the per-file checksums of the database a snapshot download would produce, so a \
-            follower can decide whether it needs the full transfer. Only the root user may read them.
+            Returns the per-file checksums of the database as a snapshot download would produce it, read \
+            through the same point-in-time window. Only the root user may read them.
+
+            This is an operator diagnostic: it answers "do these two nodes hold the same bytes?" without \
+            transferring a database. Resync itself does not consult it - a follower that falls behind the \
+            compacted Raft log always downloads the full snapshot ZIP - because a whole-file comparison is the \
+            wrong granularity for an ArcadeDB database, which is usually dominated by one bucket file that any \
+            single changed byte re-ships in full. Incremental resync is tracked as a page-level diff in #6115.
 
             This route accepts HTTP Basic only, for the same reason as the snapshot download. """
             + RAFT_REQUIRED);
     get.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
     SpecBuilders.basicAuthOnly(get);
-    // No 400: unlike the snapshot download branch, the checksums branch never validates the database
-    // name (missing/invalid characters); an unknown name simply resolves to 404. A checksum
-    // computation failure is caught locally and reported as 500.
+    // 400 since #6125: the database name is validated (non-empty, no separators, no '..', printable ASCII)
+    // BEFORE this branch is taken, exactly as on the snapshot download route, so a malformed name is refused
+    // here rather than resolving to a 404 further down. A checksum computation failure is caught locally and
+    // reported as 500.
     get.setResponses(SpecBuilders.standardResponses("200",
         SpecBuilders.jsonResponse("Per-file checksums", null),
-        "401", "403", "404", "500", "503"));
+        "400", "401", "403", "404", "500", "503"));
 
     final PathItem pathItem = new PathItem();
     pathItem.setGet(get);

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -59,6 +59,9 @@ public final class EngineMetricsBinder implements MeterBinder {
 
   private static final long SNAPSHOT_TTL_NANOS = TimeUnit.SECONDS.toNanos(1);
 
+  /** The engine times the t0 barrier in milliseconds; a {@code _seconds} series is what Prometheus expects (#6125). */
+  private static final double MILLIS_TO_SECONDS = 0.001d;
+
   /**
    * The memoized {@link Profiler} snapshot every meter reads through.
    * <p>
@@ -110,6 +113,29 @@ public final class EngineMetricsBinder implements MeterBinder {
     counter(registry, "arcadedb.engine.snapshot.preimages.captured",
         "Page pre-images copied into a snapshot shadow", "snapshotPreImagesCaptured");
 
+    // #6125: the split of windows.invalidated above. The two reasons take an operator to different places - a cap
+    // breach is answered by raising arcadedb.pageSnapshotMaxSize or giving the spill volume room, a capture failure
+    // by looking at the disk - and a single summed counter cannot say which.
+    counter(registry, "arcadedb.engine.snapshot.windows.overflowed",
+        "Snapshot windows whose shadow reached its size cap", "snapshotWindowsOverflowed");
+    counter(registry, "arcadedb.engine.snapshot.windows.failed",
+        "Snapshot windows lost to an I/O error while capturing a pre-image", "snapshotWindowsFailed");
+
+    // #6125: the t0 barrier, the ONE stall the snapshot path still has, exported as a Prometheus timer is: a count
+    // and a summed duration, so rate(seconds)/rate(count) is the average latency. It is a pair of counters rather
+    // than a real Timer because this binder reads scalars out of a memoized Profiler snapshot and never sees the
+    // individual events; the pair carries the same information a Timer's _sum and _count do.
+    counter(registry, "arcadedb.engine.snapshot.barrier.count", "Point-in-time snapshot t0 barriers executed",
+        "snapshotBarriers");
+    counter(registry, "arcadedb.engine.snapshot.barrier.seconds",
+        "Total time spent in the snapshot t0 barrier", "snapshotBarrierTime", MILLIS_TO_SECONDS);
+    counter(registry, "arcadedb.engine.snapshot.barrier.inexact",
+        "Barriers that could not prove the flush pipeline was empty at t0", "snapshotBarriersInexact");
+    // A HIGH-WATER MARK: MONOTONIC, BUT A rate() OVER IT WOULD BE MEANINGLESS, WHICH IS WHY IT IS THE ONE MONOTONIC
+    // READING HERE THAT STAYS A GAUGE
+    gauge(registry, "arcadedb.engine.snapshot.barrier.max.seconds",
+        "Longest snapshot t0 barrier observed", "snapshotBarrierMaxTime", MILLIS_TO_SECONDS);
+
     // Instantaneous readings: these go up AND down, so they are the only ones that stay gauges.
     gauge(registry, "arcadedb.engine.wal.files", "WAL files", "walTotalFiles");
     gauge(registry, "arcadedb.engine.files.open", "Open file descriptors", "totalOpenFiles");
@@ -144,16 +170,31 @@ public final class EngineMetricsBinder implements MeterBinder {
    * comes straight back.
    */
   private void counter(final MeterRegistry registry, final String name, final String description, final String jsonKey) {
+    counter(registry, name, description, jsonKey, 1d);
+  }
+
+  /**
+   * @param scale factor applied to the raw stat, for the readings the engine keeps in a different unit from the one
+   *     the series name promises (#6125: the barrier durations are milliseconds in {@code Profiler} and seconds on
+   *     the wire, which is what Prometheus dashboards and alert rules expect of a {@code _seconds} series).
+   */
+  private void counter(final MeterRegistry registry, final String name, final String description, final String jsonKey,
+      final double scale) {
     // No baseUnit(): Micrometer's Prometheus renderer splices the base unit INTO the series name
     // (arcadedb_engine_wal_bytes_written_bytes_total), which is a second, gratuitous rename on top of the _total
     // suffix this change already introduces.
-    FunctionCounter.builder(name, CACHE, c -> c.read(jsonKey))
+    FunctionCounter.builder(name, CACHE, c -> c.read(jsonKey) * scale)
         .description(description)
         .register(registry);
   }
 
   private void gauge(final MeterRegistry registry, final String name, final String description, final String jsonKey) {
-    Gauge.builder(name, CACHE, c -> c.read(jsonKey))
+    gauge(registry, name, description, jsonKey, 1d);
+  }
+
+  private void gauge(final MeterRegistry registry, final String name, final String description, final String jsonKey,
+      final double scale) {
+    Gauge.builder(name, CACHE, c -> c.read(jsonKey) * scale)
         .description(description)
         .register(registry);
   }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/PluginApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/PluginApiSpecTest.java
@@ -319,14 +319,14 @@ class PluginApiSpecTest {
 
   @Test
   void snapshotChecksumsResponseCodesMatchTheHandler() {
-    // Correction: the checksums branch (SnapshotHttpHandler.handleChecksums) never validates the
-    // database-name shape the way the download branch does, so 400 can never be returned; a checksum
-    // computation failure is caught locally and reported as 500, and the same root-only 403 check
-    // applies before either branch is reached. The brief's response set had 400 but neither 403 nor 500.
+    // #6125: the checksums branch now validates the database-name shape too - the validation was hoisted above
+    // the branch in SnapshotHttpHandler, so both routes refuse a malformed name with 400 instead of one of them
+    // relying on the downstream exact-match lookup to answer 404. A checksum computation failure is still caught
+    // locally and reported as 500, and the same root-only 403 check applies before either branch is reached.
     final Operation checksums = openAPI.getPaths()
         .get("/api/v1/ha/snapshot/{database}/checksums").getGet();
     assertThat(checksums.getResponses().keySet())
-        .containsExactlyInAnyOrder("200", "401", "403", "404", "500", "503");
+        .containsExactlyInAnyOrder("200", "400", "401", "403", "404", "500", "503");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
@@ -60,7 +60,12 @@ class EngineMetricsBinderTest {
         "arcadedb.engine.page.merges.declined", "arcadedb.engine.tx.write", "arcadedb.engine.tx.read",
         "arcadedb.engine.tx.rollbacks", "arcadedb.engine.queries", "arcadedb.engine.commands",
         "arcadedb.engine.snapshot.windows.opened", "arcadedb.engine.snapshot.windows.invalidated",
-        "arcadedb.engine.snapshot.preimages.captured" }) {
+        "arcadedb.engine.snapshot.preimages.captured",
+        // #6125: the invalidation split and the t0 barrier timer, whose sum/count pair is what a Prometheus Timer
+        // exports and what makes rate(seconds)/rate(count) the average barrier latency
+        "arcadedb.engine.snapshot.windows.overflowed", "arcadedb.engine.snapshot.windows.failed",
+        "arcadedb.engine.snapshot.barrier.count", "arcadedb.engine.snapshot.barrier.seconds",
+        "arcadedb.engine.snapshot.barrier.inexact" }) {
       final FunctionCounter counter = registry.find(name).functionCounter();
       assertThat(counter).as(name).isNotNull();
       assertThat(Double.isNaN(counter.count())).as(name).isFalse();
@@ -81,6 +86,9 @@ class EngineMetricsBinderTest {
         "arcadedb.engine.databases", "arcadedb.engine.snapshot.windows.open", "arcadedb.engine.snapshot.shadow.pages",
         "arcadedb.engine.snapshot.shadow.bytes", "arcadedb.engine.snapshot.shadow.spilled.bytes",
         "arcadedb.engine.snapshot.shadow.usage.percent", "arcadedb.engine.snapshot.window.age.ms",
+        // #6125: a high-water mark. Monotonic, but a rate() over it would be meaningless, so it is the one
+        // never-decreasing reading here that is deliberately a gauge
+        "arcadedb.engine.snapshot.barrier.max.seconds",
         "arcadedb.engine.flush.deferred.bytes" }) {
       final Gauge gauge = registry.find(name).gauge();
       assertThat(gauge).as(name).isNotNull();
@@ -128,9 +136,9 @@ class EngineMetricsBinderTest {
    * is holding and how close it is to {@code arcadedb.pageSnapshotMaxSize}, before the breach forces the backup back
    * onto the path that throttles writers.
    * <p>
-   * The shadow-usage assertion is the one that earns its keep: against the 1 GB default cap a few shadowed pages are
-   * a small FRACTION of a percent, so a reading truncated to a long would report a comfortable zero for a window
-   * that is actually filling.
+   * The shadow-usage assertion is the one that earns its keep: against a cap sized from the whole database a few
+   * shadowed pages are a small FRACTION of a percent, so a reading truncated to a long would report a comfortable
+   * zero for a window that is actually filling.
    */
   @Test
   void theSnapshotGaugesFollowAnOpenWindow() throws Exception {
@@ -174,6 +182,14 @@ class EngineMetricsBinderTest {
 
         assertThat(registry.find("arcadedb.engine.snapshot.preimages.captured").functionCounter().count()).isPositive();
         assertThat(registry.find("arcadedb.engine.snapshot.windows.opened").functionCounter().count()).isPositive();
+
+        // #6125: OPENING THE WINDOW RAN A t0 BARRIER, SO ITS TIMER MUST HAVE MOVED. THE DURATION IS ASSERTED AS
+        // NON-NEGATIVE RATHER THAN POSITIVE ON PURPOSE - AN IDLE BARRIER TAKES TENS OF MICROSECONDS AND ROUNDS TO
+        // ZERO MILLISECONDS, WHICH IS THE HEALTHY CASE, NOT A BROKEN METER
+        assertThat(registry.find("arcadedb.engine.snapshot.barrier.count").functionCounter().count()).isPositive();
+        assertThat(registry.find("arcadedb.engine.snapshot.barrier.seconds").functionCounter().count())
+            .isNotNegative();
+        assertThat(registry.find("arcadedb.engine.snapshot.barrier.max.seconds").gauge().value()).isNotNegative();
       }
 
       assertThat(awaitGauge(registry, "arcadedb.engine.snapshot.windows.open", value -> value <= windowsBefore))


### PR DESCRIPTION
Closes #6125.

Four follow-ups the benchmarks of #6116 turned up. None was a correctness bug; the first two contradict an assumption #6075/#6100 shipped on, and could only be stated once there were measurements.

## 1. `arcadedb.pageSnapshotMaxSize` sizes itself at t0

The measurement first: on a 128 MB database with the backup throttled to 32 MB/s, the copy-on-write shadow peaked at 37% of the database with a writer pausing 100 ms between transactions, 84% at 20 ms, and **100%** with a writer running flat out. The shadow holds the pre-image of every page dirtied while the window is open, so its ceiling is the working set of the backup's duration.

That makes any fixed default simply the database size above which backups silently start falling back to the suspend-and-freeze path - the very writer throttling #6075 set out to remove.

The default is now `-1` = automatic, resolved when the window opens:

```
cap = min( sum(pageCount * pageSize) at t0,   // the ceiling the shadow provably cannot exceed
           usableSpace(spill volume) / 2 )    // so a window can never be why the disk filled
```

The first term is exact rather than a heuristic: the shadow holds one pre-image per page that existed at t0, and pages appended after t0 need none (challenge C7), so it cannot grow past the t0 size of the page files. A positive value still means an absolute number of MB and `0` still means uncapped, so **no existing configuration changes meaning**.

Related, and the reason for the second term: the spill file lands in the database directory, where a breach-sized shadow competes for disk with the data it is protecting. New **`arcadedb.pageSnapshotSpillPath`** moves it to another volume, and the automatic cap is then measured against the free space there.

The two ways a window can lose its point in time are counted apart now, because they send an operator to different places: `arcadedb_engine_snapshot_windows_overflowed_total` is a tuning problem, `arcadedb_engine_snapshot_windows_failed_total` is a disk problem. Their sum remains `..._invalidated_total`. The spill-write failure also carries the file name and how far it had grown, instead of a bare "No space left on device".

## 2. The t0 barrier is single-pass, exact, and measured

#6116 measured the barrier at tens of milliseconds under load against 13 us idle, and found the driver was not the flush-queue depth - which stays near zero on an SSD - but the barrier **retrying**: it drained the flush queue in full, and a commit landing between that drain and the flush-thread suspension made it start over. After three attempts it gave up with a t0 that could sit behind the last committed transaction.

The gap is now closed by construction. `PageManager.publishPages` already holds the global page-manager lock across *both* halves of publication - the synchronous page write and the `scheduleFlushOfPages` enqueue - so the barrier takes that lock (after the apply lock, in the order it already used) and repeats the drain underneath it:

```
before:  for (attempt 1..3) { drain; suspend; if (pending) retry }   -> t0 may lag
after:   drain                       // lock-free warm-up, the bulk of the work
         applyLock.write()
           pageManagerLock()
             drain                   // converges: no publisher can run
             suspend + await batch
             build + publish t0      // single pass, t0 exact
```

`SNAPSHOT_BARRIER_ATTEMPTS` and the retry loop are gone.

Everything the barrier does under that lock shares one hard **5 s** budget, because the lock is JVM-wide and the waits those steps use elsewhere are either uncapped (the wait for the in-flight flush batch polls until a synchronous `file.write` returns) or capped only by the 60 s progress-based `arcadedb.flushAllPagesTimeout` - either of which would let one sick disk stall every committer in the process. Exhausting it is handled per step by what it costs: a pipeline that has not drained only means t0 may sit slightly behind the last commit, which is logged and accepted, while a suspension that cannot be acquired or an in-flight batch that has not landed abandons the window outright and the consumer falls back to suspend-and-freeze. For the same reason the shadow's spill directory is resolved and the free space on that volume read in the barrier's *unlocked* phase: `mkdirs` and `getUsableSpace` are blocking filesystem calls on a volume `pageSnapshotSpillPath` may deliberately point elsewhere, so what is left under the lock is arithmetic over the t0 file list.

Exactness matters beyond tidiness: the HA snapshot ship writes `lastTxId` into the `last-tx-id.bin` recency marker a follower is judged by at cold bootstrap, and a marker naming a transaction whose pages were still queued claims data the archive does not contain.

The obvious inversion still does not work and is now documented as such: suspending the flush thread before the drain makes the drain unable to ever complete, because a suspended thread defers batches instead of writing them.

New metrics, shaped the way a Prometheus timer is (`rate(seconds)/rate(count)` = average):

| Metric | Type | |
|---|---|---|
| `arcadedb_engine_snapshot_barrier_count_total` | counter | t0 barriers executed |
| `arcadedb_engine_snapshot_barrier_seconds_total` | counter | total time spent in them |
| `arcadedb_engine_snapshot_barrier_max_seconds` | gauge | the longest one observed |
| `arcadedb_engine_snapshot_barrier_inexact_total` | counter | barriers that could not prove the pipeline was empty |

The last one should stay at zero: no commit can cause it any more, so a non-zero value means index compaction was feeding the pipeline throughout - harmless for consistency, since those writes go to pages beyond the t0 page count of a file being built, but worth being able to see.

## 3. `/checksums` validates the database name before taking its branch

`SnapshotHttpHandler` dispatched the `/checksums` sub-path *before* the block rejecting `..`, separators, NUL and non-ASCII. Not exploitable - the checksums path gates on `existsDatabase`, an exact-match lookup over the already-open databases - but the guarantee lived two calls away from the handler that needed it. The decision is now one testable `resolveRoute()`: strip the sub-path, validate, then choose the branch. A malformed name answers 400 on both routes, which `PluginApiSpec` documents.

## 4. The unused checksum diff is gone

`SnapshotManager.findDifferingFiles()` was called from nothing but its own unit test, while its presence - and the `/checksums` description - suggested resync could ship only what changed. Removed rather than wired in, for two reasons. **Granularity:** an ArcadeDB database is usually dominated by one bucket file, so a whole-file comparison saves nothing the moment a single byte of it changes. **Consistency:** the checksums come from one point-in-time window and the ZIP from another, so a file that matched when it was compared can be rewritten before the transfer starts, and a follower that kept its local copy on the strength of that match would hold a database torn across two instants. Incremental resync belongs at the **page** level, on the page-version manifest of phase 3 (#6115), where both halves come from the same window. `/checksums` is documented as what it is: an operator diagnostic.

## Tests

New `Issue6125SnapshotBarrierAndCapTest` (engine) and `Issue6125SnapshotRouteValidationTest` (ha-raft).

The barrier test that earns its keep is `publicationCannotReachTheFlushPipelineWhileThePageManagerLockIsHeld`: it publishes a real bucket page from a second thread while the test holds the page-manager lock, and asserts it neither completes nor reaches the flush pipeline - then that releasing the lock lets the very same publication through, so it cannot pass vacuously. **Mutation-checked**: moving the enqueue out from under that lock turns it red. A whole-transaction version of the same test would have passed either way, because `updatePages` takes the same lock in its validation half.

The end-to-end guard (`theLastCommitBeforeTheBarrierIsAlwaysInThePointInTimeImage`) commits a marker record with four writer threads hammering around it, opens a window with no pause, and searches the point-in-time image of every page file for the marker's bytes - plus asserts no barrier reported itself inexact. It is honest about being the integration guard rather than the proof: the race the retry loop used to lose is a microsecond-wide window that cannot be provoked on demand.

Also covered: the automatic cap equals the t0 page-file size and is not the old flat 1 GB; an explicit value is still absolute MB and `0` still uncapped; the shadow spills into the configured directory, leaves nothing in the database directory, and cleans up on close; a cap breach counts as overflowed and not as failed.

Run green: 192 engine `com.arcadedb.engine.*Test`, the ha-raft snapshot unit tests, `PluginApiSpecTest` / `EngineMetricsBinderTest`, `Issue6075SnapshotBackupIT` (4/4) and `RaftFullSnapshotResyncIT` (1/1).
