### PR TITLE
docs: record the three Maven/test invocations that fail silently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,24 @@ General design principles:
 
 ## Build and Development Commands
 
-Standard Maven and npm invocations apply. The non-obvious one:
+Standard Maven and npm invocations apply. The non-obvious ones, each of which silently produces a *meaningless
+green or spuriously red* run rather than an error that tells you what you did wrong:
 
 - **Run unit tests**: `mvn verify` (use `verify`/`install`, not bare `mvn test`, for a full reactor run: the `arcadedb-gremlin-it` module consumes `arcadedb-gremlin`'s package-phase artifacts (the `shaded` uber-jar and `tests` test-jar), which a `test`-phase build never produces)
+- **Testing a subset of modules needs `-am`**: `mvn -o -pl server -am test`, not `mvn -o -pl server test`. Without
+  `-am` the module is the whole reactor, so it resolves `arcadedb-engine` and friends from `~/.m2` instead of from
+  your working tree, and can run against an artifact that predates your edits. If you added or renamed a method this
+  surfaces as a `NoSuchMethodError`; **if you only changed behaviour it surfaces as nothing at all** and the run tells
+  you precisely nothing. Installing first (`mvn install -DskipTests`) is not a reliable substitute - it has been
+  observed still resolving a stale artifact
+- **To skip a slow or flaky class, use `-DexcludedGroups`, never `-Dtest='!Foo'`**: the `@Tag` lanes (`benchmark`,
+  `slow`, `vector`) exist for this, e.g. `-DexcludedGroups=benchmark,vector`. Passing `-Dtest` in any form *replaces*
+  Surefire's default include patterns, which drags `*IT` classes into the `test` phase, where they run without the
+  Failsafe setup their fixtures need and fail by the hundred
+- **Server tests bind fixed ports** (2480 and up). Anything already listening - a server left running by an IDE, a
+  previous run, another agent - takes the requests instead, and the failures read as authentication errors
+  (`403`, "Too many failed authentication attempts") rather than as a port conflict. Check with
+  `lsof -nP -iTCP:2480 -sTCP:LISTEN` before believing a wall of red in the `server` module
 
 ## Development Guidelines
 


### PR DESCRIPTION
Follow-up to #6155 (fixes #6134). Documentation only, no code change.

Three Maven/test invocations cost a full test cycle each during that work. What they have in common is that **none of them reports the mistake you actually made** - each produces a meaningless green or a spuriously red run instead, so the natural reaction is to go debug the wrong thing.

They are added to the existing "Build and Development Commands" list, which already exists for exactly this kind of gotcha.

### 1. Module-scoped runs need `-am`

`mvn -o -pl server test` resolves `arcadedb-engine` from `~/.m2` rather than from the working tree, so it can run against an artifact that predates your edits.

This one is the most dangerous of the three, because it was only caught by luck: that change *added* a method, so it threw `NoSuchMethodError`. A change that only altered behaviour would have passed against the wrong code with no signal whatsoever, and the run would have been reported as green.

Installing first (`mvn install -DskipTests`) was tried and was **not** a reliable substitute - a module run still resolved a stale artifact afterwards. The guidance is therefore `-am`, stated without a claim about *why* the stale artifact wins, since that mechanism was never confirmed.

### 2. `-Dtest` replaces Surefire's includes, it does not add to them

`-Dtest='!LSMVectorIndexRebuildTest'` looks like "everything except this class". It is not: passing `-Dtest` in any form, exclusion-only included, discards the default include patterns and drags `*IT` classes into the `test` phase, where they run without the Failsafe setup their fixtures need.

Skipping one flaky class this way produced **318 failures and 251 errors**, none of them real.

`-DexcludedGroups` plus the existing `@Tag` lanes (`benchmark`, `slow`, `vector`) does the job correctly.

### 3. Server tests bind fixed ports

An ArcadeDB server already listening on 2480 - an IDE debug session, a previous run, a parallel agent - silently serves the requests instead. The failures then read as `403` and "Too many failed authentication attempts", i.e. as an auth or security regression, rather than as a port conflict.
