### PR TITLE
fix(#5898): a Cypher property access through a broken link raises a TypeError, not RecordNotFoundException

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
@@ -20,7 +20,9 @@ package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
 import com.arcadedb.query.opencypher.temporal.*;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -54,8 +56,7 @@ public class PropertyAccessExpression implements Expression {
     if (variable instanceof RID rid) {
       // Lazy vertex resolution: algorithm procedures store RIDs to avoid loading all vertices upfront.
       // Only resolve to Document when a property is actually accessed.
-      final Object rawValue = rid.asVertex().get(propertyName);
-      return TemporalUtil.convertFromStorage(rawValue);
+      return readLinkedProperty(rid, propertyName);
     } else if (variable instanceof Document) {
       final Object rawValue = ((Document) variable).get(propertyName);
       return TemporalUtil.convertFromStorage(rawValue);
@@ -81,6 +82,45 @@ public class PropertyAccessExpression implements Expression {
     throw new CommandExecutionException(
         "TypeError: Cannot access property '" + propertyName + "' on " +
         variable.getClass().getSimpleName() + " value");
+  }
+
+  /**
+   * Reads {@code propertyName} through a persisted LINK, shared by this (variable-bound) access path and the chained
+   * access path in {@code CypherExpressionBuilder.ChainedPropertyAccessExpression} so both dereference a RID identically.
+   * <p>
+   * The RID is resolved to a {@link Document} rather than to a {@code Vertex}: every property-bearing record - vertex,
+   * edge or plain document - is a {@code Document}, and the caller's adjacent {@code instanceof Document} branch already
+   * reads a live value of any of those three shapes the same way, so a LINK to a non-vertex record is not an error. It
+   * also removes the {@code ClassCastException} that {@code RID.asVertex()} turned into a {@link RecordNotFoundException}.
+   * <p>
+   * What remains a failure is a RID that resolves to nothing, typically because the referenced record was deleted and
+   * nothing rewrote the property holding the link. That is reported as a {@link CommandExecutionException} carrying the
+   * same {@code TypeError: Cannot access property '<name>' on ...} wording the callers use for every other base type
+   * they cannot read a property from, so the query fails the way a Cypher type error fails instead of letting an
+   * engine-level {@link RecordNotFoundException} escape the query engine (issue #5898).
+   * <p>
+   * The {@code RecordNotFoundException} is deliberately NOT kept as the cause: {@code AbstractServerHttpHandler}
+   * classifies a {@code CommandExecutionException} by {@code getCause()} when there is one, so attaching it would route
+   * the response through the catch-all arm ("Error on transaction commit") instead of the Cypher-error arm ("Cannot
+   * execute command"), i.e. re-introduce the very message this fix removes. Nothing is lost - the RID and the reason
+   * are both in the message.
+   */
+  public static Object readLinkedProperty(final RID rid, final String propertyName) {
+    final Record record;
+    try {
+      record = rid.getRecord();
+    } catch (final RecordNotFoundException e) {
+      throw new CommandExecutionException(
+          "TypeError: Cannot access property '" + propertyName + "' on " + rid +
+          ": the linked record does not exist");
+    }
+
+    if (!(record instanceof Document document))
+      throw new CommandExecutionException(
+          "TypeError: Cannot access property '" + propertyName + "' on " + rid +
+          ": the linked record has no properties");
+
+    return TemporalUtil.convertFromStorage(document.get(propertyName));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
@@ -110,17 +110,22 @@ public class PropertyAccessExpression implements Expression {
     try {
       record = rid.getRecord();
     } catch (final RecordNotFoundException e) {
-      throw new CommandExecutionException(
-          "TypeError: Cannot access property '" + propertyName + "' on " + rid +
-          ": the linked record does not exist");
+      throw new CommandExecutionException(brokenLinkMessage(rid, propertyName, "the linked record does not exist"));
     }
 
     if (!(record instanceof Document document))
-      throw new CommandExecutionException(
-          "TypeError: Cannot access property '" + propertyName + "' on " + rid +
-          ": the linked record has no properties");
+      throw new CommandExecutionException(brokenLinkMessage(rid, propertyName, "the linked record has no properties"));
 
     return TemporalUtil.convertFromStorage(document.get(propertyName));
+  }
+
+  /**
+   * Keeps the two broken-link failures on one wording. The RID takes the place the generic sibling messages give to the
+   * base type's class name: with the record gone, the link itself is the only thing left that identifies what could not
+   * be read, and it is what a caller needs to find the property still holding it.
+   */
+  private static String brokenLinkMessage(final RID rid, final String propertyName, final String reason) {
+    return "TypeError: Cannot access property '" + propertyName + "' on " + rid + ": " + reason;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
@@ -54,8 +54,8 @@ public class PropertyAccessExpression implements Expression {
       return null;
 
     if (variable instanceof RID rid) {
-      // Lazy vertex resolution: algorithm procedures store RIDs to avoid loading all vertices upfront.
-      // Only resolve to Document when a property is actually accessed.
+      // Lazy resolution: a persisted node-valued property is stored as a LINK, and algorithm procedures store RIDs to
+      // avoid loading all vertices upfront. Either way the record is loaded only when a property is actually read.
       return readLinkedProperty(rid, propertyName);
     } else if (variable instanceof Document) {
       final Object rawValue = ((Document) variable).get(propertyName);
@@ -88,29 +88,22 @@ public class PropertyAccessExpression implements Expression {
    * Reads {@code propertyName} through a persisted LINK, shared by this (variable-bound) access path and the chained
    * access path in {@code CypherExpressionBuilder.ChainedPropertyAccessExpression} so both dereference a RID identically.
    * <p>
-   * The RID is resolved to a {@link Document} rather than to a {@code Vertex}: every property-bearing record - vertex,
-   * edge or plain document - is a {@code Document}, and the caller's adjacent {@code instanceof Document} branch already
-   * reads a live value of any of those three shapes the same way, so a LINK to a non-vertex record is not an error. It
-   * also removes the {@code ClassCastException} that {@code RID.asVertex()} turned into a {@link RecordNotFoundException}.
-   * <p>
-   * What remains a failure is a RID that resolves to nothing, typically because the referenced record was deleted and
-   * nothing rewrote the property holding the link. That is reported as a {@link CommandExecutionException} carrying the
-   * same {@code TypeError: Cannot access property '<name>' on ...} wording the callers use for every other base type
-   * they cannot read a property from, so the query fails the way a Cypher type error fails instead of letting an
-   * engine-level {@link RecordNotFoundException} escape the query engine (issue #5898).
-   * <p>
-   * The resolution is {@code getRecord()} plus an {@code instanceof} rather than the more idiomatic
-   * {@code RID.asDocument()} for one reason: {@code asDocument()} answers a wrong-shaped record with a bare
-   * {@code ClassCastException}, so using it here would mean catching that - and a {@code catch (ClassCastException)}
-   * around a record lookup also swallows any unrelated cast failure raised deeper inside it, turning a real engine
-   * fault into a misleading "the linked record has no properties". The {@code instanceof} answers only the question
-   * being asked.
-   * <p>
-   * The {@code RecordNotFoundException} is deliberately NOT kept as the cause: {@code AbstractServerHttpHandler}
-   * classifies a {@code CommandExecutionException} by {@code getCause()} when there is one, so attaching it would route
-   * the response through the catch-all arm ("Error on transaction commit") instead of the Cypher-error arm ("Cannot
-   * execute command"), i.e. re-introduce the very message this fix removes. Nothing is lost - the RID and the reason
-   * are both in the message.
+   * Three decisions here are load-bearing and easy to undo by accident:
+   * <ul>
+   *   <li>The target is a {@link Document}, not a {@code Vertex}. Vertex, edge and plain document are all
+   *       {@code Document}s and the adjacent {@code instanceof Document} branch already reads all three the same way,
+   *       so a LINK to a non-vertex record is not an error - which is what {@code RID.asVertex()} made it, by
+   *       reporting its own {@code ClassCastException} as a {@link RecordNotFoundException}.</li>
+   *   <li>{@code getRecord()} plus {@code instanceof} rather than the shorter {@code RID.asDocument()}, which casts
+   *       internally: using it would mean a {@code catch (ClassCastException)} around a record lookup, which also
+   *       swallows any unrelated cast failure raised deeper inside it and reports a real engine fault as "the linked
+   *       record has no properties".</li>
+   *   <li>The {@link RecordNotFoundException} is NOT kept as the cause. {@code AbstractServerHttpHandler} classifies a
+   *       {@code CommandExecutionException} by {@code getCause()} when there is one, so attaching it routes the
+   *       response through the catch-all arm ("Error on transaction commit") instead of the Cypher-error arm ("Cannot
+   *       execute command") - the very message this replaced (issue #5898). Nothing is lost: the RID and the reason
+   *       are both in the message.</li>
+   * </ul>
    */
   public static Object readLinkedProperty(final RID rid, final String propertyName) {
     final Record record;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
@@ -99,6 +99,13 @@ public class PropertyAccessExpression implements Expression {
    * they cannot read a property from, so the query fails the way a Cypher type error fails instead of letting an
    * engine-level {@link RecordNotFoundException} escape the query engine (issue #5898).
    * <p>
+   * The resolution is {@code getRecord()} plus an {@code instanceof} rather than the more idiomatic
+   * {@code RID.asDocument()} for one reason: {@code asDocument()} answers a wrong-shaped record with a bare
+   * {@code ClassCastException}, so using it here would mean catching that - and a {@code catch (ClassCastException)}
+   * around a record lookup also swallows any unrelated cast failure raised deeper inside it, turning a real engine
+   * fault into a misleading "the linked record has no properties". The {@code instanceof} answers only the question
+   * being asked.
+   * <p>
    * The {@code RecordNotFoundException} is deliberately NOT kept as the cause: {@code AbstractServerHttpHandler}
    * classifies a {@code CommandExecutionException} by {@code getCause()} when there is one, so attaching it would route
    * the response through the catch-all arm ("Error on transaction commit") instead of the Cypher-error arm ("Cannot

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1691,11 +1691,11 @@ class CypherExpressionBuilder {
       // sees the stored RID rather than the live Vertex it saw during the write. Dereference it
       // transparently, applying the same temporal-type restoration as the single-level
       // PropertyAccessExpression, so the same expression keeps working across the transaction
-      // boundary (#5800) and stays consistent with the variable-bound access path.
-      if (baseValue instanceof RID rid) {
-        final Object rawValue = rid.asVertex().get(propertyName);
-        return TemporalUtil.convertFromStorage(rawValue);
-      }
+      // boundary (#5800) and stays consistent with the variable-bound access path - literally so: the
+      // dereference itself lives in PropertyAccessExpression, which also turns a link that resolves to
+      // nothing into a Cypher-flavored TypeError instead of a raw RecordNotFoundException (#5898).
+      if (baseValue instanceof RID rid)
+        return PropertyAccessExpression.readLinkedProperty(rid, propertyName);
 
       // Handle Document types
       if (baseValue instanceof Document) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBrokenLinkPropertyAccessIssue5898Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBrokenLinkPropertyAccessIssue5898Test.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5898: dereferencing a node-valued property whose stored LINK/RID no
+ * longer resolves must surface as a Cypher-flavored {@link CommandExecutionException}
+ * ("TypeError: Cannot access property ...") rather than a raw {@link RecordNotFoundException},
+ * which the HTTP command API turns into an unfriendly 500 instead of a client error.
+ * <p>
+ * Two property-access paths dereference a persisted LINK and both are covered here:
+ * <ul>
+ *   <li>the variable-bound path, {@code WITH holder.ref AS r RETURN r.id}
+ *       ({@code PropertyAccessExpression});</li>
+ *   <li>the chained path, {@code holder.ref.id}, reachable from ordinary Cypher since #5893
+ *       ({@code CypherExpressionBuilder.ChainedPropertyAccessExpression}).</li>
+ * </ul>
+ * A LINK to a non-vertex record (a plain document or an edge) is not broken at all - it is an
+ * ordinary property-bearing record - so both paths must read through it exactly like the adjacent
+ * {@code instanceof Document} branch already does for a live value.
+ */
+class CypherBrokenLinkPropertyAccessIssue5898Test {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/cypherbrokenlink5898").create();
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void chainedAccessOnDanglingLinkRaisesCypherTypeError() {
+    createHolderWithDanglingLink();
+
+    database.transaction(() -> assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (holder:T {role: 'holder'}) RETURN holder.ref.id AS referencedId")) {
+        rs.stream().forEach(r -> {
+        });
+      }
+    })
+        .as("a dangling LINK must not escape as a raw RecordNotFoundException")
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("TypeError: Cannot access property 'id'")
+        .hasMessageContaining("the linked record does not exist")
+        // AbstractServerHttpHandler classifies a CommandExecutionException by its cause when it has one, so keeping
+        // the RecordNotFoundException as the cause would route the HTTP response back to the generic
+        // "Error on transaction commit" arm this fix exists to avoid.
+        .as("the engine-level cause must not be attached")
+        .hasNoCause());
+  }
+
+  @Test
+  void variableBoundAccessOnDanglingLinkRaisesCypherTypeError() {
+    createHolderWithDanglingLink();
+
+    database.transaction(() -> assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (holder:T {role: 'holder'}) WITH holder.ref AS r RETURN r.id AS referencedId")) {
+        rs.stream().forEach(r -> {
+        });
+      }
+    })
+        .as("a dangling LINK must not escape as a raw RecordNotFoundException")
+        .isInstanceOf(CommandExecutionException.class)
+        .hasMessageContaining("TypeError: Cannot access property 'id'")
+        .hasMessageContaining("the linked record does not exist")
+        .as("the engine-level cause must not be attached")
+        .hasNoCause());
+  }
+
+  @Test
+  void chainedAccessOnNonVertexLinkReadsThroughTheLink() {
+    createHolderLinkingToDocument();
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (holder:T {role: 'holder'}) RETURN holder.ref.id AS referencedId")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Object referencedId = rs.next().getProperty("referencedId");
+        assertThat(referencedId).as("a LINK to a plain document is a live, property-bearing record").isNotNull();
+        assertThat(((Number) referencedId).intValue()).isEqualTo(99);
+      }
+    });
+  }
+
+  @Test
+  void variableBoundAccessOnNonVertexLinkReadsThroughTheLink() {
+    createHolderLinkingToDocument();
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (holder:T {role: 'holder'}) WITH holder.ref AS r RETURN r.id AS referencedId")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Object referencedId = rs.next().getProperty("referencedId");
+        assertThat(referencedId).as("a LINK to a plain document is a live, property-bearing record").isNotNull();
+        assertThat(((Number) referencedId).intValue()).isEqualTo(99);
+      }
+    });
+  }
+
+  /**
+   * Persists a holder vertex whose {@code ref} property is a LINK to a vertex that is then deleted,
+   * leaving the RID dangling. The delete runs in its own transaction so the value read back is a
+   * plain unresolvable RID and not the in-transaction deleted-entity marker.
+   */
+  private void createHolderWithDanglingLink() {
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (holder:T {role: 'holder'}), (target:T {role: 'target', id: 42}) "
+            + "SET holder.ref = target RETURN holder").close());
+
+    database.transaction(() -> database.command("sql", "DELETE FROM T WHERE role = 'target'").close());
+  }
+
+  /**
+   * Persists a holder vertex whose {@code ref} property is a LINK to a plain (non-vertex) document.
+   */
+  private void createHolderLinkingToDocument() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("D");
+      database.getSchema().getOrCreateVertexType("T");
+    });
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("D");
+      doc.set("id", 99);
+      doc.save();
+      final RID docRid = doc.getIdentity();
+
+      final MutableVertex holder = database.newVertex("T");
+      holder.set("role", "holder");
+      holder.set("ref", docRid);
+      holder.save();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBrokenLinkPropertyAccessIssue5898Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBrokenLinkPropertyAccessIssue5898Test.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -135,6 +136,36 @@ class CypherBrokenLinkPropertyAccessIssue5898Test {
     });
   }
 
