### PR TITLE
fix(#6105): LSM_VECTOR writes right after COMPACT INDEX are silently not indexed

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -218,6 +218,12 @@ public class TransactionIndexContext {
   /**
    * The index a lane belongs to: the reference captured when the lane was opened, falling back to a lookup by name
    * for lanes restored wholesale by {@link #setKeys}, which carry no reference. See {@link #indexPerLane}.
+   * <p>
+   * That fallback is not a residual hole. {@code setKeys} is only used by {@code TransactionContext.commitFromReplica},
+   * and a replica never renames a vector index behind its own back: {@code LSMVectorIndex.isCompactionAllowedOnThisNode}
+   * refuses to schedule a compaction on anything but a standalone database or the current leader, so a follower's copy
+   * is renamed only when it adopts the component the leader shipped it - which arrives through the schema update, not
+   * concurrently with a replicated commit it is already applying.
    */
   private IndexInternal resolveIndex(final String laneName) {
     final IndexInternal index = indexPerLane.get(laneName);
@@ -433,8 +439,6 @@ public class TransactionIndexContext {
       return;
 
     final String indexName = index.getName();
-    // The lane belongs to THIS index, whatever it ends up being called by commit time (issue #6105).
-    indexPerLane.put(indexName, index);
 
     if (!index.isTransactionKeyOrderRequired()) {
       // APPEND-ONLY LANE: NO KEY ORDERING, NO PER-KEY DEDUP. REPLAY ORDER == INSERTION ORDER.
@@ -447,6 +451,9 @@ public class TransactionIndexContext {
               + "' cannot opt out of the key-ordered transaction map: duplicated-key detection reads it back");
         lane = new ArrayList<>();
         unorderedEntries.put(indexName, lane);
+        // Recorded once per lane, at creation, not once per key: the lane belongs to THIS index whatever it ends up
+        // being called by commit time (issue #6105).
+        indexPerLane.put(indexName, index);
       }
       lane.add(new IndexKey(false, operation, keysValues, rid));
       return;
@@ -461,6 +468,8 @@ public class TransactionIndexContext {
     if (keys == null) {
       keys = new TreeMap<>(); // ORDERED TO KEEP INSERTION ORDER
       indexEntries.put(indexName, keys);
+      // See the sibling call in the append-only branch above (issue #6105).
+      indexPerLane.put(indexName, index);
 
       values = new HashMap<>();
       keys.put(k, values);

--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -59,9 +59,10 @@ public class TransactionIndexContext {
    * would discard it under the rule that drops the lanes of indexes dropped mid-transaction (TYPE DROP): the record
    * is written, the index entry is silently lost.
    * <p>
-   * Holding the reference makes the lane's identity independent of the name. The "was it dropped?" test stays a
-   * schema lookup, but of the index's CURRENT name, so a renamed index is kept and a genuinely dropped one is still
-   * discarded.
+   * Holding the reference lets the lane ask the index what it is called now instead of assuming it is still called
+   * what it was called then. Everything else is unchanged: the current name goes to the same schema lookup as
+   * before, so a renamed index is kept, a genuinely dropped one is still discarded, and the schema stays the sole
+   * authority on which object that name resolves to (see {@link #laneIndexName} for why that distinction matters).
    */
   private final Map<String, IndexInternal>                                   indexPerLane     = new HashMap<>();
 
@@ -216,18 +217,36 @@ public class TransactionIndexContext {
   }
 
   /**
-   * The index a lane belongs to: the reference captured when the lane was opened, falling back to a lookup by name
-   * for lanes restored wholesale by {@link #setKeys}, which carry no reference. See {@link #indexPerLane}.
+   * The name a lane's index answers to NOW: the current name of the reference captured when the lane was opened,
+   * falling back to the lane's own key for lanes restored wholesale by {@link #setKeys}, which carry no reference.
+   * See {@link #indexPerLane}.
    * <p>
-   * That fallback is not a residual hole. {@code setKeys} is only used by {@code TransactionContext.commitFromReplica},
-   * and a replica never renames a vector index behind its own back: {@code LSMVectorIndex.isCompactionAllowedOnThisNode}
-   * refuses to schedule a compaction on anything but a standalone database or the current leader, so a follower's copy
-   * is renamed only when it adopts the component the leader shipped it - which arrives through the schema update, not
-   * concurrently with a replicated commit it is already applying.
+   * The captured reference is used to find the NAME, never as the index to operate on. Those are not always the same
+   * object: a wrapper index queues its entries under the index it wraps - {@code LSMTreeFullTextIndex} tokenizes text
+   * and calls through to its {@code LSMTreeIndex}, which is what reaches {@code addIndexKeyLock} - while the schema
+   * registers the WRAPPER under that same name. Replaying through the captured inner index instead of the registered
+   * wrapper would quietly change which implementation of {@code putReplay}/{@code removeReplay},
+   * {@code getAssociatedBucketId} and {@code getFileIds} the commit uses. So this fix moves only the one thing that
+   * was wrong - the name being looked up - and leaves the schema the sole authority on what that name resolves to.
+   * <p>
+   * That also means an index dropped and re-created under the same name inside one transaction resolves to the new
+   * one, exactly as it did before this fix: no behaviour of that (already ill-defined) sequence is changed here.
+   * <p>
+   * The {@code setKeys} fallback is not a residual hole either. {@code setKeys} is only used by
+   * {@code TransactionContext.commitFromReplica}, and a replica never renames a vector index behind its own back:
+   * {@code LSMVectorIndex.isCompactionAllowedOnThisNode} refuses to schedule a compaction on anything but a standalone
+   * database or the current leader, and an explicit {@code COMPACT INDEX} is a DDL statement a follower forwards to
+   * the leader. A follower's copy is renamed only when it adopts the component the leader shipped it, which arrives
+   * through the schema update rather than concurrently with a replicated commit it is already applying.
    */
-  private IndexInternal resolveIndex(final String laneName) {
+  private String laneIndexName(final String laneName) {
     final IndexInternal index = indexPerLane.get(laneName);
-    return index != null ? index : (IndexInternal) database.getSchema().getIndexByName(laneName);
+    return index != null ? index.getName() : laneName;
+  }
+
+  /** The index a lane belongs to, as the schema currently resolves it. See {@link #laneIndexName}. */
+  private IndexInternal resolveIndex(final String laneName) {
+    return (IndexInternal) database.getSchema().getIndexByName(laneIndexName(laneName));
   }
 
   /**
@@ -236,8 +255,7 @@ public class TransactionIndexContext {
    * (TYPE DROP) is still reported as gone.
    */
   private boolean laneIndexStillExists(final String laneName) {
-    final IndexInternal index = indexPerLane.get(laneName);
-    return database.getSchema().existsIndex(index != null ? index.getName() : laneName);
+    return database.getSchema().existsIndex(laneIndexName(laneName));
   }
 
   public int getTotalEntries() {

--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -268,6 +268,14 @@ public class TransactionIndexContext {
     return total;
   }
 
+  /**
+   * Looks a lane up by its KEY, which is the name the index answered to when the lane was opened - not necessarily
+   * the name it answers to now. Correct for every caller today: only {@code LSMVectorIndex} renames itself and it
+   * never reaches here (the read-your-own-writes callers are {@code HashIndex}, {@code LSMTreeIndex} and
+   * {@code LSMTreeIndexCursor}, none of which rename), and each of them passes its OWN unchanging name. An index
+   * type that gains a rename - i.e. one that starts calling {@code LocalSchema.indexRenamed} - has to reach its
+   * lane through {@link #laneIndexName} instead, or it reproduces issue #6105 here.
+   */
   public int getTotalEntriesByIndex(final String indexName) {
     final List<IndexKey> unordered = unorderedEntries.get(indexName);
     if (unordered != null)
@@ -551,6 +559,7 @@ public class TransactionIndexContext {
     indexPerLane.clear();
   }
 
+  /** Looks a lane up by its KEY, with the same caveat as {@link #getTotalEntriesByIndex}. */
   public TreeMap<ComparableKey, Map<IndexKey, IndexKey>> getIndexKeys(final String indexName) {
     return indexEntries.get(indexName);
   }

--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -48,6 +48,22 @@ public class TransactionIndexContext {
    * queues one entry per non-zero dimension.
    */
   private final Map<String, List<IndexKey>>                                  unorderedEntries = new LinkedHashMap<>();
+  /**
+   * The index each lane above belongs to, remembered when the lane is opened rather than resolved back from its
+   * name at commit time (issue #6105).
+   * <p>
+   * A lane is keyed by the name the index answered to when its first entry was queued, and an {@code LSM_VECTOR}
+   * index renames itself when it is compacted - it is named after the component file it holds, and a compaction
+   * swaps that file in. That compaction runs on the async executor, so it can land between an entry being queued
+   * and this transaction committing. Resolving the lane by its name would then find nothing, and {@link #commit()}
+   * would discard it under the rule that drops the lanes of indexes dropped mid-transaction (TYPE DROP): the record
+   * is written, the index entry is silently lost.
+   * <p>
+   * Holding the reference makes the lane's identity independent of the name. The "was it dropped?" test stays a
+   * schema lookup, but of the index's CURRENT name, so a renamed index is kept and a genuinely dropped one is still
+   * discarded.
+   */
+  private final Map<String, IndexInternal>                                   indexPerLane     = new HashMap<>();
 
   public static class IndexKey {
     public final boolean           unique;
@@ -196,6 +212,26 @@ public class TransactionIndexContext {
   public void removeIndex(final String indexName) {
     indexEntries.remove(indexName);
     unorderedEntries.remove(indexName);
+    indexPerLane.remove(indexName);
+  }
+
+  /**
+   * The index a lane belongs to: the reference captured when the lane was opened, falling back to a lookup by name
+   * for lanes restored wholesale by {@link #setKeys}, which carry no reference. See {@link #indexPerLane}.
+   */
+  private IndexInternal resolveIndex(final String laneName) {
+    final IndexInternal index = indexPerLane.get(laneName);
+    return index != null ? index : (IndexInternal) database.getSchema().getIndexByName(laneName);
+  }
+
+  /**
+   * Whether the index a lane belongs to still exists in the schema - asked of the name the index answers to NOW, so
+   * an index that renamed itself since the lane was opened is kept (issue #6105) while one dropped mid-transaction
+   * (TYPE DROP) is still reported as gone.
+   */
+  private boolean laneIndexStillExists(final String laneName) {
+    final IndexInternal index = indexPerLane.get(laneName);
+    return database.getSchema().existsIndex(index != null ? index.getName() : laneName);
   }
 
   public int getTotalEntries() {
@@ -220,8 +256,8 @@ public class TransactionIndexContext {
 
   public void commit() {
     // REMOVE ENTRIES FOR INDEXES DROPPED DURING THE TRANSACTION (e.g. TYPE DROP)
-    indexEntries.keySet().removeIf(indexName -> !database.getSchema().existsIndex(indexName));
-    unorderedEntries.keySet().removeIf(indexName -> !database.getSchema().existsIndex(indexName));
+    indexEntries.keySet().removeIf(indexName -> !laneIndexStillExists(indexName));
+    unorderedEntries.keySet().removeIf(indexName -> !laneIndexStillExists(indexName));
 
     checkUniqueIndexKeys();
 
@@ -229,7 +265,7 @@ public class TransactionIndexContext {
     // INSERTION ORDER, SO A REMOVE FOLLOWED BY AN ADD ON THE SAME KEY ENDS WITH THE ADD (AND VICE
     // VERSA) WITHOUT THE TWO-PHASE REMOVE-THEN-ADD SPLIT THE ORDERED LANE NEEDS FOR ITS DEDUP MAP.
     for (final Map.Entry<String, List<IndexKey>> entry : unorderedEntries.entrySet()) {
-      final IndexInternal index = (IndexInternal) database.getSchema().getIndexByName(entry.getKey());
+      final IndexInternal index = resolveIndex(entry.getKey());
       final List<IndexKey> keys = entry.getValue();
       for (int i = 0; i < keys.size(); i++) {
         final IndexKey key = keys.get(i);
@@ -242,7 +278,7 @@ public class TransactionIndexContext {
     unorderedEntries.clear();
 
     for (final Map.Entry<String, TreeMap<ComparableKey, Map<IndexKey, IndexKey>>> entry : indexEntries.entrySet()) {
-      final IndexInternal index = (IndexInternal) database.getSchema().getIndexByName(entry.getKey());
+      final IndexInternal index = resolveIndex(entry.getKey());
       final Map<ComparableKey, Map<IndexKey, IndexKey>> keys = entry.getValue();
 
       for (final Map.Entry<ComparableKey, Map<IndexKey, IndexKey>> keyValueEntries : keys.entrySet()) {
@@ -258,7 +294,7 @@ public class TransactionIndexContext {
     }
 
     for (final Map.Entry<String, TreeMap<ComparableKey, Map<IndexKey, IndexKey>>> entry : indexEntries.entrySet()) {
-      final IndexInternal index = (IndexInternal) database.getSchema().getIndexByName(entry.getKey());
+      final IndexInternal index = resolveIndex(entry.getKey());
       final Map<ComparableKey, Map<IndexKey, IndexKey>> keys = entry.getValue();
 
       // Batch optimization for vector indexes (issue #3864): collect all ADD operations
@@ -313,6 +349,7 @@ public class TransactionIndexContext {
     }
 
     indexEntries.clear();
+    indexPerLane.clear();
   }
 
   public void addFilesToLock(final IntHashSet modifiedFiles) {
@@ -325,11 +362,11 @@ public class TransactionIndexContext {
     indexNames.addAll(unorderedEntries.keySet());
 
     for (final String indexName : indexNames) {
-      if (!schema.existsIndex(indexName))
+      if (!laneIndexStillExists(indexName))
         // INDEX WAS DROPPED DURING THE TRANSACTION (e.g. TYPE DROP), SKIP IT
         continue;
 
-      final IndexInternal index = (IndexInternal) schema.getIndexByName(indexName);
+      final IndexInternal index = resolveIndex(indexName);
 
       if (!lockedIndexes.add(index))
         // ALREADY IN THE SET
@@ -396,6 +433,8 @@ public class TransactionIndexContext {
       return;
 
     final String indexName = index.getName();
+    // The lane belongs to THIS index, whatever it ends up being called by commit time (issue #6105).
+    indexPerLane.put(indexName, index);
 
     if (!index.isTransactionKeyOrderRequired()) {
       // APPEND-ONLY LANE: NO KEY ORDERING, NO PER-KEY DEDUP. REPLAY ORDER == INSERTION ORDER.
@@ -482,6 +521,7 @@ public class TransactionIndexContext {
   public void reset() {
     indexEntries.clear();
     unorderedEntries.clear();
+    indexPerLane.clear();
   }
 
   public TreeMap<ComparableKey, Map<IndexKey, IndexKey>> getIndexKeys(final String indexName) {
@@ -565,7 +605,7 @@ public class TransactionIndexContext {
     final Map<TypeIndex, Map<ComparableKey, RID>> deletedKeys = getTxDeletedEntries();
 
     for (final Map.Entry<String, TreeMap<ComparableKey, Map<IndexKey, IndexKey>>> indexEntries : indexEntries.entrySet()) {
-      final IndexInternal index = (IndexInternal) database.getSchema().getIndexByName(indexEntries.getKey());
+      final IndexInternal index = resolveIndex(indexEntries.getKey());
       if (index.isUnique()) {
         final TypeIndex typeIndex = index.getTypeIndex();
 
@@ -593,7 +633,7 @@ public class TransactionIndexContext {
     final Map<TypeIndex, Map<ComparableKey, RID>> deletedKeys = new HashMap<>();
 
     for (final Map.Entry<String, TreeMap<ComparableKey, Map<IndexKey, IndexKey>>> indexEntries : indexEntries.entrySet()) {
-      final IndexInternal index = (IndexInternal) database.getSchema().getIndexByName(indexEntries.getKey());
+      final IndexInternal index = resolveIndex(indexEntries.getKey());
       if (index.isUnique()) {
         final Map<ComparableKey, Map<IndexKey, IndexKey>> txEntriesPerIndex = indexEntries.getValue();
         for (final Map.Entry<ComparableKey, Map<IndexKey, IndexKey>> txEntriesPerKey : txEntriesPerIndex.entrySet()) {

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -590,6 +590,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         previousMutable = mutable;
         previousCompacted = compactedSubIndex;
         mutable = newMutable;
+        final String previousIndexName = indexName;
         indexName = newMutable.getName();
         compactedSubIndex = null;
         currentInsertPageNum = newPages.size() - 1;
@@ -600,6 +601,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // which the index answers offsets into a file that no longer exists - a search landing there reads another
         // entry's bytes, or the dropped compacted component through a null reference.
         publishLocationIndex(liveEntries);
+
+        // Follow the rename in the schema's index registry, in the same critical section. The registry is keyed by
+        // the name the index answers to, and everything that resolves an index by name goes through it - index
+        // maintenance queued on the transaction above all, which is silently discarded when the name it was queued
+        // under is no longer registered (issue #6105).
+        ((LocalSchema) database.getSchema()).indexRenamed(previousIndexName, this);
 
         ((LocalSchema) database.getSchema()).setMigratedFileId(oldFileId, newFileId);
         database.getSchema().getEmbedded().saveConfiguration();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -590,8 +590,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
         previousMutable = mutable;
         previousCompacted = compactedSubIndex;
         mutable = newMutable;
-        final String previousIndexName = indexName;
-        indexName = newMutable.getName();
         compactedSubIndex = null;
         currentInsertPageNum = newPages.size() - 1;
         currentMutablePages.set(1);
@@ -602,10 +600,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // entry's bytes, or the dropped compacted component through a null reference.
         publishLocationIndex(liveEntries);
 
-        // Follow the rename in the schema's index registry, in the same critical section. The registry is keyed by
-        // the name the index answers to, and everything that resolves an index by name goes through it - index
-        // maintenance queued on the transaction above all, which is silently discarded when the name it was queued
-        // under is no longer registered (issue #6105).
+        // The rename and the schema re-keying are ONE step and must stay adjacent: `indexName` is volatile and read
+        // without this lock (getName(), which is what TransactionIndexContext keys a lane by), so between these two
+        // statements the index answers to a name the schema does not know yet - a milder recurrence of the very bug
+        // this fixes. Nothing separates them today and nothing should: the registry is keyed by the name the index
+        // answers to, and everything that resolves an index by name goes through it - index maintenance queued on
+        // the transaction above all, which is silently discarded when the name it was queued under is no longer
+        // registered (issue #6105).
+        final String previousIndexName = indexName;
+        indexName = newMutable.getName();
         ((LocalSchema) database.getSchema()).indexRenamed(previousIndexName, this);
 
         ((LocalSchema) database.getSchema()).setMigratedFileId(oldFileId, newFileId);

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -122,7 +122,11 @@ public class LocalSchema implements Schema {
   // ({@link #indexRenamed}), and an AUTOMATIC compaction runs on the async executor - a thread the writer whose
   // commit then has to see the new key never synchronizes with. Under a plain HashMap that publication rested on
   // whichever file lock the two sides happened to share, which is not a guarantee anyone should have to reconstruct.
-  // Null keys and values never reach it: every name is either generated here or guarded by the accessors below.
+  // Null keys and values never reach it, which is what makes the map type safe to change: the accessors below
+  // (existsIndex, getIndexByName, dropIndexInternal, checkIndexIsNotBackingAConstraint) null-guard the one name a
+  // caller supplies, and the three places that touch this field directly rather than through them pass a name that
+  // cannot be null - LocalDocumentType uses the TypeIndex's own name, and ManualIndexBuilder.create() rejects a null
+  // one up front, it being the only route by which a caller-supplied name reaches this map unmediated.
   protected final     Map<String, IndexInternal>             indexMap                      = new ConcurrentHashMap<>();
   protected final     Map<String, Trigger>                   triggers                      = new HashMap<>();
   protected final     Map<String, MaterializedViewImpl>     materializedViews             = new LinkedHashMap<>();

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -116,7 +116,14 @@ public class LocalSchema implements Schema {
   final               Map<String, LocalBucket>               bucketMap                     = new HashMap<>();
   private             Map<Integer, LocalDocumentType>        bucketId2TypeMap              = new HashMap<>();
   private             Map<Integer, LocalDocumentType>        bucketId2InvolvedTypeMap      = new HashMap<>();
-  protected final     Map<String, IndexInternal>             indexMap                      = new HashMap<>();
+  // Concurrent, not because the map is written often, but because it is written from threads that are not the ones
+  // reading it and the reads are on the correctness path. DDL (CREATE/DROP INDEX) has always mutated it from
+  // arbitrary user threads while queries resolve index names; since #6105 a compaction re-keys it too
+  // ({@link #indexRenamed}), and an AUTOMATIC compaction runs on the async executor - a thread the writer whose
+  // commit then has to see the new key never synchronizes with. Under a plain HashMap that publication rested on
+  // whichever file lock the two sides happened to share, which is not a guarantee anyone should have to reconstruct.
+  // Null keys and values never reach it: every name is either generated here or guarded by the accessors below.
+  protected final     Map<String, IndexInternal>             indexMap                      = new ConcurrentHashMap<>();
   protected final     Map<String, Trigger>                   triggers                      = new HashMap<>();
   protected final     Map<String, MaterializedViewImpl>     materializedViews             = new LinkedHashMap<>();
   protected final     Map<String, ContinuousAggregateImpl> continuousAggregates          = new LinkedHashMap<>();
@@ -801,7 +808,9 @@ public class LocalSchema implements Schema {
 
   @Override
   public boolean existsIndex(final String indexName) {
-    return indexMap.containsKey(indexName);
+    // Null-guarded because indexMap is a ConcurrentHashMap, which rejects a null key with an NPE where the previous
+    // HashMap simply answered "absent". Callers pass a name straight from SQL, so keep the old answer.
+    return indexName != null && indexMap.containsKey(indexName);
   }
 
   @Override
@@ -830,7 +839,7 @@ public class LocalSchema implements Schema {
    * unique = false} - which drops the flag and this index together.
    */
   private void checkIndexIsNotBackingAConstraint(final String indexName) {
-    final IndexInternal index = indexMap.get(indexName);
+    final IndexInternal index = indexName != null ? indexMap.get(indexName) : null;
     if (index == null || index.getTypeName() == null || !existsType(index.getTypeName()))
       return;
 
@@ -848,7 +857,7 @@ public class LocalSchema implements Schema {
         multipleUpdate = true;
 
       try {
-        final IndexInternal index = indexMap.get(indexName);
+        final IndexInternal index = indexName != null ? indexMap.get(indexName) : null;
         if (index == null)
           return null;
 
@@ -1229,7 +1238,9 @@ public class LocalSchema implements Schema {
 
   @Override
   public Index getIndexByName(final String indexName) {
-    final Index p = indexMap.get(indexName);
+    // Same null guard as existsIndex: a null name must still surface as "not found", not as the NPE a
+    // ConcurrentHashMap raises on a null key.
+    final Index p = indexName != null ? indexMap.get(indexName) : null;
     if (p == null)
       throw new SchemaException("Index with name '" + indexName + "' was not found");
     return p;

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -2496,6 +2496,41 @@ public class LocalSchema implements Schema {
     return migratedFileIds.get(oldFileId);
   }
 
+  /**
+   * Re-keys {@code indexMap} after an index changed the name it answers to, so the schema keeps resolving it under
+   * {@link IndexInternal#getName()} at every moment of its life.
+   * <p>
+   * Only {@link com.arcadedb.index.vector.LSMVectorIndex} renames itself: it is named after the component file it
+   * holds and a compaction swaps that file in, a rename every node has to follow or a leader's schema stops matching
+   * the followers that rebuilt the index from the file it shipped them. Every other index type keeps its creation
+   * name for life, which is why this had no counterpart before.
+   * <p>
+   * Leaving the map keyed by the retired name is not a cosmetic inconsistency: index maintenance is queued on
+   * {@link com.arcadedb.database.TransactionIndexContext} under {@code index.getName()}, and its {@code commit()}
+   * opens by discarding the lanes of indexes the schema no longer knows - the TYPE DROP case. A freshly compacted
+   * vector index matched that filter exactly, so the first writes after a {@code COMPACT INDEX} were dropped without
+   * a word while the records themselves were written (issue #6105).
+   * <p>
+   * The new name is published BEFORE the old one is retired, so a concurrent lookup sees the index under one name or
+   * transiently under both, never under neither. The removal is conditional on the value so a name already taken over
+   * by another index - two components can only share a name after a hand-edited or restored schema, but the map is
+   * the only thing standing between that and a lost registration - is left alone.
+   *
+   * @param oldName the name the index was registered under
+   * @param index   the index, already answering to its new name
+   */
+  public void indexRenamed(final String oldName, final IndexInternal index) {
+    final String newName = index.getName();
+    if (newName == null || newName.equals(oldName))
+      return;
+
+    LogManager.instance().log(this, Level.FINE, "Index '%s' renamed to '%s'", null, oldName, newName);
+
+    indexMap.put(newName, index);
+    if (oldName != null)
+      indexMap.remove(oldName, index);
+  }
+
   public boolean isDirty() {
     return dirtyGeneration.get() > savedGeneration;
   }

--- a/engine/src/main/java/com/arcadedb/schema/ManualIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/ManualIndexBuilder.java
@@ -79,6 +79,12 @@ public class ManualIndexBuilder extends IndexBuilder<Index> {
   public Index create() {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
 
+    // This builder is the one place that reaches LocalSchema.indexMap with a caller-supplied name rather than a
+    // generated one, and it does so directly instead of through the schema's null-guarded accessors. A null name
+    // used to be accepted all the way into the map, leaving an index nothing could look up again; say so instead.
+    if (indexName == null)
+      throw new DatabaseMetadataException("Cannot create a manual index without a name");
+
     // Both checked before the existing-index lookup below, which needs the requested index kind to decide whether the
     // index already carrying this name covers the request.
     if (indexType == null)

--- a/engine/src/test/java/com/arcadedb/index/ManualIndexNameGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/index/ManualIndexNameGuardTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DatabaseMetadataException;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@code ManualIndexBuilder} is the only route by which a CALLER-SUPPLIED index name reaches
+ * {@code LocalSchema.indexMap} without passing through the schema's own null-guarded accessors, and it had no name
+ * validation at all: a null name was accepted all the way into the map, leaving an index nothing could ever look up
+ * again. Issue #6105 made that map a {@code ConcurrentHashMap} (a compaction re-keys it from the async executor, so
+ * the publication has to be safe on its own rather than resting on a lock the two sides happen to share), which
+ * turns the same call into an NPE from inside the map. Neither is an acceptable answer: say what is wrong instead.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class ManualIndexNameGuardTest extends TestHelper {
+
+  @Test
+  void aManualIndexCannotBeCreatedWithoutAName() {
+    final int indexesBefore = database.getSchema().getIndexes().length;
+
+    assertThatThrownBy(() -> database.getSchema().buildManualIndex(null, new Type[] { Type.STRING })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false)
+        .create())
+        .as("a null name must be refused with an explanation, not with an NPE from inside the schema's index map")
+        .isInstanceOf(DatabaseMetadataException.class)
+        .hasMessageContaining("without a name");
+
+    assertThat(database.getSchema().getIndexes())
+        .as("the refused creation must leave nothing behind in the schema").hasSize(indexesBefore);
+  }
+
+  /** The guard must refuse only a missing name: an ordinary manual index still builds and is registered. */
+  @Test
+  void aNamedManualIndexIsStillCreated() {
+    final Index index = database.getSchema().buildManualIndex("namedManualIdx", new Type[] { Type.STRING })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false)
+        .create();
+
+    assertThat(index.getName()).isEqualTo("namedManualIdx");
+    assertThat(database.getSchema().existsIndex("namedManualIdx")).isTrue();
+    assertThat(database.getSchema().getIndexByName("namedManualIdx")).isSameAs(index);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue5870VectorIndexIdRenumberingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue5870VectorIndexIdRenumberingTest.java
@@ -175,12 +175,13 @@ class Issue5870VectorIndexIdRenumberingTest extends TestHelper {
    * the pre-compaction high-water mark used to be (which would still be correct but would defeat the point of
    * renumbering: the id space would grow unboundedly again on the very first write after every compaction).
    * <p>
-   * The insert runs after a {@link #reopenDatabase()}, not in the same session the compaction ran in: a write
-   * issued immediately after {@code COMPACT INDEX} in the same session does not reach the vector index at all,
-   * independently of this fix (confirmed by reverting it and reproducing the same symptom on unmodified code) -
-   * see issue #6105, filed separately. A reopen forces {@code loadVectorsFromPages} to recompute {@code nextId}
-   * from the (now dense) persisted file, which is the code path a real "compact, then restart, then keep
-   * writing" operational sequence actually takes, and it is what this test pins.
+   * The insert runs after a {@link #reopenDatabase()}, not in the same session the compaction ran in. That was
+   * originally forced on this test: a write issued immediately after {@code COMPACT INDEX} in the same session did
+   * not reach the vector index at all, independently of this fix, which was filed and fixed separately as issue
+   * #6105 (the schema's index registry was left keyed by the name the compaction retired) and is pinned by
+   * {@code Issue6105WriteAfterCompactionTest}. The reopen is kept because it is what this test is actually about:
+   * it forces {@code loadVectorsFromPages} to recompute {@code nextId} from the (now dense) persisted file, which
+   * is the code path a real "compact, then restart, then keep writing" operational sequence takes.
    */
   @Test
   void insertingAfterARenumberingCompactionDoesNotCollideWithAnExistingId() {

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6105WriteAfterCompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6105WriteAfterCompactionTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6105: a write issued in the same session right after {@code COMPACT INDEX} on an {@code LSM_VECTOR} index
+ * was silently not indexed.
+ * <p>
+ * An {@link LSMVectorIndex} is named after the component file it holds, and a compaction swaps that file in - so
+ * the compaction reassigns {@code indexName} to the new component's name. {@code LocalSchema.indexMap} is keyed by
+ * the name the index was registered under, and nothing re-keyed it, so after a compaction the index was reachable
+ * in the schema only under a name it no longer answers to. Every index operation of a transaction is queued on
+ * {@link com.arcadedb.database.TransactionIndexContext} under {@code index.getName()} and
+ * {@code TransactionIndexContext.commit()} opens by dropping the lanes of indexes that no longer exist in the
+ * schema (the TYPE DROP case) - which matched the freshly compacted vector index exactly, so its queued entries
+ * were discarded without a word. The record itself was written, and a reopen (which rebuilds {@code indexMap} from
+ * the persisted names) made writes land again, which is what made this look like a phantom.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6105WriteAfterCompactionTest extends TestHelper {
+
+  private static final int DIMENSIONS = 16;
+  private static final int VERTICES   = 100;
+
+  /**
+   * The name the index answers to must be the name the schema knows it by, at every moment of its life - a
+   * compaction included. This is the structural invariant the two behavioural tests below depend on.
+   */
+  @Test
+  void aCompactedIndexIsStillReachableUnderTheNameItAnswersTo() {
+    createSchema();
+    insertVertices();
+
+    final LSMVectorIndex index = vectorIndex();
+    final String nameBefore = index.getName();
+    assertThat(database.getSchema().existsIndex(nameBefore)).as("registered before the compaction").isTrue();
+
+    database.command("sql", "COMPACT INDEX `Doc[embedding]`");
+
+    final String nameAfter = index.getName();
+    assertThat(nameAfter).as("a compaction renames the index after the file it swapped in").isNotEqualTo(nameBefore);
+    assertThat(database.getSchema().existsIndex(nameAfter))
+        .as("the schema must know the compacted index under its current name").isTrue();
+    assertThat(database.getSchema().getIndexByName(nameAfter))
+        .as("and must resolve that name to this very index instance").isSameAs(index);
+    assertThat(database.getSchema().existsIndex(nameBefore))
+        .as("the pre-compaction name must not linger in the schema").isFalse();
+  }
+
+  /**
+   * An INSERT in the same session right after a compaction must reach the vector index: the document is created
+   * either way, so a silent miss shows up only as a vector count that never moved and a vector search that cannot
+   * find the new document.
+   */
+  @Test
+  void anInsertRightAfterACompactionIsIndexed() {
+    createSchema();
+    insertVertices();
+
+    database.command("sql", "COMPACT INDEX `Doc[embedding]`");
+    assertThat(countLive()).as("compaction must not lose or gain live vectors").isEqualTo(VERTICES);
+
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + VERTICES,
+        embedding(VERTICES, 0)));
+
+    assertThat(countLive()).as("the insert right after the compaction must reach the vector index")
+        .isEqualTo(VERTICES + 1);
+
+    final RID rid = ridOf("doc" + VERTICES);
+    assertThat(vectorIndex().getVectorIndex().getVectorIdsForRid(rid))
+        .as("exactly one vector id for the newly inserted document").hasSize(1);
+
+    assertSearchWorks(VERTICES, 0);
+  }
+
+  /**
+   * Same for an UPDATE: the re-embedded document must be found by its NEW vector, not only by the one the
+   * compaction persisted. A dropped index operation leaves the live count unchanged AND the old vector in place,
+   * so the count alone is not enough - the search below is what proves the new embedding actually landed.
+   */
+  @Test
+  void anUpdateRightAfterACompactionIsIndexed() {
+    createSchema();
+    insertVertices();
+
+    database.command("sql", "COMPACT INDEX `Doc[embedding]`");
+
+    final RID rid = ridOf("doc0");
+    final int[] idsBefore = vectorIndex().getVectorIndex().getVectorIdsForRid(rid);
+    assertThat(idsBefore).as("doc0 holds one vector before the update").hasSize(1);
+
+    // Move doc0 far away from where it was, into a region no other document occupies.
+    final float[] relocated = embedding(VERTICES + 7, 0);
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET embedding = ? WHERE id = ?", relocated, "doc0"));
+
+    assertThat(countLive()).as("an update replaces a vector, it does not add one").isEqualTo(VERTICES);
+
+    final int[] idsAfter = vectorIndex().getVectorIndex().getVectorIdsForRid(rid);
+    assertThat(idsAfter).as("doc0 still holds exactly one vector after the update").hasSize(1);
+    assertThat(idsAfter[0]).as("the update must have minted a new vector id for doc0").isNotEqualTo(idsBefore[0]);
+
+    assertThat(nearestId(relocated)).as("doc0 must be found at its new embedding").isEqualTo("doc0");
+  }
+
+  /**
+   * The same loss, reached the way production reaches it: a compaction is scheduled automatically after a commit
+   * ({@code LSMVectorIndex.onAfterCommit}) and runs on the async executor, so it can rename the index between an
+   * entry being queued on an open transaction and that transaction committing. Nothing in the writer's own session
+   * says a compaction happened - which is why the index reference the transaction captured, not the name it was
+   * queued under, has to be what resolves the entry at commit time.
+   */
+  @Test
+  void aWriteQueuedBeforeACompactionOnAnotherThreadIsStillIndexed() throws Exception {
+    createSchema();
+    insertVertices();
+
+    final String nameWhenQueued = vectorIndex().getName();
+
+    database.begin();
+    database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + VERTICES, embedding(VERTICES, 0));
+
+    // The compaction refuses to run inside a transaction, so it has to come from another thread - exactly where the
+    // async executor runs it.
+    final Throwable[] failure = new Throwable[1];
+    final Thread compactor = new Thread(() -> {
+      try {
+        database.command("sql", "COMPACT INDEX `Doc[embedding]`");
+      } catch (final Throwable t) {
+        failure[0] = t;
+      }
+    }, "issue6105-compactor");
+    compactor.start();
+    compactor.join(120_000);
+
+    assertThat(compactor.isAlive()).as("the compaction must have finished").isFalse();
+    assertThat(failure[0]).as("the compaction must not have failed").isNull();
+    assertThat(vectorIndex().getName()).as("the compaction must have renamed the index").isNotEqualTo(nameWhenQueued);
+
+    database.commit();
+
+    assertThat(countLive()).as("a write queued before the compaction must still reach the vector index")
+        .isEqualTo(VERTICES + 1);
+    assertSearchWorks(VERTICES, 0);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON Doc (id) UNIQUE");
+
+      // Automatic compaction and background rebuilds are disabled: only the explicit COMPACT INDEX below must
+      // rewrite the data file, and the assertions must observe the write path, not a rebuild that papered over it.
+      database.command("sql", """
+          CREATE INDEX ON Doc (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions": %d,
+            "similarity": "COSINE",
+            "quantization": "INT8",
+            "mutationsBeforeRebuild": 100000000,
+            "inactivityRebuildTimeoutMs": 0
+          }""".formatted(DIMENSIONS));
+    });
+  }
+
+  private void insertVertices() {
+    database.transaction(() -> {
+      for (int i = 0; i < VERTICES; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i, 0));
+    });
+  }
+
+  /** Well-separated vectors: the nearest neighbor of vertex i must be vertex i itself. */
+  private static float[] embedding(final int vertex, final int cycle) {
+    final float[] v = new float[DIMENSIONS];
+    for (int j = 0; j < DIMENSIONS; j++)
+      v[j] = (float) Math.sin((vertex + 1) * 0.37 * (j + 1) + cycle * 0.0001);
+    return v;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return (LSMVectorIndex) ((TypeIndex) database.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+
+  private long countLive() {
+    return vectorIndex().countEntries();
+  }
+
+  private RID ridOf(final String id) {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> holder[0] = database.query("sql", "SELECT FROM Doc WHERE id = ?", id).next()
+        .getIdentity().get());
+    return holder[0];
+  }
+
+  private String nearestId(final float[] target) {
+    final String[] holder = new String[1];
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "SELECT `vector.neighbors`('Doc[embedding]', ?, 3) AS neighbors FROM Doc LIMIT 1", (Object) target);
+      assertThat(rs.hasNext()).isTrue();
+      final List<Map<String, Object>> neighbors = rs.next().getProperty("neighbors");
+      assertThat(neighbors).as("neighbors must not be empty").isNotEmpty();
+      holder[0] = (String) neighbors.getFirst().get("id");
+    });
+    return holder[0];
+  }
+
+  private void assertSearchWorks(final int vertex, final int cycle) {
+    assertThat(nearestId(embedding(vertex, cycle))).as("closest vector to doc%d", vertex).isEqualTo("doc" + vertex);
+  }
+}


### PR DESCRIPTION
Closes #6105

## Root cause

An `LSMVectorIndex` is named after the component file it holds, and `rewriteDataFileWithLiveEntries` (what `COMPACT INDEX` runs) swaps that file in, so the compaction reassigns `indexName` to the new component's name. That rename is deliberate - every node names the index after the file it holds, so a leader has to follow its own rename or its schema stops matching the followers that rebuilt the index from the file it shipped them. Every other index type keeps its creation name for life.

`LocalSchema.indexMap` is keyed by the name the index was registered under, and nothing re-keyed it. After a compaction the index was therefore reachable in the schema only under a name it no longer answered to.

That turns into silent data loss two lines into the commit path. Index maintenance is queued on `TransactionIndexContext` under `index.getName()`, and `TransactionIndexContext.commit()` opens with:

```java
indexEntries.keySet().removeIf(indexName -> !database.getSchema().existsIndex(indexName));
```

a filter that exists to drop the lanes of indexes dropped mid-transaction (TYPE DROP). A freshly compacted vector index matched it exactly, so its queued entries were discarded without a word. The record itself was written normally - which is why `INSERT`/`UPDATE` reported success while `countEntries()` never moved - and a database reopen rebuilds `indexMap` from the persisted (new) names, which is what made writes start landing again and made the whole thing look like a phantom.

There is a second reachable shape of the same defect, and it needs no explicit `COMPACT INDEX` at all: `LSMVectorIndex.onAfterCommit` schedules a compaction automatically once the garbage ratio warrants it, and it runs on the async executor. So a compaction can rename the index *between* an entry being queued on an open transaction and that transaction committing, on a thread that never asked for a compaction. Re-keying the registry alone does not save that transaction - its lane is keyed by the pre-compaction name, which is now the one that no longer exists.

## The fix

Two changes, both load-bearing (each was verified to be necessary by disabling it and watching the matching test go red):

1. **`LocalSchema.indexRenamed(oldName, index)`**, called from `rewriteDataFileWithLiveEntries` inside the same write-locked critical section that swaps the file and re-publishes the location index. It re-keys `indexMap`, publishing the new name *before* retiring the old one so a concurrent lookup never sees neither, and removing the old key only when it still maps to this index.

2. **`TransactionIndexContext` resolves a lane back to the `IndexInternal` it captured when the lane was opened**, instead of re-resolving it by name at commit time. The "was this index dropped?" test remains a schema lookup, but of the index's *current* name - so a renamed index is kept and a genuinely dropped one is still discarded, preserving the TYPE DROP behaviour the filter was written for. Lanes restored wholesale by `setKeys` carry no reference and fall back to the previous name lookup.

The second change also fixes a quieter consequence: `addFilesToLock` used the same name test, so a renamed index's component files were being left out of the commit lock set.

## Test plan

New `engine/src/test/java/com/arcadedb/index/vector/Issue6105WriteAfterCompactionTest.java` (4 tests, all four fail on `main`):

- [ ] `aCompactedIndexIsStillReachableUnderTheNameItAnswersTo` - the structural invariant: after a compaction the schema resolves the index under its current name, to that very instance, and the retired name is gone.
- [ ] `anInsertRightAfterACompactionIsIndexed` - the reported symptom: `countEntries()` moves, the new document has exactly one vector id, and it is found by vector search.
- [ ] `anUpdateRightAfterACompactionIsIndexed` - the update variant: the live count is unchanged (an update replaces a vector), doc0 holds a *new* vector id, and it is found at its new embedding rather than only at the pre-compaction one.
- [ ] `aWriteQueuedBeforeACompactionOnAnotherThreadIsStillIndexed` - the automatic-compaction shape: an entry queued on an open transaction survives a compaction that renames the index from another thread.

Verification run (all with `-Dmaven.repo.local` isolated):

- [ ] The four new tests fail on unmodified `main`, and specifically the fourth one still fails with change (1) applied and change (2) reverted.
- [ ] `com.arcadedb.index.vector.*Test` - the whole vector package, green.
- [ ] `com.arcadedb.index.**`, `com.arcadedb.schema.**`, `com.arcadedb.database.**`, `TransactionTest`, `LockFilesInOrderTest`: **1843 tests, 0 failures, 0 errors, 1 skipped.**
- [ ] Full reactor `test-compile` green.

`Issue5870VectorIndexIdRenumberingTest` carried a Javadoc paragraph documenting this bug as an unfixed reason for its reopen-before-insert; only that comment was updated to point at the fix and the new test. No assertion in it was touched.

## Notes for review

- `indexRenamed` is the only rename hook in the schema, and `LSMVectorIndex` is the only caller, because it is the only index that renames itself. If another index type ever gains a rename, it must call this too.
- `indexRenamed` mutates `indexMap` from whichever thread ran the compaction, which for an *automatic* compaction is the async executor rather than a user thread. `indexMap` is an unsynchronized `HashMap`, but it has always been mutated off arbitrary threads - `CREATE INDEX` / `DROP INDEX` do exactly that while queries read it - so this is not a new kind of hazard, only a more frequent one. Hardening the map (a `ConcurrentHashMap`, which would also change `getIndexByName(null)` from a `SchemaException` to an NPE) felt like a separate call to make; happy to fold it in if you'd rather have it here.
