### PR TITLE
fix(#6106): a persisted vector graph is reused only when it describes the live records

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1429,12 +1429,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 "it has no manifest and holds %d nodes against %d active vectors".formatted(graphSize,
                     rebuiltOrdinalToVectorId.length) :
                 null;
-            if (staleReason == null)
+            if (staleReason == null) {
+              // Also counted, not only logged: a WARNING is easy to miss, and "is this index still on the weaker
+              // comparison?" is a question an operator should be able to ask the stats rather than the log file.
+              metrics.incrementUnverifiedGraphReuses();
               LogManager.instance().log(this, Level.WARNING,
                   "Vector index %s is reusing a persisted graph that carries no manifest: its %d nodes match the "
                       + "live vector count, but nothing on disk says they describe these records (issue #6106). "
                       + "The next graph persist writes one; REBUILD INDEX forces it now",
                   indexName, graphSize);
+            }
           } else if (persistedManifest.vectorCount() != rebuiltOrdinalToVectorId.length
               || persistedManifest.fingerprint() != LSMVectorIndexGraphManifest.fingerprintOf(
               rebuiltOrdinalToVectorId, vectorIndex::getRid)) {
@@ -2578,6 +2582,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
               // Ignore rollback errors
             }
           }
+          // This method swallows the failure and lets the index keep running without a persisted graph, so what is
+          // left on the pages outlives this process. It could be the previous generation intact (the write never
+          // touched a page), a partial rewrite whose earlier chunks already committed, or anything between - so the
+          // manifest has to refuse it. Leaving no manifest instead would read as "unverifiable" on the next open
+          // and fall back to the node-count comparison, which is what issue #6106 is about.
+          gf.getManifest().markUnusable("graph persist failed: " + e);
           LogManager.instance().log(this, Level.SEVERE,
               "PERSIST: Failed to persist graph for %s (nodes=%d, storeVectorsInGraph=%b, txStatus=%s): %s - %s",
               indexName,
@@ -2688,6 +2698,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @param persistedTo            the component the graph was written to
    * @param graphOrdinalToVectorId ordinal &rarr; vector id array the graph was built with
    */
+  /**
+   * Refuses whatever is on the graph pages after a build that did not finish. The alternative - leaving no
+   * manifest - reads as "persisted by an older version" on the next open and falls back to the node-count
+   * comparison, which is exactly the check issue #6106 replaces.
+   *
+   * @param cause what went wrong; recorded in the manifest for a human, nothing reads it back
+   */
+  private void markGraphManifestUnusable(final Exception cause) {
+    if (graphFile != null)
+      graphFile.getManifest().markUnusable("index build failed: " + cause);
+  }
+
   private void writeGraphManifest(final LSMVectorIndexGraphFile persistedTo, final int[] graphOrdinalToVectorId) {
     if (persistedTo == null || graphOrdinalToVectorId == null || graphOrdinalToVectorId.length == 0)
       return;
@@ -5938,6 +5960,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             if (startedTransaction && db.getTransaction().getStatus() == TransactionContext.STATUS.BEGUN)
               db.getWrappedDatabaseInstance().rollback();
 
+            markGraphManifestUnusable(e);
             persistBuildState(BUILD_STATE.INVALID);
 
             LogManager.instance().log(this, Level.SEVERE,
@@ -5949,6 +5972,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             if (startedTransaction && db.getTransaction().getStatus() == TransactionContext.STATUS.BEGUN)
               db.getWrappedDatabaseInstance().rollback();
 
+            markGraphManifestUnusable(e);
             persistBuildState(BUILD_STATE.INVALID);
 
             LogManager.instance().log(this, Level.SEVERE,

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2510,6 +2510,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
           database.getTransaction().setUseWAL(false);
         };
 
+        // Flipped the moment the manifest certifies the committed pages. Everything after that point - the
+        // OnDiskGraphIndex reload, the PQ persist - is about making THIS session faster, not about what is on
+        // disk, so a failure there must not un-certify a graph that committed correctly and cost the next open a
+        // rebuild it does not need.
+        boolean graphCertified = false;
+
         try {
           gf.writeGraph(graphIndex, vectors, chunkSizeMB, chunkCallback, earlyPq, earlyPqVectors);
 
@@ -2534,6 +2540,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // commit and never before: a manifest that outlived a persist which did not complete would be the one
           // thing able to certify a graph nobody built.
           writeGraphManifest(gf, finalActiveVectorIds);
+          graphCertified = true;
 
           // When storeVectorsInGraph is enabled, reload the graph as OnDiskGraphIndex so the
           // current session benefits from inline vector storage immediately. This is safe because
@@ -2587,7 +2594,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // touched a page), a partial rewrite whose earlier chunks already committed, or anything between - so the
           // manifest has to refuse it. Leaving no manifest instead would read as "unverifiable" on the next open
           // and fall back to the node-count comparison, which is what issue #6106 is about.
-          gf.getManifest().markUnusable("graph persist failed: " + e);
+          //
+          // Unless the graph already got its manifest: past that point the pages are a committed generation the
+          // manifest correctly describes, and a PQ or reload failure says nothing about them.
+          //
+          // writeGraph() marks its own failures the same way before rethrowing, so this repeats that one small
+          // write when the failure came from in there. Cheap, and on a path already logged as SEVERE.
+          if (!graphCertified)
+            gf.getManifest().markUnusable("graph persist failed: " + e);
           LogManager.instance().log(this, Level.SEVERE,
               "PERSIST: Failed to persist graph for %s (nodes=%d, storeVectorsInGraph=%b, txStatus=%s): %s - %s",
               indexName,
@@ -2686,6 +2700,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * Refuses whatever is on the graph pages after a build that did not finish. The alternative - leaving no
+   * manifest - reads as "persisted by an older version" on the next open and falls back to the node-count
+   * comparison, which is exactly the check issue #6106 replaces.
+   *
+   * @param cause what went wrong; recorded in the manifest for a human, nothing reads it back
+   */
+  private void markGraphManifestUnusable(final Exception cause) {
+    if (graphFile != null)
+      graphFile.getManifest().markUnusable("index build failed: " + cause);
+  }
+
+  /**
    * Records, next to the graph pages that have just been committed, which records that graph was built over
    * (issue #6106). Call this only after the commit: the manifest is the one thing able to certify a graph, so it
    * must never outlive a persist that did not complete.
@@ -2698,18 +2724,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @param persistedTo            the component the graph was written to
    * @param graphOrdinalToVectorId ordinal &rarr; vector id array the graph was built with
    */
-  /**
-   * Refuses whatever is on the graph pages after a build that did not finish. The alternative - leaving no
-   * manifest - reads as "persisted by an older version" on the next open and falls back to the node-count
-   * comparison, which is exactly the check issue #6106 replaces.
-   *
-   * @param cause what went wrong; recorded in the manifest for a human, nothing reads it back
-   */
-  private void markGraphManifestUnusable(final Exception cause) {
-    if (graphFile != null)
-      graphFile.getManifest().markUnusable("index build failed: " + cause);
-  }
-
   private void writeGraphManifest(final LSMVectorIndexGraphFile persistedTo, final int[] graphOrdinalToVectorId) {
     if (persistedTo == null || graphOrdinalToVectorId == null || graphOrdinalToVectorId.length == 0)
       return;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1402,24 +1402,57 @@ public class LSMVectorIndex implements Index, IndexInternal {
               "Loaded graph from disk for index: %s, graphSize=%d, ordinalToVectorIdLength=%d, vectorIndexSize=%d",
               indexName, graphSize, rebuiltOrdinalToVectorId.length, vectorIndex.size());
 
-          // CRITICAL FIX FOR #3722: Check if persisted graph is stale (has fewer vectors than currently active).
-          // This happens when vectors were added after the graph was last built and persisted.
-          // On database restart, deltaVectors (volatile) are lost and graphState is set to IMMUTABLE,
-          // so rebuildGraphBeforeSearch() never triggers. Search can only find nodes in the stale graph.
+          // CRITICAL FIX FOR #3722: a persisted graph with fewer nodes than there are active vectors is stale -
+          // vectors were added after it was last built and persisted. On database restart deltaVectors (volatile)
+          // are lost and graphState is set to IMMUTABLE, so rebuildGraphBeforeSearch() never triggers and search
+          // can only find nodes in the stale graph.
           //
-          // This is a COUNT comparison, not a content one: a persisted graph whose node count merely happens to
-          // match the current live count is treated as up to date even if it was built for a different generation
-          // of the live set. A renumbering compaction (issue #5870) makes that coincidence more likely to matter,
-          // not less - every post-compaction generation's ids are densely [0, N), so two different generations of
-          // the same index are far more likely to independently land on matching lengths than the old sparse,
-          // monotonically-growing ids ever were. Whether a real crash window can pair a stale graph with a live
-          // set of the same size this way is tracked, not confirmed, in issue #6106.
-          if (graphSize < rebuiltOrdinalToVectorId.length) {
+          // ISSUE #6106: that comparison is about how MANY vectors there are, and reusing the graph needs to know
+          // WHICH ones. The graph is addressed by ordinal, and ordinal i means a record only through the array
+          // rebuilt just above; pair a graph with an array from another generation of the live set and every node
+          // answers for a record it was never built from - a wrong-but-plausible result, not a failure. Counts
+          // cannot separate the two: since the renumbering compaction of issue #5870 every generation's ids are
+          // densely [0, N), so two generations holding different records routinely produce arrays of identical
+          // length. The manifest written next to the graph records the correspondence itself, and comparing
+          // against it is what makes the reuse safe rather than merely plausible.
+          final LSMVectorIndexGraphManifest.Content persistedManifest = graphFile.getManifest().read();
+
+          final String staleReason;
+          if (persistedManifest == null) {
+            // No manifest: a graph persisted by a version older than this check, or one whose persist was
+            // interrupted before it could write one. Judge it the historical way, by node count, rather than
+            // forcing every existing index to rebuild on the first open after an upgrade - but widen the
+            // comparison to ANY difference, because a graph larger than the live set lines its ordinals up no
+            // better than a smaller one: everything past the end of the rebuilt array is dropped as out of
+            // bounds, and everything before it can still address the wrong record.
+            staleReason = graphSize != rebuiltOrdinalToVectorId.length ?
+                "it has no manifest and holds %d nodes against %d active vectors".formatted(graphSize,
+                    rebuiltOrdinalToVectorId.length) :
+                null;
+            if (staleReason == null)
+              LogManager.instance().log(this, Level.WARNING,
+                  "Vector index %s is reusing a persisted graph that carries no manifest: its %d nodes match the "
+                      + "live vector count, but nothing on disk says they describe these records (issue #6106). "
+                      + "The next graph persist writes one; REBUILD INDEX forces it now",
+                  indexName, graphSize);
+          } else if (persistedManifest.vectorCount() != rebuiltOrdinalToVectorId.length
+              || persistedManifest.fingerprint() != LSMVectorIndexGraphManifest.fingerprintOf(
+              rebuiltOrdinalToVectorId, vectorIndex::getRid)) {
+            staleReason = "it was built over %d records the manifest fingerprints as %s, not over the %d now live".formatted(
+                persistedManifest.vectorCount(), Long.toHexString(persistedManifest.fingerprint()),
+                rebuiltOrdinalToVectorId.length);
+          } else if (graphSize != rebuiltOrdinalToVectorId.length) {
+            // The manifest agrees with the live set but the pages do not: a truncated or otherwise damaged
+            // persist. Nothing here can repair it, so rebuild.
+            staleReason = "the pages hold %d nodes while its manifest and the live set both say %d".formatted(
+                graphSize, rebuiltOrdinalToVectorId.length);
+          } else
+            staleReason = null;
+
+          if (staleReason != null) {
             LogManager.instance().log(this, Level.INFO,
-                """
-                Persisted graph is stale for index %s: graph has %d nodes but %d active vectors exist - \
-                rebuilding from scratch (fixes issue #3722: missing vectors after database restart)""",
-                indexName, graphSize, rebuiltOrdinalToVectorId.length);
+                "Persisted graph is not usable for index %s: %s - rebuilding from scratch (issues #3722, #6106)",
+                indexName, staleReason);
             // Don't use the stale graph — fall through to buildGraphFromScratch() below
           } else {
             // Graph is up to date — use it
@@ -2493,6 +2526,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
                     indexName);
           }
 
+          // Only now that the pages are committed may the manifest vouch for them (issue #6106). Written after the
+          // commit and never before: a manifest that outlived a persist which did not complete would be the one
+          // thing able to certify a graph nobody built.
+          writeGraphManifest(gf, finalActiveVectorIds);
+
           // When storeVectorsInGraph is enabled, reload the graph as OnDiskGraphIndex so the
           // current session benefits from inline vector storage immediately. This is safe because
           // the transaction has been committed above, so all graph pages are flushed and visible.
@@ -2635,6 +2673,27 @@ public class LSMVectorIndex implements Index, IndexInternal {
             + "defined only for normalized vectors, so search quality is degraded: normalize the vectors on ingest or "
             + "recreate the index with COSINE. This is reported once per index",
         indexName, nonUnit, sampled, nonUnit * 100 / sampled);
+  }
+
+  /**
+   * Records, next to the graph pages that have just been committed, which records that graph was built over
+   * (issue #6106). Call this only after the commit: the manifest is the one thing able to certify a graph, so it
+   * must never outlive a persist that did not complete.
+   * <p>
+   * The RIDs come from the live location index rather than from the build snapshot because a vector id's RID is
+   * fixed for the life of that id - an update issues a new id rather than re-pointing an existing one - so the two
+   * cannot disagree. An id whose location has since gone reads as absent here and is equally absent from the array
+   * the load path rebuilds, which makes the graph fail the check and be rebuilt: the conservative direction.
+   *
+   * @param persistedTo            the component the graph was written to
+   * @param graphOrdinalToVectorId ordinal &rarr; vector id array the graph was built with
+   */
+  private void writeGraphManifest(final LSMVectorIndexGraphFile persistedTo, final int[] graphOrdinalToVectorId) {
+    if (persistedTo == null || graphOrdinalToVectorId == null || graphOrdinalToVectorId.length == 0)
+      return;
+
+    persistedTo.getManifest().write(graphOrdinalToVectorId.length,
+        LSMVectorIndexGraphManifest.fingerprintOf(graphOrdinalToVectorId, vectorIndex::getRid));
   }
 
   private long getTxChunkSize() {
@@ -5707,6 +5766,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
         final File graphIndexFile = graphFile.getOSFile();
         if (graphIndexFile.exists())
           graphIndexFile.delete();
+        // And the sidecar that describes it: left behind, it would be read as vouching for whatever graph file a
+        // later index happened to create under the same name (issue #6106).
+        graphFile.getManifest().invalidate();
       }
 
       // NOTE: Metadata is now embedded in the schema JSON via toJSON() and is automatically
@@ -5861,6 +5923,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
             // PHASE 4: Final commit and mark READY
             if (startedTransaction)
               db.getWrappedDatabaseInstance().commit();
+
+            // buildGraphWithChunking() rewrites the graph pages inside this transaction, which drops the manifest;
+            // only here, past the commit, is there a persisted graph to vouch for again (issue #6106).
+            writeGraphManifest(graphFile, ordinalToVectorId);
 
             persistBuildState(BUILD_STATE.READY);
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
@@ -65,11 +65,18 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
   private LSMVectorIndex mainIndex;
 
   /**
+   * Says which records the graph on these pages was built over. The graph itself is addressed by ordinal and carries
+   * nothing that identifies them, so this is what makes reusing it safe (issue #6106).
+   */
+  private final LSMVectorIndexGraphManifest manifest;
+
+  /**
    * Constructor for creating a new graph file
    */
   protected LSMVectorIndexGraphFile(final DatabaseInternal database, final String name, final String filePath,
                                     final ComponentFile.MODE mode, final int pageSize) throws IOException {
     super(database, name, filePath, FILE_EXT, mode, pageSize, CURRENT_VERSION);
+    this.manifest = new LSMVectorIndexGraphManifest(getOSFile().getAbsolutePath());
   }
 
   /**
@@ -78,6 +85,14 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
   protected LSMVectorIndexGraphFile(final DatabaseInternal database, final String name, final String filePath, final int id,
                                     final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
     super(database, name, filePath, id, mode, pageSize, version);
+    this.manifest = new LSMVectorIndexGraphManifest(getOSFile().getAbsolutePath());
+  }
+
+  /**
+   * @return the sidecar recording which records the persisted graph was built over
+   */
+  public LSMVectorIndexGraphManifest getManifest() {
+    return manifest;
   }
 
   @Override
@@ -174,6 +189,12 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
 
     if (!database.isTransactionActive())
       throw new IllegalStateException("writeGraph() must be called within an active transaction");
+
+    // The pages about to be overwritten are the ones the current manifest vouches for, and the write commits in
+    // chunks, so from here until the caller has committed there is no generation of the graph anything can promise.
+    // Dropping the manifest first is what makes an interrupted persist leave "no manifest" - read as "rebuild" -
+    // rather than a half-written graph the previous manifest still appears to describe (issue #6106).
+    manifest.invalidate();
 
     try {
       if (chunkSizeMB > 0 && chunkCallback != null) {

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphFile.java
@@ -192,8 +192,10 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
 
     // The pages about to be overwritten are the ones the current manifest vouches for, and the write commits in
     // chunks, so from here until the caller has committed there is no generation of the graph anything can promise.
-    // Dropping the manifest first is what makes an interrupted persist leave "no manifest" - read as "rebuild" -
-    // rather than a half-written graph the previous manifest still appears to describe (issue #6106).
+    // Dropping the manifest FIRST is what keeps a half-written graph from being described by the manifest of the
+    // one it is replacing (issue #6106). A process killed anywhere in here therefore leaves no manifest at all,
+    // which the load path reads as "cannot be verified" and judges by node count - so any failure this method can
+    // still observe replaces it with a manifest that refuses the pages outright (see the catch below).
     manifest.invalidate();
 
     try {
@@ -293,6 +295,11 @@ public class LSMVectorIndexGraphFile extends PaginatedComponent {
       }
 
     } catch (final Exception e) {
+      // The caller rolls back and carries on without a persisted graph. Whatever the rollback leaves on these
+      // pages - the previous generation untouched, or a partial rewrite whose earlier chunks already committed -
+      // nothing here knows which, so the manifest must refuse them rather than be simply absent: absent means
+      // "unverifiable", and unverifiable falls back to the node count this whole mechanism replaces (issue #6106).
+      manifest.markUnusable("graph persist failed: " + e);
       LogManager.instance().log(this, Level.SEVERE, "Error writing graph to pages: %s", e, e.getMessage());
       throw new IndexException("Error writing graph to pages", e);
     }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -63,10 +63,18 @@ public class LSMVectorIndexGraphManifest {
   private static final long   FNV_PRIME        = 0x100000001b3L;
 
   /**
+   * {@code vectorCount} of a manifest that deliberately describes nothing. No live set can ever have a negative
+   * size, so a manifest carrying this always fails the comparison and always forces a rebuild - which is how a
+   * failed graph persist says "whatever is on these pages, do not trust it" without relying on the count
+   * comparison the absence of a manifest falls back to.
+   */
+  static final int UNUSABLE_VECTOR_COUNT = -1;
+
+  /**
    * What a persisted manifest says about the graph next to it.
    *
    * @param formatVersion version of this file's own layout
-   * @param vectorCount   number of ordinals the graph was built over
+   * @param vectorCount   number of ordinals the graph was built over, or {@link #UNUSABLE_VECTOR_COUNT}
    * @param fingerprint   fingerprint of the ordinal &rarr; (vector id, RID) correspondence
    */
   public record Content(int formatVersion, int vectorCount, long fingerprint) {
@@ -144,10 +152,36 @@ public class LSMVectorIndexGraphManifest {
   }
 
   /**
+   * Says that whatever is on the graph pages describes nothing this index can use, so the next load rebuilds
+   * instead of judging the pages by their node count.
+   * <p>
+   * This is what a FAILED graph persist leaves behind. Deleting the manifest would not do: the load path reads an
+   * absent manifest as "persisted by an older version" and falls back to the count comparison - the very
+   * comparison this class exists to replace - so a persist that died after {@link #invalidate()} but before it
+   * damaged anything would silently downgrade a perfectly good index to the weak check. Refusing the pages
+   * outright costs one rebuild, and only after an event that is already logged as SEVERE.
+   *
+   * @param reason human-readable note stored in the file; nothing reads it back
+   */
+  public void markUnusable(final String reason) {
+    write(UNUSABLE_VECTOR_COUNT, 0L, reason);
+  }
+
+  /**
    * Records the correspondence the just-committed graph was built over. Written through a temporary file so a
    * crash mid-write cannot leave a truncated manifest that reads as a valid one.
    */
   public void write(final int vectorCount, final long fingerprint) {
+    write(vectorCount, fingerprint, null);
+  }
+
+  /**
+   * The temporary file is derived from the manifest's own name, so two writers on the SAME index would race on it.
+   * They cannot: every graph persist for an index runs under {@code LSMVectorIndex.graphBuildLock}, which
+   * serialises graph builds per index, and the manifest is written from inside that persist. A future change that
+   * lifts that serialisation has to give this a per-writer name.
+   */
+  private void write(final int vectorCount, final long fingerprint, final String reason) {
     final Path temporary = path.resolveSibling(path.getFileName() + ".tmp");
     try {
       final Path parent = path.getParent();
@@ -159,6 +193,8 @@ public class LSMVectorIndexGraphManifest {
       json.put("vectorCount", vectorCount);
       // As a string: a 64-bit fingerprint is not representable in the double a JSON number decodes to.
       json.put("fingerprint", Long.toString(fingerprint));
+      if (reason != null)
+        json.put("reason", reason);
 
       Files.writeString(temporary, json.toString(), StandardCharsets.UTF_8);
       try {

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -25,6 +25,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -176,17 +177,25 @@ public class LSMVectorIndexGraphManifest {
   }
 
   /**
-   * The temporary file is derived from the manifest's own name, so two writers on the SAME index would race on it.
-   * They cannot: every graph persist for an index runs under {@code LSMVectorIndex.graphBuildLock}, which
-   * serialises graph builds per index, and the manifest is written from inside that persist. A future change that
-   * lifts that serialisation has to give this a per-writer name.
+   * The temporary file carries a per-write suffix rather than a fixed {@code .tmp} name. Graph persists for one
+   * index are serialised today - by {@code LSMVectorIndex.graphBuildLock} on the rebuild path, and by the index
+   * write lock plus the {@code INDEX_STATUS} gate on the {@code build()} path - but that is two invariants held in
+   * two different places, and a shared temp name would turn a future change to either of them into a corrupted
+   * manifest. A unique name costs nothing and removes the assumption.
    */
   private void write(final int vectorCount, final long fingerprint, final String reason) {
-    final Path temporary = path.resolveSibling(path.getFileName() + ".tmp");
+    final Path temporary = path.resolveSibling(
+        path.getFileName() + "." + Long.toHexString(System.nanoTime()) + ".tmp");
     try {
       final Path parent = path.getParent();
       if (parent != null && !Files.exists(parent))
         Files.createDirectories(parent);
+
+      // A process killed between the write and the move leaves its temporary behind. Nothing reads one - the
+      // extension is not a component one, so no scan opens it - but nothing would ever remove it either, and an
+      // index rebuilt often enough would quietly litter the database directory. Sweeping here keeps at most one
+      // generation of leftovers around, without a lifecycle of its own.
+      deleteLeftoverTemporaries(parent);
 
       final JSONObject json = new JSONObject();
       json.put("formatVersion", FORMAT_VERSION);
@@ -211,6 +220,26 @@ public class LSMVectorIndexGraphManifest {
       } catch (final IOException ignored) {
         // NOTHING ELSE TO DO
       }
+    }
+  }
+
+  /**
+   * Removes the temporaries of earlier writes of THIS manifest, matched by name so no other file can be caught.
+   *
+   * @param parent directory holding the manifest, or {@code null} when it has none
+   */
+  private void deleteLeftoverTemporaries(final Path parent) {
+    if (parent == null)
+      return;
+
+    try (final DirectoryStream<Path> leftovers = Files.newDirectoryStream(parent,
+        path.getFileName() + ".*.tmp")) {
+      for (final Path leftover : leftovers)
+        Files.deleteIfExists(leftover);
+    } catch (final Exception e) {
+      // Housekeeping only: a manifest that cannot be written is what matters, and that is reported below.
+      LogManager.instance().log(this, Level.FINE,
+          "Could not remove leftover vector graph manifest temporaries next to '%s': %s", path, e.getMessage());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.function.IntFunction;
+import java.util.logging.Level;
+
+/**
+ * Sidecar of a persisted JVector graph recording <b>which</b> vectors that graph was built over, not merely how
+ * many.
+ * <p>
+ * The graph itself stores topology addressed by ordinal; the mapping from an ordinal to a record lives outside it,
+ * recomputed from the location index every time the graph is loaded. Reusing a persisted graph is therefore only
+ * safe while that mapping is the one the graph was built with, and until issue #6106 the only thing checked was the
+ * node count. A count cannot tell two generations apart: since the renumbering compaction of issue #5870 every
+ * generation's live ids are densely {@code [0, N)}, so a graph built over one set of records and a live set holding
+ * a different set of the same size look identical to a count comparison. The graph is then reused with ordinals
+ * resolving to records its nodes were never built from, and searches answer with wrong-but-plausible neighbours
+ * rather than failing.
+ * <p>
+ * What the fingerprint covers is the ordinal &rarr; record correspondence: the vector id <b>and</b> the RID at each
+ * ordinal, in ordinal order. Fingerprinting the ids alone would not help, because dense {@code [0, N)} is exactly
+ * what two different generations both produce; it is the records behind those ids that differ.
+ * <p>
+ * Like {@link LSMVectorIndexPQFile} this is a plain file rather than a paginated component: it is a few dozen bytes
+ * read once per graph load and rewritten once per graph persist, and keeping it out of the page system means it can
+ * be removed before the graph pages are touched and written only after they are committed. That order is what makes
+ * the check safe under a crash - an interrupted persist leaves no manifest at all, and "no manifest" is never read
+ * as "the graph matches".
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+public class LSMVectorIndexGraphManifest {
+  public static final  String FILE_EXT         = "vecgraphfp";
+  static final         int    FORMAT_VERSION   = 1;
+  private static final long   FNV_OFFSET_BASIS = 0xcbf29ce484222325L;
+  private static final long   FNV_PRIME        = 0x100000001b3L;
+
+  /**
+   * What a persisted manifest says about the graph next to it.
+   *
+   * @param formatVersion version of this file's own layout
+   * @param vectorCount   number of ordinals the graph was built over
+   * @param fingerprint   fingerprint of the ordinal &rarr; (vector id, RID) correspondence
+   */
+  public record Content(int formatVersion, int vectorCount, long fingerprint) {
+  }
+
+  private final Path path;
+
+  LSMVectorIndexGraphManifest(final String graphFilePath) {
+    this.path = Path.of(graphFilePath + "." + FILE_EXT);
+  }
+
+  /**
+   * Fingerprint of the ordinal &rarr; record correspondence a graph is built over: for every ordinal, the vector id
+   * and the RID it resolves to. FNV-1a over the whole sequence, the same construction
+   * {@code LocalBucket.chunkChainTailFingerprint} uses.
+   * <p>
+   * An ordinal whose RID cannot be resolved contributes a distinct marker rather than being skipped: skipping would
+   * make an unresolvable ordinal invisible, so a live set that lost exactly that record would fingerprint the same.
+   *
+   * @param vectorIds    the ordinal &rarr; vector id array, in ordinal order
+   * @param ridOfVector  resolves a vector id to its RID, or {@code null} when the location is gone
+   */
+  public static long fingerprintOf(final int[] vectorIds, final IntFunction<RID> ridOfVector) {
+    long hash = FNV_OFFSET_BASIS;
+    hash = mixInt(hash, vectorIds.length);
+    for (final int vectorId : vectorIds) {
+      hash = mixInt(hash, vectorId);
+      final RID rid = ridOfVector.apply(vectorId);
+      if (rid == null) {
+        hash = mixInt(hash, -1);
+        hash = mixLong(hash, -1L);
+      } else {
+        hash = mixInt(hash, rid.getBucketId());
+        hash = mixLong(hash, rid.getPosition());
+      }
+    }
+    return hash;
+  }
+
+  private static long mixInt(long hash, final int value) {
+    for (int shift = 24; shift >= 0; shift -= 8) {
+      hash ^= (value >>> shift) & 0xFFL;
+      hash *= FNV_PRIME;
+    }
+    return hash;
+  }
+
+  private static long mixLong(long hash, final long value) {
+    for (int shift = 56; shift >= 0; shift -= 8) {
+      hash ^= (value >>> shift) & 0xFFL;
+      hash *= FNV_PRIME;
+    }
+    return hash;
+  }
+
+  public Path getFilePath() {
+    return path;
+  }
+
+  public boolean exists() {
+    return Files.exists(path);
+  }
+
+  /**
+   * Drops the manifest. Called before the graph pages are rewritten, so that a persist interrupted half way leaves
+   * a graph nothing vouches for instead of a graph the previous manifest still appears to describe.
+   */
+  public void invalidate() {
+    try {
+      Files.deleteIfExists(path);
+    } catch (final IOException e) {
+      LogManager.instance().log(this, Level.WARNING, "Could not remove the vector graph manifest '%s': %s", path,
+          e.getMessage());
+    }
+  }
+
+  /**
+   * Records the correspondence the just-committed graph was built over. Written through a temporary file so a
+   * crash mid-write cannot leave a truncated manifest that reads as a valid one.
+   */
+  public void write(final int vectorCount, final long fingerprint) {
+    final Path temporary = path.resolveSibling(path.getFileName() + ".tmp");
+    try {
+      final Path parent = path.getParent();
+      if (parent != null && !Files.exists(parent))
+        Files.createDirectories(parent);
+
+      final JSONObject json = new JSONObject();
+      json.put("formatVersion", FORMAT_VERSION);
+      json.put("vectorCount", vectorCount);
+      // As a string: a 64-bit fingerprint is not representable in the double a JSON number decodes to.
+      json.put("fingerprint", Long.toString(fingerprint));
+
+      Files.writeString(temporary, json.toString(), StandardCharsets.UTF_8);
+      try {
+        Files.move(temporary, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } catch (final AtomicMoveNotSupportedException e) {
+        Files.move(temporary, path, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } catch (final Exception e) {
+      // A missing manifest only costs a rebuild on the next load, so this must never fail a graph persist.
+      LogManager.instance().log(this, Level.WARNING, "Could not write the vector graph manifest '%s': %s", path,
+          e.getMessage());
+      try {
+        Files.deleteIfExists(temporary);
+      } catch (final IOException ignored) {
+        // NOTHING ELSE TO DO
+      }
+    }
+  }
+
+  /**
+   * @return what the manifest on disk says, or {@code null} when there is none, it cannot be read, or it was
+   * written by a layout this build does not know
+   */
+  public Content read() {
+    if (!Files.exists(path))
+      return null;
+
+    try {
+      final JSONObject json = new JSONObject(Files.readString(path, StandardCharsets.UTF_8));
+      final int formatVersion = json.getInt("formatVersion", -1);
+      if (formatVersion != FORMAT_VERSION) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Vector graph manifest '%s' has format version %d, expected %d: ignoring it", path, formatVersion,
+            FORMAT_VERSION);
+        return null;
+      }
+      return new Content(formatVersion, json.getInt("vectorCount", -1),
+          Long.parseLong(json.getString("fingerprint", "0")));
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "Could not read the vector graph manifest '%s': %s", path,
+          e.getMessage());
+      return null;
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifest.java
@@ -52,8 +52,18 @@ import java.util.logging.Level;
  * Like {@link LSMVectorIndexPQFile} this is a plain file rather than a paginated component: it is a few dozen bytes
  * read once per graph load and rewritten once per graph persist, and keeping it out of the page system means it can
  * be removed before the graph pages are touched and written only after they are committed. That order is what makes
- * the check safe under a crash - an interrupted persist leaves no manifest at all, and "no manifest" is never read
- * as "the graph matches".
+ * the check safe under a crash: a persist that fails observably replaces the manifest with one that refuses the
+ * pages ({@link #markUnusable}), and a process killed outright leaves none at all, which the load path treats as
+ * "cannot be verified" rather than as "the graph matches".
+ * <p>
+ * <b>This class holds no lock of its own, and callers must not write one manifest concurrently.</b> Each call is
+ * individually atomic - the file is written under a per-write temporary name and moved into place - so a reader can
+ * never see a half-written manifest. What is not defended here is the ORDER of two concurrent persists of the same
+ * index: whichever moves last wins, and if that is not the one whose pages are on disk, the manifest certifies the
+ * wrong generation. The engine serialises those persists today ({@code LSMVectorIndex.graphBuildLock} on the
+ * rebuild path, the index write lock plus the {@code INDEX_STATUS} gate on the {@code build()} path), and anything
+ * that changes either has to keep that true - moving the serialisation in here would only turn an ordering problem
+ * into a shorter ordering problem, since the pages and the manifest are written at different times by design.
  *
  * @author Roberto Franchini (r.franchini@arcadedata.com)
  */
@@ -194,7 +204,8 @@ public class LSMVectorIndexGraphManifest {
       // A process killed between the write and the move leaves its temporary behind. Nothing reads one - the
       // extension is not a component one, so no scan opens it - but nothing would ever remove it either, and an
       // index rebuilt often enough would quietly litter the database directory. Sweeping here keeps at most one
-      // generation of leftovers around, without a lifecycle of its own.
+      // generation of leftovers around, without a lifecycle of its own. It is one directory listing per graph
+      // persist, an operation that has just walked every live vector twice.
       deleteLeftoverTemporaries(parent);
 
       final JSONObject json = new JSONObject();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
@@ -46,6 +46,11 @@ class LSMVectorIndexMetrics {
   // many candidates the data puts between it and the query, which no fixed budget can guarantee (issue #5761), so
   // this is the signal to raise efSearch on the index or the query.
   private final AtomicLong groupedSearchesShortOfLimit = new AtomicLong(0);
+  // Times a persisted graph was reused on the strength of its node count alone, because it carries no manifest
+  // saying which records it was built over (issue #6106) - a graph written by a version older than the manifest, or
+  // one restored from a backup, which does not carry the sidecar. Non-zero means this index is still being judged by
+  // the weaker comparison; REBUILD INDEX, or any graph persist, writes a manifest and takes it off that path.
+  private final AtomicLong unverifiedGraphReuses = new AtomicLong(0);
 
   // Vector fetch source tracking
   private final AtomicLong vectorFetchFromQuantized = new AtomicLong(0);
@@ -84,6 +89,10 @@ class LSMVectorIndexMetrics {
 
   void incrementGroupedSearchesShortOfLimit() {
     groupedSearchesShortOfLimit.incrementAndGet();
+  }
+
+  void incrementUnverifiedGraphReuses() {
+    unverifiedGraphReuses.incrementAndGet();
   }
 
   // Vector fetch source tracking methods
@@ -181,6 +190,7 @@ class LSMVectorIndexMetrics {
     stats.put("graphRebuildCount", graphRebuildCount.get());
     stats.put("bruteForceScans", bruteForceScans.get());
     stats.put("groupedSearchesShortOfLimit", groupedSearchesShortOfLimit.get());
+    stats.put("unverifiedGraphReuses", unverifiedGraphReuses.get());
     stats.put("compactionCount", compactionCount.get());
 
     stats.put("vectorFetchFromQuantized", vectorFetchFromQuantized.get());
@@ -200,6 +210,7 @@ class LSMVectorIndexMetrics {
     graphRebuildCount.set(0);
     bruteForceScans.set(0);
     groupedSearchesShortOfLimit.set(0);
+    unverifiedGraphReuses.set(0);
     compactionCount.set(0);
     vectorFetchFromQuantized.set(0);
     vectorFetchFromDocuments.set(0);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6106StaleVectorGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6106StaleVectorGraphTest.java
@@ -21,6 +21,8 @@ package com.arcadedb.index.vector;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
@@ -215,6 +217,31 @@ class Issue6106StaleVectorGraphTest extends TestHelper {
     assertThat(vectorIndex().getStats().get("unverifiedGraphReuses"))
         .as("but the index has to say it is running on the weaker comparison").isEqualTo(1L);
     assertThat(selfRetrieved).as("%d of %d found", selfRetrieved, LIVE).isGreaterThanOrEqualTo(LIVE * 99 / 100);
+  }
+
+  /**
+   * The sidecar sits next to the graph file and its name ends in the graph file's own extension plus one more, so
+   * the only thing keeping the {@code FileManager} from opening it as a page-backed component is that the scan
+   * matches on the LAST extension. Everything downstream of that rule - the backup enumeration, the HA
+   * {@code /checksums} walk - follows. Its temporaries have to be as invisible, or a crash between the write and
+   * the atomic move would leave something a scan might try to open.
+   */
+  @Test
+  void theSidecarIsNeverMistakenForAComponentFile() {
+    createSchema(database);
+    insertDocs(database, 0, 8);
+    buildAndPersistGraph();
+
+    final String graph = graphFileIn(database.getDatabasePath()).getName();
+    assertThat(LocalDatabase.isComponentFileName(graph)).as("the graph file itself IS one").isTrue();
+    assertThat(LocalDatabase.isComponentFileName(graph + "." + LSMVectorIndexGraphManifest.FILE_EXT))
+        .as("its manifest is not, or the FileManager would open a JSON file as pages").isFalse();
+    assertThat(LocalDatabase.isComponentFileName(graph + "." + LSMVectorIndexGraphManifest.FILE_EXT + ".1a2b.tmp"))
+        .as("and neither is a temporary left behind by an interrupted manifest write").isFalse();
+
+    assertThat(((DatabaseInternal) database).getFileManager().getFiles().stream()
+        .anyMatch(f -> f != null && LSMVectorIndexGraphManifest.FILE_EXT.equals(f.getFileExtension())))
+        .as("nothing registered the sidecar as a component, so backup and file shipping never see it").isFalse();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6106StaleVectorGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6106StaleVectorGraphTest.java
@@ -156,6 +156,68 @@ class Issue6106StaleVectorGraphTest extends TestHelper {
   }
 
   /**
+   * A graph persist that fails leaves pages nobody can describe: the write drops the manifest before touching a
+   * page, and the rollback may or may not have put the previous generation back. Leaving no manifest at all would
+   * read as "persisted by an older version" on the next open and fall back to the node count - so a failed persist
+   * writes a manifest that refuses the pages instead. Without that, an index that had a verified graph is silently
+   * demoted to the weaker comparison by a failure that never damaged anything.
+   */
+  @Test
+  void aFailedPersistLeavesAManifestThatRefusesTheGraphRatherThanNoneAtAll() throws Exception {
+    createSchema(database);
+    insertDocs(database, 0, LIVE);
+    buildAndPersistGraph();
+
+    final String databasePath = database.getDatabasePath();
+    database.close();
+
+    // What LSMVectorIndexGraphFile.writeGraph() and LSMVectorIndex.build() leave behind when they fail: the graph
+    // pages are whatever the rollback made of them - here, still perfectly valid - and the manifest refuses them.
+    new LSMVectorIndexGraphManifest(graphFileIn(databasePath).getPath()).markUnusable("simulated persist failure");
+
+    database = factory.open();
+
+    final int selfRetrieved = countDocsThatAreTheirOwnNearestNeighbour(liveDocIds());
+
+    assertThat(vectorIndex().getStats().get("graphRebuildCount"))
+        .as("a graph a failed persist could not vouch for must be rebuilt, not judged by its node count")
+        .isEqualTo(1L);
+    assertThat(vectorIndex().getStats().get("unverifiedGraphReuses"))
+        .as("and it must not be counted as an unverified reuse either: it was not reused").isEqualTo(0L);
+    assertThat(selfRetrieved).as("the rebuilt graph answers correctly: %d of %d found", selfRetrieved, LIVE)
+        .isGreaterThanOrEqualTo(LIVE * 99 / 100);
+  }
+
+  /**
+   * The one case that still rides on the node count is a graph with no manifest at all - written by a version older
+   * than this mechanism, or restored from a backup, which does not carry the sidecar. It is reused, because the
+   * alternative is a full rebuild of every existing index on the first open after an upgrade, and the reuse is
+   * counted so an operator can ask the stats rather than grep the log for the WARNING.
+   */
+  @Test
+  void aGraphWithNoManifestIsReusedButCounted() {
+    createSchema(database);
+    insertDocs(database, 0, LIVE);
+    buildAndPersistGraph();
+
+    final String databasePath = database.getDatabasePath();
+    database.close();
+
+    assertThat(new File(manifestOf(databasePath).toString()).delete())
+        .as("remove the sidecar, leaving the graph the way a pre-manifest version wrote it").isTrue();
+
+    database = factory.open();
+
+    final int selfRetrieved = countDocsThatAreTheirOwnNearestNeighbour(liveDocIds());
+
+    assertThat(vectorIndex().getStats().get("graphRebuildCount"))
+        .as("its node count matches, so it is reused rather than rebuilt").isEqualTo(0L);
+    assertThat(vectorIndex().getStats().get("unverifiedGraphReuses"))
+        .as("but the index has to say it is running on the weaker comparison").isEqualTo(1L);
+    assertThat(selfRetrieved).as("%d of %d found", selfRetrieved, LIVE).isGreaterThanOrEqualTo(LIVE * 99 / 100);
+  }
+
+  /**
    * The fingerprint has to cover the RIDs and not only the vector ids: dense {@code [0, N)} is precisely the id list
    * that every generation of a compacted index produces, so ids alone cannot tell two of them apart.
    */

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6106StaleVectorGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6106StaleVectorGraphTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6106: a persisted JVector graph used to be accepted on reload purely because its node count matched the
+ * number of currently live vectors. A count says nothing about WHICH records the graph was built over, and since the
+ * renumbering compaction of issue #5870 every generation of an index carries ids densely in {@code [0, N)} - so two
+ * different generations produce id lists of exactly the same shape and length. Pairing one generation's graph with
+ * another's ordinal map is silent: ordinal {@code i} addresses a record the node was never built from, so searches
+ * answer with wrong-but-plausible neighbours instead of failing.
+ * <p>
+ * The reproduction places exactly that pair on disk: a graph of 400 nodes built over one set of records, next to an
+ * index whose 400 live vectors carry the same dense ids {@code [0, 400)} but belong to different records. The two
+ * are indistinguishable by any count, which is what makes this the input the old check could not reject. Building
+ * the pair through a crash is not possible today - see the class comment of {@link LSMVectorIndexGraphManifest} and
+ * the note below - so it is assembled at the file level, which is the same on-disk state.
+ * <p>
+ * <b>Reachability.</b> Two accidents currently keep the engine off this input: a composition change without a
+ * compaction leaves tombstones, and any tombstone already forces a rebuild (issue #3135); and a compaction renames
+ * the index component, after which {@code discoverAndLoadGraphFile()} no longer recognises the graph file at all, so
+ * the graph is rebuilt rather than reused. Neither is a check of what the graph contains, and the second one costs a
+ * full rebuild on the first open after every compaction. The manifest is what makes the correspondence explicit
+ * rather than accidental.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("vector")
+class Issue6106StaleVectorGraphTest extends TestHelper {
+  private static final int DIMENSIONS = 48;
+  private static final int LIVE       = 400;
+  /** Records inserted and deleted in the donor database before its index exists, to shift its RIDs. */
+  private static final int RID_SHIFT  = 60;
+  /**
+   * Well under the live count on purpose. The beam is what makes the topology matter at all: widen it towards the
+   * node count and the search visits everything, finds the right answer whatever the edges say, and the test stops
+   * testing anything.
+   */
+  private static final int EF_SEARCH  = 32;
+
+  @Test
+  void aGraphBuiltOverOtherRecordsWithTheSameDenseIdsIsNotReused() throws Exception {
+    createSchema(database);
+    insertDocs(database, 0, LIVE);
+    buildAndPersistGraph();
+
+    final String databasePath = database.getDatabasePath();
+    database.close();
+
+    // A graph of exactly LIVE nodes whose ordinals carry the same dense ids [0, LIVE) but resolve to other records.
+    // Its manifest travels with it, the way the pair would survive a crash together.
+    installGraphOfAnotherGeneration(databasePath, LIVE, true);
+
+    database = factory.open();
+
+    final List<String> live = liveDocIds();
+    assertThat(live).hasSize(LIVE);
+
+    final int selfRetrieved = countDocsThatAreTheirOwnNearestNeighbour(live);
+
+    assertThat(vectorIndex().getStats().get("graphRebuildCount"))
+        .as("the graph on disk describes other records: it must be rebuilt, not paired with this ordinal map")
+        .isEqualTo(1L);
+    assertThat(selfRetrieved)
+        .as("after the rebuild every live record must be its own nearest neighbour: %d of %d found", selfRetrieved,
+            LIVE)
+        .isGreaterThanOrEqualTo(LIVE * 99 / 100);
+  }
+
+  /**
+   * A graph persisted before the manifest existed carries none, and is still judged by node count alone. That
+   * comparison used to reject only a graph SMALLER than the live set (issue #3722), and reuse a larger one - whose
+   * ordinals line up no better: everything past the end of the rebuilt map is dropped as out of bounds and
+   * everything before it can address the wrong record.
+   */
+  @Test
+  void aLegacyGraphWithMoreNodesThanLiveVectorsIsNotReused() throws Exception {
+    createSchema(database);
+    insertDocs(database, 0, LIVE);
+    buildAndPersistGraph();
+
+    final String databasePath = database.getDatabasePath();
+    database.close();
+
+    installGraphOfAnotherGeneration(databasePath, LIVE + 40, false);
+
+    database = factory.open();
+
+    final int selfRetrieved = countDocsThatAreTheirOwnNearestNeighbour(liveDocIds());
+
+    assertThat(vectorIndex().getStats().get("graphRebuildCount"))
+        .as("a graph with %d nodes cannot describe %d live vectors, whichever side is bigger", LIVE + 40, LIVE)
+        .isEqualTo(1L);
+    assertThat(selfRetrieved).as("and after the rebuild the answers are right: %d of %d found", selfRetrieved, LIVE)
+        .isGreaterThanOrEqualTo(LIVE * 99 / 100);
+  }
+
+  /**
+   * The other half of the contract: a graph that really does describe the live set must still be reused as it is, or
+   * every restart would pay for a full rebuild it does not need.
+   */
+  @Test
+  void anUntouchedGraphIsStillReusedAcrossARestart() {
+    createSchema(database);
+    insertDocs(database, 0, LIVE);
+    buildAndPersistGraph();
+
+    reopenDatabase();
+
+    final List<String> live = liveDocIds();
+    final int selfRetrieved = countDocsThatAreTheirOwnNearestNeighbour(live);
+
+    assertThat(vectorIndex().getStats().get("graphRebuildCount"))
+        .as("nothing changed between the persist and the reopen: the persisted graph must be used as it is")
+        .isEqualTo(0L);
+    assertThat(selfRetrieved).as("and it must answer correctly: %d of %d found", selfRetrieved, LIVE)
+        .isGreaterThanOrEqualTo(LIVE * 95 / 100);
+  }
+
+  /**
+   * The fingerprint has to cover the RIDs and not only the vector ids: dense {@code [0, N)} is precisely the id list
+   * that every generation of a compacted index produces, so ids alone cannot tell two of them apart.
+   */
+  @Test
+  void theFingerprintSeparatesTwoGenerationsCarryingTheSameDenseIds() {
+    final int[] denseIds = new int[LIVE];
+    for (int i = 0; i < LIVE; i++)
+      denseIds[i] = i;
+
+    final long first = LSMVectorIndexGraphManifest.fingerprintOf(denseIds,
+        id -> new com.arcadedb.database.RID(3, id));
+    final long second = LSMVectorIndexGraphManifest.fingerprintOf(denseIds,
+        id -> new com.arcadedb.database.RID(3, id + RID_SHIFT));
+
+    assertThat(second).as("same ids, other records: the fingerprint must not match").isNotEqualTo(first);
+    assertThat(LSMVectorIndexGraphManifest.fingerprintOf(denseIds, id -> new com.arcadedb.database.RID(3, id)))
+        .as("and it must be stable for the same correspondence").isEqualTo(first);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  /**
+   * Builds, in a throwaway database, a graph over records that are not the ones the test database holds, and drops
+   * it onto the test database's graph file. With {@code nodes == LIVE} the two are indistinguishable by any count:
+   * same number of nodes, and the same dense vector ids {@code [0, LIVE)}, over different records. That is exactly
+   * the pair the old check could not reject.
+   *
+   * @param databasePath the test database, closed
+   * @param nodes        how many vectors the donor graph should cover
+   * @param withManifest whether the donor's manifest travels with its graph, as the two would survive a crash
+   *                     together; false leaves the graph unaccompanied, which is what a graph persisted by a
+   *                     version older than the manifest looks like
+   */
+  private void installGraphOfAnotherGeneration(final String databasePath, final int nodes,
+      final boolean withManifest) throws IOException {
+    final String donorPath = getDatabasePath() + "-donor";
+    FileUtils.deleteRecursively(new File(donorPath));
+
+    final DatabaseFactory donorFactory = new DatabaseFactory(donorPath);
+    final Database donor = donorFactory.create();
+    try {
+      // The bucket positions are consumed BEFORE the vector index exists, so these records never reach it: the
+      // donor index ends up with dense ids [0, nodes) exactly like the test database, over higher RIDs.
+      donor.transaction(() -> {
+        donor.command("sql", "CREATE DOCUMENT TYPE Doc");
+        donor.command("sql", "CREATE PROPERTY Doc.id STRING");
+        donor.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      });
+      donor.transaction(() -> {
+        for (int i = 0; i < RID_SHIFT; i++)
+          donor.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "filler" + i, embedding(100_000 + i));
+        donor.command("sql", "DELETE FROM Doc");
+      });
+
+      donor.transaction(() -> {
+        final TypeLSMVectorIndexBuilder builder = (TypeLSMVectorIndexBuilder) donor.getSchema()
+            .buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType();
+        builder.withDimensions(DIMENSIONS).withEfSearch(EF_SEARCH).create();
+      });
+
+      insertDocs(donor, LIVE, LIVE + nodes);
+      vectorIndexOf(donor).buildVectorGraphNow();
+
+      final LSMVectorIndex index = vectorIndexOf(donor);
+      assertThat(index.getVectorIndex().size()).as("the donor graph must cover %d vectors", nodes).isEqualTo(nodes);
+      assertThat(index.getVectorIndex().getAllVectorIds().max().orElse(-1))
+          .as("and carry dense ids, so no count can tell the two graphs apart").isEqualTo(nodes - 1);
+
+      final String path = donor.getDatabasePath();
+      donor.close();
+
+      Files.copy(graphFileIn(path).toPath(), graphFileIn(databasePath).toPath(),
+          StandardCopyOption.REPLACE_EXISTING);
+
+      Files.deleteIfExists(manifestOf(databasePath));
+      if (withManifest) {
+        assertThat(manifestOf(path)).as("the donor must have recorded what its own graph covers").exists();
+        Files.copy(manifestOf(path), manifestOf(databasePath), StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      if (donor.isOpen())
+        donor.close();
+      FileUtils.deleteRecursively(new File(donorPath));
+    }
+  }
+
+  private void createSchema(final Database db) {
+    db.transaction(() -> {
+      db.command("sql", "CREATE DOCUMENT TYPE Doc");
+      db.command("sql", "CREATE PROPERTY Doc.id STRING");
+      db.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+
+      final TypeLSMVectorIndexBuilder builder = (TypeLSMVectorIndexBuilder) db.getSchema()
+          .buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType();
+      builder.withDimensions(DIMENSIONS).withEfSearch(EF_SEARCH).create();
+    });
+  }
+
+  private void insertDocs(final Database db, final int fromInclusive, final int toExclusive) {
+    db.transaction(() -> {
+      for (int i = fromInclusive; i < toExclusive; i++)
+        db.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i));
+    });
+  }
+
+  private void buildAndPersistGraph() {
+    vectorIndex().buildVectorGraphNow();
+  }
+
+  private List<String> liveDocIds() {
+    final List<String> ids = new ArrayList<>();
+    final ResultSet rs = database.query("sql", "SELECT id FROM Doc");
+    while (rs.hasNext())
+      ids.add(rs.next().getProperty("id"));
+    return ids;
+  }
+
+  /**
+   * A record's own embedding is at distance zero from itself, so a graph that describes the live set returns it
+   * first, every time. A graph whose ordinals address other records leaves the beam walking edges that mean nothing
+   * for these vectors, and the count collapses towards the beam width over the node count.
+   */
+  private int countDocsThatAreTheirOwnNearestNeighbour(final List<String> docIds) {
+    final int[] found = { 0 };
+    database.transaction(() -> {
+      for (final String id : docIds) {
+        final int doc = Integer.parseInt(id.substring("doc".length()));
+        final ResultSet rs = database.query("sql",
+            "SELECT `vector.neighbors`('Doc[embedding]', ?, 1) AS neighbors FROM schema:types LIMIT 1",
+            (Object) embedding(doc));
+        assertThat(rs.hasNext()).isTrue();
+        final List<Map<String, Object>> neighbors = rs.next().getProperty("neighbors");
+        if (neighbors != null && !neighbors.isEmpty() && id.equals(neighbors.getFirst().get("id")))
+          found[0]++;
+      }
+    });
+    return found[0];
+  }
+
+  /**
+   * Pseudo-random and unrelated between records on purpose: embeddings built from a smooth function of the record
+   * number describe the same manifold whatever the ordinal offset, so a foreign graph would keep answering
+   * correctly for the wrong reason.
+   */
+  private static float[] embedding(final int doc) {
+    final Random random = new Random(0x6106L * 31 + doc);
+    final float[] v = new float[DIMENSIONS];
+    for (int j = 0; j < DIMENSIONS; j++)
+      v[j] = (float) random.nextGaussian();
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return vectorIndexOf(database);
+  }
+
+  private static LSMVectorIndex vectorIndexOf(final Database db) {
+    return (LSMVectorIndex) ((TypeIndex) db.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+
+  private static File graphFileIn(final String databasePath) {
+    final File[] files = new File(databasePath)
+        .listFiles((dir, name) -> name.endsWith("." + LSMVectorIndexGraphFile.FILE_EXT));
+    assertThat(files).as("the index must have persisted its graph").isNotNull().hasSize(1);
+    return files[0];
+  }
+
+  private static Path manifestOf(final String databasePath) {
+    return Path.of(graphFileIn(databasePath).getPath() + "." + LSMVectorIndexGraphManifest.FILE_EXT);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifestTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphManifestTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The sidecar of {@link LSMVectorIndexGraphFile}, on its own. Every one of these behaviours decides whether a
+ * persisted graph is reused or rebuilt (issue #6106), and each is cheaper to pin here than through a database:
+ * anything this class cannot read has to read as "no manifest", never as a manifest that happens to agree.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class LSMVectorIndexGraphManifestTest {
+
+  @TempDir
+  Path directory;
+
+  @Test
+  void aWrittenManifestReadsBackAsItself() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+    final long fingerprint = LSMVectorIndexGraphManifest.fingerprintOf(new int[] { 0, 1, 2 },
+        id -> new RID(3, id * 10L));
+
+    manifest.write(3, fingerprint);
+
+    assertThat(manifest.exists()).isTrue();
+    final LSMVectorIndexGraphManifest.Content content = manifest.read();
+    assertThat(content).isNotNull();
+    assertThat(content.vectorCount()).isEqualTo(3);
+    assertThat(content.fingerprint()).as("a 64-bit fingerprint must survive the round trip whole")
+        .isEqualTo(fingerprint);
+  }
+
+  /**
+   * The fingerprint is stored as a string precisely because a JSON number decodes through a double, which cannot
+   * hold 64 significant bits. A value that exercises the low bits is the one that catches a regression here.
+   */
+  @Test
+  void aFingerprintUsingTheFullSixtyFourBitsSurvives() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+    final long awkward = -6_148_914_691_236_517_206L; // 0xAAAA...AAAA
+
+    manifest.write(7, awkward);
+
+    assertThat(manifest.read().fingerprint()).isEqualTo(awkward);
+  }
+
+  /** No live set can have a negative size, which is what makes an unusable manifest impossible to match. */
+  @Test
+  void anUnusableManifestCannotBeMatchedByAnyLiveSet() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+    manifest.write(12, 1234L);
+
+    manifest.markUnusable("simulated persist failure");
+
+    final LSMVectorIndexGraphManifest.Content content = manifest.read();
+    assertThat(content).as("it is present - absence would read as 'older version' and fall back to the node count")
+        .isNotNull();
+    assertThat(content.vectorCount()).isNegative();
+  }
+
+  @Test
+  void aTruncatedOrCorruptedManifestReadsAsAbsent() throws IOException {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+    manifest.write(5, 99L);
+
+    Files.writeString(manifestPath(), "{\"formatVersion\": 1, \"vectorCou", StandardCharsets.UTF_8);
+
+    assertThat(manifest.read()).as("unparseable must never be read as a manifest that agrees").isNull();
+  }
+
+  @Test
+  void aManifestFromAnotherLayoutReadsAsAbsent() throws IOException {
+    final JSONObject fromTheFuture = new JSONObject();
+    fromTheFuture.put("formatVersion", LSMVectorIndexGraphManifest.FORMAT_VERSION + 1);
+    fromTheFuture.put("vectorCount", 5);
+    fromTheFuture.put("fingerprint", "99");
+    Files.writeString(manifestPath(), fromTheFuture.toString(), StandardCharsets.UTF_8);
+
+    assertThat(manifest().read()).as("fields this build does not know may mean anything: rebuild instead").isNull();
+  }
+
+  @Test
+  void readingAndInvalidatingAMissingManifestAreSilentNoOps() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+
+    assertThat(manifest.exists()).isFalse();
+    assertThat(manifest.read()).isNull();
+    manifest.invalidate();
+    assertThat(manifest.exists()).isFalse();
+  }
+
+  @Test
+  void invalidateRemovesTheManifestSoNothingVouchesForThePages() {
+    final LSMVectorIndexGraphManifest manifest = manifest();
+    manifest.write(4, 7L);
+
+    manifest.invalidate();
+
+    assertThat(manifest.exists()).isFalse();
+    assertThat(manifest.read()).isNull();
+  }
+
+  /**
+   * A process killed between the temporary write and the atomic move leaves the temporary behind for good: nothing
+   * else in the engine knows the file exists. The next write sweeps it.
+   */
+  @Test
+  void aLeftoverTemporaryIsSweptByTheNextWrite() throws IOException {
+    final Path leftover = directory.resolve("graph.vecgraph." + LSMVectorIndexGraphManifest.FILE_EXT + ".dead.tmp");
+    final Path unrelated = directory.resolve("graph.vecgraph");
+    Files.writeString(leftover, "half written", StandardCharsets.UTF_8);
+    Files.writeString(unrelated, "the graph itself", StandardCharsets.UTF_8);
+
+    manifest().write(1, 1L);
+
+    assertThat(leftover).as("the sweep must remove an abandoned temporary of this manifest").doesNotExist();
+    assertThat(unrelated).as("and must match by name, so it cannot reach anything else").exists();
+    try (final Stream<Path> files = Files.list(directory)) {
+      assertThat(files.map(p -> p.getFileName().toString()).filter(n -> n.endsWith(".tmp")).toList())
+          .as("and the write must leave no temporary of its own behind").isEqualTo(List.of());
+    }
+  }
+
+  private LSMVectorIndexGraphManifest manifest() {
+    return new LSMVectorIndexGraphManifest(directory.resolve("graph.vecgraph").toString());
+  }
+
+  private Path manifestPath() {
+    return directory.resolve("graph.vecgraph." + LSMVectorIndexGraphManifest.FILE_EXT);
+  }
+}


### PR DESCRIPTION
Closes #6105

## Root cause

An `LSMVectorIndex` is named after the component file it holds, and `rewriteDataFileWithLiveEntries` (what `COMPACT INDEX` runs) swaps that file in, so the compaction reassigns `indexName` to the new component's name. That rename is deliberate - every node names the index after the file it holds, so a leader has to follow its own rename or its schema stops matching the followers that rebuilt the index from the file it shipped them. Every other index type keeps its creation name for life.

`LocalSchema.indexMap` is keyed by the name the index was registered under, and nothing re-keyed it. After a compaction the index was therefore reachable in the schema only under a name it no longer answered to.

That turns into silent data loss two lines into the commit path. Index maintenance is queued on `TransactionIndexContext` under `index.getName()`, and `TransactionIndexContext.commit()` opens with:

```java
indexEntries.keySet().removeIf(indexName -> !database.getSchema().existsIndex(indexName));
```

a filter that exists to drop the lanes of indexes dropped mid-transaction (TYPE DROP). A freshly compacted vector index matched it exactly, so its queued entries were discarded without a word. The record itself was written normally - which is why `INSERT`/`UPDATE` reported success while `countEntries()` never moved - and a database reopen rebuilds `indexMap` from the persisted (new) names, which is what made writes start landing again and made the whole thing look like a phantom.

There is a second reachable shape of the same defect, and it needs no explicit `COMPACT INDEX` at all: `LSMVectorIndex.onAfterCommit` schedules a compaction automatically once the garbage ratio warrants it, and it runs on the async executor. So a compaction can rename the index *between* an entry being queued on an open transaction and that transaction committing, on a thread that never asked for a compaction. Re-keying the registry alone does not save that transaction - its lane is keyed by the pre-compaction name, which is now the one that no longer exists.

## The fix

Two changes, both load-bearing (each was verified to be necessary by disabling it and watching the matching test go red):

1. **`LocalSchema.indexRenamed(oldName, index)`**, called from `rewriteDataFileWithLiveEntries` inside the same write-locked critical section that swaps the file and re-publishes the location index. It re-keys `indexMap`, publishing the new name *before* retiring the old one so a concurrent lookup never sees neither, and removing the old key only when it still maps to this index.

2. **`TransactionIndexContext` resolves a lane back to the `IndexInternal` it captured when the lane was opened**, instead of re-resolving it by name at commit time. The "was this index dropped?" test remains a schema lookup, but of the index's *current* name - so a renamed index is kept and a genuinely dropped one is still discarded, preserving the TYPE DROP behaviour the filter was written for. Lanes restored wholesale by `setKeys` carry no reference and fall back to the previous name lookup.

The second change also fixes a quieter consequence: `addFilesToLock` used the same name test, so a renamed index's component files were being left out of the commit lock set.

## Test plan

New `engine/src/test/java/com/arcadedb/index/vector/Issue6105WriteAfterCompactionTest.java` (4 tests, all four fail on `main`):

- [ ] `aCompactedIndexIsStillReachableUnderTheNameItAnswersTo` - the structural invariant: after a compaction the schema resolves the index under its current name, to that very instance, and the retired name is gone.
- [ ] `anInsertRightAfterACompactionIsIndexed` - the reported symptom: `countEntries()` moves, the new document has exactly one vector id, and it is found by vector search.
- [ ] `anUpdateRightAfterACompactionIsIndexed` - the update variant: the live count is unchanged (an update replaces a vector), doc0 holds a *new* vector id, and it is found at its new embedding rather than only at the pre-compaction one.
- [ ] `aWriteQueuedBeforeACompactionOnAnotherThreadIsStillIndexed` - the automatic-compaction shape: an entry queued on an open transaction survives a compaction that renames the index from another thread.

Verification run (all with `-Dmaven.repo.local` isolated):

- [ ] The four new tests fail on unmodified `main`, and specifically the fourth one still fails with change (1) applied and change (2) reverted.
- [ ] `com.arcadedb.index.vector.*Test` - the whole vector package, green.
- [ ] `com.arcadedb.index.**`, `com.arcadedb.schema.**`, `com.arcadedb.database.**`, `TransactionTest`, `LockFilesInOrderTest`: **1843 tests, 0 failures, 0 errors, 1 skipped.**
- [ ] Full reactor `test-compile` green.

`Issue5870VectorIndexIdRenumberingTest` carried a Javadoc paragraph documenting this bug as an unfixed reason for its reopen-before-insert; only that comment was updated to point at the fix and the new test. No assertion in it was touched.

## Notes for review

- `indexRenamed` is the only rename hook in the schema, and `LSMVectorIndex` is the only caller, because it is the only index that renames itself. If another index type ever gains a rename, it must call this too.
- `indexRenamed` mutates `indexMap` from whichever thread ran the compaction, which for an *automatic* compaction is the async executor rather than a user thread. `indexMap` is an unsynchronized `HashMap`, but it has always been mutated off arbitrary threads - `CREATE INDEX` / `DROP INDEX` do exactly that while queries read it - so this is not a new kind of hazard, only a more frequent one. Hardening the map (a `ConcurrentHashMap`, which would also change `getIndexByName(null)` from a `SchemaException` to an NPE) felt like a separate call to make; happy to fold it in if you'd rather have it here.
