### PR TITLE
feat(#6157): add APOC-compatible coll.toSet and coll.pairsMin Cypher functions

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/CypherFunctionRegistry.java
+++ b/engine/src/main/java/com/arcadedb/function/CypherFunctionRegistry.java
@@ -259,9 +259,11 @@ public final class CypherFunctionRegistry {
     register(new CollInsert());
     register(new CollMax());
     register(new CollMin());
+    register(new CollPairsMin());
     register(new CollRemove());
     register(new CollSort());
     register(new CollSum());
+    register(new CollToSet());
     register(new CollUnion());
     register(new CollUnionAll());
   }

--- a/engine/src/main/java/com/arcadedb/function/coll/CollPairsMin.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollPairsMin.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * coll.pairsMin(list) - Returns the consecutive-element pairs of a list, e.g. {@code coll.pairsMin([1, 2, 3])}
+ * returns {@code [[1, 2], [2, 3]]}. Unlike {@code coll.pairs}, the trailing incomplete pair is dropped instead of
+ * being padded with {@code null}, so a list of fewer than two elements yields an empty list.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class CollPairsMin extends AbstractCollFunction {
+  @Override
+  protected String getSimpleName() {
+    return "pairsMin";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns the consecutive-element pairs of a list, dropping the trailing incomplete pair";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    checkArity(args);
+    final List<Object> list = asList(args[0]);
+    if (list == null)
+      return null;
+
+    final int pairCount = list.size() - 1;
+    if (pairCount <= 0)
+      return new ArrayList<>(0);
+
+    final List<Object> result = new ArrayList<>(pairCount);
+    for (int i = 0; i < pairCount; i++) {
+      final List<Object> pair = new ArrayList<>(2);
+      pair.add(list.get(i));
+      pair.add(list.get(i + 1));
+      result.add(pair);
+    }
+    return result;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/coll/CollPairsMin.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollPairsMin.java
@@ -25,8 +25,9 @@ import java.util.List;
 
 /**
  * coll.pairsMin(list) - Returns the consecutive-element pairs of a list, e.g. {@code coll.pairsMin([1, 2, 3])}
- * returns {@code [[1, 2], [2, 3]]}. Unlike {@code coll.pairs}, the trailing incomplete pair is dropped instead of
- * being padded with {@code null}, so a list of fewer than two elements yields an empty list.
+ * returns {@code [[1, 2], [2, 3]]}. Where APOC's {@code apoc.coll.pairs} pads the trailing incomplete pair with
+ * {@code null}, this one drops it, so a list of fewer than two elements yields an empty list. Only the dropping
+ * variant is implemented here; there is no {@code coll.pairs} in this engine.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/function/coll/CollToSet.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollToSet.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * coll.toSet(list) - Returns a unique list backed by a set, i.e. the given list with duplicates removed.
+ * Order is not significant to the caller, but the order of first occurrence is preserved so the result is
+ * deterministic. Like the rest of the {@code coll.*} namespace, duplicates are recognized by object equality,
+ * so {@code coll.toSet([1, 1.0])} keeps both elements.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class CollToSet extends AbstractCollFunction {
+  @Override
+  protected String getSimpleName() {
+    return "toSet";
+  }
+
+  @Override
+  public int getMinArgs() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns a unique list from the given list, preserving the order of first occurrence";
+  }
+
+  @Override
+  public Object execute(final Object[] args, final CommandContext context) {
+    checkArity(args);
+    final List<Object> list = asList(args[0]);
+    if (list == null)
+      return null;
+    return new ArrayList<>(new LinkedHashSet<>(list));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/coll/CollPairsMinTest.java
+++ b/engine/src/test/java/com/arcadedb/function/coll/CollPairsMinTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Direct-invocation tests for coll.pairsMin. The Cypher-level behavior is covered by CypherMissingFunctionsTest;
+ * what needs a direct call is the argument shape a Cypher list literal can never produce - a Collection that is
+ * not a List, which AbstractCollFunction.asList copies rather than casts.
+ */
+class CollPairsMinTest {
+
+  private final CollPairsMin fn = new CollPairsMin();
+
+  @Test
+  void pairsACollectionThatIsNotAList() {
+    // ArrayDeque is a Collection but not a List, and it iterates in insertion order, so the pairing is well defined.
+    final Collection<Object> source = new ArrayDeque<>(List.of("a", "b", "c"));
+    @SuppressWarnings("unchecked")
+    final List<Object> result = (List<Object>) fn.execute(new Object[] { source }, null);
+    assertThat(result).containsExactly(List.of("a", "b"), List.of("b", "c"));
+  }
+
+  @Test
+  void doesNotMutateSource() {
+    final List<Object> source = new ArrayList<>(List.of("a", "b", "c"));
+    fn.execute(new Object[] { source }, null);
+    assertThat(source).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  void nullListReturnsNull() {
+    assertThat(fn.execute(new Object[] { null }, null)).isNull();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/coll/CollToSetTest.java
+++ b/engine/src/test/java/com/arcadedb/function/coll/CollToSetTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.coll;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Direct-invocation tests for coll.toSet. The Cypher-level behavior is covered by CypherMissingFunctionsTest;
+ * what needs a direct call is the argument shape a Cypher list literal can never produce - a Collection that is
+ * not a List, which AbstractCollFunction.asList copies rather than casts.
+ */
+class CollToSetTest {
+
+  private final CollToSet fn = new CollToSet();
+
+  @Test
+  void dedupesACollectionThatIsNotAList() {
+    // ArrayDeque is a Collection but not a List, and unlike a Set it can still carry the duplicates under test.
+    final Collection<Object> source = new ArrayDeque<>(List.of("a", "b", "a", "c"));
+    @SuppressWarnings("unchecked")
+    final List<Object> result = (List<Object>) fn.execute(new Object[] { source }, null);
+    assertThat(result).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  void doesNotMutateSource() {
+    final List<Object> source = new ArrayList<>(List.of("a", "b", "a"));
+    fn.execute(new Object[] { source }, null);
+    assertThat(source).containsExactly("a", "b", "a");
+  }
+
+  @Test
+  void nullListReturnsNull() {
+    assertThat(fn.execute(new Object[] { null }, null)).isNull();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -103,6 +103,18 @@ class CypherBuiltInFunctionsTest extends TestHelper {
   }
 
   @Test
+  void apocPrefixCompatibilityForCollToSetAndPairsMin() {
+    // Issue #6157: the last two apoc.coll.* functions a migrating customer's query catalogue still referenced.
+    assertThat(CypherFunctionRegistry.hasFunction("coll.toSet")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("coll.pairsMin")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.coll.toSet")).isTrue();
+    assertThat(CypherFunctionRegistry.hasFunction("apoc.coll.pairsMin")).isTrue();
+
+    assertThat(CypherFunctionRegistry.get("apoc.coll.toSet")).isSameAs(CypherFunctionRegistry.get("coll.toSet"));
+    assertThat(CypherFunctionRegistry.get("apoc.coll.pairsMin")).isSameAs(CypherFunctionRegistry.get("coll.pairsMin"));
+  }
+
+  @Test
   void apocPrefixCompatibilityForProcedures() {
     // Test that procedures can be accessed with "apoc." prefix
     assertThat(CypherProcedureRegistry.hasProcedure("apoc.merge.relationship")).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
@@ -474,13 +474,18 @@ class CypherMissingFunctionsTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void collPairsMinDropsTheTrailingIncompletePair() {
-    // This is the whole difference from coll.pairs: no [3, null] tail is appended.
+    // This is the whole difference from APOC's coll.pairs: no [3, null] tail is appended. Assert the last pair
+    // specifically, so this stays a check on the tail rather than a restatement of collPairsMin()'s size check.
     final ResultSet rs = database.query("opencypher", "RETURN coll.pairsMin([1, 2, 3]) AS result");
     assertThat(rs.hasNext()).isTrue();
-    @SuppressWarnings("unchecked")
     final List<Object> result = rs.next().getProperty("result");
-    assertThat(result).hasSize(2);
+
+    final List<Object> last = (List<Object>) result.get(result.size() - 1);
+    assertThat(last).doesNotContainNull();
+    assertThat(((Number) last.get(0)).longValue()).isEqualTo(2L);
+    assertThat(((Number) last.get(1)).longValue()).isEqualTo(3L);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -373,6 +374,177 @@ class CypherMissingFunctionsTest {
     @SuppressWarnings("unchecked")
     final List<Object> result = rs.next().getProperty("result");
     assertThat(result).hasSize(4);
+  }
+
+  // ========== coll.toSet ==========
+  @Test
+  void collToSet() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.toSet([1, 2, 2, 3]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(3);
+    assertThat(((Number) result.get(0)).longValue()).isEqualTo(1L);
+    assertThat(((Number) result.get(1)).longValue()).isEqualTo(2L);
+    assertThat(((Number) result.get(2)).longValue()).isEqualTo(3L);
+  }
+
+  @Test
+  void collToSetEmpty() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.toSet([]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void collToSetNull() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.toSet(null) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((Object) rs.next().getProperty("result")).isNull();
+  }
+
+  @Test
+  void collToSetKeepsNullElement() {
+    // A null element is a value like any other, so it survives dedup exactly once.
+    final ResultSet rs = database.query("opencypher", "RETURN coll.toSet([1, null, 1, null]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(2);
+    assertThat(((Number) result.get(0)).longValue()).isEqualTo(1L);
+    assertThat(result.get(1)).isNull();
+  }
+
+  @Test
+  void collToSetDedupsByTypeAndValue() {
+    // Same caveat as coll.union/coll.distinct: dedup is by object equality, so an integer and a float of the
+    // same numeric value are NOT collapsed. Pinned here so the whole coll.* namespace stays consistent.
+    final ResultSet rs = database.query("opencypher", "RETURN coll.toSet([1, 1.0]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(2);
+  }
+
+  @Test
+  void collToSetWrongArity() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.toSet([1, 2], [3]) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void collToSetNonListArgument() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.toSet('not a list') AS result").hasNext())
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("coll.toSet() requires a list argument");
+  }
+
+  @Test
+  void collToSetApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.coll.toSet([1, 2, 2, 3]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(3);
+    assertThat(((Number) result.get(0)).longValue()).isEqualTo(1L);
+    assertThat(((Number) result.get(1)).longValue()).isEqualTo(2L);
+    assertThat(((Number) result.get(2)).longValue()).isEqualTo(3L);
+  }
+
+  // ========== coll.pairsMin ==========
+  @Test
+  @SuppressWarnings("unchecked")
+  void collPairsMin() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.pairsMin([1, 2, 3]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(2);
+
+    final List<Object> first = (List<Object>) result.get(0);
+    assertThat(first).hasSize(2);
+    assertThat(((Number) first.get(0)).longValue()).isEqualTo(1L);
+    assertThat(((Number) first.get(1)).longValue()).isEqualTo(2L);
+
+    final List<Object> second = (List<Object>) result.get(1);
+    assertThat(second).hasSize(2);
+    assertThat(((Number) second.get(0)).longValue()).isEqualTo(2L);
+    assertThat(((Number) second.get(1)).longValue()).isEqualTo(3L);
+  }
+
+  @Test
+  void collPairsMinDropsTheTrailingIncompletePair() {
+    // This is the whole difference from coll.pairs: no [3, null] tail is appended.
+    final ResultSet rs = database.query("opencypher", "RETURN coll.pairsMin([1, 2, 3]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(2);
+  }
+
+  @Test
+  void collPairsMinSingleElement() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.pairsMin([1]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void collPairsMinEmpty() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.pairsMin([]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    @SuppressWarnings("unchecked")
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void collPairsMinNull() {
+    final ResultSet rs = database.query("opencypher", "RETURN coll.pairsMin(null) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat((Object) rs.next().getProperty("result")).isNull();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void collPairsMinOfNestedLists() {
+    // The elements themselves may be lists: pairing is positional and does not look inside them.
+    final ResultSet rs = database.query("opencypher", "RETURN coll.pairsMin([[1, 2], [3, 4]]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(1);
+
+    final List<Object> pair = (List<Object>) result.get(0);
+    assertThat(pair).hasSize(2);
+    assertThat((List<Object>) pair.get(0)).hasSize(2);
+    assertThat((List<Object>) pair.get(1)).hasSize(2);
+  }
+
+  @Test
+  void collPairsMinWrongArity() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.pairsMin([1, 2], [3]) AS result").hasNext())
+        .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void collPairsMinNonListArgument() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.pairsMin('not a list') AS result").hasNext())
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("coll.pairsMin() requires a list argument");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void collPairsMinApocPrefix() {
+    final ResultSet rs = database.query("opencypher", "RETURN apoc.coll.pairsMin([1, 2, 3]) AS result");
+    assertThat(rs.hasNext()).isTrue();
+    final List<Object> result = rs.next().getProperty("result");
+    assertThat(result).hasSize(2);
+    assertThat((List<Object>) result.get(0)).hasSize(2);
+    assertThat((List<Object>) result.get(1)).hasSize(2);
   }
 
   // ========== elementId ==========


### PR DESCRIPTION
Closes #6157

Adds the last two `apoc.coll.*` functions the migrating customer's lineage query still referenced: `coll.toSet(list)`, which returns the list with duplicates removed, and `coll.pairsMin(list)`, which returns the consecutive-element pairs of a list and drops the trailing incomplete pair instead of padding it with `null`. Both are new `AbstractCollFunction` subclasses in `com.arcadedb.function.coll` registered in `CypherFunctionRegistry.registerCollFunctions()`, so they are reachable under both the bare `coll.` spelling and the `apoc.coll.` prefix.

## Design notes

**Nothing else needed wiring.** `CypherFunctionFactory` resolves namespaced functions generically through `CypherFunctionRegistry.get()/hasFunction()`, and those normalize the `apoc.` prefix away before the map lookup - there is no explicit alias registration, so the prefixed spelling works the moment the function is registered. `FunctionValidator`'s parse-time arity table deliberately holds no `coll.*` entries (`CypherSemanticValidator` skips the unknown-function check for any dotted name), so arity is enforced at runtime by each function's own `checkArity(args)`. The ANTLR grammar already parses arbitrary dotted names. Registration is therefore the only wiring change.

**Dedup semantics of `coll.toSet` follow the rest of the namespace, deliberately.** The existing `collUnionDedupsByTypeAndValue` test pins that `coll.union([1], [1.0])` keeps both elements: duplicates in `coll.*` are recognized by Java object equality, not by Cypher `=` semantics, so `1` and `1.0` do not collapse. `coll.toSet` matches `coll.distinct` exactly rather than reaching for `DistinctNumericKey` (the canonicalization used by `RETURN DISTINCT`, `UNION`, `count(DISTINCT ...)` and `collect(DISTINCT ...)` since #5789), because making one new function in the namespace behave differently from its two neighbours would be a worse surprise than the existing gap. `collToSetDedupsByTypeAndValue` pins the chosen behavior so the decision is visible rather than accidental. Extending `DistinctNumericKey` across the whole `coll.*` namespace is a separate, pre-existing question and is worth its own issue.

**`checkArity(args)` over a hand-rolled length check.** The `coll` package is currently split between the two: `checkArity` throws `CommandSemanticException` (HTTP 400, a caller mistake), while the hand-rolled checks in `CollDistinct`/`CollFlatten`/others throw `CommandExecutionException` (HTTP 500). Both new functions use `checkArity`, matching `CollUnion`/`CollUnionAll`/`CollSum`/`CollAvg` and the 400-for-caller-error convention.

**Order.** The issue notes that order is not significant for `toSet`, but the implementation preserves order of first occurrence via `LinkedHashSet` (as APOC itself does), so results are deterministic across runs.

## Test plan

- [x] 18 new tests, all confirmed to fail before the registration change and pass after (`Unknown function: coll.toset` / `coll.pairsmin`).
- [x] `coll.toSet`: basic dedup, empty list, `null` argument, a `null` element deduped exactly once, the numeric-type caveat, wrong arity (`CommandSemanticException`), non-list argument, and an `apoc.`-prefixed round trip.
- [x] `coll.pairsMin`: `[1,2,3]` -> `[[1,2],[2,3]]`, the dropped trailing pair, single-element and empty lists -> `[]`, `null` argument, the issue's own nested-list example `[[1,2],[3,4]]` -> one pair, wrong arity, non-list argument, and an `apoc.`-prefixed round trip.
- [x] Registry identity: `apoc.coll.toSet` and `apoc.coll.pairsMin` resolve to the same instances as their bare spellings (`CypherBuiltInFunctionsTest`).
- [x] The two non-list-argument tests assert on the message text, not just the exception type - `Unknown function` is itself a `CommandExecutionException`, so a type-only assertion passed before the fix and would not have discriminated.
- [x] Regression sweep, 364 tests green: `CypherMissingFunctionsTest`, `CypherBuiltInFunctionsTest`, `OpenCypherListFunctionsComprehensiveTest`, `CypherFunctionArityRegistryTest`, `FunctionRegistryTest`, `ProcedureRegistryTest`, `CypherFunctionArgumentValidationIssue5910Test`, `CypherFunctionArgumentValidationIssue5794Test`.

## Review cycles

**Cycle 1 - `5575b797`.** Approved from a code standpoint, one nit acted on and one declined.
- *Fixed:* `CollPairsMin`'s Javadoc read "Unlike `coll.pairs`", which implies a sibling function. Verified by grep that `coll.pairs` does not exist in this engine; reworded to attribute the padding variant to APOC and to state explicitly that only the dropping variant is implemented here.
- *Declined as written, improved instead:* the bot called `collPairsMin` and `collPairsMinDropsTheTrailingIncompletePair` redundant (both asserting `hasSize(2)` on the same query) and said it was not worth blocking. Rather than delete a test, the second one now asserts the last pair is `[2, 3]` and contains no null, so it pins the trailing-drop behavior instead of restating a size check.

**Cycle 2 - `2caf6e83`.** No bugs found, nothing blocking. Its one nit was a real coverage gap: nothing exercised `AbstractCollFunction.asList`'s branch for a `Collection` that is not a `List` (`new ArrayList<>((Collection<Object>) arg)`). That branch cannot be reached through a Cypher list literal, so it is now covered by direct-invocation tests in the existing `com.arcadedb.function.coll` test package, alongside `CollRemoveTest`: `CollToSetTest` and `CollPairsMinTest` feed an `ArrayDeque` so the branch is actually hit, and also pin no-source-mutation and null handling.

**Cycle 3 - `1b1761ad`.** Clean approval, no actionable items. Its only observation is a forward-looking naming note: if a future PR adds the padding variant as `coll.pairs`, the pair of names should be checked for readability together.

## Follow-ups deliberately left out of scope

- The `coll.*` namespace is split between `checkArity` (`CommandSemanticException`, HTTP 400) and hand-rolled length checks (`CommandExecutionException`, HTTP 500) - `CollDistinct`, `CollFlatten`, `CollMax`, `CollMin`, `CollSort`, `CollInsert` still use the latter. Both new functions use `checkArity`; converging the rest is a separate change.
- Whether `DistinctNumericKey` canonicalization should apply across the whole `coll.*` namespace, so `coll.union`/`coll.distinct`/`coll.toSet` collapse `1` and `1.0` the way `RETURN DISTINCT` and `UNION` have since #5789. Changing it here would have made one function disagree with its two neighbours.
