### PR TITLE
feat(#6091): the cluster can name a peer's gRPC address, so a follower's refusal is dialable

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -1048,7 +1048,8 @@ public class BoltNetworkExecutor extends Thread {
     final List<Map<String, Object>> servers = new ArrayList<>();
 
     final HAServerPlugin ha = server.getHA();
-    final HAServerPlugin.BoltRoutingTable table = ha != null ? ha.getBoltRoutingTable() : null;
+    final HAServerPlugin.RoutingTable table = ha != null ?
+        ha.getRoutingTable(HAServerPlugin.ROUTING_PROTOCOL.BOLT) : null;
 
     if (table != null) {
       // HA cluster with a known leader: the leader is the writer and a router, followers are readers and

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1836,6 +1836,13 @@ public enum GlobalConfiguration {
       Default is 1000, generous for any real BOLT message.""",
       Integer.class, 1000),
 
+  // gRPC
+  GRPC_PORT("arcadedb.grpc.port", SCOPE.SERVER, """
+      TCP/IP port number used for incoming connections for the gRPC plugin. Registered here, rather than read as a \
+      bare key by the plugin alone, because HA has to know the port a peer's gRPC endpoint listens on to advertise a \
+      dialable address for it (see the 'grpc' field of arcadedb.ha.serverList). Default is 50051""",
+      Integer.class, 50051),
+
   // REDIS
   REDIS_PORT("arcadedb.redis.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for Redis plugin. Default is 6379", Integer.class, 6379),

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/GrpcClientErrorMapper.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/GrpcClientErrorMapper.java
@@ -23,7 +23,9 @@ import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.remote.RemoteException;
+import com.arcadedb.server.grpc.LeaderRedirectProtocol;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
@@ -90,9 +92,28 @@ final class GrpcClientErrorMapper {
       case "com.arcadedb.exception.RecordNotFoundException" -> new RecordNotFoundException(msg, null);
       case "com.arcadedb.exception.TimeoutException" -> new TimeoutException(msg);
       case "java.lang.SecurityException" -> new SecurityException(msg);
+      case "com.arcadedb.network.binary.ServerIsNotTheLeaderException" ->
+          new ServerIsNotTheLeaderException(msg, leaderAddress(trailers));
       // Unknown class: let the caller fall back to status-code mapping.
       default -> null;
     };
+  }
+
+  /**
+   * Returns the address to redirect to when a follower refused an RPC that only the leader may run: the
+   * leader's gRPC address when the cluster could resolve one, otherwise its HTTP address. Both may be absent -
+   * a refusal issued during an election names no leader at all - and the exception then carries a null address,
+   * which is what {@code ServerIsNotTheLeaderException} means by "retry, destination unknown".
+   * <p>
+   * The gRPC address is preferred because it is the only one of the two this client can actually dial. The HTTP
+   * address is kept as a fallback because it is always known when a leader is, and a caller that can map an
+   * HTTP endpoint to its gRPC port is better off than one told nothing.
+   */
+  private static String leaderAddress(final Metadata trailers) {
+    if (trailers == null)
+      return null;
+    final String grpcAddress = trailers.get(LeaderRedirectProtocol.LEADER_GRPC_ADDRESS);
+    return grpcAddress != null ? grpcAddress : trailers.get(LeaderRedirectProtocol.LEADER_HTTP_ADDRESS);
   }
 
   /**

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6091LeaderRedirectMappingTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6091LeaderRedirectMappingTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.remote.RemoteException;
+import com.arcadedb.server.grpc.LeaderRedirectProtocol;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A follower that refuses work only the leader may run says where to go instead, and it says it in a form a
+ * client can act on rather than only in prose (issue #6091). This covers the client half: the refusal comes back
+ * as the same {@code ServerIsNotTheLeaderException} the HTTP protocol raises for the same situation, carrying the
+ * address to redirect to, so a caller switches on a type and reads a field instead of pattern-matching an error
+ * message that was never a contract.
+ * <p>
+ * No server is required.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6091LeaderRedirectMappingTest {
+
+  private static StatusRuntimeException refusal(final String grpcAddress, final String httpAddress) {
+    final Metadata trailers = new Metadata();
+    trailers.put(GrpcClientErrorMapper.EXCEPTION_CLASS_KEY, ServerIsNotTheLeaderException.class.getName());
+    if (grpcAddress != null)
+      trailers.put(LeaderRedirectProtocol.LEADER_GRPC_ADDRESS, grpcAddress);
+    if (httpAddress != null)
+      trailers.put(LeaderRedirectProtocol.LEADER_HTTP_ADDRESS, httpAddress);
+    return Status.FAILED_PRECONDITION.withDescription("this server is not the cluster leader")
+        .asRuntimeException(trailers);
+  }
+
+  @Test
+  @DisplayName("the gRPC address wins: it is the only one of the two this client can dial")
+  void grpcAddressIsPreferredOverTheHttpOne() {
+    final RuntimeException rebuilt = GrpcClientErrorMapper.toException(
+        refusal("leader.example.com:50051", "leader.example.com:2480"));
+
+    assertThat(rebuilt).isInstanceOf(ServerIsNotTheLeaderException.class)
+        .isInstanceOf(NeedRetryException.class)
+        .hasMessageContaining("not the cluster leader");
+    assertThat(((ServerIsNotTheLeaderException) rebuilt).getLeaderAddress()).isEqualTo("leader.example.com:50051");
+  }
+
+  @Test
+  @DisplayName("with no gRPC address resolvable the HTTP one is still better than nothing")
+  void fallsBackToTheHttpAddressWhenNoGrpcAddressIsAdvertised() {
+    final RuntimeException rebuilt = GrpcClientErrorMapper.toException(refusal(null, "leader.example.com:2480"));
+
+    assertThat(((ServerIsNotTheLeaderException) rebuilt).getLeaderAddress()).isEqualTo("leader.example.com:2480");
+  }
+
+  @Test
+  @DisplayName("a refusal issued mid-election names no leader, and that is not an error either")
+  void leaderAddressIsNullWhenTheClusterKnowsOfNone() {
+    final RuntimeException rebuilt = GrpcClientErrorMapper.toException(refusal(null, null));
+
+    assertThat(rebuilt).isInstanceOf(ServerIsNotTheLeaderException.class);
+    assertThat(((ServerIsNotTheLeaderException) rebuilt).getLeaderAddress()).isNull();
+  }
+
+  /**
+   * The exception class trailer is what selects the type. Without it - an older server - the FAILED_PRECONDITION
+   * status has no mapping of its own and the caller gets the generic remote error, exactly as before this change:
+   * a leader-address trailer alone must not start inventing types.
+   */
+  @Test
+  @DisplayName("no exception-class trailer: unchanged legacy mapping, no type invented from the address alone")
+  void addressTrailerAloneDoesNotChangeTheMappedType() {
+    final Metadata trailers = new Metadata();
+    trailers.put(LeaderRedirectProtocol.LEADER_GRPC_ADDRESS, "leader.example.com:50051");
+    final RuntimeException rebuilt = GrpcClientErrorMapper.toException(
+        Status.FAILED_PRECONDITION.withDescription("nope").asRuntimeException(trailers));
+
+    assertThat(rebuilt).isInstanceOf(RemoteException.class).isNotInstanceOf(ServerIsNotTheLeaderException.class);
+  }
+}

--- a/grpc/src/main/java/com/arcadedb/server/grpc/LeaderRedirectProtocol.java
+++ b/grpc/src/main/java/com/arcadedb/server/grpc/LeaderRedirectProtocol.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.Metadata;
+
+/**
+ * Trailers a follower puts on an RPC it refuses because the work may only run on the cluster leader, so a caller
+ * can redirect itself instead of parsing prose out of the error description (issue #6091). They live in the module
+ * that owns the protocol definition rather than on either side of it, so the server writing them and the client
+ * reading them cannot drift apart.
+ * <p>
+ * The gRPC address is the one to dial for the RPC that was just refused; it is present only when the cluster can
+ * resolve it, which needs either a {@code grpc:} field in the object form of {@code arcadedb.ha.serverList} or a
+ * homogeneous deployment where the derive-from-local-port fallback is correct. The HTTP address is always
+ * resolvable and is kept as the fallback a human reads - it is not an address this RPC can be retried on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class LeaderRedirectProtocol {
+
+  /** The leader's client-reachable gRPC address ({@code host:port}), when the cluster can resolve one. */
+  public static final Metadata.Key<String> LEADER_GRPC_ADDRESS = Metadata.Key.of("arcadedb-leader-grpc-address",
+      Metadata.ASCII_STRING_MARSHALLER);
+
+  /** The leader's HTTP address ({@code host:port}). Always known when a leader is; never dialable over gRPC. */
+  public static final Metadata.Key<String> LEADER_HTTP_ADDRESS = Metadata.Key.of("arcadedb-leader-http-address",
+      Metadata.ASCII_STRING_MARSHALLER);
+
+  private LeaderRedirectProtocol() {
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -42,6 +42,7 @@ import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -72,6 +73,7 @@ import com.google.protobuf.Timestamp;
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
@@ -2692,19 +2694,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             // state (schema dictionary, type metadata) that only the leader can serialize, and running it on a
             // follower hits the race in Dictionary.getIdByName as the local state-machine apply runs
             // concurrently with this thread (issue #4122). The HTTP endpoint relays the payload to the leader;
-            // this stream cannot, because the HA plugin exposes the leader's HTTP address only and relaying a
-            // bulk load through a follower would double the traffic of the transport chosen to avoid exactly
-            // that. It is refused before a single record is written, so the caller can redirect and retry
-            // without having to reconcile a partial load.
+            // this stream does not, because relaying a bulk load through a follower would double the traffic of
+            // the transport chosen to avoid exactly that. It is refused before a single record is written, and
+            // names an address the caller can dial, so redirecting costs it neither a partial load to reconcile
+            // nor knowledge of the deployment's port-mapping convention.
             final HAServerPlugin ha = arcadeServer != null ? arcadeServer.getHA() : null;
             if (ha != null && !ha.isLeader()) {
-              final String leader = ha.getLeaderAddress();
               errorSent[0] = true;
-              out.onError(Status.FAILED_PRECONDITION.withDescription(
-                  "graphBatchLoad: this server is not the cluster leader and a graph batch load must run on the leader. "
-                      + (leader != null && !leader.isBlank() ?
-                      "Reconnect to the leader at '" + leader + "' (HTTP address; use its gRPC port) and retry" :
-                      "The leader is currently unknown, retry once the election has settled")).asException());
+              out.onError(notTheLeader(ha, "graphBatchLoad", "a graph batch load must run on the leader"));
               return;
             }
 
@@ -2882,6 +2879,55 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         .setPartialCommit(counts[0] > 0 || edgesCommitted > 0)
         .build());
     return trailers;
+  }
+
+  /**
+   * The refusal a follower answers with when an RPC may only run on the cluster leader (issue #6091). It names
+   * where to go instead in two forms, because a message a person reads and a value a client can act on are not
+   * the same thing:
+   * <ul>
+   *   <li>the leader's client-reachable <b>gRPC</b> address on the {@code LEADER_GRPC_ADDRESS} trailer, which
+   *       is the address the refused call can be retried on. Present when the cluster can resolve one - either
+   *       a {@code grpc:} field in {@code arcadedb.ha.serverList} or a deployment homogeneous enough for the
+   *       derive-from-local-port fallback;</li>
+   *   <li>the leader's <b>HTTP</b> address on {@code LEADER_HTTP_ADDRESS}, which is always known when a leader
+   *       is but is not an address this call can be retried on. It is the diagnostic of last resort, and what
+   *       the description falls back to naming.</li>
+   * </ul>
+   * The description says the same thing in prose so an operator reading a log is not left to decode trailers,
+   * but a client redirecting itself should read the trailer: the wording is not a contract, and the client-side
+   * mapper turns the pair into a {@code ServerIsNotTheLeaderException} carrying the address, the same type the
+   * HTTP protocol raises for the same situation.
+   */
+  private static StatusException notTheLeader(final HAServerPlugin ha, final String rpc, final String why) {
+    // One routing-table read: writer and readers come from a single leader snapshot, so a concurrent election
+    // cannot make the address named here disagree with the leader the rest of the answer is about.
+    final HAServerPlugin.RoutingTable grpcRouting = ha.getRoutingTable(HAServerPlugin.ROUTING_PROTOCOL.GRPC);
+    final String grpcLeader = blankToNull(grpcRouting != null ? grpcRouting.writer() : null);
+    final String httpLeader = blankToNull(ha.getLeaderAddress());
+
+    final String where;
+    if (grpcLeader != null)
+      where = "Reconnect to the leader at '" + grpcLeader + "' (gRPC address) and retry";
+    else if (httpLeader != null)
+      where = "Reconnect to the leader at '" + httpLeader + "' (HTTP address; use its gRPC port) and retry";
+    else
+      where = "The leader is currently unknown, retry once the election has settled";
+
+    final Metadata trailers = new Metadata();
+    trailers.put(GrpcErrorMapper.EXCEPTION_CLASS_KEY, ServerIsNotTheLeaderException.class.getName());
+    if (grpcLeader != null)
+      trailers.put(LeaderRedirectProtocol.LEADER_GRPC_ADDRESS, grpcLeader);
+    if (httpLeader != null)
+      trailers.put(LeaderRedirectProtocol.LEADER_HTTP_ADDRESS, httpLeader);
+
+    return Status.FAILED_PRECONDITION.withDescription(
+        rpc + ": this server is not the cluster leader and " + why + ". " + where).asException(trailers);
+  }
+
+  /** An address the cluster could not resolve and one it resolved to nothing are the same answer here. */
+  private static String blankToNull(final String address) {
+    return address != null && !address.isBlank() ? address : null;
   }
 
   private Object[] toPropertyArray(final Map<String, GrpcValue> properties) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.grpc;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerPlugin;
