### PR TITLE
fix(#6135): RETURN * must see variables exported by CALL subquery, WITH and CALL...YIELD

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -1759,50 +1759,118 @@ public class CypherSemanticValidator {
   private void validateReturnStar(final CypherStatement statement) {
     if (statement.getReturnClause() == null)
       return;
-    for (final ReturnClause.ReturnItem item : statement.getReturnClause().getReturnItems()) {
-      if (item.getExpression() instanceof StarExpression ||
-          (item.getExpression() instanceof VariableExpression &&
-              "*".equals(((VariableExpression) item.getExpression()).getVariableName()))) {
-        // RETURN * requires at least one named variable in scope
-        boolean hasNamedVars = false;
-        for (final MatchClause matchClause : statement.getMatchClauses()) {
-          if (matchClause.hasPathPatterns())
-            for (final PathPattern path : matchClause.getPathPatterns()) {
-              for (final NodePattern node : path.getNodes())
-                if (node.getVariable() != null && !node.getVariable().isEmpty()) {
-                  hasNamedVars = true;
-                  break;
-                }
-              if (hasNamedVars)
-                break;
-              for (final RelationshipPattern rel : path.getRelationships())
-                if (rel.getVariable() != null && !rel.getVariable().isEmpty()) {
-                  hasNamedVars = true;
-                  break;
-                }
-              if (hasNamedVars)
-                break;
-              if (path.hasPathVariable()) {
-                hasNamedVars = true;
-                break;
-              }
-            }
-          if (hasNamedVars)
-            break;
+    for (final ReturnClause.ReturnItem item : statement.getReturnClause().getReturnItems())
+      if (isStarItem(item) && !statementDeclaresAnyVariable(statement))
+        throw new CommandParsingException("NoVariablesInScope: RETURN * is not allowed when there are no variables in scope");
+  }
+
+  private static boolean isStarItem(final ReturnClause.ReturnItem item) {
+    return item.getExpression() instanceof StarExpression ||
+        (item.getExpression() instanceof VariableExpression &&
+            "*".equals(((VariableExpression) item.getExpression()).getVariableName()));
+  }
+
+  /**
+   * Whether this statement's own clauses put at least one name into scope - the pool {@code RETURN *} draws from.
+   * Deliberately not the same question as "what is in scope here", which for an {@code EXISTS { } / COUNT { } /
+   * COLLECT { }} body also includes every variable the enclosing row seeds it with ({@link #checkSubqueryExpressionScope}):
+   * a body that does nothing but {@code RETURN *} must still be rejected, exactly as a standalone {@code RETURN *}
+   * is, and is (see {@code CypherSubqueryBodyIssue5656Test#returnStarWithNothingInScopeIsRejectedInsideABodyAsOutsideOne}).
+   * <p>
+   * Before issue #6135 this only looked at the statement's {@code MATCH} patterns and {@code UNWIND} variables, so a
+   * name put into scope any other way - a {@code WITH} projection, a {@code CALL ... YIELD} output, or a variable a
+   * {@code CALL { }} subquery returns - was invisible to it, and {@code RETURN *} was rejected even though the
+   * executor would have projected the name correctly had it been allowed to run.
+   */
+  private static boolean statementDeclaresAnyVariable(final CypherStatement statement) {
+    final List<ClauseEntry> clauses = statement.getClausesInOrder();
+    if (clauses == null || clauses.isEmpty()) {
+      // Some builder paths leave the ordered list empty; the per-kind getters still answer (mirrors buildVarTypes).
+      for (final MatchClause matchClause : statement.getMatchClauses())
+        if (matchClause.hasPathPatterns())
+          for (final PathPattern path : matchClause.getPathPatterns())
+            if (pathDeclaresVariable(path))
+              return true;
+      if (statement.getCreateClause() != null && !statement.getCreateClause().isEmpty())
+        for (final PathPattern path : statement.getCreateClause().getPathPatterns())
+          if (pathDeclaresVariable(path))
+            return true;
+      return statement.getMergeClause() != null && pathDeclaresVariable(statement.getMergeClause().getPathPattern());
+    }
+
+    for (final ClauseEntry entry : clauses) {
+      switch (entry.getType()) {
+      case MATCH -> {
+        final MatchClause matchClause = entry.getTypedClause();
+        if (matchClause.hasPathPatterns())
+          for (final PathPattern path : matchClause.getPathPatterns())
+            if (pathDeclaresVariable(path))
+              return true;
+      }
+      case CREATE -> {
+        final CreateClause createClause = entry.getTypedClause();
+        if (createClause != null && !createClause.isEmpty())
+          for (final PathPattern path : createClause.getPathPatterns())
+            if (pathDeclaresVariable(path))
+              return true;
+      }
+      case MERGE -> {
+        final MergeClause mergeClause = entry.getTypedClause();
+        if (mergeClause != null && pathDeclaresVariable(mergeClause.getPathPattern()))
+          return true;
+      }
+      case WITH -> {
+        final WithClause withClause = entry.getTypedClause();
+        for (final ReturnClause.ReturnItem item : withClause.getItems())
+          if (!isStarItem(item) && item.getOutputName() != null && !"*".equals(item.getOutputName()))
+            return true;
+      }
+      case UNWIND -> {
+        if (((UnwindClause) entry.getTypedClause()).getVariable() != null)
+          return true;
+      }
+      case LOAD_CSV -> {
+        if (((LoadCSVClause) entry.getTypedClause()).getVariable() != null)
+          return true;
+      }
+      case CALL -> {
+        final CallClause callClause = entry.getTypedClause();
+        if (callClause.hasYield())
+          for (final CallClause.YieldItem item : callClause.getYieldItems())
+            if (item.getOutputName() != null)
+              return true;
+      }
+      case SUBQUERY -> {
+        // What a CALL { } subquery returns becomes an ordinary variable of the enclosing scope, exactly like WITH.
+        final SubqueryClause subqueryClause = entry.getTypedClause();
+        if (subqueryClause.getInnerStatement() != null) {
+          final ReturnClause innerReturn = subqueryClause.getInnerStatement().getReturnClause();
+          if (innerReturn != null)
+            for (final ReturnClause.ReturnItem item : innerReturn.getReturnItems())
+              if (item.getOutputName() != null)
+                return true;
         }
-        // Also check UNWIND and WITH for variables
-        if (!hasNamedVars) {
-          for (final UnwindClause unwind : statement.getUnwindClauses()) {
-            if (unwind.getVariable() != null) {
-              hasNamedVars = true;
-              break;
-            }
-          }
-        }
-        if (!hasNamedVars)
-          throw new CommandParsingException("NoVariablesInScope: RETURN * is not allowed when there are no variables in scope");
+      }
+      default -> {
+        // No binding of its own.
+      }
       }
     }
+    return false;
+  }
+
+  private static boolean pathDeclaresVariable(final PathPattern path) {
+    if (path == null)
+      return false;
+    if (path.hasPathVariable())
+      return true;
+    for (final NodePattern node : path.getNodes())
+      if (node.getVariable() != null && !node.getVariable().isEmpty())
+        return true;
+    for (final RelationshipPattern rel : path.getRelationships())
+      if (rel.getVariable() != null && !rel.getVariable().isEmpty())
+        return true;
+    return false;
   }
 
   // ==============================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6135ReturnStarSubqueryScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6135ReturnStarSubqueryScopeTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6135: {@code RETURN *} rejected a variable that was in scope only because it was exported by a preceding
+ * {@code CALL { }} subquery, a {@code WITH} projection, or a {@code CALL ... YIELD}. The check backing
+ * {@code RETURN *} scanned only the statement's own {@code MATCH} patterns and {@code UNWIND} variables, so any
+ * other way of putting a name into scope was invisible to it - not because those names are not in scope (the
+ * executor projects them correctly once {@code RETURN *} is allowed to run at all), but because the parse-time
+ * guard that decides whether {@code RETURN *} is legal never looked at them.
+ * <p>
+ * Neo4j (the openCypher reference implementation) accepts every query below: a {@code CALL { }} subquery's
+ * {@code RETURN} items become ordinary variables of the enclosing scope, exactly like a {@code WITH}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6135ReturnStarSubqueryScopeTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:P {name: 'a'})-[:KNOWS]->(:P {name: 'b'})");
+  }
+
+  @Test
+  void returnStarSeesAVariableExportedByACallSubquery() {
+    try (final ResultSet rs = database.query("opencypher", "CALL { MATCH (n:P) RETURN n } RETURN *")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.getPropertyNames()).containsExactly("n");
+      assertThat(row.<Object>getProperty("n")).isNotNull();
+    }
+  }
+
+  @Test
+  void returnStarSeesAVariableExportedByACallSubqueryAlongsideOuterVariables() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:P {name: 'a'}) CALL { MATCH (m:P {name: 'b'}) RETURN m } RETURN *")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.getPropertyNames()).containsExactlyInAnyOrder("a", "m");
+    }
+  }
+
+  @Test
+  void returnStarSeesAWithProjectedAlias() {
+    try (final ResultSet rs = database.query("opencypher", "WITH 1 AS x RETURN *")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("x").intValue()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void returnStarSeesACallYieldVariable() {
+    try (final ResultSet rs = database.query("opencypher", "CALL db.labels() YIELD label RETURN *")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().getPropertyNames()).containsExactly("label");
+    }
+  }
+
+  @Test
+  void returnStarWithNothingInScopeIsStillRejected() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN *").close())
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("NoVariablesInScope");
+  }
+
+  @Test
+  void returnStarInsideACallSubqueryBodyStillFollowsTheSameRule() {
+    assertThatCode(() -> database.query("opencypher", "CALL { MATCH (n:P) WITH n CALL { MATCH (m:P) RETURN m } "
+        + "RETURN * } RETURN *").close()).doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #6135: `CALL { MATCH (n) RETURN n } RETURN *` was rejected with `NoVariablesInScope`, even though `n` is a bona fide variable of the enclosing scope after the subquery, exactly like a `WITH` projection would be.
- Root cause: `CypherSemanticValidator.validateReturnStar()` decided whether any variable was in scope with its own ad hoc scan of only `MATCH` patterns and `UNWIND` variables, ignoring every other way Cypher puts a name into scope: `WITH` projections, `CALL ... YIELD` outputs, and `CALL { } RETURN ...` subquery exports.
- Replaced that scan with a walk over `getClausesInOrder()` covering every clause kind that binds a name into the statement's own scope (`MATCH`, `CREATE`, `MERGE`, `WITH`, `UNWIND`, `LOAD CSV`, `CALL YIELD`, `CALL` subquery `RETURN`), matching Neo4j (the openCypher reference implementation), which accepts all of these forms.
- Existing regression coverage (`CypherSubqueryBodyIssue5656Test#returnStarWithNothingInScopeIsRejectedInsideABodyAsOutsideOne`) already pinned down that a bare `RETURN *` inside an `EXISTS { }`/`COUNT { }`/`COLLECT { }` body must still be rejected unless the body binds something of its own - the fix preserves that distinction (those bodies' *inherited* outer-row seed does not count, only what the body itself declares).

## Test plan
- [x] New regression test `Issue6135ReturnStarSubqueryScopeTest` covering: the issue's exact repro, a mix of outer + subquery-exported variables, a `WITH`-only alias, a `CALL ... YIELD` output, that a truly empty-scope `RETURN *` is still rejected, and a nested `CALL { }` body following the same rule.
- [x] Ran the full `com.arcadedb.query.opencypher.**` test package (engine module) - all green.
- [x] Ran the targeted regression suite around subquery scope / RETURN * (`Issue5444ReturnStarInternalVariablesTest`, `CypherSubqueryBodyIssue5656Test`, `CypherVariableUsageTest`, `Issue5257CallSubqueryRelationshipScopeTest`, `Issue5825ExistsSubqueryScopeTest`, `CypherCallYieldWithVariablesTest`, `CypherSubqueryParseTimeValidationIssue5626Test`, `CypherFollowUpsIssue5602Test`, `CypherCallVectorNeighborsTest`, `CypherUncorrelatedSubqueryCountPushDownIssue5686Test`, `CypherCountPushDownPreconditionsIssue5715Test`) - all pass.
- [x] `mvn -pl engine -am compile` clean.