### PR TITLE
fix(#6094): a bare CALL to a write CypherProcedure is no longer classified read-only

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/procedure/Procedure.java
+++ b/engine/src/main/java/com/arcadedb/function/procedure/Procedure.java
@@ -163,4 +163,40 @@ public interface Procedure {
   default boolean isWriteProcedure() {
     return false;
   }
+
+  /**
+   * Refines {@link #isWriteProcedure()} for one particular call site, given whatever that site's arguments the
+   * parser could resolve to constants.
+   * <p>
+   * {@link #isWriteProcedure()} answers for the procedure as a whole, at registration time, which for most
+   * procedures is the whole truth. It is not for a procedure that runs a caller-supplied query string
+   * ({@code apoc.do.when}): such a procedure has to answer {@code true} unconditionally, because at registration
+   * time it has no idea what its caller will pass. At a call site whose arguments are literals it does know, and
+   * this overload is where it says so - which matters because {@code isReadOnly()} on the enclosing statement
+   * decides HA routing, the {@code Database.query()} idempotency gate and the follower's forward-to-leader
+   * decision (issue #6094).
+   * <p>
+   * <b>A refinement may only narrow.</b> The caller checks {@link #isWriteProcedure()} first and only consults
+   * this overload when that answered {@code true}, so returning {@code true} here from a read-only procedure has
+   * no effect.
+   * <p>
+   * <b>{@code false} is a claim that needs proof.</b> An implementation may answer {@code false} only where it
+   * can show this call will not write - either because nothing it could run writes, or because the call cannot
+   * execute at all (its own argument checks reject it before any work starts, which is worth narrowing for:
+   * otherwise a caller on {@code Database.query()} gets {@code QueryNotIdempotentException} in place of the
+   * actionable error). Everywhere the arguments leave it genuinely unsure - a {@code null} entry, a value it
+   * cannot interpret - it must keep the conservative {@code true}; guessing "read-only" is what silently
+   * bypasses replication.
+   *
+   * @param literalArguments one entry per argument written at the call site, holding the argument's constant
+   *                         value when the parser resolved it to a literal and {@code null} otherwise (a
+   *                         parameter, a variable, any computed expression - and also a literal {@code null}, the
+   *                         two being indistinguishable here on purpose, since both must be treated
+   *                         conservatively). Never {@code null} itself; empty for a call with no arguments.
+   *
+   * @return true if this particular call can modify the database
+   */
+  default boolean isWriteProcedure(final Object[] literalArguments) {
+    return isWriteProcedure();
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
@@ -18,6 +18,9 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -151,8 +154,9 @@ public class SimpleCypherStatement implements CypherStatement {
     this.hasRemove = hasRemove;
     final boolean hasForeach = this.clausesInOrder.stream().anyMatch(c -> c.getType() == ClauseEntry.ClauseType.FOREACH);
     final boolean writeSubquery = anyWriteSubquery(this.clausesInOrder);
+    final boolean writeProcedureCall = anyWriteProcedureCall(this.callClauses);
     this.readOnly = !hasCreate && !hasMerge && !hasDelete && !hasRemove && !hasForeach
-        && (setClause == null || setClause.isEmpty()) && !writeSubquery;
+        && (setClause == null || setClause.isEmpty()) && !writeSubquery && !writeProcedureCall;
 
     // Pre-compute flags used by CypherExecutionPlan.execute() to avoid repeated clause scanning
     this.hasVariableLengthPath = computeHasVariableLengthPath();
@@ -245,6 +249,55 @@ public class SimpleCypherStatement implements CypherStatement {
         return true;
     }
     return false;
+  }
+
+  /**
+   * Returns {@code true} when any top-level {@code CALL} in this statement targets a registered write
+   * {@link CypherProcedure}. Without this, {@code CALL merge.node(...) YIELD node RETURN node} - a statement with
+   * no CREATE/SET/MERGE/DELETE/REMOVE/FOREACH clause of its own - classified as read-only, and that flag is what
+   * {@code OpenCypherQueryEngine.executionDatabase()} uses to pick between the raw database instance and the
+   * Raft-aware wrapper. On HA the raw instance commits pages locally without proposing them to Raft, and a
+   * follower runs the statement locally instead of forwarding it to the leader, because the same flag backs
+   * {@code analyze().isIdempotent()}. Harmless until #6073 gave {@code CallStep} an auto-commit; live since.
+   * See issue #6094, and #5492/#5655 for the same failure class on other write steps.
+   * <p>
+   * A {@code CALL} nested in a {@code CALL { ... }} subquery is already covered: {@link #anyWriteSubquery}
+   * recurses through the inner statement's own {@code isReadOnly()}, which now accounts for this.
+   * <p>
+   * A name that resolves to no registered procedure is left alone - it is not this method's business to guess
+   * what a SQL-function fallback or an outright unknown name does. The registry lookup is a static
+   * case-insensitive map read that also strips the {@code apoc.} prefix, so both spellings of one procedure
+   * classify identically, and it costs nothing at execution time: this runs once per parse, and parsed
+   * statements are cached per query text.
+   */
+  private static boolean anyWriteProcedureCall(final List<CallClause> calls) {
+    if (calls.isEmpty())
+      return false;
+    for (final CallClause call : calls) {
+      final CypherProcedure procedure = CypherProcedureRegistry.get(call.getProcedureName());
+      // A per-call refinement may only narrow, so a procedure that never writes needs no second look.
+      if (procedure == null || !procedure.isWriteProcedure())
+        continue;
+      if (procedure.isWriteProcedure(literalArguments(call)))
+        return true;
+    }
+    return false;
+  }
+
+  /**
+   * The constant value of every argument at a call site, with {@code null} wherever the parser produced anything
+   * other than a literal (a parameter, a variable, a computed expression). Fed to
+   * {@link CypherProcedure#isWriteProcedure(Object[])} so a procedure whose behaviour depends on its arguments -
+   * {@code apoc.do.when} runs caller-supplied query strings - can classify one particular call rather than being
+   * pinned to the conservative answer it must give for the procedure as a whole.
+   */
+  private static Object[] literalArguments(final CallClause call) {
+    final List<Expression> arguments = call.getArguments();
+    final Object[] values = new Object[arguments.size()];
+    for (int i = 0; i < values.length; i++)
+      if (arguments.get(i) instanceof LiteralExpression literal)
+        values[i] = literal.getValue();
+    return values;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.control;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.query.QueryEngine;
+import com.arcadedb.query.opencypher.parser.Cypher25AntlrParser;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -103,6 +104,60 @@ public class DoWhen implements CypherProcedure {
   @Override
   public boolean isWriteProcedure() {
     return true;
+  }
+
+  /**
+   * Classifies one specific {@code CALL apoc.do.when(...)} site from the branch queries it was written with.
+   * {@link #isWriteProcedure()} has to answer "writes" for every call - at registration time the branch strings
+   * do not exist yet - but at a call site that spells them out as literals the answer is knowable, and the call
+   * is a write only if a branch it could actually run is one.
+   * <p>
+   * Both branches are weighed, never only the one the condition selects: {@code condition} is an arbitrary
+   * expression evaluated per row, so which branch runs is not a parse-time fact even where it happens to be
+   * written here as a literal.
+   * <p>
+   * A call that cannot get as far as running a branch cannot write, so it is not classified as a write: a wrong
+   * argument count, or a branch argument that is a literal of the wrong type, is rejected by {@link #execute}'s
+   * own checks before anything runs. Answering "writes" for those would replace their actionable error
+   * (<em>"ifQuery must be a string"</em>) with {@code QueryNotIdempotentException} for every caller using
+   * {@link Database#query}, which is a worse answer to the same mistake and tells the caller nothing.
+   * <p>
+   * What stays conservative is genuine ignorance: a branch supplied as {@code $param} (or a literal
+   * {@code null}, which is indistinguishable here), and a branch string this method cannot parse. The latter is
+   * conservative rather than "cannot run" on purpose - {@code OpenCypherQueryEngine} strips an
+   * {@code EXPLAIN}/{@code PROFILE} prefix before parsing and {@code PROFILE} does execute, so a
+   * string that fails a bare parse here is not proof that nothing runs. A wrong "read-only" would route the
+   * statement to the raw database instance on HA and let {@link Database#query} run it, which is exactly the bug
+   * this classification exists to prevent (issue #6094).
+   */
+  @Override
+  public boolean isWriteProcedure(final Object[] literalArguments) {
+    // Rejected by validateArgs() at execution before a branch can run; let that error surface.
+    if (literalArguments.length < getMinArgs() || literalArguments.length > getMaxArgs())
+      return false;
+    return branchMayWrite(literalArguments[1]) || branchMayWrite(literalArguments[2]);
+  }
+
+  /**
+   * Whether a branch argument could run something that writes. Only two answers are "yes": a query string that
+   * parses into a non-read-only statement, and an argument the parser could not resolve to a literal at all.
+   * A blank branch runs nothing ({@link #execute} returns an empty stream for it) and a non-string literal is
+   * rejected by {@code extractString} before any branch runs.
+   */
+  private static boolean branchMayWrite(final Object branchQuery) {
+    if (branchQuery == null)
+      // Dynamic, or a literal null - the two are indistinguishable here, so assume the worst.
+      return true;
+    if (!(branchQuery instanceof String query))
+      return false;
+    if (query.isBlank())
+      return false;
+    try {
+      return !new Cypher25AntlrParser().parse(query).isReadOnly();
+    } catch (final Exception e) {
+      // Unparseable as written. Not proof that nothing runs (see the EXPLAIN/PROFILE note above), so assume it writes.
+      return true;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/control/DoWhen.java
@@ -143,6 +143,13 @@ public class DoWhen implements CypherProcedure {
    * parses into a non-read-only statement, and an argument the parser could not resolve to a literal at all.
    * A blank branch runs nothing ({@link #execute} returns an empty stream for it) and a non-string literal is
    * rejected by {@code extractString} before any branch runs.
+   * <p>
+   * The parse here is deliberately recursive and it terminates. A branch string may itself contain
+   * {@code CALL apoc.do.when(...)}, so this reaches {@code SimpleCypherStatement}'s constructor, its
+   * {@code anyWriteProcedureCall}, and back into this method. Each step strictly consumes one level of the
+   * literal nesting written into the query text, which is finite and in practice shallow - every level has to
+   * escape the quoting of the level around it, so the text grows exponentially in the depth. The parser used is
+   * a fresh instance and holds no state shared with the parse in progress around it.
    */
   private static boolean branchMayWrite(final Object branchQuery) {
     if (branchQuery == null)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6094WriteProcedureCallClassificationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6094WriteProcedureCallClassificationTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.exception.QueryNotIdempotentException;
+import com.arcadedb.query.OperationType;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6094: a bare top-level {@code CALL} to a registered write
+ * {@code CypherProcedure} - with no CREATE/SET/MERGE/DELETE/REMOVE/FOREACH clause anywhere in the statement -
+ * was classified {@code isReadOnly() == true}, because {@code SimpleCypherStatement} only inspected
+ * {@code CALL { ... }} subquery blocks and never the statement's own {@code callClauses}.
+ * <p>
+ * That flag is the single discriminator behind three behaviours:
+ * <ul>
+ *   <li>{@code OpenCypherQueryEngine.executionDatabase()} - a read-only statement is planned against the raw
+ *       database instance, a writing one against {@code getWrappedDatabaseInstance()}. On HA only the wrapped
+ *       (Raft-aware) instance may {@code begin()}/{@code commit()}; the raw one applies pages locally without
+ *       proposing them to Raft (#5492, #5655). Since #6073's fix, {@code CallStep} does auto-commit, so the
+ *       misclassification became a live Raft bypass.</li>
+ *   <li>{@code analyze().isIdempotent()} - {@code RaftReplicatedDatabase.command()} forwards a non-idempotent
+ *       command to the leader; a misclassified one runs entirely locally on a follower.</li>
+ *   <li>{@code OpenCypherQueryEngine.query()}'s idempotency gate, which is what keeps {@code Database.query()}
+ *       reserved for reads.</li>
+ * </ul>
+ * The routing test below is deliberately not vacuous: off HA {@code getWrappedDatabaseInstance()} returns the
+ * database itself, so the test installs a distinguishable wrapper first via
+ * {@code LocalDatabase.setWrappedDatabaseInstance}, exactly as the HA server does.
+ */
+class Issue6094WriteProcedureCallClassificationTest {
+  private Database database;
+
+  /**
+   * A write procedure that mutates nothing: it only records which {@link Database} instance the plan handed it,
+   * which is precisely what {@code executionDatabase()} decides. Registered per test and unregistered afterwards.
+   */
+  private static class DatabaseProbeProcedure implements CypherProcedure {
+    private final String  name;
+    private final boolean write;
+    private Database      seenDatabase;
+
+    private DatabaseProbeProcedure(final String name, final boolean write) {
+      this.name = name;
+      this.write = write;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public int getMinArgs() {
+      return 0;
+    }
+
+    @Override
+    public int getMaxArgs() {
+      return 0;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Test probe capturing the database instance the plan executes against";
+    }
+
+    @Override
+    public List<String> getYieldFields() {
+      return List.of("ok");
+    }
+
+    @Override
+    public boolean isWriteProcedure() {
+      return write;
+    }
+
+    @Override
+    public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+      validateArgs(args);
+      seenDatabase = context.getDatabase();
+      final ResultInternal row = new ResultInternal();
+      row.setProperty("ok", true);
+      return Stream.of(row);
+    }
+  }
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6094");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Person");
+  }
+
+  @AfterEach
+  void teardown() {
+    CypherProcedureRegistry.unregister("test.probeWrite");
+    CypherProcedureRegistry.unregister("test.probeRead");
+    if (database != null) {
+      // Undo any wrapper installed by a routing test before dropping, so drop() runs on the real instance.
+      final LocalDatabase local = (LocalDatabase) database;
+      local.setWrappedDatabaseInstance(local);
+      database.drop();
+    }
+  }
+
+  private boolean isIdempotent(final String query) {
+    return database.getQueryEngine("opencypher").analyze(query).isIdempotent();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Classification
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void bareCallToWriteProcedureIsNotIdempotent() {
+    assertThat(isIdempotent("CALL merge.node(['Person'], {name:'X'}, {}) YIELD node RETURN node")).isFalse();
+    assertThat(isIdempotent("MATCH (a:Person), (b:Person) CALL merge.relationship(a, 'KNOWS', {}, {}, b) YIELD rel RETURN rel"))
+        .isFalse();
+    assertThat(isIdempotent("MATCH (a:Person), (b:Person) CALL apoc.refactor.mergeNodes([a,b], {}) YIELD node RETURN node"))
+        .isFalse();
+    assertThat(isIdempotent("MATCH (a:Person) CALL apoc.refactor.cloneNodesWithRelationships([a], {}) YIELD output RETURN output"))
+        .isFalse();
+  }
+
+  @Test
+  void bareCallToReadOnlyProcedureStaysIdempotent() {
+    assertThat(isIdempotent("CALL meta.stats() YIELD value RETURN value")).isTrue();
+    assertThat(isIdempotent("MATCH (n:Person) RETURN n")).isTrue();
+  }
+
+  /**
+   * The "apoc." prefix is stripped by the registry, so both spellings of the same procedure must classify
+   * identically - otherwise the alias would be a silent bypass of the whole fix.
+   */
+  @Test
+  void apocPrefixedSpellingClassifiesTheSameWay() {
+    assertThat(isIdempotent("CALL apoc.merge.node(['Person'], {name:'X'}, {}) YIELD node RETURN node")).isFalse();
+  }
+
+  /**
+   * An unregistered CALL target (resolved later as a SQL function, or rejected at execution) must not be
+   * guessed at: classification stays on the clauses actually present, as before this fix.
+   */
+  @Test
+  void unknownProcedureCallIsUnaffected() {
+    assertThat(isIdempotent("CALL db.labels() YIELD label RETURN label")).isTrue();
+  }
+
+  /**
+   * {@code anyWriteSubquery} recurses through the inner statement's own {@code isReadOnly()}, so correcting the
+   * top-level classification transitively covers a write-procedure CALL nested in a {@code CALL { ... }} block.
+   */
+  @Test
+  void writeProcedureCallInsideCallSubqueryIsNotIdempotent() {
+    assertThat(isIdempotent(
+        "CALL { CALL merge.node(['Person'], {name:'X'}, {}) YIELD node RETURN node } RETURN node")).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // do.when: per-call refinement
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * {@code DoWhen.isWriteProcedure()} is unconditionally true - at registration time it cannot know what the
+   * caller's branch strings do. Given the literal branch strings of one particular call site it can, and a call
+   * whose branches are both statically read-only stays idempotent, so the long-standing
+   * {@code database.query("...CALL apoc.do.when(...)...")} usage keeps working.
+   */
+  @Test
+  void doWhenWithReadOnlyLiteralBranchesStaysIdempotent() {
+    assertThat(isIdempotent("CALL apoc.do.when(true, 'RETURN 1 AS x', 'RETURN 2 AS x', {}) YIELD value RETURN value"))
+        .isTrue();
+    assertThat(isIdempotent("CALL apoc.do.when(false, 'RETURN 1 AS x', '', {}) YIELD value RETURN value")).isTrue();
+  }
+
+  @Test
+  void doWhenWithAWritingLiteralBranchIsNotIdempotent() {
+    assertThat(isIdempotent(
+        "CALL apoc.do.when(true, \"CREATE (n:Person {name: 'Bob'}) RETURN n\", '', {}) YIELD value RETURN value")).isFalse();
+    // The else branch counts too: the condition is not statically known in general.
+    assertThat(isIdempotent(
+        "CALL apoc.do.when(false, 'RETURN 1 AS x', \"CREATE (n:Person) RETURN n\", {}) YIELD value RETURN value")).isFalse();
+  }
+
+  /**
+   * A branch supplied as a parameter cannot be classified at parse time, so it falls back to the conservative
+   * "this writes" answer rather than being assumed read-only.
+   */
+  @Test
+  void doWhenWithDynamicBranchArgumentIsConservativelyAWrite() {
+    assertThat(isIdempotent("CALL apoc.do.when(true, $q, '', {}) YIELD value RETURN value")).isFalse();
+  }
+
+  /**
+   * A branch string that does not parse as written stays a write - a bare parse failing is not proof that
+   * nothing runs, since the engine strips an {@code EXPLAIN}/{@code PROFILE} prefix before parsing and
+   * {@code PROFILE} does execute. What must not happen is the classification throwing while the <em>outer</em>
+   * query is being parsed.
+   */
+  @Test
+  void doWhenWithUnparseableBranchIsConservativelyAWriteAndDoesNotThrowAtParseTime() {
+    assertThat(isIdempotent("CALL apoc.do.when(true, 'NOT CYPHER AT ALL', '', {}) YIELD value RETURN value")).isFalse();
+  }
+
+  /**
+   * A call the procedure's own argument checks reject cannot reach a branch, so it cannot write, and
+   * classifying it a write would replace its actionable error with {@code QueryNotIdempotentException} for
+   * every caller on {@code Database.query()}. These two shapes are what {@code DoWhenTest} pins the error type
+   * of; this test pins the classification that lets those errors through.
+   */
+  @Test
+  void doWhenCallsThatCannotRunAtAllAreNotClassifiedAsWrites() {
+    // Wrong argument count: validateArgs() rejects it before any branch runs.
+    assertThat(isIdempotent("CALL apoc.do.when(true, 'RETURN 1') YIELD value RETURN value")).isTrue();
+    // Branch argument is a literal of the wrong type: extractString() rejects it before any branch runs.
+    assertThat(isIdempotent("CALL apoc.do.when(true, 1, '', {}) YIELD value RETURN value")).isTrue();
+    assertThat(isIdempotent("CALL apoc.do.when(false, 'RETURN 1 AS x', 1, {}) YIELD value RETURN value")).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Consequences
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * {@code Database.query()} is reserved for idempotent statements. Before the fix it silently accepted - and
+   * executed - a bare CALL to a write procedure.
+   */
+  @Test
+  void queryRejectsBareCallToWriteProcedure() {
+    assertThatThrownBy(() -> database.query("opencypher",
+        "CALL merge.node(['Person'], {name:'X'}, {}) YIELD node RETURN node"))
+        .isInstanceOf(QueryNotIdempotentException.class);
+  }
+
+  @Test
+  void commandStillExecutesBareCallToWriteProcedure() {
+    try (final ResultSet rs = database.command("opencypher",
+        "CALL merge.node(['Person'], {name:'John'}, {age: 30}) YIELD node RETURN node")) {
+      assertThat(rs.next().getVertex().get().get("age")).isEqualTo(30L);
+    }
+    try (final ResultSet check = database.query("sql", "SELECT FROM Person WHERE name = 'John'")) {
+      assertThat(check.hasNext()).isTrue();
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // HA routing: executionDatabase() must resolve the wrapped (Raft-aware) instance
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * Installs a distinguishable {@link DatabaseInternal} wrapper, the way the HA server installs
+   * {@code RaftReplicatedDatabase}, so that "raw instance" and "wrapped instance" are two different objects and
+   * the routing assertion can tell them apart.
+   */
+  private DatabaseInternal installDistinguishableWrapper() {
+    final LocalDatabase real = (LocalDatabase) database;
+    final DatabaseInternal wrapper = (DatabaseInternal) Proxy.newProxyInstance(
+        DatabaseInternal.class.getClassLoader(), new Class<?>[] { DatabaseInternal.class },
+        (proxy, method, args) -> {
+          // Mirrors RaftReplicatedDatabase: the wrapper is its own wrapped instance.
+          if ("getWrappedDatabaseInstance".equals(method.getName()) && method.getParameterCount() == 0)
+            return proxy;
+          try {
+            return method.invoke(real, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
+    real.setWrappedDatabaseInstance(wrapper);
+    return wrapper;
+  }
+
+  @Test
+  void bareCallToWriteProcedureIsPlannedAgainstTheWrappedInstance() {
+    final DatabaseProbeProcedure probe = new DatabaseProbeProcedure("test.probeWrite", true);
+    CypherProcedureRegistry.registerOrReplace(probe);
+
+    final DatabaseInternal wrapper = installDistinguishableWrapper();
+
+    try (final ResultSet rs = database.command("opencypher", "CALL test.probeWrite() YIELD ok RETURN ok")) {
+      assertThat(rs.next().<Boolean>getProperty("ok")).isTrue();
+    }
+
+    assertThat(probe.seenDatabase).isSameAs(wrapper);
+    assertThat(probe.seenDatabase).isNotSameAs(database);
+  }
+
+  /**
+   * The counterpart that proves the routing assertion above discriminates: a read-only CALL keeps the raw
+   * instance, so a read-only statement does not acquire the wrapper's read barrier.
+   */
+  @Test
+  void bareCallToReadOnlyProcedureIsPlannedAgainstTheRawInstance() {
+    final DatabaseProbeProcedure probe = new DatabaseProbeProcedure("test.probeRead", false);
+    CypherProcedureRegistry.registerOrReplace(probe);
+
+    final DatabaseInternal wrapper = installDistinguishableWrapper();
+
+    try (final ResultSet rs = database.command("opencypher", "CALL test.probeRead() YIELD ok RETURN ok")) {
+      assertThat(rs.next().<Boolean>getProperty("ok")).isTrue();
+    }
+
+    assertThat(probe.seenDatabase).isSameAs(database);
+    assertThat(probe.seenDatabase).isNotSameAs(wrapper);
+  }
+
+  /**
+   * The security/permission axis: a statement whose only write is a procedure CALL must not be reported as a
+   * pure read by {@code analyze().getOperationTypes()} either, or a read-only principal would be allowed to run
+   * it.
+   */
+  @Test
+  void operationTypesOfABareWriteProcedureCallAreNotReadOnly() {
+    assertThat(database.getQueryEngine("opencypher")
+        .analyze("CALL merge.node(['Person'], {name:'X'}, {}) YIELD node RETURN node")
+        .getOperationTypes())
+        .doesNotContain(OperationType.READ);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6094WriteProcedureCallClassificationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6094WriteProcedureCallClassificationTest.java
@@ -256,6 +256,22 @@ class Issue6094WriteProcedureCallClassificationTest {
     assertThat(isIdempotent("CALL apoc.do.when(false, 'RETURN 1 AS x', 1, {}) YIELD value RETURN value")).isTrue();
   }
 
+  /**
+   * A branch string may itself be a {@code do.when} call, so classification recurses: parse the branch, which
+   * builds a statement, which classifies its own CALL, which parses that call's branches. It terminates on the
+   * nesting actually written in the text, and the verdict must still travel all the way out - a write buried two
+   * levels down is a write.
+   */
+  @Test
+  void doWhenNestedInsideADoWhenBranchIsClassifiedThroughBothLevels() {
+    assertThat(isIdempotent(
+        "CALL apoc.do.when(true, \"CALL apoc.do.when(true, 'RETURN 1 AS x', '', {}) YIELD value RETURN value\", '', {}) "
+            + "YIELD value RETURN value")).isTrue();
+    assertThat(isIdempotent(
+        "CALL apoc.do.when(true, \"CALL apoc.do.when(true, 'CREATE (n:Person) RETURN n', '', {}) YIELD value RETURN value\", "
+            + "'', {}) YIELD value RETURN value")).isFalse();
+  }
+
   // ---------------------------------------------------------------------------------------------------------
   // Consequences
   // ---------------------------------------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/control/DoWhenTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/control/DoWhenTest.java
@@ -98,9 +98,15 @@ class DoWhenTest {
     assertThat(value.get("greeting")).isEqualTo("hello");
   }
 
+  /**
+   * Issued through {@code command()}, not {@code query()}: a do.when whose branch is a literal CREATE is a write,
+   * and since issue #6094 the statement is classified as one, so {@code query()}'s idempotency gate refuses it -
+   * the same convention {@code RefactorMergeNodesTest} and {@code CallStepWriteProcedureAutoCommitTest} already
+   * follow for the other write procedures. The assertions below are unchanged.
+   */
   @Test
   void writeSubQueryIsPersisted() {
-    final ResultSet rs = database.query("opencypher",
+    final ResultSet rs = database.command("opencypher",
         "CALL apoc.do.when(true, \"CREATE (n:Person {name: 'Bob'}) RETURN n\", '', {}) YIELD value RETURN value");
     assertThat(rs.hasNext()).isTrue();
     rs.next();


### PR DESCRIPTION
Closes #6094

## What was wrong

`SimpleCypherStatement`'s `readOnly` flag never looked at the statement's own `callClauses`. `anyWriteSubquery`
only inspects `CALL { ... }` blocks (added for #4191), so a bare top-level `CALL merge.node(...) YIELD node
RETURN node` - a statement with no CREATE/SET/MERGE/DELETE/REMOVE/FOREACH clause of its own - classified as
`isReadOnly() == true`.

That single flag backs three decisions:

| consumer | effect of the misclassification |
| --- | --- |
| `OpenCypherQueryEngine.executionDatabase()` | plans against the raw database instead of `getWrappedDatabaseInstance()`. On an HA leader `LocalDatabase.commit()` applies the pages locally and never proposes them to Raft (#5492, #5655). |
| `analyze().isIdempotent()` | `RaftReplicatedDatabase.command()` evaluates `isExecutedByTheLeader() \|\| isDDL() \|\| !isIdempotent()` as `false \|\| false \|\| false`, so a **follower executes the write entirely locally** instead of forwarding it to the leader. |
| `OpenCypherQueryEngine.query()`'s idempotency gate | `Database.query()` silently accepted and executed a write-procedure `CALL`. |

Harmless before #6073's fix (a write procedure with no caller transaction always threw before anything could
commit); live since PR #6093 gave `CallStep` an auto-commit.

## The fix

Three small pieces:

1. **`SimpleCypherStatement.anyWriteProcedureCall(callClauses)`** - mirrors `anyWriteSubquery`, resolving each
   `CallClause`'s procedure through `CypherProcedureRegistry.get()` (a static, case-insensitive map read that
   also strips the `apoc.` prefix, so both spellings classify identically) and folding the answer into
   `readOnly`. A name that resolves to no registered procedure is left alone. This also covers a write-procedure
   `CALL` nested inside `CALL { ... }`, since `anyWriteSubquery` already recurses through `inner.isReadOnly()`.
   It runs once per parse and parsed statements are cached per query text, so execution pays nothing.

2. **`Procedure.isWriteProcedure(Object[] literalArguments)`** - a new default method that lets a procedure
   refine its verdict for one particular call site, given the arguments the parser resolved to literals. The
   contract is documented as *narrow only*: `anyWriteProcedureCall` checks the no-arg `isWriteProcedure()`
   first and only consults the overload when that already said "writes", and every entry a procedure cannot
   resolve statically must keep the conservative answer.

3. **`DoWhen.isWriteProcedure(Object[])`** - the reason the mechanical fix was not landable on its own.
   `DoWhen.isWriteProcedure()` must return `true` unconditionally, because at registration time it cannot know
   what query strings its caller will hand it. At a call site that spells the branches out as string literals
   it *can* know: the call is a write only if a branch it could actually run is one, checked by parsing them
   (`Cypher25AntlrParser.parse(...).isReadOnly()`). Both branches are weighed, never just the one a literal
   condition selects - the condition is an arbitrary per-row expression, so which branch runs is not a
   parse-time fact.

   The line between "not a write" and "conservatively a write" is drawn at *can this call reach a branch at
   all*:

   - **Not a write** - a blank branch (runs nothing), a branch that parses read-only, a wrong argument count,
     and a branch argument that is a literal of the wrong type. The last two are rejected by `execute()`'s own
     checks before anything runs, so they cannot write; classifying them as writes would replace their
     actionable error (*"ifQuery must be a string"*) with `QueryNotIdempotentException` for every caller on
     `Database.query()`, which is a worse answer to the same mistake. Three `DoWhenTest` tests assert exactly
     those error types.
   - **Conservatively a write** - a branch supplied as `$param` (or a literal `null`, indistinguishable here),
     and a branch string that does not parse as written. The second is deliberately *not* treated as "cannot
     run": `OpenCypherQueryEngine` strips an `EXPLAIN`/`PROFILE` prefix before parsing and `PROFILE` does
     execute, so a bare parse failing here is not proof that nothing runs.

   An unparseable branch also must not make the *outer* query fail to parse - that error still belongs to
   execution, and a test pins it.

Without piece 3, correcting the classification reclassifies **every** `apoc.do.when(...)` call, read-only
branches included, and 10 of `DoWhenTest`'s 11 tests fail with `QueryNotIdempotentException` - they call
`database.query(...)` with branches that are read-only in practice. With it, 9 of those 10 keep passing
untouched.

## The one existing test that changed, and why

`DoWhenTest.writeSubQueryIsPersisted` asserted that

```java
database.query("opencypher", "CALL apoc.do.when(true, \"CREATE (n:Person {name: 'Bob'}) RETURN n\", '', {}) ...")
```

persists the node. That is the bug, written down as an expectation: it is a write executed through the API
reserved for idempotent statements. Its `query(` is now `command(`; **every assertion in it is unchanged**, and
the identical scenario was already covered through `command()` by
`CallStepWriteProcedureAutoCommitTest.doWhenAutoCommitsWriteSubQueryWithNoExplicitTransaction`. This is option
(b) from the issue's "Resolving this cleanly needs one of" list, narrowed by piece 3 from all 10 calls to just
this one.

## New tests

`engine/src/test/java/com/arcadedb/query/opencypher/Issue6094WriteProcedureCallClassificationTest` - 15 tests.
9 of them fail on `main` and pass here (verified by disarming the `readOnly` term and re-running: 14 run at that
point, 9 failures); the rest are the controls that must *not* change - a read-only procedure CALL stays
idempotent, an unregistered CALL target is untouched, a read-only `do.when` stays idempotent, a `do.when` its
own argument checks reject stays idempotent so its real error survives, `command()` still executes the write,
and a read-only CALL still keeps the raw instance.

The routing test is deliberately not vacuous. Off HA `getWrappedDatabaseInstance()` returns the database
itself, so asserting "the wrapped instance was chosen" would pass either way. The test installs a
distinguishable `DatabaseInternal` wrapper first via `LocalDatabase.setWrappedDatabaseInstance` - a
`java.lang.reflect.Proxy` delegating to the real instance, the same technique
`Issue5666ConcurrentGraphBatchTest` already uses, and the same installation point `RaftReplicatedDatabase`'s
constructor uses - then registers a probe `CypherProcedure` that records `context.getDatabase()` and asserts
the identity of what the plan handed it. A read-only twin of the same probe asserts the raw instance, so the
pair proves the switch discriminates rather than just leaning one way.

## Test plan

All four already run green on this branch:

- [x] `mvn -pl engine test -Dtest=Issue6094WriteProcedureCallClassificationTest` - **15/15**
- [x] `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.procedures.**,Issue6094...'` - **365, 0 failures**
      (DoWhenTest 11/11, RefactorMergeNodesTest, the algo/path/meta/refactor suites)
- [x] `mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**'` - **8239 run, 0 failures, 98 skipped**
      across the whole engine openCypher suite including the TCK
- [x] `mvn -pl engine test -Dtest='com.arcadedb.function.**,DoWhenTest,CallStepWriteProcedureAutoCommitTest'` -
      **1177, 0 failures** (the `Procedure` change is additive, but it is shared with the SQL engine)
- [x] The tests can fail: disarming the `readOnly` term turned 9 of them red, and each of those 9 asserts one of
      the three consumers above

## Known scope limits

- The classification is static. A write procedure reached through a mechanism the parser cannot see at all
  still classifies on the clauses present; this fix covers registered procedures named directly at a `CALL`
  site, which is every route in the engine today.
- `analyze().getOperationTypes()` for a statement whose only write is a procedure CALL falls into the existing
  conservative `{CREATE, UPDATE, DELETE}` fallback rather than reporting a narrower set. That is the same
  answer a writing `CALL { ... }` subquery already gets, and it is the safe direction for a permission check.
- `hasWriteBeforeMatch()` still does not count a `CALL` as a write clause for the optimizer's fast-path
  ordering check. That predicate is about clause *order* and is unchanged by this PR; a `CALL` before a `MATCH`
  behaves exactly as it did before.
- A literal `null` written for `do.when`'s `elseQuery` - `apoc.do.when(cond, 'RETURN 1', null, {})`, which
  legitimately means "no else branch" and never writes - is now conservatively classified a write, so that one
  rare spelling can no longer go through `Database.query()`. `literalArguments` cannot tell a literal `null`
  from an argument it could not resolve at all (both arrive as a `null` entry), and of the two only the
  conservative answer is safe. Spelling the same thing as `''` classifies read-only, and both are covered by
  `doWhenWithReadOnlyLiteralBranchesStaysIdempotent`.
- `DoWhen.branchMayWrite`'s nested parse has no explicit depth guard. It is bounded by the nesting literally
  written into the query text, and each level has to escape the quoting of the one around it, so the text grows
  exponentially in the depth - a guard would add a knob with no reachable failure behind it. The recursion is
  documented at the method and pinned by `doWhenNestedInsideADoWhenBranchIsClassifiedThroughBothLevels`, which
  checks the verdict travels out through both levels. Its `catch (Exception)` is deliberately broad for the
  same reason the "unparseable" case is conservative: any failure to decide has to fall to "assume it writes".