+  @Test
+  void chainedAccessOnEdgeLinkReadsThroughTheLink() {
+    createHolderLinkingToEdge();
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (holder:T {role: 'holder'}) RETURN holder.ref.id AS referencedId")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Object referencedId = rs.next().getProperty("referencedId");
+        assertThat(referencedId).as("a LINK to an edge is a live, property-bearing record").isNotNull();
+        assertThat(((Number) referencedId).intValue()).isEqualTo(77);
+      }
+    });
+  }
+
+  @Test
+  void variableBoundAccessOnEdgeLinkReadsThroughTheLink() {
+    createHolderLinkingToEdge();
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (holder:T {role: 'holder'}) WITH holder.ref AS r RETURN r.id AS referencedId")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Object referencedId = rs.next().getProperty("referencedId");
+        assertThat(referencedId).as("a LINK to an edge is a live, property-bearing record").isNotNull();
+        assertThat(((Number) referencedId).intValue()).isEqualTo(77);
+      }
+    });
+  }
+
   /**
    * Persists a holder vertex whose {@code ref} property is a LINK to a vertex that is then deleted,
    * leaving the RID dangling. The delete runs in its own transaction so the value read back is a
@@ -166,6 +197,36 @@ class CypherBrokenLinkPropertyAccessIssue5898Test {
       final MutableVertex holder = database.newVertex("T");
       holder.set("role", "holder");
       holder.set("ref", docRid);
+      holder.save();
+    });
+  }
+
+  /**
+   * Persists a holder vertex whose {@code ref} property is a LINK to an edge. An edge is stored differently from a
+   * vertex or a plain document, so it gets its own fixture instead of being covered by analogy: what the fix relies on
+   * is that all three are {@link com.arcadedb.database.Document}s, and only running one proves it.
+   */
+  private void createHolderLinkingToEdge() {
+    database.transaction(() -> {
+      database.getSchema().getOrCreateVertexType("T");
+      database.getSchema().getOrCreateEdgeType("E");
+    });
+
+    database.transaction(() -> {
+      final MutableVertex from = database.newVertex("T");
+      from.set("role", "from");
+      from.save();
+
+      final MutableVertex to = database.newVertex("T");
+      to.set("role", "to");
+      to.save();
+
+      final MutableEdge edge = from.newEdge("E", to, "id", 77);
+      edge.save();
+
+      final MutableVertex holder = database.newVertex("T");
+      holder.set("role", "holder");
+      holder.set("ref", edge.getIdentity());
       holder.save();
     });
   }

