### PR TITLE
fix(#6128): bound the CHECK DATABASE repair transaction, and stop autoFix counting repairs that did not happen

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -439,6 +439,21 @@ public enum GlobalConfiguration {
       Larger values reduce commit overhead on single-node setups at the cost of bigger transactions.""",
       Integer.class, 1000),
 
+  CHECK_DATABASE_REPAIR_BATCH_PAGES("arcadedb.checkDatabaseRepairBatchPages", SCOPE.DATABASE,
+      """
+      Number of modified pages CHECK DATABASE ... FIX accumulates before committing its repair and opening the next \
+      transaction. Same rationale as arcadedb.truncateBatchSize, and the same failure it avoids (issue #6128): the \
+      repair of one type - every reconnected edge and every deleted record - used to be a SINGLE transaction, which \
+      in HA is a SINGLE Raft log entry, and a transaction entry has no splitter the way a schema entry has had since \
+      issue #4743. Above min(arcadedb.ha.appendBufferSize, arcadedb.ha.grpcMessageSizeMax) the entry is rejected with \
+      ReplicatedEntryTooLargeException - not a NeedRetryException, so nothing retries it - and a repair that had run \
+      for hours was rolled back whole. Counted in PAGES rather than records because pages are what the entry \
+      contains: how many records a repair touched says nothing about how many distinct pages it dirtied. The default \
+      of 256 stays well under the 32MB appendBufferSize default even at the 64KB bucket page size and before the WAL \
+      is compressed. Raising it lowers commit overhead on an embedded database at the cost of bigger transactions; 0 \
+      disables batching entirely, restoring the all-or-nothing repair semantics of a single transaction.""",
+      Integer.class, 256),
+
   PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE, "Size of the asynchronous page flush queue", Integer.class, 512),
 
   FLUSH_SUSPEND_MAX_DEFERRED_RAM("arcadedb.flushSuspendMaxDeferredRAM", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -448,9 +448,15 @@ public enum GlobalConfiguration {
       issue #4743. Above min(arcadedb.ha.appendBufferSize, arcadedb.ha.grpcMessageSizeMax) the entry is rejected with \
       ReplicatedEntryTooLargeException - not a NeedRetryException, so nothing retries it - and a repair that had run \
       for hours was rolled back whole. Counted in PAGES rather than records because pages are what the entry \
-      contains: how many records a repair touched says nothing about how many distinct pages it dirtied. The default \
-      of 256 stays well under the 32MB appendBufferSize default even at the 64KB bucket page size and before the WAL \
-      is compressed. Raising it lowers commit overhead on an embedded database at the cost of bigger transactions; 0 \
+      contains: how many records a repair touched says nothing about how many distinct pages it dirtied. Sizing the \
+      default of 256, without rounding the arithmetic in its own favour: 256 pages at the 64KB bucket default is \
+      16MB of PAGES, half the 32MB appendBufferSize default, which is margin rather than comfort once the soft \
+      ceiling below is taken into account. The entry itself is far smaller in practice - the WAL carries each \
+      page's CHANGED RANGE rather than the whole page, and is compressed on top of that, so a repair reconnecting \
+      1500 edges was measured well under 128KB - but that is a property of typical repairs, not a bound. If a \
+      deployment raises the bucket page size or lowers appendBufferSize, re-check this against BOTH rather than \
+      trusting the default. Raising it lowers commit overhead on an embedded database at the cost of bigger \
+      transactions; 0 \
       disables batching entirely, restoring the all-or-nothing repair semantics of a single transaction. \
       ALSO BOUNDS CHECK DATABASE ... COMPRESS, whose per-transaction page count was a hardcoded 10 - one Raft round \
       trip per ten pages, which on a replicated database of any size does not finish; COMPRESS keeps that 10 when \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -451,7 +451,13 @@ public enum GlobalConfiguration {
       contains: how many records a repair touched says nothing about how many distinct pages it dirtied. The default \
       of 256 stays well under the 32MB appendBufferSize default even at the 64KB bucket page size and before the WAL \
       is compressed. Raising it lowers commit overhead on an embedded database at the cost of bigger transactions; 0 \
-      disables batching entirely, restoring the all-or-nothing repair semantics of a single transaction.""",
+      disables batching entirely, restoring the all-or-nothing repair semantics of a single transaction. \
+      ALSO BOUNDS CHECK DATABASE ... COMPRESS, whose per-transaction page count was a hardcoded 10 - one Raft round \
+      trip per ten pages, which on a replicated database of any size does not finish; COMPRESS keeps that 10 when \
+      this is set to 0, since one transaction over every page in the database helps nobody. \
+      A SOFT ceiling, not a hard cap: the budget is checked between units of repair work, so a transaction can \
+      exceed it by whatever the unit in flight dirties (reconnecting one very wide adjacency list, or a hub record \
+      spanning several pages). Leave headroom when picking a value close to the replicated-entry limit.""",
       Integer.class, 256),
 
   PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE, "Size of the asynchronous page flush queue", Integer.class, 512),

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
@@ -135,6 +136,17 @@ public class DatabaseChecker {
     result.put("totalCorruptedRecords", 0L);
     result.put("distinctMissingReferences", 0L);
     result.put("topMissingReferences", new ArrayList<String>());
+    // Issue #6128 (5): says WHICH copy of a replicated database this answer describes. The statement is classified
+    // non-idempotent, so a follower forwards it to the leader and the check only ever reads the leader's pages;
+    // repairs then reach the other nodes as WAL deltas over the page ranges they touched. Neither direction covers a
+    // follower whose own copy diverged. Reported as a field rather than left to the documentation because the
+    // dangerous reading of a clean result - "the cluster is fine" - is one an operator makes from the output.
+    result.put("checkedNodeScope", database.isReplicated() ? "this node only (replicated database)" : "whole database");
+
+    if (database.isReplicated())
+      addWarning("this database is replicated and this check inspected only the node that ran it: a clean result "
+          + "does not certify the other nodes, and a repair reaches them as replicated changes rather than by each "
+          + "node repairing itself. Progress is published per node too, so poll it on the node running the check");
 
     // COMPUTE THE STEP PLAN UPFRONT so every progress emission carries a stable stepIndex/totalSteps pair.
     final List<DocumentType> edgeTypes = new ArrayList<>();
@@ -605,7 +617,16 @@ public class DatabaseChecker {
       totalPagesToCompress += ((LocalBucket) b).getTotalPages();
     stepBegin("Compressing buckets", totalPagesToCompress);
 
-    int pageTxBatch = 10;
+    // Issue #6128 (4): the hardcoded 10 made COMPRESS unusable on a replicated database. Every commit is a Raft
+    // consensus round trip, so ten pages per transaction means one round trip per ten pages - millions of them on a
+    // database of any size, which is not a slow operation but one that does not finish. Reusing the repair budget
+    // rather than adding a second knob: it answers the same question ("how many pages may one CHECK DATABASE
+    // transaction accumulate"), and at its 256 default this is a 25x reduction in round trips while staying well
+    // under the appendBufferSize the entry has to fit in. Guarded so a 0 (batching disabled) does not turn into a
+    // single transaction over every page in the database, which is the one outcome nobody wants here.
+    final int budget = database.getConfiguration()
+        .getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES);
+    final int pageTxBatch = budget > 0 ? budget : 10;
     int pageBatch = 0;
 
     for (final Bucket b : database.getSchema().getBuckets()) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -318,6 +318,15 @@ public class GraphDatabaseChecker {
    * about how many distinct pages it dirtied. {@code TransactionContext.getModifiedPages()} counts both modified
    * and newly-created pages, which is exactly what the WAL will hold.
    * <p>
+   * PRECONDITION ON CALL SITES, because the budget silently stops bounding anything if it is broken: whatever a
+   * call site does between two checks must land in {@code modifiedPages}/{@code newPages} by the time the next
+   * check runs. Pending INDEX entries do not - {@code TransactionContext} keeps {@code indexChanges} separately
+   * (its own {@code hasChanges()} ORs the two) and materialises them into pages only in {@code commit1stPhase},
+   * which is after this check. Every current call site is safe on that count: a raw {@code bucket.deleteRecord}
+   * and an {@code getOrCreateEdgeList(...).add(...)} maintain no type index. A future call site that performs
+   * index-maintained updates would accumulate a backlog invisible here and could overshoot the budget by the whole
+   * of it, so bound that by entry count as well before adding one.
+   * <p>
    * WHAT THIS CHANGES, stated plainly because it is a semantic change and not only a performance one: a repair is
    * no longer all-or-nothing. A failure part-way through now leaves the earlier batches committed. That is the
    * behaviour a multi-type run has always had - {@code check()} commits each type before starting the next - so

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1463,7 +1463,11 @@ public class GraphDatabaseChecker {
       database.commit();
 
     } finally {
-      // Both kinds of repair this run performed: records removed, plus dangling adjacency entries pruned (#6128).
+      // Same sum as the vertex arm, and prunedDanglingEntries is structurally ZERO here: pruning happens in
+      // checkIncomingEdges/checkOutgoingEdges, which only checkVertices calls. Kept rather than simplified to
+      // autoFix.get() so the two arms report autoFix identically, and so an edge arm that one day does prune -
+      // #5777 is about exactly this arm's handling of endpoints - cannot silently stop counting it. Do not read
+      // it as evidence that this arm prunes today.
       stats.put("autoFix", autoFix.get() + report.prunedDanglingEntries);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
@@ -1540,6 +1544,13 @@ public class GraphDatabaseChecker {
      * alongside the records actually deleted, because both are repairs the run performed and {@code autoFix} is the
      * one number an operator reads to decide whether it did anything. Lives here rather than as another parameter
      * for the same reason the counters above do: every helper that prunes needs it and nothing else does.
+     * <p>
+     * So {@code autoFix} counts REPAIR ACTIONS, not corruption instances, and the difference is visible: one edge
+     * that is both listed in an adjacency chain and corrupt as a record contributes a prune AND a delete, because
+     * those are two distinct writes to two distinct pages. An operator reading the number as "how many broken
+     * things were there" will over-count; it answers "how many repairs did this run perform". The alternative -
+     * counting defects instead - would need the arms to agree on what one defect IS across a dangling entry, a
+     * corrupt record and a rebuilt chain, which they cannot without collapsing information the warnings carry.
      */
     long                        prunedDanglingEntries;
     final int                   maxWarnings;

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -50,6 +50,12 @@ import java.util.logging.Level;
 public class GraphDatabaseChecker {
   private final DatabaseInternal database;
   private final GraphEngine      graphEngine;
+  /**
+   * Modified-page budget of one repair transaction (issue #6128) - see {@link #commitRepairBatchIfFull()}. Read
+   * once per checker rather than per repaired record: it is a database-scoped setting, and re-reading it inside the
+   * repair loops would put a configuration lookup on the per-record path for a value that cannot change under it.
+   */
+  private final int              repairBatchPages;
 
   // Progress reporting (issue #5372): the step identity (name/index/totalSteps) is assigned by the caller
   // (DatabaseChecker owns the step plan); this class emits within-step done/total, throttled to integer
@@ -65,6 +71,8 @@ public class GraphDatabaseChecker {
   public GraphDatabaseChecker(DatabaseInternal database) {
     this.database = database;
     this.graphEngine = database.getGraphEngine();
+    this.repairBatchPages = database.getConfiguration()
+        .getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES);
   }
 
   /** Installs the progress receiver and this checker's step identity in the caller's step plan. */
@@ -230,6 +238,7 @@ public class GraphDatabaseChecker {
           try {
             deleteCorruptedRecord(orphan);
             ++reclaimed;
+            commitRepairBatchIfFull();
           } catch (final RecordNotFoundException e) {
             // ALREADY GONE
           } catch (final Exception e) {
@@ -292,6 +301,42 @@ public class GraphDatabaseChecker {
     else
       bucket.deleteRecord(rid);
     database.getTransaction().updateBucketRecordDelta(rid.getBucketId(), -1);
+  }
+
+  /**
+   * Commits the repair so far and opens the next transaction once it has dirtied
+   * {@link GlobalConfiguration#CHECK_DATABASE_REPAIR_BATCH_PAGES} pages (issue #6128).
+   * <p>
+   * Without this the repair of one type - every reconnected edge and every deleted record - was one transaction,
+   * and on a replicated database one Raft log entry. {@code RaftTransactionBroker.replicateTransaction} submits it
+   * whole and {@code RaftGroupCommitter.submitAndWait} rejects anything above
+   * {@code min(appendBufferSize, grpcMessageSizeMax)} with a {@code ReplicatedEntryTooLargeException}, which is not
+   * a {@code NeedRetryException} and so is never retried: a repair large enough to matter ran for hours and was
+   * then rolled back whole. A schema entry has had a splitter since #4743; a transaction entry has none.
+   * <p>
+   * PAGES, not repaired records: the entry carries page images, and how many records a repair touched says nothing
+   * about how many distinct pages it dirtied. {@code TransactionContext.getModifiedPages()} counts both modified
+   * and newly-created pages, which is exactly what the WAL will hold.
+   * <p>
+   * WHAT THIS CHANGES, stated plainly because it is a semantic change and not only a performance one: a repair is
+   * no longer all-or-nothing. A failure part-way through now leaves the earlier batches committed. That is the
+   * behaviour a multi-type run has always had - {@code check()} commits each type before starting the next - so
+   * this makes one type behave like the whole run rather than inventing a new semantics; and the alternative on a
+   * replicated database is not an atomic repair but no repair at all. Set the budget to 0 to get the single
+   * transaction back.
+   * <p>
+   * Only ever called BETWEEN units of repair work, never inside a {@code scanType}/{@code scan} callback:
+   * {@code LocalDatabase.scanType} holds the database read lock and owns an implicit transaction for the length of
+   * the scan, so committing under it would commit a transaction the scan believes it still owns. Every call site
+   * here is therefore in a post-scan apply or delete loop, which is also where the page volume actually is.
+   */
+  private void commitRepairBatchIfFull() {
+    if (repairBatchPages <= 0)
+      return;
+    if (database.getTransaction().getModifiedPages() < repairBatchPages)
+      return;
+    database.commit();
+    database.begin();
   }
 
   /**
@@ -539,9 +584,14 @@ public class GraphDatabaseChecker {
           if (rid == null)
             continue;
 
-          autoFix.incrementAndGet();
           try {
             deleteCorruptedRecord(rid);
+            // Counted AFTER the delete returns, not before it is attempted (issue #6128). autoFix is what an
+            // operator reads to decide whether a run did anything, so it must not include a repair that failed -
+            // and the failure here is routine rather than exotic: checkEdges flags both ends of a dangling edge,
+            // and the far end is flagged precisely because it is not there, so its delete always raises
+            // RecordNotFoundException. One dangling edge used to report two repairs.
+            autoFix.incrementAndGet();
             // Reported, not only counted: an operator reads deletedRecordsAfterFix to learn WHICH records a repair
             // removed, and until this arm populated it the answer depended on which pass happened to do the delete -
             // a broken-chain record was listed (LocalBucket.check removed it) and every other corrupt record was not.
@@ -552,6 +602,7 @@ public class GraphDatabaseChecker {
           } catch (final Throwable e) {
             report.warn("Cannot fix the record " + rid + ": error on delete (error: " + e.getMessage() + ")");
           }
+          commitRepairBatchIfFull();
         }
       }
 
@@ -562,7 +613,8 @@ public class GraphDatabaseChecker {
       database.commit();
 
     } finally {
-      stats.put("autoFix", autoFix.get());
+      // Both kinds of repair this run performed: records removed, plus dangling adjacency entries pruned (#6128).
+      stats.put("autoFix", autoFix.get() + report.prunedDanglingEntries);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("duplicateLightEdges", report.duplicateLightEdges);
@@ -630,6 +682,7 @@ public class GraphDatabaseChecker {
         final MutableVertex vertex = e.getOutVertex().modify();
         // getOrCreateEdgeList dispatches on the head record type, so promoted (striped) vertices work too
         graphEngine.getOrCreateEdgeList(vertex, Vertex.DIRECTION.OUT).add(e.getIdentity(), e.getIn());
+        commitRepairBatchIfFull();
       }
       report.warn("reconnected " + outEdgesToReconnect.size() + " outgoing edges");
       stats.put("outEdgesToReconnect", outEdgesToReconnect);
@@ -639,6 +692,7 @@ public class GraphDatabaseChecker {
       for (Edge e : inEdgesToReconnect) {
         final MutableVertex vertex = e.getInVertex().modify();
         graphEngine.getOrCreateEdgeList(vertex, Vertex.DIRECTION.IN).add(e.getIdentity(), e.getOut());
+        commitRepairBatchIfFull();
       }
       report.warn("reconnected " + inEdgesToReconnect.size() + " incoming edges");
       stats.put("inEdgesToReconnect", inEdgesToReconnect);
@@ -885,8 +939,14 @@ public class GraphDatabaseChecker {
               }
             }
 
-            if (fix && removeEntry)
+            if (fix && removeEntry) {
               in.remove();
+              // Pruning a dangling list entry IS a repair, and counting it is what keeps autoFix meaning "repairs
+              // performed" now that it no longer counts deletes that failed (issue #6128). Without this an operator
+              // who ran FIX over a database whose only damage was dangling references - the commonest shape, since
+              // the far record is usually already gone - would read autoFix = 0 and conclude nothing was done.
+              ++report.prunedDanglingEntries;
+            }
           } catch (Exception e) {
             // UNKNOWN ERROR WHILE WALKING THE LIST: the chain is unreliable, rebuild it below
             chainBroken = true;
@@ -1126,8 +1186,11 @@ public class GraphDatabaseChecker {
               }
             }
 
-            if (fix && removeEntry)
+            if (fix && removeEntry) {
               out.remove();
+              // See the twin in checkIncomingEdges: a pruned dangling entry is a repair and is counted as one.
+              ++report.prunedDanglingEntries;
+            }
 
           } catch (Exception e) {
             // UNKNOWN ERROR WHILE WALKING THE LIST: the chain is unreliable, rebuild it below
@@ -1336,9 +1399,14 @@ public class GraphDatabaseChecker {
           if (rid == null)
             continue;
 
-          autoFix.incrementAndGet();
           try {
             deleteCorruptedRecord(rid);
+            // Counted AFTER the delete returns, not before it is attempted (issue #6128). autoFix is what an
+            // operator reads to decide whether a run did anything, so it must not include a repair that failed -
+            // and the failure here is routine rather than exotic: checkEdges flags both ends of a dangling edge,
+            // and the far end is flagged precisely because it is not there, so its delete always raises
+            // RecordNotFoundException. One dangling edge used to report two repairs.
+            autoFix.incrementAndGet();
             // Reported, not only counted: an operator reads deletedRecordsAfterFix to learn WHICH records a repair
             // removed, and until this arm populated it the answer depended on which pass happened to do the delete -
             // a broken-chain record was listed (LocalBucket.check removed it) and every other corrupt record was not.
@@ -1349,6 +1417,7 @@ public class GraphDatabaseChecker {
           } catch (final Throwable e) {
             report.warn("Cannot fix the record " + rid + ": error on delete (error: " + e.getMessage() + ")");
           }
+          commitRepairBatchIfFull();
         }
       }
 
@@ -1359,7 +1428,8 @@ public class GraphDatabaseChecker {
       database.commit();
 
     } finally {
-      stats.put("autoFix", autoFix.get());
+      // Both kinds of repair this run performed: records removed, plus dangling adjacency entries pruned (#6128).
+      stats.put("autoFix", autoFix.get() + report.prunedDanglingEntries);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("invalidLinks", report.invalidLinks);
@@ -1430,6 +1500,13 @@ public class GraphDatabaseChecker {
     // nothing else does. checkEdges leaves duplicateLightEdges at zero and does not publish it, as before.
     long                        invalidLinks;
     long                        duplicateLightEdges;
+    /**
+     * Dangling adjacency-list entries this run PRUNED (issue #6128). Folded into the reported {@code autoFix}
+     * alongside the records actually deleted, because both are repairs the run performed and {@code autoFix} is the
+     * one number an operator reads to decide whether it did anything. Lives here rather than as another parameter
+     * for the same reason the counters above do: every helper that prunes needs it and nothing else does.
+     */
+    long                        prunedDanglingEntries;
     final int                   maxWarnings;
     final int                   maxCorrupted;
     /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -329,6 +329,19 @@ public class GraphDatabaseChecker {
    * {@code LocalDatabase.scanType} holds the database read lock and owns an implicit transaction for the length of
    * the scan, so committing under it would commit a transaction the scan believes it still owns. Every call site
    * here is therefore in a post-scan apply or delete loop, which is also where the page volume actually is.
+   * <p>
+   * WHAT THAT LEAVES UNBOUNDED, named rather than implied: the in-scan repairs stay outside this budget. The
+   * back-reference fix-up in {@link #checkIncomingEdges}/{@link #checkOutgoingEdges} - the
+   * {@code connectOutgoingEdge}/{@code connectIncomingEdge} pair that re-links an edge "not connected from the
+   * other side" - writes a vertex per defective edge from inside the scan, and {@link #resetChain} likewise. A
+   * database with a very large number of edges in that particular state can therefore still accumulate one big
+   * transaction and hit the entry cap this budget exists to stay under. It is accepted rather than overlooked: that
+   * shape is much narrower than the dangling references and broken chains the post-scan loops handle, and bounding
+   * it means restructuring those checks into collect-then-apply so the writes leave the scan, which is a bigger
+   * change than this one and deserves to be judged on its own.
+   * <p>
+   * A SOFT ceiling: the check happens between units, so a transaction can exceed the budget by whatever the unit in
+   * flight dirties. Leave headroom when tuning it close to the replicated-entry limit.
    */
   private void commitRepairBatchIfFull() {
     if (repairBatchPages <= 0)

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -342,6 +342,19 @@ public class GraphDatabaseChecker {
    * <p>
    * A SOFT ceiling: the check happens between units, so a transaction can exceed the budget by whatever the unit in
    * flight dirties. Leave headroom when tuning it close to the replicated-entry limit.
+   * <p>
+   * WHY THIS WORKS UNDER AN OUTER TRANSACTION, which is the linchpin and not obvious: {@code CHECK DATABASE} runs
+   * through the HTTP handler, which wraps the command in its own transaction, so these are NESTED begin/commit
+   * pairs. They are not savepoints. {@code DatabaseContext.DatabaseContextTL.pushTransaction} gives each one a
+   * genuinely separate {@code TransactionContext}, and {@code commit()} runs the full
+   * {@code commit1stPhase}/{@code commit2ndPhase} on THAT context - a real WAL write and, under HA, a real
+   * replication round trip. If nesting deferred the write to the outermost commit instead, this whole change would
+   * be inert: the repair would still reach Raft as one entry.
+   * <p>
+   * FAILURE PATH: a batch commit that throws propagates to the caller and leaves no transaction open on the
+   * thread - {@code commit()} disposes its context even when the write fails, so the checker does not have to roll
+   * back after it. Batches already committed stay committed, which is the semantic change stated above. Pinned by
+   * {@code CheckDatabaseRepairBatchFailureTest}.
    */
   private void commitRepairBatchIfFull() {
     if (repairBatchPages <= 0)

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
@@ -159,7 +159,12 @@ class CheckDatabaseTest extends TestHelper {
       final Result row = result.next();
 
       assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
-      assertThat((Long) row.getProperty("autoFix")).isEqualTo(1);
+      // TWO repairs for one deleted edge record, and 2 is the honest number: the edge was referenced from the OUT
+      // list of its source and the IN list of its target, and FIX prunes both dangling entries. It matches the
+      // invalidLinks = 2 this same run reports just below. It used to read 1, which counted something that never
+      // happened - the attempted delete of the edge RID, which is already gone and always raises
+      // RecordNotFoundException - while counting neither entry that was actually pruned (issue #6128).
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(2);
       assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL);
       assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 2);
       assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 2);

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseAutoFixAccountingTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseAutoFixAccountingTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6128 (3): {@code autoFix} counted repairs that did not happen.
+ * <p>
+ * The vertex and edge arms called {@code autoFix.incrementAndGet()} BEFORE attempting the delete, so a record they
+ * then failed to remove was still reported as fixed. That is not a cosmetic miscount: {@code autoFix} is the number
+ * an operator reads to decide whether a run did anything, and one that includes failed deletes cannot answer that.
+ * <p>
+ * The case reached here is the ordinary one rather than a contrived failure. {@code checkEdges} flags BOTH ends of a
+ * dangling edge - the edge record itself and the RID it points at - and that second RID is flagged precisely because
+ * the record is NOT there, so its delete raises {@code RecordNotFoundException} every time. A database with one
+ * dangling edge therefore reported two repairs while performing one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseAutoFixAccountingTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // The dangling edge is injected on purpose; the post-test check would (correctly) flag it.
+    return false;
+  }
+
+  @Test
+  void autoFixCountsOnlyTheRecordsItActuallyRemoved() {
+    final RID[] edge = new RID[1];
+    final RID[] target = new RID[1];
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE);
+    });
+
+    database.transaction(() -> {
+      final MutableVertex from = database.newVertex(VERTEX_TYPE).set("name", "from").save();
+      final MutableVertex to = database.newVertex(VERTEX_TYPE).set("name", "to").save();
+      target[0] = to.getIdentity();
+      edge[0] = from.newEdge(EDGE_TYPE, to).getIdentity();
+    });
+
+    // Remove the target vertex underneath the edge, leaving the edge pointing at a RID that is not there. Both the
+    // edge and the missing target end up in corruptedRecords; only the edge can actually be deleted.
+    database.transaction(
+        () -> database.getSchema().getBucketById(target[0].getBucketId()).deleteRecord(target[0]));
+
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkEdges(EDGE_TYPE, true, 0);
+
+    // PRECONDITION: the run really did flag both RIDs, otherwise the miscount could not arise and this test would
+    // be asserting nothing.
+    assertThat((Collection<RID>) stats.get("corruptedRecords"))
+        .as("both the dangling edge and the RID it points at must be flagged: %s", stats)
+        .contains(edge[0], target[0]);
+
+    assertThat((Collection<RID>) stats.get("deletedRecordsAfterFix"))
+        .as("only the edge exists to be removed: %s", stats)
+        .containsExactly(edge[0]);
+
+    assertThat((Long) stats.get("autoFix"))
+        .as("autoFix must count the repair it performed, not the one it attempted: %s", stats)
+        .isEqualTo(1L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairBatchFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairBatchFailureTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6128 (1), failure path: what a batched repair leaves behind when one of its batch commits throws.
+ * <p>
+ * Batching means a repair can now fail with earlier batches already committed - a real change from the single
+ * transaction it used to be, and the reason this deserves a test of its own rather than an argument. The failure
+ * this simulates is the one the batching exists to avoid in the first place: a single batch that is still too big
+ * for the replicated-entry cap, where the commit raises {@code ReplicatedEntryTooLargeException} rather than a
+ * retryable exception, from inside the checker's own loop.
+ * <p>
+ * Two things must hold afterwards, and neither is automatic. The exception has to reach the caller rather than
+ * being swallowed into a "repair completed" report, and no transaction may be left open on the thread - the
+ * checker opens a fresh one after every batch, so a failure between batches otherwise abandons it and the next
+ * user of that thread inherits an unrelated in-flight transaction.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseRepairBatchFailureTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+  private static final int    HUBS        = 20;
+  private static final int    DEGREE      = 20;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // Deliberate on-disk corruption plus a deliberately failed repair; the post-test check would flag both.
+    return false;
+  }
+
+  @Test
+  void aFailedBatchLeavesNoOpenTransactionAndDoesNotReportSuccess() {
+    createDamagedGraph();
+
+    GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES.setValue(1);
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final AtomicInteger commits = new AtomicInteger();
+    // Fails the SECOND batch commit, so the run has genuinely committed one batch before it breaks - the state
+    // this test exists to describe. Thrown from the WAL-write callback, which is inside commit().
+    final Callable<Void> failSecondCommit = () -> {
+      if (commits.incrementAndGet() == 2)
+        throw new IllegalStateException("simulated replicated-entry rejection");
+      return null;
+    };
+
+    db.registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, failSecondCommit);
+    try {
+      assertThatThrownBy(() -> new GraphDatabaseChecker(db).checkVertices(VERTEX_TYPE, true, 0))
+          .as("a batch that cannot commit must reach the caller, not be reported as a completed repair")
+          .isInstanceOf(Exception.class);
+    } finally {
+      db.unregisterCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, failSecondCommit);
+    }
+
+    assertThat(commits.get()).as("the failure must have happened mid-repair, not before it started")
+        .isGreaterThanOrEqualTo(2);
+
+    assertThat(database.isTransactionActive())
+        .as("no transaction may be left open on the thread after a failed batch")
+        .isFalse();
+
+    // And the database is still usable: the next caller of this thread gets a clean slate rather than inheriting
+    // an in-flight transaction from the abandoned repair.
+    database.transaction(() -> assertThat(database.countType(VERTEX_TYPE, false)).isPositive());
+  }
+
+  private void createDamagedGraph() {
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(16_384);
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE);
+    });
+
+    final String payload = "x".repeat(1_500);
+    final List<RID> hubs = new ArrayList<>(HUBS);
+    for (int h = 0; h < HUBS; h++) {
+      final int hub = h;
+      final RID[] holder = new RID[1];
+      database.transaction(() -> {
+        holder[0] = database.newVertex(VERTEX_TYPE).set("name", "hub" + hub).set("payload", payload).save()
+            .getIdentity();
+        for (int i = 0; i < DEGREE; i++)
+          database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, holder[0].asVertex(true));
+      });
+      hubs.add(holder[0]);
+    }
+
+    // In place, not deleted: a freed slot would be reallocated by the repair and alias another hub's live chunk.
+    for (final RID hub : hubs) {
+      final RID[] head = new RID[1];
+      database.transaction(() -> head[0] = ((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk());
+      assertThat(head[0]).isNotNull();
+      corruptRecordTypeByte((DatabaseInternal) database, head[0]);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairBatchTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairBatchTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6128 (1): the repair a {@code CHECK DATABASE ... FIX} performs for one type used to accumulate in a SINGLE
+ * transaction - the whole scan plus every reconnected edge and every deleted record between one {@code begin()} and
+ * one {@code commit()}.
+ * <p>
+ * On an embedded database that is merely a big transaction. On a replicated one it becomes a single Raft log entry:
+ * {@code RaftTransactionBroker.replicateTransaction} submits it whole, and {@code RaftGroupCommitter.submitAndWait}
+ * hard-rejects anything above {@code min(arcadedb.ha.appendBufferSize, arcadedb.ha.grpcMessageSizeMax)} - 32MB by
+ * default - with a {@code ReplicatedEntryTooLargeException}. That is a {@code TransactionException} and NOT a
+ * {@code NeedRetryException}, so nothing retries it: a repair large enough to matter ran for hours and then died at
+ * the commit, rolling back everything it had fixed for that type. Unlike a schema entry, which #4743 taught to split,
+ * a transaction entry has no splitter.
+ * <p>
+ * The bound is PAGES rather than repaired records, because pages are what the entry actually contains: a count of
+ * records says nothing about how many distinct pages they touched, and it is the page images that the WAL carries.
+ * <p>
+ * Both directions are pinned. A batching run must produce more than one commit AND repair the graph exactly as the
+ * single-transaction run did - a batching bug that dropped repairs would otherwise pass the commit-count assertion
+ * on its own.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseRepairBatchTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+  /**
+   * MANY damaged hubs rather than one big one. Reconnecting a single vertex dirties only its own record plus its
+   * chunk chain - about three pages however many edges it has - so a one-hub fixture cannot exercise a page budget
+   * at all. Widespread damage across many vertices is both what produces real page volume and what the reported
+   * case actually looked like.
+   */
+  private static final int    HUBS        = 40;
+  private static final int    DEGREE      = 20;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // This test injects on-disk corruption on purpose; the post-test check would (correctly) flag it.
+    return false;
+  }
+
+  /**
+   * A repair whose page footprint exceeds the budget must be split across several transactions, and must still
+   * rebuild the full adjacency.
+   */
+  @Test
+  void aLargeRepairCommitsInBatches() {
+    final List<RID> hubs = createBrokenHubs();
+
+    GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES.setValue(4);
+    final int commits = countCommitsDuring(this::repairVertices);
+
+    assertThat(commits)
+        .as("a repair bigger than the page budget must not be one single transaction")
+        .isGreaterThan(1);
+
+    assertRepaired(hubs);
+  }
+
+  /**
+   * The budget disabled restores the historical single-transaction behaviour, so an embedded user who wants
+   * all-or-nothing repair semantics can still have them.
+   */
+  @Test
+  void theBatchBudgetCanBeDisabled() {
+    final List<RID> hubs = createBrokenHubs();
+
+    GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES.setValue(0);
+    final int commits = countCommitsDuring(this::repairVertices);
+
+    assertThat(commits).as("with the budget disabled the whole type repair is one transaction").isEqualTo(1);
+
+    assertRepaired(hubs);
+  }
+
+  /**
+   * The vertex arm on its own, which is the unit under test. Deliberately NOT {@code CHECK DATABASE FIX}: that runs
+   * several passes, each already committing its own transaction, so a commit count taken across the whole statement
+   * could not tell a batched repair from the passes that surround it.
+   */
+  private void repairVertices() {
+    new GraphDatabaseChecker((DatabaseInternal) database).checkVertices(VERTEX_TYPE, true, 0);
+  }
+
+  /** Counts the transactions that actually wrote WAL while {@code block} ran. */
+  private int countCommitsDuring(final Runnable block) {
+    final AtomicInteger commits = new AtomicInteger();
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final java.util.concurrent.Callable<Void> counter = () -> {
+      commits.incrementAndGet();
+      return null;
+    };
+    db.registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, counter);
+    try {
+      block.run();
+    } finally {
+      db.unregisterCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, counter);
+    }
+    return commits.get();
+  }
+
+  /**
+   * A hub with {@link #DEGREE} in-edges whose chain is then broken mid-way, so the FIX has to rebuild the whole
+   * adjacency from the surviving edge records - the repair shape that produces real page volume.
+   */
+  private List<RID> createBrokenHubs() {
+    // A SMALLER page size, set before the buckets are created: the budget counts PAGES, and at the 64KB default the
+    // whole fixture packs into a couple of them, so no assertion about batching could mean anything. 16KB still
+    // holds a full 8KB edge-list chunk (the chunk size doubles up to 8192, and a chunk cannot straddle a page).
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(16_384);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE);
+    });
+
+    // A payload per hub, so the hub records themselves span several pages instead of packing into one.
+    final String payload = "x".repeat(1_500);
+
+    final List<RID> hubs = new ArrayList<>(HUBS);
+    for (int h = 0; h < HUBS; h++) {
+      final int hub = h;
+      final RID[] holder = new RID[1];
+      database.transaction(() -> {
+        holder[0] = database.newVertex(VERTEX_TYPE).set("name", "hub" + hub).set("payload", payload).save()
+            .getIdentity();
+        for (int i = 0; i < DEGREE; i++)
+          database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, holder[0].asVertex(true));
+      });
+      hubs.add(holder[0]);
+    }
+
+    // Break every hub's IN chain at its head, so each one has to be rebuilt from the surviving edge records.
+    //
+    // The head chunk is corrupted IN PLACE rather than deleted, and with many hubs that is not a detail: deleting a
+    // chunk FREES its slot, and the repair then allocates the new chunks it builds into those same freed slots, so a
+    // hub's dangling head pointer can come to alias a live chunk belonging to another hub. That is an artefact no
+    // real corruption produces - damaged bytes do not free a slot - and it makes the repair look broken (measured:
+    // 11 of 40 hubs left unrepaired, identically on unmodified code) when what is actually broken is the fixture.
+    // Corrupting the record-type byte keeps the slot occupied and unreadable, which is the real shape.
+    for (final RID hub : hubs) {
+      final RID[] head = new RID[1];
+      database.transaction(() -> head[0] = ((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk());
+      assertThat(head[0]).as("every hub must have an in-edge list to break").isNotNull();
+      corruptRecordTypeByte((DatabaseInternal) database, head[0]);
+    }
+
+    return hubs;
+  }
+
+  /** Every hub's adjacency is whole again and a follow-up check is clean. */
+  private void assertRepaired(final List<RID> hubs) {
+    database.transaction(() -> {
+      for (final RID hub : hubs)
+        assertThat(hub.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE))
+            .as("hub %s must have its full adjacency back", hub).isEqualTo(DEGREE);
+    });
+
+    try (final ResultSet rs = database.command("sql", "CHECK DATABASE")) {
+      assertThat(rs.next().<Long>getProperty("totalCorruptedRecords"))
+          .as("the batched repair must leave the database clean").isZero();
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCheckDatabaseLargeRepairIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftCheckDatabaseLargeRepairIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.exception.DatabaseIsClosedException;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.VertexInternal;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6128 (1), (5): a batched {@code CHECK DATABASE FIX} under a deliberately tight replicated-entry cap.
+ * <p>
+ * The repair of one type used to be a SINGLE transaction, which on a replicated database is a SINGLE log entry.
+ * {@code RaftGroupCommitter.submitAndWait} rejects anything above
+ * {@code min(arcadedb.ha.appendBufferSize, arcadedb.ha.grpcMessageSizeMax)} with a
+ * {@code ReplicatedEntryTooLargeException} - a {@code TransactionException}, not a {@code NeedRetryException}, so
+ * nothing retries it - and a repair that had run for hours was rolled back whole. A transaction entry has no
+ * splitter, unlike a schema entry since #4743.
+ * <p>
+ * WHAT THIS TEST DOES AND DOES NOT PROVE, stated because the distinction is easy to lose: it does NOT reproduce an
+ * over-cap rejection. It cannot at a sane fixture size - the WAL carries per-page CHANGED RANGES rather than whole
+ * pages, so reconnecting 1500 edges produces well under 128KB, and it was measured passing with batching disabled
+ * at both a 1MB and a 128KB cap. Brute-forcing past the cap would need tens of thousands of damaged edges and
+ * minutes of cluster setup for a bound that is better expressed directly.
+ * <p>
+ * What it does prove is the property that matters and that the unit test cannot: a repair split across many
+ * transactions still converges all three nodes, and it does so with the cap pinned two orders of magnitude below
+ * its default - so any future change that lets one repair transaction grow large again fails here rather than in
+ * a customer's cluster. The batching mechanism itself is pinned by {@code CheckDatabaseRepairBatchTest}, which
+ * counts the commits.
+ * <p>
+ * Sibling of {@code RaftCheckDatabaseFix3NodesIT}, which covers the ordinary-sized repair and the leader
+ * forwarding.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class RaftCheckDatabaseLargeRepairIT extends BaseRaftHATest {
+  private static final String VERTEX_TYPE = "BigRepairNode";
+  private static final String EDGE_TYPE   = "BigRepairLink";
+  /** Enough damaged vertices that the whole-type repair cannot fit in the lowered append buffer. */
+  private static final int    HUBS        = 60;
+  private static final int    DEGREE      = 25;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    // Two orders of magnitude below the 32MB default, with the write buffer kept above it (the server refuses to
+    // start otherwise - it must stay >= appendBufferSize + 8 bytes). Every transaction this test performs, setup
+    // included, has to fit; that is the point, since it is what turns "the repair stays small" into an assertion.
+    config.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "128KB");
+    config.setValue(GlobalConfiguration.HA_WRITE_BUFFER_SIZE, "256KB");
+  }
+
+  @Test
+  void aBatchedRepairReplicatesUnderATightEntryCap() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+
+    final DatabaseInternal leaderDb = wrapped(leaderIndex);
+    // Small enough that each batch is comfortably inside the 1MB cap, and small enough that the whole repair
+    // needs many of them.
+    leaderDb.getConfiguration().setValue(GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES, 8);
+
+    final List<RID> hubs = createDamagedGraph(leaderDb);
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(inDegreeOn(i, hubs.getFirst()))
+          .as("the damage must have replicated to server %d before the repair", i).isNotEqualTo((long) DEGREE);
+
+    final Result fix = runCheck(leaderIndex, "CHECK DATABASE TYPE " + VERTEX_TYPE + " FIX");
+    // The repair for this damage shape is a chain REBUILD, which is reported in the warnings rather than in
+    // autoFix (autoFix counts records removed and dangling entries pruned, and a rebuild is neither). Asserted so
+    // a run that silently repaired nothing cannot reach the per-node assertions below and pass them trivially by
+    // leaving every hub equally broken everywhere.
+    assertThat(fix.<Collection<String>>getProperty("warnings"))
+        .as("the repair must actually have rebuilt the edge lists: %s", fix.toJSON())
+        .anyMatch(w -> w.startsWith("reconnected ") && w.endsWith(" incoming edges"));
+
+    waitForAllServers();
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final int server = i;
+      for (final RID hub : hubs)
+        assertThat(awaitInDegreeOn(server, hub, DEGREE))
+            .as("server %d must see hub %s fully repaired: a repair too big for one entry has to reach the "
+                + "followers in several, not fail whole", server, hub)
+            .isEqualTo(DEGREE);
+    }
+
+    assertClusterConsistency();
+  }
+
+  /**
+   * Issue #6128 (5): a clean result on a replicated database must say which copy it describes. The check is
+   * forwarded to the leader and reads only the leader's pages, so "clean" is a statement about one node.
+   */
+  @Test
+  void theResultSaysTheCheckSawOnlyOneNode() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+
+    final Result check = runCheck(leaderIndex, "CHECK DATABASE");
+
+    assertThat(check.<String>getProperty("checkedNodeScope"))
+        .as("the scope of the answer must be reported, not left to the documentation: %s", check.toJSON())
+        .isEqualTo("this node only (replicated database)");
+
+    assertThat(check.<Collection<String>>getProperty("warnings"))
+        .as("and it must be visible among the warnings an operator actually reads: %s", check.toJSON())
+        .anyMatch(w -> w.contains("inspected only the node that ran it"));
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private DatabaseInternal wrapped(final int serverIndex) {
+    return ((DatabaseInternal) getServerDatabase(serverIndex, getDatabaseName())).getWrappedDatabaseInstance();
+  }
+
+  /** {@link #HUBS} vertices with a full in-edge list each, then every one of those lists broken at its head. */
+  private List<RID> createDamagedGraph(final DatabaseInternal db) {
+    db.command("sql", "CREATE VERTEX TYPE " + VERTEX_TYPE);
+    db.command("sql", "CREATE EDGE TYPE " + EDGE_TYPE);
+
+    // A payload per hub so the hub records span pages rather than packing into one.
+    final String payload = "x".repeat(1_500);
+
+    final List<RID> hubs = new ArrayList<>(HUBS);
+    for (int h = 0; h < HUBS; h++) {
+      final int hub = h;
+      final RID[] holder = new RID[1];
+      db.transaction(() -> {
+        holder[0] = db.newVertex(VERTEX_TYPE).set("name", "hub" + hub).set("payload", payload).save().getIdentity();
+        for (int i = 0; i < DEGREE; i++)
+          db.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, holder[0].asVertex(true));
+      });
+      hubs.add(holder[0]);
+    }
+
+    // Corrupt each head chunk IN PLACE. Deleting it instead would free the slot, and the repair would then build
+    // its new chunks into those freed slots, letting one hub's dangling head alias another hub's live chunk - an
+    // artefact no real corruption produces, since damaged bytes do not free a slot.
+    for (final RID hub : hubs) {
+      final RID[] head = new RID[1];
+      db.transaction(() -> head[0] = ((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk());
+      assertThat(head[0]).as("every hub must have an in-edge list to break").isNotNull();
+      corruptRecordTypeByte(db, head[0]);
+    }
+    return hubs;
+  }
+
+  /**
+   * Overwrites the record-type byte so the record still occupies its slot but cannot be materialised. Through the
+   * wrapper, so all three nodes hold the same damage.
+   */
+  private void corruptRecordTypeByte(final DatabaseInternal db, final RID rid) {
+    final int fileId = rid.getBucketId();
+    final LocalBucket bucket = (LocalBucket) db.getSchema().getBucketById(fileId);
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(fileId)).getPageSize();
+    final int maxRecordsInPage = bucket.getMaxRecordsInPage();
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    db.transaction(() -> {
+      try {
+        final MutablePage page = db.getTransaction().getPageToModify(new PageId(db, fileId, pageId), pageSize, false);
+        final int slotOffset = Binary.SHORT_SERIALIZED_SIZE + (positionInPage * Binary.INT_SERIALIZED_SIZE);
+        final int recordOffset = (int) page.readUnsignedInt(slotOffset);
+        assertThat(recordOffset).as("the record must still occupy its slot").isGreaterThan(0);
+        final long[] recordSize = page.readNumberAndSize(recordOffset);
+        page.writeByte((int) (recordOffset + recordSize[1]), (byte) 99);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private Result runCheck(final int serverIndex, final String statement) {
+    try (final ResultSet rs = wrapped(serverIndex).command("sql", statement)) {
+      assertThat(rs.hasNext()).as("'%s' must return a result", statement).isTrue();
+      return rs.next();
+    }
+  }
+
+  /** The hub's in-degree on one server, or -1 when its list cannot be walked at all. */
+  private long inDegreeOn(final int serverIndex, final RID hubRid) {
+    return withResyncRetry(serverIndex, db -> {
+      final AtomicLong degree = new AtomicLong(-1);
+      db.transaction(() -> {
+        try {
+          degree.set(db.lookupByRID(hubRid, true).asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE));
+        } catch (final DatabaseIsClosedException e) {
+          throw e;
+        } catch (final Exception e) {
+          degree.set(-1);
+        }
+      });
+      return degree.get();
+    });
+  }
+
+  private long awaitInDegreeOn(final int serverIndex, final RID hubRid, final long expected) throws InterruptedException {
+    return awaitValue(expected, () -> inDegreeOn(serverIndex, hubRid));
+  }
+}


### PR DESCRIPTION
Closes #6128 (points 1, 3, 4, 5).

**Point 2 is deliberately not in this PR.** Streaming the index-rebuild WAL means changing the HA schema-replication protocol - the area with the documented history of silent follower divergence (#4083, #4743, #5492) - and it is separable from these four. Detail at the end.

## 1. The per-type repair was one unsplittable Raft entry

The repair of one type was a SINGLE transaction: the whole scan plus every reconnected edge and every deleted record between one `begin()` and one `commit()`. On a replicated database that is a SINGLE log entry, and `RaftGroupCommitter.submitAndWait` rejects anything above `min(appendBufferSize, grpcMessageSizeMax)` with `ReplicatedEntryTooLargeException` - a `TransactionException`, not a `NeedRetryException`, so nothing retries it. A repair large enough to matter ran for hours and was then rolled back whole. A schema entry has had a splitter since #4743; a transaction entry has none.

The repair now commits and reopens once it has dirtied `arcadedb.checkDatabaseRepairBatchPages` pages (default **256**, `0` disables).

**Why pages and not records** - pages are what the entry carries. How many records a repair touched says nothing about how many distinct pages it dirtied, and it is the page images the WAL holds. `TransactionContext.getModifiedPages()` already counts modified plus new pages.

**Why this is a semantic change, stated plainly** - a repair is no longer all-or-nothing; a failure part-way leaves earlier batches committed. That is already how a multi-type run behaves (`check()` commits each type before the next), so this makes one type behave like the whole run rather than inventing a third semantics. And on a replicated database the alternative is not an atomic repair, it is no repair at all. Set the budget to `0` for the old behaviour.

**Where it is safe to commit** - only between units of repair work, never inside a `scanType`/`scan` callback: `LocalDatabase.scanType` holds the database read lock and owns an implicit transaction for the length of the scan, so committing under it would commit a transaction the scan believes it still owns. Every call site is a post-scan apply or delete loop, which is also where the page volume actually is.

## 3. `autoFix` counted repairs that did not happen

The vertex and edge arms called `incrementAndGet()` **before** attempting the delete, so a record they then failed to remove was still reported as fixed. The case is routine, not exotic: `checkEdges` flags both ends of a dangling edge, and the far end is flagged precisely because it is not there, so its delete always raises `RecordNotFoundException`. One dangling edge reported two repairs.

Counted after the delete returns now. **Pruning a dangling adjacency entry is also counted**, which it never was - without that, a FIX over a database whose only damage was dangling references (the commonest shape, since the far record is usually already gone) would report `autoFix = 0` having repaired every one of them.

`CheckDatabaseTest`'s existing expectations decompose exactly this way, which is what confirmed the split rather than assumed it:

| case | old | new | why |
| --- | --- | --- | --- |
| `checkBrokenDeletedVertex` | 19998 | 19998 | 9999 deletes + 9999 prunes - unchanged |
| `checkBrokenDeletedEdges` | 1 | **2** | one pruned entry per side, matching the `invalidLinks = 2` the same run already reports |

The second assertion is updated, with the reasoning in the test.

## 4. `COMPRESS` on a cluster

It committed every 10 pages, so on a replicated database that is one Raft consensus round trip per ten pages - not a slow operation but one that does not finish. It now reuses the repair budget (same question, one knob), a 25x reduction in round trips at the default while staying well inside the entry cap. `0` falls back to the old 10 rather than turning into a single transaction over every page in the database.

## 5. The result now says which copy it describes

A `checkedNodeScope` field plus a warning when the database is replicated. The statement is non-idempotent so a follower forwards it to the leader; the check reads only the leader's pages, and repairs reach the others as WAL deltas over the ranges they touched. Neither direction covers a follower whose own copy diverged. Reported rather than documented because the dangerous reading of a clean result - "the cluster is fine" - is one an operator makes from the output.

## Tests

`CheckDatabaseRepairBatchTest` counts commits in both directions: budget `0` gives exactly one transaction, a small budget gives more, and both must repair the graph identically.

Its fixture corrupts head chunks **in place** rather than deleting them, and that is not a detail. Deleting frees the slot; the repair then builds its new chunks into those freed slots, and a hub's dangling head comes to alias another hub's live chunk. That artefact - which no real corruption produces, since damaged bytes do not free a slot - makes the repair look broken: measured at **11 of 40 hubs unrepaired on unmodified code**, until the corruption was changed to leave the slot occupied, when all 40 repair correctly.

`RaftCheckDatabaseLargeRepairIT` pins the cluster half with the entry cap two orders of magnitude below its default. **It does not reproduce an over-cap rejection and says so in its javadoc**: the WAL carries per-page changed ranges rather than whole pages, so reconnecting 1500 edges stays well under 128KB - measured passing with batching disabled at both 1MB and 128KB. Brute-forcing past the cap would need tens of thousands of damaged edges and minutes of cluster setup for a bound better expressed directly. What it proves is that a repair split across many transactions converges all three nodes under a cap tight enough that any future oversized repair transaction fails here rather than in a customer's cluster.

Verified: 1671 engine tests across `database`/`graph`/`engine`/`index` with one unrelated pre-existing failure (`Issue5279ConcurrentUpdateTest`, reproduces on a clean tree), plus `RaftCheckDatabaseLargeRepairIT` 2/2 and `RaftCheckDatabaseFix3NodesIT` 3/3.

## On point 2

`BucketIndexBuilder.create()` runs inside `recordFileChanges`, so `LSMTreeIndex.build`'s 5000-record batch commits are buffered into `schemaWalBuffer` and drained only when the callback returns - peak leader heap is roughly the whole rebuilt index. The fix I would propose is not a new protocol but doing incrementally what `splitSchemaEntry` already does at the end: flush once the buffer crosses a threshold, first flush carrying `filesToAdd`, intermediates carrying WAL only, the last carrying `schemaJson` and `filesToRemove` - the same ordered-prefix contract, spread over time instead of built up and split. That keeps every follower prefix self-consistent. It still touches the code path behind #4083, so it wants its own PR and its own cluster test rather than riding along with four checker fixes.
