### PR TITLE
fix(#6104): reject Windows-illegal characters and reserved device names in bucket names

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -559,6 +559,17 @@ public class LocalSchema implements Schema {
     });
   }
 
+  // The rest of the NTFS/Windows-reserved character set, beyond '/', '\' and '*' which are checked separately
+  // above: '<', '>', ':', '"', '|' and '?'.
+  private static final String WINDOWS_ILLEGAL_CHARS = "<>:\"|?";
+
+  // Windows reserves these as device names for the segment of a file name up to (and not including) the first
+  // dot, regardless of what an extension or further dotted segment says: "CON.txt" is refused exactly like "CON".
+  private static final Set<String> WINDOWS_RESERVED_NAMES = Set.of(//
+      "CON", "PRN", "AUX", "NUL",//
+      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",//
+      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9");
+
   /**
    * A bucket name becomes the last path segment of its component file, so it must address a file inside the
    * database directory and nothing else. A type name reaches the same place already percent-encoded by
@@ -568,6 +579,12 @@ public class LocalSchema implements Schema {
    * Dots inside the name are deliberately allowed: the component-file name is parsed right-to-left, peeling the
    * fixed {@code .fileId.pageSize.vVersion.ext} tail, so a dot in the name survives the round trip. Only a name
    * that is exactly "." or ".." references a directory.
+   * <p>
+   * The remaining checks reject the rest of the NTFS/Windows-illegal character set and the reserved device stems
+   * ({@code CON}, {@code PRN}, {@code AUX}, {@code NUL}, {@code COM1}-{@code COM9}, {@code LPT1}-{@code LPT9}).
+   * Nothing here is a directory-escape concern, since a bucket name is never used as anything but the last path
+   * segment: it is error quality on Windows, turning a raw {@code IOException} out of {@code Files.move}/file
+   * creation into a {@code SchemaException} that names the offending character or stem at validation time.
    */
   public static void checkValidBucketName(final String bucketName) {
     if (bucketName == null || bucketName.isEmpty())
@@ -579,6 +596,18 @@ public class LocalSchema implements Schema {
     // '*' is left untouched by URLEncoder and is not a legal file name character on Windows.
     if (bucketName.indexOf('*') > -1)
       throw new SchemaException("Invalid bucket name '" + bucketName + "': it cannot contain '*'");
+
+    for (int i = 0; i < bucketName.length(); ++i) {
+      final char c = bucketName.charAt(i);
+      if (c < 0x20 || WINDOWS_ILLEGAL_CHARS.indexOf(c) > -1)
+        throw new SchemaException(
+            "Invalid bucket name '" + bucketName + "': it cannot contain the character '" + c + "' (illegal on Windows)");
+    }
+
+    final int firstDot = bucketName.indexOf('.');
+    final String stem = firstDot > -1 ? bucketName.substring(0, firstDot) : bucketName;
+    if (WINDOWS_RESERVED_NAMES.contains(stem.toUpperCase(Locale.ROOT)))
+      throw new SchemaException("Invalid bucket name '" + bucketName + "': '" + stem + "' is a reserved device name on Windows");
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -95,6 +95,18 @@ public class LocalSchema implements Schema {
   public static final String                                 CACHED_COUNT_FILE_NAME_LEGACY = "cached-count.json"; // DEPRECATED FROM v25.2.1
   public static final String                                 STATISTICS_FILE_NAME          = "statistics.json";
   public static final int                                    BUILD_TX_BATCH_SIZE           = 100_000;
+
+  // The rest of the NTFS/Windows-reserved character set beyond '/', '\' and '*', which checkValidBucketName()
+  // checks separately: '<', '>', ':', '"', '|' and '?'.
+  private static final String                                WINDOWS_ILLEGAL_CHARS         = "<>:\"|?";
+
+  // Windows reserves these as device names for the segment of a file name up to (and not including) the first
+  // dot, regardless of what an extension or further dotted segment says: "CON.txt" is refused exactly like "CON".
+  private static final Set<String>                           WINDOWS_RESERVED_NAMES        = Set.of(//
+      "CON", "PRN", "AUX", "NUL",//
+      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",//
+      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9");
+
   final               IndexFactory                           indexFactory                  = new IndexFactory();
   final               Map<String, LocalDocumentType>         types                         = new ConcurrentHashMap<>();
   private             String                                 encoding                      = DEFAULT_ENCODING;
@@ -559,17 +571,6 @@ public class LocalSchema implements Schema {
     });
   }
 
-  // The rest of the NTFS/Windows-reserved character set, beyond '/', '\' and '*' which are checked separately
-  // above: '<', '>', ':', '"', '|' and '?'.
-  private static final String WINDOWS_ILLEGAL_CHARS = "<>:\"|?";
-
-  // Windows reserves these as device names for the segment of a file name up to (and not including) the first
-  // dot, regardless of what an extension or further dotted segment says: "CON.txt" is refused exactly like "CON".
-  private static final Set<String> WINDOWS_RESERVED_NAMES = Set.of(//
-      "CON", "PRN", "AUX", "NUL",//
-      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",//
-      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9");
-
   /**
    * A bucket name becomes the last path segment of its component file, so it must address a file inside the
    * database directory and nothing else. A type name reaches the same place already percent-encoded by
@@ -599,9 +600,13 @@ public class LocalSchema implements Schema {
 
     for (int i = 0; i < bucketName.length(); ++i) {
       final char c = bucketName.charAt(i);
-      if (c < 0x20 || WINDOWS_ILLEGAL_CHARS.indexOf(c) > -1)
+      if (c < 0x20 || WINDOWS_ILLEGAL_CHARS.indexOf(c) > -1) {
+        // A control character is not printable, so render it as \\uXXXX to keep the exception message and any
+        // log it lands in readable.
+        final String printableChar = c < 0x20 ? String.format("\\u%04x", (int) c) : String.valueOf(c);
         throw new SchemaException(
-            "Invalid bucket name '" + bucketName + "': it cannot contain the character '" + c + "' (illegal on Windows)");
+            "Invalid bucket name '" + bucketName + "': it cannot contain the character '" + printableChar + "' (illegal on Windows)");
+      }
     }
 
     final int firstDot = bucketName.indexOf('.');

--- a/engine/src/test/java/com/arcadedb/schema/BucketNameValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/BucketNameValidationTest.java
@@ -114,4 +114,42 @@ class BucketNameValidationTest extends TestHelper {
     assertThat(database.getSchema().getType("acme.Customer").getBuckets(false).getFirst().getName())
         .isEqualTo("acme.Customer_0");
   }
+
+  /**
+   * A bucket name is used verbatim as a file name, so any character NTFS/Windows refuses in a file name must be
+   * rejected here too: {@code / \} are already covered as path separators, this covers the rest of the reserved
+   * set (issue #6104).
+   */
+  @Test
+  void createBucketRejectsWindowsIllegalCharacters() {
+    for (final String name : List.of("a<b", "a>b", "a:b", "a\"b", "a|b", "a?b", "a\u0000b", "a\u001fb"))
+      assertThatThrownBy(() -> database.getSchema().createBucket(name))
+          .as("bucket name '%s' must be rejected", name)
+          .isInstanceOf(SchemaException.class);
+  }
+
+  /**
+   * {@code CON}, {@code PRN}, {@code AUX}, {@code NUL}, {@code COM1-9} and {@code LPT1-9} address a reserved
+   * Windows device rather than a regular file, whether or not an extension follows: {@code CON.txt} is refused by
+   * the OS exactly like bare {@code CON} is, because it looks only at the segment before the first dot (#6104).
+   */
+  @Test
+  void createBucketRejectsWindowsReservedDeviceNames() {
+    for (final String name : List.of("CON", "con", "PRN", "AUX", "NUL", "COM1", "com9", "LPT1", "LPT9", "CON.dat", "nul.backup"))
+      assertThatThrownBy(() -> database.getSchema().createBucket(name))
+          .as("bucket name '%s' must be rejected", name)
+          .isInstanceOf(SchemaException.class);
+  }
+
+  /**
+   * A reserved stem is only reserved as the exact segment before the first dot: a name that merely starts with
+   * one, or that contains one as a later dot-separated segment, addresses an ordinary file and must be accepted.
+   */
+  @Test
+  void createBucketAcceptsNamesThatOnlyResembleReservedDeviceNames() {
+    for (final String name : List.of("CONFIG", "console", "NULL", "COM10", "COM0", "LPT10", "a.CON", "Concurrent"))
+      assertThatCode(() -> database.getSchema().createBucket(name))
+          .as("bucket name '%s' must be accepted", name)
+          .doesNotThrowAnyException();
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #6104.

`LocalSchema.checkValidBucketName()` already rejected path separators, the `.`/`..` sentinels and `*`, but let the rest of the NTFS-illegal character set through: `< > : " | ?` and control characters, plus the reserved device stems `CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`, `LPT1`-`LPT9`.

A bucket name is used verbatim as the last path segment of its component file with no percent-encoding, so any of those reached the filesystem unchanged and failed later with a raw `IOException` (out of `Files.move`/file creation) instead of a `SchemaException` naming the offending character at validation time.

- Added the remaining Windows-illegal characters (`< > : " | ?` and control chars `< 0x20`) to the existing per-character check.
- Added a reserved-device-name check: matches Windows semantics precisely by comparing the segment of the name up to (not including) the first `.` against the reserved stems, case-insensitively, so `CON.dat` is rejected exactly like bare `CON`, while `CONFIG` or `a.CON` are accepted.

### Why `Neo4jImporter.validateLabel()` is intentionally untouched

The issue suggested keeping the importer's `validateLabel()` in step. I checked instead of assuming:

- A type name is always run through `FileUtils.encode()` (`URLEncoder`) before it reaches disk, which already turns `< > : " | ?` and control characters into safe `%XX` sequences. `validateLabel()`'s existing checks are deliberately scoped to only the handful of characters/sequences that *survive* that encoding unchanged (`/ \ . .. * ,` and the label separator) - see its own doc comment.
- A type-derived bucket name is always built as `<encodedTypeName>_<index>` (`TypeBuilder.java`), so it can never collide with a bare reserved device name like `CON` - the mandatory `_0` suffix always breaks the match.

So the gap this issue describes only exists on the direct `CREATE BUCKET` path, which is exactly where this fix is applied. Adding the same checks to `validateLabel()` would be dead code for a scenario that structurally cannot happen there.

## Test plan
- [x] New unit tests in `BucketNameValidationTest`: rejects the remaining illegal characters (including control characters), rejects reserved device stems (with and without a following dot, case-insensitively), and accepts names that only resemble a reserved stem (`CONFIG`, `a.CON`, `COM10`, etc.)
- [x] `mvn -pl engine test -Dtest=BucketNameValidationTest` - 8/8 pass
- [x] Full `com.arcadedb.schema.**` package test suite - no regressions (40/40 classes pass)
- [x] `Neo4jImporterLabelCharactersIT` - no regressions (3/3 pass)
- [x] `mvn -pl engine compile` - clean