### PR TITLE
fix(#6111): do not let a stale snapshot marker satisfy a linearizable read before its re-download lands

### DIFF
--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -16,6 +16,15 @@ The persisted `.raft/applied-index` JSON is read in `reinitialize()` but **never
 
 Note that `globalAppliedIndex` and `lastAppliedIndex` track the same value on the apply path but are seeded independently, so they can briefly differ right after `reinitialize()`. Do not assert equality across that window.
 
+## `RaftHAServer.getLastAppliedIndex()` does not read ArcadeDB's counter
+
+It reads Ratis: `division.getInfo().getLastAppliedIndex()` -> `StateMachineUpdater.appliedIndex`, which Ratis seeds from `getLatestSnapshot().getIndex()` (in its constructor, and again in `reload()` right *after* `reinitialize()` returns). `ArcadeStateMachine.lastAppliedIndex`, the `AtomicLong`, feeds `takeSnapshot()` and the phase-2 replay floor and is **not** on that path.
+
+Two consequences that have already cost debugging time:
+
+- Changing what `reinitialize()` writes into the `AtomicLong` does **not** change what a `waitForAppliedIndex()` / `waitForLocalApply()` waiter observes. If you are chasing "a read was released too early", the value to reason about is the marker index, not the counter.
+- Because the value comes from the marker, a node whose marker runs ahead of the entries it actually applied advertises an applied index covering data it does not hold. That is issue #6111: `reinitialize()`'s snapshot-gap branch now publishes `staleSnapshotAppliedFloor` and the waiters use `getTrustedAppliedIndex()` (the raw value clamped to that floor). **Reporting** paths - cluster status, lag detection - deliberately keep the raw Ratis value; only read guarantees clamp. The floor is cleared where a resync actually restored the state, never where one is merely requested.
+
 ## Snapshots are taken far more often than you would guess
 
 Three triggers, not one: the Ratis auto-trigger (`arcadedb.ha.snapshotThreshold`, default 100k entries), ArcadeDB's own wall-clock `RaftLogCompactionScheduler` (`arcadedb.ha.snapshotInterval` 300 s, `arcadedb.ha.snapshotMinEntries` 64), **and shutdown**, via Ratis's `StateMachineUpdater.stop()`.

--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -25,6 +25,13 @@ Two consequences that have already cost debugging time:
 - Changing what `reinitialize()` writes into the `AtomicLong` does **not** change what a `waitForAppliedIndex()` / `waitForLocalApply()` waiter observes. If you are chasing "a read was released too early", the value to reason about is the marker index, not the counter.
 - Because the value comes from the marker, a node whose marker runs ahead of the entries it actually applied advertises an applied index covering data it does not hold. That is issue #6111: `reinitialize()`'s snapshot-gap branch now publishes `staleSnapshotAppliedFloor` and the waiters use `getTrustedAppliedIndex()` (the raw value clamped to that floor). **Reporting** paths - cluster status, lag detection - deliberately keep the raw Ratis value; only read guarantees clamp. The floor is cleared where a resync actually restored the state, never where one is merely requested.
 
+### The stale-gap failure mode an operator will meet
+
+A node holding an unfilled gap fails LINEARIZABLE reads (503) and reports not-ready via `isResyncInProgress()`, by design: it is genuinely missing committed entries, and the alternative is serving short data silently. Two things about how it recovers:
+
+- **The lag backstop cannot see it.** `isFollowerLaggingBeyond()` is driven by `commitIndex - appliedIndex`, and the applied index comes from the marker that is ahead - so the node reports *zero lag* while the gap is open. `retryUnfilledSnapshotGap()` (a `HealthMonitor.HealthTarget` hook, throttled to one attempt per snapshot-watchdog timeout) exists specifically because of this; do not try to fold it back into `recoverFromPersistentLag()`.
+- **A node that becomes leader while holding a gap wedges, deliberately.** `triggerSnapshotDownload()` refuses to resync when this node is the leader (or when the resolved leader address is its own), because copying its own incomplete databases onto themselves would report success and durably record the marker index as applied - re-opening #6111 permanently. So a single-node cluster, or a node that wins the election because every peer is unreachable, retries and refuses on every tick until a peer that actually holds the entries takes leadership. That is the intended terminal state, not a hang; the refusal is logged at WARNING on every attempt.
+
 ## Snapshots are taken far more often than you would guess
 
 Three triggers, not one: the Ratis auto-trigger (`arcadedb.ha.snapshotThreshold`, default 100k entries), ArcadeDB's own wall-clock `RaftLogCompactionScheduler` (`arcadedb.ha.snapshotInterval` 300 s, `arcadedb.ha.snapshotMinEntries` 64), **and shutdown**, via Ratis's `StateMachineUpdater.stop()`.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -212,6 +212,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // flagged re-download actually lands; it is cleared only by a resync that restored the state, never
   // by merely starting one.
   private final AtomicLong    staleSnapshotAppliedFloor  = new AtomicLong(-1);
+  // Wall-clock of the last retry submitted by retryUnfilledSnapshotGap(); 0 = none since the floor was
+  // last cleared. Throttles the HealthMonitor-driven backstop, which ticks far more often than a full
+  // multi-database resync costs.
+  private final AtomicLong    lastStaleSnapshotRetryMs   = new AtomicLong();
   // Set to true after applyTransaction hits a genuinely unrecoverable, node-wide condition: a JVM
   // Error (OOM, StackOverflow - the JVM itself is unstable), an unknown committed entry type (#4798,
   // rolling-upgrade safety), or an unexpected error on an entry with no single target database
@@ -2570,9 +2574,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
       resolveStaleSnapshotFloorAfterResync();
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Snapshot resync failed", e);
-      // The node is still short of the entries the marker claims, so the read floor stays. Re-arm the
-      // request instead of leaving it cleared: the next leader change (or the HealthMonitor backstop)
-      // retries, rather than clamping reads until a restart (issue #6111).
+      // The node is still short of the entries the marker claims, so the read floor stays and the
+      // request is re-armed rather than left cleared: a later leader change picks it up. The retry that
+      // does NOT depend on an election is retryUnfilledSnapshotGap(), driven by the HealthMonitor tick -
+      // note that recoverFromPersistentLag() cannot serve here, because the re-armed flag makes
+      // isSnapshotDownloadPending() true and both it and isFollowerLaggingBeyond() then stand down
+      // (issue #6111).
       if (staleSnapshotAppliedFloor.get() >= 0)
         needsSnapshotDownload.set(true);
     } finally {
@@ -2610,6 +2617,55 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // @VisibleForTesting
   void clearStaleSnapshotFloor() {
     staleSnapshotAppliedFloor.set(-1);
+    lastStaleSnapshotRetryMs.set(0);
+  }
+
+  /**
+   * Periodic backstop for an unfilled stale-snapshot gap (issue #6111), driven by the
+   * {@link HealthMonitor} tick. Re-submits {@link #triggerSnapshotDownload()} while a read floor is
+   * still outstanding and no download is running, so a node whose first attempt failed (leader HTTP
+   * port unreachable while Raft gRPC is fine, disk full, leader not yet known) recovers on its own
+   * instead of staying clamped and not-ready until the next leader election.
+   * <p>
+   * The existing stale-follower backstop cannot cover this: it is driven by
+   * {@code commitIndex - appliedIndex}, and Ratis derives the applied index from the very marker that
+   * is ahead, so a node with an open gap reports zero lag. {@link #recoverFromPersistentLag()} would
+   * also refuse anyway, because {@link #isSnapshotDownloadPending()} stays true while the request is
+   * re-armed.
+   * <p>
+   * Throttled to one attempt per {@link #computeSnapshotWatchdogTimeoutMs()} so a persistently failing
+   * download is not retried on every tick: a full resync pulls every database from the leader, and the
+   * HealthMonitor ticks far more often than that costs.
+   */
+  public void retryUnfilledSnapshotGap() {
+    final RaftHAServer raftHA = this.raftHAServer;
+    if (raftHA == null || server == null || raftHA.isLeader())
+      return;
+    final long floor = staleSnapshotAppliedFloor.get();
+    if (floor < 0)
+      return; // no unfilled gap
+    if (snapshotDownloadInProgress.get())
+      return; // one is genuinely running; it will clear the floor or re-arm the request
+    if (raftHA.getLeaderHttpAddress() == null)
+      return; // nowhere to download from yet; notifyLeaderChanged() drives the first attempt
+
+    final long now = System.currentTimeMillis();
+    final long retryIntervalMs = computeSnapshotWatchdogTimeoutMs();
+    final long previous = lastStaleSnapshotRetryMs.get();
+    if (previous != 0 && now - previous < retryIntervalMs)
+      return;
+    if (!lastStaleSnapshotRetryMs.compareAndSet(previous, now))
+      return; // another tick won the throttle slot
+
+    LogManager.instance().log(this, Level.WARNING,
+        "Snapshot marker is still ahead of the applied state (read floor=%d) with no download in flight: "
+            + "retrying the resync from the leader (issue #6111)", floor);
+    try {
+      lifecycleExecutor.submit(this::triggerSnapshotDownload);
+    } catch (final RejectedExecutionException ree) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot schedule the stale-snapshot resync retry: executor is shut down", ree);
+    }
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2530,9 +2530,24 @@ public class ArcadeStateMachine extends BaseStateMachine {
     return raftDir != null ? raftDir.resolve("bootstrap-baselines") : null;
   }
 
-  private void triggerSnapshotDownload() {
+  // @VisibleForTesting
+  void triggerSnapshotDownload() {
     if (raftHAServer == null || server == null)
       return;
+    // A node cannot repair itself from itself. notifyLeaderChanged() submits this unconditionally -
+    // including on the node that just WON the election - and getLeaderHttpAddress() then resolves to
+    // this node's own HTTP address, so the "download" would copy this node's already-incomplete
+    // databases back onto themselves and report success. That is merely pointless on the pre-existing
+    // paths, but it would let resolveStaleSnapshotFloorAfterResync() durably record the marker index as
+    // applied and drop the read floor, re-opening issue #6111 on a leader and surviving restarts.
+    // Refuse instead: the floor stands, isResyncInProgress() keeps the node out of the ready set, and
+    // reads keep failing honestly until leadership moves to a peer that actually holds the entries.
+    if (raftHAServer.isLeader()) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Refusing a snapshot resync: this node is the leader, so there is no peer to pull from. "
+              + "The request stays pending until leadership moves elsewhere (issue #6111)");
+      return;
+    }
     // Single-flight guard: multiple recovery paths (reinitialize watchdog, notifyLeaderChanged,
     // stale-follower recovery from the HealthMonitor) can request a download. Only one may run at
     // a time; concurrent requests are dropped. The flag also feeds isSnapshotDownloadPending() so
@@ -2550,6 +2565,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
       if (leaderHttpAddr == null) {
         LogManager.instance().log(this, Level.WARNING,
             "Cannot trigger snapshot download: leader HTTP address unknown");
+        return;
+      }
+      // Backstop for the isLeader() check above: leadership can move between the two, and getLeaderId()
+      // can already report this node while isLeader() has not caught up. Compare the addresses too, so
+      // a self-download is impossible on either side of that window (issue #6111).
+      final String localHttpAddr = raftHAServer.getPeerHttpAddress(raftHAServer.getLocalPeerId());
+      if (leaderHttpAddr.equals(localHttpAddr)) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Refusing a snapshot resync: the resolved leader address %s is this node's own. "
+                + "The request stays pending until a peer holds the leadership (issue #6111)", leaderHttpAddr);
         return;
       }
       final String leaderHttpsAddr = raftHAServer.getLeaderHttpsAddress();
