### PR TITLE
fix(#6168): memoize the unreferenced-file count, give "reached by name" one home, de-flake two sampled/timing-dependent tests

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/UnreferencedFiles.java
+++ b/engine/src/main/java/com/arcadedb/engine/UnreferencedFiles.java
@@ -146,6 +146,15 @@ public class UnreferencedFiles {
    * leader's value outright - so the entry is valid only while BOTH halves are unchanged, never while they are "not
    * newer".
    * <p>
+   * <b>What the gate rests on, stated so it can be checked.</b> Because the version can move BACKWARDS, equality of
+   * the pair is only as good as this: within one database's lineage a given schema version denotes one schema
+   * CONTENT, so returning to a version means returning to the claimed-file set that version described - and the
+   * cached count is the count of that set. The file half needs no such assumption; it only ever increases, so an
+   * equal value means no file was registered or dropped in between, full stop. A stale answer therefore needs two
+   * nodes to have assigned the same version to DIFFERENT schema content, which is schema divergence - a condition
+   * that breaks replication itself long before it misreports a gauge, and is not a state this cache should be
+   * designed around.
+   * <p>
    * <b>Thread safety without a lock.</b> The gate is read BEFORE the walk and published with the count afterwards,
    * so a change that lands mid-walk tags the result with the gate it was computed under, and the next call - seeing
    * the newer gate - recomputes. Two callers racing can therefore duplicate work or overwrite each other's entry,

--- a/engine/src/main/java/com/arcadedb/engine/UnreferencedFiles.java
+++ b/engine/src/main/java/com/arcadedb/engine/UnreferencedFiles.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.InternalBucketNaming;
 import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.LocalSchema;
 
@@ -31,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 /**
@@ -64,8 +66,8 @@ import java.util.function.Supplier;
  * false positive on a healthy database - the one outcome that would make this diagnostic worse than useless.
  * Manual indexes are claimed for the same reason: they are bound to no type by design. So is any bucket whose NAME
  * is derived from a type's or a claimed bucket's - the edge-list buckets of a vertex bucket, a super-node stripe
- * pool, a paired external bucket - see {@link #isDerivedFromAnOwner}, which recognises the convention rather than
- * the individual features that follow it.
+ * pool, a paired external bucket - see {@link InternalBucketNaming#ownerOf}, the one home of that convention, which
+ * recognises the SHAPE rather than the individual features that follow it.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -116,19 +118,69 @@ public class UnreferencedFiles {
    * case, where there is nothing to describe, and it keeps a node that IS leaking files from paying for strings
    * every refresh throws away.
    * <p>
-   * The walk itself is NOT memoized, and the whole of it - including rebuilding the claimed-file set - runs on every
-   * refresh. That is deliberate for a diagnostic reading live state, and it is in-memory work with no I/O, but it
-   * does scale with the schema: one {@code getFileIds()} per index, each taking that index's read lock. Should a
-   * database with tens of thousands of components ever make that visible, the gate is
-   * {@code (FileManager.getModificationCount(), schema version)} - between them those two cover every way the answer
-   * can change, since a file this walk would newly report appeared either as a file (the first) or as a schema
-   * change that stopped claiming one (the second). Recorded rather than implemented: a cached count that goes stale
-   * is a worse diagnostic than a slightly expensive one.
+   * This runs the WHOLE walk, including rebuilding the claimed-file set, on every call. A caller on a timer wants
+   * {@link MemoizedCount} instead, which skips it while the answer provably cannot have changed.
    */
   public static long count(final DatabaseInternal database) {
     final long[] count = { 0 };
     walk(database, (fileId, file, reason) -> ++count[0]);
     return count[0];
+  }
+
+  /**
+   * A {@link #count} that skips the walk while the answer provably cannot have changed (issue #6168, item 1).
+   * <p>
+   * <b>Why one is needed.</b> The per-node {@code arcadedb.ha.schema.unreferenced_files} gauge is refreshed every 5
+   * seconds for every open replicated database, and each refresh rebuilt the whole claimed-file set: every type,
+   * every bucket, and one {@code getFileIds()} per index, which takes that index's read lock and allocates a list.
+   * It is in-memory with no I/O, so it is cheap on ordinary schemas, but the cost scaled with SCHEMA SIZE rather
+   * than with the size of the problem being diagnosed - on every node, forever, whether or not anything is wrong.
+   * <p>
+   * <b>Why the cached value cannot go stale</b>, which is the only reason memoizing a diagnostic is acceptable at
+   * all. The gate is the pair {@code (FileManager.getModificationCount(), schema version)}, and between them those
+   * two cover every way the answer can change: a file this walk would newly report either appeared as a FILE, which
+   * bumps the modification count on registration and on drop, or appeared because a SCHEMA change stopped claiming
+   * one, which bumps the schema version. Neither can move without invalidating the entry.
+   * <p>
+   * <b>Equality, not ordering.</b> The schema version is not monotonic on a follower - a schema reload assigns the
+   * leader's value outright - so the entry is valid only while BOTH halves are unchanged, never while they are "not
+   * newer".
+   * <p>
+   * <b>Thread safety without a lock.</b> The gate is read BEFORE the walk and published with the count afterwards,
+   * so a change that lands mid-walk tags the result with the gate it was computed under, and the next call - seeing
+   * the newer gate - recomputes. Two callers racing can therefore duplicate work or overwrite each other's entry,
+   * and both outcomes are a recompute, never a stale answer. One instance per database, held by whoever owns the
+   * refresh, so it dies with the database rather than needing to be evicted.
+   */
+  public static class MemoizedCount {
+    /** The gate and the count it produced, published as one object so a reader can never see a torn pair. */
+    private record Entry(long fileModificationCount, long schemaVersion, long count) {
+    }
+
+    private volatile Entry     entry;
+    /** How many times the walk actually ran. Diagnostic, and what the regression test asserts on. */
+    private final    AtomicLong recomputations = new AtomicLong();
+
+    /** The count, from the cache when the gate is unchanged and from a fresh {@link #count} walk otherwise. */
+    public long get(final DatabaseInternal database) {
+      final long fileModificationCount = database.getFileManager().getModificationCount();
+      final long schemaVersion = database.getSchema().getEmbedded().getVersion();
+
+      final Entry cached = entry;
+      if (cached != null && cached.fileModificationCount == fileModificationCount
+          && cached.schemaVersion == schemaVersion)
+        return cached.count;
+
+      final long counted = count(database);
+      recomputations.incrementAndGet();
+      entry = new Entry(fileModificationCount, schemaVersion, counted);
+      return counted;
+    }
+
+    /** Number of walks performed so far: the memoization is only worth anything if this stops growing. */
+    public long getRecomputations() {
+      return recomputations.get();
+    }
   }
 
   /**
@@ -163,7 +215,7 @@ public class UnreferencedFiles {
           // Purpose is restored from the schema at load time and reset to PRIMARY when it is not, so it can only be
           // used to EXCLUDE: anything not claiming to be a plain data bucket is left to whoever paired it.
           && bucket.getPurpose() == LocalBucket.Purpose.PRIMARY
-          && !isDerivedFromAnOwner(bucket.getName(), owners)) {
+          && !InternalBucketNaming.isDerivedFromAnOwner(bucket.getName(), owners)) {
         reported.set(fileId);
         consumer.accept(fileId, file, () -> "bucket '" + bucket.getName() + "' belongs to no type");
       }
@@ -216,34 +268,6 @@ public class UnreferencedFiles {
           claim(claimed, fileId);
 
     return claimed;
-  }
-
-  /**
-   * Whether a bucket no type lists is nevertheless OWNED by one, because its name is derived from a type's or a
-   * claimed bucket's - {@code Hub_sn_stripe_3}, {@code V_0_out_edges}, {@code Doc_0_ext}.
-   * <p>
-   * A GENERAL rule, and deliberately so. This started as a list of the conventions in the engine and CI found the
-   * one that list was missing (the super-node stripe pools of #5156, whose buckets no type lists and which
-   * {@code StripedEdgeList} reaches by composing the type name), which is the proof that enumerating them is not a
-   * closed problem: every internal bucket names itself after the schema object it belongs to, and the next feature
-   * to add one will follow the same convention rather than register with this class. Recognising the convention
-   * itself covers them all, including the ones not written yet.
-   * <p>
-   * What it costs is a false NEGATIVE: a genuinely orphaned bucket that happens to be named after a surviving type
-   * goes unreported. That is the right side to fail on for a diagnostic whose findings invite deletion - and the
-   * shape that motivated it is not affected, since a session abandoned before it published left no type to derive
-   * the name from.
-   * <p>
-   * Matched by successive underscore-delimited prefixes rather than by scanning the owner set, so the cost is a few
-   * hash lookups per candidate instead of one pass over every type in the schema.
-   */
-  private static boolean isDerivedFromAnOwner(final String bucketName, final Set<String> owners) {
-    for (int underscore = bucketName.indexOf('_'); underscore > 0; underscore = bucketName.indexOf('_',
-        underscore + 1))
-      if (owners.contains(bucketName.substring(0, underscore)))
-        return true;
-
-    return false;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -28,6 +28,7 @@ import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.InternalBucketNaming;
 import com.arcadedb.schema.LocalVertexType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.utility.CollectionUtils;
@@ -393,8 +394,8 @@ public class GraphDatabaseChecker {
       if (!(type instanceof LocalVertexType))
         continue;
       for (final Bucket vb : type.getBuckets(false)) {
-        addSegmentBucketIfInternal(ids, vb.getName() + GraphEngine.OUT_EDGES_SUFFIX);
-        addSegmentBucketIfInternal(ids, vb.getName() + GraphEngine.IN_EDGES_SUFFIX);
+        addSegmentBucketIfInternal(ids, InternalBucketNaming.outEdgesBucketName(vb.getName()));
+        addSegmentBucketIfInternal(ids, InternalBucketNaming.inEdgesBucketName(vb.getName()));
       }
       // Super-node stripe pool (per type). Pools are created contiguously from slot 0 (see
       // GraphEngine.dropVertexType): sweep until the first gap AT OR PAST the configured pool size, stepping over

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -43,6 +43,7 @@ import com.arcadedb.exception.ValidationException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
+import com.arcadedb.schema.InternalBucketNaming;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
@@ -67,9 +68,6 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.it)
  */
 public class GraphEngine {
-  public static final String OUT_EDGES_SUFFIX = "_out_edges";
-  public static final String IN_EDGES_SUFFIX  = "_in_edges";
-
   public static final IterableGraph<Vertex> EMPTY_VERTEX_LIST = new IterableGraph<>() {
     @Override
     public Iterator<Vertex> iterator() {
@@ -115,24 +113,29 @@ public class GraphEngine {
 
   public List<Bucket> createVertexAdditionalBuckets(final LocalBucket b) {
     final Bucket[] outInBuckets = new Bucket[2];
-    if (database.getSchema().existsBucket(b.getName() + OUT_EDGES_SUFFIX))
-      outInBuckets[0] = database.getSchema().getBucketByName(b.getName() + OUT_EDGES_SUFFIX);
-    else
-      outInBuckets[0] = database.getSchema().createBucket(b.getName() + OUT_EDGES_SUFFIX);
+    final String outEdgesBucket = InternalBucketNaming.outEdgesBucketName(b.getName());
+    final String inEdgesBucket = InternalBucketNaming.inEdgesBucketName(b.getName());
 
-    if (database.getSchema().existsBucket(b.getName() + IN_EDGES_SUFFIX))
-      outInBuckets[1] = database.getSchema().getBucketByName(b.getName() + IN_EDGES_SUFFIX);
+    if (database.getSchema().existsBucket(outEdgesBucket))
+      outInBuckets[0] = database.getSchema().getBucketByName(outEdgesBucket);
     else
-      outInBuckets[1] = database.getSchema().createBucket(b.getName() + IN_EDGES_SUFFIX);
+      outInBuckets[0] = database.getSchema().createBucket(outEdgesBucket);
+
+    if (database.getSchema().existsBucket(inEdgesBucket))
+      outInBuckets[1] = database.getSchema().getBucketByName(inEdgesBucket);
+    else
+      outInBuckets[1] = database.getSchema().createBucket(inEdgesBucket);
     return List.of(outInBuckets);
   }
 
   public void dropVertexType(final VertexType type) {
     for (final Bucket b : type.getBuckets(false)) {
-      if (database.getSchema().existsBucket(b.getName() + OUT_EDGES_SUFFIX))
-        database.getSchema().dropBucket(b.getName() + OUT_EDGES_SUFFIX);
-      if (database.getSchema().existsBucket(b.getName() + IN_EDGES_SUFFIX))
-        database.getSchema().dropBucket(b.getName() + IN_EDGES_SUFFIX);
+      final String outEdgesBucket = InternalBucketNaming.outEdgesBucketName(b.getName());
+      final String inEdgesBucket = InternalBucketNaming.inEdgesBucketName(b.getName());
+      if (database.getSchema().existsBucket(outEdgesBucket))
+        database.getSchema().dropBucket(outEdgesBucket);
+      if (database.getSchema().existsBucket(inEdgesBucket))
+        database.getSchema().dropBucket(inEdgesBucket);
     }
 
     // DROP THE SUPER-NODE STRIPE POOL, IF THE TYPE EVER PROMOTED A VERTEX (#5156)
@@ -1896,9 +1899,9 @@ public class GraphEngine {
     final Bucket vertexBucket = database.getSchema().getBucketById(bucketId);
 
     if (direction == Vertex.DIRECTION.OUT)
-      return vertexBucket.getName() + OUT_EDGES_SUFFIX;
+      return InternalBucketNaming.outEdgesBucketName(vertexBucket.getName());
     else if (direction == Vertex.DIRECTION.IN)
-      return vertexBucket.getName() + IN_EDGES_SUFFIX;
+      return InternalBucketNaming.inEdgesBucketName(vertexBucket.getName());
 
     throw new IllegalArgumentException("Invalid direction");
   }

--- a/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
+++ b/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
@@ -29,6 +29,7 @@ import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.schema.InternalBucketNaming;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.utility.InterleavedIterator;
@@ -86,9 +87,6 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class StripedEdgeList extends EdgeLinkedList {
-  // Package-visible for GraphDatabaseChecker's orphan reclaim, which identifies stripe buckets by name.
-  static final String STRIPE_BUCKET_INFIX = "_sn_stripe_";
-
   /** Guards against stampeding pool creations: one in-flight creation per database+type (value = start ms). */
   private static final ConcurrentHashMap<String, Long> POOLS_IN_CREATION = new ConcurrentHashMap<>();
   /** One-shot diagnostic latch: warn ONCE per type if a pool creation looks stuck (see ensureStripePool). */
@@ -120,7 +118,7 @@ public class StripedEdgeList extends EdgeLinkedList {
    * real hubs are typically hot in a single direction and the pool size is the tuning lever.
    */
   public static String stripeBucketName(final String typeName, final int slot) {
-    return typeName + STRIPE_BUCKET_INFIX + slot;
+    return InternalBucketNaming.superNodeStripeBucketName(typeName, slot);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/InternalBucketNaming.java
+++ b/engine/src/main/java/com/arcadedb/schema/InternalBucketNaming.java
@@ -133,9 +133,18 @@ public class InternalBucketNaming {
    * Matched by successive underscore-delimited prefixes rather than by scanning {@code ownerNames}, so the cost is a
    * few hash lookups per candidate instead of one pass over every type in the schema. Owner names may themselves
    * contain underscores ({@code V_0}), which is why every prefix is tried and not only the first.
+   * <p>
+   * <b>The SHORTEST matching prefix wins</b>, and that tie-break is arbitrary rather than principled: with both
+   * {@code My} and {@code My_Type_0} in the owner set, {@code My_Type_0_out_edges} is attributed to {@code My}. It
+   * does not matter to the question this method exists to answer - "is this bucket owned by anything?", which is
+   * what {@link #isDerivedFromAnOwner} asks and is the only thing consumed today. A caller that uses the returned
+   * NAME for something attribution-sensitive (reporting it to an operator, deciding what to delete alongside it)
+   * has to establish which owner it wants first; this method will not have chosen it for them.
    *
    * @param bucketName the bucket whose ownership is in question
    * @param ownerNames names of the schema objects that can own a bucket: types, and buckets a type already claims
+   *
+   * @return the shortest prefix of {@code bucketName} that is in {@code ownerNames}, or {@code null} if none is
    */
   public static String ownerOf(final String bucketName, final Set<String> ownerNames) {
     for (int underscore = bucketName.indexOf('_'); underscore > 0; underscore = bucketName.indexOf('_',

--- a/engine/src/main/java/com/arcadedb/schema/InternalBucketNaming.java
+++ b/engine/src/main/java/com/arcadedb/schema/InternalBucketNaming.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import java.util.Set;
+
+/**
+ * The one home of "reached by name": the bucket names the engine composes from the name of the schema object that
+ * owns them, and the rule that recognises one (issue #6168, item 5).
+ * <p>
+ * A bucket can be referenced by the engine without any type listing it among its buckets. The reference is a NAMING
+ * CONVENTION - {@code V_0_out_edges} belongs to vertex bucket {@code V_0}, {@code Hub_sn_stripe_3} to type
+ * {@code Hub}, {@code Doc_0_ext} to primary bucket {@code Doc_0} - and until this class existed each feature composed
+ * its own names and every consumer that had to ask "is this bucket referenced?" re-encoded the convention on its own.
+ * That cost real time: #6152's unreferenced-file classifier shipped with an explicit list of the conventions it knew
+ * about, CI found the one the list was missing, and 17 test classes went red reporting every promoted super-node's
+ * stripe pool as an orphan.
+ * <p>
+ * <b>Two halves, and they answer different questions.</b>
+ * <ul>
+ *   <li>{@link Convention} and the {@code composeXXX} methods are the DECLARATION side: a feature that names buckets
+ *       after their owner declares its convention here and gets recognition with it, instead of leaving it to be
+ *       discovered later by whoever is debugging a false positive.</li>
+ *   <li>{@link #ownerOf} is the RECOGNITION side, and it is deliberately NOT driven by the enum. It matches the
+ *       SHAPE - {@code <owner>_<anything>} for an owner the caller knows about - so it covers conventions that were
+ *       never declared here, including the ones not written yet. Enumerating them is not a closed problem; that is
+ *       precisely what CI proved on #6152. The enum documents and composes, it does not gate.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class InternalBucketNaming {
+
+  /**
+   * The conventions the engine composes today, each with the suffix it appends to its owner's name.
+   * <p>
+   * A declaration, not a whitelist: {@link #ownerOf} recognises the shape rather than this list, so adding a
+   * constant here buys composition and documentation, and forgetting to add one does NOT make the new buckets look
+   * like orphans.
+   */
+  public enum Convention {
+    /** Outgoing edge-list bucket of a VERTEX BUCKET: {@code <vertexBucket>_out_edges} (GraphEngine). */
+    OUT_EDGES("_out_edges"),
+    /** Incoming edge-list bucket of a VERTEX BUCKET: {@code <vertexBucket>_in_edges} (GraphEngine). */
+    IN_EDGES("_in_edges"),
+    /** Super-node stripe pool of a VERTEX TYPE: {@code <type>_sn_stripe_<slot>} (StripedEdgeList, #5156). */
+    SUPER_NODE_STRIPE("_sn_stripe_"),
+    /** Paired external-property bucket of a PRIMARY BUCKET: {@code <primaryBucket>_ext} (LocalDocumentType). */
+    EXTERNAL_PROPERTY("_ext");
+
+    private final String suffix;
+
+    Convention(final String suffix) {
+      this.suffix = suffix;
+    }
+
+    /** The text appended to the owner's name. For {@link #SUPER_NODE_STRIPE} the slot ordinal follows it. */
+    public String suffix() {
+      return suffix;
+    }
+
+    /** The name this convention gives to the bucket owned by {@code ownerName}. */
+    public String compose(final String ownerName) {
+      return ownerName + suffix;
+    }
+  }
+
+  private InternalBucketNaming() {
+  }
+
+  /** Name of the outgoing edge-list bucket of the given vertex bucket. */
+  public static String outEdgesBucketName(final String vertexBucketName) {
+    return Convention.OUT_EDGES.compose(vertexBucketName);
+  }
+
+  /** Name of the incoming edge-list bucket of the given vertex bucket. */
+  public static String inEdgesBucketName(final String vertexBucketName) {
+    return Convention.IN_EDGES.compose(vertexBucketName);
+  }
+
+  /** Name of the {@code slot}-th bucket of the super-node stripe pool of the given type. */
+  public static String superNodeStripeBucketName(final String typeName, final int slot) {
+    return Convention.SUPER_NODE_STRIPE.compose(typeName) + slot;
+  }
+
+  /** Name of the external-property bucket paired to the given primary bucket. */
+  public static String externalPropertyBucketName(final String primaryBucketName) {
+    return Convention.EXTERNAL_PROPERTY.compose(primaryBucketName);
+  }
+
+  /**
+   * Whether the name is shaped like one of a vertex bucket's two edge-list buckets. Asked when a type rename has to
+   * carry its internal buckets along and must refuse to rename anything it does not recognise.
+   */
+  public static boolean isEdgeListBucketName(final String bucketName) {
+    return bucketName.endsWith(Convention.OUT_EDGES.suffix()) || bucketName.endsWith(Convention.IN_EDGES.suffix());
+  }
+
+  /**
+   * Whether the name is shaped like an external-property bucket's. Used to warn a user creating a bucket that would
+   * collide with the pairing before the collision turns into a {@code SchemaException} on a later property change.
+   */
+  public static boolean looksLikeAnExternalPropertyBucketName(final String bucketName) {
+    return bucketName.endsWith(Convention.EXTERNAL_PROPERTY.suffix());
+  }
+
+  /**
+   * The owner among {@code ownerNames} whose name this bucket's is derived from, or {@code null} if none is -
+   * {@code Hub_sn_stripe_3} for {@code Hub}, {@code V_0_out_edges} for {@code V_0}, {@code Doc_0_ext} for
+   * {@code Doc_0}.
+   * <p>
+   * <b>The general rule, deliberately.</b> It does not consult {@link Convention}, so a bucket named after its owner
+   * by a convention nobody declared here is still recognised. What it costs is a false NEGATIVE - a genuinely
+   * orphaned bucket that happens to be named after a surviving type is attributed to it - which is the right side to
+   * fail on for a caller whose findings invite deletion.
+   * <p>
+   * Matched by successive underscore-delimited prefixes rather than by scanning {@code ownerNames}, so the cost is a
+   * few hash lookups per candidate instead of one pass over every type in the schema. Owner names may themselves
+   * contain underscores ({@code V_0}), which is why every prefix is tried and not only the first.
+   *
+   * @param bucketName the bucket whose ownership is in question
+   * @param ownerNames names of the schema objects that can own a bucket: types, and buckets a type already claims
+   */
+  public static String ownerOf(final String bucketName, final Set<String> ownerNames) {
+    for (int underscore = bucketName.indexOf('_'); underscore > 0; underscore = bucketName.indexOf('_',
+        underscore + 1)) {
+      final String candidate = bucketName.substring(0, underscore);
+      if (ownerNames.contains(candidate))
+        return candidate;
+    }
+
+    return null;
+  }
+
+  /** Whether {@link #ownerOf} finds an owner for this bucket, for callers that need only the predicate. */
+  public static boolean isDerivedFromAnOwner(final String bucketName, final Set<String> ownerNames) {
+    return ownerOf(bucketName, ownerNames) != null;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1504,7 +1504,7 @@ public class LocalDocumentType implements DocumentType {
     // Atomic check-and-create: two threads racing through ensureExternalBuckets()/addBucketInternal() must not
     // both attempt to allocate the paired _ext bucket and trip schema.createBucket's "already exists" guard.
     externalBucketIdByPrimaryBucketId.computeIfAbsent(primary.getFileId(), pid -> {
-      final String extName = primary.getName() + "_ext";
+      final String extName = InternalBucketNaming.externalPropertyBucketName(primary.getName());
       final LocalBucket external;
       if (schema.bucketMap.containsKey(extName)) {
         external = schema.bucketMap.get(extName);
@@ -1648,7 +1648,7 @@ public class LocalDocumentType implements DocumentType {
     for (final Bucket primaryBucket : buckets) {
       if (externalBucketIdByPrimaryBucketId.containsKey(primaryBucket.getFileId()))
         continue;
-      final String candidateName = primaryBucket.getName() + "_ext";
+      final String candidateName = InternalBucketNaming.externalPropertyBucketName(primaryBucket.getName());
       final LocalBucket candidate = schema.bucketMap.get(candidateName);
       if (candidate == null)
         continue;

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -553,7 +553,7 @@ public class LocalSchema implements Schema {
     // with the matching prefix later gains an EXTERNAL property; ensureExternalBucketFor() rejects with a
     // SchemaException at that point. Surfacing the constraint at create time is much cheaper than debugging
     // the later failure.
-    if (version == LocalBucket.CURRENT_VERSION && bucketName.endsWith("_ext"))
+    if (version == LocalBucket.CURRENT_VERSION && InternalBucketNaming.looksLikeAnExternalPropertyBucketName(bucketName))
       LogManager.instance().log(this, Level.WARNING,
           """
           Bucket name '%s' ends with '_ext'. The engine reserves the '<primaryName>_ext' suffix for paired\

--- a/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
@@ -22,7 +22,6 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.exception.SchemaException;
-import com.arcadedb.graph.GraphEngine;
 import com.arcadedb.graph.MutableVertex;
 
 import java.io.IOException;

--- a/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
@@ -53,7 +53,7 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
       for (Bucket bucket : additionalBuckets) {
         final String oldBucketName = bucket.getName();
 
-        if (!oldBucketName.endsWith(GraphEngine.OUT_EDGES_SUFFIX) && !oldBucketName.endsWith(GraphEngine.IN_EDGES_SUFFIX))
+        if (!InternalBucketNaming.isEdgeListBucketName(oldBucketName))
           throw new SchemaException(
               "Cannot rename bucket '" + oldBucketName + "' because it does not follow the naming convention");
 

--- a/engine/src/test/java/com/arcadedb/engine/Issue6168MemoizedUnreferencedCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6168MemoizedUnreferencedCountTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.UnreferencedFiles.MemoizedCount;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6168, item 1: the unreferenced-file count is memoized behind a (file modification count, schema version)
+ * gate, because the HA gauge that publishes it rebuilds the whole claimed-file set every 5 seconds for every open
+ * replicated database.
+ * <p>
+ * A memoized diagnostic is only worth having if it cannot go stale, so the tests below are about the GATE and not
+ * about the saving: one per half of it (a file appeared / a schema change stopped claiming one), each proving that
+ * the OTHER half did not move, plus an end-to-end walk of a mutation sequence where the memoized answer has to agree
+ * with a fresh one at every step.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6168MemoizedUnreferencedCountTest extends TestHelper {
+
+  /** No underscore, so the derived-name rule can never attribute it to a type and call it claimed. */
+  private static final String DETACHED_BUCKET = "detachedbucket";
+
+  @Test
+  void anUnchangedDatabaseIsAnsweredFromTheCache() {
+    final MemoizedCount memoized = new MemoizedCount();
+
+    assertThat(memoized.get(db())).as("a healthy database").isZero();
+    assertThat(memoized.getRecomputations()).as("the first call has nothing cached").isEqualTo(1);
+
+    for (int i = 0; i < 10; i++)
+      assertThat(memoized.get(db())).isZero();
+
+    assertThat(memoized.getRecomputations())
+        .as("nothing changed, so the walk - one getFileIds() per index, each taking that index's read lock - must "
+            + "not have run again")
+        .isEqualTo(1);
+  }
+
+  /**
+   * The first half of the gate. A standalone {@code CREATE BUCKET} leaves a file no type claims, and it is a FILE
+   * that appeared, which is what {@code FileManager.getModificationCount()} answers for.
+   */
+  @Test
+  void aNewFileInvalidatesTheEntry() {
+    final MemoizedCount memoized = new MemoizedCount();
+    assertThat(memoized.get(db())).isZero();
+
+    database.getSchema().createBucket(DETACHED_BUCKET);
+    try {
+      assertThat(memoized.get(db())).as("the new file is claimed by nothing and must be counted").isEqualTo(1);
+      assertThat(memoized.getRecomputations()).isEqualTo(2);
+    } finally {
+      database.getSchema().dropBucket(DETACHED_BUCKET);
+    }
+
+    assertThat(memoized.get(db())).as("and dropping it takes the count back down").isZero();
+  }
+
+  /**
+   * The second half of the gate, and the one a file counter alone cannot cover: detaching a bucket from its type
+   * creates and drops nothing, so the answer changes with NO file having moved. Asserting the file modification
+   * count is unchanged across the mutation is what makes this a test of the schema-version half specifically.
+   */
+  @Test
+  void aSchemaChangeThatStopsClaimingAFileInvalidatesTheEntry() {
+    final MemoizedCount memoized = new MemoizedCount();
+
+    final DocumentType type = database.getSchema().createDocumentType("Issue6168Owner");
+    type.createProperty("id", Type.INTEGER);
+    final Bucket detached = database.getSchema().createBucket(DETACHED_BUCKET);
+    type.addBucket(detached);
+
+    assertThat(memoized.get(db())).as("a bucket its type lists is claimed").isZero();
+
+    final long filesBefore = db().getFileManager().getModificationCount();
+    type.removeBucket(detached);
+    assertThat(db().getFileManager().getModificationCount())
+        .as("detaching a bucket creates and drops no file, so only the schema version can have moved")
+        .isEqualTo(filesBefore);
+
+    assertThat(memoized.get(db())).as("nothing claims the bucket any more").isEqualTo(1);
+    assertThat(memoized.get(db())).isEqualTo(UnreferencedFiles.count(db()));
+
+    database.getSchema().dropBucket(DETACHED_BUCKET);
+    database.getSchema().dropType("Issue6168Owner");
+  }
+
+  /**
+   * The property that actually matters, asserted over a sequence rather than at one point: whatever the gate does,
+   * the memoized answer is the answer a fresh walk gives. A gate that missed a change would show up here as a
+   * disagreement at the step after it.
+   */
+  @Test
+  void theMemoizedAnswerAgreesWithAFreshWalkAtEveryStep() {
+    final MemoizedCount memoized = new MemoizedCount();
+    assertThatBothAgree(memoized);
+
+    final DocumentType type = database.getSchema().createDocumentType("Issue6168Seq");
+    type.createProperty("id", Type.INTEGER);
+    assertThatBothAgree(memoized);
+
+    type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+    assertThatBothAgree(memoized);
+
+    final Bucket detached = database.getSchema().createBucket(DETACHED_BUCKET);
+    assertThatBothAgree(memoized);
+
+    type.addBucket(detached);
+    assertThatBothAgree(memoized);
+
+    type.removeBucket(detached);
+    assertThatBothAgree(memoized);
+
+    database.getSchema().dropBucket(DETACHED_BUCKET);
+    assertThatBothAgree(memoized);
+
+    database.getSchema().dropType("Issue6168Seq");
+    assertThatBothAgree(memoized);
+  }
+
+  private void assertThatBothAgree(final MemoizedCount memoized) {
+    assertThat(memoized.get(db())).isEqualTo(UnreferencedFiles.count(db()));
+  }
+
+  /** The count reads the file manager and the schema registries, both of which live on the internal interface. */
+  private DatabaseInternal db() {
+    return (DatabaseInternal) database;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerOrphanReclaimTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.DatabaseChecker;
 import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.schema.InternalBucketNaming;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -283,8 +284,8 @@ class GraphDatabaseCheckerOrphanReclaimTest extends TestHelper {
 
     // A document type whose ONLY bucket is literally named "<x>_out_edges" (suffix collision), and a document
     // type whose default bucket name CONTAINS the stripe infix "_sn_stripe_" (infix collision).
-    final String suffixBucketName = "Ledger" + GraphEngine.OUT_EDGES_SUFFIX;
-    final String infixTypeName    = "Audit" + StripedEdgeList.STRIPE_BUCKET_INFIX + "journal";
+    final String suffixBucketName = InternalBucketNaming.outEdgesBucketName("Ledger");
+    final String infixTypeName    = InternalBucketNaming.Convention.SUPER_NODE_STRIPE.compose("Audit") + "journal";
     final int    suffixDocs       = 20;
     final int    infixDocs        = 15;
 

--- a/engine/src/test/java/com/arcadedb/schema/InternalBucketNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/InternalBucketNamingTest.java
@@ -70,7 +70,9 @@ class InternalBucketNamingTest {
   @Test
   void triesEveryUnderscorePrefixSoOwnersMayContainUnderscores() {
     assertThat(InternalBucketNaming.ownerOf("My_Type_0_out_edges", Set.of("My_Type_0"))).isEqualTo("My_Type_0");
-    // The SHORTEST matching prefix wins, which only matters when both are owners; either answer means "owned".
+    // The SHORTEST matching prefix wins. Pinned so the tie-break is a documented property rather than an accident
+    // of the loop, but it is arbitrary: what the only consumer asks is "owned by anything?", and both answers say
+    // yes. See ownerOf's javadoc before using the returned NAME for anything attribution-sensitive.
     assertThat(InternalBucketNaming.ownerOf("My_Type_0_out_edges", Set.of("My", "My_Type_0"))).isEqualTo("My");
   }
 

--- a/engine/src/test/java/com/arcadedb/schema/InternalBucketNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/InternalBucketNamingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6168, item 5: "reached by name" now has one home, so the composition side and the recognition side cannot
+ * drift apart the way they had started to (the convention lived in {@code UnreferencedFiles}, in
+ * {@code GraphDatabaseChecker}, in {@code GraphEngine}, in {@code StripedEdgeList} and twice as a bare
+ * {@code "_ext"} literal in the schema package).
+ * <p>
+ * The load-bearing test is {@link #recognisesAConventionNobodyDeclared}: recognition matches the SHAPE and is not
+ * driven by {@link InternalBucketNaming.Convention}, which is what stops the next feature that names buckets after
+ * their owner from being discovered as a false orphan in CI - the way the super-node stripe pools of #5156 were, on
+ * #6152, taking 17 test classes red.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class InternalBucketNamingTest {
+
+  @Test
+  void composesEveryConventionTheEngineUses() {
+    assertThat(InternalBucketNaming.outEdgesBucketName("V_0")).isEqualTo("V_0_out_edges");
+    assertThat(InternalBucketNaming.inEdgesBucketName("V_0")).isEqualTo("V_0_in_edges");
+    assertThat(InternalBucketNaming.superNodeStripeBucketName("Hub", 3)).isEqualTo("Hub_sn_stripe_3");
+    assertThat(InternalBucketNaming.externalPropertyBucketName("Doc_0")).isEqualTo("Doc_0_ext");
+  }
+
+  @Test
+  void attributesEachComposedNameBackToTheOwnerThatComposedIt() {
+    final Set<String> owners = Set.of("V_0", "Hub", "Doc_0");
+
+    assertThat(InternalBucketNaming.ownerOf("V_0_out_edges", owners)).isEqualTo("V_0");
+    assertThat(InternalBucketNaming.ownerOf("V_0_in_edges", owners)).isEqualTo("V_0");
+    assertThat(InternalBucketNaming.ownerOf("Hub_sn_stripe_3", owners)).isEqualTo("Hub");
+    assertThat(InternalBucketNaming.ownerOf("Doc_0_ext", owners)).isEqualTo("Doc_0");
+  }
+
+  /**
+   * The point of the general rule. A convention that does not exist yet - and therefore is not in the enum - is
+   * still recognised, because what is matched is {@code <owner>_<anything>} and not a list of suffixes.
+   */
+  @Test
+  void recognisesAConventionNobodyDeclared() {
+    assertThat(InternalBucketNaming.ownerOf("Hub_some_future_thing_7", Set.of("Hub"))).isEqualTo("Hub");
+  }
+
+  /** An owner name may itself contain underscores, so every prefix has to be tried, not only the first. */
+  @Test
+  void triesEveryUnderscorePrefixSoOwnersMayContainUnderscores() {
+    assertThat(InternalBucketNaming.ownerOf("My_Type_0_out_edges", Set.of("My_Type_0"))).isEqualTo("My_Type_0");
+    // The SHORTEST matching prefix wins, which only matters when both are owners; either answer means "owned".
+    assertThat(InternalBucketNaming.ownerOf("My_Type_0_out_edges", Set.of("My", "My_Type_0"))).isEqualTo("My");
+  }
+
+  @Test
+  void reportsNoOwnerWhenTheNameIsDerivedFromNothingKnown() {
+    assertThat(InternalBucketNaming.ownerOf("orphan_bucket", Set.of("Hub", "V_0"))).isNull();
+    assertThat(InternalBucketNaming.isDerivedFromAnOwner("orphan_bucket", Set.of("Hub"))).isFalse();
+    // No underscore at all: nothing to derive from.
+    assertThat(InternalBucketNaming.ownerOf("detachedbucket", Set.of("detached"))).isNull();
+    // A name that IS an owner's is not derived from it - it is the owner, and an owner's own bucket is claimed
+    // through the schema rather than through this rule.
+    assertThat(InternalBucketNaming.ownerOf("Hub", Set.of("Hub"))).isNull();
+  }
+
+  /** The suffix check a type rename uses to refuse to carry along an internal bucket it does not recognise. */
+  @Test
+  void recognisesAnEdgeListBucketNameByItsSuffixAlone() {
+    assertThat(InternalBucketNaming.isEdgeListBucketName("V_0_out_edges")).isTrue();
+    assertThat(InternalBucketNaming.isEdgeListBucketName("V_0_in_edges")).isTrue();
+    assertThat(InternalBucketNaming.isEdgeListBucketName("V_0")).isFalse();
+    assertThat(InternalBucketNaming.isEdgeListBucketName("Hub_sn_stripe_0")).isFalse();
+  }
+
+  /**
+   * The suffix check the schema uses to warn a user before {@code CREATE BUCKET} sets up a collision that only
+   * surfaces later, as a {@code SchemaException} on an EXTERNAL property change.
+   */
+  @Test
+  void recognisesAnExternalPropertyBucketNameByItsSuffixAlone() {
+    assertThat(InternalBucketNaming.looksLikeAnExternalPropertyBucketName("Doc_0_ext")).isTrue();
+    assertThat(InternalBucketNaming.looksLikeAnExternalPropertyBucketName("whatever_ext")).isTrue();
+    assertThat(InternalBucketNaming.looksLikeAnExternalPropertyBucketName("Doc_0")).isFalse();
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6070GrpcGraphBatchIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6070GrpcGraphBatchIT.java
@@ -318,12 +318,19 @@ public class Issue6070GrpcGraphBatchIT extends BaseGraphServerTest {
    * the readiness wait raises the real failure before a re-send could reach the wire either way. What it pins
    * is the contract a caller sees, which must hold however grpc-java resolves that internally: the committed
    * buffer survives exactly once, and {@code close()} adds no second, misleading failure.
+   * <p>
+   * <b>WHICH of the two raises it is a race, so this test does not bet on one</b> (issue #6168, item 3). Whether
+   * the server's error reaches the client while the body is still sending or only once {@code close()} half-closes
+   * depends on scheduling, and asserting the body specifically made this fail 4 of 6 CI runs on a PR whose diff
+   * touched no gRPC code at all. What it asserts is what actually holds: the load raises EXACTLY ONE failure,
+   * wherever it surfaces, and the committed buffer is durable exactly once.
    */
   @Test
   void aFailureOnAnInteriorFlushIsNotResentByClose() {
     grpc.command("sql", "CREATE PROPERTY `" + PERSON + "`.tag IF NOT EXISTS STRING (MANDATORY TRUE)");
 
     final AtomicReference<Throwable> fromBody = new AtomicReference<>();
+    final AtomicReference<Throwable> fromClose = new AtomicReference<>();
 
     // Chunk and server-side buffer both 2, so the first two vertices are committed as a whole buffer before the
     // buffer holding the bad one fails. The 400 that follow make sure the failure is observed by a later send
@@ -339,16 +346,20 @@ public class Issue6070GrpcGraphBatchIT extends BaseGraphServerTest {
       } catch (final RuntimeException e) {
         fromBody.set(e);
       }
-    } catch (final RuntimeException fromClose) {
-      // close() may re-raise the same failure; what it must not do is raise a different, misleading one on top
-      // of it, which is what half-closing or re-sending on a call the server already terminated produces.
-      assertThat(fromClose).as("close() must not invent a failure of its own on top of the real one")
+    } catch (final RuntimeException raisedByClose) {
+      fromClose.set(raisedByClose);
+      // close() may raise the failure the body never saw, or re-raise the same one; what it must not do is raise a
+      // different, misleading one on top of it, which is what half-closing or re-sending on a call the server
+      // already terminated produces.
+      assertThat(raisedByClose).as("close() must not invent a failure of its own on top of the real one")
           .hasMessageNotContaining("call already closed")
           .hasMessageNotContaining("already half-closed")
           .hasMessageNotContaining("Stream is already completed");
     }
 
-    assertThat(fromBody.get()).as("the load violates the schema, so it must fail during the body").isNotNull();
+    assertThat(fromBody.get() != null ? fromBody.get() : fromClose.get())
+        .as("the load violates the schema, so it must fail - in the body if the server's error got there in time, "
+            + "otherwise at close()").isNotNull();
 
     // The buffer that completed before the failure is durable, and exactly once: a chunk handed to a terminated
     // stream and then sent again by close() would show up here as a duplicate.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -20,7 +20,6 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.engine.UnreferencedFiles;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAServerPlugin;
@@ -2495,11 +2494,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * node that LOST leadership mid-session is the only one that logs the files it could not retire;
    * this is how the nodes still holding them say so, which is what makes the SEVERE line actionable
    * without reading a data directory by hand.
+   * <p>
+   * The count is memoized on the database behind a (file modification count, schema version) gate (issue #6168),
+   * so this refresh - every 5 seconds, per open database, forever - walks the schema only when one of the two has
+   * actually moved.
    */
   public List<HAReplicationStatsProvider.UnreferencedFilesSample> getUnreferencedFilesSamples() {
     final List<HAReplicationStatsProvider.UnreferencedFilesSample> samples = new ArrayList<>();
     forEachOpenReplicatedDatabase((name, db) -> samples.add(
-        new HAReplicationStatsProvider.UnreferencedFilesSample(name, UnreferencedFiles.count(db))));
+        new HAReplicationStatsProvider.UnreferencedFilesSample(name, db.getUnreferencedFilesCount())));
     return samples;
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -50,6 +50,7 @@ import com.arcadedb.engine.PageManager;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.engine.UnreferencedFiles;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.engine.WALFileFactory;
 import com.arcadedb.exception.ArcadeDBException;
@@ -183,6 +184,15 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private final        AtomicLong                                        schemaInstalmentsShipped = new AtomicLong();
   private final        AtomicLong                                        schemaInstalmentTotalMs  = new AtomicLong();
   private final        AtomicLong                                        schemaInstalmentMaxMs    = new AtomicLong();
+
+  /**
+   * Memoized unreferenced-file count behind the (file modification count, schema version) gate (issue #6168).
+   * <p>
+   * Lives HERE, on the database instance, rather than in a map on the server: the gauge that reads it is refreshed
+   * per open replicated database, so a per-instance holder needs no keying and no eviction - it is collected with
+   * the database it describes. See {@link UnreferencedFiles.MemoizedCount} for why the cached value cannot go stale.
+   */
+  private final        UnreferencedFiles.MemoizedCount                   unreferencedFiles        = new UnreferencedFiles.MemoizedCount();
 
   /**
    * Bookkeeping for a {@code recordFileChanges} session that ships its WAL incrementally (issue #6136).
@@ -2016,6 +2026,15 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   /** The longest single instalment this database has shipped, in milliseconds (issue #6144). */
   public long getSchemaWalInstalmentMaxTimeMs() {
     return schemaInstalmentMaxMs.get();
+  }
+
+  /**
+   * Files this node holds that no schema component claims (issue #6143), memoized behind the gate described on
+   * {@link UnreferencedFiles.MemoizedCount}: the walk runs only when a file or the schema has actually changed
+   * since the last refresh.
+   */
+  public long getUnreferencedFilesCount() {
+    return unreferencedFiles.get(proxied);
   }
 
   @Override

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6116ChecksumsPointInTimeTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6116ChecksumsPointInTimeTest.java
@@ -164,7 +164,13 @@ class Issue6116ChecksumsPointInTimeTest {
     final double fallback = suspendedFractionWhileComputingChecksums(false);
     final double withSnapshot = suspendedFractionWhileComputingChecksums(true);
 
-    assertThat(fallback).as("the fallback path must still freeze the files for the whole read").isGreaterThan(0.9);
+    // THE CONTROL'S THRESHOLD IS DELIBERATELY LOOSE (issue #6168, item 4). Its only job is to prove this machine's
+    // sampler sees suspensions at all, and it is a SAMPLED FRACTION: the handler does real work either side of the
+    // suspension window, and on a 4-CPU runner a spinning sampler does not distribute its samples evenly over the
+    // computation. At 0.9 the control - not the behaviour under test - was what failed CI, at 0.8953. Anything
+    // comfortably above the 0.5 the real assertion allows still separates "frozen for the read" from "not frozen",
+    // which is the whole of what this comparison has to establish.
+    assertThat(fallback).as("the fallback path must still freeze the files for the whole read").isGreaterThan(0.75);
     assertThat(withSnapshot).as("the snapshot path must not hold the flush suspension for the read (fallback was %f)",
         fallback).isLessThan(0.5);
   }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6168UnreferencedFilesGaugeWiringTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6168UnreferencedFilesGaugeWiringTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.FileManager;
+import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.index.Index;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #6168, item 1: the wiring between the HA gauge and the memoized walk.
+ * <p>
+ * {@code UnreferencedFiles.MemoizedCount} is tested on its own against a real database in the engine module
+ * ({@code Issue6168MemoizedUnreferencedCountTest}); what is left over is the delegation this class holds -
+ * {@link RaftHAServer#getUnreferencedFilesSamples()} asks the DATABASE for its count, and the database answers from
+ * an instance of the cache it owns, over the database it wraps. Two things can be wrong there and neither is caught
+ * by the engine test: the count could be taken over the wrong instance, and the cache could be re-created per call,
+ * which would publish correct numbers while quietly doing the very work the memoization exists to avoid.
+ * <p>
+ * Mocked rather than clustered, deliberately. A gauge reading a per-instance field needs no consensus to exercise,
+ * and #6168 item 6 is about the integration lanes being red for reasons unrelated to the change under test - adding
+ * an integration test for a delegation would be moving in the wrong direction. The mock's file manager is what makes
+ * the second property observable at all: how many times the walk actually read the file list.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6168UnreferencedFilesGaugeWiringTest {
+
+  private static final String DB_PATH = "/tmp/issue6168-gauge-wiring-test";
+
+  private LocalDatabase          proxied;
+  private FileManager            fileManager;
+  private LocalSchema            localSchema;
+  private RaftReplicatedDatabase database;
+
+  @BeforeEach
+  void setUp() {
+    fileManager = mock(FileManager.class);
+    when(fileManager.getModificationCount()).thenReturn(1L);
+    // One file the schema has no component for: the shape an abandoned instalment leaves on a follower, and the
+    // cheapest thing the walk can find. Reported by the FIRST arm of the walk, so no type or index is needed.
+    final ComponentFile orphan = mock(ComponentFile.class);
+    when(orphan.getFileName()).thenReturn("orphan.0.65536.v0.bucket");
+    when(fileManager.getFiles()).thenReturn(List.of(orphan));
+
+    localSchema = mock(LocalSchema.class);
+    when(localSchema.getVersion()).thenReturn(7L);
+    when(localSchema.getTypes()).thenReturn(List.of());
+    when(localSchema.getIndexes()).thenReturn(new Index[0]);
+    when(localSchema.getFileByIdIfExists(0)).thenReturn(null);
+
+    final Schema schema = mock(Schema.class);
+    when(schema.getEmbedded()).thenReturn(localSchema);
+
+    proxied = mock(LocalDatabase.class);
+    when(proxied.getDatabasePath()).thenReturn(DB_PATH);
+    when(proxied.getName()).thenReturn("issue6168");
+    when(proxied.getTransactionManager()).thenReturn(mock(TransactionManager.class));
+    when(proxied.getFileManager()).thenReturn(fileManager);
+    when(proxied.getSchema()).thenReturn(schema);
+
+    database = new RaftReplicatedDatabase(null, proxied, mock(RaftHAServer.class));
+  }
+
+  @AfterEach
+  void tearDown() {
+    DatabaseContext.INSTANCE.removeContext(DB_PATH);
+  }
+
+  /**
+   * The count the gauge publishes is taken over the database this wrapper proxies, and the cache is a field of the
+   * wrapper rather than something built per call - so the refresh that runs every 5 seconds for the life of the
+   * process walks the schema once and then stops.
+   */
+  @Test
+  void theGaugeAnswersFromTheDatabasesOwnCacheAndWalksOnlyOnce() {
+    assertThat(database.getUnreferencedFilesCount()).as("the file no component claims is counted").isEqualTo(1);
+
+    for (int refresh = 0; refresh < 10; refresh++)
+      assertThat(database.getUnreferencedFilesCount()).isEqualTo(1);
+
+    verify(fileManager, times(1)).getFiles();
+  }
+
+  /** ...and the gate still reaches through the delegation: a file change makes the next refresh walk again. */
+  @Test
+  void aFileChangeIsSeenThroughTheDelegation() {
+    assertThat(database.getUnreferencedFilesCount()).isEqualTo(1);
+
+    when(fileManager.getModificationCount()).thenReturn(2L);
+
+    assertThat(database.getUnreferencedFilesCount()).isEqualTo(1);
+    verify(fileManager, times(2)).getFiles();
+  }
+
+  /** Same for the other half of the gate, which no file counter could cover. */
+  @Test
+  void aSchemaChangeIsSeenThroughTheDelegation() {
+    assertThat(database.getUnreferencedFilesCount()).isEqualTo(1);
+
+    when(localSchema.getVersion()).thenReturn(8L);
+
+    assertThat(database.getUnreferencedFilesCount()).isEqualTo(1);
+    verify(fileManager, times(2)).getFiles();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/Issue6075SnapshotBackupIT.java
@@ -131,7 +131,11 @@ class Issue6075SnapshotBackupIT {
     final double withSnapshot = measureSuspendedFraction(true);
     final double withoutSnapshot = measureSuspendedFraction(false);
 
-    assertThat(withoutSnapshot).as("the fallback path must still suspend flushing for the whole backup").isGreaterThan(0.9);
+    // THE CONTROL'S THRESHOLD IS DELIBERATELY LOOSE, for the reason spelled out on the twin of this assertion in
+    // Issue6116ChecksumsPointInTimeTest (issue #6168, item 4): it is a SAMPLED fraction of a run that does real
+    // work either side of the suspension window, so on a busy CI runner it cannot be relied on to reach 0.9, and
+    // proving the sampler sees suspensions at all is the only thing the control is for.
+    assertThat(withoutSnapshot).as("the fallback path must still suspend flushing for the whole backup").isGreaterThan(0.75);
     assertThat(withSnapshot).as("a snapshot backup must not hold the flush suspension for its duration").isLessThan(0.5);
   }
 


### PR DESCRIPTION
Closes four of the six follow-ups in #6168. **Item 2 (reclaiming unreferenced files) is deliberately not in this PR** - it is a file deletion driven by inference on a replica, on a code path whose history (#4083, #4743, #5443, #5492) is silent divergence rather than exceptions, for an impact that is only wasted disk. The issue itself says it wants its own change and its own risk assessment, so #6168 stays open for it.

---

## 1. Memoize the unreferenced-file count behind a modification/version gate

`UnreferencedFiles.count()` feeds the per-node `arcadedb.ha.schema.unreferenced_files` gauge, which `HAReplicationMetrics` refreshes **every 5 seconds for every open replicated database**, rebuilding the whole claimed-file set each time: every type, every bucket, one `getFileIds()` per index taking that index's read lock and allocating a list. The cost scaled with SCHEMA SIZE rather than with the size of the problem being diagnosed.

New `UnreferencedFiles.MemoizedCount` implements the gate the javadoc had already worked out, `(FileManager.getModificationCount(), schema version)`. Between them those two cover every way the answer can change: a file this walk would newly report either appeared as a FILE (bumps the modification count, on registration and on drop) or appeared because a SCHEMA change stopped claiming one (bumps the schema version). Neither can move without invalidating the entry, which is the only reason memoizing a diagnostic is acceptable at all.

Three details worth review:

- **Equality on both halves, never "not newer".** The schema version is not monotonic on a follower - a schema reload assigns the leader's value outright.
- **Lock-free, and the ordering is what makes it safe.** The gate is read BEFORE the walk and published with the count afterwards, so a change landing mid-walk tags the result with the gate it was computed under and the next call recomputes. Racing callers can duplicate work or overwrite each other's entry; both outcomes are a recompute, never a stale answer.
- **Where it lives.** One instance per database, on `RaftReplicatedDatabase`, rather than a map on `RaftHAServer` - the gauge is refreshed per open database, so a per-instance holder needs no keying and no eviction and is collected with the database it describes.

## 5. "Reached by name" now has one home

New `com.arcadedb.schema.InternalBucketNaming`. A bucket can be referenced by the engine without any type listing it, through a naming convention, and the knowledge was in six places: composed in `GraphEngine` (`_out_edges`/`_in_edges`), in `StripedEdgeList` (`_sn_stripe_`) and twice as a bare `"_ext"` literal in `LocalDocumentType`/`LocalSchema`, and recognised independently in `UnreferencedFiles.isDerivedFromAnOwner` and `GraphDatabaseChecker`.

**The two halves answer different questions and only one of them is a registry:**

- `Convention` + the `composeXXX` helpers are the DECLARATION side. A feature that names buckets after their owner declares its convention here and gets recognition with it, instead of leaving it to be discovered by whoever debugs the false positive later.
- `ownerOf` is the RECOGNITION side and is deliberately **not** driven by the enum. It matches the shape `<owner>_<anything>`, so it covers conventions that were never declared - including ones not written yet. Enumerating them is not a closed problem: that is exactly what CI proved on #6152, when the classifier's explicit list turned out to be missing the super-node stripe pools of #5156 and 17 test classes went red through `TestHelper.checkDatabaseIntegrity`.

`GraphEngine.OUT_EDGES_SUFFIX`/`IN_EDGES_SUFFIX` and `StripedEdgeList.STRIPE_BUCKET_INFIX` are removed rather than left as second copies; every consumer goes through the new class.

## 3. `Issue6070GrpcGraphBatchIT.aFailureOnAnInteriorFlushIsNotResentByClose` is no longer a bet on timing

It asserted the failure surfaced during the body. Whether the server's error reaches the client before or after the body finishes is a race - measured on #6152, whose diff touches nothing in gRPC or batch: **failed 4 of 6 CI runs, passed the other 2**, across commits with byte-identical gRPC code. It now accepts either surfacing point and keeps the check the test is really about: the failure is raised exactly once and `close()` does not invent a second one on top of it. The `countOf(PERSON) == 2` assertion holds either way - chunks handed to a terminated stream are dropped, so no further buffer commits whichever branch raises.

## 4. Sampled controls with no tolerance

`Issue6116ChecksumsPointInTimeTest`'s control asserted a sampled fraction `> 0.9` and failed CI at `0.8953148525374192` - that is the CONTROL failing, not the behaviour under test. The control's only job is to prove this machine's sampler sees suspensions at all, and a sampled fraction of a run that does real work either side of the suspension window cannot be relied on to reach 0.9 on a 4-CPU runner. Widened to 0.75, which still separates it from the 0.5 the real assertion (`withSnapshot < 0.5`, wide margin, unchanged) allows.

`Issue6075SnapshotBackupIT` carries the byte-identical control at 0.9 and is one of the `integration-tests` lane's recurring offenders named in item 6, so it is widened with it rather than left to fail next.

## 6. The chronically red `integration-tests` lane

Not a code change: items 3 and 4 are the triage. Both recurring offenders named in the issue are addressed here.

---

## Tests

- **New** `InternalBucketNamingTest` (7): composition of every convention, attribution of each composed name back to its owner, owners containing underscores, no-owner cases, and the load-bearing one - a convention nobody declared is still recognised.
- **New** `Issue6168MemoizedUnreferencedCountTest` (4): one test per half of the gate, each proving the OTHER half did not move (the schema-only case asserts `getModificationCount()` is unchanged across `removeBucket`), plus a mutation sequence where the memoized answer must equal a fresh walk at every step.
- Re-ran green: `com.arcadedb.graph.**` (515), `com.arcadedb.schema.**` (440), `com.arcadedb.engine.**` + `com.arcadedb.index.**` (1757), `Issue6116ChecksumsPointInTimeTest` (5), `Issue6144SchemaInstalmentMetricsTest` (4). Full reactor builds.
- `Issue6070GrpcGraphBatchIT` could not be run locally (a foreign service already owns port 2480 on this machine); it compiles, and CI is the authority on it - which is the point of the change.
