### PR TITLE
fix(#6148): CALL proc() YIELD * now binds the procedure's output fields

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CallStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CallStep.java
@@ -33,22 +33,15 @@ import com.arcadedb.function.CypherFunctionRegistry;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
 import com.arcadedb.query.sql.executor.*;
-import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.EdgeType;
-import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -284,42 +277,28 @@ public class CallStep extends AbstractExecutionStep {
       args.add(evaluator.evaluate(argExpr, inputRow, context));
     }
 
-    // Handle built-in Cypher procedures
-    switch (procedureName.toLowerCase(Locale.ROOT)) {
-      case "db.labels":
-        return getLabels(context);
-      case "db.relationshiptypes":
-        return getRelationshipTypes(context);
-      case "db.propertykeys":
-        return getPropertyKeys(context);
-      case "db.schema":
-      case "db.schema.visualization":
-        return getSchemaVisualization(context);
-      default:
-        // Check the procedure registry first
-        final CypherProcedure procedure = CypherProcedureRegistry.get(procedureName);
-        if (procedure != null) {
-          return executeProcedure(procedure, args.toArray(), inputRow, context);
-        }
+    // Check the procedure registry first (built-in Neo4j-compatible procedures like db.labels() are registered
+    // here too, so their declared yield fields are available to CypherSemanticValidator for YIELD * - issue #6148)
+    final CypherProcedure procedure = CypherProcedureRegistry.get(procedureName);
+    if (procedure != null)
+      return executeProcedure(procedure, args.toArray(), inputRow, context);
 
-        // Check the function registry
-        final StatelessFunction function = CypherFunctionRegistry.get(procedureName);
-        if (function != null) {
-          return executeFunction(function, args.toArray(), context);
-        }
+    // Check the function registry
+    final StatelessFunction function = CypherFunctionRegistry.get(procedureName);
+    if (function != null)
+      return executeFunction(function, args.toArray(), context);
 
-        // Try to call as custom function (DEFINE FUNCTION) first
-        if (!namespace.isEmpty()) {
-          final Object customResult = callCustomFunction(namespace, simpleName, args, context);
-          if (customResult != null)
-            return customResult;
-        }
-
-        // Fall back to ArcadeDB SQL function (try full name first, e.g. "vector.neighbors", then simple name)
-        if (functionFactory.getSQLFunctionFactory().hasFunction(procedureName))
-          return callSQLFunction(procedureName, args, context);
-        return callSQLFunction(simpleName, args, context);
+    // Try to call as custom function (DEFINE FUNCTION) first
+    if (!namespace.isEmpty()) {
+      final Object customResult = callCustomFunction(namespace, simpleName, args, context);
+      if (customResult != null)
+        return customResult;
     }
+
+    // Fall back to ArcadeDB SQL function (try full name first, e.g. "vector.neighbors", then simple name)
+    if (functionFactory.getSQLFunctionFactory().hasFunction(procedureName))
+      return callSQLFunction(procedureName, args, context);
+    return callSQLFunction(simpleName, args, context);
   }
 
   /**
@@ -451,74 +430,6 @@ public class CallStep extends AbstractExecutionStep {
         return null;
       throw new CommandExecutionException("Error executing custom function: " + libraryName + "." + functionName, e);
     }
-  }
-
-  /**
-   * Returns all vertex type names.
-   */
-  private List<Map<String, Object>> getLabels(final CommandContext context) {
-    final List<Map<String, Object>> results = new ArrayList<>();
-    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-      if (type instanceof VertexType && !type.getName().contains("~")) {
-        results.add(CollectionUtils.singletonMap("label", type.getName()));
-      }
-    }
-    return results;
-  }
-
-  /**
-   * Returns all edge type names.
-   */
-  private List<Map<String, Object>> getRelationshipTypes(final CommandContext context) {
-    final List<Map<String, Object>> results = new ArrayList<>();
-    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-      if (type instanceof EdgeType && !type.getName().contains("~")) {
-        results.add(CollectionUtils.singletonMap("relationshipType", type.getName()));
-      }
-    }
-    return results;
-  }
-
-  /**
-   * Returns all property keys across all types.
-   */
-  private List<Map<String, Object>> getPropertyKeys(final CommandContext context) {
-    final Set<String> propertyKeys = new HashSet<>();
-    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-      if (!type.getName().contains("~")) {
-        for (final String propName : type.getPropertyNames()) {
-          propertyKeys.add(propName);
-        }
-      }
-    }
-    final List<Map<String, Object>> results = new ArrayList<>();
-    for (final String key : propertyKeys) {
-      results.add(CollectionUtils.singletonMap("propertyKey", key));
-    }
-    return results;
-  }
-
-  /**
-   * Returns schema visualization data.
-   */
-  private List<Map<String, Object>> getSchemaVisualization(final CommandContext context) {
-    final List<Map<String, Object>> results = new ArrayList<>();
-    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-      if (type.getName().contains("~"))
-        continue;
-      final Map<String, Object> typeInfo = new HashMap<>();
-      typeInfo.put("name", type.getName());
-      if (type instanceof VertexType) {
-        typeInfo.put("type", "node");
-      } else if (type instanceof EdgeType) {
-        typeInfo.put("type", "relationship");
-      } else {
-        typeInfo.put("type", "document");
-      }
-      typeInfo.put("properties", new ArrayList<>(type.getPropertyNames()));
-      results.add(typeInfo);
-    }
-    return results;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CallStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CallStep.java
@@ -54,11 +54,10 @@ import java.util.stream.Stream;
  * CALL functionName() YIELD result
  * </pre>
  * <p>
