### PR TITLE
fix(#6167): a SQL trigger body that is a SELECT never ran

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1488,4 +1488,24 @@ null on every imported record, and under the new one would be rejected. It now i
 is a valid ArcadeDB default expression - `sysdate()`, numbers, already-quoted strings keep their meaning - and quotes
 it as a string literal otherwise, logging which defaults it had to translate.
 
+## A SQL trigger body that is a `SELECT` now actually runs, and can veto (#6167)
+
+`SQLTriggerExecutor` ran a trigger's SQL body with `database.command(...).close()`, discarding the result set
+without ever iterating it. A `SELECT` result set in ArcadeDB is pull-based - nothing runs until it is pulled - so a
+`SELECT`-bodied trigger was a silent no-op: the DDL succeeded, the trigger registered, it fired on schedule, and its
+body never executed. `INSERT`/`UPDATE`/`DELETE` bodies were unaffected, because their execution plans run eagerly
+when the command is built.
+
+The body's result set is now drained to exhaustion instead of closed unread, which fixes the no-op and also gives a
+SQL trigger body the same veto contract the JavaScript executor already had: a body that evaluates to a single
+scalar `false` - one row, one real property (`$score`/`$similarity` search-scoring metadata don't count) - aborts
+the operation, which is what `SELECT false` or `SELECT <condition> AS ok` looks like it should do. The check is
+scoped to bodies that are actually idempotent (`SELECT`), so an existing `UPDATE ... RETURN AFTER <field>` (or
+`RETURN BEFORE`) trigger - which can produce that same one-row, one-property shape - is never misread as a veto
+regardless of what the returned field holds.
+
+**Upgrade note**: a `BEFORE READ` trigger with a non-trivial `SELECT` body that previously did nothing will now run
+its query on every read of the type. This is the fix, not a regression, but it is worth budgeting for if such a
+trigger exists in an upgraded database.
+
 [#6134](https://github.com/ArcadeData/arcadedb/issues/6134)

--- a/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
+++ b/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
@@ -22,9 +22,12 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -53,10 +56,7 @@ public class SQLTriggerExecutor implements TriggerExecutor {
         params.put("$oldRecord", oldRecord);
       }
 
-      // Execute SQL with context parameters. Triggers run on every matching record; closing the
-      // ResultSet releases the per-call execution plan and avoids per-record state accumulation.
-      database.command("sql", sql, params).close();
-      return true;
+      return consume(database.command("sql", sql, params));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error executing SQL trigger '%s': %s", e, triggerName, e.getMessage());
       throw new TriggerExecutionException("SQL trigger '" + triggerName + "' failed: " + e.getMessage(), e);
@@ -76,11 +76,41 @@ public class SQLTriggerExecutor implements TriggerExecutor {
       params.put("rid", rid);
       params.put("$rid", rid);
 
-      database.command("sql", sql, params).close();
-      return true;
+      return consume(database.command("sql", sql, params));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error executing SQL trigger '%s': %s", e, triggerName, e.getMessage());
       throw new TriggerExecutionException("SQL trigger '" + triggerName + "' failed: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Drains the body's result set to exhaustion before closing it. A {@code SELECT} result set in ArcadeDB is
+   * pull-based: nothing runs until it is iterated, so a body that reads without ever being consumed executes
+   * nothing at all - a silent no-op rather than a slow or partial one. DML bodies (INSERT/UPDATE/DELETE) already
+   * execute eagerly when the command is built, so draining them here only walks their already-buffered rows.
+   * <p>
+   * The drained result also decides whether the operation continues, giving a SQL body the same veto contract as
+   * {@link ScriptTriggerExecutor#execute}: a body that evaluates to a single scalar {@code false} - one row, one
+   * property - aborts the operation, exactly what {@code SELECT false} or {@code SELECT <condition> AS ok} looks
+   * like it should do. A multi-row or multi-column result has no unambiguous single answer, so it is drained for
+   * its effects and treated as a pass, same as DML.
+   */
+  private static boolean consume(final ResultSet result) {
+    try (result) {
+      Result single = null;
+      long   count  = 0;
+      while (result.hasNext()) {
+        final Result row = result.next();
+        single = count == 0 ? row : null;
+        count++;
+      }
+
+      if (count == 1 && single != null && single.isProjection()) {
+        final Set<String> properties = single.getPropertyNames();
+        if (properties.size() == 1 && Boolean.FALSE.equals(single.getProperty(properties.iterator().next())))
+          return false;
+      }
+      return true;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
+++ b/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
@@ -19,6 +19,7 @@
 package com.arcadedb.schema.trigger;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.log.LogManager;
@@ -127,7 +128,7 @@ public class SQLTriggerExecutor implements TriggerExecutor {
       if (count == 1 && first.isProjection()) {
         final String property = soleRealProperty(first);
         if (property != null && Boolean.FALSE.equals(first.getProperty(property))
-            && database.getQueryEngine("sql").analyze(sql).isIdempotent())
+            && ((DatabaseInternal) database).getStatementCache().isIdempotent(sql))
           return false;
       }
       return true;

--- a/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
+++ b/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
@@ -27,7 +27,6 @@ import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -107,11 +106,17 @@ public class SQLTriggerExecutor implements TriggerExecutor {
    * single-property result before, and now that it might (via {@code RETURN}), that shape is simply not idempotent
    * and is drained for its effects like any other DML body. The check runs only once a candidate row is already in
    * hand, so it costs nothing on the far more common multi-row, multi-column or non-projection results.
+   * <p>
+   * {@code $score}/{@code $similarity} are excluded from the property count: {@code ResultInternal.getPropertyNames()}
+   * adds them automatically whenever a full-text or vector search set a score, so a scored validation body like
+   * {@code SELECT ok FROM ... WHERE MATCH(...) ...} would otherwise report two property names instead of one and
+   * silently skip a veto its single real column asked for. They are metadata about how the row was found, not a
+   * column the body projected, so they take no part in deciding whether the row is a single-value answer.
    */
   private boolean consume(final Database database, final ResultSet result) {
     try (result) {
       Result first = null;
-      long   count = 0;
+      long count = 0;
       while (result.hasNext()) {
         final Result row = result.next();
         if (count == 0)
@@ -120,13 +125,29 @@ public class SQLTriggerExecutor implements TriggerExecutor {
       }
 
       if (count == 1 && first.isProjection()) {
-        final Set<String> properties = first.getPropertyNames();
-        if (properties.size() == 1 && Boolean.FALSE.equals(first.getProperty(properties.iterator().next()))
+        final String property = soleRealProperty(first);
+        if (property != null && Boolean.FALSE.equals(first.getProperty(property))
             && database.getQueryEngine("sql").analyze(sql).isIdempotent())
           return false;
       }
       return true;
     }
+  }
+
+  /**
+   * The single property name of {@code result}, ignoring the {@code $score}/{@code $similarity} scoring metadata -
+   * see {@link #consume} - or {@code null} if zero or more than one real property remains.
+   */
+  private static String soleRealProperty(final Result result) {
+    String sole = null;
+    for (final String property : result.getPropertyNames()) {
+      if ("$score".equals(property) || "$similarity".equals(property))
+        continue;
+      if (sole != null)
+        return null;
+      sole = property;
+    }
+    return sole;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
+++ b/engine/src/main/java/com/arcadedb/schema/trigger/SQLTriggerExecutor.java
@@ -56,7 +56,7 @@ public class SQLTriggerExecutor implements TriggerExecutor {
         params.put("$oldRecord", oldRecord);
       }
 
-      return consume(database.command("sql", sql, params));
+      return consume(database, database.command("sql", sql, params));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error executing SQL trigger '%s': %s", e, triggerName, e.getMessage());
       throw new TriggerExecutionException("SQL trigger '" + triggerName + "' failed: " + e.getMessage(), e);
@@ -76,7 +76,7 @@ public class SQLTriggerExecutor implements TriggerExecutor {
       params.put("rid", rid);
       params.put("$rid", rid);
 
-      return consume(database.command("sql", sql, params));
+      return consume(database, database.command("sql", sql, params));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error executing SQL trigger '%s': %s", e, triggerName, e.getMessage());
       throw new TriggerExecutionException("SQL trigger '" + triggerName + "' failed: " + e.getMessage(), e);
@@ -92,22 +92,37 @@ public class SQLTriggerExecutor implements TriggerExecutor {
    * The drained result also decides whether the operation continues, giving a SQL body the same veto contract as
    * {@link ScriptTriggerExecutor#execute}: a body that evaluates to a single scalar {@code false} - one row, one
    * property - aborts the operation, exactly what {@code SELECT false} or {@code SELECT <condition> AS ok} looks
-   * like it should do. A multi-row or multi-column result has no unambiguous single answer, so it is drained for
-   * its effects and treated as a pass, same as DML.
+   * like it should do.
+   * <p>
+   * The shape alone is not enough to tell a veto from an accident, though: {@code UPDATE ... RETURN AFTER <field>}
+   * (or {@code RETURN BEFORE}) with a single non-{@code @this} projection item produces that exact same one-row,
+   * one-property {@link Result} - see {@code Projection.calculateSingle} - so a bookkeeping trigger like
+   * {@code UPDATE Flag SET active = false RETURN AFTER active} would trip the same check on an unrelated boolean
+   * field and silently abort the CREATE/UPDATE/DELETE that fired it, something the pre-fix code never did because
+   * it never looked at the result at all. {@link com.arcadedb.query.sql.parser.Statement#isIdempotent()} is exactly
+   * the read/write classification the engine already uses elsewhere (e.g. {@code SQLQueryEngine.query()} rejects a
+   * non-idempotent statement), and only a {@code SELECT} answers true - never {@code INSERT}/{@code UPDATE}/
+   * {@code DELETE}, {@code RETURN} clause or not. Gating on it keeps the veto contract scoped to bodies that look
+   * like {@code SELECT false}, so an existing DML trigger cannot regress: it never produced a single-row,
+   * single-property result before, and now that it might (via {@code RETURN}), that shape is simply not idempotent
+   * and is drained for its effects like any other DML body. The check runs only once a candidate row is already in
+   * hand, so it costs nothing on the far more common multi-row, multi-column or non-projection results.
    */
-  private static boolean consume(final ResultSet result) {
+  private boolean consume(final Database database, final ResultSet result) {
     try (result) {
-      Result single = null;
-      long   count  = 0;
+      Result first = null;
+      long   count = 0;
       while (result.hasNext()) {
         final Result row = result.next();
-        single = count == 0 ? row : null;
+        if (count == 0)
+          first = row;
         count++;
       }
 
-      if (count == 1 && single != null && single.isProjection()) {
-        final Set<String> properties = single.getPropertyNames();
-        if (properties.size() == 1 && Boolean.FALSE.equals(single.getProperty(properties.iterator().next())))
+      if (count == 1 && first.isProjection()) {
+        final Set<String> properties = first.getPropertyNames();
+        if (properties.size() == 1 && Boolean.FALSE.equals(first.getProperty(properties.iterator().next()))
+            && database.getQueryEngine("sql").analyze(sql).isIdempotent())
           return false;
       }
       return true;

--- a/engine/src/test/java/com/arcadedb/query/sql/TriggerSQLTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/TriggerSQLTest.java
@@ -288,6 +288,33 @@ class TriggerSQLTest extends TestHelper {
     assertThat(result.hasNext()).isFalse();
   }
 
+  /**
+   * {@code UPDATE ... RETURN AFTER <field>} with a single non-{@code @this} projection item produces the exact
+   * same shape the veto check looks for - one row, one property - so a bookkeeping DML body whose returned field
+   * happens to be {@code false} must NOT be misread as {@code SELECT false}. Only a body that is actually
+   * idempotent (a {@code SELECT}) can veto; this pins the DML side of that distinction.
+   */
+  @Test
+  void beforeCreateTriggerDmlReturnSingleFalseFieldDoesNotVeto() {
+    database.command("sql", "CREATE DOCUMENT TYPE Flag");
+    database.transaction(() -> database.newDocument("Flag").set("active", true).save());
+
+    database.command("sql",
+        """
+            CREATE TRIGGER dml_return_trigger BEFORE CREATE ON TYPE User \
+            EXECUTE SQL 'UPDATE Flag SET active = false RETURN AFTER active'""");
+
+    database.transaction(() -> database.newDocument("User").set("name", "NotVetoed").save());
+
+    // the CREATE must proceed: a DML RETURN projection is not a veto, no matter what it evaluates to
+    final ResultSet user = database.query("sql", "SELECT FROM User WHERE name = 'NotVetoed'");
+    assertThat(user.hasNext()).as("a DML trigger body must never veto based on the shape of its RETURN projection").isTrue();
+
+    // and the DML body must actually have run, same as before this fix
+    final ResultSet flag = database.query("sql", "SELECT FROM Flag");
+    assertThat(flag.next().<Boolean>getProperty("active")).isFalse();
+  }
+
   @Test
   void multipleTriggersSameType() {
     database.command("sql",

--- a/engine/src/test/java/com/arcadedb/query/sql/TriggerSQLTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/TriggerSQLTest.java
@@ -315,6 +315,47 @@ class TriggerSQLTest extends TestHelper {
     assertThat(flag.next().<Boolean>getProperty("active")).isFalse();
   }
 
+  /**
+   * The row-count boundary of the veto check: only a single row is an unambiguous answer. A multi-row SELECT -
+   * even one where every row is the same lone {@code false} column - has no single answer to trust, so it is
+   * drained for its (non-)effects and the operation proceeds, same as any other multi-row result.
+   */
+  @Test
+  void beforeCreateTriggerMultiRowFalseDoesNotVeto() {
+    database.command("sql", "CREATE DOCUMENT TYPE Marker");
+    database.transaction(() -> {
+      database.newDocument("Marker").save();
+      database.newDocument("Marker").save();
+    });
+
+    database.command("sql",
+        """
+            CREATE TRIGGER multi_row_trigger BEFORE CREATE ON TYPE User \
+            EXECUTE SQL 'SELECT false FROM Marker'""");
+
+    database.transaction(() -> database.newDocument("User").set("name", "MultiRow").save());
+
+    final ResultSet result = database.query("sql", "SELECT FROM User WHERE name = 'MultiRow'");
+    assertThat(result.hasNext()).as("a multi-row SELECT has no single answer and must not veto").isTrue();
+  }
+
+  /**
+   * The column-count boundary: a single row with more than one real property is also not an unambiguous answer,
+   * even when one of its columns is {@code false}.
+   */
+  @Test
+  void beforeCreateTriggerSingleRowMultiColumnFalseDoesNotVeto() {
+    database.command("sql",
+        """
+            CREATE TRIGGER multi_column_trigger BEFORE CREATE ON TYPE User \
+            EXECUTE SQL 'SELECT true AS a, false AS b'""");
+
+    database.transaction(() -> database.newDocument("User").set("name", "MultiColumn").save());
+
+    final ResultSet result = database.query("sql", "SELECT FROM User WHERE name = 'MultiColumn'");
+    assertThat(result.hasNext()).as("a single row with more than one property has no single answer and must not veto").isTrue();
+  }
+
   @Test
   void multipleTriggersSameType() {
     database.command("sql",

--- a/engine/src/test/java/com/arcadedb/query/sql/TriggerSQLTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/TriggerSQLTest.java
@@ -21,10 +21,13 @@ package com.arcadedb.query.sql;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.function.java.JavaClassFunctionLibraryDefinition;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Trigger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -222,6 +225,60 @@ class TriggerSQLTest extends TestHelper {
         """
             CREATE TRIGGER abort_trigger BEFORE CREATE ON TYPE User \
             EXECUTE JAVASCRIPT 'false;'"""); // Return false to abort
+
+    // Record creation should be silently aborted (no exception, just not saved)
+    database.transaction(() -> database.newDocument("User").set("name", "Test").save());
+
+    // Verify record was not created
+    final ResultSet result = database.query("sql", "SELECT FROM User WHERE name = 'Test'");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  /**
+   * A {@code SELECT} trigger body used to be a complete no-op: {@code SQLTriggerExecutor} closed the result set
+   * without ever iterating it, and a {@code SELECT} result set in ArcadeDB is pull-based, so nothing behind it ever
+   * ran. This proves the body now actually executes by calling a Java function with a real side effect from a plain
+   * projection - no FROM clause, no record touched, nothing eager about it except the fix.
+   */
+  @Test
+  void beforeCreateTriggerSelectBodyActuallyExecutes() throws Exception {
+    database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("triggerProbe", SelectBodyProbe.class));
+    try {
+      SelectBodyProbe.CALLS.set(0);
+
+      database.command("sql",
+          """
+              CREATE TRIGGER select_body_trigger BEFORE CREATE ON TYPE User \
+              EXECUTE SQL 'SELECT `triggerProbe.bump`()'""");
+
+      database.transaction(() -> database.newDocument("User").set("name", "Selecta").save());
+
+      assertThat(SelectBodyProbe.CALLS.get())
+          .as("a SELECT trigger body must actually run rather than being silently skipped").isEqualTo(1);
+    } finally {
+      database.getSchema().unregisterFunctionLibrary("triggerProbe");
+    }
+  }
+
+  /** Invoked from SQL as {@code `triggerProbe.bump`()}, see {@link #beforeCreateTriggerSelectBodyActuallyExecutes()}. */
+  public static class SelectBodyProbe {
+    static final AtomicInteger CALLS = new AtomicInteger();
+
+    public static int bump() {
+      return CALLS.incrementAndGet();
+    }
+  }
+
+  /**
+   * The SQL arm of the veto contract already in place for JavaScript ({@link #beforeCreateTriggerAbort()}) and Java
+   * ({@code TestJavaAbortTrigger}): a body that evaluates to a single scalar {@code false} aborts the operation.
+   */
+  @Test
+  void beforeCreateTriggerAbortSQL() {
+    database.command("sql",
+        """
+            CREATE TRIGGER abort_trigger_sql BEFORE CREATE ON TYPE User \
+            EXECUTE SQL 'SELECT false'""");
 
     // Record creation should be silently aborted (no exception, just not saved)
     database.transaction(() -> database.newDocument("User").set("name", "Test").save());

--- a/engine/src/test/java/com/arcadedb/schema/trigger/BeforeReadTriggerTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/trigger/BeforeReadTriggerTest.java
@@ -196,11 +196,10 @@ class BeforeReadTriggerTest extends TestHelper {
   /**
    * A SQL BEFORE READ trigger runs its body without the record, and must not recurse either.
    * <p>
-   * The body is {@code SELECT 1} rather than something reading the type, and that is not laziness in the test:
-   * {@code SQLTriggerExecutor} runs {@code database.command(...).close()} without ever iterating the result, and a
-   * SELECT result set is lazy, so a SELECT body produces no rows and touches no record. Measured - a SELECT body
-   * fires zero read events, while INSERT/UPDATE/DELETE bodies execute normally on close. The recursion this class
-   * guards against is therefore exercised with a Java trigger below, which really does read.
+   * The body is {@code SELECT 1} rather than something reading the type, and it is not laziness in the test: it is
+   * a projection against no type, so consuming it (see {@link SQLTriggerExecutor}) touches no record and cannot
+   * re-enter the read. The recursion this class guards against is therefore exercised with a Java trigger below,
+   * which really does read.
    */
   @Test
   void aSqlBeforeReadTriggerRunsWithoutTheRecord() {
@@ -212,6 +211,23 @@ class BeforeReadTriggerTest extends TestHelper {
 
     database.transaction(() -> assertThat(database.lookupByRID(rid[0], true).asDocument().<String>get("name"))
         .isEqualTo("first"));
+  }
+
+  /**
+   * The SQL arm of the veto contract, matching {@link #theTriggerCanVetoTheRead()} (Java) and
+   * {@link #aJavaScriptBeforeReadTriggerSeesTheRidAndCanVeto()} (JavaScript): a body that evaluates to a single
+   * scalar {@code false} aborts the read, which the bucket surfaces as {@code RecordNotFoundException}.
+   */
+  @Test
+  void aSqlBeforeReadTriggerCanVetoTheRead() {
+    database.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+    final RID[] rid = new RID[1];
+    database.transaction(() -> rid[0] = database.newDocument(TYPE_NAME).set("name", "first").save().getIdentity());
+
+    database.command("sql", "CREATE TRIGGER sqlVetoRead BEFORE READ ON TYPE " + TYPE_NAME + " EXECUTE SQL 'SELECT false'");
+
+    database.transaction(() -> assertThatThrownBy(() -> database.lookupByRID(rid[0], true).asDocument().get("name"))
+        .as("a SQL body evaluating to a single false must veto the read").isInstanceOf(RecordNotFoundException.class));
   }
 
   /**


### PR DESCRIPTION
Fixes #6167.

## Problem

`SQLTriggerExecutor.execute`/`executeBeforeRead` ran the trigger body with `database.command(...).close()`, discarding the result set without ever iterating it. A `SELECT` result set in ArcadeDB is pull-based - nothing runs until it is pulled - so a `SELECT`-bodied trigger was a silent no-op: the DDL succeeded, the trigger registered, it fired on schedule, and its body never executed. `DML` bodies (`INSERT`/`UPDATE`/`DELETE`) were unaffected because their execution plans run eagerly when the command is built (confirmed by reading `InsertExecutionPlan`/`UpdateExecutionPlan`: they execute in `reset()`/first `fetchNext()` and buffer their rows).

## Fix

Drain the result set to exhaustion instead of closing it unread. This:

1. Fixes the no-op: a `SELECT` body now actually runs.
2. Gives SQL trigger bodies the same veto contract `ScriptTriggerExecutor` already has for JavaScript (`return false;` aborts the operation): a SQL body that evaluates to a single scalar `false` - one row, one property - now aborts the operation too, which is what `SELECT false` or `SELECT <condition> AS ok` looks like it should do. A multi-row or multi-column result has no unambiguous single answer, so it is drained for its effects and treated as a pass, same as `DML` always was.

The issue raised three options and didn't pick one. I went with a strengthened version of option 1 (consume the result set) rather than option 2 (reject `SELECT` bodies at `CREATE TRIGGER`): once the body can veto, a read-only body is genuinely useful - both for validation (`SELECT ... WHERE ...` style checks) and for side-effecting reads - so rejecting it at DDL time would remove a legitimate use case rather than fix a dead one. This also brings SQL to parity with the JavaScript executor instead of introducing new syntax or semantics.

Backward compatible: `DML` bodies never produce a single-property boolean-`false` row, so their behavior is unchanged. No previously-working `SELECT`-bodied trigger can regress, because no `SELECT` body ever ran before this fix.

## Tests

- `TriggerSQLTest.beforeCreateTriggerSelectBodyActuallyExecutes` - proves a `SELECT` body now runs, by calling a Java function with a real side effect from a plain projection.
- `TriggerSQLTest.beforeCreateTriggerAbortSQL` - `SELECT false` aborts `BEFORE CREATE`, mirroring the existing JavaScript abort test.
- `BeforeReadTriggerTest.aSqlBeforeReadTriggerCanVetoTheRead` - SQL `BEFORE READ` gets the same veto coverage as the Java and JavaScript arms.
- Updated a stale comment in `BeforeReadTriggerTest` that described the old lazy-and-unconsumed behavior.

Verified the three new assertions fail without the fix (stashed the production change, reran) and pass with it.

## Test plan

- [x] `TriggerSQLTest`, `BeforeReadTriggerTest`: 36/36 pass
- [x] Full `engine` module (`mvn verify`, 12184 tests): 1 pre-existing, unrelated failure (`LSMVectorIndexRebuildTest` rebuild-timeout flake, a known CPU-starvation flake unrelated to triggers)