@@ -80,7 +81,9 @@ public class GrpcServerPlugin implements ServerPlugin {
   // Configuration keys as simple strings
   private static final String CONFIG_PREFIX              = "arcadedb.grpc.";
   private static final String CONFIG_ENABLED             = CONFIG_PREFIX + "enabled";
-  private static final String CONFIG_PORT                = CONFIG_PREFIX + "port";
+  // Registered as GlobalConfiguration.GRPC_PORT: HA resolves a peer's dialable gRPC address from the same
+  // key and default, so the two must not be able to drift apart (issue #6091).
+  private static final String CONFIG_PORT                = GlobalConfiguration.GRPC_PORT.getKey();
   private static final String CONFIG_HOST                = CONFIG_PREFIX + "host";
   private static final String CONFIG_MODE                = CONFIG_PREFIX + "mode";
   private static final String CONFIG_XDS_PORT            = CONFIG_PREFIX + "xds.port";
@@ -139,7 +142,7 @@ public class GrpcServerPlugin implements ServerPlugin {
 
   private void startStandardServer(ContextConfiguration config) throws IOException {
 
-    int port = getConfigInt(config, CONFIG_PORT, 50051);
+    int port = getConfigInt(config, CONFIG_PORT, GlobalConfiguration.GRPC_PORT.getValueAsInteger());
     String host = getConfigString(config, CONFIG_HOST, "0.0.0.0");
 
     NettyServerBuilder serverBuilder;

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6091GraphBatchLoadLeaderRedirectIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6091GraphBatchLoadLeaderRedirectIT.java
@@ -21,6 +21,7 @@ package com.arcadedb.server.grpc;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.server.ha.raft.BaseRaftHATest;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -45,27 +46,25 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * A graph batch load must not run on a follower (issue #6070). The bulk path mutates state that only the leader
- * can serialize - the schema dictionary above all - so running it on a follower races the local state-machine
- * apply in {@code Dictionary.getIdByName}, which is the corruption issue #4122 was about and the reason the
- * HTTP endpoint relays the payload to the leader instead of loading it locally.
+ * A follower refuses a graph batch load (issue #6070) and tells the caller where to go instead. Until issue #6091
+ * the only address HA could expose was the leader's <b>HTTP</b> one, so the refusal had to say "use its gRPC port"
+ * and a client redirecting itself had to already know the deployment's port-mapping convention. It now names an
+ * address that can be dialled, on the trailers as well as in the message.
  * <p>
- * {@code GraphBatchLoad} had no such guard: it took the load wherever the client happened to connect. It does not
- * relay the way HTTP does, because relaying a bulk load through a follower would double the traffic of the
- * transport chosen to avoid exactly that, so it refuses - before writing anything, and naming the leader, so the
- * caller can redirect rather than reconcile a load that got half-way. That the named address is one the caller can
- * actually dial is issue #6091, covered by {@link Issue6091GraphBatchLoadLeaderRedirectIT}.
- * <p>
- * What makes this worth a cluster test rather than a unit test is the second assertion: the same load, over the
- * same RPC, must still succeed against the leader. A guard that refused everywhere would pass a test that only
- * checked the follower.
+ * The assertion that matters is the last one: the refused load is retried <b>against the address the refusal
+ * named</b>, taken from the trailer and dialled as-is, and it succeeds. A test that only compared the string
+ * against the port it configured would pass just as well if the server had named the follower's own port - and
+ * that is precisely the mistake the derive-from-local-port fallback makes on a heterogeneous cluster, which is
+ * this cluster.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
+class Issue6091GraphBatchLoadLeaderRedirectIT extends BaseRaftHATest {
 
-  private static final int    BASE_GRPC_PORT = 51091;
-  private static final String VERTEX_TYPE    = "Issue6070LeaderGuardNode";
+  private static final int    BASE_RAFT_PORT = 2434;
+  private static final int    BASE_HTTP_PORT = 2480;
+  private static final int    BASE_GRPC_PORT = 51101;
+  private static final String VERTEX_TYPE    = "Issue6091RedirectNode";
 
   private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user",
       Metadata.ASCII_STRING_MARSHALLER);
@@ -77,6 +76,26 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
   private ManagedChannel channel;
 
   @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected String getServerAddresses() {
+    // Object form so each node declares the gRPC port it actually binds. Three nodes on one host cannot share a
+    // port, so this is also the deployment shape where deriving a peer's port from this node's would be wrong.
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < getServerCount(); i++) {
+      if (i > 0)
+        sb.append(",");
+      sb.append("localhost:{raft:").append(BASE_RAFT_PORT + i)
+          .append(",http:").append(BASE_HTTP_PORT + i)
+          .append(",grpc:").append(BASE_GRPC_PORT + i).append("}");
+    }
+    return sb.toString();
+  }
+
+  @Override
   protected void onServerConfiguration(final ContextConfiguration config) {
     super.onServerConfiguration(config);
 
@@ -84,7 +103,7 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
     final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
 
     config.setValue("arcadedb.grpc.enabled", "true");
-    config.setValue("arcadedb.grpc.port", String.valueOf(BASE_GRPC_PORT + index));
+    config.setValue(GlobalConfiguration.GRPC_PORT.getKey(), String.valueOf(BASE_GRPC_PORT + index));
     config.setValue("arcadedb.grpc.host", "localhost");
     config.setValue("arcadedb.grpc.reflection.enabled", "false");
     config.setValue("arcadedb.grpc.health.enabled", "false");
@@ -97,34 +116,17 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
       config.setValue(GlobalConfiguration.SERVER_PLUGINS, existingPlugins + "," + pluginEntry);
   }
 
-  @Override
-  protected int getServerCount() {
-    return 3;
-  }
-
   @AfterEach
   void teardownGrpcClient() throws InterruptedException {
-    if (channel != null) {
-      channel.shutdown();
-      channel.awaitTermination(5, TimeUnit.SECONDS);
-      channel = null;
-    }
+    closeChannel();
   }
 
   @Test
-  void aLoadOnAFollowerIsRefusedAndTheSameLoadOnTheLeaderSucceeds() throws Exception {
+  void theRefusalNamesAnAddressTheLoadActuallySucceedsOn() throws Exception {
     final int leaderIndex = findLeaderIndex();
     assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = anyFollowerOf(leaderIndex);
 
-    int followerIndex = -1;
-    for (int i = 0; i < getServerCount(); i++)
-      if (i != leaderIndex) {
-        followerIndex = i;
-        break;
-      }
-    assertThat(followerIndex).as("At least one follower must exist").isGreaterThanOrEqualTo(0);
-
-    // Schema through the leader, so the guard under test is the only thing the load depends on.
     final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
     leaderDb.transaction(() -> {
       if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
@@ -132,73 +134,61 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
     });
     waitForAllServers();
 
-    // The follower refuses, and says where to go instead.
-    final Throwable refusal = loadOneVertex(followerIndex, "onFollower");
-    assertThat(refusal).as("a load aimed at a follower must be refused, not silently taken")
-        .isInstanceOf(StatusRuntimeException.class);
+    final Throwable refusal = loadOneVertex("localhost:" + (BASE_GRPC_PORT + followerIndex), "onFollower");
+    assertThat(refusal).as("a load aimed at a follower must be refused").isInstanceOf(StatusRuntimeException.class);
 
     final StatusRuntimeException failure = (StatusRuntimeException) refusal;
-    assertThat(failure.getStatus().getCode()).as("the caller has to be able to tell this from an engine fault")
-        .isEqualTo(Status.Code.FAILED_PRECONDITION);
-    assertThat(failure.getStatus().getDescription()).contains("not the cluster leader");
+    assertThat(failure.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
 
-    // Refused before writing anything: nothing to reconcile anywhere in the cluster.
+    final Metadata trailers = failure.getTrailers();
+    assertThat(trailers).as("the refusal must carry trailers, not only prose").isNotNull();
+
+    final String advertised = trailers.get(LeaderRedirectProtocol.LEADER_GRPC_ADDRESS);
+    assertThat(advertised).as("the leader's gRPC address must be advertised in a form a client can dial")
+        .isEqualTo("localhost:" + (BASE_GRPC_PORT + leaderIndex));
+    assertThat(advertised).as("naming the refusing node's own port would send the caller straight back here")
+        .isNotEqualTo("localhost:" + (BASE_GRPC_PORT + followerIndex));
+
+    // The HTTP address stays available as the human-readable fallback, and is a different endpoint entirely.
+    assertThat(trailers.get(LeaderRedirectProtocol.LEADER_HTTP_ADDRESS))
+        .as("the HTTP address must still be reported").isNotNull().isNotEqualTo(advertised);
+
+    // The typed redirect: the same class the HTTP protocol raises for this, carrying the same address.
+    assertThat(trailers.get(GrpcErrorMapper.EXCEPTION_CLASS_KEY))
+        .isEqualTo(ServerIsNotTheLeaderException.class.getName());
+
+    // The message says it too, in the gRPC wording rather than the HTTP-with-a-caveat one it used to.
+    assertThat(failure.getStatus().getDescription()).contains("not the cluster leader")
+        .contains("'" + advertised + "' (gRPC address)").doesNotContain("use its gRPC port");
+
+    // Nothing was written before the refusal: there is no partial load to reconcile anywhere.
     waitForAllServers();
     for (int i = 0; i < getServerCount(); i++)
       assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
-          .as("server %d must hold nothing from the refused load", i)
-          .isZero();
+          .as("server %d must hold nothing from the refused load", i).isZero();
 
-    // The very same load against the leader goes through, and replicates.
-    assertThat(loadOneVertex(leaderIndex, "onLeader")).as("the leader must still accept the load").isNull();
+    // And now the point of all of it: dial the advertised address verbatim and the load goes through.
+    assertThat(loadOneVertex(advertised, "onRedirect")).as("the advertised address must accept the load").isNull();
 
     waitForAllServers();
     for (int i = 0; i < getServerCount(); i++)
       assertThat(getServerDatabase(i, getDatabaseName()).countType(VERTEX_TYPE, true))
-          .as("server %d (leader=%d) must see the vertex loaded on the leader", i, leaderIndex)
-          .isEqualTo(1);
+          .as("server %d must see the redirected load", i).isEqualTo(1);
   }
 
-  /**
-   * The refusal names the leader, which is a fact about the cluster's layout. It must therefore come after the
-   * caller has been resolved against the database it asked for, the way every other RPC on this service starts.
-   * A follower asked to load into a database that cannot be reached has to answer about that database, not
-   * volunteer where the leader lives - and the difference is only observable on a follower, because that is the
-   * only place the leadership branch is reached at all.
-   */
-  @Test
-  void aFollowerResolvesTheDatabaseBeforeNamingTheLeader() throws Exception {
-    final int leaderIndex = findLeaderIndex();
-    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
-
-    int followerIndex = -1;
+  private int anyFollowerOf(final int leaderIndex) {
     for (int i = 0; i < getServerCount(); i++)
-      if (i != leaderIndex) {
-        followerIndex = i;
-        break;
-      }
-    assertThat(followerIndex).as("At least one follower must exist").isGreaterThanOrEqualTo(0);
-
-    final Throwable refusal = loadOneVertexInto(followerIndex, "unauthorized", "Issue6070NoSuchDatabase");
-
-    assertThat(refusal).as("a load naming a database that cannot be reached must be refused").isNotNull();
-    assertThat(refusal.getMessage())
-        .as("the refusal must be about the database, not about where the leader is")
-        .doesNotContain("not the cluster leader")
-        .doesNotContain("Reconnect to the leader");
+      if (i != leaderIndex)
+        return i;
+    throw new IllegalStateException("At least one follower must exist");
   }
 
   /**
-   * Runs a one-vertex load against the given server and returns the failure it ended with, or null if it
-   * succeeded.
+   * Runs a one-vertex load against the given {@code host:port} gRPC target and returns the failure it ended with,
+   * or null if it succeeded. The target is a string on purpose: it is what the server advertised.
    */
-  private Throwable loadOneVertex(final int serverIndex, final String tempId) throws Exception {
-    return loadOneVertexInto(serverIndex, tempId, getDatabaseName());
-  }
-
-  private Throwable loadOneVertexInto(final int serverIndex, final String tempId, final String databaseName)
-      throws Exception {
-    channel = ManagedChannelBuilder.forAddress("localhost", BASE_GRPC_PORT + serverIndex).usePlaintext().build();
+  private Throwable loadOneVertex(final String target, final String tempId) throws Exception {
+    channel = ManagedChannelBuilder.forTarget(target).usePlaintext().build();
     try {
       final Channel authenticated = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
 
@@ -224,7 +214,7 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
           });
 
       observer.onNext(GraphBatchChunk.newBuilder()
-          .setDatabase(databaseName)
+          .setDatabase(getDatabaseName())
           .setCredentials(DatabaseCredentials.newBuilder()
               .setUsername("root")
               .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
@@ -240,6 +230,12 @@ class Issue6070GraphBatchLoadLeaderGuardIT extends BaseRaftHATest {
       assertThat(done.await(30, TimeUnit.SECONDS)).as("the load must terminate one way or the other").isTrue();
       return errorRef.get();
     } finally {
+      closeChannel();
+    }
+  }
+
+  private void closeChannel() throws InterruptedException {
+    if (channel != null) {
       channel.shutdown();
       channel.awaitTermination(5, TimeUnit.SECONDS);
       channel = null;

--- a/ha-raft/CLAUDE.md
+++ b/ha-raft/CLAUDE.md
@@ -44,7 +44,7 @@ The shutdown trigger has a counterintuitive consequence when reproducing durabil
 
 - `getStats()` - feeds `ha.network.replicas` in `/api/v1/server?mode=cluster`
 - `getReplicaAddresses()` - feeds `ha.replicaAddresses` in the same response
-- the Bolt routing address resolver
+- `getRoutingTable(protocol)` - the client routing table, one resolver shared by Bolt and gRPC
 
 Each has its own local `excludeId` derivation (`leaderId != null ? leaderId : localPeerId`, or the leader directly). They are not factored into a shared helper, so a fix applied to one silently leaves the others wrong and the cluster API response internally inconsistent.
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -329,8 +329,8 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   }
 
   @Override
-  public BoltRoutingTable getBoltRoutingTable() {
-    return raftHAServer != null ? raftHAServer.getBoltRoutingTable() : null;
+  public RoutingTable getRoutingTable(final ROUTING_PROTOCOL protocol) {
+    return raftHAServer != null ? raftHAServer.getRoutingTable(protocol) : null;
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -72,9 +72,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.UUID;
@@ -145,8 +147,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // Client-reachable Bolt endpoints (optional object-form 'bolt' field in HA_SERVER_LIST). Advertised
   // in the Bolt ROUTE routing table so neo4j:// drivers can discover leader/followers.
   private final    Map<RaftPeerId, String> boltAddresses      = new HashMap<>();
-  // Logged at most once: warns operators that Bolt routing addresses are derived (not explicitly configured).
-  private final    AtomicBoolean           boltFallbackWarned = new AtomicBoolean(false);
+  // Client-reachable gRPC endpoints (optional object-form 'grpc' field in HA_SERVER_LIST). Advertised in the
+  // gRPC routing table so a caller refused on a follower is told an address it can actually dial (issue #6091).
+  private final    Map<RaftPeerId, String> grpcAddresses      = new HashMap<>();
+  // Logged at most once per protocol: warns operators that routing addresses are derived, not configured.
+  private final    Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicBoolean> routingFallbackWarned = createRoutingFallbackLatches();
   private final    Map<RaftPeerId, String> peerDisplayNames   = new ConcurrentHashMap<>();
   private final    String                  clusterName;
 
@@ -252,6 +257,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     this.httpAddresses.putAll(parsed.httpAddresses());
     this.httpsAddresses.putAll(parsed.httpsAddresses());
     this.boltAddresses.putAll(parsed.boltAddresses());
+    this.grpcAddresses.putAll(parsed.grpcAddresses());
 
     RaftPeerId resolvedLocalPeerId;
     try {
@@ -1672,28 +1678,28 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
-   * Builds a single-snapshot Bolt routing table (leader as writer, followers as readers) from one
-   * {@link #getLeaderId()} read, so a concurrent leader change cannot make the writer and reader sets
+   * Builds a single-snapshot routing table for one client protocol (leader as writer, followers as readers)
+   * from one {@link #getLeaderId()} read, so a concurrent leader change cannot make the writer and reader sets
    * mutually inconsistent. Returns {@code null} when no leader is known or the leader has no resolvable
-   * Bolt address. Readers reflect the configured cluster membership, matching {@link #getReplicaAddresses()};
-   * peers whose Bolt address cannot be resolved are skipped.
+   * address for that protocol. Readers reflect the configured cluster membership, matching
+   * {@link #getReplicaAddresses()}; peers whose address cannot be resolved are skipped.
    */
-  public HAServerPlugin.BoltRoutingTable getBoltRoutingTable() {
+  public HAServerPlugin.RoutingTable getRoutingTable(final HAServerPlugin.ROUTING_PROTOCOL protocol) {
     final RaftPeerId leaderId = getLeaderId();
     if (leaderId == null)
       return null;
-    final String writer = resolveBoltAddress(leaderId);
+    final String writer = resolveRoutingAddress(protocol, leaderId);
     if (writer == null)
       return null;
     final List<String> readers = new ArrayList<>();
     for (final RaftPeer peer : raftGroup.getPeers()) {
       if (!peer.getId().equals(leaderId)) {
-        final String reader = resolveBoltAddress(peer.getId());
+        final String reader = resolveRoutingAddress(protocol, peer.getId());
         if (reader != null)
           readers.add(reader);
       }
     }
-    return new HAServerPlugin.BoltRoutingTable(writer, List.copyOf(readers));
+    return new HAServerPlugin.RoutingTable(protocol, writer, List.copyOf(readers));
   }
 
   /**
@@ -1724,40 +1730,73 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
-   * Resolves the client-reachable Bolt address (host:boltPort) of a peer. Returns the address declared
-   * with the object-form {@code bolt:} field when present; otherwise derives it from the peer's Raft host
-   * plus this node's local Bolt port. The fallback is correct only for homogeneous deployments where every
-   * node listens on the same Bolt port (e.g. a Kubernetes StatefulSet); a one-time WARNING is logged so
-   * operators declare explicit Bolt ports for heterogeneous clusters. Returns {@code null} when the peer is
-   * unknown or the local Bolt port is unavailable.
+   * Resolves the client-reachable address (host:port) of a peer for one client protocol. Returns the address
+   * declared with the matching object-form field ({@code bolt:} / {@code grpc:}) when present; otherwise
+   * derives it from the peer's Raft host plus <em>this</em> node's local port for that protocol. The fallback
+   * is correct only for homogeneous deployments where every node listens on the same port (e.g. a Kubernetes
+   * StatefulSet); a one-time WARNING per protocol is logged so operators declare explicit ports for
+   * heterogeneous clusters. Returns {@code null} when the peer is unknown or the local port is unavailable.
    */
-  private String resolveBoltAddress(final RaftPeerId peerId) {
+  private String resolveRoutingAddress(final HAServerPlugin.ROUTING_PROTOCOL protocol, final RaftPeerId peerId) {
     if (peerId == null)
       return null;
-    final String configured = boltAddresses.get(peerId);
+    final String configured = declaredRoutingAddresses(protocol).get(peerId);
     if (configured != null)
       return configured;
-    final int localBoltPort = configuration.getValueAsInteger(GlobalConfiguration.BOLT_PORT);
-    final String derived = deriveBoltAddress(peerRaftAddress(peerId), localBoltPort);
-    if (derived != null && boltFallbackWarned.compareAndSet(false, true))
+    final int localPort = localRoutingPort(protocol);
+    final String derived = deriveRoutingAddress(peerRaftAddress(peerId), localPort);
+    if (derived != null && routingFallbackWarned.get(protocol).compareAndSet(false, true)) {
+      final String field = routingConfigField(protocol);
       LogManager.instance().log(this, Level.WARNING,
-          "HA Bolt routing addresses are not configured in '%s': deriving peer Bolt endpoints from each peer's Raft host plus this node's Bolt port (%d). "
-              + "This is correct only when every node listens on the same Bolt port (e.g. a Kubernetes StatefulSet). For clusters with heterogeneous "
-              + "Bolt ports, declare them explicitly using the 'host:{raft:..,bolt:..}' object syntax in %s.",
-          GlobalConfiguration.HA_SERVER_LIST.getKey(), localBoltPort, GlobalConfiguration.HA_SERVER_LIST.getKey());
+          "HA %s routing addresses are not configured in '%s': deriving every peer's %s endpoint from its Raft host plus this node's "
+              + "own %s port (%d). That is correct only when every node listens on the same port (e.g. a Kubernetes StatefulSet); on a "
+              + "cluster with heterogeneous ports, declare them explicitly with the 'host:{raft:..,%s:..}' object syntax in %s.",
+          protocol.name(), GlobalConfiguration.HA_SERVER_LIST.getKey(), protocol.name(), protocol.name(), localPort,
+          field, GlobalConfiguration.HA_SERVER_LIST.getKey());
+    }
     return derived;
   }
 
+  /** The explicitly declared addresses for one client protocol, as parsed from {@code HA_SERVER_LIST}. */
+  private Map<RaftPeerId, String> declaredRoutingAddresses(final HAServerPlugin.ROUTING_PROTOCOL protocol) {
+    return switch (protocol) {
+      case BOLT -> boltAddresses;
+      case GRPC -> grpcAddresses;
+    };
+  }
+
+  /** This node's own listening port for one client protocol, used by the derive fallback. */
+  private int localRoutingPort(final HAServerPlugin.ROUTING_PROTOCOL protocol) {
+    return switch (protocol) {
+      case BOLT -> configuration.getValueAsInteger(GlobalConfiguration.BOLT_PORT);
+      case GRPC -> configuration.getValueAsInteger(GlobalConfiguration.GRPC_PORT);
+    };
+  }
+
+  /** The {@code HA_SERVER_LIST} object-form field an operator writes to declare this protocol's port. */
+  private static String routingConfigField(final HAServerPlugin.ROUTING_PROTOCOL protocol) {
+    return protocol.name().toLowerCase(Locale.ENGLISH);
+  }
+
+  /** One "already warned" latch per client protocol, so a derived Bolt address does not mute the gRPC warning. */
+  private static Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicBoolean> createRoutingFallbackLatches() {
+    final Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicBoolean> latches = new EnumMap<>(
+        HAServerPlugin.ROUTING_PROTOCOL.class);
+    for (final HAServerPlugin.ROUTING_PROTOCOL protocol : HAServerPlugin.ROUTING_PROTOCOL.values())
+      latches.put(protocol, new AtomicBoolean(false));
+    return latches;
+  }
+
   /**
-   * Derives a Bolt address (host:boltPort) by combining a peer's Raft host with the given Bolt port.
+   * Derives a client-reachable address (host:port) by combining a peer's Raft host with the given port.
    * Returns {@code null} when the port is not positive or the host cannot be extracted. Package-private
    * for testing.
    */
-  static String deriveBoltAddress(final String raftAddress, final int boltPort) {
-    if (raftAddress == null || boltPort <= 0)
+  static String deriveRoutingAddress(final String raftAddress, final int port) {
+    if (raftAddress == null || port <= 0)
       return null;
     final String host = extractHost(raftAddress);
-    return host != null ? host + ":" + boltPort : null;
+    return host != null ? host + ":" + port : null;
   }
 
   private String deriveHttpAddressWithWarning(final String raftAddress) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
@@ -45,10 +45,12 @@ final class RaftPeerAddressResolver {
    * prefix and is empty when no entry uses that syntax.
    * The {@code boltAddresses} map is empty when no entry declares the object-form {@code bolt} field;
    * it holds the client-reachable Bolt address advertised in the ROUTE routing table.
+   * The {@code grpcAddresses} map is empty when no entry declares the object-form {@code grpc} field;
+   * it holds the client-reachable gRPC address advertised in the gRPC routing table.
    */
   public record ParsedPeerList(List<RaftPeer> peers, Map<RaftPeerId, String> httpAddresses,
                                Map<RaftPeerId, String> httpsAddresses, Map<RaftPeerId, String> peerNames,
-                               Map<RaftPeerId, String> boltAddresses) {
+                               Map<RaftPeerId, String> boltAddresses, Map<RaftPeerId, String> grpcAddresses) {
   }
 
   private RaftPeerAddressResolver() {
@@ -59,13 +61,14 @@ final class RaftPeerAddressResolver {
    * <p>
    * Each entry supports two interchangeable syntaxes.
    * <p>
-   * <b>1. Object form</b> (recommended for readability): {@code host:{raft:2434,http:2480,https:2490,bolt:7687,priority:10}}.
+   * <b>1. Object form</b> (recommended for readability):
+   * {@code host:{raft:2434,http:2480,https:2490,bolt:7687,grpc:50051,priority:10}}.
    * The fields are unordered and all optional except that {@code raft} defaults to {@code defaultPort}
-   * when omitted ({@code http}/{@code https}/{@code bolt} are simply not stored when absent, {@code priority}
-   * defaults to 0). This avoids the positional ambiguity of the colon form. Example:
-   * {@code frankfurt@db1:{raft:2434,http:2480,https:2490,bolt:7687}}. The {@code bolt} field is the
-   * client-reachable Bolt address advertised in the ROUTE routing table and is available only in the object
-   * form (the positional colon form has no Bolt field).
+   * when omitted ({@code http}/{@code https}/{@code bolt}/{@code grpc} are simply not stored when absent,
+   * {@code priority} defaults to 0). This avoids the positional ambiguity of the colon form. Example:
+   * {@code frankfurt@db1:{raft:2434,http:2480,https:2490,bolt:7687,grpc:50051}}. The {@code bolt} and
+   * {@code grpc} fields are the client-reachable addresses advertised in the routing table of their
+   * protocol and are available only in the object form (the positional colon form has no room for them).
    * <p>
    * <b>2. Positional (colon) form</b>:
    * <ul>
@@ -113,6 +116,7 @@ final class RaftPeerAddressResolver {
     final Map<RaftPeerId, String> httpAddresses = new HashMap<>(entries.size());
     final Map<RaftPeerId, String> httpsAddresses = new HashMap<>(entries.size());
     final Map<RaftPeerId, String> boltAddresses = new HashMap<>(entries.size());
+    final Map<RaftPeerId, String> grpcAddresses = new HashMap<>(entries.size());
     final Map<RaftPeerId, String> peerNames = new HashMap<>(entries.size());
     final Map<String, String> nameToEntry = new HashMap<>(entries.size());
 
@@ -138,11 +142,12 @@ final class RaftPeerAddressResolver {
       String httpAddress = null;
       String httpsAddress = null;
       String boltAddress = null;
+      String grpcAddress = null;
       int priority = 0;
 
       final int braceIdx = entry.indexOf('{');
       if (braceIdx >= 0) {
-        // Object form: host:{raft:2434,http:2480,https:2490,priority:10}
+        // Object form: host:{raft:2434,http:2480,https:2490,bolt:7687,grpc:50051,priority:10}
         final PeerSpec spec = parseObjectForm(entry, braceIdx, defaultPort);
         final String host = applyDnsSuffix(spec.host, k8sDnsSuffix);
         raftAddress = host + ":" + spec.raftPort;
@@ -152,6 +157,8 @@ final class RaftPeerAddressResolver {
           httpsAddress = host + ":" + spec.httpsPort;
         if (spec.boltPort != null)
           boltAddress = host + ":" + spec.boltPort;
+        if (spec.grpcPort != null)
+          grpcAddress = host + ":" + spec.grpcPort;
         priority = spec.priority;
       } else {
         final String[] parts = entry.split(":");
@@ -160,7 +167,7 @@ final class RaftPeerAddressResolver {
           throw new ServerException(
               "Invalid peer address format '" + entry
                   + "'. Expected [name@]host[:raftPort[:httpPort[:priority[:httpsPort]]]] "
-                  + "or [name@]host:{raft:..,http:..,https:..,priority:..}");
+                  + "or [name@]host:{raft:..,http:..,https:..,bolt:..,grpc:..,priority:..}");
 
         final String host = applyDnsSuffix(parts[0], k8sDnsSuffix);
 
@@ -203,6 +210,8 @@ final class RaftPeerAddressResolver {
         httpsAddresses.put(peer.getId(), httpsAddress);
       if (boltAddress != null)
         boltAddresses.put(peer.getId(), boltAddress);
+      if (grpcAddress != null)
+        grpcAddresses.put(peer.getId(), grpcAddress);
       if (peerName != null)
         peerNames.put(peer.getId(), peerName);
     }
@@ -228,7 +237,8 @@ final class RaftPeerAddressResolver {
         Collections.unmodifiableMap(httpAddresses),
         Collections.unmodifiableMap(httpsAddresses),
         Collections.unmodifiableMap(peerNames),
-        Collections.unmodifiableMap(boltAddresses));
+        Collections.unmodifiableMap(boltAddresses),
+        Collections.unmodifiableMap(grpcAddresses));
   }
 
   /** Resolved ports for a single peer entry, regardless of the syntax it was written in. */
@@ -238,23 +248,25 @@ final class RaftPeerAddressResolver {
     final Integer httpPort;  // null when not specified
     final Integer httpsPort; // null when not specified
     final Integer boltPort;  // null when not specified
+    final Integer grpcPort;  // null when not specified
     final int     priority;
 
     PeerSpec(final String host, final int raftPort, final Integer httpPort, final Integer httpsPort, final Integer boltPort,
-        final int priority) {
+        final Integer grpcPort, final int priority) {
       this.host = host;
       this.raftPort = raftPort;
       this.httpPort = httpPort;
       this.httpsPort = httpsPort;
       this.boltPort = boltPort;
+      this.grpcPort = grpcPort;
       this.priority = priority;
     }
   }
 
   /**
-   * Parses the object form {@code host:{raft:..,http:..,https:..,bolt:..,priority:..}} into a {@link PeerSpec}.
-   * Fields are unordered and all optional; {@code raft} defaults to {@code defaultPort}. Unknown or
-   * duplicated keys throw {@link ServerException}.
+   * Parses the object form {@code host:{raft:..,http:..,https:..,bolt:..,grpc:..,priority:..}} into a
+   * {@link PeerSpec}. Fields are unordered and all optional; {@code raft} defaults to {@code defaultPort}.
+   * Unknown or duplicated keys throw {@link ServerException}.
    */
   private static PeerSpec parseObjectForm(final String entry, final int braceIdx, final int defaultPort) {
     if (!entry.endsWith("}"))
@@ -272,6 +284,7 @@ final class RaftPeerAddressResolver {
     Integer httpPort = null;
     Integer httpsPort = null;
     Integer boltPort = null;
+    Integer grpcPort = null;
     int priority = 0;
     final Map<String, String> seen = new HashMap<>();
 
@@ -293,13 +306,15 @@ final class RaftPeerAddressResolver {
         case "http" -> httpPort = parseIntField(value, "http", entry);
         case "https" -> httpsPort = parseIntField(value, "https", entry);
         case "bolt" -> boltPort = parseIntField(value, "bolt", entry);
+        case "grpc" -> grpcPort = parseIntField(value, "grpc", entry);
         case "priority" -> priority = parseIntField(value, "priority", entry);
         default -> throw new ServerException(
-            "Unknown key '" + key + "' in peer address '" + entry + "'. Supported keys: raft, http, https, bolt, priority");
+            "Unknown key '" + key + "' in peer address '" + entry
+                + "'. Supported keys: raft, http, https, bolt, grpc, priority");
         }
       }
     }
-    return new PeerSpec(host, raftPort, httpPort, httpsPort, boltPort, priority);
+    return new PeerSpec(host, raftPort, httpPort, httpsPort, boltPort, grpcPort, priority);
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6091GrpcRoutingTableDerivedIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6091GrpcRoutingTableDerivedIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.HAServerPlugin;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The half of gRPC routing that needs no configuration: with no {@code grpc:} field declared, a peer's gRPC
+ * endpoint is its Raft host plus <b>this</b> node's gRPC port (issue #6091). That is correct for a homogeneous
+ * deployment - a Kubernetes StatefulSet, where every pod listens on the same port - and knowingly wrong for a
+ * heterogeneous one, which is why the field exists and why the fallback logs a one-time WARNING.
+ * <p>
+ * The assertion below is deliberately written against the port <i>this node</i> was configured with rather than
+ * the default, so it fails if the resolver ever stops reading {@link GlobalConfiguration#GRPC_PORT} - the setting
+ * the gRPC plugin itself binds. {@link Issue6091GrpcRoutingTableIT} covers the declared case.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6091GrpcRoutingTableDerivedIT extends BaseRaftHATest {
+
+  /** Deliberately not the 50051 default: a test that passes on the default cannot tell it was read at all. */
+  private static final int LOCAL_GRPC_PORT = 50081;
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    // No gRPC plugin is started: the routing table answers from configuration, and a listening socket would only
+    // add two ports to bind. What is under test is which port the cluster ADVERTISES.
+    config.setValue(GlobalConfiguration.GRPC_PORT, LOCAL_GRPC_PORT);
+  }
+
+  @Test
+  void undeclaredGrpcEndpointsFallBackToThisNodesGrpcPort() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    waitForAllServers();
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final HAServerPlugin.RoutingTable table = getRaftPlugin(i)
+          .getRoutingTable(HAServerPlugin.ROUTING_PROTOCOL.GRPC);
+
+      assertThat(table).as("server %d must still produce a routing table with nothing declared", i).isNotNull();
+      assertThat(table.writer()).as("server %d must derive the leader's endpoint from its own gRPC port", i)
+          .isEqualTo("localhost:" + LOCAL_GRPC_PORT);
+      assertThat(table.readers()).as("server %d", i).containsExactly("localhost:" + LOCAL_GRPC_PORT);
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6091GrpcRoutingTableIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6091GrpcRoutingTableIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.server.HAServerPlugin;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The cluster can name a peer's client-reachable gRPC endpoint (issue #6091). Before this, HA knew a peer's Raft,
+ * HTTP and Bolt addresses but not its gRPC one, so a gRPC RPC refusing work that only the leader may run could
+ * only point at the leader's HTTP address and tell the caller to work out the port mapping itself.
+ * <p>
+ * The addresses here are <b>declared</b>, with the object-form {@code grpc:} field, which is the case that has to
+ * work for a heterogeneous deployment - and the only one an in-process cluster can exercise honestly, since three
+ * nodes sharing localhost cannot share a port. {@link Issue6091GrpcRoutingTableDerivedIT} covers the other half,
+ * the derive-from-this-node's-port fallback used when nothing is declared.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6091GrpcRoutingTableIT extends BaseRaftHATest {
+
+  private static final int BASE_RAFT = 2434;
+  private static final int BASE_HTTP = 2480;
+  private static final int BASE_GRPC = 50071;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected String getServerAddresses() {
+    // Object form so each node declares its own gRPC port: the nodes share localhost and differ only by port,
+    // which is precisely the shape the derive-from-local-port fallback cannot express.
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < getServerCount(); i++) {
+      if (i > 0)
+        sb.append(",");
+      sb.append("localhost:{raft:").append(BASE_RAFT + i)
+          .append(",http:").append(BASE_HTTP + i)
+          .append(",grpc:").append(BASE_GRPC + i).append("}");
+    }
+    return sb.toString();
+  }
+
+  @Test
+  void everyNodeNamesTheSameLeaderGrpcAddress() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    waitForAllServers();
+
+    final String leaderGrpc = "localhost:" + (BASE_GRPC + leaderIndex);
+    final List<String> followerGrpc = new ArrayList<>();
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex)
+        followerGrpc.add("localhost:" + (BASE_GRPC + i));
+
+    // Asked of the leader AND of each follower: routing is a fact about the cluster, not about who is answering.
+    for (int i = 0; i < getServerCount(); i++) {
+      final HAServerPlugin.RoutingTable table = getRaftPlugin(i)
+          .getRoutingTable(HAServerPlugin.ROUTING_PROTOCOL.GRPC);
+
+      assertThat(table).as("server %d must be able to build a gRPC routing table", i).isNotNull();
+      assertThat(table.protocol()).isEqualTo(HAServerPlugin.ROUTING_PROTOCOL.GRPC);
+      assertThat(table.writer()).as("server %d (leader=%d) must name the leader's declared gRPC port", i, leaderIndex)
+          .isEqualTo(leaderGrpc);
+      assertThat(table.readers()).as("server %d must name every follower's declared gRPC port", i)
+          .containsExactlyInAnyOrderElementsOf(followerGrpc);
+    }
+  }
+
+  /**
+   * Bolt and gRPC resolve through the same code with different inputs. This cluster declares gRPC ports and no
+   * Bolt ones, so the two tables must disagree: if they agreed, one protocol would be reading the other's map -
+   * the single failure a shared resolver can introduce that a one-protocol test cannot see.
+   */
+  @Test
+  void theBoltTableIsNotTheGrpcTable() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).isGreaterThanOrEqualTo(0);
+
+    final HAServerPlugin.RoutingTable grpc = getRaftPlugin(leaderIndex)
+        .getRoutingTable(HAServerPlugin.ROUTING_PROTOCOL.GRPC);
+    final HAServerPlugin.RoutingTable bolt = getRaftPlugin(leaderIndex)
+        .getRoutingTable(HAServerPlugin.ROUTING_PROTOCOL.BOLT);
+
+    assertThat(grpc.writer()).isEqualTo("localhost:" + (BASE_GRPC + leaderIndex));
+    assertThat(bolt).isNotNull();
+    assertThat(bolt.protocol()).isEqualTo(HAServerPlugin.ROUTING_PROTOCOL.BOLT);
+    // No bolt: field declared, so Bolt falls back to this node's Bolt port - which is not a gRPC port.
+    assertThat(bolt.writer()).isNotEqualTo(grpc.writer());
+  }
+
+  /**
+   * The writer and the readers must come from one leader snapshot: a table whose writer also appears among its
+   * readers would send a client both to and away from the same node, which is what a mid-flight leader change
+   * would produce if each side re-read the leader independently.
+   */
+  @Test
+  void theWriterIsNeverAlsoAReader() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).isGreaterThanOrEqualTo(0);
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final HAServerPlugin.RoutingTable table = getRaftPlugin(i)
+          .getRoutingTable(HAServerPlugin.ROUTING_PROTOCOL.GRPC);
+      assertThat(table.readers()).as("server %d", i).doesNotContain(table.writer());
+      assertThat(table.readers()).as("server %d", i).hasSize(getServerCount() - 1);
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
@@ -382,18 +382,74 @@ class RaftHAServerAddressParsingTest {
   }
 
   @Test
-  void deriveBoltAddressCombinesRaftHostWithBoltPort() {
-    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", 7687)).isEqualTo("db1:7687");
+  void objectFormParsesGrpcPort() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,http:2480,grpc:50051}", 2434);
+    final var peerId = parsed.peers().get(0).getId();
+    assertThat(parsed.grpcAddresses()).containsEntry(peerId, "myhost:50051");
+    assertThat(parsed.httpAddresses()).containsEntry(peerId, "myhost:2480");
   }
 
   @Test
-  void deriveBoltAddressReturnsNullForNonPositivePort() {
-    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", 0)).isNull();
-    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", -1)).isNull();
+  void objectFormWithoutGrpcLeavesGrpcAddressesEmpty() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,http:2480,bolt:7687}", 2434);
+    assertThat(parsed.grpcAddresses()).isEmpty();
   }
 
   @Test
-  void deriveBoltAddressHandlesIpv6Literal() {
-    assertThat(RaftHAServer.deriveBoltAddress("[::1]:2434", 7687)).isEqualTo("[::1]:7687");
+  void positionalFormNeverPopulatesGrpcAddresses() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:2434:2480:7:2490", 2434);
+    assertThat(parsed.grpcAddresses()).isEmpty();
+  }
+
+  @Test
+  void namedObjectFormParsesGrpcPort() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("alpha@myhost:{raft:2434,grpc:50055}", 2434);
+    final var peerId = parsed.peers().get(0).getId();
+    assertThat(parsed.grpcAddresses()).containsEntry(peerId, "myhost:50055");
+    assertThat(parsed.peerNames()).containsEntry(peerId, "alpha");
+  }
+
+  /** Bolt and gRPC are independent fields on the same entry: declaring one must not resolve the other. */
+  @Test
+  void boltAndGrpcAreParsedIndependentlyOnTheSameEntry() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "n0:{raft:2434,bolt:7687,grpc:50051},n1:{raft:2435,bolt:7688}", 2434);
+    final var first = parsed.peers().get(0).getId();
+    final var second = parsed.peers().get(1).getId();
+    assertThat(parsed.boltAddresses()).containsEntry(first, "n0:7687").containsEntry(second, "n1:7688");
+    assertThat(parsed.grpcAddresses()).containsEntry(first, "n0:50051").doesNotContainKey(second);
+  }
+
+  @Test
+  void malformedGrpcPortThrows() {
+    assertThatThrownBy(() -> RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,grpc:notaport}", 2434))
+        .isInstanceOf(ServerException.class)
+        .hasMessageContaining("grpc");
+  }
+
+  @Test
+  void grpcPortIsSuffixedWithTheK8sDnsName() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "arcadedb-0:{raft:2434,grpc:50051}", 2434, ".arcadedb.default.svc.cluster.local");
+    final var peerId = parsed.peers().get(0).getId();
+    assertThat(parsed.grpcAddresses())
+        .containsEntry(peerId, "arcadedb-0.arcadedb.default.svc.cluster.local:50051");
+  }
+
+  @Test
+  void deriveRoutingAddressCombinesRaftHostWithPort() {
+    assertThat(RaftHAServer.deriveRoutingAddress("db1:2434", 7687)).isEqualTo("db1:7687");
+    assertThat(RaftHAServer.deriveRoutingAddress("db1:2434", 50051)).isEqualTo("db1:50051");
+  }
+
+  @Test
+  void deriveRoutingAddressReturnsNullForNonPositivePort() {
+    assertThat(RaftHAServer.deriveRoutingAddress("db1:2434", 0)).isNull();
+    assertThat(RaftHAServer.deriveRoutingAddress("db1:2434", -1)).isNull();
+  }
+
+  @Test
+  void deriveRoutingAddressHandlesIpv6Literal() {
+    assertThat(RaftHAServer.deriveRoutingAddress("[::1]:2434", 7687)).isEqualTo("[::1]:7687");
   }
 }

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -113,21 +113,31 @@ public interface HAServerPlugin extends ServerPlugin {
   String getReplicaAddresses();
 
   /**
-   * Immutable snapshot of the Bolt routing topology: the current leader's client-reachable Bolt address
-   * (writer) and the non-leader replicas' Bolt addresses (readers). Both sets are derived from a single
-   * leader read so a concurrent leader change cannot make them mutually inconsistent.
+   * A client-facing wire protocol a routing view can be built for. Each names a per-peer endpoint a client
+   * dials directly, which is never the Raft address the cluster uses to talk to itself, nor - for anything
+   * but a homogeneous deployment - derivable from it. The name of a constant, lowercased, is also the field
+   * an operator writes in the object form of {@code arcadedb.ha.serverList} ({@code host:{raft:..,bolt:..,grpc:..}}).
    */
-  record BoltRoutingTable(String writer, List<String> readers) {
+  enum ROUTING_PROTOCOL {
+    BOLT, GRPC
   }
 
   /**
-   * Returns a single-snapshot Bolt routing table for the ROUTE response, or null when HA is inactive,
-   * no leader is currently known, or the leader has no resolvable Bolt address. Readers reflect the
-   * configured cluster membership (parity with {@link #getReplicaAddresses()}); a down or partitioned
-   * follower is still advertised until it leaves the group, and the driver fails over. Used to build the
-   * Bolt ROUTE routing table.
+   * Immutable snapshot of the routing topology for one client protocol: the current leader's
+   * client-reachable address (writer) and the non-leader replicas' addresses (readers). Both sets are
+   * derived from a single leader read so a concurrent leader change cannot make them mutually inconsistent.
    */
-  default BoltRoutingTable getBoltRoutingTable() {
+  record RoutingTable(ROUTING_PROTOCOL protocol, String writer, List<String> readers) {
+  }
+
+  /**
+   * Returns a single-snapshot routing table for the given client protocol, or null when HA is inactive,
+   * no leader is currently known, or the leader has no resolvable address for that protocol. Readers reflect
+   * the configured cluster membership (parity with {@link #getReplicaAddresses()}); a down or partitioned
+   * follower is still advertised until it leaves the group, and the client fails over. Used to build the
+   * Bolt ROUTE response and to name a dialable leader when a gRPC RPC refuses work only the leader may run.
+   */
+  default RoutingTable getRoutingTable(final ROUTING_PROTOCOL protocol) {
     return null;
   }
 


### PR DESCRIPTION
Closes #6091 (item 3 of #6083, the one left out of #6089).

## The problem

`graphBatchLoad` refuses a bulk load on a follower - correctly, since the bulk path mutates shared state only the leader can serialize (#4122). To let the caller redirect it named the leader, but the only address HA could expose was the leader's **HTTP** one, so the refusal had to say:

> `Reconnect to the leader at '<host:httpPort>' (HTTP address; use its gRPC port) and retry`

A client retrying automatically had to already know the deployment's port-mapping convention, and there was no way to learn the leader's gRPC address from the cluster.

## Decisions the issue asked to make deliberately

**Generalise, don't duplicate.** `BoltRoutingTable` / `getBoltRoutingTable()` become `RoutingTable(protocol, writer, readers)` / `getRoutingTable(ROUTING_PROTOCOL)`. A second single-protocol record would have invited a third, and the resolver behind it is the same code with different inputs: the declared-addresses map, this node's local port, and the one-time-warning latch are now selected per protocol, everything else is shared. The Bolt ROUTE path was updated with it; `Bolt5002RoutingTableIT` passes unchanged.

**Derive *and* declare, exactly as Bolt does.** The object form of `arcadedb.ha.serverList` takes a `grpc:` field (`host:{raft:2434,http:2480,bolt:7687,grpc:50051}`); with nothing declared, a peer's endpoint is its Raft host plus *this* node's gRPC port. That is right for a homogeneous deployment (a K8s StatefulSet) and knowingly wrong for a heterogeneous one, which is why the field exists and why the fallback logs a WARNING naming the syntax. Shipping the derive-only half would have left the heterogeneous case silently wrong - the same reason `bolt:` exists. The warning latch is per protocol now, so a derived Bolt address no longer mutes the gRPC warning.

**One RPC refuses today, but the refusal is not written for one RPC.** `notTheLeader(ha, rpc, why)` builds it, so the next RPC that has to refuse on a follower gets the same answer rather than a second dialect.

## Better than what the issue proposed

The issue asked for the address in the refusal *message*. A message is not a contract - a client redirecting itself would be pattern-matching prose. So the refusal also carries:

- `arcadedb-leader-grpc-address` - the address the refused call can be retried on;
- `arcadedb-leader-http-address` - always known when a leader is, kept as the diagnostic fallback;
- `arcadedb-exception-class: ServerIsNotTheLeaderException` - the trailer this service already uses to preserve exception types.

The gRPC client therefore rebuilds **the same exception the HTTP protocol raises for the same situation**, `ServerIsNotTheLeaderException`, with `getLeaderAddress()` returning the gRPC endpoint. Callers that already handle the HTTP leader redirect handle the gRPC one with no new code. The keys live in the shared `grpc` protocol module (`LeaderRedirectProtocol`), next to `GraphBatchProtocol`, so the two ends cannot drift.

`GlobalConfiguration.GRPC_PORT` registers the key the gRPC plugin previously read as a bare string with its own literal default. HA resolves peer endpoints from the same constant, so the two cannot disagree about which port to advertise - and the setting now honours env/system properties like every other one.

## Testing

Cluster tests, because the follower branch is unreachable on a single server (recorded in #6083: the auth interceptor short-circuits a credential-less call and forcing the branch NPEs on a null `ha`).

- **`Issue6091GraphBatchLoadLeaderRedirectIT`** (grpcw, 3 nodes, per-node `grpc:` declared) - the load refused on a follower is retried **against the address the refusal advertised, dialled verbatim**, and succeeds and replicates. A test comparing the string against the port it configured would pass just as well if the server had named the follower's own port, which is exactly the mistake to catch here.
- **`Issue6091GrpcRoutingTableIT`** (ha-raft) - every node names the same leader endpoint; the Bolt and gRPC tables disagree on a cluster that declares only gRPC ports (a shared resolver's one new failure mode is reading the other protocol's map); the writer is never also a reader.
- **`Issue6091GrpcRoutingTableDerivedIT`** (ha-raft) - the fallback, asserted against a deliberately non-default port so it fails if the resolver stops reading `GRPC_PORT`.
- **`Issue6091LeaderRedirectMappingTest`** (grpc-client) - gRPC address preferred over HTTP, HTTP as fallback, null address mid-election, and an address trailer alone does not invent a type.
- `RaftHAServerAddressParsingTest` - `grpc:` parsing, independence from `bolt:`, malformed port, K8s DNS suffix.

**Mutation-checked, all four ways:** naming only the HTTP address, pointing the gRPC lookup at the Bolt map, deriving from `BOLT_PORT`, and each fails the test that covers it.

Suites run green: `bolt` unit + `Bolt5002RoutingTableIT`, `ha-raft` unit + the new ITs, `grpcw` unit + `Issue6070*IT`, `grpc-client` unit. (Some local runs of unrelated classes fail on `HTTP port 2480 not available` - another process on this machine holds it.)

## Not in this PR

The user-facing `serverList` reference lives in the docs repo; the `grpc:` field wants the same one-paragraph note `bolt:` got there.