- * Maps Cypher procedure names to ArcadeDB SQL functions:
- * - db.labels() -> returns all type names
- * - db.relationshipTypes() -> returns all edge type names
- * - db.propertyKeys() -> returns all property keys
- * - Any SQL function can be called directly
+ * Resolution order: registered {@link CypherProcedure} (built-in Neo4j-compatible procedures like
+ * {@code db.labels()} and {@code merge.node()} are registered here too, see {@link CypherProcedureRegistry}),
+ * then a registered {@link StatelessFunction}, then a {@code DEFINE FUNCTION} library function, then any
+ * ArcadeDB SQL function.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -23,6 +23,8 @@ import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.function.math.RoundFunction;
 import com.arcadedb.query.opencypher.ast.*;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
 
 import java.util.*;
 
@@ -224,9 +226,16 @@ public class CypherSemanticValidator {
       case FOREACH -> forget(((ForeachClause) entry.getTypedClause()).getVariable(), scope, declaredHere);
       case CALL -> {
         final CallClause callClause = entry.getTypedClause();
-        if (callClause.hasYield())
-          for (final CallClause.YieldItem item : callClause.getYieldItems())
-            forget(item.getOutputName(), scope, declaredHere);
+        if (callClause.hasYield()) {
+          if (callClause.isYieldAll()) {
+            final List<String> yieldAllFields = resolveYieldAllFieldNames(callClause);
+            if (yieldAllFields != null)
+              for (final String field : yieldAllFields)
+                forget(field, scope, declaredHere);
+          } else
+            for (final CallClause.YieldItem item : callClause.getYieldItems())
+              forget(item.getOutputName(), scope, declaredHere);
+        }
       }
       case SUBQUERY -> {
         // What a nested CALL subquery returns enters this scope under a kind this phase does not track back through
@@ -353,6 +362,27 @@ public class CypherSemanticValidator {
   private static void forget(final String name, final Map<String, VarType> scope, final Set<String> declaredHere) {
     scope.remove(name);
     declaredHere.remove(name);
+  }
+
+  /**
+   * Resolves the concrete field names a {@code CALL proc() YIELD *} puts into scope (issue #6148).
+   * <p>
+   * {@code YIELD *} carries no {@link CallClause.YieldItem}s of its own ({@link CallClause#getYieldItems()} is
+   * empty even though {@link CallClause#isYieldAll()} is true), so the three CALL-handling switches in this class
+   * cannot learn what it exports the same way they learn from an explicit {@code YIELD a, b}. What it exports is
+   * exactly the calling procedure's declared {@link CypherProcedure#getYieldFields()} - the same registry
+   * {@code CallStep} consults to run the call - so this looks the procedure up there rather than guessing.
+   * <p>
+   * Returns {@code null}, not an empty list, when the name does not resolve to a registered procedure (a custom
+   * {@code DEFINE FUNCTION}, an arbitrary SQL function, or a genuinely unknown name): none of those have a
+   * statically declared output signature, so callers fall back to today's behavior for them instead of treating an
+   * unresolvable {@code YIELD *} as exporting nothing.
+   */
+  private static List<String> resolveYieldAllFieldNames(final CallClause callClause) {
+    if (!callClause.isYieldAll())
+      return null;
+    final CypherProcedure procedure = CypherProcedureRegistry.get(callClause.getProcedureName());
+    return procedure != null ? procedure.getYieldFields() : null;
   }
 
   // ==============================
@@ -641,9 +671,15 @@ public class CypherSemanticValidator {
         case CALL:
           // Procedure CALL with YIELD — exported yield variables enter scope
           final CallClause callClause = entry.getTypedClause();
-          if (callClause != null && callClause.hasYield())
-            for (final CallClause.YieldItem item : callClause.getYieldItems())
-              scope.add(item.getOutputName());
+          if (callClause != null && callClause.hasYield()) {
+            if (callClause.isYieldAll()) {
+              final List<String> yieldAllFields = resolveYieldAllFieldNames(callClause);
+              if (yieldAllFields != null)
+                scope.addAll(yieldAllFields);
+            } else
+              for (final CallClause.YieldItem item : callClause.getYieldItems())
+                scope.add(item.getOutputName());
+          }
           break;
         case SUBQUERY:
           // CALL { ... RETURN x AS y } — exported return variables enter outer scope
@@ -1835,10 +1871,17 @@ public class CypherSemanticValidator {
       }
       case CALL -> {
         final CallClause callClause = entry.getTypedClause();
-        if (callClause.hasYield())
-          for (final CallClause.YieldItem item : callClause.getYieldItems())
-            if (item.getOutputName() != null)
+        if (callClause.hasYield()) {
+          if (callClause.isYieldAll()) {
+            final List<String> yieldAllFields = resolveYieldAllFieldNames(callClause);
+            if (yieldAllFields != null && !yieldAllFields.isEmpty())
               return true;
+          } else {
+            for (final CallClause.YieldItem item : callClause.getYieldItems())
+              if (item.getOutputName() != null)
+                return true;
+          }
+        }
       }
       case SUBQUERY -> {
         // What a CALL { } subquery returns becomes an ordinary variable of the enclosing scope, exactly like WITH.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/CypherProcedureRegistry.java
@@ -21,6 +21,10 @@ package com.arcadedb.query.opencypher.procedures;
 import com.arcadedb.function.procedure.ProcedureRegistry;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.opencypher.procedures.db.DbIndexVectorQueryNodes;
+import com.arcadedb.query.opencypher.procedures.db.DbLabels;
+import com.arcadedb.query.opencypher.procedures.db.DbPropertyKeys;
+import com.arcadedb.query.opencypher.procedures.db.DbRelationshipTypes;
+import com.arcadedb.query.opencypher.procedures.db.DbSchemaVisualization;
 import com.arcadedb.query.opencypher.procedures.algo.AlgoAPSP;
 import com.arcadedb.query.opencypher.procedures.algo.AlgoAStar;
 import com.arcadedb.query.opencypher.procedures.algo.AlgoAdamicAdar;
@@ -388,6 +392,11 @@ public final class CypherProcedureRegistry {
 
   private static void registerDbProcedures() {
     register(new DbIndexVectorQueryNodes());
+    register(new DbLabels());
+    register(new DbRelationshipTypes());
+    register(new DbPropertyKeys());
+    register(new DbSchemaVisualization("db.schema"));
+    register(new DbSchemaVisualization("db.schema.visualization"));
   }
 
   private static void registerMetaProcedures() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbLabels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbLabels.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.db;
+
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.VertexType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Neo4j-compatible procedure: {@code db.labels()}
+ * <p>
+ * Returns one row per vertex type (label) declared in the database, under the field {@code label}.
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class DbLabels implements CypherProcedure {
+  public static final String NAME = "db.labels";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 0;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 0;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the name of every vertex type (label) in the database (Neo4j-compatible)";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("label");
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    final List<Result> results = new ArrayList<>();
+    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
+      if (type instanceof VertexType && !type.getName().contains("~")) {
+        final ResultInternal result = new ResultInternal();
+        result.setProperty("label", type.getName());
+        results.add(result);
+      }
+    }
+    return results.stream();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbPropertyKeys.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbPropertyKeys.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class DbPropertyKeys implements CypherProcedure {
-  public static final String NAME = "db.propertykeys";
+  public static final String NAME = "db.propertyKeys";
 
   @Override
   public String getName() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbPropertyKeys.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbPropertyKeys.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.db;
+
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.DocumentType;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Neo4j-compatible procedure: {@code db.propertyKeys()}
+ * <p>
+ * Returns one row per distinct property name declared across every type in the database, under the field
+ * {@code propertyKey}.
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class DbPropertyKeys implements CypherProcedure {
+  public static final String NAME = "db.propertykeys";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 0;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 0;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns every distinct property key declared across all types in the database (Neo4j-compatible)";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("propertyKey");
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    final Set<String> propertyKeys = new LinkedHashSet<>();
+    for (final DocumentType type : context.getDatabase().getSchema().getTypes())
+      if (!type.getName().contains("~"))
+        propertyKeys.addAll(type.getPropertyNames());
+
+    final List<Result> results = new ArrayList<>(propertyKeys.size());
+    for (final String key : propertyKeys) {
+      final ResultInternal result = new ResultInternal();
+      result.setProperty("propertyKey", key);
+      results.add(result);
+    }
+    return results.stream();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbRelationshipTypes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbRelationshipTypes.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.db;
+
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.EdgeType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Neo4j-compatible procedure: {@code db.relationshipTypes()}
+ * <p>
+ * Returns one row per edge type (relationship type) declared in the database, under the field
+ * {@code relationshipType}.
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class DbRelationshipTypes implements CypherProcedure {
+  public static final String NAME = "db.relationshiptypes";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 0;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 0;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the name of every edge type (relationship type) in the database (Neo4j-compatible)";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("relationshipType");
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    final List<Result> results = new ArrayList<>();
+    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
+      if (type instanceof EdgeType && !type.getName().contains("~")) {
+        final ResultInternal result = new ResultInternal();
+        result.setProperty("relationshipType", type.getName());
+        results.add(result);
+      }
+    }
+    return results.stream();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbRelationshipTypes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbRelationshipTypes.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class DbRelationshipTypes implements CypherProcedure {
-  public static final String NAME = "db.relationshiptypes";
+  public static final String NAME = "db.relationshipTypes";
 
   @Override
   public String getName() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbSchemaVisualization.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbSchemaVisualization.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.db;
+
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.VertexType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Neo4j-compatible procedure: {@code db.schema.visualization()}, also registered as {@code db.schema()}.
+ * <p>
+ * Returns one row per type declared in the database, under the fields {@code name}, {@code type}
+ * ({@code "node"}, {@code "relationship"} or {@code "document"}) and {@code properties}.
+ * </p>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class DbSchemaVisualization implements CypherProcedure {
+  private final String name;
+
+  public DbSchemaVisualization(final String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 0;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 0;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the database schema (type name, kind and properties) for visualization (Neo4j-compatible)";
+  }
+
+  @Override
+  public List<String> getYieldFields() {
+    return List.of("name", "type", "properties");
+  }
+
+  @Override
+  public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+    final List<Result> results = new ArrayList<>();
+    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
+      if (type.getName().contains("~"))
+        continue;
+
+      final ResultInternal result = new ResultInternal();
+      result.setProperty("name", type.getName());
+      result.setProperty("type", type instanceof VertexType ? "node" : type instanceof EdgeType ? "relationship" : "document");
+      result.setProperty("properties", new ArrayList<>(type.getPropertyNames()));
+      results.add(result);
+    }
+    return results.stream();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6148YieldStarProcedureScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6148YieldStarProcedureScopeTest.java
@@ -19,11 +19,14 @@
 package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6148: {@code CALL proc() YIELD *} never put any of the procedure's yielded output names into scope, so a
@@ -104,5 +107,24 @@ class Issue6148YieldStarProcedureScopeTest extends TestHelper {
     try (final ResultSet rs = database.query("opencypher", "CALL db.schema.visualization() YIELD * RETURN name, type, properties")) {
       assertThat(rs.hasNext()).isTrue();
     }
+  }
+
+  /**
+   * A custom {@code DEFINE FUNCTION} has no statically declared output signature - unlike a registered
+   * {@link com.arcadedb.query.opencypher.procedures.CypherProcedure}, {@code CypherProcedureRegistry} does not know
+   * it at all, so {@code resolveYieldAllFieldNames} returns {@code null} for it. This pins down that an unresolvable
+   * {@code YIELD *} keeps exactly today's (pre-fix) behavior instead of the fix guessing at a shape it cannot know.
+   */
+  @Test
+  void yieldStarOnAnUnresolvableProcedureNameKeepsPriorBehavior() {
+    database.command("sql", "DEFINE FUNCTION math.double \"SELECT :x * 2\" PARAMETERS [x] LANGUAGE sql");
+
+    assertThatThrownBy(() -> database.query("opencypher", "CALL math.double(4) YIELD * RETURN value").close())
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("UndefinedVariable");
+
+    assertThatThrownBy(() -> database.query("opencypher", "CALL math.double(4) YIELD * RETURN *").close())
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("NoVariablesInScope");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6148YieldStarProcedureScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6148YieldStarProcedureScopeTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6148: {@code CALL proc() YIELD *} never put any of the procedure's yielded output names into scope, so a
+ * named reference to one of them - or a following {@code RETURN *} - failed even though the executor projects the
+ * fields correctly once the query is allowed to run at all.
+ * <p>
+ * Root cause: {@code CypherSemanticValidator}'s {@code buildVarTypes}, {@code validateVariableScope} and
+ * {@code statementDeclaresAnyVariable} (added for issue #6135 / PR #6138) all iterated {@code callClause.getYieldItems()}
+ * to learn what a {@code CALL ... YIELD} exports, but that list is deliberately empty for {@code YIELD *}
+ * ({@code isYieldAll()} is the only signal). Neo4j (the openCypher reference implementation) treats {@code YIELD *}
+ * as an ordinary {@code YIELD} of every field the procedure declares.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6148YieldStarProcedureScopeTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:P {name: 'a'})-[:KNOWS]->(:P {name: 'b'})");
+    // db.propertyKeys() reads the schema's declared properties, not the schemaless documents themselves
+    database.command("sql", "CREATE PROPERTY P.name STRING");
+  }
+
+  @Test
+  void yieldStarBindsANamedBuiltInProcedureOutput() {
+    try (final ResultSet rs = database.query("opencypher", "CALL db.labels() YIELD * RETURN label")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.getPropertyNames()).containsExactly("label");
+      assertThat(row.<String>getProperty("label")).isEqualTo("P");
+    }
+  }
+
+  @Test
+  void yieldStarLetsReturnStarSeeTheBuiltInProcedureOutput() {
+    try (final ResultSet rs = database.query("opencypher", "CALL db.labels() YIELD * RETURN *")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().getPropertyNames()).containsExactly("label");
+    }
+  }
+
+  @Test
+  void yieldStarBindsDbRelationshipTypesOutput() {
+    try (final ResultSet rs = database.query("opencypher", "CALL db.relationshiptypes() YIELD * RETURN relationshipType")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("relationshipType")).isEqualTo("KNOWS");
+    }
+  }
+
+  @Test
+  void yieldStarBindsDbPropertyKeysOutput() {
+    try (final ResultSet rs = database.query("opencypher", "CALL db.propertykeys() YIELD * RETURN propertyKey")) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+  }
+
+  @Test
+  void yieldStarBindsARegisteredProcedureOutput() {
+    try (final ResultSet rs = database.query("opencypher", "CALL meta.stats() YIELD * RETURN value")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Object>getProperty("value")).isNotNull();
+    }
+  }
+
+  @Test
+  void yieldStarInsideACallSubqueryStillBindsTheOutput() {
+    try (final ResultSet rs = database.query("opencypher", "CALL { CALL db.labels() YIELD * RETURN label } RETURN label")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("label")).isEqualTo("P");
+    }
+  }
+
+  @Test
+  void yieldStarBindsDbSchemaOutputUnderEitherRegisteredName() {
+    try (final ResultSet rs = database.query("opencypher", "CALL db.schema() YIELD * RETURN name, type, properties")) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+    try (final ResultSet rs = database.query("opencypher", "CALL db.schema.visualization() YIELD * RETURN name, type, properties")) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6148YieldStarProcedureScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6148YieldStarProcedureScopeTest.java
@@ -110,6 +110,22 @@ class Issue6148YieldStarProcedureScopeTest extends TestHelper {
   }
 
   /**
+   * Routing the hardcoded {@code db.*} built-ins through the normal {@code CypherProcedure} dispatch (issue #6148's
+   * fix) means they now go through {@code CypherProcedure#validateArgs} like every other procedure - previously the
+   * hardcoded {@code switch} in {@code CallStep} ignored {@code args} entirely, so {@code CALL db.labels(1)} silently
+   * succeeded. Pinning this down so a future refactor cannot silently reintroduce the old, more permissive behavior.
+   */
+  @Test
+  void dbLabelsNowRejectsAnUnexpectedArgument() {
+    assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("opencypher", "CALL db.labels(1) YIELD label RETURN label")) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).isInstanceOf(CommandSemanticException.class);
+  }
+
+  /**
    * A custom {@code DEFINE FUNCTION} has no statically declared output signature - unlike a registered
    * {@link com.arcadedb.query.opencypher.procedures.CypherProcedure}, {@code CypherProcedureRegistry} does not know
    * it at all, so {@code resolveYieldAllFieldNames} returns {@code null} for it. This pins down that an unresolvable


### PR DESCRIPTION
## Summary

`CALL proc() YIELD *` never put any of the procedure's yielded output names into scope, so a named reference to one of them - or a following `RETURN *` - failed with `UndefinedVariable`/`NoVariablesInScope`, even though the executor already projects the fields correctly once the query is allowed to run at all.

```cypher
CALL db.labels() YIELD * RETURN label
-- CommandSemanticException: UndefinedVariable: Variable 'label' not defined

CALL db.labels() YIELD * RETURN *
-- CommandParsingException: NoVariablesInScope: RETURN * is not allowed when there are no variables in scope
```

Neo4j (the openCypher reference implementation) treats `YIELD *` as an ordinary `YIELD` of every output field the procedure declares, making them referenceable afterwards exactly as `CALL db.labels() YIELD label RETURN label` already is.

## Root cause

`CypherSemanticValidator`'s three CALL-handling switches (`buildVarTypes`, `validateVariableScope`, and `statementDeclaresAnyVariable`, the last added by #6138 for #6135) all learn what a `CALL ... YIELD` exports by iterating `callClause.getYieldItems()`. That list is deliberately empty for `YIELD *` (`hasYield()` is true, `isYieldAll()` is true, but there are no items), so all three silently added nothing.

Separately, five Neo4j-compatible built-ins (`db.labels`, `db.relationshipTypes`, `db.propertyKeys`, `db.schema`, `db.schema.visualization`) bypassed `CypherProcedureRegistry` entirely via a hardcoded `switch` in `CallStep`, so even a registry-based fix wouldn't have covered the issue's own reproduction case.

## Fix

- Added `CypherSemanticValidator.resolveYieldAllFieldNames`, which resolves a `YIELD *` against the calling procedure's declared `CypherProcedure#getYieldFields()` via `CypherProcedureRegistry` - the same registry `CallStep` already consults to run the call. Wired into all three CALL-handling switches. When the name doesn't resolve to a registered procedure (a custom `DEFINE FUNCTION`, an arbitrary SQL function, or an unknown name), behavior is unchanged from today rather than guessing at an output shape that isn't statically knowable.
- Converted the five hardcoded `db.*` built-ins into real `CypherProcedure` implementations (`DbLabels`, `DbRelationshipTypes`, `DbPropertyKeys`, `DbSchemaVisualization` registered under both `db.schema` and `db.schema.visualization`), registered in `CypherProcedureRegistry` like any other procedure. This removes the special-case switch in `CallStep` and makes `getYieldFields()` - previously declared on every procedure but never actually called anywhere - finally used, closing the exact registry gap the issue's own root-cause analysis flagged.

## Behavior change worth calling out

Routing the four hardcoded `db.*` built-ins through the normal `CypherProcedure` dispatch means they now go
through the same `validateArgs`/`checkArity` check as every other procedure (`getMinArgs()`/`getMaxArgs()` are
both `0`). Previously the hardcoded `switch` in `CallStep` ignored `args` entirely, so e.g. `CALL db.labels(1)`
silently succeeded and ignored the argument. Now it throws `CommandSemanticException` for the unexpected
argument, consistent with every other procedure and with Neo4j. This is more correct, but is a side effect of
the refactor rather than the headline fix, so calling it out explicitly here.

## Test plan

- [x] New regression test `Issue6148YieldStarProcedureScopeTest` reproduces the issue (fails before the fix, passes after), covering: a hardcoded built-in (`db.labels`), the other three renamed built-ins, a normally-registered procedure (`meta.stats`), `YIELD *` inside a `CALL {}` subquery, both registered names of the schema-visualization alias, and that an unresolvable procedure name (a custom `DEFINE FUNCTION`) keeps pre-fix behavior instead of the fix guessing at an unknowable output shape.
- [x] `mvn -pl engine test` for the full `com.arcadedb.query.opencypher.**` package (existing + new tests) - all green, including `Issue6135ReturnStarSubqueryScopeTest`, `CypherCallYieldWithVariablesTest`, `CypherProcedureRegistryTest`, `CypherSubqueryBodyIssue5656Test`, `CypherSemanticValidatorExceptionTest`.

Closes #6148.
