### PR TITLE
fix(#6136): bound the last two CHECK DATABASE repair paths, and ship the index-rebuild WAL in instalments

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1202,7 +1202,9 @@ costs - the reload detaches a compacted sub-index it cannot resolve yet, the lat
 in-memory component, and the follower serves only its mutable pages from then on, silently and permanently.
 
 The threshold is derived rather than configured: half the maximum replicated entry size, the same expression the
-compaction path already uses for its own chunk budget. Lowering `arcadedb.ha.appendBufferSize` lowers it too.
+compaction path already uses for its own chunk budget. Lowering `arcadedb.ha.appendBufferSize` lowers it too, and
+that is worth knowing before tuning it down: a smaller buffer means more instalments per rebuild, and therefore more
+quorum round trips taken under the write lock (see below).
 
 **What it costs**, stated precisely because it is a trade and not only a heap win. The recording session stays open
 for the whole build, so a concurrent writer on the leader still waits on it - and, before that, on the database write

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1204,10 +1204,25 @@ in-memory component, and the follower serves only its mutable pages from then on
 The threshold is derived rather than configured: half the maximum replicated entry size, the same expression the
 compaction path already uses for its own chunk budget. Lowering `arcadedb.ha.appendBufferSize` lowers it too.
 
-**What this does not change**, stated because the difference matters to an operator: the recording session stays
-open for the whole build, so a concurrent writer on the leader still waits on it - and, before that, on the database
-write lock the callback holds. Bounding the heap does not shorten that window. Shortening it means taking the build
-out of the session altogether, which is a different change on the same code path.
+**What it costs**, stated precisely because it is a trade and not only a heap win. The recording session stays open
+for the whole build, so a concurrent writer on the leader still waits on it - and, before that, on the database write
+lock the callback holds. Bounding the heap does not shorten that window, and each instalment *lengthens* it: a quorum
+round trip is now taken while that write lock is held, where the single final entry had always been submitted after
+the callback returned and the lock was released. Normally that is milliseconds against a build measured in minutes;
+against a slow or briefly partitioned quorum member it is up to `arcadedb.ha.quorumTimeout` per instalment, and the
+whole database's writers wait it out. Accepted, because the alternative is not "no round trips" - without instalments
+the one final entry carries the whole index, `splitSchemaEntry` splits it, and the same number of round trips happens
+anyway, after the lock but only once the leader has held the entire rebuilt index in heap. Making the window itself
+shorter means taking the build out of the recording session altogether, which is a different change on the same code
+path.
+
+**If the build fails after an instalment has shipped**, the followers are holding files and pages that the entry
+which would have published or retired them never reaches, because it lives after the line that threw - and every
+instalment chunk is marked `moreChunksFollow`, so there is no abandonment signal a follower could act on by itself.
+The session now sends a compensating removal, and *which* files it retires is the whole correctness of it: one the
+leader no longer has is retired (the case `BucketIndexBuilder.create()` produces, since it drops the half-built index
+from its own error handler), while one the leader still has is left alone and reported, because retiring that would
+take a state both sides agree on and make them disagree.
 
 ### The in-scan repairs are bounded too
 

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1168,3 +1168,92 @@ torn across two instants. Incremental resync belongs at the **page** level, on t
 operator diagnostic.
 
 [#6125](https://github.com/ArcadeData/arcadedb/issues/6125)
+
+## `CHECK DATABASE FIX`: the last two unbounded repair paths, and what the numbers it reports mean (#6136)
+
+#6131 bounded the repair transaction a `CHECK DATABASE ... FIX` builds, committing every
+`arcadedb.checkDatabaseRepairBatchPages` dirtied pages so that a large repair on a replicated database no longer
+runs for hours and then dies whole at the commit with `ReplicatedEntryTooLargeException`. It deliberately reached
+only the post-scan loops. These are the two paths it did not, plus the reporting the split made necessary.
+
+### The index rebuild no longer buffers its whole WAL in leader heap
+
+`BucketIndexBuilder.create()` wraps an index build in `schema.recordFileChanges(...)`, which on a Raft leader marks
+the thread so that `commit()` **buffers** instead of replicating: the files being created do not exist on the
+followers yet, so a `TX_ENTRY` referring to them would have its pages silently dropped there. `LSMTreeIndex.build()`
+then commits once per `IndexBuilder.BUILD_BATCH_SIZE` (5000) records, and every one of those WAL images stayed
+resident until the callback returned. Peak leader heap was therefore roughly the whole rebuilt index, plus a repeat
+of every page more than one batch touched - on the node that is, by construction, the cluster's leader. A
+`CHECK DATABASE FIX` over a large damaged type drops and rebuilds every index on the affected buckets, which is
+exactly that shape.
+
+The buffer is now shipped in ordered **instalments** as it fills, so leader heap is bounded by the threshold rather
+than by the size of the index. Nothing new goes on the wire: this is the ordered-prefix sequence `splitSchemaEntry`
+has produced since #4743, emitted as the payload is produced rather than after it has been built in full. Files
+first, so pages have somewhere to land; WAL in the middle; and the fields that *publish* the change - the schema
+JSON and the files to retire - only in the session's final entry. Every prefix a follower can be left holding is
+therefore self-consistent, and a partially written new file is unreferenced bytes until the last entry publishes
+it. Followers need no new code, because that sequence is the one they already receive.
+
+The one difference from a `splitSchemaEntry` split carries the whole safety argument: the last chunk of an
+instalment is still marked `moreChunksFollow`, because an instalment is not the end of the change. A follower that
+mistook it for a publication would reload its schema from a half-delivered state, and #5443 measured what that
+costs - the reload detaches a compacted sub-index it cannot resolve yet, the later real publication reuses the same
+in-memory component, and the follower serves only its mutable pages from then on, silently and permanently.
+
+The threshold is derived rather than configured: half the maximum replicated entry size, the same expression the
+compaction path already uses for its own chunk budget. Lowering `arcadedb.ha.appendBufferSize` lowers it too.
+
+**What this does not change**, stated because the difference matters to an operator: the recording session stays
+open for the whole build, so a concurrent writer on the leader still waits on it - and, before that, on the database
+write lock the callback holds. Bounding the heap does not shorten that window. Shortening it means taking the build
+out of the session altogether, which is a different change on the same code path.
+
+### The in-scan repairs are bounded too
+
+Two repairs used to write from *inside* the vertex scan, where nothing can commit: `LocalDatabase.scanType` holds
+the database read lock for the length of the scan, and the chunk iterator being walked would not survive a commit
+taken under it.
+
+- the back-reference fix-up - one write to a **far** vertex per edge found "not connected from the other side",
+  each able to allocate a fresh edge-list chunk;
+- `resetChain`, which drops an unreadable adjacency chain so it can be rebuilt from the surviving edge records.
+
+Both are now *planned* during the scan and applied after it, through the same page budget as everything else. The
+chain resets needed no new state at all: every `resetChain` call site already registered its vertex in one of the
+two reconnect sets, so those sets were the complete list. The back-reference fix-up accumulates three RIDs per
+defective edge in flat `int[]`/`long[]` arrays - and the `ArrayList<Edge>` the chain rebuild used to fill, which
+held a fully materialised record per entry, was replaced by the same structure.
+
+One in-scan write remains and is named rather than implied: the iterator `remove()` that prunes a dangling
+adjacency entry. It is not deferrable the way the others were - the removal is made through the chunk iterator's
+live position, and replaying it afterwards would turn a linear pass into a quadratic one - and it is the mildest of
+the three, rewriting a chunk page the walk is already reading and never allocating one.
+
+### `autoFix` now comes with a breakdown
+
+`autoFix` is a count of repair **actions**, not of corruption instances: after #6131 it is records deleted plus
+dangling adjacency entries pruned, so one edge that is both listed in a chain and corrupt as a record contributes
+two. A rebuilt chain, meanwhile, contributed nothing at all and was visible only in the warnings. The one number an
+operator reads to decide whether a run did anything was a mixture of three repair kinds with different weights, one
+of them invisible.
+
+`autoFix` keeps its meaning - existing readers and existing expectations depend on it - and the result now also
+carries `removedRecords`, `prunedDanglingEntries` and `reconnectedEdges`. The first two sum to `autoFix`; the third
+is deliberately not in that sum, since folding a rebuilt chain in would change every number a current run reports.
+All three are always present, zero included. The first is named `removedRecords` rather than `deletedRecords`
+because the result already carries `totalDeletedRecords` - records found in the DELETED state by the bucket scan,
+nothing to do with repair - and a key one word away from it would read as its non-total sibling.
+
+### The transaction-nesting headroom, measured rather than assumed
+
+#6136 also reported the FIX path as sitting exactly on `DatabaseContext`'s hardcoded limit of 3 nested
+transactions - the HTTP handler's, the arm's own, and the repair batch's - leaving no headroom. It does not.
+`CheckDatabaseStatement.executeSimple` opens by rolling the caller's transaction back, so the handler's level is
+released before the check starts; the arms' `begin()` then finds the last context inactive and reuses it rather
+than pushing; and the repair batch commits and re-begins at that same level. The path runs at **one** level with
+two to spare, and is now pinned both by sampling the depth it reaches and by running it under a cap of 1, so that a
+future change adding a level arrives as a red build naming the cap rather than as a `TransactionException` in a
+repair someone is running against a damaged production database.
+
+[#6136](https://github.com/ArcadeData/arcadedb/issues/6136)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1262,6 +1262,14 @@ All three are always present, zero included. The first is named `removedRecords`
 because the result already carries `totalDeletedRecords` - records found in the DELETED state by the bucket scan,
 nothing to do with repair - and a key one word away from it would read as its non-total sibling.
 
+**One key pair is gone, which is a non-additive change to that map.** `GraphDatabaseChecker.checkVertices` used to
+put the `List<Edge>` of reconnected edges under `outEdgesToReconnect`/`inEdgesToReconnect`; both keys are removed
+and `reconnectedEdges` carries the count instead. Nothing in the repository read them, and they never reached the
+`CHECK DATABASE` command result at all - `DatabaseChecker.updateStats` folds only `Long` values - so an operator
+reading the SQL output never saw them. Only a caller invoking `checkVertices` directly as an API could have, and
+holding a fully materialised `Edge` per reconnected entry was one of the unbounded-heap sources this change exists
+to remove, so they are not coming back.
+
 ### The transaction-nesting headroom, measured rather than assumed
 
 #6136 also reported the FIX path as sitting exactly on `DatabaseContext`'s hardcoded limit of 3 nested

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1302,7 +1302,11 @@ public enum GlobalConfiguration {
       ones (binary blobs, base64, encrypted fields, float vectors) map roughly 1:1. Raise it when single \
       transactions or records are bigger than the default, and raise arcadedb.ha.writeBufferSize with it \
       (it must stay >= this value + 8 bytes). Cost of raising it: a directly-allocated write buffer of \
-      writeBufferSize per server, plus up to this many bytes of heap per follower appender during catch-up.""",
+      writeBufferSize per server, plus up to this many bytes of heap per follower appender during catch-up. \
+      Cost of LOWERING it (issue #6136): an index rebuild ships its WAL to the followers in instalments of half \
+      this size, and each instalment is a quorum round trip taken while the database write lock is held, so a \
+      smaller value means more round trips and a longer window in which every writer on that database waits - \
+      up to arcadedb.ha.quorumTimeout per instalment if a quorum member is slow or briefly partitioned.""",
       String.class, "32MB"),
 
   HA_APPEND_ELEMENT_LIMIT("arcadedb.ha.appendElementLimit", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -127,6 +127,23 @@ public class DatabaseChecker {
       LogManager.instance().log(this, Level.INFO, "Integrity check of database '%s' started", null, database.getName());
 
     result.put("autoFix", 0L);
+    // Issue #6136 (3): the breakdown behind autoFix, seeded so the three keys are always present rather than
+    // appearing only on the runs that happened to perform that kind of repair.
+    //
+    // autoFix stays the ACTION count it has always been - removedRecords + prunedDanglingEntries - because
+    // existing readers and existing tests depend on it, and because "how many defects were there" is not a
+    // question the arms can answer jointly: one edge that is both listed in an adjacency chain and corrupt as a
+    // record is one defect, two repairs, two writes to two distinct pages. reconnectedEdges is NOT in the sum, for
+    // the same backward-compatibility reason - a rebuilt chain has never contributed to autoFix and making it do
+    // so would change every existing number. Read the three together to learn what a run did.
+    //
+    // "removedRecords" rather than the "deletedRecords" the issue proposed, deliberately: the result already
+    // carries "totalDeletedRecords", which counts records found in the DELETED state by the bucket scan and has
+    // nothing to do with repair, and a key differing from it by one word would read as its non-total sibling. This
+    // one is the count of "deletedRecordsAfterFix", the list of what this run actually took out.
+    result.put("removedRecords", 0L);
+    result.put("prunedDanglingEntries", 0L);
+    result.put("reconnectedEdges", 0L);
     result.put("invalidLinks", 0L);
     result.put("warnings", new LinkedHashSet<>());
     result.put("deletedRecordsAfterFix", new LinkedHashSet<>());
@@ -557,14 +574,13 @@ public class DatabaseChecker {
   }
 
   /**
-   * Removes the records this pass flagged corrupted, counting them into {@code autoFix}.
+   * Removes the records this pass flagged corrupted, counting them into {@code autoFix} and {@code removedRecords}.
    * <p>
-   * NOT quite what {@code GraphDatabaseChecker}'s vertex and edge arms count, and the difference is deliberate:
-   * they call {@code autoFix.incrementAndGet()} BEFORE attempting the delete, so a record they then fail to remove
-   * is still reported as fixed. This one counts a repair only once the delete and its counter delta have both
-   * succeeded, and counts nothing for a record that was already gone. If the two are ever unified, unify them
-   * towards THIS one: {@code autoFix} is what an operator reads to decide whether the run did anything, and a
-   * number that includes failed deletes cannot answer that.
+   * Counts a repair only once the delete and its counter delta have both succeeded, and counts nothing for a record
+   * that was already gone. {@code GraphDatabaseChecker}'s vertex and edge arms used to differ here - they counted
+   * BEFORE attempting the delete, so a record they then failed to remove was still reported as fixed - and #6128
+   * aligned them on this one: {@code autoFix} is what an operator reads to decide whether the run did anything, and
+   * a number that includes failed deletes cannot answer that.
    * <p>
    * This is not merely tidiness, and it is not optional. A corrupted record's RID goes into
    * {@code corruptedRecords}, which is what {@link #check()} turns into {@code affectedBuckets}, and every index on
@@ -598,6 +614,9 @@ public class DatabaseChecker {
         // counts depending on the scope it was asked for.
         database.getTransaction().updateBucketRecordDelta(rid.getBucketId(), -1);
         result.put("autoFix", (Long) result.get("autoFix") + 1);
+        // The per-kind arm of the same repair (issue #6136, item 3): this arm only ever deletes, so its whole
+        // contribution to autoFix is a deleted record.
+        result.put("removedRecords", (Long) result.get("removedRecords") + 1);
         // Same reason as mergeDeletedRecords: a removal nobody lists cannot be audited.
         ((LinkedHashSet<RID>) result.get("deletedRecordsAfterFix")).add(rid);
       } catch (final RecordNotFoundException e) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -540,7 +540,7 @@ public class GraphDatabaseChecker {
     final AtomicLong autoFix = new AtomicLong();
     final CheckReport report = new CheckReport(maxWarnings, maxCorrupted, verboseLevel);
     // Every repair this scan decides on, applied AFTER it under the page budget (issue #6136) - see RepairPlan.
-    final RepairPlan plan = new RepairPlan();
+    final RepairPlan plan = new RepairPlan(database);
     final Map<RID, Long> missingReferences = new HashMap<>();
     final Map<RID, String> missingReferenceErrors = new HashMap<>();
     /** Records this run actually removed, surfaced as {@code deletedRecordsAfterFix}. */
@@ -727,6 +727,32 @@ public class GraphDatabaseChecker {
    * through a union map: the second load reads the first one's uncommitted image, so both nulls survive, and the
    * two writes land on the same page - the merge would buy a map allocation and no page.
    */
+  /**
+   * Plans one back-reference, unless this walk of THIS list already planned one for the same edge (issue #6136).
+   * <p>
+   * The de-duplication is needed because the repair is deferred: the {@code isConnectedTo} probe that used to
+   * suppress a second attempt answered on a list the previous repair had already written to, and now it answers on
+   * the pre-repair list. So a list naming the same edge twice - itself corruption, and reported as such - would
+   * plant two back-references where one used to be planted. It is scoped to the one list because that is the only
+   * scope in which the duplicate can arise: across vertices the planned entries differ in the endpoint they
+   * record, which is exactly what the probe distinguished too.
+   * <p>
+   * Shared by {@link #checkIncomingEdges} and {@link #checkOutgoingEdges} rather than copied into each: the two
+   * drifting apart is what produced the bug {@link #handleDanglingEdgeListEntry} exists to fix.
+   *
+   * @param seen the caller's set, created on first use so a healthy list never allocates one
+   *
+   * @return the set to keep, whether it was just created or was already there
+   */
+  private static EdgeIdentitySet planBackReference(EdgeIdentitySet seen, final PendingLinks target,
+      final RID farVertex, final RID edge, final RID nearVertex) {
+    if (seen == null)
+      seen = new EdgeIdentitySet();
+    if (seen.add(edge))
+      target.add(farVertex, edge, nearVertex);
+    return seen;
+  }
+
   private void applyPendingChainResets(final RepairPlan plan, final CheckReport report) {
     for (final RID rid : plan.reconnectOutEdges)
       resetChain(rid, Vertex.DIRECTION.OUT, report);
@@ -810,7 +836,7 @@ public class GraphDatabaseChecker {
         continue;
 
       try {
-        final MutableVertex vertex = vertexRID.asVertex(true).modify();
+        final MutableVertex vertex = database.lookupByRID(vertexRID, true).asVertex(true).modify();
         // getOrCreateEdgeList dispatches on the head record type, so promoted (striped) vertices work too
         graphEngine.getOrCreateEdgeList(vertex, direction).add(edgeRID, pending.other(i));
         ++applied;
@@ -875,6 +901,17 @@ public class GraphDatabaseChecker {
       final CheckReport report) {
     final Set<RID> reconnectInEdges = plan.reconnectInEdges;
     final Set<RID> reconnectOutEdges = plan.reconnectOutEdges;
+
+    // Already condemned by an EARLIER vertex's far-endpoint probe: nothing here can improve on a list that is
+    // about to be dropped and rebuilt from the surviving edge records, and walking it can make things worse -
+    // an entry pointing at an edge that belongs to another vertex is diagnosed as a corrupt EDGE and deleted in
+    // fix mode, destroying a record the rebuild would have re-linked. Before #6136 this was implicit and
+    // scan-order dependent: resetChain ran inside the scan, so a vertex condemned before its own turn arrived
+    // with a null head chunk and fell out at the guard below, while the same vertex reached first was walked in
+    // full. Deferring the write made the skip explicit, which also makes it deterministic.
+    if (fix && reconnectInEdges.contains(vertexIdentity))
+      return;
+
     if (((VertexInternal) vertex).getInEdgesHeadChunk() != null) {
       EdgeLinkedList inEdges = null;
       try {
@@ -1045,12 +1082,9 @@ public class GraphDatabaseChecker {
                     // PLANNED, not written (issue #6136): this is the repair that wrote one far vertex per defective
                     // edge from inside the scan, where nothing could commit. Same write, applied afterwards under
                     // the page budget - connectOutgoingEdge is getOrCreateEdgeList(v, OUT).add(edge, target).
-                    if (fix) {
-                      if (plannedBackRefs == null)
-                        plannedBackRefs = new EdgeIdentitySet();
-                      if (plannedBackRefs.add(edgeRID))
-                        plan.backRefOutLinks.add(inVertex.getIdentity(), edge.getIdentity(), vertexIdentity);
-                    }
+                    if (fix)
+                      plannedBackRefs = planBackReference(plannedBackRefs, plan.backRefOutLinks,
+                          inVertex.getIdentity(), edge.getIdentity(), vertexIdentity);
                   }
                 }
 
@@ -1103,6 +1137,12 @@ public class GraphDatabaseChecker {
       final CheckReport report) {
     final Set<RID> reconnectOutEdges = plan.reconnectOutEdges;
     final Set<RID> reconnectInEdges = plan.reconnectInEdges;
+
+    // See the twin in checkIncomingEdges: a list already condemned by an earlier vertex's probe is skipped, which
+    // is what the immediate resetChain used to achieve by leaving a null head chunk behind (issue #6136).
+    if (fix && reconnectOutEdges.contains(vertexIdentity))
+      return;
+
     // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
     if (((VertexInternal) vertex).getOutEdgesHeadChunk() != null) {
       EdgeLinkedList outEdges = null;
@@ -1290,12 +1330,9 @@ public class GraphDatabaseChecker {
                             + vertexIdentity);
                     // PLANNED, not written - see the twin in checkIncomingEdges (issue #6136), including why the
                     // per-list de-duplication is needed now that the probe no longer sees the previous repair.
-                    if (fix) {
-                      if (plannedBackRefs == null)
-                        plannedBackRefs = new EdgeIdentitySet();
-                      if (plannedBackRefs.add(edgeRID))
-                        plan.backRefInLinks.add(outVertex.getIdentity(), edgeRID, vertexIdentity);
-                    }
+                    if (fix)
+                      plannedBackRefs = planBackReference(plannedBackRefs, plan.backRefInLinks,
+                          outVertex.getIdentity(), edgeRID, vertexIdentity);
                   }
                 }
 
@@ -1352,7 +1389,7 @@ public class GraphDatabaseChecker {
    */
   private void resetChain(final RID vertexRID, final Vertex.DIRECTION direction, final CheckReport report) {
     try {
-      final MutableVertex mutable = vertexRID.asVertex(true).modify();
+      final MutableVertex mutable = database.lookupByRID(vertexRID, true).asVertex(true).modify();
       if (direction == Vertex.DIRECTION.OUT)
         mutable.setOutEdgesHeadChunk(null);
       else
@@ -1642,18 +1679,25 @@ public class GraphDatabaseChecker {
     /** Vertices whose IN list must be dropped and rebuilt from the surviving edge records. */
     final Set<RID>     reconnectInEdges  = new HashSet<>();
     /** OUT-list entries rebuilt from the surviving edge records, for the vertices in {@link #reconnectOutEdges}. */
-    final PendingLinks rebuiltOutLinks   = new PendingLinks();
+    final PendingLinks rebuiltOutLinks;
     /** IN-list entries rebuilt from the surviving edge records, for the vertices in {@link #reconnectInEdges}. */
-    final PendingLinks rebuiltInLinks    = new PendingLinks();
+    final PendingLinks rebuiltInLinks;
     /**
      * Back-references the OUT list of an otherwise healthy far vertex was missing. Kept apart from the rebuilt
      * links rather than merged into them, even though the write is identical, because the two are reported
      * separately: "reconnected N outgoing edges" has always meant "a broken chain was rebuilt from N edge records"
      * and folding a different repair into that number would change what an existing report says.
      */
-    final PendingLinks backRefOutLinks   = new PendingLinks();
+    final PendingLinks backRefOutLinks;
     /** Back-references the IN list of an otherwise healthy far vertex was missing. */
-    final PendingLinks backRefInLinks    = new PendingLinks();
+    final PendingLinks backRefInLinks;
+
+    RepairPlan(final DatabaseInternal database) {
+      rebuiltOutLinks = new PendingLinks(database);
+      rebuiltInLinks = new PendingLinks(database);
+      backRefOutLinks = new PendingLinks(database);
+      backRefInLinks = new PendingLinks(database);
+    }
   }
 
   /**
@@ -1671,13 +1715,27 @@ public class GraphDatabaseChecker {
    * Still unbounded in the number of ENTRIES, and deliberately so: an entry is dropped only once its repair has
    * been applied, and a cap would mean silently declining to repair part of the damage. The bound that matters -
    * and the one #6128/#6136 are about - is on the transaction, not on the plan.
+   * <p>
+   * The RIDs it hands back are BOUND TO THE DATABASE ({@code database.newRID}), which is not cosmetic. Flattening
+   * to primitives loses the owning database, and a bare {@code RID} resolves one through
+   * {@code RID.resolveActiveDatabase()} - a thread-local lookup that THROWS when more than one database is in
+   * scope on the thread. That exception would be caught by the apply loop's generic handler and turned into a
+   * per-entry warning, so on a multi-database server the repair would silently decline to apply while the run
+   * still reported success. Rebuilding them here rather than at each call site means no future caller can
+   * reintroduce that.
    */
   private static final class PendingLinks {
     private static final int TRIPLE = 3;
 
+    private final DatabaseInternal database;
+
     private int[]  buckets   = new int[TRIPLE * 16];
     private long[] positions = new long[TRIPLE * 16];
     private int    size;
+
+    PendingLinks(final DatabaseInternal database) {
+      this.database = database;
+    }
 
     void add(final RID vertex, final RID edge, final RID other) {
       final int base = size * TRIPLE;
@@ -1698,7 +1756,7 @@ public class GraphDatabaseChecker {
     }
 
     private RID get(final int slot) {
-      return new RID(buckets[slot], positions[slot]);
+      return database.newRID(buckets[slot], positions[slot]);
     }
 
     int size() {

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -710,24 +710,6 @@ public class GraphDatabaseChecker {
   }
 
   /**
-   * Drops the unreadable chains the scan decided to rebuild (issue #6136, item 2). Every {@link #resetChain} call
-   * site used to do this from inside the {@code scanType} callback, one vertex record write per damaged chain and
-   * none of them inside the page budget; every one of those sites ALSO registered its vertex in one of the two
-   * reconnect sets, so those sets already were the complete list and deferring the write needs no new state.
-   * <p>
-   * Deferring it changes what the REST of the scan observes about an already-visited vertex, and the two places
-   * that can see the difference both improve: a far vertex whose list is unreadable answers the
-   * {@code isConnectedTo} probe with an exception instead of a silent empty list, and the probe's handler already
-   * treats that as "register it for a rebuild" (the set membership test that follows is what decides, and it is
-   * unchanged); and the "current vertex points at ANOTHER vertex's list" test at the head-chunk comparison now
-   * sees the shared chunk it is looking for rather than the {@code null} an earlier reset had already written,
-   * which is the case that test exists to catch.
-   * <p>
-   * A vertex registered for BOTH directions is loaded and saved twice. Left as two passes rather than merged
-   * through a union map: the second load reads the first one's uncommitted image, so both nulls survive, and the
-   * two writes land on the same page - the merge would buy a map allocation and no page.
-   */
-  /**
    * Plans one back-reference, unless this walk of THIS list already planned one for the same edge (issue #6136).
    * <p>
    * The de-duplication is needed because the repair is deferred: the {@code isConnectedTo} probe that used to
@@ -753,6 +735,24 @@ public class GraphDatabaseChecker {
     return seen;
   }
 
+  /**
+   * Drops the unreadable chains the scan decided to rebuild (issue #6136, item 2). Every {@link #resetChain} call
+   * site used to do this from inside the {@code scanType} callback, one vertex record write per damaged chain and
+   * none of them inside the page budget; every one of those sites ALSO registered its vertex in one of the two
+   * reconnect sets, so those sets already were the complete list and deferring the write needs no new state.
+   * <p>
+   * Deferring it changes what the REST of the scan observes about an already-visited vertex, and the two places
+   * that can see the difference both improve: a far vertex whose list is unreadable answers the
+   * {@code isConnectedTo} probe with an exception instead of a silent empty list, and the probe's handler already
+   * treats that as "register it for a rebuild" (the set membership test that follows is what decides, and it is
+   * unchanged); and the "current vertex points at ANOTHER vertex's list" test at the head-chunk comparison now
+   * sees the shared chunk it is looking for rather than the {@code null} an earlier reset had already written,
+   * which is the case that test exists to catch.
+   * <p>
+   * A vertex registered for BOTH directions is loaded and saved twice. Left as two passes rather than merged
+   * through a union map: the second load reads the first one's uncommitted image, so both nulls survive, and the
+   * two writes land on the same page - the merge would buy a map allocation and no page.
+   */
   private void applyPendingChainResets(final RepairPlan plan, final CheckReport report) {
     for (final RID rid : plan.reconnectOutEdges)
       resetChain(rid, Vertex.DIRECTION.OUT, report);

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -339,15 +339,17 @@ public class GraphDatabaseChecker {
    * the scan, so committing under it would commit a transaction the scan believes it still owns. Every call site
    * here is therefore in a post-scan apply or delete loop, which is also where the page volume actually is.
    * <p>
-   * WHAT THAT LEAVES UNBOUNDED, named rather than implied: the in-scan repairs stay outside this budget. The
-   * back-reference fix-up in {@link #checkIncomingEdges}/{@link #checkOutgoingEdges} - the
-   * {@code connectOutgoingEdge}/{@code connectIncomingEdge} pair that re-links an edge "not connected from the
-   * other side" - writes a vertex per defective edge from inside the scan, and {@link #resetChain} likewise. A
-   * database with a very large number of edges in that particular state can therefore still accumulate one big
-   * transaction and hit the entry cap this budget exists to stay under. It is accepted rather than overlooked: that
-   * shape is much narrower than the dangling references and broken chains the post-scan loops handle, and bounding
-   * it means restructuring those checks into collect-then-apply so the writes leave the scan, which is a bigger
-   * change than this one and deserves to be judged on its own.
+   * WHAT THAT LEAVES UNBOUNDED, named rather than implied. #6136 moved the two repairs that used to write from
+   * inside the scan - the {@code connectOutgoingEdge}/{@code connectIncomingEdge} back-reference fix-up and
+   * {@link #resetChain} - into {@link #applyPendingLinks} and {@link #applyPendingChainResets}, which are post-scan
+   * loops and therefore inside this budget. ONE in-scan write remains: the {@code in.remove()}/{@code out.remove()}
+   * that prunes a dangling adjacency entry, in both {@link #checkIncomingEdges} and {@link #checkOutgoingEdges}.
+   * It is not deferrable in the way the others were - the removal is made through the chunk iterator's live
+   * position, and replaying it afterwards would mean re-walking the list per pruned entry, turning a linear pass
+   * into a quadratic one - and it is the mildest of the three: it rewrites a chunk page the walk is already
+   * reading and never allocates a new one, where the back-reference fix-up appended to a FAR vertex's list and
+   * could allocate a chunk per repair. Still unbounded in principle, so a database whose damage is overwhelmingly
+   * dangling entries in very many distinct chunks can exceed the budget by that much.
    * <p>
    * A SOFT ceiling: the check happens between units, so a transaction can exceed the budget by whatever the unit in
    * flight dirties. Leave headroom when tuning it close to the replicated-entry limit.
@@ -537,12 +539,14 @@ public class GraphDatabaseChecker {
       final boolean fix, final int verboseLevel, final int maxWarnings, final int maxCorrupted) {
     final AtomicLong autoFix = new AtomicLong();
     final CheckReport report = new CheckReport(maxWarnings, maxCorrupted, verboseLevel);
-    final Set<RID> reconnectOutEdges = new HashSet<>();
-    final Set<RID> reconnectInEdges = new HashSet<>();
+    // Every repair this scan decides on, applied AFTER it under the page budget (issue #6136) - see RepairPlan.
+    final RepairPlan plan = new RepairPlan();
     final Map<RID, Long> missingReferences = new HashMap<>();
     final Map<RID, String> missingReferenceErrors = new HashMap<>();
     /** Records this run actually removed, surfaced as {@code deletedRecordsAfterFix}. */
     final Set<RID> deletedRecords = new LinkedHashSet<>();
+    /** Adjacency entries this run re-linked, of either kind - see the {@code reconnectedEdges} stat (issue #6136). */
+    long reconnectedEdges = 0;
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -552,15 +556,15 @@ public class GraphDatabaseChecker {
       final Consumer<Record> checkConnectivity = record -> {
         progressTick();
         try {
-          Vertex vertex = record.asVertex(true);
+          final Vertex vertex = record.asVertex(true);
 
           final RID vertexIdentity = vertex.getIdentity();
 
-          vertex = checkOutgoingEdges(fix, vertex, vertexIdentity, reconnectOutEdges, reconnectInEdges,
-              missingReferences, missingReferenceErrors, report);
+          // No longer re-assigned from the two checks: neither of them writes the vertex any more (#6136), so the
+          // saved mutable copy they used to hand back does not exist and the immutable one stays current.
+          checkOutgoingEdges(fix, vertex, vertexIdentity, plan, missingReferences, missingReferenceErrors, report);
 
-          checkIncomingEdges(fix, vertex, vertexIdentity, reconnectInEdges, reconnectOutEdges, missingReferences,
-              missingReferenceErrors, report);
+          checkIncomingEdges(fix, vertex, vertexIdentity, plan, missingReferences, missingReferenceErrors, report);
 
         } catch (final Throwable e) {
           report.warn("vertex " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
@@ -612,8 +616,32 @@ public class GraphDatabaseChecker {
       progressComplete();
 
       if (fix) {
-        if (!reconnectOutEdges.isEmpty() || !reconnectInEdges.isEmpty())
-          reconnectEdges(reconnectOutEdges, reconnectInEdges, report, stats);
+        // ORDER IS LOAD-BEARING (issue #6136). The chains are dropped FIRST: getOrCreateEdgeList appends to whatever
+        // head pointer it finds, so re-linking a vertex whose unreadable chain is still attached would append to the
+        // damaged list instead of building a fresh one. Then the surviving edge records are collected, and only then
+        // is anything written into a list - by which point every list that is being rebuilt is empty.
+        applyPendingChainResets(plan, report);
+
+        if (!plan.reconnectOutEdges.isEmpty() || !plan.reconnectInEdges.isEmpty())
+          collectEdgesToReconnect(plan, report);
+
+        // Both kinds of link land through the same loop: an entry rebuilt from a surviving edge record and a
+        // back-reference the far vertex was missing are the same write - add (edge, other endpoint) to a list.
+        // They are counted and reported apart, see RepairPlan.
+        final long rebuiltOut = applyPendingLinks(plan.rebuiltOutLinks, Vertex.DIRECTION.OUT, null, report);
+        if (rebuiltOut > 0)
+          report.warn("reconnected " + rebuiltOut + " outgoing edges");
+
+        final long rebuiltIn = applyPendingLinks(plan.rebuiltInLinks, Vertex.DIRECTION.IN, null, report);
+        if (rebuiltIn > 0)
+          report.warn("reconnected " + rebuiltIn + " incoming edges");
+
+        final long backRefs = applyPendingLinks(plan.backRefOutLinks, Vertex.DIRECTION.OUT, plan.reconnectOutEdges, report)
+            + applyPendingLinks(plan.backRefInLinks, Vertex.DIRECTION.IN, plan.reconnectInEdges, report);
+        if (backRefs > 0)
+          report.warn("re-linked " + backRefs + " edges that were not connected from the other side");
+
+        reconnectedEdges = rebuiltOut + rebuiltIn + backRefs;
 
         for (final RID rid : report.corruptedRecords) {
           if (rid == null)
@@ -650,6 +678,12 @@ public class GraphDatabaseChecker {
     } finally {
       // Both kinds of repair this run performed: records removed, plus dangling adjacency entries pruned (#6128).
       stats.put("autoFix", autoFix.get() + report.prunedDanglingEntries);
+      // The breakdown behind that sum, plus the repair kind it never included (issue #6136, item 3). autoFix keeps
+      // its meaning for every existing reader; these say which arms it decomposes into and add the one that was
+      // only ever visible in the warnings.
+      stats.put("removedRecords", autoFix.get());
+      stats.put("prunedDanglingEntries", report.prunedDanglingEntries);
+      stats.put("reconnectedEdges", reconnectedEdges);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("duplicateLightEdges", report.duplicateLightEdges);
@@ -665,23 +699,47 @@ public class GraphDatabaseChecker {
   }
 
   /**
-   * Rebuilds the edge lists of the registered vertices from the surviving edge records. NOTE: this is a FULL
-   * scan of every edge type, even when a single vertex needs reconnection - acceptable because it runs only in
-   * fix mode on an already-damaged database, and the pre-existing reconnect path had the same cost. A rebuilt
-   * entry may still point to a far endpoint vertex that no longer exists (the edge record survives, its target
-   * does not): that is the same behaviour as before and the {@code checkEdges} pass reports it.
+   * Drops the unreadable chains the scan decided to rebuild (issue #6136, item 2). Every {@link #resetChain} call
+   * site used to do this from inside the {@code scanType} callback, one vertex record write per damaged chain and
+   * none of them inside the page budget; every one of those sites ALSO registered its vertex in one of the two
+   * reconnect sets, so those sets already were the complete list and deferring the write needs no new state.
+   * <p>
+   * Deferring it changes what the REST of the scan observes about an already-visited vertex, and the two places
+   * that can see the difference both improve: a far vertex whose list is unreadable answers the
+   * {@code isConnectedTo} probe with an exception instead of a silent empty list, and the probe's handler already
+   * treats that as "register it for a rebuild" (the set membership test that follows is what decides, and it is
+   * unchanged); and the "current vertex points at ANOTHER vertex's list" test at the head-chunk comparison now
+   * sees the shared chunk it is looking for rather than the {@code null} an earlier reset had already written,
+   * which is the case that test exists to catch.
+   * <p>
+   * A vertex registered for BOTH directions is loaded and saved twice. Left as two passes rather than merged
+   * through a union map: the second load reads the first one's uncommitted image, so both nulls survive, and the
+   * two writes land on the same page - the merge would buy a map allocation and no page.
    */
-  private void reconnectEdges(Set<RID> reconnectOutEdges, Set<RID> reconnectInEdges, CheckReport report,
-      Map<String, Object> stats) {
+  private void applyPendingChainResets(final RepairPlan plan, final CheckReport report) {
+    for (final RID rid : plan.reconnectOutEdges)
+      resetChain(rid, Vertex.DIRECTION.OUT, report);
+    for (final RID rid : plan.reconnectInEdges)
+      resetChain(rid, Vertex.DIRECTION.IN, report);
+  }
+
+  /**
+   * Collects the surviving edge records that belong in the chains being rebuilt. NOTE: this is a FULL scan of
+   * every edge type, even when a single vertex needs reconnection - acceptable because it runs only in fix mode on
+   * an already-damaged database, and the pre-existing reconnect path had the same cost. A rebuilt entry may still
+   * point to a far endpoint vertex that no longer exists (the edge record survives, its target does not): that is
+   * the same behaviour as before and the {@code checkEdges} pass reports it.
+   * <p>
+   * Collects RIDs, not records: the {@code ArrayList<Edge>} this used to fill held a fully materialised edge per
+   * entry and was the second unbounded accumulation #6136 names - see {@link PendingLinks}.
+   */
+  private void collectEdgesToReconnect(final RepairPlan plan, final CheckReport report) {
     // BROWSE ALL THE EDGES AND COLLECT THE ONES PART OF THE RECONNECTION
     final List<EdgeType> edgeTypes = new ArrayList<>();
     for (DocumentType schemaType : database.getSchema().getTypes()) {
       if (schemaType instanceof EdgeType t)
         edgeTypes.add(t);
     }
-
-    final List<Edge> outEdgesToReconnect = new ArrayList<>();
-    final List<Edge> inEdgesToReconnect = new ArrayList<>();
 
     progressBegin(progressStepName == null ? "Rebuilding edge lists" : progressStepName + " - rebuilding edge lists", -1);
 
@@ -696,12 +754,12 @@ public class GraphDatabaseChecker {
           if (report.corruptedRecords.contains(e.getIdentity()))
             // ABOUT TO BE DELETED BY THE FIX: re-adding it would rebuild a dangling entry
             return true;
-          if (reconnectOutEdges.contains(e.getOut()))
-            outEdgesToReconnect.add(e);
+          if (plan.reconnectOutEdges.contains(e.getOut()))
+            plan.rebuiltOutLinks.add(e.getOut(), e.getIdentity(), e.getIn());
           // A unidirectional edge is never stored in the target's IN list: rebuilding it there would invent
           // adjacency that never existed.
-          if (bidirectional && reconnectInEdges.contains(e.getIn()))
-            inEdgesToReconnect.add(e);
+          if (bidirectional && plan.reconnectInEdges.contains(e.getIn()))
+            plan.rebuiltInLinks.add(e.getIn(), e.getIdentity(), e.getOut());
         } catch (final Exception e) {
           warnUnreadableEdgeDuringRebuild(report, record.getIdentity(), e);
         }
@@ -711,27 +769,49 @@ public class GraphDatabaseChecker {
         return true;
       });
     }
+  }
 
-    if (!outEdgesToReconnect.isEmpty()) {
-      for (Edge e : outEdgesToReconnect) {
-        final MutableVertex vertex = e.getOutVertex().modify();
+  /**
+   * Writes the planned adjacency entries, committing every {@code arcadedb.checkDatabaseRepairBatchPages} dirtied
+   * pages. This is the loop the in-scan repairs of #6136 were moved into: it is a post-scan apply, so
+   * {@link #commitRepairBatchIfFull()} is legal here in a way it never was inside the scan.
+   *
+   * @param skipVertices when non-null, vertices whose whole list is being rebuilt from the surviving edge records:
+   *                     a back-reference planned for one of them is dropped rather than written, because the
+   *                     rebuild re-creates the entry anyway. The set can still grow AFTER the entry was planned -
+   *                     a later vertex in the same scan can register this one - which is why the test is repeated
+   *                     here against its final contents instead of being left to the one made during the scan.
+   *
+   * @return how many entries were actually written
+   */
+  private long applyPendingLinks(final PendingLinks pending, final Vertex.DIRECTION direction,
+      final Set<RID> skipVertices, final CheckReport report) {
+    long applied = 0;
+    for (int i = 0; i < pending.size(); i++) {
+      final RID vertexRID = pending.vertex(i);
+      if (skipVertices != null && skipVertices.contains(vertexRID))
+        continue;
+
+      final RID edgeRID = pending.edge(i);
+      if (report.corruptedRecords.contains(edgeRID))
+        // ABOUT TO BE DELETED BY THE FIX: re-linking it would build a dangling entry. Same guard the rebuild scan
+        // applies, repeated here because the corrupted set also keeps growing while the scan runs.
+        continue;
+
+      try {
+        final MutableVertex vertex = vertexRID.asVertex(true).modify();
         // getOrCreateEdgeList dispatches on the head record type, so promoted (striped) vertices work too
-        graphEngine.getOrCreateEdgeList(vertex, Vertex.DIRECTION.OUT).add(e.getIdentity(), e.getIn());
-        commitRepairBatchIfFull();
+        graphEngine.getOrCreateEdgeList(vertex, direction).add(edgeRID, pending.other(i));
+        ++applied;
+      } catch (final RecordNotFoundException e) {
+        // The vertex is gone - another arm of this same run deleted it - so there is no list to link into.
+        report.warn("vertex " + vertexRID + " no longer exists, edge " + edgeRID + " was not re-linked to it");
+      } catch (final Exception e) {
+        report.warn("vertex " + vertexRID + " could not be re-linked to edge " + edgeRID + " (error: " + describe(e) + ")");
       }
-      report.warn("reconnected " + outEdgesToReconnect.size() + " outgoing edges");
-      stats.put("outEdgesToReconnect", outEdgesToReconnect);
+      commitRepairBatchIfFull();
     }
-
-    if (!inEdgesToReconnect.isEmpty()) {
-      for (Edge e : inEdgesToReconnect) {
-        final MutableVertex vertex = e.getInVertex().modify();
-        graphEngine.getOrCreateEdgeList(vertex, Vertex.DIRECTION.IN).add(e.getIdentity(), e.getOut());
-        commitRepairBatchIfFull();
-      }
-      report.warn("reconnected " + inEdgesToReconnect.size() + " incoming edges");
-      stats.put("inEdgesToReconnect", inEdgesToReconnect);
-    }
+    return applied;
   }
 
   private static void warnUnreadableEdgeDuringRebuild(final CheckReport report, final Object rid,
@@ -779,9 +859,11 @@ public class GraphDatabaseChecker {
     ++report.invalidLinks;
   }
 
-  private void checkIncomingEdges(boolean fix, Vertex vertex, RID vertexIdentity, Set<RID> reconnectInEdges,
-      Set<RID> reconnectOutEdges, Map<RID, Long> missingReferences, Map<RID, String> missingReferenceErrors,
-      CheckReport report) {
+  private void checkIncomingEdges(final boolean fix, final Vertex vertex, final RID vertexIdentity,
+      final RepairPlan plan, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors,
+      final CheckReport report) {
+    final Set<RID> reconnectInEdges = plan.reconnectInEdges;
+    final Set<RID> reconnectOutEdges = plan.reconnectOutEdges;
     if (((VertexInternal) vertex).getInEdgesHeadChunk() != null) {
       EdgeLinkedList inEdges = null;
       try {
@@ -794,12 +876,18 @@ public class GraphDatabaseChecker {
         final RID headChunkRID = ((VertexInternal) vertex).getInEdgesHeadChunk();
         report.warn("vertex " + vertexIdentity + " in edges record " + headChunkRID
             + " is not valid" + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
-        if (fix) {
-          vertex = resetChain(vertex, Vertex.DIRECTION.IN);
+        if (fix)
           reconnectInEdges.add(vertexIdentity);
-        }
       } else {
         Iterator<Pair<RID, RID>> in = null;
+        // Back-references already planned WHILE WALKING THIS ONE LIST (issue #6136). Deferring the repair means a
+        // second entry for the same edge no longer sees the first one's write, and the isConnectedTo probe that
+        // used to suppress it answers on the pre-repair list; without this a list that names the same edge twice -
+        // itself corruption, and reported as such - would plant two back-references where one used to be planted.
+        // Scoped to the list because that is the only scope in which the duplicate can arise: across vertices the
+        // planned entries differ in the endpoint they record, which is exactly what the probe distinguished too.
+        // Lazily created, so a healthy list never pays for it.
+        EdgeIdentitySet plannedBackRefs = null;
         boolean chainBroken = false;
         String chainError = null;
         try {
@@ -905,10 +993,8 @@ public class GraphDatabaseChecker {
                     if (((VertexInternal) vertex).getInEdgesHeadChunk().equals(wrongInVertex.getInEdgesHeadChunk())) {
                       // CURRENT VERTEX POINTS TO ANOTHER LINKED LIST. SEARCHING FOR ITS CORRECT LINKED LIST LATER.
                       // Mutate ONLY in fix mode: a plain check must stay read-only.
-                      if (fix) {
+                      if (fix)
                         reconnectInEdges.add(vertexIdentity);
-                        vertex = resetChain(vertex, Vertex.DIRECTION.IN);
-                      }
 
                       // SKIP THE REST OF THE EDGES
                       break;
@@ -938,20 +1024,21 @@ public class GraphDatabaseChecker {
                     // The FAR vertex's OUT list is unreadable: never blame this edge record for it (before this
                     // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
                     // Register the far vertex so its list is rebuilt from the surviving edge records instead.
-                    if (reconnectOutEdges.add(inVertex.getIdentity())) {
+                    if (reconnectOutEdges.add(inVertex.getIdentity()))
                       report.warn("vertex " + inVertex.getIdentity() + " outgoing edge list is unreadable (error: "
                               + describe(probeError) + ")" + (fix ? ", rebuilding it from the surviving edge records" : ""));
-                      if (fix)
-                        resetChain(inVertex, Vertex.DIRECTION.OUT);
-                    }
                   }
                   if (connected != null && !connected && !reconnectOutEdges.contains(inVertex.getIdentity())) {
                     report.warn("edge " + edgeRID + " was not connected from the incoming vertex " + edge.getOut() + " to the vertex "
                             + vertexIdentity);
+                    // PLANNED, not written (issue #6136): this is the repair that wrote one far vertex per defective
+                    // edge from inside the scan, where nothing could commit. Same write, applied afterwards under
+                    // the page budget - connectOutgoingEdge is getOrCreateEdgeList(v, OUT).add(edge, target).
                     if (fix) {
-                      inVertex = inVertex.modify();
-                      database.getGraphEngine().connectOutgoingEdge(inVertex, vertexIdentity, edge);
-                      ((MutableVertex) inVertex).save();
+                      if (plannedBackRefs == null)
+                        plannedBackRefs = new EdgeIdentitySet();
+                      if (plannedBackRefs.add(edgeRID))
+                        plan.backRefOutLinks.add(inVertex.getIdentity(), edge.getIdentity(), vertexIdentity);
                     }
                   }
                 }
@@ -993,18 +1080,18 @@ public class GraphDatabaseChecker {
         if (chainBroken) {
           report.warn("error on loading incoming edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
                   + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
-          if (fix) {
-            vertex = resetChain(vertex, Vertex.DIRECTION.IN);
+          if (fix)
             reconnectInEdges.add(vertexIdentity);
-          }
         }
       }
     }
   }
 
-  private Vertex checkOutgoingEdges(final boolean fix, Vertex vertex, final RID vertexIdentity,
-      final Set<RID> reconnectOutEdges, final Set<RID> reconnectInEdges, final Map<RID, Long> missingReferences,
-      final Map<RID, String> missingReferenceErrors, final CheckReport report) {
+  private void checkOutgoingEdges(final boolean fix, final Vertex vertex, final RID vertexIdentity,
+      final RepairPlan plan, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors,
+      final CheckReport report) {
+    final Set<RID> reconnectOutEdges = plan.reconnectOutEdges;
+    final Set<RID> reconnectInEdges = plan.reconnectInEdges;
     // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
     if (((VertexInternal) vertex).getOutEdgesHeadChunk() != null) {
       EdgeLinkedList outEdges = null;
@@ -1018,14 +1105,14 @@ public class GraphDatabaseChecker {
         final RID headChunkRID = ((VertexInternal) vertex).getOutEdgesHeadChunk();
         report.warn("vertex " + vertexIdentity + " out edges record " + headChunkRID
             + " is not valid" + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
-        if (fix) {
-          vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
+        if (fix)
           reconnectOutEdges.add(vertexIdentity);
-        }
       } else {
         Iterator<Pair<RID, RID>> out = null;
         // Lazily created: only a vertex that actually has lightweight edges pays for it.
         EdgeIdentitySet seenLightEdges = null;
+        // Per-list de-duplication of the planned back-references - see the twin in checkIncomingEdges (#6136).
+        EdgeIdentitySet plannedBackRefs = null;
         boolean chainBroken = false;
         String chainError = null;
         try {
@@ -1150,10 +1237,8 @@ public class GraphDatabaseChecker {
                     if (((VertexInternal) vertex).getOutEdgesHeadChunk().equals(wrongOutVertex.getOutEdgesHeadChunk())) {
                       // CURRENT VERTEX POINTS TO ANOTHER LINKED LIST. SEARCHING FOR ITS CORRECT LINKED LIST LATER.
                       // Mutate ONLY in fix mode: a plain check must stay read-only.
-                      if (fix) {
+                      if (fix)
                         reconnectOutEdges.add(vertexIdentity);
-                        vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
-                      }
 
                       // SKIP THE REST OF THE EDGES
                       break;
@@ -1185,20 +1270,20 @@ public class GraphDatabaseChecker {
                     // The FAR vertex's IN list is unreadable: never blame this edge record for it (before this
                     // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
                     // Register the far vertex so its list is rebuilt from the surviving edge records instead.
-                    if (reconnectInEdges.add(outVertex.getIdentity())) {
+                    if (reconnectInEdges.add(outVertex.getIdentity()))
                       report.warn("vertex " + outVertex.getIdentity() + " incoming edge list is unreadable (error: "
                               + describe(probeError) + ")" + (fix ? ", rebuilding it from the surviving edge records" : ""));
-                      if (fix)
-                        resetChain(outVertex, Vertex.DIRECTION.IN);
-                    }
                   }
                   if (connected != null && !connected && !reconnectInEdges.contains(outVertex.getIdentity())) {
                     report.warn("edge " + edgeRID + " was not connected from the outgoing vertex " + edge.getIn() + " back to the vertex "
                             + vertexIdentity);
+                    // PLANNED, not written - see the twin in checkIncomingEdges (issue #6136), including why the
+                    // per-list de-duplication is needed now that the probe no longer sees the previous repair.
                     if (fix) {
-                      outVertex = outVertex.modify();
-                      database.getGraphEngine().connectIncomingEdge(outVertex, vertexIdentity, edgeRID);
-                      ((MutableVertex) outVertex).save();
+                      if (plannedBackRefs == null)
+                        plannedBackRefs = new EdgeIdentitySet();
+                      if (plannedBackRefs.add(edgeRID))
+                        plan.backRefInLinks.add(outVertex.getIdentity(), edgeRID, vertexIdentity);
                     }
                   }
                 }
@@ -1238,30 +1323,37 @@ public class GraphDatabaseChecker {
         if (chainBroken) {
           report.warn("error on loading outgoing edges from vertex " + vertexIdentity + " (error: " + chainError + ")"
                   + (fix ? ", rebuilding the edge list from the surviving edge records" : ""));
-          if (fix) {
-            vertex = resetChain(vertex, Vertex.DIRECTION.OUT);
+          if (fix)
             reconnectOutEdges.add(vertexIdentity);
-          }
         }
       }
     }
-    return vertex;
   }
 
   /**
    * Nulls the vertex's head-chunk pointer for the given direction, dropping the unreadable chain so the
-   * adjacency can be rebuilt from the surviving edge records by {@link #reconnectEdges}. Each edge record
-   * stores its own out/in vertex RIDs, so losing the linked list does not lose the graph. Returns the saved
-   * mutable copy so callers keep operating on the fresh vertex.
+   * adjacency can be rebuilt from the surviving edge records by {@link #collectEdgesToReconnect}. Each edge record
+   * stores its own out/in vertex RIDs, so losing the linked list does not lose the graph.
+   * <p>
+   * Takes a RID and re-loads: since #6136 this only ever runs AFTER the scan that decided on it, so there is no
+   * live vertex object to hand it. Loaded with content - {@code modify()} copies whatever the immutable holds, so
+   * a lazily-loaded one would save the properties away.
    */
-  private Vertex resetChain(final Vertex vertex, final Vertex.DIRECTION direction) {
-    final MutableVertex mutable = vertex.modify();
-    if (direction == Vertex.DIRECTION.OUT)
-      mutable.setOutEdgesHeadChunk(null);
-    else
-      mutable.setInEdgesHeadChunk(null);
-    mutable.save();
-    return mutable;
+  private void resetChain(final RID vertexRID, final Vertex.DIRECTION direction, final CheckReport report) {
+    try {
+      final MutableVertex mutable = vertexRID.asVertex(true).modify();
+      if (direction == Vertex.DIRECTION.OUT)
+        mutable.setOutEdgesHeadChunk(null);
+      else
+        mutable.setInEdgesHeadChunk(null);
+      mutable.save();
+    } catch (final RecordNotFoundException e) {
+      // The vertex is gone - another arm of this same run deleted it - so there is no chain left to drop.
+    } catch (final Exception e) {
+      report.warn("vertex " + vertexRID + " " + direction + " edge list could not be dropped for rebuild (error: "
+          + describe(e) + ")");
+    }
+    commitRepairBatchIfFull();
   }
 
   public Map<String, Object> checkEdges(final String typeName, final boolean fix, final int verboseLevel) {
@@ -1469,6 +1561,12 @@ public class GraphDatabaseChecker {
       // #5777 is about exactly this arm's handling of endpoints - cannot silently stop counting it. Do not read
       // it as evidence that this arm prunes today.
       stats.put("autoFix", autoFix.get() + report.prunedDanglingEntries);
+      // The same breakdown the vertex arm publishes (issue #6136, item 3), so a reader never has to know which arm
+      // produced a number. reconnectedEdges is structurally zero here for the reason prunedDanglingEntries is:
+      // this arm plans no re-links.
+      stats.put("removedRecords", autoFix.get());
+      stats.put("prunedDanglingEntries", report.prunedDanglingEntries);
+      stats.put("reconnectedEdges", 0L);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("invalidLinks", report.invalidLinks);
@@ -1508,6 +1606,108 @@ public class GraphDatabaseChecker {
     else if (missingReferences.size() < maxTracked) {
       missingReferences.put(target, 1L);
       missingReferenceErrors.put(target, error);
+    }
+  }
+
+  /**
+   * The repairs a vertex scan DECIDED on but deliberately did not perform, so that every write leaves the scan and
+   * lands in a loop {@link #commitRepairBatchIfFull()} can bound (issue #6136, item 2).
+   * <p>
+   * Before this, the two checks wrote from inside the {@code scanType} callback - one vertex record per
+   * {@link #resetChain} and one adjacency entry per edge "not connected from the other side" - and nothing could
+   * commit under them, because {@code LocalDatabase.scanType} holds the database read lock and the chunk iterator
+   * being walked would not survive a commit. A database with a very large number of edges in that state therefore
+   * still accumulated one oversized transaction and hit the {@code ReplicatedEntryTooLargeException} that #6131
+   * removed everywhere else.
+   * <p>
+   * The two RID sets were already here doing half of this: EVERY {@code resetChain} call site also registered its
+   * vertex in one of them, so the set of lists to rebuild IS the set of chains to reset, and deferring the reset
+   * costs no extra memory at all. Only the back-reference fix-up needed an accumulator, and it is a
+   * {@link PendingLinks} rather than a collection of records for the reason stated there.
+   */
+  private static final class RepairPlan {
+    /** Vertices whose OUT list must be dropped and rebuilt from the surviving edge records. */
+    final Set<RID>     reconnectOutEdges = new HashSet<>();
+    /** Vertices whose IN list must be dropped and rebuilt from the surviving edge records. */
+    final Set<RID>     reconnectInEdges  = new HashSet<>();
+    /** OUT-list entries rebuilt from the surviving edge records, for the vertices in {@link #reconnectOutEdges}. */
+    final PendingLinks rebuiltOutLinks   = new PendingLinks();
+    /** IN-list entries rebuilt from the surviving edge records, for the vertices in {@link #reconnectInEdges}. */
+    final PendingLinks rebuiltInLinks    = new PendingLinks();
+    /**
+     * Back-references the OUT list of an otherwise healthy far vertex was missing. Kept apart from the rebuilt
+     * links rather than merged into them, even though the write is identical, because the two are reported
+     * separately: "reconnected N outgoing edges" has always meant "a broken chain was rebuilt from N edge records"
+     * and folding a different repair into that number would change what an existing report says.
+     */
+    final PendingLinks backRefOutLinks   = new PendingLinks();
+    /** Back-references the IN list of an otherwise healthy far vertex was missing. */
+    final PendingLinks backRefInLinks    = new PendingLinks();
+  }
+
+  /**
+   * An append-only list of adjacency entries to (re)create, each the triple (vertex whose list gains the entry,
+   * edge, the other endpoint the entry records).
+   * <p>
+   * PRIMITIVE ARRAYS, not a {@code List} of anything. This is the one structure #6136 adds that grows with the
+   * amount of damage, and the accumulation it replaces is the warning: {@code reconnectEdges} held an
+   * {@code ArrayList<Edge>} of every edge to re-link, i.e. a fully materialised record - properties and all - per
+   * entry, which is unbounded heap in exactly the way the WAL growth this change fixes was unbounded. Three RIDs
+   * flattened into an {@code int[]} plus a {@code long[]} is 36 bytes per entry with no per-object header and no
+   * card-marking, against a couple of hundred for the record it used to keep alive, and the apply loop rebuilds
+   * the RID objects one entry at a time.
+   * <p>
+   * Still unbounded in the number of ENTRIES, and deliberately so: an entry is dropped only once its repair has
+   * been applied, and a cap would mean silently declining to repair part of the damage. The bound that matters -
+   * and the one #6128/#6136 are about - is on the transaction, not on the plan.
+   */
+  private static final class PendingLinks {
+    private static final int TRIPLE = 3;
+
+    private int[]  buckets   = new int[TRIPLE * 16];
+    private long[] positions = new long[TRIPLE * 16];
+    private int    size;
+
+    void add(final RID vertex, final RID edge, final RID other) {
+      final int base = size * TRIPLE;
+      if (base + TRIPLE > buckets.length) {
+        final int newLength = buckets.length + (buckets.length >> 1) + TRIPLE;
+        buckets = Arrays.copyOf(buckets, newLength);
+        positions = Arrays.copyOf(positions, newLength);
+      }
+      set(base, vertex);
+      set(base + 1, edge);
+      set(base + 2, other);
+      ++size;
+    }
+
+    private void set(final int slot, final RID rid) {
+      buckets[slot] = rid.getBucketId();
+      positions[slot] = rid.getPosition();
+    }
+
+    private RID get(final int slot) {
+      return new RID(buckets[slot], positions[slot]);
+    }
+
+    int size() {
+      return size;
+    }
+
+    boolean isEmpty() {
+      return size == 0;
+    }
+
+    RID vertex(final int i) {
+      return get(i * TRIPLE);
+    }
+
+    RID edge(final int i) {
+      return get(i * TRIPLE + 1);
+    }
+
+    RID other(final int i) {
+      return get(i * TRIPLE + 2);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -616,32 +616,7 @@ public class GraphDatabaseChecker {
       progressComplete();
 
       if (fix) {
-        // ORDER IS LOAD-BEARING (issue #6136). The chains are dropped FIRST: getOrCreateEdgeList appends to whatever
-        // head pointer it finds, so re-linking a vertex whose unreadable chain is still attached would append to the
-        // damaged list instead of building a fresh one. Then the surviving edge records are collected, and only then
-        // is anything written into a list - by which point every list that is being rebuilt is empty.
-        applyPendingChainResets(plan, report);
-
-        if (!plan.reconnectOutEdges.isEmpty() || !plan.reconnectInEdges.isEmpty())
-          collectEdgesToReconnect(plan, report);
-
-        // Both kinds of link land through the same loop: an entry rebuilt from a surviving edge record and a
-        // back-reference the far vertex was missing are the same write - add (edge, other endpoint) to a list.
-        // They are counted and reported apart, see RepairPlan.
-        final long rebuiltOut = applyPendingLinks(plan.rebuiltOutLinks, Vertex.DIRECTION.OUT, null, report);
-        if (rebuiltOut > 0)
-          report.warn("reconnected " + rebuiltOut + " outgoing edges");
-
-        final long rebuiltIn = applyPendingLinks(plan.rebuiltInLinks, Vertex.DIRECTION.IN, null, report);
-        if (rebuiltIn > 0)
-          report.warn("reconnected " + rebuiltIn + " incoming edges");
-
-        final long backRefs = applyPendingLinks(plan.backRefOutLinks, Vertex.DIRECTION.OUT, plan.reconnectOutEdges, report)
-            + applyPendingLinks(plan.backRefInLinks, Vertex.DIRECTION.IN, plan.reconnectInEdges, report);
-        if (backRefs > 0)
-          report.warn("re-linked " + backRefs + " edges that were not connected from the other side");
-
-        reconnectedEdges = rebuiltOut + rebuiltIn + backRefs;
+        reconnectedEdges = applyRepairPlan(plan, report);
 
         for (final RID rid : report.corruptedRecords) {
           if (rid == null)
@@ -696,6 +671,42 @@ public class GraphDatabaseChecker {
     }
 
     return stats;
+  }
+
+  /**
+   * Performs every repair the vertex scan planned, in the ONE order that is correct (issue #6136).
+   * <p>
+   * ORDER IS LOAD-BEARING. The chains are dropped FIRST: {@code getOrCreateEdgeList} appends to whatever head
+   * pointer it finds, so re-linking a vertex whose unreadable chain is still attached would append to the damaged
+   * list instead of building a fresh one. Then the surviving edge records are collected, and only then is anything
+   * written into a list - by which point every list being rebuilt is empty.
+   * <p>
+   * Both kinds of link go through the same apply loop, because an entry rebuilt from a surviving edge record and a
+   * back-reference the far vertex was missing are the same write: add (edge, other endpoint) to a list. They are
+   * counted and reported apart for the reason given on {@link RepairPlan}.
+   *
+   * @return how many adjacency entries were re-linked, of either kind
+   */
+  private long applyRepairPlan(final RepairPlan plan, final CheckReport report) {
+    applyPendingChainResets(plan, report);
+
+    if (!plan.reconnectOutEdges.isEmpty() || !plan.reconnectInEdges.isEmpty())
+      collectEdgesToReconnect(plan, report);
+
+    final long rebuiltOut = applyPendingLinks(plan.rebuiltOutLinks, Vertex.DIRECTION.OUT, null, report);
+    if (rebuiltOut > 0)
+      report.warn("reconnected " + rebuiltOut + " outgoing edges");
+
+    final long rebuiltIn = applyPendingLinks(plan.rebuiltInLinks, Vertex.DIRECTION.IN, null, report);
+    if (rebuiltIn > 0)
+      report.warn("reconnected " + rebuiltIn + " incoming edges");
+
+    final long backRefs = applyPendingLinks(plan.backRefOutLinks, Vertex.DIRECTION.OUT, plan.reconnectOutEdges, report)
+        + applyPendingLinks(plan.backRefInLinks, Vertex.DIRECTION.IN, plan.reconnectInEdges, report);
+    if (backRefs > 0)
+      report.warn("re-linked " + backRefs + " edges that were not connected from the other side");
+
+    return rebuiltOut + rebuiltIn + backRefs;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -504,7 +504,7 @@ public class GraphDatabaseChecker {
    * without paying a full type scan - the strict delete path in {@code GraphEngine.deleteVertex} names this
    * command in its error message.
    * <p>
-   * The edge-record scan inside {@link #reconnectEdges} is NOT scoped: rebuilding an adjacency means finding
+   * The edge-record scan inside {@link #collectEdgesToReconnect} is NOT scoped: rebuilding an adjacency means finding
    * every surviving edge that points at the vertex, and no index maps endpoints back to edges. So the scoped run
    * saves the vertex passes, not the edge pass.
    * <p>
@@ -651,14 +651,7 @@ public class GraphDatabaseChecker {
       database.commit();
 
     } finally {
-      // Both kinds of repair this run performed: records removed, plus dangling adjacency entries pruned (#6128).
-      stats.put("autoFix", autoFix.get() + report.prunedDanglingEntries);
-      // The breakdown behind that sum, plus the repair kind it never included (issue #6136, item 3). autoFix keeps
-      // its meaning for every existing reader; these say which arms it decomposes into and add the one that was
-      // only ever visible in the warnings.
-      stats.put("removedRecords", autoFix.get());
-      stats.put("prunedDanglingEntries", report.prunedDanglingEntries);
-      stats.put("reconnectedEdges", reconnectedEdges);
+      putRepairCounters(stats, autoFix.get(), report.prunedDanglingEntries, reconnectedEdges);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("duplicateLightEdges", report.duplicateLightEdges);
@@ -1607,14 +1600,9 @@ public class GraphDatabaseChecker {
       // checkIncomingEdges/checkOutgoingEdges, which only checkVertices calls. Kept rather than simplified to
       // autoFix.get() so the two arms report autoFix identically, and so an edge arm that one day does prune -
       // #5777 is about exactly this arm's handling of endpoints - cannot silently stop counting it. Do not read
-      // it as evidence that this arm prunes today.
-      stats.put("autoFix", autoFix.get() + report.prunedDanglingEntries);
-      // The same breakdown the vertex arm publishes (issue #6136, item 3), so a reader never has to know which arm
-      // produced a number. reconnectedEdges is structurally zero here for the reason prunedDanglingEntries is:
+      // it as evidence that this arm prunes today. reconnectedEdges is structurally zero here for the same reason:
       // this arm plans no re-links.
-      stats.put("removedRecords", autoFix.get());
-      stats.put("prunedDanglingEntries", report.prunedDanglingEntries);
-      stats.put("reconnectedEdges", 0L);
+      putRepairCounters(stats, autoFix.get(), report.prunedDanglingEntries, 0L);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("invalidLinks", report.invalidLinks);
@@ -1627,6 +1615,26 @@ public class GraphDatabaseChecker {
     }
 
     return stats;
+  }
+
+  /**
+   * Publishes what a repair run did: the {@code autoFix} total both arms have always reported, plus the per-kind
+   * breakdown behind it (issue #6136, item 3).
+   * <p>
+   * {@code autoFix} keeps its meaning for every existing reader - it is the count of repair ACTIONS, records
+   * removed plus dangling adjacency entries pruned - and the breakdown says which arms it decomposes into.
+   * {@code reconnectedEdges} is deliberately OUTSIDE that sum: a rebuilt chain has never contributed to
+   * {@code autoFix}, and folding it in would change every number a current run reports.
+   * <p>
+   * One helper rather than the same four lines in both arms, so a reader never has to check whether they still
+   * agree - the drift the {@code #5777} comment in {@code checkEdges} is guarding against from the other side.
+   */
+  private static void putRepairCounters(final Map<String, Object> stats, final long removedRecords,
+      final long prunedDanglingEntries, final long reconnectedEdges) {
+    stats.put("autoFix", removedRecords + prunedDanglingEntries);
+    stats.put("removedRecords", removedRecords);
+    stats.put("prunedDanglingEntries", prunedDanglingEntries);
+    stats.put("reconnectedEdges", reconnectedEdges);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseBackReferenceRepairTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseBackReferenceRepairTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -124,7 +125,7 @@ class CheckDatabaseBackReferenceRepairTest extends TestHelper {
   private int countCommitsDuring(final Runnable block) {
     final AtomicInteger commits = new AtomicInteger();
     final DatabaseInternal db = (DatabaseInternal) database;
-    final java.util.concurrent.Callable<Void> counter = () -> {
+    final Callable<Void> counter = () -> {
       commits.incrementAndGet();
       return null;
     };

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseBackReferenceRepairTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseBackReferenceRepairTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6136 (2): the two repairs {@code CHECK DATABASE ... FIX} used to perform from INSIDE the vertex scan.
+ * <p>
+ * #6131 bounded every post-scan repair loop with {@code arcadedb.checkDatabaseRepairBatchPages} and deliberately left
+ * the in-scan ones alone, because {@code LocalDatabase.scanType} holds the database read lock for the length of the
+ * scan and the chunk iterator being walked would not survive a commit taken under it. That left the back-reference
+ * fix-up - one write to a FAR vertex per edge found "not connected from the other side", each able to allocate a
+ * fresh edge-list chunk - accumulating in a transaction nothing could split. On a replicated database that
+ * transaction is one Raft log entry, and a large enough one is rejected outright with
+ * {@code ReplicatedEntryTooLargeException}, which is not a {@code NeedRetryException}.
+ * <p>
+ * The repair is now PLANNED during the scan and applied after it, so it goes through the same page budget as
+ * everything else. Both directions are pinned: a run over the budget must produce more than one transaction, and
+ * both settings must repair the graph identically - a deferral bug that silently dropped repairs would otherwise
+ * satisfy the commit-count assertion on its own.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseBackReferenceRepairTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+  /**
+   * One damaged PAIR per unit, not one damaged hub: the repair writes to the far vertex of each defective edge, so
+   * the page volume comes from how many DISTINCT far vertices need a chunk, not from how many edges one of them has.
+   */
+  private static final int    PAIRS       = 60;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // The fixture leaves a deliberately half-connected graph; the post-test check would (correctly) flag it.
+    return false;
+  }
+
+  /**
+   * A back-reference repair whose page footprint exceeds the budget must be split across several transactions, and
+   * must still re-link every edge.
+   */
+  @Test
+  void theBackReferenceRepairIsSplitAcrossTransactions() {
+    final List<RID> targets = createHalfConnectedPairs();
+
+    GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES.setValue(4);
+    final int commits = countCommitsDuring(this::repairVertices);
+
+    assertThat(commits)
+        .as("a back-reference repair bigger than the page budget must not be one single transaction")
+        .isGreaterThan(1);
+
+    assertRepaired(targets);
+  }
+
+  /** The budget disabled restores the historical single-transaction behaviour, and repairs exactly the same graph. */
+  @Test
+  void theBackReferenceRepairIsWholeWithTheBudgetDisabled() {
+    final List<RID> targets = createHalfConnectedPairs();
+
+    GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES.setValue(0);
+    final int commits = countCommitsDuring(this::repairVertices);
+
+    assertThat(commits).as("with the budget disabled the whole type repair is one transaction").isEqualTo(1);
+
+    assertRepaired(targets);
+  }
+
+  /**
+   * The repair is reported as its own kind (issue #6136, item 3) rather than being invisible: it never contributed
+   * to {@code autoFix} and, before the breakdown existed, an operator could only find it in the warnings.
+   */
+  @Test
+  void theRepairIsCountedAsReconnectedEdges() {
+    createHalfConnectedPairs();
+
+    GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES.setValue(0);
+    final Map<String, Object> stats = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkVertices(VERTEX_TYPE, true, 0);
+
+    assertThat((Long) stats.get("reconnectedEdges"))
+        .as("every re-linked back-reference must be counted").isEqualTo(PAIRS);
+    assertThat((Long) stats.get("autoFix"))
+        .as("nothing was deleted and nothing was pruned, so autoFix stays zero - which is exactly why the "
+            + "breakdown had to be added").isZero();
+  }
+
+  /** The vertex arm on its own: a full CHECK DATABASE FIX runs several passes that each commit. */
+  private void repairVertices() {
+    new GraphDatabaseChecker((DatabaseInternal) database).checkVertices(VERTEX_TYPE, true, 0);
+  }
+
+  /** Counts the transactions that actually wrote WAL while {@code block} ran. */
+  private int countCommitsDuring(final Runnable block) {
+    final AtomicInteger commits = new AtomicInteger();
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final java.util.concurrent.Callable<Void> counter = () -> {
+      commits.incrementAndGet();
+      return null;
+    };
+    db.registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, counter);
+    try {
+      block.run();
+    } finally {
+      db.unregisterCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, counter);
+    }
+    return commits.get();
+  }
+
+  /**
+   * {@link #PAIRS} source-target pairs joined by one edge each, with every TARGET's incoming chain detached
+   * afterwards.
+   * <p>
+   * That is the exact shape of the defect: the edge record and the source's outgoing entry are both intact, so the
+   * scan reads a perfectly healthy edge and finds that the vertex on the other end does not list it - which is what
+   * {@code isConnectedTo} answers when the head chunk is simply absent. Nothing here is unreadable, so no chain is
+   * rebuilt and no record is deleted, and the back-reference fix-up is the ONLY repair the run performs.
+   *
+   * @return the target RIDs, in creation order
+   */
+  private List<RID> createHalfConnectedPairs() {
+    // A SMALLER page size, set before the buckets are created: the budget counts PAGES, and at the 64KB default the
+    // whole fixture packs into a couple of them, so no assertion about batching could mean anything.
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(16_384);
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE);
+    });
+
+    // A payload per vertex, so the vertex records span several pages instead of packing into one.
+    final String payload = "x".repeat(1_500);
+
+    final List<RID> targets = new ArrayList<>(PAIRS);
+    for (int p = 0; p < PAIRS; p++) {
+      final int pair = p;
+      final RID[] holder = new RID[1];
+      database.transaction(() -> {
+        final MutableVertex target = database.newVertex(VERTEX_TYPE).set("name", "target" + pair).set("payload", payload)
+            .save();
+        database.newVertex(VERTEX_TYPE).set("name", "source" + pair).set("payload", payload).save()
+            .newEdge(EDGE_TYPE, target);
+        holder[0] = target.getIdentity();
+      });
+      targets.add(holder[0]);
+    }
+
+    // Detach every target's IN chain. Not corruption of the chunk - the pointer is simply dropped, which is what a
+    // half-applied write leaves behind and what makes isConnectedTo answer "no" instead of throwing.
+    database.transaction(() -> {
+      for (final RID target : targets) {
+        final MutableVertex mutable = target.asVertex(true).modify();
+        mutable.setInEdgesHeadChunk(null);
+        mutable.save();
+      }
+    });
+
+    database.transaction(() -> {
+      for (final RID target : targets)
+        assertThat(target.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE))
+            .as("the fixture must actually leave target %s unconnected from its side", target).isZero();
+    });
+
+    return targets;
+  }
+
+  /** Every target lists its edge again, and a second check finds nothing left to re-link. */
+  private void assertRepaired(final List<RID> targets) {
+    database.transaction(() -> {
+      for (final RID target : targets)
+        assertThat(target.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE))
+            .as("target %s must be connected from its own side again", target).isEqualTo(1);
+    });
+
+    final Map<String, Object> second = new GraphDatabaseChecker((DatabaseInternal) database)
+        .checkVertices(VERTEX_TYPE, false, 0);
+    assertThat((Long) second.get("totalWarnings"))
+        .as("a repaired graph must give the checker nothing left to say").isZero();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairBreakdownTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairBreakdownTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6136 (3): {@code autoFix} is a sum of repair ACTIONS of different kinds, and one kind was not in it at all.
+ * <p>
+ * After #6128 it counts records deleted plus dangling adjacency entries pruned. Both are genuine repairs and both are
+ * genuine writes to distinct pages, so the number is not wrong - but an operator reading it as "how many broken
+ * things were there" over-counts (one edge that is both listed in a chain and corrupt as a record contributes two),
+ * and a rebuilt chain contributes NOTHING, being reported only in the warnings. So the one number an operator reads
+ * to decide whether a run did anything mixed three kinds with different weights, one of them invisible.
+ * <p>
+ * {@code autoFix} is deliberately unchanged - existing readers and existing expectations depend on it, and
+ * redefining it as "defects fixed" would need the arms to agree on what one defect IS across a dangling entry, a
+ * corrupt record and a rebuilt chain, which they cannot without collapsing information the warnings carry. What is
+ * added is the breakdown: {@code removedRecords}, {@code prunedDanglingEntries} and {@code reconnectedEdges}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseRepairBreakdownTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+  private static final int    DEGREE      = 30;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // These tests inject on-disk corruption on purpose; the post-test check would (correctly) flag it.
+    return false;
+  }
+
+  /**
+   * A raw-deleted edge record: both of its adjacency entries are pruned and nothing is deleted (the record is
+   * already gone), so the whole of {@code autoFix} is the prune arm. That is the commonest damage shape there is,
+   * and until the breakdown existed the report could not say which arm produced the number.
+   */
+  @Test
+  void aPrunedDanglingEntryIsReportedApartFromADeletedRecord() {
+    createGraph();
+
+    final RID edge = anyEdge();
+    database.transaction(() -> database.getSchema().getBucketById(edge.getBucketId()).deleteRecord(edge));
+
+    final Result row = runFix();
+
+    assertThat((Long) row.getProperty("autoFix"))
+        .as("one raw-deleted edge leaves a dangling entry on each side").isEqualTo(2L);
+    assertThat((Long) row.getProperty("prunedDanglingEntries"))
+        .as("both repairs were prunes").isEqualTo(2L);
+    assertThat((Long) row.getProperty("removedRecords"))
+        .as("the edge record was already gone, so nothing was deleted").isZero();
+    assertThat((Long) row.getProperty("reconnectedEdges"))
+        .as("no chain was rebuilt and no back-reference was missing").isZero();
+    assertBreakdownAddsUp(row);
+  }
+
+  /**
+   * A rebuilt chain: {@code reconnectedEdges} carries it, and {@code autoFix} deliberately still does not - which is
+   * the whole point of adding a separate counter rather than folding it in and changing every existing number.
+   */
+  @Test
+  void aRebuiltChainIsCountedAndIsStillNotPartOfAutoFix() {
+    final RID hub = createGraph();
+
+    final RID[] head = new RID[1];
+    database.transaction(() -> head[0] = ((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk());
+    assertThat(head[0]).as("the hub must have an in-edge list to break").isNotNull();
+    corruptRecordTypeByte((DatabaseInternal) database, head[0]);
+
+    final Result row = runFix();
+
+    assertThat((Long) row.getProperty("reconnectedEdges"))
+        .as("every entry rebuilt from a surviving edge record must be counted").isEqualTo(DEGREE);
+    assertThat((Long) row.getProperty("autoFix"))
+        .as("a rebuilt chain has never contributed to autoFix and must not start to")
+        .isEqualTo((Long) row.getProperty("removedRecords") + (Long) row.getProperty("prunedDanglingEntries"));
+    assertBreakdownAddsUp(row);
+
+    database.transaction(() -> assertThat(hub.asVertex(true).countEdges(Vertex.DIRECTION.IN, EDGE_TYPE))
+        .as("the adjacency must actually be back").isEqualTo(DEGREE));
+  }
+
+  /** A clean database reports the breakdown as zeroes rather than omitting the keys. */
+  @Test
+  void theBreakdownIsAlwaysPresent() {
+    createGraph();
+
+    final Result row = runFix();
+
+    assertThat((Long) row.getProperty("removedRecords")).isZero();
+    assertThat((Long) row.getProperty("prunedDanglingEntries")).isZero();
+    assertThat((Long) row.getProperty("reconnectedEdges")).isZero();
+    assertBreakdownAddsUp(row);
+  }
+
+  /** The invariant the breakdown promises: {@code autoFix} is exactly its two constituent arms. */
+  private static void assertBreakdownAddsUp(final Result row) {
+    assertThat((Long) row.getProperty("autoFix"))
+        .as("autoFix is documented as removedRecords + prunedDanglingEntries")
+        .isEqualTo((Long) row.getProperty("removedRecords") + (Long) row.getProperty("prunedDanglingEntries"));
+  }
+
+  private Result runFix() {
+    try (final ResultSet rs = database.command("sql", "CHECK DATABASE FIX")) {
+      return rs.next();
+    }
+  }
+
+  private RID anyEdge() {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> holder[0] = database.iterateType(EDGE_TYPE, false).next().getIdentity());
+    return holder[0];
+  }
+
+  /** A hub with {@link #DEGREE} incoming edges. */
+  private RID createGraph() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE);
+    });
+
+    final RID[] holder = new RID[1];
+    database.transaction(() -> {
+      holder[0] = database.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity();
+      for (int i = 0; i < DEGREE; i++)
+        database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, holder[0].asVertex(true));
+    });
+    return holder[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseTransactionNestingTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseTransactionNestingTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Issue #6136 (4): how many transaction levels {@code CHECK DATABASE ... FIX} consumes, pinned deliberately.
+ * <p>
+ * {@code DatabaseContext.DatabaseContextTL.pushTransaction} refuses once {@code transactions.size() + 1 > maxNested},
+ * and {@code maxNested} is a hardcoded 3 with no configuration key and no caller anywhere in the codebase. The issue
+ * reported the FIX path as sitting exactly on that cap - the HTTP handler's transaction, the arm's own, and the
+ * repair batch's - which would leave no headroom at all.
+ * <p>
+ * IT DOES NOT, and the reason is worth recording rather than rediscovering. {@code CheckDatabaseStatement.executeSimple}
+ * opens by rolling the caller's transaction back, so the handler's level is released before the check starts; the
+ * arms' {@code begin()} then finds the last context inactive and REUSES it rather than pushing
+ * ({@code LocalDatabase.begin} only pushes when the last transaction is active); and
+ * {@code commitRepairBatchIfFull()} commits and re-begins at that same level rather than nesting under it. The path
+ * runs at ONE level with two to spare.
+ * <p>
+ * The conclusion #6131 drew from the wrong premise still holds and is the one that matters: these are real
+ * {@code commit()} calls on a real {@code TransactionContext}, so each is a genuine WAL write and, under HA, a
+ * genuine replication round trip. Nesting would not have made them savepoints either - it was never the mechanism.
+ * <p>
+ * Pinned both ways so that a future change adding a level anywhere on this path arrives as a red build naming the
+ * cap, rather than as a {@code TransactionException} in a repair someone is running against a damaged production
+ * database - whose message ("Check your code if you are beginning new transactions without closing the previous one
+ * by mistake") would point at a bug that is not the real one. Raising {@code maxNested} is the wrong answer: the
+ * limit is a real guard against leaked transactions, and the useful thing is knowing when this path eats into it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseTransactionNestingTest extends TestHelper {
+  private static final String VERTEX_TYPE     = "Node";
+  private static final String EDGE_TYPE       = "Link";
+  private static final int    DEGREE          = 20;
+  /** What {@code DatabaseContext.DatabaseContextTL} initialises {@code maxNested} to. */
+  private static final int    DEFAULT_MAX_NESTED = 3;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // The fixture injects on-disk corruption on purpose; the post-test check would (correctly) flag it.
+    return false;
+  }
+
+  /**
+   * The deepest nesting the FIX path actually reaches, sampled at every transaction it commits - which is every
+   * transaction it opens, since the repair batches, the per-type arms and the reclaim all end in a commit.
+   */
+  @Test
+  void theFixPathRunsAtOneTransactionLevel() {
+    createBrokenHub();
+
+    final AtomicInteger deepest = new AtomicInteger();
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final Callable<Void> sampler = () -> {
+      deepest.accumulateAndGet(database.getNestedTransactions(), Math::max);
+      return null;
+    };
+
+    db.registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, sampler);
+    try {
+      // The HTTP handler shape: the command arrives with a transaction already open on the thread.
+      database.begin();
+      try (final ResultSet rs = database.command("sql", "CHECK DATABASE FIX")) {
+        assertThat(rs.next().<String>getProperty("operation")).isEqualTo("check database");
+      }
+    } finally {
+      db.unregisterCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, sampler);
+      if (database.isTransactionActive())
+        database.rollback();
+    }
+
+    assertThat(deepest.get()).as("the FIX path must have committed at least one transaction to sample").isPositive();
+    assertThat(deepest.get())
+        .as("CHECK DATABASE FIX must stay at one transaction level: it has %d of the %d the context allows, and "
+            + "anything that adds a level here spends headroom that has no configuration key to restore",
+            deepest.get(), DEFAULT_MAX_NESTED)
+        .isEqualTo(1);
+  }
+
+  /**
+   * The same statement under the tightest cap the mechanism can express. This is the assertion that bites first: a
+   * new level anywhere on the path fails here with the cap named, whatever the sampled depth happens to be.
+   */
+  @Test
+  void theFixPathSurvivesTheTightestNestingCap() {
+    createBrokenHub();
+
+    final DatabaseContext.DatabaseContextTL context = DatabaseContext.INSTANCE.getContext(database.getDatabasePath());
+    final int previous = context.getMaxNested();
+    context.setMaxNested(1);
+    try {
+      assertThatCode(() -> {
+        database.begin();
+        try (final ResultSet rs = database.command("sql", "CHECK DATABASE FIX")) {
+          rs.next();
+        }
+      }).as("CHECK DATABASE FIX must not need more than one transaction level").doesNotThrowAnyException();
+    } finally {
+      // The context is thread-local and the thread is reused by the rest of the suite: never leave the cap moved.
+      context.setMaxNested(previous);
+      if (database.isTransactionActive())
+        database.rollback();
+    }
+
+    assertThat(previous).as("the hardcoded default this test is measuring headroom against")
+        .isEqualTo(DEFAULT_MAX_NESTED);
+  }
+
+  /** A hub whose in-edge chain is broken, so FIX has real repair work to do rather than an empty pass. */
+  private void createBrokenHub() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE);
+    });
+
+    final RID[] hub = new RID[1];
+    database.transaction(() -> {
+      hub[0] = database.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity();
+      for (int i = 0; i < DEGREE; i++)
+        database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, hub[0].asVertex(true));
+    });
+
+    final RID[] head = new RID[1];
+    database.transaction(() -> head[0] = ((VertexInternal) hub[0].asVertex(true)).getInEdgesHeadChunk());
+    assertThat(head[0]).as("the hub must have an in-edge list to break").isNotNull();
+    corruptRecordTypeByte((DatabaseInternal) database, head[0]);
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1551,15 +1551,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
             removeFiles.put(c.fileId, c.fileName);
         }
 
-      // Reconcile what the instalments already shipped (issue #6136). A file an instalment created is not
-      // re-announced - it exists on the followers - and, more importantly, one the session went on to DROP has to
-      // be retired explicitly: FileManager.dropFile cancels the recorded create when both happen inside one
-      // session, so without this the file would survive on the followers and nowhere else.
       final SchemaInstalmentState instalmentState = schemaInstalments.get();
-      if (instalmentState != null && !instalmentState.shippedFiles.isEmpty())
-        for (final Map.Entry<Integer, String> shipped : instalmentState.shippedFiles.entrySet())
-          if (addFiles.remove(shipped.getKey()) == null)
-            removeFiles.putIfAbsent(shipped.getKey(), shipped.getValue());
+      reconcileInstalmentFiles(instalmentState, addFiles, removeFiles);
 
       if (schemaChanged)
         serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
@@ -1611,6 +1604,26 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       schemaBucketDeltaBuffer.get().clear();
       proxied.getFileManager().stopRecordingChanges();
     }
+  }
+
+  /**
+   * Folds what the instalments already shipped into the session's FINAL file maps (issue #6136).
+   * <p>
+   * A file an instalment created is not re-announced - it exists on the followers already. More importantly, one
+   * the session went on to DROP has to be retired explicitly: {@code FileManager.dropFile} CANCELS the recorded
+   * create when both happen inside one session, so the final entry would say nothing about a file the followers
+   * were told to create, and it would survive there and nowhere else.
+   * <p>
+   * A no-op when no instalment went out, which is every session small enough to ship in one entry.
+   */
+  private static void reconcileInstalmentFiles(final SchemaInstalmentState state, final Map<Integer, String> addFiles,
+      final Map<Integer, String> removeFiles) {
+    if (state == null || state.shippedFiles.isEmpty())
+      return;
+
+    for (final Map.Entry<Integer, String> shipped : state.shippedFiles.entrySet())
+      if (addFiles.remove(shipped.getKey()) == null)
+        removeFiles.putIfAbsent(shipped.getKey(), shipped.getValue());
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -106,12 +106,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -152,6 +154,43 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   // install the rewritten sealed files atomically with the buffered mutable-bucket clear WAL.
   private static final ThreadLocal<List<RaftLogEntryCodec.TsSealedBlob>> compactionSealedBuffer =
       ThreadLocal.withInitial(ArrayList::new);
+  /**
+   * Non-null only while a {@code recordFileChanges} session on THIS thread is shipping its buffered WAL in
+   * instalments (issue #6136). Thread-local for the same reason the buffers are, and null everywhere else - notably
+   * in {@code runWithCompactionReplication}, which buffers too but produces a bounded amount of it and chunks its
+   * synthetic WAL as it serializes.
+   */
+  private static final ThreadLocal<SchemaInstalmentState>                schemaInstalments      = new ThreadLocal<>();
+  /**
+   * How many schema-WAL instalments this JVM has shipped since it started (issue #6136). A process-wide
+   * observability counter, not per-database state: the question it answers - "did a schema session have to ship
+   * its WAL incrementally, and how often?" - is asked of a node, and a leader runs one such session at a time
+   * anyway. Zero on a node that never crossed the threshold, which is every node until an index is rebuilt or a
+   * DDL callback writes more than half a Raft entry's worth of pages.
+   */
+  private static final AtomicLong                                        schemaInstalmentsShipped = new AtomicLong();
+
+  /**
+   * Bookkeeping for a {@code recordFileChanges} session that ships its WAL incrementally (issue #6136).
+   * <p>
+   * An index rebuild inside such a session commits once per {@code IndexBuilder.BUILD_BATCH_SIZE} records, and
+   * every one of those commits buffered a full WAL image that was only drained when the callback returned: peak
+   * leader heap was the whole rebuilt index, plus a repeat of every page touched by more than one batch. This
+   * accumulates the same thing but flushes it as an ordered prefix once it crosses a threshold, so heap is bounded
+   * by the threshold instead of by the size of the index.
+   */
+  private static final class SchemaInstalmentState {
+    /** Raw bytes of WAL currently sitting in {@link #schemaWalBuffer}. */
+    private long                       bufferedBytes;
+    /**
+     * Files an instalment already told the followers to create, so the final entry neither re-ships them nor
+     * forgets to retire one that the session went on to drop - {@code FileManager.dropFile} CANCELS the recorded
+     * create when both happen inside one session, which would otherwise leave the file on the followers only.
+     */
+    private final Map<Integer, String> shippedFiles = new LinkedHashMap<>();
+    /** How many instalments went out; the final entry is unconditional once this is non-zero. */
+    private int                        instalments;
+  }
 
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
@@ -340,8 +379,12 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
           if (phase1 != null) {
             tx.commit2ndPhase(phase1);
-            schemaWalBuffer.get().add(phase1.result.toByteArray());
+            final byte[] wal = phase1.result.toByteArray();
+            schemaWalBuffer.get().add(wal);
             schemaBucketDeltaBuffer.get().add(new HashMap<>(tx.getBucketRecordDelta()));
+            final SchemaInstalmentState state = schemaInstalments.get();
+            if (state != null)
+              state.bufferedBytes += wal.length;
           } else
             tx.reset();
           if (getSchema().getEmbedded().isDirty())
@@ -351,6 +394,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         }
         return null;
       });
+      // Ships OUTSIDE the read lock: the instalment is a Raft round trip, and it needs none of what the block
+      // above holds. The enclosing recordFileChanges callback still owns the database WRITE lock throughout - it
+      // has for the whole build already - so this adds round trips to a window that is fully exclusive anyway,
+      // and it is what keeps the buffer bounded rather than growing with the whole rebuilt index (issue #6136).
+      flushSchemaWalBufferIfFull();
       return;
     }
 
@@ -1479,9 +1527,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // and the outer callback's remaining commits would ship separate TX_ENTRYs instead of riding its
     // SCHEMA_ENTRY - the ordering hazard of issue #4083.
     final Boolean outerSchemaCommitThread = isSchemaCommitThread.get();
+    // Saved and restored for exactly the reason the mark above is: a session opened on ANOTHER database from
+    // inside this callback must not take over this one's instalment bookkeeping (issue #6136).
+    final SchemaInstalmentState outerInstalments = schemaInstalments.get();
     schemaWalBuffer.get().clear();
     schemaBucketDeltaBuffer.get().clear();
     isSchemaCommitThread.set(Boolean.TRUE);
+    schemaInstalments.set(new SchemaInstalmentState());
 
     try {
       final RET result = proxied.recordFileChanges(callback);
@@ -1498,6 +1550,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           else
             removeFiles.put(c.fileId, c.fileName);
         }
+
+      // Reconcile what the instalments already shipped (issue #6136). A file an instalment created is not
+      // re-announced - it exists on the followers - and, more importantly, one the session went on to DROP has to
+      // be retired explicitly: FileManager.dropFile cancels the recorded create when both happen inside one
+      // session, so without this the file would survive on the followers and nowhere else.
+      final SchemaInstalmentState instalmentState = schemaInstalments.get();
+      if (instalmentState != null && !instalmentState.shippedFiles.isEmpty())
+        for (final Map.Entry<Integer, String> shipped : instalmentState.shippedFiles.entrySet())
+          if (addFiles.remove(shipped.getKey()) == null)
+            removeFiles.putIfAbsent(shipped.getKey(), shipped.getValue());
 
       if (schemaChanged)
         serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
@@ -1519,12 +1581,17 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // next ordinary transaction touching one of those pages fails on them with WALVersionGapException,
       // marking the database diverged. The sibling runWithCompactionReplication guards the same buffers
       // with walEntries.isEmpty() included.
-      if (!addFiles.isEmpty() || !removeFiles.isEmpty() || schemaChanged || !walEntries.isEmpty()) {
+      // ... and unconditionally once an instalment went out: those entries are all marked as delivery-only, so
+      // the session's final entry is the only thing that publishes the change. Leaving it out because nothing was
+      // left to say would strand the followers on a half-delivered state they never reload from.
+      final int shippedInstalments = instalmentState != null ? instalmentState.instalments : 0;
+      if (!addFiles.isEmpty() || !removeFiles.isEmpty() || schemaChanged || !walEntries.isEmpty()
+          || shippedInstalments > 0) {
         final RaftHAServer raft = requireRaftServer();
         raft.getTransactionBroker().replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries, bucketDeltas);
         HALog.log(this, HALog.DETAILED,
-            "Schema changes replicated via Raft: addFiles=%d, removeFiles=%d, schemaChanged=%s, embeddedWalEntries=%d",
-            addFiles.size(), removeFiles.size(), schemaChanged, walEntries.size());
+            "Schema changes replicated via Raft: addFiles=%d, removeFiles=%d, schemaChanged=%s, embeddedWalEntries=%d, instalments=%d",
+            addFiles.size(), removeFiles.size(), schemaChanged, walEntries.size(), shippedInstalments);
 
         if (HALog.isEnabled(HALog.DETAILED))
           logSchemaPayloadDiagnostics("recordFileChanges", serializedSchema, addFiles, removeFiles);
@@ -1536,10 +1603,85 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         isSchemaCommitThread.remove();
       else
         isSchemaCommitThread.set(outerSchemaCommitThread);
+      if (outerInstalments == null)
+        schemaInstalments.remove();
+      else
+        schemaInstalments.set(outerInstalments);
       schemaWalBuffer.get().clear();
       schemaBucketDeltaBuffer.get().clear();
       proxied.getFileManager().stopRecordingChanges();
     }
+  }
+
+  /**
+   * Ships the buffered schema WAL as an ordered instalment once it crosses the threshold (issue #6136).
+   * <p>
+   * WHAT THIS FIXES. {@code BucketIndexBuilder.create()} wraps the whole build in {@code recordFileChanges}, which
+   * marks this thread so that {@code commit()} BUFFERS instead of replicating; {@code LSMTreeIndex.build()} then
+   * commits once per {@code IndexBuilder.BUILD_BATCH_SIZE} records. Every one of those WAL images stayed in leader
+   * heap until the callback returned, so peak heap was roughly the whole rebuilt index plus a repeat of every page
+   * more than one batch touched. A {@code CHECK DATABASE FIX} that rebuilds the indexes of a large damaged type is
+   * exactly that shape, on a node that is already the cluster's leader.
+   * <p>
+   * WHY IT IS SAFE, which is the whole question on this path - #4083, #4743 and #5492 all surfaced here as SILENT
+   * follower divergence rather than as an exception. It ships nothing new: it is the ordered-prefix sequence
+   * {@code splitSchemaEntry} has produced since #4743, emitted as the payload is produced rather than after it is
+   * built. Files first, WAL in the middle, and the publishing fields - schema JSON, {@code filesToRemove} - only in
+   * the session's final entry, so every prefix a follower can be left holding is self-consistent: the files exist
+   * before pages land in them, and a partially written new file is unreferenced bytes until the last entry
+   * publishes it. Followers need no new code, because that sequence is the one they already receive.
+   * <p>
+   * THE THRESHOLD is derived, not configured: half the maximum replicated entry size, the same expression
+   * {@code runWithCompactionReplication} uses for its own chunk budget. It is SOFT - tested between buffered
+   * commits, so one batch can overshoot it - which is why {@code replicateSchemaInstalment} can still split.
+   * <p>
+   * WHAT IT DOES NOT FIX, stated because the difference matters: the recording session stays open for the whole
+   * build, so a concurrent writer still waits on {@link #waitForActiveRecordingSession()} (and, before that, on the
+   * database write lock the callback holds). Bounding the heap does not shorten the window, and shortening it means
+   * taking the build out of the session altogether - a different change, on the same code path, worth its own
+   * judgement.
+   */
+  private void flushSchemaWalBufferIfFull() {
+    final SchemaInstalmentState state = schemaInstalments.get();
+    if (state == null)
+      return;
+
+    final RaftTransactionBroker broker = requireRaftServer().getTransactionBroker();
+    if (state.bufferedBytes < Math.max(1024L, broker.maxEntrySize() / 2))
+      return;
+
+    // Only the files created since the previous instalment: an already-announced one exists on the followers, and
+    // re-announcing it would make createNewFiles run over a file that is being written into.
+    final Map<Integer, String> newFiles = new LinkedHashMap<>();
+    final List<FileManager.FileChange> changes = proxied.getFileManager().getRecordedChanges();
+    if (changes != null)
+      for (final FileManager.FileChange c : changes)
+        if (c.create && !state.shippedFiles.containsKey(c.fileId))
+          newFiles.put(c.fileId, c.fileName);
+
+    final List<byte[]> walEntries = new ArrayList<>(schemaWalBuffer.get());
+    final List<Map<Integer, Integer>> bucketDeltas = new ArrayList<>(schemaBucketDeltaBuffer.get());
+
+    // Drained only after the entry is committed: a failed instalment leaves the buffer holding the ONLY copy of
+    // those pages that can reach a follower, so clearing first would turn a replication error into silent
+    // divergence - the failure mode this whole code path exists to avoid.
+    broker.replicateSchemaInstalment(getName(), newFiles, walEntries, bucketDeltas);
+
+    schemaWalBuffer.get().clear();
+    schemaBucketDeltaBuffer.get().clear();
+    state.bufferedBytes = 0;
+    state.shippedFiles.putAll(newFiles);
+    ++state.instalments;
+    schemaInstalmentsShipped.incrementAndGet();
+
+    HALog.log(this, HALog.DETAILED,
+        "Schema WAL instalment %d for database '%s' shipped: newFiles=%d, walEntries=%d",
+        state.instalments, getName(), newFiles.size(), walEntries.size());
+  }
+
+  /** Schema-WAL instalments shipped by this JVM since it started - see {@link #schemaInstalmentsShipped}. */
+  public static long getSchemaWalInstalmentsShipped() {
+    return schemaInstalmentsShipped.get();
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -210,7 +210,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
      * chunk created.
      */
     private int                        instalments;
-
   }
 
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
@@ -1694,6 +1693,22 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * masking that with a replication error would replace a diagnosable failure with a confusing one. A compensation
    * that fails is therefore logged at SEVERE naming every file it could not retire, which is what an operator
    * needs to clean them up by hand.
+   * <p>
+   * WHEN THE COMPENSATION ITSELF CANNOT RUN, named because it is the most Raft-idiomatic way for this path to fail
+   * and it is a consequence instalments introduce. {@code recordFileChanges} checks {@code isLeader()} once, at the
+   * top; nothing re-checks it per instalment, and {@code requireRaftServer()} only asserts that a server exists,
+   * not that this node still leads. If leadership moves away after an instalment has shipped - failover, a brief
+   * partition, a manual step-down, all normal Raft events rather than application bugs - this node can no longer
+   * submit entries, so the removal below fails and lands in the SEVERE branch.
+   * <p>
+   * Before instalments that case cost nothing: nothing had reached a follower, so the final {@code replicateSchema}
+   * simply failed and the caller saw a retryable error. Now it leaves files on the other nodes that only an
+   * operator can remove, which is why the log line has to name them. Deliberately not "solved" here: re-checking
+   * leadership per instalment would narrow the window without closing it (leadership can move between the check
+   * and the submit), and a node that is no longer leader has no way to make the cluster do anything. The real fix
+   * is for the new leader to reclaim unreferenced files, which is a garbage-collection feature this database does
+   * not have. Tracked as issue #6143, along with the fact that this SEVERE branch is reasoned about rather than
+   * covered - the step-down has to land between an instalment and the unwind to reach it.
    */
   private void retireAbandonedInstalments(final SchemaInstalmentState state) {
     if (state == null || state.instalments == 0)
@@ -1733,11 +1748,14 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           toRetire.size(), toRetire.values());
 
     } catch (final Exception e) {
+      // Names the leadership case, because it is both the likeliest cause and the one where "retry the operation"
+      // is the wrong advice: this node cannot make the cluster do anything any more, so the files stay until
+      // somebody removes them.
       LogManager.instance().log(this, Level.SEVERE,
           "Schema session on database '%s' failed after shipping %d instalment(s) AND the compensating removal "
-              + "could not be replicated. The other nodes are holding file(s) this node does not have and nothing "
+              + "could not be replicated%s. The other nodes are holding file(s) this node does not have and nothing "
               + "will reclaim them: %s. Remove them manually once the cluster is healthy", e, getName(),
-          state.instalments, toRetire.values());
+          state.instalments, isLeader() ? "" : " because this node is no longer the leader", toRetire.values());
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1605,6 +1605,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         // diagnostic that threw would otherwise send the finally block into retireAbandonedInstalments to report a
         // divergence that does not exist. Harmless for on-disk state - the compensation only ever targets files
         // this node no longer has, and it still has them - but it would put an operator on a phantom hunt.
+        //
+        // Assigned a SECOND time after this block, and neither assignment is redundant: this one covers a throw
+        // between here and there, the other covers the path where this block is not entered at all.
         published = true;
         HALog.log(this, HALog.DETAILED,
             "Schema changes replicated via Raft: addFiles=%d, removeFiles=%d, schemaChanged=%s, embeddedWalEntries=%d, instalments=%d",
@@ -1614,8 +1617,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           logSchemaPayloadDiagnostics("recordFileChanges", serializedSchema, addFiles, removeFiles);
       }
 
-      // The block above was not entered: there was nothing to say, which can only happen when no instalment went
-      // out either (an instalment forces the condition), so there is nothing for the compensation to do.
+      // The SECOND of the two assignments (see the one inside the block above). This one covers the path where the
+      // block was not entered at all: there was nothing to say, which can only happen when no instalment went out
+      // either - an instalment forces the condition - so there is nothing for the compensation to do.
       published = true;
       return result;
     } finally {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -180,6 +180,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * by the threshold instead of by the size of the index.
    */
   private static final class SchemaInstalmentState {
+    /**
+     * Raw buffered bytes at which the next instalment goes out: half the maximum replicated entry size, the same
+     * expression {@code runWithCompactionReplication} uses for its own chunk budget. Resolved ONCE per session
+     * rather than per buffered commit - it cannot change under a session, and the alternative puts a
+     * {@code requireRaftServer().getTransactionBroker()} hop on every batch commit of an index build.
+     */
+    private final long                 threshold;
     /** Raw bytes of WAL currently sitting in {@link #schemaWalBuffer}. */
     private long                       bufferedBytes;
     /**
@@ -190,6 +197,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     private final Map<Integer, String> shippedFiles = new LinkedHashMap<>();
     /** How many instalments went out; the final entry is unconditional once this is non-zero. */
     private int                        instalments;
+
+    SchemaInstalmentState(final long threshold) {
+      this.threshold = threshold;
+    }
   }
 
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
@@ -1530,10 +1541,17 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // Saved and restored for exactly the reason the mark above is: a session opened on ANOTHER database from
     // inside this callback must not take over this one's instalment bookkeeping (issue #6136).
     final SchemaInstalmentState outerInstalments = schemaInstalments.get();
+    final SchemaInstalmentState instalmentState = new SchemaInstalmentState(
+        Math.max(1024L, requireRaftServer().getTransactionBroker().maxEntrySize() / 2));
     schemaWalBuffer.get().clear();
     schemaBucketDeltaBuffer.get().clear();
     isSchemaCommitThread.set(Boolean.TRUE);
-    schemaInstalments.set(new SchemaInstalmentState());
+    schemaInstalments.set(instalmentState);
+
+    // Set only once the session's FINAL entry has gone out. Everything an instalment shipped before that is
+    // delivery-only, so leaving this false is what tells the finally block that the followers are holding an
+    // abandoned prefix and it has to be retired - see retireAbandonedInstalments (issue #6136).
+    boolean published = false;
 
     try {
       final RET result = proxied.recordFileChanges(callback);
@@ -1551,7 +1569,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
             removeFiles.put(c.fileId, c.fileName);
         }
 
-      final SchemaInstalmentState instalmentState = schemaInstalments.get();
       reconcileInstalmentFiles(instalmentState, addFiles, removeFiles);
 
       if (schemaChanged)
@@ -1577,7 +1594,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // ... and unconditionally once an instalment went out: those entries are all marked as delivery-only, so
       // the session's final entry is the only thing that publishes the change. Leaving it out because nothing was
       // left to say would strand the followers on a half-delivered state they never reload from.
-      final int shippedInstalments = instalmentState != null ? instalmentState.instalments : 0;
+      final int shippedInstalments = instalmentState.instalments;
       if (!addFiles.isEmpty() || !removeFiles.isEmpty() || schemaChanged || !walEntries.isEmpty()
           || shippedInstalments > 0) {
         final RaftHAServer raft = requireRaftServer();
@@ -1590,8 +1607,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           logSchemaPayloadDiagnostics("recordFileChanges", serializedSchema, addFiles, removeFiles);
       }
 
+      published = true;
       return result;
     } finally {
+      if (!published)
+        retireAbandonedInstalments(instalmentState);
       if (outerSchemaCommitThread == null)
         isSchemaCommitThread.remove();
       else
@@ -1603,6 +1623,90 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       schemaWalBuffer.get().clear();
       schemaBucketDeltaBuffer.get().clear();
       proxied.getFileManager().stopRecordingChanges();
+    }
+  }
+
+  /**
+   * Retires what the instalments of a session that never reached its final entry left on the followers
+   * (issue #6136).
+   * <p>
+   * WHY THIS IS NEEDED, and it is a risk the instalments introduce rather than one that was already there. Before
+   * them, the whole buffered WAL sat in leader heap and NOTHING reached a follower until the callback returned, so
+   * a build that threw part-way - a source record the builder cannot read, an I/O error, a quorum timeout on a
+   * later instalment - left the followers untouched. Now the files an instalment announced and the pages it
+   * delivered are already there, and the entry that would have published or retired them is never sent, because it
+   * lives after the line that threw. Every instalment chunk is marked {@code moreChunksFollow} by design, so there
+   * is no "this sequence is abandoned" signal a follower could act on by itself; the leader has to say so.
+   * <p>
+   * WHAT IT SENDS is one ordinary publishing entry - {@code moreChunksFollow} false - carrying nothing but
+   * {@code filesToRemove}, and the removal list FOLLOWS THE LEADER rather than simply undoing every announcement.
+   * That distinction is the whole correctness of this method, and getting it wrong swaps one divergence for
+   * another:
+   * <ul>
+   *   <li>a file the leader NO LONGER HAS is retired. This is the case that matters, because it is the one the
+   *       principal caller produces: {@code BucketIndexBuilder.create()} drops the half-built index from its own
+   *       error handler, so the leader has already let the file go and only the followers are still holding it;</li>
+   *   <li>a file the leader STILL HAS is left alone, and reported. A failed DDL can leave the leader holding a
+   *       created-but-unpublished file - the schema was never saved, so nothing references it there either - and
+   *       retiring it on the followers would take a state both sides agree on and make them disagree. The
+   *       leader-side orphan is a pre-existing consequence of a DDL that throws, not something instalments
+   *       introduce, and this method deliberately does not try to repair it.</li>
+   * </ul>
+   * Pages an instalment applied to PRE-EXISTING files are left alone for the same reason: {@code commit()} ran
+   * {@code commit2ndPhase} before buffering, so the leader holds them too and the two sides already agree.
+   * <p>
+   * IT CANNOT THROW. It runs from a {@code finally} that is usually unwinding the build's own exception, and
+   * masking that with a replication error would replace a diagnosable failure with a confusing one. A compensation
+   * that fails is therefore logged at SEVERE naming every file it could not retire, which is what an operator
+   * needs to clean them up by hand.
+   */
+  private void retireAbandonedInstalments(final SchemaInstalmentState state) {
+    if (state == null || state.instalments == 0)
+      return;
+
+    // Only what the leader has already let go of - see the javadoc: retiring a file the leader kept would turn an
+    // agreed state into a diverged one.
+    final Map<Integer, String> toRetire = new LinkedHashMap<>();
+    final Map<Integer, String> keptByLeader = new LinkedHashMap<>();
+    for (final Map.Entry<Integer, String> shipped : state.shippedFiles.entrySet())
+      if (proxied.getFileManager().existsFile(shipped.getKey()))
+        keptByLeader.put(shipped.getKey(), shipped.getValue());
+      else
+        toRetire.put(shipped.getKey(), shipped.getValue());
+
+    if (!keptByLeader.isEmpty())
+      LogManager.instance().log(this, Level.WARNING,
+          "Schema session on database '%s' failed after shipping %d instalment(s); file(s) %s exist on every node "
+              + "but no schema references them, because the change was never published. Left in place: this node "
+              + "holds them too, so the cluster is consistent", null, getName(), state.instalments,
+          keptByLeader.values());
+
+    if (toRetire.isEmpty()) {
+      if (keptByLeader.isEmpty())
+        // WAL-only instalments: those pages went to files that already existed and the leader committed them
+        // locally before buffering, so there is nothing to undo. Still reported, because an interrupted
+        // replicated session is not a normal event.
+        LogManager.instance().log(this, Level.WARNING,
+            "Schema session on database '%s' failed after shipping %d WAL instalment(s); they created no file, so "
+                + "there is nothing to retire on the other nodes", null, getName(), state.instalments);
+      return;
+    }
+
+    try {
+      requireRaftServer().getTransactionBroker().replicateSchema(getName(), "", Collections.emptyMap(), toRetire,
+          Collections.emptyList(), Collections.emptyList());
+
+      LogManager.instance().log(this, Level.WARNING,
+          "Schema session on database '%s' failed after shipping %d instalment(s); retired the %d file(s) they had "
+              + "created on the other nodes, matching this node: %s", null, getName(), state.instalments,
+          toRetire.size(), toRetire.values());
+
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.SEVERE,
+          "Schema session on database '%s' failed after shipping %d instalment(s) AND the compensating removal "
+              + "could not be replicated. The other nodes are holding file(s) this node does not have and nothing "
+              + "will reclaim them: %s. Remove them manually once the cluster is healthy", e, getName(),
+          state.instalments, toRetire.values());
     }
   }
 
@@ -1648,6 +1752,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * {@code runWithCompactionReplication} uses for its own chunk budget. It is SOFT - tested between buffered
    * commits, so one batch can overshoot it - which is why {@code replicateSchemaInstalment} can still split.
    * <p>
+   * THE RISK IT DOES INTRODUCE, and how it is paid for: a build that throws after an instalment has gone out
+   * leaves the followers holding files and pages the session will never publish, where before them nothing reached
+   * a follower until the callback returned. {@link #retireAbandonedInstalments} sends the compensating removal.
+   * <p>
    * WHAT IT DOES NOT FIX, stated because the difference matters: the recording session stays open for the whole
    * build, so a concurrent writer still waits on {@link #waitForActiveRecordingSession()} (and, before that, on the
    * database write lock the callback holds). Bounding the heap does not shorten the window, and shortening it means
@@ -1656,12 +1764,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    */
   private void flushSchemaWalBufferIfFull() {
     final SchemaInstalmentState state = schemaInstalments.get();
-    if (state == null)
+    if (state == null || state.bufferedBytes < state.threshold)
       return;
 
     final RaftTransactionBroker broker = requireRaftServer().getTransactionBroker();
-    if (state.bufferedBytes < Math.max(1024L, broker.maxEntrySize() / 2))
-      return;
 
     // Only the files created since the previous instalment: an already-announced one exists on the followers, and
     // re-announcing it would make createNewFiles run over a file that is being written into.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -182,9 +182,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    */
   private static final class SchemaInstalmentState {
     /**
-     * Raw buffered bytes at which the next instalment goes out: half the maximum replicated entry size, the same
-     * expression {@code runWithCompactionReplication} uses for its own chunk budget. Zero until the session's
-     * FIRST buffered commit resolves it.
+     * Raw buffered bytes at which the next instalment goes out: {@code RaftTransactionBroker.walChunkBudget()},
+     * shared with the compaction path so the two cannot drift apart. Zero until the session's FIRST BUFFERED
+     * commit resolves it.
      * <p>
      * Resolved once, and lazily, for two different reasons. Once, because it cannot change under a session and the
      * alternative puts a {@code requireRaftServer().getTransactionBroker()} hop on every batch commit of an index
@@ -1806,11 +1806,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    */
   private void flushSchemaWalBufferIfFull() {
     final SchemaInstalmentState state = schemaInstalments.get();
-    if (state == null)
+    // bufferedBytes == 0 covers BOTH "nothing buffered yet" and "just flushed", and is tested before the threshold
+    // is resolved rather than after. This method runs after EVERY commit inside the session, including ones that
+    // buffered nothing (commit1stPhase returning null), so resolving first would call requireRaftServer() on a
+    // no-op commit - the case the lazy resolution exists to keep working while the Raft server is transiently
+    // absent. Zero bytes can never reach a positive threshold anyway, so nothing is lost by leaving early.
+    if (state == null || state.bufferedBytes == 0)
       return;
 
     if (state.threshold == 0)
-      state.threshold = Math.max(1024L, requireRaftServer().getTransactionBroker().maxEntrySize() / 2);
+      state.threshold = requireRaftServer().getTransactionBroker().walChunkBudget();
 
     if (state.bufferedBytes < state.threshold)
       return;
@@ -1966,7 +1971,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // #4743: chunked against the maximum replicated entry size so a big compacted index does not
       // produce one oversized Raft entry (which would make the leader step down, over and over).
       final RaftTransactionBroker broker = requireRaftServer().getTransactionBroker();
-      final long walChunkBudget = Math.max(1024L, broker.maxEntrySize() / 2);
+      final long walChunkBudget = broker.walChunkBudget();
       for (final int fileId : addFiles.keySet())
         appendFilePagesAsWal(fileId, walChunkBudget, walEntries, bucketDeltas, 0);
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -182,11 +182,17 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private static final class SchemaInstalmentState {
     /**
      * Raw buffered bytes at which the next instalment goes out: half the maximum replicated entry size, the same
-     * expression {@code runWithCompactionReplication} uses for its own chunk budget. Resolved ONCE per session
-     * rather than per buffered commit - it cannot change under a session, and the alternative puts a
-     * {@code requireRaftServer().getTransactionBroker()} hop on every batch commit of an index build.
+     * expression {@code runWithCompactionReplication} uses for its own chunk budget. Zero until the session's
+     * FIRST buffered commit resolves it.
+     * <p>
+     * Resolved once, and lazily, for two different reasons. Once, because it cannot change under a session and the
+     * alternative puts a {@code requireRaftServer().getTransactionBroker()} hop on every batch commit of an index
+     * build. Lazily, because {@code requireRaftServer()} throws a retryable {@code NeedRetryException} while the
+     * Raft server is transiently absent (restart, failover), and resolving it when the session OPENS would fail a
+     * {@code recordFileChanges} that buffers nothing and would have completed as a harmless no-op. A session that
+     * does buffer needs the server to replicate anyway, so nothing is lost by asking then.
      */
-    private final long                 threshold;
+    private long                       threshold;
     /** Raw bytes of WAL currently sitting in {@link #schemaWalBuffer}. */
     private long                       bufferedBytes;
     /**
@@ -198,9 +204,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     /** How many instalments went out; the final entry is unconditional once this is non-zero. */
     private int                        instalments;
 
-    SchemaInstalmentState(final long threshold) {
-      this.threshold = threshold;
-    }
   }
 
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
@@ -1541,8 +1544,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // Saved and restored for exactly the reason the mark above is: a session opened on ANOTHER database from
     // inside this callback must not take over this one's instalment bookkeeping (issue #6136).
     final SchemaInstalmentState outerInstalments = schemaInstalments.get();
-    final SchemaInstalmentState instalmentState = new SchemaInstalmentState(
-        Math.max(1024L, requireRaftServer().getTransactionBroker().maxEntrySize() / 2));
+    final SchemaInstalmentState instalmentState = new SchemaInstalmentState();
     schemaWalBuffer.get().clear();
     schemaBucketDeltaBuffer.get().clear();
     isSchemaCommitThread.set(Boolean.TRUE);
@@ -1599,6 +1601,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           || shippedInstalments > 0) {
         final RaftHAServer raft = requireRaftServer();
         raft.getTransactionBroker().replicateSchema(getName(), serializedSchema, addFiles, removeFiles, walEntries, bucketDeltas);
+        // Set HERE, not after the logging below: the change is published the moment that call returns, and a
+        // diagnostic that threw would otherwise send the finally block into retireAbandonedInstalments to report a
+        // divergence that does not exist. Harmless for on-disk state - the compensation only ever targets files
+        // this node no longer has, and it still has them - but it would put an operator on a phantom hunt.
+        published = true;
         HALog.log(this, HALog.DETAILED,
             "Schema changes replicated via Raft: addFiles=%d, removeFiles=%d, schemaChanged=%s, embeddedWalEntries=%d, instalments=%d",
             addFiles.size(), removeFiles.size(), schemaChanged, walEntries.size(), shippedInstalments);
@@ -1607,6 +1614,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           logSchemaPayloadDiagnostics("recordFileChanges", serializedSchema, addFiles, removeFiles);
       }
 
+      // The block above was not entered: there was nothing to say, which can only happen when no instalment went
+      // out either (an instalment forces the condition), so there is nothing for the compensation to do.
       published = true;
       return result;
     } finally {
@@ -1618,8 +1627,18 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         isSchemaCommitThread.set(outerSchemaCommitThread);
       if (outerInstalments == null)
         schemaInstalments.remove();
-      else
+      else {
+        // The WAL buffers are STATIC thread-locals shared with the outer frame, and the lines below clear them.
+        // The outer frame's byte count must not go on describing WAL that is no longer there, or its next
+        // threshold test would fire against a buffer that no longer holds what the count claims. Zeroing it keeps
+        // the counter and the buffer telling the same story.
+        //
+        // NOTE this does not make a nested session on ANOTHER database safe - the outer frame's buffered WAL is
+        // destroyed by that clear, which is a pre-existing property of sharing one static buffer and is why
+        // isSchemaCommitThread is saved and restored around it. Nothing in the index-rebuild path nests that way.
+        outerInstalments.bufferedBytes = 0;
         schemaInstalments.set(outerInstalments);
+      }
       schemaWalBuffer.get().clear();
       schemaBucketDeltaBuffer.get().clear();
       proxied.getFileManager().stopRecordingChanges();
@@ -1756,15 +1775,31 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * leaves the followers holding files and pages the session will never publish, where before them nothing reached
    * a follower until the callback returned. {@link #retireAbandonedInstalments} sends the compensating removal.
    * <p>
-   * WHAT IT DOES NOT FIX, stated because the difference matters: the recording session stays open for the whole
-   * build, so a concurrent writer still waits on {@link #waitForActiveRecordingSession()} (and, before that, on the
-   * database write lock the callback holds). Bounding the heap does not shorten the window, and shortening it means
-   * taking the build out of the session altogether - a different change, on the same code path, worth its own
-   * judgement.
+   * WHAT IT COSTS, stated precisely because it is a real trade and not only a heap win. The recording session stays
+   * open for the whole build, so a concurrent writer still waits on {@link #waitForActiveRecordingSession()} and,
+   * before that, on the database write lock the callback holds. Bounding the heap does not shorten that window -
+   * and each instalment LENGTHENS it, because {@code submitAndWait} is a quorum round trip taken while that write
+   * lock is held, where the single final entry has always been submitted after the callback returned and the lock
+   * was released. Normally that is milliseconds against a build measured in minutes. Against a slow or briefly
+   * partitioned quorum member it is up to {@code HA_QUORUM_TIMEOUT} per instalment, and the whole database's
+   * writers wait it out.
+   * <p>
+   * Accepted, because the alternative is not "no round trips": without instalments the one final entry carries the
+   * whole index, {@code splitSchemaEntry} splits it, and the same number of round trips happens anyway - after the
+   * lock, but only after the leader has held the entire rebuilt index in heap, which is the failure this exists to
+   * prevent. Paying for a bounded heap with round trips inside a window that is already fully exclusive is the
+   * better side of that trade. Making the window itself shorter means taking the build out of the recording
+   * session altogether - a different change, on the same code path, worth its own judgement.
    */
   private void flushSchemaWalBufferIfFull() {
     final SchemaInstalmentState state = schemaInstalments.get();
-    if (state == null || state.bufferedBytes < state.threshold)
+    if (state == null)
+      return;
+
+    if (state.threshold == 0)
+      state.threshold = Math.max(1024L, requireRaftServer().getTransactionBroker().maxEntrySize() / 2);
+
+    if (state.bufferedBytes < state.threshold)
       return;
 
     final RaftTransactionBroker broker = requireRaftServer().getTransactionBroker();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -115,6 +115,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.IntPredicate;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -1577,7 +1578,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
             removeFiles.put(c.fileId, c.fileName);
         }
 
-      reconcileInstalmentFiles(instalmentState, addFiles, removeFiles);
+      reconcileInstalmentFiles(instalmentState.shippedFiles, addFiles, removeFiles);
 
       if (schemaChanged)
         serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
@@ -1626,6 +1627,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       // The SECOND of the two assignments (see the one inside the block above). This one covers the path where the
       // block was not entered at all: there was nothing to say, which can only happen when no instalment went out
       // either - an instalment forces the condition - so there is nothing for the compensation to do.
+      //
+      // ADDING CODE ABOVE THIS LINE: everything between the first assignment and here is code that can throw AFTER
+      // the change has already been published, and this flag is what decides whether the finally block goes on to
+      // retire the instalments' files. Decide deliberately which side of it your code belongs on rather than
+      // dropping it in above.
       published = true;
       return result;
     } finally {
@@ -1697,11 +1703,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // agreed state into a diverged one.
     final Map<Integer, String> toRetire = new LinkedHashMap<>();
     final Map<Integer, String> keptByLeader = new LinkedHashMap<>();
-    for (final Map.Entry<Integer, String> shipped : state.shippedFiles.entrySet())
-      if (proxied.getFileManager().existsFile(shipped.getKey()))
-        keptByLeader.put(shipped.getKey(), shipped.getValue());
-      else
-        toRetire.put(shipped.getKey(), shipped.getValue());
+    partitionAbandonedFiles(state.shippedFiles, proxied.getFileManager()::existsFile, toRetire, keptByLeader);
 
     if (!keptByLeader.isEmpty())
       LogManager.instance().log(this, Level.WARNING,
@@ -1749,12 +1751,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * <p>
    * A no-op when no instalment went out, which is every session small enough to ship in one entry.
    */
-  private static void reconcileInstalmentFiles(final SchemaInstalmentState state, final Map<Integer, String> addFiles,
+  // @VisibleForTesting
+  static void reconcileInstalmentFiles(final Map<Integer, String> shippedFiles, final Map<Integer, String> addFiles,
       final Map<Integer, String> removeFiles) {
-    if (state == null || state.shippedFiles.isEmpty())
+    if (shippedFiles == null || shippedFiles.isEmpty())
       return;
 
-    for (final Map.Entry<Integer, String> shipped : state.shippedFiles.entrySet())
+    for (final Map.Entry<Integer, String> shipped : shippedFiles.entrySet())
       if (addFiles.remove(shipped.getKey()) == null)
         removeFiles.putIfAbsent(shipped.getKey(), shipped.getValue());
   }
@@ -1822,6 +1825,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // its WAL volume produces, so the second factor does not grow with the first. A future DDL that creates MANY
     // files through this buffered path would make it quadratic and should carry the shipped/unshipped split
     // forward instead; an index into the list is not that, since dropFile removes entries from the middle of it.
+    // Tracked as issue #6142.
     final Map<Integer, String> newFiles = new LinkedHashMap<>();
     final List<FileManager.FileChange> changes = proxied.getFileManager().getRecordedChanges();
     if (changes != null)
@@ -1858,6 +1862,27 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     HALog.log(this, HALog.DETAILED,
         "Schema WAL instalment %d for database '%s' shipped: newFiles=%d, walEntries=%d",
         state.instalments, getName(), newFiles.size(), walEntries.size());
+  }
+
+  /**
+   * Splits what the instalments announced into what must be retired on the other nodes and what must be left alone,
+   * by the one rule that keeps the compensation from trading one divergence for another: THIS NODE OWNS THE TRUTH.
+   * A file it no longer has is retired; a file it still has is left, because both sides holding an unpublished file
+   * is a state they agree on and retiring it would end that agreement. See {@link #retireAbandonedInstalments}.
+   * <p>
+   * Static and side-effect-free so the bookkeeping can be pinned without a cluster - it is map arithmetic across a
+   * session, which is exactly the kind of logic that regresses silently.
+   *
+   * @param existsLocally answers whether this node still holds a given file id
+   */
+  // @VisibleForTesting
+  static void partitionAbandonedFiles(final Map<Integer, String> shippedFiles, final IntPredicate existsLocally,
+      final Map<Integer, String> toRetire, final Map<Integer, String> keptLocally) {
+    for (final Map.Entry<Integer, String> shipped : shippedFiles.entrySet())
+      if (existsLocally.test(shipped.getKey()))
+        keptLocally.put(shipped.getKey(), shipped.getValue());
+      else
+        toRetire.put(shipped.getKey(), shipped.getValue());
   }
 
   /** Schema-WAL instalments shipped by this JVM since it started - see {@link #schemaInstalmentsShipped}. */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -196,12 +196,18 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     /** Raw bytes of WAL currently sitting in {@link #schemaWalBuffer}. */
     private long                       bufferedBytes;
     /**
-     * Files an instalment already told the followers to create, so the final entry neither re-ships them nor
-     * forgets to retire one that the session went on to drop - {@code FileManager.dropFile} CANCELS the recorded
-     * create when both happen inside one session, which would otherwise leave the file on the followers only.
+     * Files an instalment told the followers to create - or MAY have, see the increment site - so the final entry
+     * neither re-ships them nor forgets to retire one that the session went on to drop:
+     * {@code FileManager.dropFile} CANCELS the recorded create when both happen inside one session, which would
+     * otherwise leave the file on the followers only.
      */
     private final Map<Integer, String> shippedFiles = new LinkedHashMap<>();
-    /** How many instalments went out; the final entry is unconditional once this is non-zero. */
+    /**
+     * How many instalments were STARTED; the final entry is unconditional once this is non-zero. Counted before
+     * the entry is submitted rather than after, for the reason given at the increment: an instalment over the cap
+     * is several entries, and a failure part-way through one still leaves the followers holding what its first
+     * chunk created.
+     */
     private int                        instalments;
 
   }
@@ -1826,17 +1832,28 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     final List<byte[]> walEntries = new ArrayList<>(schemaWalBuffer.get());
     final List<Map<Integer, Integer>> bucketDeltas = new ArrayList<>(schemaBucketDeltaBuffer.get());
 
-    // Drained only after the entry is committed: a failed instalment leaves the buffer holding the ONLY copy of
-    // those pages that can reach a follower, so clearing first would turn a replication error into silent
-    // divergence - the failure mode this whole code path exists to avoid.
-    broker.replicateSchemaInstalment(getName(), newFiles, walEntries, bucketDeltas);
-
-    schemaWalBuffer.get().clear();
-    schemaBucketDeltaBuffer.get().clear();
-    state.bufferedBytes = 0;
+    // ANNOUNCED BEFORE IT IS SENT, and deliberately so. replicateSchemaInstalment is not one entry: an instalment
+    // that overshoots the cap - which the SOFT threshold makes reachable, since it is tested between buffered
+    // commits and one batch can carry more than the whole budget - goes through splitSchemaEntry and becomes
+    // several submitAndWait calls, the FIRST of which carries the file creations. A failure on a later chunk would
+    // then leave the followers holding files this bookkeeping had never recorded, so retireAbandonedInstalments
+    // would not know to retire them, and on a first instalment it would not even log, having seen no instalment at
+    // all. Recording the intent first makes the bookkeeping pessimistic: it says "the followers MAY hold these",
+    // which is what a compensation needs. Over-retiring costs nothing - the follower's FileManager.dropFile
+    // no-ops on a file id it does not have.
     state.shippedFiles.putAll(newFiles);
     ++state.instalments;
     schemaInstalmentsShipped.incrementAndGet();
+
+    broker.replicateSchemaInstalment(getName(), newFiles, walEntries, bucketDeltas);
+
+    // The WAL buffer, by contrast, is drained only AFTER the entry is committed: it holds the ONLY copy of those
+    // pages that can reach a follower, so clearing it before a failure would turn a replication error into silent
+    // divergence - the failure mode this whole code path exists to avoid. The two orders are opposite because the
+    // two risks are: announcing too much costs a no-op removal, forgetting WAL costs a diverged follower.
+    schemaWalBuffer.get().clear();
+    schemaBucketDeltaBuffer.get().clear();
+    state.bufferedBytes = 0;
 
     HALog.log(this, HALog.DETAILED,
         "Schema WAL instalment %d for database '%s' shipped: newFiles=%d, walEntries=%d",

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1810,6 +1810,12 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
     // Only the files created since the previous instalment: an already-announced one exists on the followers, and
     // re-announcing it would make createNewFiles run over a file that is being written into.
+    //
+    // This re-reads the WHOLE recorded-changes list per instalment, so it is O(instalments x file changes). Fine
+    // for the caller this exists for - an index rebuild records one or two file changes however many instalments
+    // its WAL volume produces, so the second factor does not grow with the first. A future DDL that creates MANY
+    // files through this buffered path would make it quadratic and should carry the shipped/unshipped split
+    // forward instead; an index into the list is not that, since dropFile removes entries from the middle of it.
     final Map<Integer, String> newFiles = new LinkedHashMap<>();
     final List<FileManager.FileChange> changes = proxied.getFileManager().getRecordedChanges();
     if (changes != null)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -130,7 +130,7 @@ public class RaftTransactionBroker {
    * <p>
    * {@link #splitSchemaEntry} splits a payload that has already been built in full; this is the same ordered-prefix
    * contract applied to a payload that is still growing. The producer is
-   * {@code RaftReplicatedDatabase.flushSchemaWalBuffer}: an index rebuild inside a {@code recordFileChanges}
+   * {@code RaftReplicatedDatabase.flushSchemaWalBufferIfFull}: an index rebuild inside a {@code recordFileChanges}
    * callback commits once per build batch, and every one of those commits used to sit in leader heap until the
    * callback returned, so peak heap was the whole rebuilt index.
    * <p>

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -126,6 +126,41 @@ public class RaftTransactionBroker {
   }
 
   /**
+   * Ships ONE intermediate instalment of a schema change that is still being produced (issue #6136).
+   * <p>
+   * {@link #splitSchemaEntry} splits a payload that has already been built in full; this is the same ordered-prefix
+   * contract applied to a payload that is still growing. The producer is
+   * {@code RaftReplicatedDatabase.flushSchemaWalBuffer}: an index rebuild inside a {@code recordFileChanges}
+   * callback commits once per build batch, and every one of those commits used to sit in leader heap until the
+   * callback returned, so peak heap was the whole rebuilt index.
+   * <p>
+   * The instalment carries the newly created files (so they exist before any page lands in them) and WAL, and
+   * NOTHING that publishes: no schema JSON, no {@code filesToRemove}, no sealed blobs. Every chunk it produces is
+   * marked {@code moreChunksFollow}, INCLUDING the last one - the session's own final entry is the only thing that
+   * publishes, and a follower that reloaded its schema here would do it from a half-delivered state, which #5443
+   * showed to be sticky rather than merely wasteful. A leader that dies between instalments therefore leaves its
+   * followers holding unreferenced bytes, which is the same state a failure part-way through
+   * {@link #splitSchemaEntry} leaves.
+   */
+  public void replicateSchemaInstalment(final String dbName, final Map<Integer, String> filesToAdd,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas) {
+    final ByteString entry = RaftLogEntryCodec.encodeSchemaEntry(dbName, "", filesToAdd, Collections.emptyMap(),
+        walEntries, bucketDeltas, Collections.emptyList(), true);
+
+    final long cap = groupCommitter.maxEntrySize();
+    if (entry.size() <= cap) {
+      groupCommitter.submitAndWait(entry.toByteArray());
+      return;
+    }
+
+    // The instalment threshold is a soft one - it is tested BETWEEN buffered commits, so one very large batch can
+    // overshoot it - and the cap is hard, so the splitter still has to be reachable from here.
+    for (final ByteString chunk : splitSchemaEntry(dbName, "", filesToAdd, Collections.emptyMap(), walEntries,
+        bucketDeltas, Collections.emptyList(), cap, entry.size(), true))
+      groupCommitter.submitAndWait(chunk.toByteArray());
+  }
+
+  /**
    * Splits a schema change that does not fit one Raft entry into an ordered sequence of
    * {@code SCHEMA_ENTRY} entries (issue #4743).
    * <p>
@@ -156,6 +191,21 @@ public class RaftTransactionBroker {
       final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
       final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
       final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs, final long cap, final int singleEntrySize) {
+    return splitSchemaEntry(dbName, schemaJson, filesToAdd, filesToRemove, walEntries, bucketDeltas, sealedFileBlobs,
+        cap, singleEntrySize, false);
+  }
+
+  /**
+   * @param moreAfterLast when true the LAST chunk is marked {@code moreChunksFollow} as well, because these chunks
+   *                      are one instalment of a change that is still being produced and nothing here publishes it -
+   *                      see {@link #replicateSchemaInstalment}.
+   */
+  // @VisibleForTesting
+  static List<ByteString> splitSchemaEntry(final String dbName, final String schemaJson,
+      final Map<Integer, String> filesToAdd, final Map<Integer, String> filesToRemove,
+      final List<byte[]> walEntries, final List<Map<Integer, Integer>> bucketDeltas,
+      final List<RaftLogEntryCodec.TsSealedBlob> sealedFileBlobs, final long cap, final int singleEntrySize,
+      final boolean moreAfterLast) {
 
     // Worst-case non-WAL payload: the first entry carries filesToAdd, the last one the schema JSON,
     // filesToRemove and the sealed blobs. Measured by encoding both headers with no WAL at all.
@@ -223,7 +273,7 @@ public class RaftTransactionBroker {
           last ? filesToRemove : Collections.emptyMap(),
           walGroups.get(g), deltaGroups.get(g),
           last ? sealedFileBlobs : Collections.emptyList(),
-          !last);
+          !last || moreAfterLast);
 
       if (chunk.size() > cap)
         // A single WAL entry (or the header plus one WAL entry) still does not fit. Fail loudly rather

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftTransactionBroker.java
@@ -299,6 +299,19 @@ public class RaftTransactionBroker {
   }
 
   /**
+   * How much RAW payload a producer should accumulate before shipping it, for the two that build their WAL
+   * incrementally: {@code runWithCompactionReplication}, which chunks a compacted file as it serializes it, and
+   * {@code flushSchemaWalBufferIfFull}, which ships a schema session's buffered WAL in instalments (#6136).
+   * <p>
+   * Half the entry cap, so a chunk still fits after the per-WAL framing and the header the codec adds, with the
+   * floor keeping it usable when the cap is configured very small in a test. Shared rather than written twice
+   * because the two producers must not drift apart if the policy is ever retuned.
+   */
+  long walChunkBudget() {
+    return Math.max(1024L, maxEntrySize() / 2);
+  }
+
+  /**
    * Replicates an install-database entry so replicas create or snapshot-sync the database.
    */
   public void replicateInstallDatabase(final String dbName, final boolean forceSnapshot) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6136InstalmentFileBookkeepingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6136InstalmentFileBookkeepingTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6136: the file bookkeeping a schema session carries across its instalments, pinned WITHOUT a cluster.
+ * <p>
+ * Both rules below are map arithmetic spread over the life of a session, which is exactly the kind of logic that
+ * regresses silently - and both decide whether a follower ends up holding a file no schema references. They are
+ * covered end to end by {@code RaftSchemaWalInstalment3NodesIT}, but that is a {@code @Tag("slow")} three-node test
+ * whose failure says "the nodes disagree" rather than which rule got it wrong. These run in the fast lane and name
+ * the rule.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6136InstalmentFileBookkeepingTest {
+
+  // -------------------------------------------------------------------------------------------------------------
+  // reconcileInstalmentFiles: what the session's FINAL entry has to say about what its instalments announced
+  // -------------------------------------------------------------------------------------------------------------
+
+  /** A file an instalment announced exists on the followers already, so the final entry must not repeat it. */
+  @Test
+  void aFileAnInstalmentAnnouncedIsNotAnnouncedAgain() {
+    final Map<Integer, String> shipped = files(7, "idx_7.ptree");
+    final Map<Integer, String> addFiles = files(7, "idx_7.ptree");
+    final Map<Integer, String> removeFiles = new LinkedHashMap<>();
+
+    RaftReplicatedDatabase.reconcileInstalmentFiles(shipped, addFiles, removeFiles);
+
+    assertThat(addFiles).as("re-announcing it would run createNewFiles over a file being written into").isEmpty();
+    assertThat(removeFiles).as("the session still wants the file, so nothing is retired").isEmpty();
+  }
+
+  /**
+   * The case that makes this method necessary. {@code FileManager.dropFile} CANCELS the recorded create when a
+   * session creates and then drops the same file, so the final entry's own maps say nothing at all about it - and
+   * the followers were told to create it. Without the compensating removal it would survive there and nowhere else.
+   */
+  @Test
+  void aFileTheSessionCreatedAndThenDroppedIsRetired() {
+    final Map<Integer, String> shipped = files(7, "idx_7.ptree");
+    // Neither map mentions file 7: the create was cancelled by the drop, which is what FileManager records.
+    final Map<Integer, String> addFiles = files(9, "other_9.ptree");
+    final Map<Integer, String> removeFiles = new LinkedHashMap<>();
+
+    RaftReplicatedDatabase.reconcileInstalmentFiles(shipped, addFiles, removeFiles);
+
+    assertThat(removeFiles).as("the followers hold it and this node does not, so the final entry must retire it")
+        .containsExactly(Map.entry(7, "idx_7.ptree"));
+    assertThat(addFiles).as("a file no instalment announced is untouched").containsExactly(Map.entry(9, "other_9.ptree"));
+  }
+
+  /** An explicit removal the session already recorded wins: the announced name must not overwrite it. */
+  @Test
+  void anExplicitRemovalIsNotOverwritten() {
+    final Map<Integer, String> shipped = files(7, "stale_name.ptree");
+    final Map<Integer, String> addFiles = new LinkedHashMap<>();
+    final Map<Integer, String> removeFiles = files(7, "current_name.ptree");
+
+    RaftReplicatedDatabase.reconcileInstalmentFiles(shipped, addFiles, removeFiles);
+
+    assertThat(removeFiles).containsExactly(Map.entry(7, "current_name.ptree"));
+  }
+
+  /** A session that shipped no instalment is left exactly as it was - the overwhelmingly common case. */
+  @Test
+  void aSessionThatShippedNothingIsUntouched() {
+    final Map<Integer, String> addFiles = files(9, "other_9.ptree");
+    final Map<Integer, String> removeFiles = new LinkedHashMap<>();
+
+    RaftReplicatedDatabase.reconcileInstalmentFiles(new LinkedHashMap<>(), addFiles, removeFiles);
+
+    assertThat(addFiles).containsExactly(Map.entry(9, "other_9.ptree"));
+    assertThat(removeFiles).isEmpty();
+  }
+
+  // -------------------------------------------------------------------------------------------------------------
+  // partitionAbandonedFiles: what a session that never published has to undo
+  // -------------------------------------------------------------------------------------------------------------
+
+  /**
+   * THIS NODE OWNS THE TRUTH, and both halves matter. A file it let go of is retired - the case
+   * {@code BucketIndexBuilder.create()} produces, since it drops the half-built index from its own error handler,
+   * leaving only the followers holding it. A file it still has is LEFT: both sides holding an unpublished file is a
+   * state they agree on, and retiring it would end that agreement, swapping one divergence for another.
+   */
+  @Test
+  void onlyTheFilesThisNodeNoLongerHasAreRetired() {
+    final Map<Integer, String> shipped = new LinkedHashMap<>();
+    shipped.put(7, "dropped_7.ptree");
+    shipped.put(8, "kept_8.ptree");
+
+    final Set<Integer> stillHere = Set.of(8);
+    final Map<Integer, String> toRetire = new LinkedHashMap<>();
+    final Map<Integer, String> keptLocally = new LinkedHashMap<>();
+
+    RaftReplicatedDatabase.partitionAbandonedFiles(shipped, stillHere::contains, toRetire, keptLocally);
+
+    assertThat(toRetire).as("this node let it go, so the followers must too")
+        .containsExactly(Map.entry(7, "dropped_7.ptree"));
+    assertThat(keptLocally).as("this node still has it, so retiring it on the followers would DIVERGE them")
+        .containsExactly(Map.entry(8, "kept_8.ptree"));
+  }
+
+  /** Nothing announced, nothing to decide - the case where the instalments carried WAL only. */
+  @Test
+  void anInstalmentThatCreatedNoFileHasNothingToRetire() {
+    final Map<Integer, String> toRetire = new LinkedHashMap<>();
+    final Map<Integer, String> keptLocally = new LinkedHashMap<>();
+
+    RaftReplicatedDatabase.partitionAbandonedFiles(new LinkedHashMap<>(), id -> true, toRetire, keptLocally);
+
+    assertThat(toRetire).isEmpty();
+    assertThat(keptLocally).isEmpty();
+  }
+
+  private static Map<Integer, String> files(final int fileId, final String fileName) {
+    final Map<Integer, String> map = new LinkedHashMap<>();
+    map.put(fileId, fileName);
+    return map;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6136SchemaWalInstalmentTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6136SchemaWalInstalmentTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6136 (1): an instalment of a schema change that is still being produced must never look like the entry that
+ * publishes it.
+ * <p>
+ * {@code RaftReplicatedDatabase.flushSchemaWalBuffer} ships the WAL an index rebuild accumulates while it is still
+ * accumulating, instead of holding the whole rebuilt index in leader heap until the {@code recordFileChanges}
+ * callback returns. It reuses the ordered-prefix contract #4743 built for {@code splitSchemaEntry}, with ONE
+ * difference that carries the whole safety argument: the last chunk of an instalment is still marked
+ * {@code moreChunksFollow}, because the instalment is not the end of the change.
+ * <p>
+ * Getting that wrong does not throw. A follower that takes an instalment's last chunk for a publication reloads its
+ * schema from a half-delivered state, and #5443 measured what that costs: the reload DETACHES a compacted sub-index
+ * it cannot resolve yet, the later real publication reuses the same in-memory component, and the follower serves
+ * only its mutable pages from then on - 1897 of 60000 entries missing, silently and permanently.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6136SchemaWalInstalmentTest {
+
+  /**
+   * An instalment big enough to need splitting: every chunk of it, the last one included, must be delivery-only,
+   * and none of them may carry anything that publishes.
+   */
+  @Test
+  void everyChunkOfAnInstalmentIsMarkedAsHavingMoreToFollow() {
+    final long cap = 32 * 1024L;
+    final Map<Integer, String> filesToAdd = new LinkedHashMap<>();
+    filesToAdd.put(77, "Person_0_1234567890_77.v1.bucket");
+
+    final List<byte[]> wal = incompressibleWal(24, 4 * 1024);
+    final List<Map<Integer, Integer>> deltas = new ArrayList<>(Collections.nCopies(wal.size(), Map.of()));
+
+    final ByteString single = RaftLogEntryCodec.encodeSchemaEntry("graph", "", filesToAdd,
+        Collections.emptyMap(), wal, deltas, Collections.emptyList(), true);
+    assertThat(single.size()).as("the unsplit instalment must be over the cap for this test to mean anything")
+        .isGreaterThan((int) cap);
+
+    final List<ByteString> chunks = RaftTransactionBroker.splitSchemaEntry("graph", "", filesToAdd,
+        Collections.emptyMap(), wal, deltas, Collections.emptyList(), cap, single.size(), true);
+
+    assertThat(chunks).hasSizeGreaterThan(1);
+
+    final List<RaftLogEntryCodec.DecodedEntry> decoded = new ArrayList<>();
+    for (final ByteString chunk : chunks) {
+      assertThat(chunk.size()).as("every chunk must be replicable").isLessThanOrEqualTo((int) cap);
+      decoded.add(RaftLogEntryCodec.decode(chunk));
+    }
+
+    for (final RaftLogEntryCodec.DecodedEntry entry : decoded) {
+      assertThat(entry.moreChunksFollow())
+          .as("an instalment never publishes, so no chunk of it may tell a follower to reload").isTrue();
+      assertThat(entry.schemaJson()).as("only the session's final entry carries the schema").isEmpty();
+      assertThat(entry.filesToRemove()).as("only the session's final entry retires files").isEmpty();
+    }
+
+    assertThat(decoded.getFirst().filesToAdd())
+        .as("files first, so the pages that follow have somewhere to land").isEqualTo(filesToAdd);
+    for (int i = 1; i < decoded.size(); i++)
+      assertThat(decoded.get(i).filesToAdd()).as("only the first chunk creates files").isEmpty();
+
+    // No WAL entry may be lost or reordered.
+    final List<byte[]> reassembled = new ArrayList<>();
+    for (final RaftLogEntryCodec.DecodedEntry e : decoded)
+      reassembled.addAll(e.walEntries());
+    assertThat(reassembled).hasSameSizeAs(wal);
+    for (int i = 0; i < wal.size(); i++)
+      assertThat(reassembled.get(i)).isEqualTo(wal.get(i));
+  }
+
+  /**
+   * The pre-existing behaviour is untouched: a change split because it was built too big STILL publishes on its last
+   * chunk. Pinned next to the instalment case because the two differ by one boolean and nothing else.
+   */
+  @Test
+  void aSplitOfACompleteChangeStillPublishesOnItsLastChunk() {
+    final long cap = 32 * 1024L;
+    final String schemaJson = "{\"types\":{\"Person\":{}}}";
+
+    final List<byte[]> wal = incompressibleWal(24, 4 * 1024);
+    final List<Map<Integer, Integer>> deltas = new ArrayList<>(Collections.nCopies(wal.size(), Map.of()));
+
+    final ByteString single = RaftLogEntryCodec.encodeSchemaEntry("graph", schemaJson, Collections.emptyMap(),
+        Collections.emptyMap(), wal, deltas, Collections.emptyList());
+
+    final List<ByteString> chunks = RaftTransactionBroker.splitSchemaEntry("graph", schemaJson,
+        Collections.emptyMap(), Collections.emptyMap(), wal, deltas, Collections.emptyList(), cap, single.size());
+
+    assertThat(chunks).hasSizeGreaterThan(1);
+
+    final List<RaftLogEntryCodec.DecodedEntry> decoded = new ArrayList<>();
+    for (final ByteString chunk : chunks)
+      decoded.add(RaftLogEntryCodec.decode(chunk));
+
+    for (int i = 0; i < decoded.size() - 1; i++)
+      assertThat(decoded.get(i).moreChunksFollow()).as("chunk %d is not the end of the change", i).isTrue();
+    assertThat(decoded.getLast().moreChunksFollow())
+        .as("the last chunk of a complete change IS the publication").isFalse();
+    assertThat(decoded.getLast().schemaJson()).isEqualTo(schemaJson);
+  }
+
+  /** Incompressible payloads: a compressible pattern would make every chunk fit and prove nothing. */
+  private static List<byte[]> incompressibleWal(final int count, final int size) {
+    final List<byte[]> wal = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      final byte[] chunk = new byte[size];
+      for (int b = 0; b < chunk.length; b++)
+        chunk[b] = (byte) ((i * 31 + b * 17 + (b >> 3)) ^ (b * 7));
+      wal.add(chunk);
+    }
+    return wal;
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftSchemaWalInstalment3NodesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftSchemaWalInstalment3NodesIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.DatabaseIsClosedException;
+import com.arcadedb.index.Index;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6136 (1): an index rebuild on the leader used to buffer its WHOLE WAL in leader heap.
+ * <p>
+ * {@code BucketIndexBuilder.create()} wraps the build in {@code recordFileChanges}, which marks the thread so that
+ * {@code RaftReplicatedDatabase.commit()} buffers instead of replicating; {@code LSMTreeIndex.build()} then commits
+ * once per {@code IndexBuilder.BUILD_BATCH_SIZE} records and every one of those WAL images stayed resident until the
+ * callback returned. Peak leader heap was roughly the whole rebuilt index, plus a repeat of every page that more
+ * than one batch touched - on a node that is, by construction, the cluster's leader. A {@code CHECK DATABASE FIX}
+ * over a large damaged type is exactly that shape, which is where the report came from.
+ * <p>
+ * The buffer is now shipped in ORDERED INSTALMENTS as it fills, so heap is bounded by the threshold rather than by
+ * the size of the index. That is a change to the schema-replication protocol, the one area of this module whose
+ * history - #4083, #4743, #5443, #5492 - is silent follower divergence rather than exceptions, so what this test
+ * exists to prove is not that the flushing happens but that the cluster is still correct when it does.
+ * <p>
+ * The append buffer is pinned two orders of magnitude below its default, which drags the instalment threshold
+ * (half the maximum entry size) down with it, so an ordinary rebuild crosses it many times. Both halves are
+ * asserted: that instalments actually went out - otherwise the test would pass on the old code and prove nothing -
+ * and that all three nodes end up with a complete, queryable index.
+ * <p>
+ * Sibling of {@code Issue6136SchemaWalInstalmentTest}, which pins the entry shape without a cluster.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class RaftSchemaWalInstalment3NodesIT extends BaseRaftHATest {
+  private static final String TYPE_NAME  = "InstalmentDoc";
+  private static final String INDEX_NAME = "instalmentIdxName";
+  /**
+   * Comfortably more than one {@code IndexBuilder.BUILD_BATCH_SIZE} (5000), so the rebuild produces several
+   * buffered WAL entries rather than one - which is what there is to ship in instalments in the first place.
+   */
+  private static final int    RECORDS    = 12_000;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    // Two orders of magnitude below the 32MB default, with the write buffer kept above it (the server refuses to
+    // start otherwise - it must stay >= appendBufferSize + 8 bytes). The instalment threshold is derived from this,
+    // so lowering it is what makes an ordinary-sized rebuild exercise the path at all.
+    config.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "128KB");
+    config.setValue(GlobalConfiguration.HA_WRITE_BUFFER_SIZE, "256KB");
+  }
+
+  @Test
+  void anIndexRebuildShipsItsWalInInstalmentsAndStillConvergesEveryNode() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+
+    final DatabaseInternal leaderDb = wrapped(leaderIndex);
+
+    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+    leaderDb.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".name STRING");
+    leaderDb.command("sql",
+        "CREATE INDEX `" + INDEX_NAME + "` ON " + TYPE_NAME + "(name) NOTUNIQUE");
+
+    // A payload per record so the index build has real page volume to buffer.
+    final String payload = "x".repeat(400);
+    for (int batch = 0; batch < RECORDS / 1_000; batch++) {
+      final int base = batch * 1_000;
+      leaderDb.transaction(() -> {
+        for (int i = 0; i < 1_000; i++)
+          leaderDb.newDocument(TYPE_NAME).set("name", "n" + (base + i)).set("payload", payload).save();
+      });
+    }
+
+    waitForAllServers();
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitIndexEntriesOn(i, RECORDS))
+          .as("server %d must hold the whole index before the rebuild", i).isEqualTo(RECORDS);
+
+    final long instalmentsBefore = RaftReplicatedDatabase.getSchemaWalInstalmentsShipped();
+
+    try (final ResultSet rs = leaderDb.command("sql", "REBUILD INDEX `" + INDEX_NAME + "`")) {
+      assertThat(rs.hasNext()).as("REBUILD INDEX must return a result").isTrue();
+      rs.next();
+    }
+
+    assertThat(RaftReplicatedDatabase.getSchemaWalInstalmentsShipped() - instalmentsBefore)
+        .as("the rebuild must have shipped its buffered WAL incrementally rather than holding all of it: without "
+            + "instalments this assertion is the only thing that fails, and every other one below passes on the "
+            + "old code")
+        .isPositive();
+
+    waitForAllServers();
+
+    for (int i = 0; i < getServerCount(); i++)
+      assertThat(awaitIndexEntriesOn(i, RECORDS))
+          .as("server %d must hold a COMPLETE rebuilt index: an instalment sequence whose prefix a follower "
+              + "misread would leave it serving only part of it, silently", i)
+          .isEqualTo(RECORDS);
+
+    // And the index is actually usable, not merely the right size: a follower that detached the component on a
+    // mis-read instalment answers a lookup from its mutable pages alone.
+    for (int i = 0; i < getServerCount(); i++) {
+      final int server = i;
+      assertThat(countByNameOn(server, "n7777")).as("server %d must resolve an indexed lookup", server).isEqualTo(1);
+    }
+
+    assertClusterConsistency();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private DatabaseInternal wrapped(final int serverIndex) {
+    return ((DatabaseInternal) getServerDatabase(serverIndex, getDatabaseName())).getWrappedDatabaseInstance();
+  }
+
+  /** Live entries of the index on one server, or -1 when it cannot be read at all. */
+  private long indexEntriesOn(final int serverIndex) {
+    return withResyncRetry(serverIndex, db -> {
+      try {
+        final Index index = db.getSchema().getIndexByName(INDEX_NAME);
+        return index != null ? index.countEntries() : -1L;
+      } catch (final DatabaseIsClosedException e) {
+        throw e;
+      } catch (final Exception e) {
+        return -1L;
+      }
+    });
+  }
+
+  private long awaitIndexEntriesOn(final int serverIndex, final long expected) throws InterruptedException {
+    return awaitValue(expected, () -> indexEntriesOn(serverIndex));
+  }
+
+  private long countByNameOn(final int serverIndex, final String name) {
+    return withResyncRetry(serverIndex, db -> {
+      try (final ResultSet rs = db.query("sql", "SELECT count(*) AS total FROM " + TYPE_NAME + " WHERE name = ?",
+          name)) {
+        return rs.hasNext() ? rs.next().<Long>getProperty("total") : -1L;
+      }
+    });
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftSchemaWalInstalment3NodesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftSchemaWalInstalment3NodesIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6136 (1): an index rebuild on the leader used to buffer its WHOLE WAL in leader heap.
@@ -56,8 +57,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @Tag("slow")
 class RaftSchemaWalInstalment3NodesIT extends BaseRaftHATest {
-  private static final String TYPE_NAME  = "InstalmentDoc";
-  private static final String INDEX_NAME = "instalmentIdxName";
+  private static final String TYPE_NAME        = "InstalmentDoc";
+  private static final String INDEX_NAME       = "instalmentIdxName";
+  private static final String ABANDONED_BUCKET = "instalment_abandoned";
   /**
    * Comfortably more than one {@code IndexBuilder.BUILD_BATCH_SIZE} (5000), so the rebuild produces several
    * buffered WAL entries rather than one - which is what there is to ship in instalments in the first place.
@@ -137,6 +139,71 @@ class RaftSchemaWalInstalment3NodesIT extends BaseRaftHATest {
     assertClusterConsistency();
   }
 
+  /**
+   * The risk instalments introduce, and the compensation that pays for it.
+   * <p>
+   * Before them, the whole buffered WAL sat in leader heap and NOTHING reached a follower until the
+   * {@code recordFileChanges} callback returned, so a build that threw part-way left the followers untouched. Now
+   * the files an instalment announced are already there, and the entry that would have published or retired them
+   * is never sent, because it lives after the line that threw - and every instalment chunk is marked
+   * {@code moreChunksFollow}, so there is no signal a follower could act on by itself.
+   * <p>
+   * This reproduces exactly the shape the principal caller produces: {@code BucketIndexBuilder.create()} drops the
+   * half-built index from its own error handler, so the leader lets the file go and only the followers are left
+   * holding it. The assertion is the invariant that matters - EVERY node agrees on whether the file exists - not
+   * merely "the followers dropped it", because a compensation that retired a file the leader had KEPT would
+   * satisfy the narrow assertion while creating the divergence the retirement exists to prevent.
+   */
+  @Test
+  void aSessionThatFailsAfterAnInstalmentRetiresWhatItAnnounced() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+
+    final DatabaseInternal leaderDb = wrapped(leaderIndex);
+    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+
+    final long instalmentsBefore = RaftReplicatedDatabase.getSchemaWalInstalmentsShipped();
+    final int[] abandonedFileId = { -1 };
+
+    // A DDL session that creates a file, ships more than one instalment's worth of WAL, then fails the way a
+    // half-way index build does: it lets its own file go before the exception leaves the callback.
+    assertThatThrownBy(() -> leaderDb.recordFileChanges(() -> {
+      leaderDb.getSchema().createBucket(ABANDONED_BUCKET);
+      abandonedFileId[0] = leaderDb.getSchema().getBucketByName(ABANDONED_BUCKET).getFileId();
+
+      final String payload = "y".repeat(400);
+      for (int batch = 0; batch < 8; batch++) {
+        leaderDb.begin();
+        for (int i = 0; i < 500; i++)
+          leaderDb.newDocument(TYPE_NAME).set("name", "abandoned" + batch + "_" + i).set("payload", payload).save();
+        leaderDb.commit();
+      }
+
+      leaderDb.getSchema().dropBucket(ABANDONED_BUCKET);
+      throw new IllegalStateException("simulated mid-build failure");
+    })).as("the failure must reach the caller unchanged, not be swallowed or replaced by the compensation")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("simulated mid-build failure");
+
+    assertThat(RaftReplicatedDatabase.getSchemaWalInstalmentsShipped() - instalmentsBefore)
+        .as("the session must actually have shipped an instalment, or this test proves nothing").isPositive();
+    assertThat(abandonedFileId[0]).as("the session must have created a file to abandon").isNotNegative();
+
+    waitForAllServers();
+
+    final boolean onLeader = fileExistsOn(leaderIndex, abandonedFileId[0]);
+    assertThat(onLeader).as("the callback dropped the bucket, so this node must not have the file").isFalse();
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final int server = i;
+      assertThat(awaitFileExistsOn(server, abandonedFileId[0], onLeader))
+          .as("server %d must agree with the node that ran the DDL about file %d: an instalment announced it and "
+              + "nothing ever published it, so a follower left holding it leaks a file no schema references",
+              server, abandonedFileId[0])
+          .isEqualTo(onLeader);
+    }
+  }
+
   // ---------------------------------------------------------------------------------------------------------------
 
   private DatabaseInternal wrapped(final int serverIndex) {
@@ -159,6 +226,17 @@ class RaftSchemaWalInstalment3NodesIT extends BaseRaftHATest {
 
   private long awaitIndexEntriesOn(final int serverIndex, final long expected) throws InterruptedException {
     return awaitValue(expected, () -> indexEntriesOn(serverIndex));
+  }
+
+  /** Whether the paginated file is present in one server's FileManager, which is what an instalment created. */
+  private boolean fileExistsOn(final int serverIndex, final int fileId) {
+    return withResyncRetry(serverIndex,
+        db -> ((DatabaseInternal) db).getFileManager().existsFile(fileId));
+  }
+
+  private boolean awaitFileExistsOn(final int serverIndex, final int fileId, final boolean expected)
+      throws InterruptedException {
+    return awaitValue(expected ? 1 : 0, () -> fileExistsOn(serverIndex, fileId) ? 1 : 0) == 1;
   }
 
   private long countByNameOn(final int serverIndex, final String name) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftSchemaWalInstalment3NodesIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftSchemaWalInstalment3NodesIT.java
@@ -23,6 +23,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.DatabaseIsClosedException;
 import com.arcadedb.index.Index;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.Tag;
@@ -88,10 +89,9 @@ class RaftSchemaWalInstalment3NodesIT extends BaseRaftHATest {
 
     final DatabaseInternal leaderDb = wrapped(leaderIndex);
 
-    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
-    leaderDb.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".name STRING");
-    leaderDb.command("sql",
-        "CREATE INDEX `" + INDEX_NAME + "` ON " + TYPE_NAME + "(name) NOTUNIQUE");
+    ddlOnLeader("CREATE DOCUMENT TYPE " + TYPE_NAME);
+    ddlOnLeader("CREATE PROPERTY " + TYPE_NAME + ".name STRING");
+    ddlOnLeader("CREATE INDEX `" + INDEX_NAME + "` ON " + TYPE_NAME + "(name) NOTUNIQUE");
 
     // A payload per record so the index build has real page volume to buffer.
     final String payload = "x".repeat(400);
@@ -159,9 +159,9 @@ class RaftSchemaWalInstalment3NodesIT extends BaseRaftHATest {
     final int leaderIndex = findLeaderIndex();
     assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
 
-    final DatabaseInternal leaderDb = wrapped(leaderIndex);
-    leaderDb.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+    ddlOnLeader("CREATE DOCUMENT TYPE " + TYPE_NAME);
 
+    final DatabaseInternal leaderDb = wrapped(leaderIndex);
     final long instalmentsBefore = RaftReplicatedDatabase.getSchemaWalInstalmentsShipped();
     final int[] abandonedFileId = { -1 };
 
@@ -205,6 +205,30 @@ class RaftSchemaWalInstalment3NodesIT extends BaseRaftHATest {
   }
 
   // ---------------------------------------------------------------------------------------------------------------
+
+  /**
+   * Runs a DDL statement on whichever node is leader RIGHT NOW, re-resolving on the way.
+   * <p>
+   * {@code findLeaderIndex()} answers for the moment it is called, and an election can land between that answer and
+   * the next statement - schema changes must run on the leader, so the statement then fails with
+   * {@code ServerIsNotTheLeaderException} during setup and the test reports a flake that says nothing about what it
+   * is testing. It is a {@code NeedRetryException} precisely because retrying is the designed response.
+   */
+  private void ddlOnLeader(final String sql) throws InterruptedException {
+    ServerIsNotTheLeaderException lastError = null;
+    for (int attempt = 0; attempt < 20; attempt++) {
+      final int leaderIndex = findLeaderIndex();
+      if (leaderIndex >= 0)
+        try {
+          wrapped(leaderIndex).command("sql", sql);
+          return;
+        } catch (final ServerIsNotTheLeaderException e) {
+          lastError = e;
+        }
+      Thread.sleep(500);
+    }
+    throw lastError != null ? lastError : new IllegalStateException("no leader to run '" + sql + "' on");
+  }
 
   private DatabaseInternal wrapped(final int serverIndex) {
     return ((DatabaseInternal) getServerDatabase(serverIndex, getDatabaseName())).getWrappedDatabaseInstance();


### PR DESCRIPTION
Closes #6136.

All four items, plus a correction: **item 4's premise is wrong**, and the useful part of it is a test either way.

---

## 1. The index rebuild buffered its whole WAL in leader heap

`BucketIndexBuilder.create()` wraps an index build in `schema.recordFileChanges(...)`, which on a Raft leader sets
`isSchemaCommitThread` so `commit()` **buffers** instead of replicating - the files being created do not exist on
the followers yet, and `TransactionManager.applyChanges` silently skips pages for a fileId it does not have.
`LSMTreeIndex.build()` then commits once per `IndexBuilder.BUILD_BATCH_SIZE` (5000) records, and every one of those
WAL images stayed in `schemaWalBuffer` until the callback returned. Peak leader heap was roughly the whole rebuilt
index plus a repeat of every page more than one batch touched - on the node that is, by construction, the leader.
`CHECK DATABASE FIX` drops and rebuilds every index on an affected bucket, which is exactly that shape.

The buffer is now shipped in ordered **instalments** as it fills. Heap is bounded by the threshold instead of by the
size of the index.

**Nothing new goes on the wire.** This is the ordered-prefix sequence `splitSchemaEntry` has produced since #4743,
emitted as the payload is produced rather than after it is built: files first so pages have somewhere to land, WAL
in the middle, and the publishing fields - schema JSON, `filesToRemove` - only in the session's final entry. Every
prefix a follower can be left holding is self-consistent, and a partially written file is unreferenced bytes until
the last entry publishes it. Followers need no new code because that is the sequence they already receive.

One difference from a `splitSchemaEntry` split carries the whole safety argument: **the last chunk of an instalment
is still marked `moreChunksFollow`**, because an instalment is not the end of the change. A follower that took it
for a publication would reload its schema from a half-delivered state, and #5443 measured what that costs - the
reload detaches a compacted sub-index it cannot resolve yet, the later real publication reuses the same in-memory
component, and the follower serves only its mutable pages from then on, silently and for good.

The threshold is **derived, not configured**: half the maximum replicated entry size, the same expression
`runWithCompactionReplication` already uses for its own chunk budget. No new setting. It is soft - tested between
buffered commits - so `replicateSchemaInstalment` can still split.

Two details worth calling out for review:

- **create-then-drop inside one session.** `FileManager.dropFile` CANCELS the recorded create when both happen in
  one session. An instalment that already announced the create would otherwise leave the file on the followers and
  nowhere else, so the final entry reconciles: what an instalment shipped and the session no longer lists as a
  create is added to `filesToRemove`.
- **the buffer is drained only after the entry commits.** It holds the only copy of those pages that can reach a
  follower, so clearing first would turn a replication error into silent divergence.

### The alternative I did not take, and why

The issue suggests incremental flushing, which is what this does. The bigger alternative - take the build **out** of
the recording session: one small SCHEMA_ENTRY that creates the files and marks the index unusable, the batches as
ordinary replicated TX entries, one small SCHEMA_ENTRY to publish - is strictly better on every axis: bounded heap
*and* no write lock held for the whole build *and* no async pool parked *and* no concurrent writer stalled. It is
also a change to what index creation means for embedded users (an index visible-but-unusable, and a leader crash
mid-build leaving one permanently so), on the code path whose entire history is silent follower divergence. It
wants its own issue and its own judgement, so this change buys the heap bound at no protocol risk and I have said
plainly in the javadoc what it does **not** buy:

**the recording session still stays open for the whole build**, so a concurrent writer on the leader still waits on
`waitForActiveRecordingSession` - and, before that, on the database write lock the callback holds. Bounding heap
does not shorten that window.

## 2. The in-scan repairs are bounded

#6131 bounded the post-scan loops and deliberately left the two repairs that write from *inside* the vertex scan,
where nothing can commit: `LocalDatabase.scanType` holds the database read lock, and the chunk iterator being walked
would not survive a commit taken under it. Those two are now planned during the scan and applied after it, through
the same page budget.

The **chain resets needed no accumulator at all**, which is the part I would draw a reviewer's eye to: every one of
the eight `resetChain` call sites already registered its vertex in `reconnectOutEdges`/`reconnectInEdges`, so those
sets already *were* the complete list of chains to drop. Deferring them costs zero extra memory.

The **back-reference fix-up** does need one, and the issue is right that it must not trade WAL growth for heap
growth: it accumulates three RIDs per defective edge in flat `int[]`/`long[]` arrays, 36 bytes an entry with no
per-object header. The `ArrayList<Edge>` the chain rebuild used to fill - a fully materialised record per entry,
properties included - was replaced by the same structure, so this removes more heap than it adds.

Three consequences of deferring, all deliberate:

- the apply loop re-tests its guards against the **final** contents of the corrupted-record and reconnect sets,
  which keep growing while the scan runs. Strictly better than the in-scan test: a back-reference planned for a
  vertex some later vertex registered for a full rebuild is now dropped instead of written and immediately
  discarded.
- the "current vertex points at ANOTHER vertex's list" head-chunk comparison now sees the shared chunk rather than
  the `null` an earlier reset had already written - which is the case that test exists to catch.
- a list naming the same edge **twice** would now plant two back-references, because the second entry no longer sees
  the first one's write. Closed with a per-list `EdgeIdentitySet` (the zero-boxing `RidHashSet` one, lazily
  allocated), scoped to the one list because that is the only scope in which the duplicate can arise - across
  vertices the planned entries differ in the endpoint they record, exactly as the probe distinguished them.

**One in-scan write remains, and I have named it rather than implied it**: the iterator `remove()` that prunes a
dangling entry. It is not deferrable the way the others were - the removal is made through the chunk iterator's live
position, and replaying it would turn a linear pass into a quadratic one - and it is the mildest of the three,
rewriting a chunk page the walk already holds and never allocating one, where the back-reference fix-up appended to
a far vertex's list and could allocate a chunk per repair.

## 3. `autoFix` keeps its meaning and gains a breakdown

`removedRecords`, `prunedDanglingEntries`, `reconnectedEdges`, always present, zero included. The first two sum to
`autoFix`; the third deliberately does not, because a rebuilt chain has never contributed to it and folding it in
would change every number a current run reports.

Named `removedRecords`, not the `deletedRecords` the issue proposed: the result already carries
`totalDeletedRecords` - records found in the DELETED state by the bucket scan, nothing to do with repair - and a key
one word away from it would read as its non-total sibling.

The stale javadoc on `DatabaseChecker.deleteCorruptedRecords`, which still described the graph arms as counting
before the delete and said to unify towards this one, is corrected: #6131 already unified them, the other way round.

## 4. The nesting cap: the premise is wrong, there are two levels to spare

The issue reports `CHECK DATABASE FIX` over HTTP as using all three of `DatabaseContext`'s nested-transaction
levels. It uses **one**. `CheckDatabaseStatement.executeSimple` opens by rolling the caller's transaction back, so
the handler's level is released before the check starts; `LocalDatabase.begin` pushes only when the last context is
*active*, so the arms reuse it; and `commitRepairBatchIfFull` commits and re-begins at that same level rather than
nesting under it.

The conclusion #6131 drew from the wrong premise still holds and is the one that mattered: these are real
`commit()` calls on a real `TransactionContext`, so each is a genuine WAL write and, under HA, a genuine
replication round trip. Nesting was never the mechanism for that.

The test the issue asks for is worth having either way, and is here in two forms: sampling the depth the FIX path
actually reaches, and running the whole statement under `maxNested = 1`. A future change that adds a level arrives
as a red build naming the cap, instead of as a `TransactionException` in a repair someone is running against a
damaged production database - whose message points at a bug that would not be the real one.

---

## Tests

| test | proves |
| --- | --- |
| `CheckDatabaseBackReferenceRepairTest` | the back-reference repair splits across transactions under a small budget, is one transaction with the budget disabled, repairs identically either way, and is counted |
| `CheckDatabaseRepairBreakdownTest` | the breakdown decomposes `autoFix` on three damage shapes, and a rebuilt chain is counted without entering the sum |
| `CheckDatabaseTransactionNestingTest` | the FIX path runs at one transaction level, and survives a cap of 1 |
| `Issue6136SchemaWalInstalmentTest` | every chunk of an instalment is delivery-only and carries nothing that publishes; a split of a *complete* change still publishes on its last chunk |
| `RaftSchemaWalInstalment3NodesIT` | a 3-node rebuild under a 128KB append buffer ships instalments and leaves all three nodes with a complete, queryable index |

Each new test was **mutation-checked against unmodified code**: `CheckDatabaseBackReferenceRepairTest` fails 2 of 3
(the batching assertion reads `commits = 1`), and `RaftSchemaWalInstalment3NodesIT` fails on the instalment count
alone with the flush disabled - every other assertion in it passes on the old code, which is stated in the test so
nobody mistakes it for coverage it does not give.

Regression: the full engine unit lane, plus the ha-raft schema/index ITs.
