### PR TITLE
fix(#5933): a compressible bulk transaction can no longer commit an entry no node can apply

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1299,7 +1299,10 @@ public enum GlobalConfiguration {
       it is rejected with a state-machine error that makes the leader step down; the write then fails with \
       ReplicatedEntryTooLargeException naming this setting. The size compared against it is the COMPRESSED \
       WAL of the transaction, so text/JSON payloads shrink far below their raw size while incompressible \
-      ones (binary blobs, base64, encrypted fields, float vectors) map roughly 1:1. Raise it when single \
+      ones (binary blobs, base64, encrypted fields, float vectors) map roughly 1:1. Compression does NOT \
+      make the transaction unbounded, though (issue #5933): every node has to materialize the WAL in full to \
+      apply it, so a second, fixed ceiling of 64MB applies to the UNCOMPRESSED WAL of one entry regardless of \
+      this setting, and a transaction above it is rejected with the same exception. Raise it when single \
       transactions or records are bigger than the default, and raise arcadedb.ha.writeBufferSize with it \
       (it must stay >= this value + 8 bytes). Cost of raising it: a directly-allocated write buffer of \
       writeBufferSize per server, plus up to this many bytes of heap per follower appender during catch-up. \

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -101,6 +101,27 @@ public final class RaftLogEntryCodec {
   }
 
   /**
+   * Validates a length field for a section read STRAIGHT off the stream, so the array it asks for is never
+   * allocated before the entry is known to actually carry that many bytes.
+   * <p>
+   * {@code remaining} is the exact number of bytes left in the entry: the stream is backed by a
+   * {@link ByteString}, whose {@code available()} is exact and is already load-bearing in {@link #decode}
+   * (the trailing-byte corruption check and the optional-section probes both depend on it). That makes it a
+   * far tighter bound than any constant - a corrupt or forged length is refused here rather than turning into
+   * a several-hundred-MB allocation that {@code readFully} would then fail on anyway. The absolute ceiling
+   * stays as a backstop.
+   * <p>
+   * This bound does NOT apply to the length of a section that is decompressed, which is legitimately many
+   * times the bytes present; {@link #checkDecompressedLength} covers that one.
+   */
+  private static void checkByteLength(final int length, final int remaining, final String context) {
+    checkByteLength(length, context);
+    if (length > remaining)
+      throw new IllegalStateException("Invalid byte length " + length + " in " + context + ": only " + remaining
+          + " bytes remain in the entry (truncated or corrupted replication payload)");
+  }
+
+  /**
    * Validates the uncompressed length a compressed section claims, before {@code decompress} allocates it.
    * Beyond the absolute ceiling the claim is also bounded by what the compressed bytes present in the entry
    * could possibly expand to, so raising {@link #MAX_DECODED_ENTRY_BYTES} cannot turn the decoder into an
@@ -494,7 +515,7 @@ public final class RaftLogEntryCodec {
   private static DecodedEntry decodeTxEntry(final DataInputStream dis, final String databaseName) throws IOException {
     final int uncompressedLength = dis.readInt();
     final int compressedLength = dis.readInt();
-    checkByteLength(compressedLength, "TX_ENTRY compressed WAL");
+    checkByteLength(compressedLength, dis.available(), "TX_ENTRY compressed WAL");
     checkDecompressedLength(uncompressedLength, compressedLength, "TX_ENTRY uncompressed WAL");
     final byte[] compressed = new byte[compressedLength];
     dis.readFully(compressed);
@@ -515,7 +536,7 @@ public final class RaftLogEntryCodec {
 
   private static DecodedEntry decodeSchemaEntry(final DataInputStream dis, final String databaseName) throws IOException {
     final int schemaLen = dis.readInt();
-    checkByteLength(schemaLen, "SCHEMA_ENTRY schemaJson");
+    checkByteLength(schemaLen, dis.available(), "SCHEMA_ENTRY schemaJson");
     final byte[] schemaBytes = new byte[schemaLen];
     dis.readFully(schemaBytes);
     final String schemaJson = new String(schemaBytes, StandardCharsets.UTF_8);
@@ -539,7 +560,7 @@ public final class RaftLogEntryCodec {
         for (int i = 0; i < walCount; i++) {
           final int walUncompressedLen = dis.readInt();
           final int walCompressedLen = dis.readInt();
-          checkByteLength(walCompressedLen, "SCHEMA_ENTRY WAL compressed");
+          checkByteLength(walCompressedLen, dis.available(), "SCHEMA_ENTRY WAL compressed");
           checkDecompressedLength(walUncompressedLen, walCompressedLen, "SCHEMA_ENTRY WAL uncompressed");
           final byte[] walCompressed = new byte[walCompressedLen];
           dis.readFully(walCompressed);
@@ -574,7 +595,7 @@ public final class RaftLogEntryCodec {
           final long expectedCrc = dis.readLong();
           final int uncompressedLen = dis.readInt();
           final int compressedLen = dis.readInt();
-          checkByteLength(compressedLen, "SCHEMA_ENTRY sealed blob compressed");
+          checkByteLength(compressedLen, dis.available(), "SCHEMA_ENTRY sealed blob compressed");
           checkDecompressedLength(uncompressedLen, compressedLen, "SCHEMA_ENTRY sealed blob uncompressed");
           final byte[] compressed = new byte[compressedLen];
           dis.readFully(compressed);
@@ -612,7 +633,7 @@ public final class RaftLogEntryCodec {
   private static DecodedEntry decodeBootstrapFingerprintEntry(final DataInputStream dis, final String databaseName)
       throws IOException {
     final int fpLen = dis.readInt();
-    checkByteLength(fpLen, "BOOTSTRAP_FINGERPRINT fingerprint");
+    checkByteLength(fpLen, dis.available(), "BOOTSTRAP_FINGERPRINT fingerprint");
     final byte[] fpBytes = new byte[fpLen];
     dis.readFully(fpBytes);
     final String fingerprint = new String(fpBytes, StandardCharsets.UTF_8);
@@ -623,7 +644,7 @@ public final class RaftLogEntryCodec {
 
   private static DecodedEntry decodeSecurityUsersEntry(final DataInputStream dis) throws IOException {
     final int length = dis.readInt();
-    checkByteLength(length, "SECURITY_USERS_ENTRY");
+    checkByteLength(length, dis.available(), "SECURITY_USERS_ENTRY");
     final byte[] bytes = new byte[length];
     dis.readFully(bytes);
     final String usersJson = new String(bytes, StandardCharsets.UTF_8);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.compression.CompressionFactory;
+import com.arcadedb.network.binary.ReplicatedEntryTooLargeException;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 import java.io.ByteArrayOutputStream;
@@ -40,8 +41,51 @@ import java.util.zip.CRC32;
  */
 public final class RaftLogEntryCodec {
 
-  /** Maximum allowed size for a single byte array allocation during decoding (64 MB). */
+  /**
+   * Ceiling a PRODUCER applies to the uncompressed payload it packs into one replicated entry (64 MB).
+   * <p>
+   * Issue #5933: the submit-time gate in {@code RaftGroupCommitter.submitAndWait} measures the ENCODED entry,
+   * whose WAL this codec has already LZ4-compressed, while the applier has to materialize that WAL again in
+   * full. A well-compressing bulk transaction - repetitive, text/JSON-heavy migration data - therefore used to
+   * pass the submit gate on its compressed size, reach a Raft quorum, commit at a fixed log index, and only
+   * then fail the decode-time bound on every node that tried to apply it. A committed entry cannot be taken
+   * back, so every node halted on it and replayed into the same failure on every restart: a permanent,
+   * cluster-wide crash loop from a single oversized write.
+   * <p>
+   * The gates now agree by construction: nothing is encoded that could not be decoded. This value has to stay
+   * at or above {@code GlobalConfiguration.maxReplicatedRaftEntrySize}'s default, or an INCOMPRESSIBLE
+   * transaction that replicates fine today (raw size ~= compressed size) would start being rejected here.
+   */
   static final int MAX_ENTRY_BYTES = 64 * 1024 * 1024;
+
+  /**
+   * Ceiling a CONSUMER accepts when decoding (512 MB), deliberately well above {@link #MAX_ENTRY_BYTES}.
+   * <p>
+   * Being liberal in what is accepted is what lets a cluster ALREADY holding an oversized committed entry -
+   * written by a version that had no producer-side bound - apply it and come back up, instead of crash-looping
+   * on it forever with no operator-side recovery. It is also why the two ceilings must never be equal: a
+   * decoder no more permissive than the encoder leaves no margin for entries produced by another version.
+   * <p>
+   * This is a wire-format constant and NOT configurable on purpose. A node whose ceiling differed from its
+   * peers' would apply entries they reject, which is exactly the divergence the state machine halts to
+   * prevent. {@code RaftPropertiesBuilder} refuses at startup any configured entry cap above it.
+   */
+  static final int MAX_DECODED_ENTRY_BYTES = 512 * 1024 * 1024;
+
+  /**
+   * Upper bound on how far the LZ4 block format can expand its input, used to reject an absurd uncompressed
+   * length BEFORE the array it asks for is allocated. A block sequence spends at least a token byte plus a
+   * two-byte offset per match, and every additional length-extension byte adds at most 255 output bytes, so
+   * the ratio converges to - and never reaches - 255:1, so a well-formed block can never trip this bound.
+   * Real WAL pages sit in the low single digits, so in practice it only ever fires on a corrupt or hostile
+   * length field.
+   * <p>
+   * It is tied to the block format of {@code CompressionFactory.getDefault()}, which every section here is
+   * compressed with: swapping that for an algorithm with a higher maximum ratio means revisiting this value
+   * FIRST, or entries a peer legitimately produced would be refused - and refusing a committed entry is the
+   * cluster-wide crash loop #5933 is about.
+   */
+  private static final int MAX_LZ4_EXPANSION_RATIO = 255;
 
   /** Maximum allowed element count for collections during decoding. */
   static final int MAX_COLLECTION_SIZE = 1_000_000;
@@ -51,9 +95,43 @@ public final class RaftLogEntryCodec {
   }
 
   private static void checkByteLength(final int length, final String context) {
-    if (length < 0 || length > MAX_ENTRY_BYTES)
+    if (length < 0 || length > MAX_DECODED_ENTRY_BYTES)
       throw new IllegalStateException(
-          "Invalid byte length " + length + " in " + context + " (max " + MAX_ENTRY_BYTES + ")");
+          "Invalid byte length " + length + " in " + context + " (max " + MAX_DECODED_ENTRY_BYTES + ")");
+  }
+
+  /**
+   * Validates the uncompressed length a compressed section claims, before {@code decompress} allocates it.
+   * Beyond the absolute ceiling the claim is also bounded by what the compressed bytes present in the entry
+   * could possibly expand to, so raising {@link #MAX_DECODED_ENTRY_BYTES} cannot turn the decoder into an
+   * allocation amplifier for a corrupt length field.
+   */
+  private static void checkDecompressedLength(final int uncompressedLength, final int compressedLength,
+      final String context) {
+    checkByteLength(uncompressedLength, context);
+    if ((long) uncompressedLength > (long) compressedLength * MAX_LZ4_EXPANSION_RATIO)
+      throw new IllegalStateException("Invalid byte length " + uncompressedLength + " in " + context
+          + ": above the " + MAX_LZ4_EXPANSION_RATIO + ":1 maximum expansion ratio of the " + compressedLength
+          + " compressed bytes carried by the entry");
+  }
+
+  /**
+   * Producer-side bound, applied to every section this codec COMPRESSES (issue #5933). The submit-time gate
+   * only ever sees the compressed result, so this is the one place a payload that no node could decompress can
+   * still be stopped before it reaches the Raft log. The failure is a {@link ReplicatedEntryTooLargeException}
+   * - a {@code TransactionException} and NOT a {@code NeedRetryException} - because retrying resubmits the
+   * identical, equally undeliverable payload.
+   */
+  private static void checkProducedPayloadLength(final int length, final String databaseName, final String context) {
+    if (length > MAX_ENTRY_BYTES)
+      throw new ReplicatedEntryTooLargeException(String.format(
+          """
+          %s for database '%s' is %d bytes uncompressed, above the %d bytes of uncompressed payload a single \
+          replicated Raft entry may carry. Compression is not what bounds it: the entry is LZ4-compressed for \
+          the wire but every node has to materialize it in full to apply it, so a well-compressing bulk \
+          transaction can slip under arcadedb.ha.appendBufferSize and still be too large to apply. Reduce the \
+          batch size - fewer rows per GraphBatch / SQL transaction, or smaller records.""",
+          context, databaseName, length, MAX_ENTRY_BYTES));
   }
 
   private static void checkCollectionSize(final int size, final String context) {
@@ -121,6 +199,8 @@ public final class RaftLogEntryCodec {
 
       dos.writeByte(RaftLogEntryType.TX_ENTRY.getId());
       dos.writeUTF(databaseName);
+
+      checkProducedPayloadLength(walData.length, databaseName, "Transaction WAL");
 
       final byte[] compressed = CompressionFactory.getDefault().compress(walData);
       dos.writeInt(walData.length);       // uncompressed length (for decompression)
@@ -211,6 +291,7 @@ public final class RaftLogEntryCodec {
       dos.writeInt(walCount);
       for (int i = 0; i < walCount; i++) {
         final byte[] walData = walEntries.get(i);
+        checkProducedPayloadLength(walData.length, databaseName, "Schema change WAL entry " + (i + 1) + "/" + walCount);
         final byte[] compressedWal = CompressionFactory.getDefault().compress(walData);
         dos.writeInt(walData.length);         // uncompressed length
         dos.writeInt(compressedWal.length);   // compressed length
@@ -232,7 +313,7 @@ public final class RaftLogEntryCodec {
       for (int i = 0; i < blobCount; i++) {
         final TsSealedBlob blob = sealedFileBlobs.get(i);
         final byte[] raw = blob.bytes() != null ? blob.bytes() : new byte[0];
-        checkByteLength(raw.length, "SCHEMA_ENTRY sealed blob uncompressed");
+        checkProducedPayloadLength(raw.length, databaseName, "Sealed TimeSeries store '" + blob.fileName() + "'");
         final CRC32 crc = new CRC32();
         crc.update(raw);
         final byte[] compressed = CompressionFactory.getDefault().compress(raw);
@@ -412,9 +493,9 @@ public final class RaftLogEntryCodec {
 
   private static DecodedEntry decodeTxEntry(final DataInputStream dis, final String databaseName) throws IOException {
     final int uncompressedLength = dis.readInt();
-    checkByteLength(uncompressedLength, "TX_ENTRY uncompressed WAL");
     final int compressedLength = dis.readInt();
     checkByteLength(compressedLength, "TX_ENTRY compressed WAL");
+    checkDecompressedLength(uncompressedLength, compressedLength, "TX_ENTRY uncompressed WAL");
     final byte[] compressed = new byte[compressedLength];
     dis.readFully(compressed);
     final byte[] walData = CompressionFactory.getDefault().decompress(compressed, uncompressedLength);
@@ -457,9 +538,9 @@ public final class RaftLogEntryCodec {
         bucketDeltas = new ArrayList<>(walCount);
         for (int i = 0; i < walCount; i++) {
           final int walUncompressedLen = dis.readInt();
-          checkByteLength(walUncompressedLen, "SCHEMA_ENTRY WAL uncompressed");
           final int walCompressedLen = dis.readInt();
           checkByteLength(walCompressedLen, "SCHEMA_ENTRY WAL compressed");
+          checkDecompressedLength(walUncompressedLen, walCompressedLen, "SCHEMA_ENTRY WAL uncompressed");
           final byte[] walCompressed = new byte[walCompressedLen];
           dis.readFully(walCompressed);
           final byte[] walData = CompressionFactory.getDefault().decompress(walCompressed, walUncompressedLen);
@@ -492,9 +573,9 @@ public final class RaftLogEntryCodec {
           final String fileName = dis.readUTF();
           final long expectedCrc = dis.readLong();
           final int uncompressedLen = dis.readInt();
-          checkByteLength(uncompressedLen, "SCHEMA_ENTRY sealed blob uncompressed");
           final int compressedLen = dis.readInt();
           checkByteLength(compressedLen, "SCHEMA_ENTRY sealed blob compressed");
+          checkDecompressedLength(uncompressedLen, compressedLen, "SCHEMA_ENTRY sealed blob uncompressed");
           final byte[] compressed = new byte[compressedLen];
           dis.readFully(compressed);
           final byte[] raw = CompressionFactory.getDefault().decompress(compressed, uncompressedLen);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
@@ -147,6 +147,20 @@ class RaftPropertiesBuilder {
               + minWriteBuffer + " bytes). Increase writeBufferSize or decrease appendBufferSize");
     RaftServerConfigKeys.Log.setWriteBufferSize(properties, writeBuffer);
 
+    // #5933: the codec's decode ceiling is a wire-format constant, identical on every node, so the configured
+    // entry cap must never sit above it. An entry between the two would pass the submit gate, reach a quorum
+    // and COMMIT - and only then fail to decode on every node applying it. A committed entry cannot be taken
+    // back, so the cluster halts on that log index and replays into the same failure on every restart. Fail at
+    // startup, where the operator can act on it.
+    final long maxEntrySize = maxReplicatedEntrySize(configuration);
+    if (maxEntrySize > RaftLogEntryCodec.MAX_DECODED_ENTRY_BYTES)
+      throw new ConfigurationException(
+          "The maximum replicated Raft entry size (" + maxEntrySize + " bytes, the smaller of "
+              + "arcadedb.ha.appendBufferSize and arcadedb.ha.grpcMessageSizeMax) is above the "
+              + RaftLogEntryCodec.MAX_DECODED_ENTRY_BYTES + " bytes a Raft log entry can be decoded from. "
+              + "Lower arcadedb.ha.appendBufferSize (and arcadedb.ha.grpcMessageSizeMax with it, if that is the "
+              + "smaller of the two) to at most that value");
+
     // #4743: the gRPC frame cap is NOT the effective per-entry ceiling - the appender byte limit is
     // enforced per-entry too, and an entry above it makes the leader step down (see
     // maxReplicatedEntrySize). Surface the mismatch once at startup: without it operators tune

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5933CompressibleTxEntrySizeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5933CompressibleTxEntrySizeTest.java
@@ -195,6 +195,28 @@ class Issue5933CompressibleTxEntrySizeTest {
   }
 
   /**
+   * A length field for a section read straight off the stream is bounded by the bytes the entry ACTUALLY
+   * carries, which is exact and far tighter than any constant - so raising the absolute ceiling cannot make a
+   * forged length a bigger allocation than it was before. Both the compressed WAL of a TX_ENTRY and the
+   * (uncompressed) schema JSON of a SCHEMA_ENTRY go through it.
+   */
+  @Test
+  void aLengthLongerThanTheEntryIsRefusedBeforeItIsAllocated() {
+    final ByteString forgedTx = forgeTxEntry("heimdall", 64, 300 * 1024 * 1024,
+        CompressionFactory.getDefault().compress("a short transaction".getBytes()));
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(forgedTx))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("TX_ENTRY compressed WAL")
+        .hasMessageContaining("bytes remain in the entry");
+
+    final ByteString forgedSchema = forgeSchemaEntryWithSchemaLength("heimdall", 300 * 1024 * 1024);
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(forgedSchema))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("SCHEMA_ENTRY schemaJson")
+        .hasMessageContaining("bytes remain in the entry");
+  }
+
+  /**
    * Nothing that replicated before may stop replicating now: ordinary transactions, compressible or not, must
    * still round-trip byte for byte.
    */
@@ -253,19 +275,43 @@ class Issue5933CompressibleTxEntrySizeTest {
 
   private static ByteString forgeTxEntry(final String databaseName, final int uncompressedLength,
       final byte[] compressed) {
+    return forgeTxEntry(databaseName, uncompressedLength, compressed.length, compressed);
+  }
+
+  /**
+   * @param declaredCompressedLength written into the frame instead of the payload's real length, so a forged
+   *                                 length field can be exercised without hand-writing the whole frame twice
+   */
+  private static ByteString forgeTxEntry(final String databaseName, final int uncompressedLength,
+      final int declaredCompressedLength, final byte[] compressed) {
     try {
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
       final DataOutputStream dos = new DataOutputStream(baos);
       dos.writeByte(RaftLogEntryType.TX_ENTRY.getId());
       dos.writeUTF(databaseName);
       dos.writeInt(uncompressedLength);
-      dos.writeInt(compressed.length);
+      dos.writeInt(declaredCompressedLength);
       dos.write(compressed);
       dos.writeInt(0); // no bucket deltas
       dos.flush();
       return ByteString.copyFrom(baos.toByteArray());
     } catch (final IOException e) {
       throw new IllegalStateException("Failed to forge TX entry", e);
+    }
+  }
+
+  private static ByteString forgeSchemaEntryWithSchemaLength(final String databaseName, final int schemaLength) {
+    try {
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final DataOutputStream dos = new DataOutputStream(baos);
+      dos.writeByte(RaftLogEntryType.SCHEMA_ENTRY.getId());
+      dos.writeUTF(databaseName);
+      dos.writeInt(schemaLength);
+      dos.write("{}".getBytes());
+      dos.flush();
+      return ByteString.copyFrom(baos.toByteArray());
+    } catch (final IOException e) {
+      throw new IllegalStateException("Failed to forge SCHEMA entry", e);
     }
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5933CompressibleTxEntrySizeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5933CompressibleTxEntrySizeTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.compression.CompressionFactory;
+import com.arcadedb.exception.ConfigurationException;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.network.binary.ReplicatedEntryTooLargeException;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #5933: a bulk insert into a 4-node Raft cluster committed a {@code TX_ENTRY}
+ * that no node could ever apply, and every node crash-looped on the same Raft log index forever.
+ * <p>
+ * Two independent, mismatched size gates guarded transaction replication:
+ * <ul>
+ *   <li>at SUBMIT time {@code RaftGroupCommitter.submitAndWait} bounds the ENCODED entry, whose WAL the
+ *       codec has already LZ4-compressed, against {@code min(appendBufferSize, grpcMessageSizeMax)};</li>
+ *   <li>at APPLY time {@code RaftLogEntryCodec.decode} bounded the UNCOMPRESSED WAL length against a
+ *       hardcoded 64MB constant unrelated to either setting.</li>
+ * </ul>
+ * A migration-shaped transaction (repetitive, text/JSON-heavy) only has to compress by ~2.4x to pass the
+ * first gate and fail the second: the reporter's entry was 77,158,147 bytes uncompressed. By the time the
+ * decode fails the entry is durably committed at a fixed log index on a majority of the cluster, so
+ * {@code ArcadeStateMachine} halts the node to avoid divergence and replay deterministically reproduces the
+ * same failure on every restart, on every node.
+ * <p>
+ * The fix makes the two gates agree by construction: the ENCODER refuses to build an entry the decoder
+ * could not accept, so an unappliable entry can never reach the log; and the decoder's ceiling is raised
+ * well above the producer's, so a cluster already holding such an entry applies it and recovers instead of
+ * crash-looping.
+ */
+class Issue5933CompressibleTxEntrySizeTest {
+
+  /** The reporter's payload: 77,158,147 bytes of uncompressed WAL, well-compressing migration data. */
+  private static final int REPORTED_WAL_SIZE = 77_158_147;
+
+  /** Shared across the tests so the 77MB allocation is paid once rather than once per test. */
+  private static byte[] compressibleWal;
+
+  @BeforeAll
+  static void buildCompressiblePayload() {
+    // Repetitive, text-shaped content: exactly the profile of a bulk migration WAL, and what makes the
+    // compressed entry sail under the submit gate while the raw WAL is above the old decode ceiling.
+    compressibleWal = new byte[REPORTED_WAL_SIZE];
+    final byte[] pattern = "{\"@type\":\"Customer\",\"name\":\"ACME\",\"city\":\"Rome\"}".getBytes();
+    for (int i = 0; i < compressibleWal.length; i++)
+      compressibleWal[i] = pattern[i % pattern.length];
+  }
+
+  @AfterAll
+  static void releasePayload() {
+    compressibleWal = null;
+  }
+
+  /**
+   * The gap itself: the reporter's transaction compresses far below the submit gate while its raw WAL sits
+   * above the decode ceiling. Asserted directly so the test still means something if the constants move.
+   */
+  @Test
+  void theReportedTransactionPassesTheSubmitGateOnItsCompressedSize() {
+    final int compressedSize = CompressionFactory.getDefault().compress(compressibleWal).length;
+    final long submitGate = GlobalConfiguration.maxReplicatedRaftEntrySize(new ContextConfiguration());
+
+    assertThat(submitGate).as("stock configuration: the appender byte limit binds").isEqualTo(32L * 1024 * 1024);
+    assertThat((long) compressedSize).as("the compressed entry is what the submit gate measures, and it fits")
+        .isLessThan(submitGate);
+    assertThat(compressibleWal.length).as("the raw WAL is what the applier has to materialize, and it did not fit")
+        .isGreaterThan(RaftLogEntryCodec.MAX_ENTRY_BYTES);
+  }
+
+  /**
+   * The fix: the producer refuses the transaction instead of committing an entry no node can apply. The
+   * failure has to be non-retryable, or the caller would resubmit the same doomed entry forever.
+   */
+  @Test
+  void anUnappliableTransactionIsRejectedBeforeItCanBeProposed() {
+    assertThatThrownBy(() -> RaftLogEntryCodec.encodeTxEntry("heimdall", compressibleWal, Collections.emptyMap()))
+        .isInstanceOf(ReplicatedEntryTooLargeException.class)
+        .isNotInstanceOf(NeedRetryException.class)
+        .hasMessageContaining("heimdall")
+        .hasMessageContaining(String.valueOf(REPORTED_WAL_SIZE))
+        .hasMessageContaining("uncompressed");
+  }
+
+  /**
+   * Same gap, same fix, for the WAL embedded in a {@code SCHEMA_ENTRY}: {@code splitSchemaEntry} groups WAL
+   * entries by raw size but only re-checks the COMPRESSED chunk against the cap, so one indivisible,
+   * well-compressing WAL entry crosses the same mismatch.
+   */
+  @Test
+  void anUnappliableSchemaWalEntryIsRejectedBeforeItCanBeProposed() {
+    assertThatThrownBy(() -> RaftLogEntryCodec.encodeSchemaEntry("heimdall", "{}", Collections.emptyMap(),
+        Collections.emptyMap(), List.of(compressibleWal), List.of(Collections.emptyMap())))
+        .isInstanceOf(ReplicatedEntryTooLargeException.class)
+        .isNotInstanceOf(NeedRetryException.class)
+        .hasMessageContaining("uncompressed");
+  }
+
+  /**
+   * Recovery for a cluster that is ALREADY bricked. The entry at index 45275 is durably committed; the only
+   * way those nodes ever start again is for the upgraded decoder to accept it. So the decoder's ceiling sits
+   * well above the producer's, and an entry written by the old encoder decodes intact.
+   */
+  @Test
+  void anAlreadyCommittedOversizedTransactionDecodesInsteadOfHaltingTheNode() {
+    final ByteString legacyEntry = encodeTxEntryWithoutProducerGuard("heimdall", compressibleWal);
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(legacyEntry);
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.TX_ENTRY);
+    assertThat(decoded.databaseName()).isEqualTo("heimdall");
+    assertThat(decoded.walData()).hasSize(REPORTED_WAL_SIZE);
+    assertThat(decoded.walData()).isEqualTo(compressibleWal);
+  }
+
+  /**
+   * The decode ceiling is what a node ACCEPTS and the encode ceiling is what it PRODUCES; the first must stay
+   * strictly above the second or the mismatch this issue is about comes straight back. It is also a wire-format
+   * constant rather than a configurable: a node whose ceiling differed from its peers' would apply an entry
+   * they reject, which is the divergence the state machine halts to prevent.
+   */
+  @Test
+  void theDecoderAcceptsStrictlyMoreThanTheEncoderProduces() {
+    assertThat(RaftLogEntryCodec.MAX_DECODED_ENTRY_BYTES).isGreaterThan(RaftLogEntryCodec.MAX_ENTRY_BYTES);
+
+    // And the producer ceiling must not sit BELOW the submit gate, or an INCOMPRESSIBLE transaction that
+    // replicates fine today (raw size ~= compressed size) would start being rejected by the new check.
+    assertThat((long) RaftLogEntryCodec.MAX_ENTRY_BYTES)
+        .isGreaterThanOrEqualTo(GlobalConfiguration.maxReplicatedRaftEntrySize(new ContextConfiguration()));
+  }
+
+  /**
+   * Raising the decode ceiling must not turn the decoder into an allocation amplifier: a corrupt or hostile
+   * length field claiming hundreds of MB behind a handful of compressed bytes is refused on the LZ4 format's
+   * own expansion bound, before any array is allocated.
+   */
+  @Test
+  void aCorruptUncompressedLengthIsRefusedWithoutAllocatingIt() {
+    final byte[] tinyPayload = CompressionFactory.getDefault().compress("a short transaction".getBytes());
+    final ByteString forged = forgeTxEntry("heimdall", 400 * 1024 * 1024, tinyPayload);
+
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(forged))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("TX_ENTRY uncompressed WAL")
+        .hasMessageContaining("expansion ratio");
+  }
+
+  /**
+   * And the absolute ceiling still stands for a claim large enough to clear the ratio bound: a length above it
+   * is refused rather than allocated.
+   */
+  @Test
+  void aLengthAboveTheDecodeCeilingIsStillRefused() {
+    // Sized so the ratio bound alone would let this through - the absolute ceiling is what must catch it.
+    final int claimed = RaftLogEntryCodec.MAX_DECODED_ENTRY_BYTES + 1;
+    final byte[] payload = new byte[claimed / 255 + 1024];
+    final ByteString forged = forgeTxEntry("heimdall", claimed, payload);
+
+    assertThatThrownBy(() -> RaftLogEntryCodec.decode(forged))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("TX_ENTRY uncompressed WAL");
+  }
+
+  /**
+   * Nothing that replicated before may stop replicating now: ordinary transactions, compressible or not, must
+   * still round-trip byte for byte.
+   */
+  @Test
+  void ordinaryTransactionsStillRoundTripUnchanged() {
+    final byte[] incompressible = new byte[1024 * 1024];
+    for (int i = 0; i < incompressible.length; i++)
+      incompressible[i] = (byte) ((i * 2654435761L) >>> 13);
+
+    for (final byte[] wal : List.of(incompressible, new byte[1024 * 1024])) {
+      final Map<Integer, Integer> deltas = Map.of(7, 3, 9, -1);
+      final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(
+          RaftLogEntryCodec.encodeTxEntry("graph", wal, deltas));
+      assertThat(decoded.walData()).isEqualTo(wal);
+      assertThat(decoded.bucketRecordDelta()).isEqualTo(deltas);
+    }
+  }
+
+  /**
+   * Boundary: the producer check is "greater than", so a transaction of exactly the ceiling still replicates.
+   */
+  @Test
+  void aTransactionExactlyAtTheProducerCeilingIsAccepted() {
+    final byte[] atTheLimit = new byte[RaftLogEntryCodec.MAX_ENTRY_BYTES];
+    assertThatNoException()
+        .isThrownBy(() -> RaftLogEntryCodec.encodeTxEntry("graph", atTheLimit, Collections.emptyMap()));
+  }
+
+  /**
+   * The complement of the fix on the configuration side: the decode ceiling is a wire-format constant, so an
+   * entry cap configured ABOVE it would recreate exactly this issue for entries between the two. Fail at
+   * startup, where an operator can act on it, rather than at apply time on a committed entry.
+   */
+  @Test
+  void anEntryCapAboveTheDecodeCeilingIsRefusedAtStartup() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "1GB");
+    cfg.setValue(GlobalConfiguration.HA_WRITE_BUFFER_SIZE, "1025MB");
+    cfg.setValue(GlobalConfiguration.HA_GRPC_MESSAGE_SIZE_MAX, 1024L * 1024 * 1024);
+
+    assertThatThrownBy(() -> RaftPropertiesBuilder.build(cfg))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.appendBufferSize");
+
+    // The stock defaults must of course still build.
+    assertThatNoException().isThrownBy(() -> RaftPropertiesBuilder.build(new ContextConfiguration()));
+  }
+
+  /**
+   * Reproduces what the pre-fix encoder wrote: the TX_ENTRY frame with no producer-side bound on the
+   * uncompressed WAL length. This is what sits at index 45275 in the reporter's Raft log.
+   */
+  private static ByteString encodeTxEntryWithoutProducerGuard(final String databaseName, final byte[] walData) {
+    return forgeTxEntry(databaseName, walData.length, CompressionFactory.getDefault().compress(walData));
+  }
+
+  private static ByteString forgeTxEntry(final String databaseName, final int uncompressedLength,
+      final byte[] compressed) {
+    try {
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final DataOutputStream dos = new DataOutputStream(baos);
+      dos.writeByte(RaftLogEntryType.TX_ENTRY.getId());
+      dos.writeUTF(databaseName);
+      dos.writeInt(uncompressedLength);
+      dos.writeInt(compressed.length);
+      dos.write(compressed);
+      dos.writeInt(0); // no bucket deltas
+      dos.flush();
+      return ByteString.copyFrom(baos.toByteArray());
+    } catch (final IOException e) {
+      throw new IllegalStateException("Failed to forge TX entry", e);
+    }
+  }
+}


### PR DESCRIPTION
Closes #5933

## The defect

Transaction replication was guarded by two size gates that measured different things:

| | where | what it measured | against |
|---|---|---|---|
| submit | `RaftGroupCommitter.submitAndWait` | the **encoded** entry, whose WAL `RaftLogEntryCodec.encodeTxEntry` has already **LZ4-compressed** | `min(arcadedb.ha.appendBufferSize, arcadedb.ha.grpcMessageSizeMax)` - 32MB by default |
| apply | `RaftLogEntryCodec.decodeTxEntry` | the **uncompressed** WAL length | a hardcoded `MAX_ENTRY_BYTES = 64MB`, unrelated to either setting |

A transaction only has to compress by ~2.4x to sit under the first gate and over the second, which is unremarkable for LZ4 on WAL pages carrying repeated property names and text/JSON values - exactly the profile of the reporter's OrientDB migration. Such an entry passes the submit gate, reaches a Raft quorum, and **commits durably at a fixed log index**. Only then does every node fail to decode it:

```
CRITICAL: Unexpected error applying Raft log entry at index 45275. Shutting down to prevent state divergence.
java.lang.IllegalStateException: Invalid byte length 77158147 in TX_ENTRY uncompressed WAL (max 67108864)
```

`ArcadeStateMachine` halts the node to avoid divergence, and its recovery model assumes the failure was transient. It is not: replay reproduces the same deterministic failure on the same index, on every node, on every restart. One oversized write bricks the entire cluster with no operator-side recovery.

## The fix

The two gates now agree by construction, in the one place that owns the wire format.

**1. The producer refuses to build an entry the consumer could not accept.** `encodeTxEntry` (and the WAL entries embedded in `encodeSchemaEntry`, which `splitSchemaEntry` also groups by raw size but only re-checks compressed) validate the *uncompressed* payload against `MAX_ENTRY_BYTES` and throw `ReplicatedEntryTooLargeException` - a `TransactionException`, deliberately **not** a `NeedRetryException`, since retrying resubmits the same undeliverable payload. The transaction fails on the leader, before anything is proposed, with a message that names the real constraint. `RaftReplicatedDatabase.replicateAndCommitLocally` already routes `ArcadeDBException` to "the entry never reached the log": ticket released, transaction rolled back.

`MAX_ENTRY_BYTES` stays at 64MB, which is above the 32MB default submit gate - so no *incompressible* transaction that replicates today (raw size ~= compressed size) starts being rejected.

**2. The consumer's ceiling is raised well above the producer's** (`MAX_DECODED_ENTRY_BYTES = 512MB`). This is what lets a cluster **already** holding such a committed entry apply it and come back up after the upgrade, instead of crash-looping on it forever. Conservative in what it sends, liberal in what it accepts: the asymmetry is the invariant, so entries produced by any version in the safe range remain appliable.

**3. Raising the decode ceiling does not turn the decoder into an allocation amplifier.** Two bounds, each exact for the thing it guards, both applied *before* any array is allocated:

- a length field for a section read **straight off the stream** (a compressed WAL, the schema JSON, the users JSON, the bootstrap fingerprint) is bounded by the bytes the entry **actually carries** - `dis.available()`, which is exact for a `ByteString`-backed stream and is already load-bearing in `decode` (the trailing-byte corruption check and the optional-section probes both depend on it). This is strictly tighter than the old flat 64MB constant, so a forged length now costs *less* than before the ceiling was raised, not more;
- a **decompressed** length is legitimately many times the bytes present, so `available()` cannot bound it. It is bounded instead by what those compressed bytes could possibly expand to - `255:1`, the LZ4 block format's asymptotic maximum, which a well-formed block can never reach. Genuine WAL ratios sit in the low single digits.

**4. The remaining way to recreate the mismatch is closed at startup.** The decode ceiling is a wire-format constant and is deliberately **not** configurable - a node whose ceiling differed from its peers' would apply entries they reject, which is the divergence the state machine halts to prevent. So `RaftPropertiesBuilder.build` now refuses at boot any configured entry cap above it, where an operator can act on it, rather than at apply time on an already-committed entry.

The `arcadedb.ha.appendBufferSize` documentation now states that compression does not make a transaction unbounded and that a second, fixed ceiling applies to the uncompressed WAL - the gap the issue called out as "never mentioned in the startup banner that documents the replication size limit".

## Alternatives considered

- **Bounding the claimed uncompressed length by `dis.available()`** (the issue's first suggestion). Wrong for a *decompressed* field, whose length is legitimately many times the bytes remaining - hence the expansion-ratio bound there instead. Applied to the lengths that *are* read straight off the stream it is exact, and it is applied (point 3 above).
- **Chunking `replicateTransaction` the way `replicateSchema` splits** (the issue's second suggestion). A schema change is safe to split because every prefix of the sequence is self-consistent; a transaction is not - its WAL must apply atomically, so followers would have to buffer chunks and apply them as a unit, with the leader-dies-mid-sequence case to reconcile. That is a feature, not a bug fix, and it does not help a cluster that is already down.
- **Making `MAX_ENTRY_BYTES` track `grpcMessageSizeMax`** (the issue's third suggestion). Per-node configuration of a decode ceiling is unsafe: two nodes with different values disagree about which entries are appliable, which is this bug with extra steps. Hence the fixed constant plus the startup validation.

## Test plan

New: `ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5933CompressibleTxEntrySizeTest` (11 tests, well under a second).

- [x] **Red proven first**: with the guards neutralised, 5 of the 10 fail, one of them with the reporter's verbatim exception - `Invalid byte length 77158147 in TX_ENTRY uncompressed WAL (max 67108864)`.
- [x] The gap itself is asserted directly, not assumed: the reporter's 77,158,147-byte payload compresses to under the 32MB submit gate while its raw size is over the producer ceiling.
- [x] The transaction is rejected before it can be proposed, with a non-retryable `ReplicatedEntryTooLargeException` naming the database and the size.
- [x] Same for a `SCHEMA_ENTRY`'s embedded WAL.
- [x] Recovery: an entry written by the pre-fix encoder (hand-framed in the test, since the fixed encoder refuses to produce one) decodes byte-for-byte instead of halting the node.
- [x] The decode ceiling stays strictly above the producer ceiling, and the producer ceiling stays at or above the default submit gate.
- [x] A forged 400MB uncompressed length behind a handful of compressed bytes is refused on the expansion ratio, without allocating it; a length above the absolute ceiling is refused too.
- [x] A forged 300MB length for a section read straight off the stream - the compressed WAL of a `TX_ENTRY`, the schema JSON of a `SCHEMA_ENTRY` - is refused against the bytes the entry actually carries.
- [x] Ordinary transactions - compressible and incompressible - still round-trip unchanged, and a transaction exactly at the ceiling is still accepted (the check is `>`, not `>=`).
- [x] A configured entry cap above the decode ceiling fails at startup; the stock defaults still build.
- [x] Full `ha-raft` unit suite green.