--- a/server/src/test/java/com/arcadedb/server/http/Issue5898BrokenLinkPropertyAccessHttpTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/Issue5898BrokenLinkPropertyAccessHttpTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5898 over HTTP, which is the surface it was reported from. Dereferencing a Cypher property whose stored
+ * LINK no longer resolves used to let a {@code RecordNotFoundException} out of the query engine; the auto-commit
+ * wrapper in {@code DatabaseAbstractHandler} re-throws it inside a {@code TransactionException}, and
+ * {@code AbstractServerHttpHandler} - which classifies by {@code getCause()} - has no arm for it, so the client was
+ * told "Error on transaction commit" and learned nothing about what actually failed.
+ * <p>
+ * What this pins is the message, not the status: a Cypher {@code TypeError} is a 500 by deliberate design (the
+ * #5219 rationale in {@code AbstractServerHttpHandler}, matching TinkerPop's {@code SERVER_ERROR_SCRIPT_EVALUATION}),
+ * and this failure must be classified as one of those rather than as the catch-all commit failure. Asserting the
+ * status alone would pass on the very bug being fixed, since both shapes answer 500.
+ */
+class Issue5898BrokenLinkPropertyAccessHttpTest extends BaseGraphServerTest {
+
+  @Test
+  void aDanglingLinkIsReportedAsACypherTypeError() throws Exception {
+    testEachServer(serverIndex -> {
+      executeCommand(serverIndex, "opencypher",
+          "CREATE (holder:LinkHolder {role: 'holder'}), (target:LinkHolder {role: 'target', id: 42}) "
+              + "SET holder.ref = target");
+
+      // Deleted in its own request, so the read below meets a genuinely unresolvable RID rather than the
+      // in-transaction deleted-entity marker.
+      executeCommand(serverIndex, "sql", "DELETE FROM LinkHolder WHERE role = 'target'");
+
+      final JSONObject error = commandExpecting(serverIndex, 500, "opencypher",
+          "MATCH (holder:LinkHolder {role: 'holder'}) RETURN holder.ref.id AS referencedId");
+
+      assertThat(error.getString("detail"))
+          .as("the client is told which property could not be read, and through which link")
+          .contains("TypeError: Cannot access property 'id'");
+      assertThat(error.getString("error"))
+          .as("classified as a failed command, not as a failed commit")
+          .isEqualTo("Cannot execute command");
+    });
+  }
+
+  /**
+   * The control: a link that still resolves must keep answering 200 with the referenced value, so the test above
+   * cannot pass by breaking every dereference.
+   */
+  @Test
+  void aLiveLinkStillDereferences() throws Exception {
+    testEachServer(serverIndex -> {
+      executeCommand(serverIndex, "opencypher",
+          "CREATE (holder:LiveLinkHolder {role: 'holder'}), (target:LiveLinkHolder {role: 'target', id: 7}) "
+              + "SET holder.ref = target");
+
+      final JSONObject response = executeCommand(serverIndex, "opencypher",
+          "MATCH (holder:LiveLinkHolder {role: 'holder'}) RETURN holder.ref.id AS referencedId");
+
+      // The Cypher engine answers a records/columns envelope rather than the flat array SQL returns.
+      final JSONObject result = response.getJSONObject("result");
+      assertThat(result.getJSONArray("records").getJSONObject(0).getInt("referencedId")).isEqualTo(7);
+    });
+  }
+
+  /** Posts a command, asserts the HTTP status, and returns the parsed body (the error body on a failure). */
+  private JSONObject commandExpecting(final int serverIndex, final int expectedStatus, final String language,
+      final String command) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/graph").openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+
+    final JSONObject payload = new JSONObject();
+    payload.put("language", language);
+    payload.put("command", command);
+    formatPayload(connection, payload);
+    connection.connect();
+
+    try {
+      // The status is read BEFORE the body: which stream carries it depends on the status, and asking for the error
+      // stream of a successful response hands back null.
+      final int status = connection.getResponseCode();
+      final String body = status < 400 ? readResponse(connection) : readError(connection);
+      assertThat(status).as("HTTP status for `%s`; body: %s", command, body).isEqualTo(expectedStatus);
+      return new JSONObject(body);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}


### PR DESCRIPTION
Closes #5898

## Summary

Both Cypher property-access paths that dereference a persisted node-valued property - `PropertyAccessExpression` (variable-bound, `WITH holder.ref AS r RETURN r.id`) and `CypherExpressionBuilder.ChainedPropertyAccessExpression` (chained, `holder.ref.id`, reachable from ordinary Cypher since #5893) - resolved the stored LINK with `rid.asVertex()`. That call throws `RecordNotFoundException` when the RID no longer resolves, and `RID.asVertex()` also converts its own `ClassCastException` into a `RecordNotFoundException`, so a link to a plain document or an edge failed the same way. Either shape let an engine-level exception escape the query engine instead of the `TypeError: Cannot access property '<name>' on ...` these two `evaluate()` methods produce for every other base type they cannot read from. Over the HTTP command API the auto-commit wrapper in `DatabaseAbstractHandler` wraps it in a `TransactionException`, and `AbstractServerHttpHandler` - which classifies by `getCause()` - finds no arm for `RecordNotFoundException` and falls through to the catch-all "Error on transaction commit", hiding the real reason.

The dereference now lives in one place, `PropertyAccessExpression.readLinkedProperty(rid, propertyName)`, called by both paths, and it resolves the RID to a `Document` rather than to a `Vertex`. That is the substantive half of the fix: vertex, edge and plain document are all `Document`s, and the branch immediately after the RID branch in both callers already reads a live value of any of those three shapes exactly that way - so a link to a non-vertex record is not broken at all, and the `ClassCastException` path disappears rather than being re-labelled. What remains a genuine failure is a RID that resolves to nothing (the referenced record was deleted and nothing rewrote the property holding the link); that is reported as a `CommandExecutionException` carrying the existing TypeError wording plus the RID and the reason.

One deliberate detail, pinned by an assertion in the test: the `RecordNotFoundException` is **not** attached as the cause. `AbstractServerHttpHandler` classifies a `CommandExecutionException` by its cause when it has one, so attaching it would route the response straight back to the "Error on transaction commit" arm this change exists to get away from. Nothing is lost - the RID and the reason are both in the message.

### Scope note on the HTTP status code

The issue describes the symptom as "an unfriendly 500". After this change the status is still 500, now via the `CommandExecutionException` arm ("Cannot execute command") carrying the TypeError message, because that is the deliberate mapping for *every* Cypher `TypeError` (see the #5219 rationale comment in `AbstractServerHttpHandler`, matching TinkerPop's `SERVER_ERROR_SCRIPT_EVALUATION`). Making a Cypher `TypeError` a 4xx is a separate decision about the whole family, not something to special-case for broken links, so it is not taken here. What this PR delivers is the consistency the issue actually asks for: the failure is now the same Cypher-flavored error as every other unreadable base type, with a message that names the RID, instead of an engine-internal exception surfacing as "Error on transaction commit".

Adjacent gap noticed and left alone: an *unwrapped* `RecordNotFoundException` maps to 404, but a wrapped one has no arm and degrades to 500. That asymmetry is in the server module and unrelated to Cypher property access.

## Test plan

New regression test `engine/src/test/java/com/arcadedb/query/opencypher/CypherBrokenLinkPropertyAccessIssue5898Test.java`, four cases covering both access paths against both failure shapes. All four fail on `main` (2 with the raw `RecordNotFoundException: Record #1:1 not found` from the dangling link, 2 with `Record #1:0 not found` from the `asVertex()` cast on a document link) and pass with the fix.

- [ ] `chainedAccessOnDanglingLinkRaisesCypherTypeError` - `holder.ref.id` where `ref` points at a deleted vertex raises `CommandExecutionException` with `TypeError: Cannot access property 'id'`, `the linked record does not exist`, and no cause.
- [ ] `variableBoundAccessOnDanglingLinkRaisesCypherTypeError` - same for `WITH holder.ref AS r RETURN r.id`.
- [ ] `chainedAccessOnNonVertexLinkReadsThroughTheLink` - `holder.ref.id` where `ref` is a LINK to a plain document returns the property instead of failing.
- [ ] `variableBoundAccessOnNonVertexLinkReadsThroughTheLink` - same for the variable-bound path.
- [ ] `CypherNodeValuedPropertyDereferenceIssue5800Test` (3 tests) still green - the #5800/#5893 behavior, including the temporal-type restoration through a chained link, is unchanged.
- [ ] Full `com.arcadedb.query.opencypher.**` package: 8237 tests, 0 failures, 0 errors.

```
mvn -pl engine test -Dtest='com.arcadedb.query.opencypher.**' -DexcludedGroups=benchmark,slow,vector
```