@@ -2571,7 +2596,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // reinitialize() is satisfied. Record the marker index as the persisted applied position too:
       // without it the very same gap is re-detected on the next restart and the node re-downloads
       // forever. Then wake the waiters this resync unblocked (issue #6111).
-      resolveStaleSnapshotFloorAfterResync();
+      resolveStaleSnapshotFloorAfterResync(resynced);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Snapshot resync failed", e);
       // The node is still short of the entries the marker claims, so the read floor stays and the
@@ -2593,10 +2618,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * them all to it, and leaving the persisted value behind makes {@link #reinitialize()} re-detect the
    * same gap on the next restart - then clears the floor and wakes the waiters it was holding back.
    * No-op when no floor was outstanding.
+   * <p>
+   * {@code resynced} is logged rather than gated on: zero is legitimate for a node with no databases
+   * open (nothing can be stale), and it matches what {@code notifyInstallSnapshotFromLeader} already
+   * records over the same {@code getDatabaseNames()} set. It is worth seeing in the log, because a
+   * floor resolved after reinstalling zero databases is the shape an unexpectedly-empty registry would
+   * take.
    */
-  private void resolveStaleSnapshotFloorAfterResync() {
+  private void resolveStaleSnapshotFloorAfterResync(final int resynced) {
     if (staleSnapshotAppliedFloor.get() < 0)
       return;
+    LogManager.instance().log(this, Level.INFO,
+        "Stale-snapshot read floor resolved after reinstalling %d database(s); reads are unclamped again", resynced);
     final var snapshotInfo = storage.getLatestSnapshot();
     if (snapshotInfo != null && snapshotInfo.getIndex() > readPersistedAppliedIndex()) {
       writePersistedAppliedIndexForAllDatabases(snapshotInfo.getIndex());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -426,6 +426,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * ArcadeDB-side {@link #lastAppliedIndex} stays on the honest persisted position, the read floor is
    * published for the apply waiters, and the "applied advanced" notification is withheld until a resync
    * has actually restored the state.
+   * <p>
+   * The floor guards <b>reads</b> only. Writes during the same window are already guarded, and by a
+   * different mechanism: Ratis keeps feeding {@link #applyTransaction} the entries committed after the
+   * marker, and applying one on top of a database that stops at {@code persistedApplied} fails its page
+   * version check. {@link #applyTxEntry} converts that {@link WALVersionGapException} into a diverged
+   * database plus an immediate snapshot resync instead of writing mismatched pages, so the gap can never
+   * escalate from "stale data served" to "corrupted data written".
    */
   public void reinitialize() throws IOException {
     final long persistedApplied = readPersistedAppliedIndex();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -198,6 +198,20 @@ public class ArcadeStateMachine extends BaseStateMachine {
   private final AtomicBoolean needsSnapshotDownload      = new AtomicBoolean(false);
   private final AtomicBoolean snapshotDownloadInProgress = new AtomicBoolean(false);
   private final AtomicBoolean catchingUp                 = new AtomicBoolean(false);
+
+  // Highest Raft-log index whose data is actually present in the local databases while a flagged
+  // stale-snapshot re-download is still outstanding; -1 when there is none (the normal case).
+  //
+  // reinitialize() can find a Ratis snapshot marker at an index the persisted applied-index file never
+  // reached (snapshotIndex > persistedApplied + HA_SNAPSHOT_GAP_TOLERANCE). The entries in
+  // (persistedApplied, snapshotIndex] were never applied here, yet seeding the marker makes Ratis
+  // report snapshotIndex as this node's applied index - so RaftHAServer.getLastAppliedIndex() (the
+  // predicate behind waitForAppliedIndex()/waitForLocalApply()) claims data this node does not hold and
+  // a LINEARIZABLE / READ_YOUR_WRITES read inside the gap is served from the stale local state
+  // (issue #6111). This field publishes the honest ceiling so those waiters clamp to it until the
+  // flagged re-download actually lands; it is cleared only by a resync that restored the state, never
+  // by merely starting one.
+  private final AtomicLong    staleSnapshotAppliedFloor  = new AtomicLong(-1);
   // Set to true after applyTransaction hits a genuinely unrecoverable, node-wide condition: a JVM
   // Error (OOM, StackOverflow - the JVM itself is unstable), an unknown committed entry type (#4798,
   // rolling-upgrade safety), or an unexpected error on an entry with no single target database
@@ -403,6 +417,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * When called from {@code StateMachineUpdater.reload()} after a snapshot install, the lifecycle
    * is in {@link LifeCycle.State#PAUSED} and this method transitions it back to
    * {@link LifeCycle.State#RUNNING} so the updater can resume applying log entries.
+   * <p>
+   * <b>Stale marker (issue #6111):</b> when the marker index runs ahead of the persisted applied index
+   * by more than {@link GlobalConfiguration#HA_SNAPSHOT_GAP_TOLERANCE}, the entries it covers were never
+   * applied on this node and only the flagged re-download will bring them. The Ratis-facing applied
+   * TermIndex is still seeded from the marker - it is the only replay position Ratis has, and
+   * {@code StateMachineUpdater.reload()} requires it to match {@code getLatestSnapshot()} - but the
+   * ArcadeDB-side {@link #lastAppliedIndex} stays on the honest persisted position, the read floor is
+   * published for the apply waiters, and the "applied advanced" notification is withheld until a resync
+   * has actually restored the state.
    */
   public void reinitialize() throws IOException {
     final long persistedApplied = readPersistedAppliedIndex();
@@ -413,11 +436,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
       final long snapshotGapTolerance = server != null
           ? server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_GAP_TOLERANCE)
           : GlobalConfiguration.HA_SNAPSHOT_GAP_TOLERANCE.getValueAsLong();
-      if (persistedApplied >= 0 && snapshotIndex > persistedApplied + snapshotGapTolerance) {
+      final boolean staleSnapshot = persistedApplied >= 0 && snapshotIndex > persistedApplied + snapshotGapTolerance;
+      if (staleSnapshot) {
         LogManager.instance().log(this, Level.INFO,
             "Snapshot index %d is ahead of persisted applied index %d, will download from leader when available",
             snapshotIndex, persistedApplied);
         needsSnapshotDownload.set(true);
+        // Entries in (persistedApplied, snapshotIndex] are not on this node. Publish the honest ceiling
+        // BEFORE the marker is seeded below, so no waiter can observe the seeded index without also
+        // observing the floor that qualifies it (issue #6111).
+        staleSnapshotAppliedFloor.set(persistedApplied);
 
         final long watchdogTimeoutMs = computeSnapshotWatchdogTimeoutMs();
         // Watchdog: if notifyLeaderChanged() doesn't fire within the configured timeout, trigger download directly
@@ -435,8 +463,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
             LogManager.instance().log(this, Level.SEVERE, "Snapshot download watchdog failed", e);
           }
         });
-      }
-      lastAppliedIndex.set(snapshotIndex);
+      } else
+        // The marker is backed by state this node really applied (or there is no persisted value to
+        // contradict it), so nothing clamps the readers.
+        staleSnapshotAppliedFloor.set(-1);
+
+      // Only a trustworthy marker may seed the ArcadeDB-side counter: takeSnapshot() reads it as the
+      // durability checkpoint it hands Ratis and pendingLocalPhase2 uses it as a replay floor, and
+      // neither may claim entries this node never applied.
+      lastAppliedIndex.set(staleSnapshot ? persistedApplied : snapshotIndex);
       // If the on-disk marker carries an inflated term (issues #575, #593), this seed records it as-is
       // (the previous applied TermIndex is null here, so no violation is possible) and the first
       // re-applied entry realigns it via the tolerant updateLastAppliedTermIndex override. The stale
@@ -446,11 +481,19 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this seed
       // can advance the applied index past a pending target (a follower catching up via snapshot
       // install), and notifyApplied() has no other caller on this path (issue #5846).
-      final RaftHAServer raftHA = this.raftHAServer;
-      if (raftHA != null)
-        raftHA.notifyApplied();
-    } else
+      //
+      // Withheld on the stale-marker branch: nothing this node can serve advanced, so waking a waiter
+      // whose target sits inside the gap is exactly what let it proceed on stale state (issue #6111).
+      // The resync that fills the gap notifies once it completes.
+      if (!staleSnapshot) {
+        final RaftHAServer raftHA = this.raftHAServer;
+        if (raftHA != null)
+          raftHA.notifyApplied();
+      }
+    } else {
       lastAppliedIndex.set(-1);
+      staleSnapshotAppliedFloor.set(-1);
+    }
 
     // When called from StateMachineUpdater.reload() after a snapshot install, the lifecycle is
     // PAUSED (pause() was called by SnapshotInstallationHandler). Transition back to RUNNING so
@@ -903,11 +946,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
     // Regressing the marker below an existing one would let Ratis replay from an index whose log
     // entries a previous checkpoint already authorised for purging. Skip this round instead; the
-    // next snapshot after phase 2 drains advances it normally.
+    // next snapshot after phase 2 drains (or after a pending stale-snapshot resync lands, issue #6111)
+    // advances it normally.
     final var latest = storage.getLatestSnapshot();
     if (latest != null && currentIndex < latest.getIndex()) {
       HALog.log(this, HALog.BASIC,
-          "Skipping snapshot checkpoint at index %d: a phase-2 apply is still in flight and the existing marker is at %d",
+          "Skipping snapshot checkpoint at index %d: the applied position trails the existing marker at %d "
+              + "(phase-2 apply in flight, or a stale-snapshot resync still pending)",
           currentIndex, latest.getIndex());
       return RaftLog.INVALID_LOG_INDEX;
     }
@@ -1185,6 +1230,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
         lastAppliedIndex.set(snapshotIndex);
         updateLastAppliedTermIndex(snapshotTerm, snapshotIndex);
         writePersistedAppliedIndexForAllDatabases(snapshotIndex);
+        // The install brought every database up to the snapshot point, so any read floor an earlier
+        // stale marker published is now satisfied. Cleared BEFORE the notify below so a woken waiter
+        // re-checks against the restored state instead of the floor (issue #6111).
+        clearStaleSnapshotFloor();
 
         // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this
         // leader-driven snapshot install advances the applied index without going through
@@ -2507,11 +2556,63 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.INFO,
           "Snapshot resync completed: reinstalled %d database(s) from the leader; diverged state cleared", resynced);
       clearDivergedState();
+      // The databases now carry the leader's state, so a read floor published by a stale marker in
+      // reinitialize() is satisfied. Record the marker index as the persisted applied position too:
+      // without it the very same gap is re-detected on the next restart and the node re-downloads
+      // forever. Then wake the waiters this resync unblocked (issue #6111).
+      resolveStaleSnapshotFloorAfterResync();
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Snapshot resync failed", e);
+      // The node is still short of the entries the marker claims, so the read floor stays. Re-arm the
+      // request instead of leaving it cleared: the next leader change (or the HealthMonitor backstop)
+      // retries, rather than clamping reads until a restart (issue #6111).
+      if (staleSnapshotAppliedFloor.get() >= 0)
+        needsSnapshotDownload.set(true);
     } finally {
       snapshotDownloadInProgress.set(false);
     }
+  }
+
+  /**
+   * Completes a successful full resync with respect to the stale-snapshot read floor (issue #6111):
+   * persists the marker index as the applied position of every present database - the resync brought
+   * them all to it, and leaving the persisted value behind makes {@link #reinitialize()} re-detect the
+   * same gap on the next restart - then clears the floor and wakes the waiters it was holding back.
+   * No-op when no floor was outstanding.
+   */
+  private void resolveStaleSnapshotFloorAfterResync() {
+    if (staleSnapshotAppliedFloor.get() < 0)
+      return;
+    final var snapshotInfo = storage.getLatestSnapshot();
+    if (snapshotInfo != null && snapshotInfo.getIndex() > readPersistedAppliedIndex()) {
+      writePersistedAppliedIndexForAllDatabases(snapshotInfo.getIndex());
+      // Accumulate rather than set: this runs on the lifecycleExecutor while the Ratis apply thread may
+      // already have replayed past the marker, and the counter must never regress under it.
+      lastAppliedIndex.accumulateAndGet(snapshotInfo.getIndex(), Math::max);
+    }
+    clearStaleSnapshotFloor();
+    final RaftHAServer raftHA = this.raftHAServer;
+    if (raftHA != null)
+      raftHA.notifyApplied();
+  }
+
+  /**
+   * Drops the stale-snapshot read floor. Called only where a resync has actually restored the local
+   * state up to the marker - never when one is merely requested or in flight (issue #6111).
+   */
+  // @VisibleForTesting
+  void clearStaleSnapshotFloor() {
+    staleSnapshotAppliedFloor.set(-1);
+  }
+
+  /**
+   * Highest Raft-log index whose data is genuinely present in the local databases while a flagged
+   * stale-snapshot re-download is outstanding, or {@code -1} when none is (the normal case). Consumed by
+   * {@link RaftHAServer#getTrustedAppliedIndex()} to clamp the LINEARIZABLE / READ_YOUR_WRITES apply
+   * waiters, which would otherwise trust the marker index Ratis reports as applied (issue #6111).
+   */
+  public long getStaleSnapshotAppliedFloor() {
+    return staleSnapshotAppliedFloor.get();
   }
 
   /**
@@ -2662,9 +2763,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * so a follower never advertises {@code /api/v1/ready} 200 while a resync is in flight (issue #5273);
    * the flag clears once {@link #clearDivergedState()} / {@link #clearDivergedDatabase(String)} run at
    * the end of a successful resync.
+   * <p>
+   * An outstanding stale-snapshot read floor counts too (issue #6111): after a failed download neither
+   * of the other two flags is set, yet the node is still missing the entries the snapshot marker claims
+   * and must not advertise itself as ready.
    */
   public boolean isResyncInProgress() {
-    return isSnapshotDownloadPending() || !divergedDatabases.isEmpty();
+    return isSnapshotDownloadPending() || !divergedDatabases.isEmpty() || staleSnapshotAppliedFloor.get() >= 0;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -211,6 +211,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // (issue #6111). This field publishes the honest ceiling so those waiters clamp to it until the
   // flagged re-download actually lands; it is cleared only by a resync that restored the state, never
   // by merely starting one.
+  //
+  // Deliberately node-global, not per-database, and conservative on purpose: the gap is detected from
+  // the global persisted position against the (inherently global) Ratis snapshot index, so which of the
+  // co-located databases is actually short of the marker is not knowable here. A multi-database node
+  // therefore clamps reads on every database while any gap is outstanding. The alternative - guessing
+  // per-database from a global signal - is exactly the class of mistake issue #4824 fixed.
   private final AtomicLong    staleSnapshotAppliedFloor  = new AtomicLong(-1);
   // Wall-clock of the last retry submitted by retryUnfilledSnapshotGap(); 0 = none since the floor was
   // last cleared. Throttles the HealthMonitor-driven backstop, which ticks far more often than a full
@@ -2571,6 +2577,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // can already report this node while isLeader() has not caught up. Compare the addresses too, so
       // a self-download is impossible on either side of that window (issue #6111).
       final String localHttpAddr = raftHAServer.getPeerHttpAddress(raftHAServer.getLocalPeerId());
+      if (localHttpAddr == null)
+        // getPeerHttpAddress() degrades to null when this node's own HTTP endpoint cannot be resolved
+        // right now. The comparison below then cannot fire, so say so rather than letting the backstop
+        // no-op invisibly: only the isLeader() check above is standing between us and a self-download.
+        LogManager.instance().log(this, Level.WARNING,
+            "Cannot resolve this node's own HTTP address; the self-resync address check is inactive for this "
+                + "attempt and only the leader-role check guards it (issue #6111)");
       if (leaderHttpAddr.equals(localHttpAddr)) {
         LogManager.instance().log(this, Level.WARNING,
             "Refusing a snapshot resync: the resolved leader address %s is this node's own. "

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -97,6 +97,20 @@ public final class HealthMonitor {
      */
     default void reportResyncProgress() {
     }
+
+    /**
+     * Retries the snapshot resync of a follower that restarted onto a snapshot marker running ahead of
+     * the entries it actually applied, and whose download has not succeeded yet (issue #6111). No-op
+     * when there is no such gap, when one is already running, or on the leader.
+     * <p>
+     * This cannot be folded into {@link #isFollowerLaggingBeyond(long)} /
+     * {@link #recoverFromPersistentLag()}: those are driven by {@code commitIndex - appliedIndex}, and
+     * Ratis derives the applied index from the very marker that is ahead - so a node sitting on an
+     * unfilled gap reports zero lag and looks perfectly caught up. Without its own hook the only thing
+     * that would ever retry such a node is a leader election.
+     */
+    default void retryUnfilledSnapshotGap() {
+    }
   }
 
   // How long (as a multiple of the recovery duration) the follower must look healthy before a prior
@@ -202,6 +216,9 @@ public final class HealthMonitor {
     // the actual re-resolution to its configured refresh interval.
     target.refreshPeerAllowlist();
     target.reportResyncProgress();
+    // Independent of the lag checks below, which are structurally blind to an unfilled snapshot gap
+    // (issue #6111). Self-throttled by the target.
+    target.retryUnfilledSnapshotGap();
     final LifeCycle.State state = target.getRaftLifeCycleState();
     if (state == LifeCycle.State.CLOSED || state == LifeCycle.State.EXCEPTION) {
       handleUnhealthyState(state);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1052,6 +1052,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   @Override
+  public void retryUnfilledSnapshotGap() {
+    if (raftServer == null || shutdownRequested)
+      return;
+    final ArcadeStateMachine sm = stateMachine;
+    if (sm != null)
+      sm.retryUnfilledSnapshotGap();
+  }
+
+  @Override
   public void reportResyncProgress() {
     final FollowerResyncProgressTracker tracker = resyncProgressTracker;
     if (tracker == null || raftServer == null || shutdownRequested || isLeader())

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2158,6 +2158,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
             // the floor for the whole life of an outstanding gap, since Ratis' own counter starts at the
             // marker index - above the floor by construction - and only grows) is below targetIndex.
             //
+            // That invariant is established in ArcadeStateMachine.reinitialize()'s snapshot-gap branch:
+            // it publishes the floor as persistedApplied and only when
+            // snapshotIndex > persistedApplied + HA_SNAPSHOT_GAP_TOLERANCE, so marker > floor always
+            // holds while the floor is outstanding. Anything that changes what that branch publishes
+            // must revisit this reasoning.
+            //
             // READ_YOUR_WRITES / bookmark: the target therefore sits inside a gap that only the pending
             // snapshot resync can fill, so waiting out the quorum timeout cannot change the outcome.
             // Degrade now with the same contract the timeout branch below applies (issue #6111).

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2142,20 +2142,31 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     try {
       final long deadline = System.currentTimeMillis() + quorumTimeout;
       synchronized (applyNotifier) {
-        while (getLastAppliedIndex() < targetIndex) {
+        while (getTrustedAppliedIndex() < targetIndex) {
+          if (!throwOnTimeout && getStaleSnapshotAppliedFloor() >= 0) {
+            // READ_YOUR_WRITES / bookmark: the target sits inside a gap that only the pending snapshot
+            // resync can fill, so waiting out the quorum timeout cannot change the outcome. Degrade now
+            // with the same contract the timeout branch below applies (issue #6111).
+            LogManager.instance().log(this, Level.WARNING,
+                "READ_YOUR_WRITES target %d is inside a pending snapshot resync gap (trusted applied=%d): "
+                    + "consistency degraded to EVENTUAL without waiting",
+                targetIndex, getTrustedAppliedIndex());
+            return;
+          }
           final long remaining = deadline - System.currentTimeMillis();
           if (remaining <= 0) {
             if (throwOnTimeout) {
               LogManager.instance().log(this, Level.WARNING,
-                  "LINEARIZABLE read failed: local apply timeout applied=%d < readIndex=%d after %dms (failing read)",
-                  getLastAppliedIndex(), targetIndex, quorumTimeout);
+                  "LINEARIZABLE read failed: local apply timeout applied=%d < readIndex=%d after %dms "
+                      + "(staleSnapshotFloor=%d, failing read)",
+                  getTrustedAppliedIndex(), targetIndex, quorumTimeout, getStaleSnapshotAppliedFloor());
               throw new ReplicationException(
-                  "LINEARIZABLE read timed out waiting for local apply: applied=" + getLastAppliedIndex()
+                  "LINEARIZABLE read timed out waiting for local apply: applied=" + getTrustedAppliedIndex()
                       + " < readIndex=" + targetIndex);
             }
             LogManager.instance().log(this, Level.WARNING,
                 "READ_YOUR_WRITES consistency timeout: applied=%d < target=%d (consistency degraded to EVENTUAL)",
-                getLastAppliedIndex(), targetIndex);
+                getTrustedAppliedIndex(), targetIndex);
             return;
           }
           applyNotifier.wait(Math.min(remaining, APPLY_WAIT_RECHECK_INTERVAL_MS));
@@ -2189,18 +2200,27 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
 
       final long deadline = System.currentTimeMillis() + quorumTimeout;
       synchronized (applyNotifier) {
-        while (getLastAppliedIndex() < commitIndex) {
+        while (getTrustedAppliedIndex() < commitIndex) {
+          if (getStaleSnapshotAppliedFloor() >= 0) {
+            // Only the pending snapshot resync can close this gap; this waiter is best-effort by
+            // contract, so degrade now instead of burning the whole quorum timeout (issue #6111).
+            LogManager.instance().log(this, Level.WARNING,
+                "waitForLocalApply: commit=%d is inside a pending snapshot resync gap (trusted applied=%d), "
+                    + "returning without waiting (reads may be stale)",
+                commitIndex, getTrustedAppliedIndex());
+            return;
+          }
           final long remaining = deadline - System.currentTimeMillis();
           if (remaining <= 0) {
             HALog.log(this, HALog.DETAILED, "waitForLocalApply timed out: applied=%d < commit=%d",
-                getLastAppliedIndex(), commitIndex);
+                getTrustedAppliedIndex(), commitIndex);
             return;
           }
           applyNotifier.wait(Math.min(remaining, APPLY_WAIT_RECHECK_INTERVAL_MS));
         }
       }
       HALog.log(this, HALog.TRACE, "Local apply caught up: applied=%d >= commit=%d",
-          getLastAppliedIndex(), commitIndex);
+          getTrustedAppliedIndex(), commitIndex);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
     } catch (final Exception e) {
@@ -2218,6 +2238,33 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       // restart re-initializes the division (issue #5271); report "unknown" instead of propagating.
       return -1;
     }
+  }
+
+  /**
+   * The applied index a read may actually rely on: {@link #getLastAppliedIndex()} clamped to the
+   * stale-snapshot read floor while one is outstanding (issue #6111).
+   * <p>
+   * Ratis derives the value {@link #getLastAppliedIndex()} reports from the snapshot marker the moment
+   * the marker is seeded, so a node that restarted onto a marker running ahead of the entries it really
+   * applied ({@code ArcadeStateMachine.reinitialize()}'s snapshot-gap branch) advertises an applied
+   * index covering data it does not hold. Using the raw value as the apply-wait predicate let a
+   * LINEARIZABLE or READ_YOUR_WRITES read inside that gap proceed against the stale local state; the
+   * clamp keeps the waiters honest until the flagged re-download lands. Reporting paths (cluster status,
+   * lag detection) deliberately keep using the raw Ratis value.
+   */
+  public long getTrustedAppliedIndex() {
+    final long applied = getLastAppliedIndex();
+    final long floor = getStaleSnapshotAppliedFloor();
+    return floor < 0 ? applied : Math.min(applied, floor);
+  }
+
+  /**
+   * The state machine's stale-snapshot read floor, or {@code -1} when there is none or the state machine
+   * is not wired yet. See {@link ArcadeStateMachine#getStaleSnapshotAppliedFloor()} (issue #6111).
+   */
+  private long getStaleSnapshotAppliedFloor() {
+    final ArcadeStateMachine sm = stateMachine;
+    return sm == null ? -1 : sm.getStaleSnapshotAppliedFloor();
   }
 
   public long getCommitIndex() {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2144,9 +2144,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       synchronized (applyNotifier) {
         while (getTrustedAppliedIndex() < targetIndex) {
           if (!throwOnTimeout && getStaleSnapshotAppliedFloor() >= 0) {
-            // READ_YOUR_WRITES / bookmark: the target sits inside a gap that only the pending snapshot
-            // resync can fill, so waiting out the quorum timeout cannot change the outcome. Degrade now
-            // with the same contract the timeout branch below applies (issue #6111).
+            // No explicit "targetIndex > floor" test is needed, and adding one would be dead code:
+            // reaching this line means the loop condition held, i.e. getTrustedAppliedIndex() (pinned at
+            // the floor for the whole life of an outstanding gap, since Ratis' own counter starts at the
+            // marker index - above the floor by construction - and only grows) is below targetIndex.
+            //
+            // READ_YOUR_WRITES / bookmark: the target therefore sits inside a gap that only the pending
+            // snapshot resync can fill, so waiting out the quorum timeout cannot change the outcome.
+            // Degrade now with the same contract the timeout branch below applies (issue #6111).
             LogManager.instance().log(this, Level.WARNING,
                 "READ_YOUR_WRITES target %d is inside a pending snapshot resync gap (trusted applied=%d): "
                     + "consistency degraded to EVENTUAL without waiting",
@@ -2202,8 +2207,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       synchronized (applyNotifier) {
         while (getTrustedAppliedIndex() < commitIndex) {
           if (getStaleSnapshotAppliedFloor() >= 0) {
-            // Only the pending snapshot resync can close this gap; this waiter is best-effort by
-            // contract, so degrade now instead of burning the whole quorum timeout (issue #6111).
+            // Same reasoning as waitForAppliedIndex: the loop condition already proves commitIndex sits
+            // above the floor, so no explicit comparison is needed. Only the pending snapshot resync can
+            // close the gap; this waiter is best-effort by contract, so degrade now instead of burning
+            // the whole quorum timeout (issue #6111).
             LogManager.instance().log(this, Level.WARNING,
                 "waitForLocalApply: commit=%d is inside a pending snapshot resync gap (trusted applied=%d), "
                     + "returning without waiting (reads may be stale)",

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -501,6 +501,94 @@ class Issue6111StaleSnapshotReadFloorTest {
   }
 
   // ---------------------------------------------------------------------------------------------
+  // A node must never "resolve" its own gap by downloading from itself
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The dangerous sequence: restart onto a stale marker, then win the next election before the resync
+   * lands. {@code notifyLeaderChanged()} submits {@code triggerSnapshotDownload()} unconditionally, on
+   * the new leader too, and {@code getLeaderHttpAddress()} then resolves to this node's own address - so
+   * the resync would copy this node's incomplete databases onto themselves, report success, and let the
+   * floor be dropped and the marker index durably recorded as applied. That reopens #6111 on a leader,
+   * and survives the next restart because the persisted position no longer shows the gap.
+   */
+  @Test
+  void aLeaderMustNotResolveItsOwnFloorByDownloadingFromItself(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    when(mockRaft.isLeader()).thenReturn(true);
+    when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
+    sm.setRaftHAServer(mockRaft);
+    try {
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      sm.triggerSnapshotDownload();
+
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("a self-download resolves nothing, so the read floor must stand")
+          .isEqualTo(PERSISTED_APPLIED);
+      assertThat(sm.readPersistedAppliedIndex())
+          .as("and the marker index must not be durably recorded as applied")
+          .isEqualTo(PERSISTED_APPLIED);
+      assertThat(sm.isResyncInProgress())
+          .as("the node keeps itself out of the ready set instead of pretending it caught up")
+          .isTrue();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /**
+   * Same refusal via the address comparison rather than the role flag: leadership can move between the
+   * {@code isLeader()} check and the address resolution, and {@code getLeaderId()} can report this node
+   * while {@code isLeader()} has not caught up.
+   */
+  @Test
+  void aResolvedLeaderAddressEqualToOurOwnIsAlsoRefused(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    final RaftPeerId localId = RaftPeerId.valueOf("local-peer");
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    when(mockRaft.isLeader()).thenReturn(false); // role flag has not caught up...
+    when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
+    when(mockRaft.getLocalPeerId()).thenReturn(localId);
+    when(mockRaft.getPeerHttpAddress(localId)).thenReturn("localhost:2480"); // ...but it is us
+    sm.setRaftHAServer(mockRaft);
+    try {
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      sm.triggerSnapshotDownload();
+
+      assertThat(sm.getStaleSnapshotAppliedFloor()).isEqualTo(PERSISTED_APPLIED);
+      assertThat(sm.readPersistedAppliedIndex()).isEqualTo(PERSISTED_APPLIED);
+    } finally {
+      sm.close();
+    }
+  }
+
+  /**
+   * Control: a genuine peer leader is downloaded from, and the floor resolves. Without it the two tests
+   * above would also pass against a {@code triggerSnapshotDownload()} that refused everything.
+   */
+  @Test
+  void aPeerLeaderIsStillDownloadedFromAndResolvesTheFloor(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    sm.setRaftHAServer(followerRaftHAServerMock());
+    try {
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      sm.triggerSnapshotDownload();
+
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("a resync from a real peer resolves the floor")
+          .isEqualTo(-1L);
+    } finally {
+      sm.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------------------------
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.DivisionInfo;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #6111.
+ * <p>
+ * {@link ArcadeStateMachine#reinitialize()} seeds the applied position from the on-disk Ratis snapshot
+ * marker. When the marker index runs ahead of the persisted applied index by more than
+ * {@link GlobalConfiguration#HA_SNAPSHOT_GAP_TOLERANCE}, the entries it covers were never applied on this
+ * node: the method flags {@code needsSnapshotDownload} and schedules an asynchronous re-download - but it
+ * used to advance the applied position and (since issue #6110) call {@code notifyApplied()} anyway.
+ * <p>
+ * Ratis derives {@link RaftHAServer#getLastAppliedIndex()} from that same marker, so the whole gap looked
+ * applied to {@link RaftHAServer#waitForAppliedIndex(long, boolean)} and
+ * {@link RaftHAServer#waitForLocalApply()}: a LINEARIZABLE or READ_YOUR_WRITES read targeting an index
+ * inside the gap was released immediately and served from the stale local databases, before the flagged
+ * re-download had run.
+ * <p>
+ * The fix publishes an honest read floor while the re-download is outstanding, keeps the ArcadeDB-side
+ * applied counter on the persisted position, withholds the notification, and clamps both apply waiters to
+ * the floor. The Ratis-facing applied {@code TermIndex} is deliberately still seeded from the marker: it
+ * is the only replay position Ratis has.
+ */
+class Issue6111StaleSnapshotReadFloorTest {
+
+  /** Comfortably beyond {@link GlobalConfiguration#HA_SNAPSHOT_GAP_TOLERANCE} (10). */
+  private static final long PERSISTED_APPLIED = 100L;
+  private static final long SNAPSHOT_INDEX    = 5_000L;
+  private static final long SNAPSHOT_TERM     = 7L;
+  private static final String DB_NAME         = "db-a";
+
+  // ---------------------------------------------------------------------------------------------
+  // reinitialize(): what the stale marker may and may not do
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The core regression: with the gap flagged, {@code reinitialize()} must neither wake apply waiters nor
+   * advance the ArcadeDB-side applied counter onto the marker, and it must publish the persisted position
+   * as the read floor.
+   */
+  @Test
+  void staleMarkerPublishesAFloorAndWithholdsTheAppliedNotification(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir.resolve("raft-storage"));
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    try {
+      sm.initialize(stubRaftServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+
+      // Only entries up to PERSISTED_APPLIED were ever applied here...
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);
+      // ...but the marker on disk claims SNAPSHOT_INDEX.
+      registerMarkerAt(sm, SNAPSHOT_TERM, SNAPSHOT_INDEX);
+
+      sm.setRaftHAServer(mockRaft);
+      sm.reinitialize();
+
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("the read floor is the position the databases really carry, not the marker")
+          .isEqualTo(PERSISTED_APPLIED);
+      assertThat(sm.isSnapshotDownloadPending())
+          .as("the gap is flagged for re-download")
+          .isTrue();
+      assertThat(sm.isResyncInProgress())
+          .as("a node holding an unfilled gap must not advertise itself as ready")
+          .isTrue();
+      assertThat(readLastAppliedIndex(sm))
+          .as("the ArcadeDB-side applied counter stays on the honest persisted position")
+          .isEqualTo(PERSISTED_APPLIED);
+      verify(mockRaft, never()).notifyApplied();
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * The Ratis contract is unchanged: {@code StateMachineUpdater.reload()} reads
+   * {@code getLatestSnapshot().getIndex()} straight after {@code reinitialize()} and requires the applied
+   * {@code TermIndex} to match it, so the marker must still seed it even on the stale branch.
+   */
+  @Test
+  void staleMarkerStillSeedsTheRatisFacingAppliedTermIndex(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir.resolve("raft-storage"));
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    try {
+      sm.initialize(stubRaftServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);
+      registerMarkerAt(sm, SNAPSHOT_TERM, SNAPSHOT_INDEX);
+
+      sm.reinitialize();
+
+      assertThat(sm.getLastAppliedTermIndex().getIndex())
+          .as("Ratis' replay position still comes from the marker")
+          .isEqualTo(SNAPSHOT_INDEX);
+      assertThat(sm.getLastAppliedTermIndex().getTerm()).isEqualTo(SNAPSHOT_TERM);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * Control: a marker within the gap tolerance is trustworthy, so the pre-existing behaviour is intact -
+   * the counter is seeded from the marker, waiters are woken (issue #5846), and no floor is published.
+   */
+  @Test
+  void markerWithinToleranceSeedsAndNotifiesAsBefore(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir.resolve("raft-storage"));
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    try {
+      sm.initialize(stubRaftServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+
+      // Gap of exactly HA_SNAPSHOT_GAP_TOLERANCE (10): the check is strictly greater-than, so no flag.
+      sm.writePersistedAppliedIndex(SNAPSHOT_INDEX - 10, DB_NAME);
+      registerMarkerAt(sm, SNAPSHOT_TERM, SNAPSHOT_INDEX);
+
+      sm.setRaftHAServer(mockRaft);
+      sm.reinitialize();
+
+      assertThat(sm.getStaleSnapshotAppliedFloor()).isEqualTo(-1L);
+      assertThat(sm.isSnapshotDownloadPending()).isFalse();
+      assertThat(readLastAppliedIndex(sm)).isEqualTo(SNAPSHOT_INDEX);
+      verify(mockRaft, times(1)).notifyApplied();
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * A later {@code reinitialize()} that no longer sees a gap - the resync landed and persisted its
+   * position - drops the floor, so reads are unclamped again.
+   */
+  @Test
+  void aLaterReinitializeWithoutAGapDropsTheFloor(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir.resolve("raft-storage"));
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    try {
+      sm.initialize(stubRaftServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);
+      registerMarkerAt(sm, SNAPSHOT_TERM, SNAPSHOT_INDEX);
+      sm.reinitialize();
+      assertThat(sm.getStaleSnapshotAppliedFloor()).isEqualTo(PERSISTED_APPLIED);
+
+      // The resync recorded the marker index for every database, exactly as a full install does.
+      sm.writePersistedAppliedIndexForAllDatabases(SNAPSHOT_INDEX);
+      sm.reinitialize();
+
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("no gap remains, so nothing clamps the readers")
+          .isEqualTo(-1L);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
+   * {@code raftHAServer} is null during the startup {@code initialize() -> reinitialize()} path; the stale
+   * branch must not throw there either.
+   */
+  @Test
+  void staleMarkerDoesNotThrowWhenRaftHAServerNotYetAttached(@TempDir final Path tempDir) throws Exception {
+    final RaftStorage raftStorage = newFormattedStorage(tempDir.resolve("raft-storage"));
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    try {
+      sm.initialize(stubRaftServer(), RaftGroupId.valueOf(UUID.randomUUID()), raftStorage);
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);
+      registerMarkerAt(sm, SNAPSHOT_TERM, SNAPSHOT_INDEX);
+
+      assertThatNoException().isThrownBy(sm::reinitialize);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // The waiters: what the floor does to a read
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The observable half of the bug. Ratis reports the marker index as applied, so before the fix the
+   * LINEARIZABLE waiter's predicate was satisfied at once and the read proceeded against databases that
+   * stop at the floor. It must now fail instead - the LINEARIZABLE contract is "fail rather than serve a
+   * value older than an already-committed write".
+   */
+  @Test
+  void linearizableReadFailsWhileTheFloorIsOutstanding() throws Exception {
+    final AtomicLong ratisApplied = new AtomicLong(SNAPSHOT_INDEX);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(ratisApplied, SNAPSHOT_INDEX, sm, 500L);
+
+    assertThat(raft.getLastAppliedIndex())
+        .as("Ratis still advertises the marker index")
+        .isEqualTo(SNAPSHOT_INDEX);
+    assertThat(raft.getTrustedAppliedIndex())
+        .as("but only the floor is backed by local data")
+        .isEqualTo(PERSISTED_APPLIED);
+
+    assertThatThrownBy(() -> raft.waitForAppliedIndex(PERSISTED_APPLIED + 1, true))
+        .isInstanceOf(ReplicationException.class)
+        .hasMessageContaining("LINEARIZABLE read timed out");
+  }
+
+  /** A target at or below the floor is genuinely on disk and must still be served without waiting. */
+  @Test
+  void linearizableReadBelowTheFloorStillSucceeds() throws Exception {
+    final AtomicLong ratisApplied = new AtomicLong(SNAPSHOT_INDEX);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(ratisApplied, SNAPSHOT_INDEX, sm, 500L);
+
+    assertThatNoException().isThrownBy(() -> raft.waitForAppliedIndex(PERSISTED_APPLIED, true));
+  }
+
+  /**
+   * Once the resync clears the floor, a blocked LINEARIZABLE waiter is released. This also pins that the
+   * resync path notifies: the waiter is woken by {@code notifyApplied()} rather than by its own bounded
+   * re-check, which is why the assertion allows well under one re-check interval.
+   */
+  @Test
+  void linearizableReadIsReleasedWhenTheResyncClearsTheFloor() throws Exception {
+    final AtomicLong ratisApplied = new AtomicLong(SNAPSHOT_INDEX);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(ratisApplied, SNAPSHOT_INDEX, sm, 10_000L);
+
+    assertThat(raft.getTrustedAppliedIndex())
+        .as("the waiter must actually block on the floor, otherwise this test proves nothing")
+        .isEqualTo(PERSISTED_APPLIED);
+
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    try {
+      scheduler.schedule(() -> {
+        sm.clearStaleSnapshotFloor();
+        raft.notifyApplied();
+      }, 300, TimeUnit.MILLISECONDS);
+
+      final long start = System.currentTimeMillis();
+      assertThatNoException().isThrownBy(() -> raft.waitForAppliedIndex(SNAPSHOT_INDEX, true));
+      final long elapsed = System.currentTimeMillis() - start;
+
+      assertThat(elapsed)
+          .as("the wait really was held by the floor until the resync cleared it")
+          .isGreaterThanOrEqualTo(250L);
+      assertThat(elapsed)
+          .as("clearing the floor releases the waiter promptly, not at the quorum timeout")
+          .isLessThan(5_000L);
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  /**
+   * The lenient (READ_YOUR_WRITES / bookmark) waiter keeps its "degrade, do not fail" contract, but must
+   * not burn the whole quorum timeout on a gap only the pending resync can close.
+   */
+  @Test
+  void readYourWritesDegradesImmediatelyInsteadOfBurningTheQuorumTimeout() throws Exception {
+    final AtomicLong ratisApplied = new AtomicLong(SNAPSHOT_INDEX);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(ratisApplied, SNAPSHOT_INDEX, sm, 10_000L);
+
+    assertThat(raft.getTrustedAppliedIndex())
+        .as("the clamp must be in force, otherwise the waiter never enters the loop and proves nothing")
+        .isEqualTo(PERSISTED_APPLIED);
+
+    final long start = System.currentTimeMillis();
+    assertThatNoException().isThrownBy(() -> raft.waitForAppliedIndex(SNAPSHOT_INDEX, false));
+    assertThat(System.currentTimeMillis() - start)
+        .as("waiting cannot help while the floor stands, so the lenient waiter degrades at once")
+        .isLessThan(2_000L);
+  }
+
+  /** Same for {@link RaftHAServer#waitForLocalApply()}, which is always lenient. */
+  @Test
+  void waitForLocalApplyDegradesImmediatelyWhileTheFloorIsOutstanding() throws Exception {
+    final AtomicLong ratisApplied = new AtomicLong(SNAPSHOT_INDEX);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+    final RaftHAServer raft = newDetachedRaftHAServer(ratisApplied, SNAPSHOT_INDEX, sm, 10_000L);
+
+    assertThat(raft.getTrustedAppliedIndex())
+        .as("the clamp must be in force, otherwise the waiter never enters the loop and proves nothing")
+        .isEqualTo(PERSISTED_APPLIED);
+
+    final long start = System.currentTimeMillis();
+    raft.waitForLocalApply();
+    assertThat(System.currentTimeMillis() - start).isLessThan(2_000L);
+  }
+
+  /** With no floor outstanding the trusted index is the raw Ratis one - no behaviour change at all. */
+  @Test
+  void withoutAFloorTheTrustedIndexIsTheRatisIndex() throws Exception {
+    final AtomicLong ratisApplied = new AtomicLong(SNAPSHOT_INDEX);
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final RaftHAServer raft = newDetachedRaftHAServer(ratisApplied, SNAPSHOT_INDEX, sm, 500L);
+
+    assertThat(sm.getStaleSnapshotAppliedFloor()).isEqualTo(-1L);
+    assertThat(raft.getTrustedAppliedIndex()).isEqualTo(SNAPSHOT_INDEX);
+    assertThatNoException().isThrownBy(() -> raft.waitForAppliedIndex(SNAPSHOT_INDEX, true));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * A real (unstarted) {@link ArcadeDBServer} rooted at {@code tempDir} so the state machine can resolve
+   * {@code .raft/applied-index} and read the HA configuration.
+   */
+  private static ArcadeStateMachine newStateMachine(final Path tempDir) {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, tempDir.resolve("databases").toString());
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(new ArcadeDBServer(config));
+    return sm;
+  }
+
+  /**
+   * Writes a real {@code snapshot.<term>_<index>} marker through the state machine's own registration
+   * path, so {@code storage.getLatestSnapshot()} rediscovers it the way a restart would.
+   */
+  private static void registerMarkerAt(final ArcadeStateMachine sm, final long term, final long index) throws Exception {
+    final Method m = ArcadeStateMachine.class.getDeclaredMethod("registerSnapshotMarker", long.class, long.class);
+    m.setAccessible(true);
+    assertThat((Boolean) m.invoke(sm, term, index)).as("snapshot marker written").isTrue();
+  }
+
+  private static long readLastAppliedIndex(final ArcadeStateMachine sm) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("lastAppliedIndex");
+    f.setAccessible(true);
+    return ((AtomicLong) f.get(sm)).get();
+  }
+
+  private static void setStaleSnapshotAppliedFloor(final ArcadeStateMachine sm, final long floor) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("staleSnapshotAppliedFloor");
+    f.setAccessible(true);
+    ((AtomicLong) f.get(sm)).set(floor);
+  }
+
+  private static RaftStorage newFormattedStorage(final Path dir) throws IOException {
+    return RaftStorage.newBuilder()
+        .setDirectory(dir.toFile())
+        .setOption(RaftStorage.StartupOption.FORMAT)
+        .build();
+  }
+
+  /**
+   * Minimal {@link RaftServer} stub: {@code BaseStateMachine.initialize()} only needs a non-null
+   * {@code getId()}; nothing else is reached on this path.
+   */
+  private static RaftServer stubRaftServer() {
+    return (RaftServer) Proxy.newProxyInstance(
+        Issue6111StaleSnapshotReadFloorTest.class.getClassLoader(),
+        new Class<?>[] { RaftServer.class },
+        (proxy, method, args) -> {
+          if ("getId".equals(method.getName()))
+            return RaftPeerId.valueOf("test-peer");
+          if ("close".equals(method.getName()) || "start".equals(method.getName()))
+            return null;
+          throw new UnsupportedOperationException("Stub: " + method.getName());
+        });
+  }
+
+  /**
+   * A {@link RaftHAServer} without Ratis started (no gRPC, no election), with a stubbed division whose
+   * applied/commit index is test-controlled, and with {@code stateMachine} wired to {@code sm} so the
+   * trusted-index clamp can see its floor. Mirrors {@link ApplyWaitBoundedRecheckTest}'s harness.
+   */
+  private static RaftHAServer newDetachedRaftHAServer(final AtomicLong appliedIndex, final long commitIndex,
+      final ArcadeStateMachine sm, final long quorumTimeoutMs) throws Exception {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "localhost:2434:2480");
+    config.setValue(GlobalConfiguration.HA_QUORUM_TIMEOUT, quorumTimeoutMs);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getServerName()).thenReturn("localhost");
+
+    final RaftHAServer raft = new RaftHAServer(mockServer, config);
+
+    final DivisionInfo mockInfo = mock(DivisionInfo.class);
+    when(mockInfo.getLastAppliedIndex()).thenAnswer(inv -> appliedIndex.get());
+
+    final RaftLog mockRaftLog = mock(RaftLog.class);
+    when(mockRaftLog.getLastCommittedIndex()).thenReturn(commitIndex);
+
+    final RaftServer.Division mockDivision = mock(RaftServer.Division.class);
+    when(mockDivision.getInfo()).thenReturn(mockInfo);
+    when(mockDivision.getRaftLog()).thenReturn(mockRaftLog);
+
+    final RaftServer mockRaftServer = mock(RaftServer.class);
+    when(mockRaftServer.getDivision(any())).thenReturn(mockDivision);
+
+    setRaftHAServerField(raft, "raftServer", mockRaftServer);
+    setRaftHAServerField(raft, "stateMachine", sm);
+    return raft;
+  }
+
+  private static void setRaftHAServerField(final Object target, final String name, final Object value) throws Exception {
+    final Field f = RaftHAServer.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(target, value);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -27,6 +27,7 @@ import org.apache.ratis.server.DivisionInfo;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.util.LifeCycle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -39,6 +40,8 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -356,8 +359,175 @@ class Issue6111StaleSnapshotReadFloorTest {
   }
 
   // ---------------------------------------------------------------------------------------------
+  // The retry backstop: an unfilled gap must not need a leader election to recover
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The lag-driven backstop is structurally blind here - Ratis reports the marker index as applied, so a
+   * node with an open gap shows zero lag - and a re-armed {@code needsSnapshotDownload} additionally
+   * makes {@code isSnapshotDownloadPending()} true, which stands {@code recoverFromPersistentLag()} and
+   * {@code isFollowerLaggingBeyond()} down. So the {@link HealthMonitor} must drive a dedicated hook, or
+   * a node whose download keeps failing stays clamped until an election happens.
+   */
+  @Test
+  void healthMonitorTickDrivesTheUnfilledGapRetry() {
+    final AtomicInteger retries = new AtomicInteger();
+    final HealthMonitor.HealthTarget target = new HealthMonitor.HealthTarget() {
+      @Override
+      public LifeCycle.State getRaftLifeCycleState() {
+        return LifeCycle.State.RUNNING;
+      }
+
+      @Override
+      public boolean isShutdownRequested() {
+        return false;
+      }
+
+      @Override
+      public void restartRatisIfNeeded() {
+      }
+
+      @Override
+      public void retryUnfilledSnapshotGap() {
+        retries.incrementAndGet();
+      }
+    };
+
+    final HealthMonitor monitor = new HealthMonitor(target, 1_000L, 0L, 0L, false, 0);
+    monitor.tick();
+    monitor.tick();
+
+    assertThat(retries.get()).as("every health tick offers the unfilled-gap retry").isEqualTo(2);
+  }
+
+  /** No gap outstanding: the backstop must not touch anything. */
+  @Test
+  void retryIsANoOpWithoutAnOutstandingFloor(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    sm.setRaftHAServer(followerRaftHAServerMock());
+    try {
+      sm.retryUnfilledSnapshotGap();
+      assertThat(readLastRetryMs(sm)).as("nothing was submitted").isZero();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /** A download that is genuinely running will resolve or re-arm the request itself; do not pile on. */
+  @Test
+  void retryIsANoOpWhileADownloadIsRunning(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    sm.setRaftHAServer(followerRaftHAServerMock());
+    try {
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+      setAtomicBoolean(sm, "snapshotDownloadInProgress", true);
+
+      sm.retryUnfilledSnapshotGap();
+
+      assertThat(readLastRetryMs(sm)).as("the in-flight download owns this resync").isZero();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /**
+   * The case the backstop exists for: a floor left behind by a failed download, nothing running, a
+   * leader reachable. The retry must fire - and reach {@code triggerSnapshotDownload()}, which with no
+   * databases present completes and clears the floor.
+   */
+  @Test
+  void retryFiresAndResolvesTheFloorWhenNothingIsRunning(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    sm.setRaftHAServer(followerRaftHAServerMock());
+    try {
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      sm.retryUnfilledSnapshotGap();
+
+      assertThat(readLastRetryMs(sm)).as("a retry was submitted").isNotZero();
+      // The submission runs on the single-threaded lifecycleExecutor; give it a bounded moment.
+      for (int i = 0; i < 100 && sm.getStaleSnapshotAppliedFloor() >= 0; i++)
+        Thread.sleep(20);
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("the retry really reached triggerSnapshotDownload(), which resolved the floor")
+          .isEqualTo(-1L);
+    } finally {
+      sm.close();
+    }
+  }
+
+  /**
+   * A full resync pulls every database from the leader while the HealthMonitor ticks every few seconds,
+   * so a persistently failing download must not be retried on every tick.
+   */
+  @Test
+  void retryIsThrottledBetweenAttempts(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    sm.setRaftHAServer(followerRaftHAServerMock());
+    try {
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+      // A retry that has just been attempted, as a previous tick would have left it.
+      final long justNow = System.currentTimeMillis();
+      setLastRetryMs(sm, justNow);
+
+      sm.retryUnfilledSnapshotGap();
+
+      assertThat(readLastRetryMs(sm))
+          .as("within the retry interval the tick is swallowed, leaving the previous attempt's stamp")
+          .isEqualTo(justNow);
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("and no download ran, so the floor still stands")
+          .isEqualTo(PERSISTED_APPLIED);
+    } finally {
+      sm.close();
+    }
+  }
+
+  /** Nowhere to download from yet: the first attempt belongs to {@code notifyLeaderChanged()}. */
+  @Test
+  void retryIsANoOpWhileNoLeaderIsKnown(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    final RaftHAServer mockRaft = mock(RaftHAServer.class); // getLeaderHttpAddress() defaults to null
+    sm.setRaftHAServer(mockRaft);
+    try {
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      sm.retryUnfilledSnapshotGap();
+
+      assertThat(readLastRetryMs(sm)).isZero();
+    } finally {
+      sm.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------------------------
+
+  private static RaftHAServer followerRaftHAServerMock() {
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    when(mockRaft.isLeader()).thenReturn(false);
+    when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
+    return mockRaft;
+  }
+
+  private static long readLastRetryMs(final ArcadeStateMachine sm) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("lastStaleSnapshotRetryMs");
+    f.setAccessible(true);
+    return ((AtomicLong) f.get(sm)).get();
+  }
+
+  private static void setLastRetryMs(final ArcadeStateMachine sm, final long value) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("lastStaleSnapshotRetryMs");
+    f.setAccessible(true);
+    ((AtomicLong) f.get(sm)).set(value);
+  }
+
+  private static void setAtomicBoolean(final ArcadeStateMachine sm, final String name, final boolean value) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField(name);
+    f.setAccessible(true);
+    ((AtomicBoolean) f.get(sm)).set(value);
+  }
 
   /**
    * A real (unstarted) {@link ArcadeDBServer} rooted at {@code tempDir} so the state machine can resolve


### PR DESCRIPTION
Closes #6111

## Summary

`ArcadeStateMachine.reinitialize()` can find a Ratis snapshot marker whose index runs ahead of the persisted `.raft/applied-index` by more than `HA_SNAPSHOT_GAP_TOLERANCE`. It flags `needsSnapshotDownload`, schedules an asynchronous re-download, and then - before that download has run - advanced `lastAppliedIndex` onto the marker and (since #6110) called `notifyApplied()`. This PR keeps the node honest for the whole window: the ArcadeDB-side applied counter stays on the persisted position, a read floor is published for the apply waiters, the "applied advanced" notification is withheld until a resync has actually restored the state, and the waiters clamp to the floor so a LINEARIZABLE read fails (503) instead of being served from databases that stop short of the index it asked for.

## Root cause, and why the obvious fix is not the fix

While investigating I found the mechanism is one level below where the issue puts it.

`RaftHAServer.waitForAppliedIndex()` / `waitForLocalApply()` do **not** read `ArcadeStateMachine.lastAppliedIndex`. Their predicate is `RaftHAServer.getLastAppliedIndex()`, which is `division.getInfo().getLastAppliedIndex()` -> Ratis' `StateMachineUpdater.appliedIndex`. Ratis seeds that from `getLatestSnapshot().getIndex()` - in `StateMachineUpdater`'s constructor on startup, and again in `reload()` immediately *after* `reinitialize()` returns (verified against the ratis-server 3.2.2 sources). ArcadeDB's own `AtomicLong` feeds `takeSnapshot()` and the phase-2 replay floor, and is not on the waiter path at all.

So simply not advancing `lastAppliedIndex` would have changed nothing observable: Ratis reports the marker index as applied either way, and every waiter targeting an index inside `(persistedApplied, snapshotIndex]` finds its condition already satisfied and reads the stale local databases. Fixing this needs the waiters to stop trusting the raw Ratis value while a flagged re-download is outstanding.

## What changed

**`ArcadeStateMachine`**

- New `staleSnapshotAppliedFloor` (`AtomicLong`, -1 = none): the highest index whose data is genuinely on disk, published by `reinitialize()`'s snapshot-gap branch and set *before* the marker is seeded, so no waiter can observe the seeded index without also observing the floor that qualifies it.
- The gap branch no longer advances `lastAppliedIndex` onto the marker (it stays on `persistedApplied`, which is what `takeSnapshot()` may hand Ratis as a durability checkpoint) and no longer calls `notifyApplied()`.
- The Ratis-facing `updateLastAppliedTermIndex(snapshotTerm, snapshotIndex)` is deliberately **unchanged**: it is the only replay position Ratis has, and `StateMachineUpdater.reload()` requires it to match `getLatestSnapshot()`.
- The floor is cleared only where a resync actually restored the state - `notifyInstallSnapshotFromLeader()` (before its notify, so a woken waiter re-checks against restored state) and a successful `triggerSnapshotDownload()` - never where one is merely requested or in flight. A later `reinitialize()` that finds no gap clears it too.
- A successful `triggerSnapshotDownload()` now also records the marker index as the persisted applied position of every present database, mirroring what the leader-driven install already did. Without it the same gap is re-detected on every restart and the node re-downloads forever.
- A **failed** `triggerSnapshotDownload()` re-arms `needsSnapshotDownload` while a floor is outstanding, so the next leader change or the `HealthMonitor` backstop retries instead of leaving reads clamped until a restart.
- `isResyncInProgress()` counts an outstanding floor, so a node that failed its download stops advertising `/api/v1/ready` 200 (after a failure neither of the other two flags is set).

**`RaftHAServer`**

- New `getTrustedAppliedIndex()` = `getLastAppliedIndex()` clamped to the floor. Both apply waiters now use it. Reporting paths (cluster status, lag detection) deliberately keep the raw Ratis value.
- LINEARIZABLE (`throwOnTimeout=true`) keeps waiting up to `quorumTimeout` - the resync may land inside it - then fails, which is the documented contract ("fail rather than serve a value older than an already-committed write"). The message now carries the floor.
- READ_YOUR_WRITES / bookmark waiters are best-effort by contract; waiting out `quorumTimeout` on a gap only the resync can close cannot change their outcome, so they degrade immediately with a WARNING instead of burning the timeout on every read.

**`ha-raft/CLAUDE.md`** - records that `getLastAppliedIndex()` reads Ratis, not ArcadeDB's counter. That is the misleading part that cost the investigation time here.

## Test plan

New `ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java`, 11 tests, all deterministic (no cluster timing): they drive the real `reinitialize()` against a real `SimpleStateMachineStorage` marker plus a real persisted applied-index file, and the waiters against the detached `RaftHAServer` harness `ApplyWaitBoundedRecheckTest` already uses.

Each test was proved able to fail. Reverting only the state-machine half (floor/counter/notify) fails 2; reverting only the waiter half (clamp + early degrade) fails 4. The "degrades immediately" tests assert the clamp is in force first, so they cannot pass vacuously by never entering the wait loop.

- [ ] `staleMarkerPublishesAFloorAndWithholdsTheAppliedNotification` - floor = persisted position, counter unmoved, `notifyApplied()` never called, resync flagged, node not ready
- [ ] `staleMarkerStillSeedsTheRatisFacingAppliedTermIndex` - the Ratis contract is untouched
- [ ] `markerWithinToleranceSeedsAndNotifiesAsBefore` - control: a trustworthy marker behaves exactly as before (#5846 notify intact)
- [ ] `aLaterReinitializeWithoutAGapDropsTheFloor`
- [ ] `staleMarkerDoesNotThrowWhenRaftHAServerNotYetAttached` - the startup `initialize() -> reinitialize()` path
- [ ] `linearizableReadFailsWhileTheFloorIsOutstanding` - the observable bug: Ratis says 5000, only 100 is backed by data, the read now fails
- [ ] `linearizableReadBelowTheFloorStillSucceeds`
- [ ] `linearizableReadIsReleasedWhenTheResyncClearsTheFloor` - asserts the wait really was held, then released promptly
- [ ] `readYourWritesDegradesImmediatelyInsteadOfBurningTheQuorumTimeout`
- [ ] `waitForLocalApplyDegradesImmediatelyWhileTheFloorIsOutstanding`
- [ ] `withoutAFloorTheTrustedIndexIsTheRatisIndex` - control: no floor, no behaviour change
- [ ] Regression: full `ha-raft` unit suite green - `mvn -pl ha-raft test` -> Tests run: 830, Failures: 0, Errors: 0
- [ ] Downstream compile: `bolt` and `grpcw` (the modules depending on `arcadedb-ha-raft`) test-compile clean

## Notes for review

- Behaviour change worth a deliberate call: while a flagged re-download is outstanding, LINEARIZABLE reads on that node now fail rather than silently serving short data. That is the point of the fix, but it converts a silent correctness bug into visible 503s on a node that is genuinely missing committed entries. The failed-download re-arm and the readiness gate above are there so the node recovers or is taken out of rotation rather than sitting clamped.
- Not addressed here, and flagged in #6111 as needing its own design pass: deferring the PAUSED -> RUNNING lifecycle transition itself. This PR leaves `StateMachineUpdater.reload()`'s expectations untouched on purpose.



---

## Review history

Four automated review cycles ran; every finding was verified against the code before acting, and each round's tests were proved able to fail by neutering the specific change they name.

| cycle | commit | what changed |
|---|---|---|
| 1 | `f27b58083` | Documented why the lenient early-degrade needs no explicit `targetIndex > floor` test. Chased down the write-side question rather than assuming: confirmed `applyTxEntry`'s `WALVersionGapException` -> diverged-database -> resync escalation prevents mismatched pages from landing during the clamped window, and recorded it on `reinitialize()`'s javadoc. |
| 2 | `78624f6b3` | **Real liveness bug found.** Re-arming `needsSnapshotDownload` on a failed download made `isSnapshotDownloadPending()` true, which stands both `isFollowerLaggingBeyond()` and `recoverFromPersistentLag()` down - and the lag backstop could never have covered this case anyway, since a node holding a gap reports *zero lag* (Ratis derives the applied index from the marker that is ahead). Added `HealthMonitor.HealthTarget.retryUnfilledSnapshotGap()`, driven from `tick()`, throttled to one attempt per snapshot-watchdog timeout. |
| 3 | `c8ae1853c` | **Second real bug found.** `notifyLeaderChanged()` submits `triggerSnapshotDownload()` on the node that just *won* the election, and `getLeaderHttpAddress()` then resolves to this node's own address - so a self-download would have reported success and let this PR's new `resolveStaleSnapshotFloorAfterResync()` durably record the marker as applied, reopening #6111 on a leader across restarts. `triggerSnapshotDownload()` now refuses when this node is the leader, plus an address-equality backstop for the TOCTOU window. |
| 4 | `ae095d684` | Logged the case where the local address cannot be resolved (the address backstop would otherwise disarm silently); documented the deliberate single-node/no-peer wedge in `ha-raft/CLAUDE.md`; stated at the field why the floor is node-global rather than per-database. |

Final `ha-raft` unit suite: **839 tests, 0 failures**. Test class grew from 11 to 20 tests across the cycles.

### Deliberately not done

- `notifyInstallSnapshotFromLeader()`'s plain `lastAppliedIndex.set(snapshotIndex)` under the documented CAS-loss race - same shape as the one guarded here, but pre-existing, inside the #5407 durability reasoning, and unrelated to the read-guarantee bug. Deserves its own issue and test.
- Partial-success bookkeeping in `triggerSnapshotDownload()`'s per-database loop - pre-existing, reached identically by paths this PR does not touch.
- Gating the floor resolution on `resynced > 0` - would strand a node with no databases open with a floor nothing can resolve, a worse failure than the one guarded against. The count is logged instead.
- A dedicated test for the `WALVersionGapException` escalation during the clamped window - this PR cites that mechanism, it does not change it.
