### PR TITLE
perf(#6174): fold a constant-false filter and LIMIT 0 at plan time instead of scanning the target

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1540,6 +1540,13 @@ What the fold deliberately keeps:
 The fold applies wherever a `SELECT` plan is built, so a subquery, a `DELETE ... WHERE 1=0` and an
 `UPDATE ... WHERE 1=0` are covered by the same code.
 
+The two spellings are not recognised the same way, and it is worth being explicit about the difference. A
+constant-false filter is folded only when the statement itself says so, never through a function. A `LIMIT 0`
+truncates the result to nothing whatever the filter would have done, so the filter is not evaluated at all - which
+means a predicate that raises at runtime stops raising: `SELECT * FROM T WHERE 1/0 = 1` reports a division by zero,
+and the same statement with `LIMIT 0` now returns an empty result instead. Nothing else can observe the difference,
+since no row was going to come back either way.
+
 One behaviour change worth naming, and one wrong answer found next to it. `count(*)` on a bare type is answered
 from the bucket counters by a hardwired plan that replaces the whole step chain - and returned without chaining the
 statement's `SKIP` or `LIMIT` at all. So `SELECT count(*) FROM T LIMIT 0` returned one row, and

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1509,3 +1509,45 @@ its query on every read of the type. This is the fix, not a regression, but it i
 trigger exists in an upgraded database.
 
 [#6134](https://github.com/ArcadeData/arcadedb/issues/6134)
+
+## A constant-false filter and `LIMIT 0` are folded at plan time, so a schema probe stops scanning its target (#6174)
+
+`SELECT * FROM (SELECT name FROM Character) SPARK_GEN_SUBQ_0 WHERE 1=0` is not an academic shape: it is what Spark,
+and several BI tools over the Postgres wire, send to discover a query's schema - one probe per pushed-down query,
+against the real target. The planner had no notion of a filter that is false for every row, so it built the full
+scan and let the filter step drain it: every probe read the whole type to return nothing that the statement itself
+did not already say. `LIMIT 0` is the other common spelling of the same intent and cost the same.
+
+Both are now recognised while the plan is built and answered with an `EMPTY RESULT` source step in place of the
+target fetch, which is what `EXPLAIN` now shows. Recognition is structural, over the condition tree the statement
+wrote - through parentheses, and through AND/OR (an AND is false when any term is, an OR only when every
+alternative is) - and folds only comparisons whose **both** operands are literals, evaluated by the very same
+`BinaryCondition.evaluate` the filter step would have called. A bound parameter is never folded, because the plan
+outlives the execution that bound it; nor is a function call, because nothing on `SQLFunction` marks a function as
+pure and classifying a statement must not be a reason to invoke one. `WHERE uuid() = 'x'` and `WHERE ? = 0` are
+therefore still planned as scans, as they must be.
+
+What the fold deliberately keeps:
+
+- **The target is still resolved**, so `SELECT FROM ATypeThatDoesNotExist WHERE 1=0` still reports the missing type
+  rather than quietly returning nothing. Only the scan is dropped, after the fetch has been planned.
+- **Everything downstream of the fetch stays in the plan** and receives no row, which is exactly what it receives
+  today from the filter being removed: `SELECT count(*) FROM T WHERE 1=0` still returns its one row with 0, and the
+  same statement with a `GROUP BY` still returns none.
+- **A `LET` evaluated once per statement still runs**; only the per-record `LET` and the per-record projection work
+  disappear, along with the rows that were never going to come back.
+
+The fold applies wherever a `SELECT` plan is built, so a subquery, a `DELETE ... WHERE 1=0` and an
+`UPDATE ... WHERE 1=0` are covered by the same code.
+
+One behaviour change worth naming: `SELECT count(*) FROM T LIMIT 0` used to return one row. `count(*)` on a bare
+type is answered from the bucket counters by a hardwired plan that returned before any `LIMIT`/`SKIP` step was
+chained, so the `LIMIT 0` was ignored. It now returns no rows, which is what the clause asks for and what every
+other engine answers. This is the SQL twin of the Cypher defect fixed in #5715, where the CSR count push-down
+replaced the whole step chain and `RETURN count(*) LIMIT 0` likewise returned a row.
+
+The Postgres wire protocol reuses this recognition instead of its own copy: the schema-probe detection added in
+#6172 now calls `WhereClause.isAlwaysFalse()`, and the ~90 lines that duplicated it in `PostgresNetworkExecutor`
+are gone.
+
+[#6174](https://github.com/ArcadeData/arcadedb/issues/6174)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1543,10 +1543,11 @@ The fold applies wherever a `SELECT` plan is built, so a subquery, a `DELETE ...
 One behaviour change worth naming, and one wrong answer found next to it. `count(*)` on a bare type is answered
 from the bucket counters by a hardwired plan that replaces the whole step chain - and returned without chaining the
 statement's `SKIP` or `LIMIT` at all. So `SELECT count(*) FROM T LIMIT 0` returned one row, and
-`SELECT count(*) FROM T SKIP 1` handed back the very row it was told to skip. The first is now folded away before
-the hardwired plan is even considered; the second is fixed by chaining both steps after the count, which costs
-nothing on a plan that produces a single row. This is the SQL twin of the Cypher defect fixed in #5715, where the
-CSR count push-down replaced the whole step chain and `RETURN count(*) LIMIT 0` likewise returned a row.
+`SELECT count(*) FROM T SKIP 1` handed back the very row it was told to skip; `SELECT max(indexedProperty) FROM T
+SKIP 1`, which is answered the same way from the index, did too. The `LIMIT 0` spelling is now folded away before
+the hardwired plan is even considered; the rest is fixed by chaining both steps after the count/max/min, which
+costs nothing on a plan that produces a single row. This is the SQL twin of the Cypher defect fixed in #5715, where
+the CSR count push-down replaced the whole step chain and `RETURN count(*) LIMIT 0` likewise returned a row.
 
 The Postgres wire protocol reuses this recognition instead of its own copy: the schema-probe detection added in
 #6172 now calls `WhereClause.isAlwaysFalse()`, and the ~90 lines that duplicated it in `PostgresNetworkExecutor`

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1540,11 +1540,13 @@ What the fold deliberately keeps:
 The fold applies wherever a `SELECT` plan is built, so a subquery, a `DELETE ... WHERE 1=0` and an
 `UPDATE ... WHERE 1=0` are covered by the same code.
 
-One behaviour change worth naming: `SELECT count(*) FROM T LIMIT 0` used to return one row. `count(*)` on a bare
-type is answered from the bucket counters by a hardwired plan that returned before any `LIMIT`/`SKIP` step was
-chained, so the `LIMIT 0` was ignored. It now returns no rows, which is what the clause asks for and what every
-other engine answers. This is the SQL twin of the Cypher defect fixed in #5715, where the CSR count push-down
-replaced the whole step chain and `RETURN count(*) LIMIT 0` likewise returned a row.
+One behaviour change worth naming, and one wrong answer found next to it. `count(*)` on a bare type is answered
+from the bucket counters by a hardwired plan that replaces the whole step chain - and returned without chaining the
+statement's `SKIP` or `LIMIT` at all. So `SELECT count(*) FROM T LIMIT 0` returned one row, and
+`SELECT count(*) FROM T SKIP 1` handed back the very row it was told to skip. The first is now folded away before
+the hardwired plan is even considered; the second is fixed by chaining both steps after the count, which costs
+nothing on a plan that produces a single row. This is the SQL twin of the Cypher defect fixed in #5715, where the
+CSR count push-down replaced the whole step chain and `RETURN count(*) LIMIT 0` likewise returned a row.
 
 The Postgres wire protocol reuses this recognition instead of its own copy: the schema-probe detection added in
 #6172 now calls `WhereClause.isAlwaysFalse()`, and the ~90 lines that duplicated it in `PostgresNetworkExecutor`

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/EmptySourceStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/EmptySourceStep.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.exception.TimeoutException;
+
+/**
+ * Row source of a statement the planner proved empty by reading the statement alone: a filter that is false for every
+ * record ({@code WHERE 1=0}) or a {@code LIMIT 0}. It takes the place of the target fetch, which is why nothing
+ * downstream ever asks the storage for a page.
+ * <p>
+ * It differs from {@link EmptyStep}, which is what the planner chains when the <i>data</i> turns out to make a fetch
+ * pointless (an empty bucket list, a variable that resolved to no record), in being cacheable: "this statement cannot
+ * return a row" is a property of its text and holds for every execution that reuses the plan, whereas
+ * {@link EmptyStep} encodes one execution's data.
+ * <p>
+ * Like {@link EmptyStep} it does pull its previous step once, so a {@code LET} evaluated once per statement still
+ * runs. That costs nothing here because the steps it can follow are exactly those: the fetch is not part of the
+ * chain.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class EmptySourceStep extends AbstractExecutionStep {
+  private final String reason;
+
+  public EmptySourceStep(final CommandContext context, final String reason) {
+    super(context);
+    this.reason = reason;
+  }
+
+  @Override
+  public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
+    pullPrevious(context, nRecords);
+    return new InternalResultSet();
+  }
+
+  @Override
+  public boolean canBeCached() {
+    return true;
+  }
+
+  @Override
+  public ExecutionStep copy(final CommandContext context) {
+    return new EmptySourceStep(context, reason);
+  }
+
+  @Override
+  public String prettyPrint(final int depth, final int indent) {
+    return ExecutionStepInternal.getIndent(depth, indent) + "+ EMPTY RESULT (" + reason + ")";
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -242,9 +242,13 @@ public class SelectExecutionPlanner {
     if (info.expand && info.distinct)
       throw new CommandExecutionException("Cannot execute a statement with DISTINCT expand(), please use a subquery");
 
+    // A statement whose own text proves that it cannot return a row is answered without touching the storage. This is
+    // read off the clauses as the statement wrote them, before optimizeQuery() rearranges them into index searches.
+    final String emptyReason = emptyByConstructionReason(context);
+
     optimizeQuery(info, context);
 
-    if (handleHardwiredOptimizations(selectExecutionPlan, context))
+    if (emptyReason == null && handleHardwiredOptimizations(selectExecutionPlan, context))
       return selectExecutionPlan;
 
     handleGlobalLet(selectExecutionPlan, info, context);
@@ -266,26 +270,77 @@ public class SelectExecutionPlanner {
 
     handleFetchFromTarget(selectExecutionPlan, info, context);
 
-    if (info.globalLetPresent)
-      // do the raw fetch remotely, then do the rest on the coordinator
+    if (emptyReason != null)
+      foldEmptyByConstruction(selectExecutionPlan, info, context, emptyReason);
+    else {
+      if (info.globalLetPresent)
+        // do the raw fetch remotely, then do the rest on the coordinator
+        buildExecutionPlan(selectExecutionPlan, info);
+
+      handleLet(selectExecutionPlan, info, context);
+
+      handleWhere(selectExecutionPlan, info, context);
+
       buildExecutionPlan(selectExecutionPlan, info);
 
-    handleLet(selectExecutionPlan, info, context);
+      handleProjectionsBlock(selectExecutionPlan, info, context);
 
-    handleWhere(selectExecutionPlan, info, context);
-
-    buildExecutionPlan(selectExecutionPlan, info);
-
-    handleProjectionsBlock(selectExecutionPlan, info, context);
-
-    if (info.timeout != null)
-      selectExecutionPlan.chain(new AccumulatingTimeoutStep(info.timeout, context));
+      if (info.timeout != null)
+        selectExecutionPlan.chain(new AccumulatingTimeoutStep(info.timeout, context));
+    }
 
     if (useCache && !context.isProfiling() && statement.executionPlanCanBeCached() && selectExecutionPlan.canBeCached()
         && db.getExecutionPlanCache().getLastInvalidation() < planningStart)
       db.getExecutionPlanCache().put(statement.getOriginalStatement(), selectExecutionPlan);
 
     return selectExecutionPlan;
+  }
+
+  /**
+   * Tells whether the statement cannot return a row no matter what the database contains, and why - the reason is
+   * what the plan prints in place of the fetch it does not do. {@code null} means "not decidable from the statement",
+   * which is the answer for everything but the two shapes below.
+   * <p>
+   * Both are how a client asks for a query's columns without asking for its rows: Spark and several BI tools over the
+   * Postgres wire send one such probe per pushed-down query, against the real target (issue #6174).
+   */
+  private String emptyByConstructionReason(final CommandContext context) {
+    if (info.whereClause != null && info.whereClause.isAlwaysFalse(context))
+      return "the filter is false for every record";
+
+    if (info.limit != null && info.limit.isAlwaysEmpty())
+      return "LIMIT 0";
+
+    return null;
+  }
+
+  /**
+   * Replaces the target fetch with an {@link EmptySourceStep} and leaves the rest of the plan alone. The fetch has
+   * already been planned when this runs, and is discarded rather than skipped, so a statement that names a type that
+   * does not exist is still reported as such - only the scan goes.
+   * <p>
+   * Everything downstream of the fetch is kept and receives no row, which is exactly what it receives today from the
+   * filter step this fold removes: {@code SELECT count(*) FROM T WHERE 1=0} still counts to zero and still returns
+   * its one row, and the same clause with a GROUP BY still returns none. What the fold does skip is the per-record
+   * {@code LET} and the per-record work the projections would do, neither of which can be observed by a statement
+   * that returns no row. A {@code LET} evaluated once per statement is chained ahead of this step and still runs.
+   */
+  private void foldEmptyByConstruction(final SelectExecutionPlan plan, final QueryPlanningInfo info,
+      final CommandContext context, final String reason) {
+    // the fetch steps are dropped, not chained: close them so that a step which took something in its constructor
+    // (a sub-plan, an index reference) does not outlive the plan that will never run it
+    if (info.fetchExecutionPlan != null && !info.fetchExecutionPlan.getSteps().isEmpty())
+      info.fetchExecutionPlan.close();
+
+    info.fetchExecutionPlan = null;
+    info.planCreated = true;
+
+    plan.chain(new EmptySourceStep(context, reason));
+
+    handleProjectionsBlock(plan, info, context);
+
+    if (info.timeout != null)
+      plan.chain(new AccumulatingTimeoutStep(info.timeout, context));
   }
 
   public static void handleProjectionsBlock(final SelectExecutionPlan result, final QueryPlanningInfo info,

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -485,9 +485,10 @@ public class SelectExecutionPlanner {
 
   /**
    * A hardwired plan replaces the whole step chain, so the SKIP and LIMIT of the statement have to be chained here or
-   * they are not chained at all - which is how {@code SELECT count(*) FROM T SKIP 1} used to hand back the very row
-   * it was told to skip. The single row these plans produce makes both steps cheap; {@code LIMIT 0} does not even
-   * reach this point, {@link #emptyByConstructionReason} claims it first.
+   * they are not chained at all - which is how {@code SELECT count(*) FROM T SKIP 1}, and equally
+   * {@code SELECT max(indexedProperty) FROM T SKIP 1}, used to hand back the very row they were told to skip. The
+   * single row these plans produce makes both steps cheap; {@code LIMIT 0} does not even reach this point,
+   * {@link #emptyByConstructionReason} claims it first.
    */
   private static void handleSkipAndLimitAfterHardwired(final SelectExecutionPlan result, final QueryPlanningInfo info,
       final CommandContext context) {
@@ -623,6 +624,7 @@ public class SelectExecutionPlanner {
 
     // Create the optimized execution step
     result.chain(new MaxMinFromIndexStep(index, info.projection.getAllAliases().getFirst(), maxMinInfo.isMax, context));
+    handleSkipAndLimitAfterHardwired(result, info, context);
     return true;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -479,7 +479,23 @@ public class SelectExecutionPlanner {
       return false;
 
     result.chain(new CountFromTypeStep(info.target.toString(), info.projection.getAllAliases().getFirst(), context));
+    handleSkipAndLimitAfterHardwired(result, info, context);
     return true;
+  }
+
+  /**
+   * A hardwired plan replaces the whole step chain, so the SKIP and LIMIT of the statement have to be chained here or
+   * they are not chained at all - which is how {@code SELECT count(*) FROM T SKIP 1} used to hand back the very row
+   * it was told to skip. The single row these plans produce makes both steps cheap; {@code LIMIT 0} does not even
+   * reach this point, {@link #emptyByConstructionReason} claims it first.
+   */
+  private static void handleSkipAndLimitAfterHardwired(final SelectExecutionPlan result, final QueryPlanningInfo info,
+      final CommandContext context) {
+    if (info.skip != null)
+      result.chain(new SkipExecutionStep(info.skip, context));
+
+    if (info.limit != null)
+      result.chain(new LimitExecutionStep(info.limit, context));
   }
 
   private boolean handleHardwiredCountOnIndex(final SelectExecutionPlan result, final QueryPlanningInfo info,
@@ -501,12 +517,14 @@ public class SelectExecutionPlanner {
       return false;
     }
     result.chain(new CountFromIndexStep(targetIndex, info.projection.getAllAliases().getFirst(), context));
+    handleSkipAndLimitAfterHardwired(result, info, context);
     return true;
   }
 
   /**
    * returns true if the query is minimal, ie. no WHERE condition, no UNWIND, no GROUP/ORDER BY, no LET.
-   * SKIP/LIMIT are allowed because all hardwired optimizations (count, max, min) return a single row.
+   * SKIP/LIMIT are allowed because all hardwired optimizations (count, max, min) return a single row, and because
+   * the plan chains the two steps itself - see {@link #handleSkipAndLimitAfterHardwired}.
    */
   private boolean isMinimalQuery(final QueryPlanningInfo info) {
     return info.projectionAfterOrderBy == null && info.globalLetClause == null && info.perRecordLetClause == null

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -303,6 +303,11 @@ public class SelectExecutionPlanner {
    * <p>
    * Both are how a client asks for a query's columns without asking for its rows: Spark and several BI tools over the
    * Postgres wire send one such probe per pushed-down query, against the real target (issue #6174).
+   * <p>
+   * The two reasons are not decided the same way. A constant-false filter is folded only when the statement itself
+   * says so, never through a function - see {@link Expression#isLiteral()}. A {@code LIMIT 0} truncates the result to
+   * nothing whatever the filter would have done, so the filter is simply not evaluated: a predicate that raises at
+   * runtime ({@code WHERE 1/0 = 1 LIMIT 0}) stops raising, which is the one way the difference can be observed.
    */
   private String emptyByConstructionReason(final CommandContext context) {
     if (info.whereClause != null && info.whereClause.isAlwaysFalse(context))

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -338,7 +338,6 @@ public class SelectExecutionPlanner {
       info.fetchExecutionPlan.close();
 
     info.fetchExecutionPlan = null;
-    info.planCreated = true;
 
     plan.chain(new EmptySourceStep(context, reason));
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AndBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AndBlock.java
@@ -228,5 +228,15 @@ public class AndBlock extends BooleanExpression {
     }
     return true;
   }
+
+  @Override
+  public boolean isAlwaysFalse(final CommandContext context) {
+    // an empty AND block is the neutral element, ie. TRUE
+    for (final BooleanExpression exp : subBlocks) {
+      if (exp.isAlwaysFalse(context))
+        return true;
+    }
+    return false;
+  }
 }
 /* JavaCC - OriginalChecksum=cf1f66cc86cfc93d357f9fcdfa4a4604 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -354,6 +354,18 @@ public class BaseExpression extends MathExpression {
     return identifier != null && modifier == null && identifier.isBaseIdentifier();
   }
 
+  @Override
+  public boolean isLiteral() {
+    // a modifier is a method call or a field/index access applied to the value: no longer a bare literal
+    if (modifier != null)
+      return false;
+
+    if (number != null || string != null || isNull)
+      return true;
+
+    return expression != null && expression.isLiteral();
+  }
+
   public boolean isEarlyCalculated(CommandContext context) {
     if (number != null || inputParam != null || string != null)
       return true;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
@@ -49,6 +49,24 @@ public class BinaryCondition extends BooleanExpression {
     return operator.execute(context != null ? context.getDatabase() : null, leftVal, rightVal);
   }
 
+  /**
+   * Folds the comparison at plan time, but only when both of its operands are written in the statement as literals
+   * ({@code 1 = 0}, {@code 'a' = 'b'}, {@code 1 = 1 + 1}). See {@link Expression#isLiteral()} for why a bound
+   * parameter and a function call are excluded even though both could be computed without a record.
+   */
+  @Override
+  public boolean isAlwaysFalse(final CommandContext context) {
+    if (left == null || right == null || !left.isLiteral() || !right.isLiteral())
+      return false;
+
+    try {
+      return Boolean.FALSE.equals(evaluate((Result) null, context));
+    } catch (final Exception e) {
+      // a comparison the operator cannot make (eg. between incompatible types) is left to the runtime to report
+      return false;
+    }
+  }
+
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
     left.toString(params, builder);
     builder.append(" ");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BooleanExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BooleanExpression.java
@@ -101,6 +101,11 @@ public abstract class BooleanExpression extends SimpleNode {
     }
 
     @Override
+    public boolean isAlwaysFalse(final CommandContext context) {
+      return true;
+    }
+
+    @Override
     public List<String> getMatchPatternInvolvedAliases() {
       return null;
     }
@@ -275,6 +280,22 @@ public abstract class BooleanExpression extends SimpleNode {
    * @return
    */
   public boolean isAlwaysTrue() {
+    return false;
+  }
+
+  /**
+   * Whether the expression is false for every record, decidable from the statement alone. This is what marks a filter
+   * as a schema probe ({@code WHERE 1=0}, the shape Spark and several BI tools send to discover a query's columns) and
+   * lets the planner answer it without a scan.
+   * <p>
+   * Only comparisons between {@link Expression#isLiteral() literal} operands are folded, so nothing here reads a
+   * record, binds a parameter or calls a function: a plan built on this answer stays correct for every execution that
+   * reuses it. Like {@link #isAlwaysTrue()} this is an optimization, so it is allowed to return false negatives - a
+   * subclass that cannot decide cheaply, or at all, inherits {@code false}.
+   *
+   * @param context the context used to fold the literal comparison, never used to read data
+   */
+  public boolean isAlwaysFalse(final CommandContext context) {
     return false;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
@@ -111,6 +111,30 @@ public class Expression extends SimpleNode {
     return false;
   }
 
+  /**
+   * Whether the expression is built out of literals alone - a number, a string, a boolean, null, or arithmetic over
+   * them - so that its value is written in the statement itself and cannot change between two executions of the same
+   * plan.
+   * <p>
+   * This is deliberately narrower than {@link #isEarlyCalculated(CommandContext)}, which only asks whether an
+   * expression can be computed without a record. That admits any function call whose arguments need no record, and
+   * nothing on {@code SQLFunction} distinguishes a pure function from one with a side effect; it also admits a bound
+   * parameter, whose value belongs to one execution and must never be baked into a cached plan. Plan-time constant
+   * folding asks this question of statements that are overwhelmingly not constant at all, so it must never reach a
+   * function: {@code WHERE someStatefulFunction() = 42} would otherwise have that function invoked just to be
+   * classified.
+   */
+  public boolean isLiteral() {
+    if (isNull || booleanValue != null)
+      return true;
+
+    // a RID, a JSON object, a nested condition or an array concatenation is never a bare literal
+    if (rid != null || json != null || whereCondition != null || arrayConcatExpression != null)
+      return false;
+
+    return mathExpression != null && mathExpression.isLiteral();
+  }
+
   public boolean isEarlyCalculated(final CommandContext context) {
     if (isNull)
       return true;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Limit.java
@@ -79,6 +79,15 @@ public class Limit extends SimpleNode {
     throw new CommandExecutionException("No value for LIMIT");
   }
 
+  /**
+   * Whether this clause truncates the result to nothing, decidable from the statement alone: {@code LIMIT 0}, the
+   * other common spelling of a schema probe. A limit that resolves through a bound parameter or an expression is
+   * deliberately not folded - its value belongs to one execution, and the plan is reused across them.
+   */
+  public boolean isAlwaysEmpty() {
+    return num != null && num.getValue() != null && NumberUtils.saturateToInt(num.getValue()) == 0;
+  }
+
   public Limit setValue(final int value) {
     num = new PInteger().setValue(value);
     return this;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -1096,6 +1096,22 @@ public class MathExpression extends SimpleNode {
     return true;
   }
 
+  /**
+   * A compound arithmetic expression is a literal one only when every one of its operands is. Subclasses that carry
+   * their operands somewhere else than {@link #childExpressions} (an array literal, a CASE) inherit the {@code false}
+   * an empty operand list gives: see {@link Expression#isLiteral()} for why this answer stays on the safe side.
+   */
+  public boolean isLiteral() {
+    if (childExpressions.isEmpty())
+      return false;
+
+    for (final MathExpression operand : childExpressions) {
+      if (!operand.isLiteral())
+        return false;
+    }
+    return true;
+  }
+
   public boolean isAggregate(CommandContext context) {
     for (final MathExpression expr : this.childExpressions) {
       if (expr.isAggregate(context))

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -1098,8 +1098,10 @@ public class MathExpression extends SimpleNode {
 
   /**
    * A compound arithmetic expression is a literal one only when every one of its operands is. Subclasses that carry
-   * their operands somewhere else than {@link #childExpressions} (an array literal, a CASE) inherit the {@code false}
-   * an empty operand list gives: see {@link Expression#isLiteral()} for why this answer stays on the safe side.
+   * their operands somewhere else than {@link #childExpressions} - an array literal, a CASE, and the arithmetic
+   * parenthesis of {@code (1) = 0} - inherit the {@code false} an empty operand list gives: see
+   * {@link Expression#isLiteral()} for why this answer stays on the safe side. Those are missed folds, not unsafe
+   * ones, and each subclass is free to answer for itself if a shape ever turns out to be worth recognizing.
    */
   public boolean isLiteral() {
     if (childExpressions.isEmpty())

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NotBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NotBlock.java
@@ -140,5 +140,14 @@ public class NotBlock extends BooleanExpression {
 
     return sub.isAlwaysTrue();
   }
+
+  @Override
+  public boolean isAlwaysFalse(final CommandContext context) {
+    if (sub == null)
+      return false;
+
+    // NOT <always true> is false for every record; without the NOT this block is a pass-through
+    return negate ? sub.isAlwaysTrue() : sub.isAlwaysFalse(context);
+  }
 }
 /* JavaCC - OriginalChecksum=1926313b3f854235aaa20811c22d583b (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
@@ -201,5 +201,18 @@ public class OrBlock extends BooleanExpression {
     }
     return false;
   }
+
+  @Override
+  public boolean isAlwaysFalse(final CommandContext context) {
+    if (subBlocks.isEmpty())
+      return false;
+
+    // the disjunction is false only when every one of its alternatives is
+    for (final BooleanExpression exp : subBlocks) {
+      if (!exp.isAlwaysFalse(context))
+        return false;
+    }
+    return true;
+  }
 }
 /* JavaCC - OriginalChecksum=98d3077303a598705894dbb7bd4e1573 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisBlock.java
@@ -85,5 +85,10 @@ public class ParenthesisBlock extends BooleanExpression {
   public boolean isAlwaysTrue() {
     return subElement.isAlwaysTrue();
   }
+
+  @Override
+  public boolean isAlwaysFalse(final CommandContext context) {
+    return subElement.isAlwaysFalse(context);
+  }
 }
 /* JavaCC - OriginalChecksum=9a16b6cf7d051382acb94c45067631a9 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
@@ -201,6 +201,15 @@ public class WhereClause extends SimpleNode {
     return flattened;
   }
 
+  /**
+   * Whether this filter discards every record, decidable from the statement alone (eg. {@code WHERE 1=0}).
+   *
+   * @see BooleanExpression#isAlwaysFalse(CommandContext)
+   */
+  public boolean isAlwaysFalse(final CommandContext context) {
+    return baseExpression != null && baseExpression.isAlwaysFalse(context);
+  }
+
   public void setBaseExpression(final BooleanExpression baseExpression) {
     this.baseExpression = baseExpression;
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.ArithmeticErrorException;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Pins the planner fold of a filter that is false for every row ({@code WHERE 1=0}) and of {@code LIMIT 0}: the
@@ -157,6 +159,20 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
 
     assertThat(names("SELECT FROM Character LIMIT ?", 0)).isEmpty();
     assertThat(names("SELECT FROM Character LIMIT ?", 2)).hasSize(2);
+
+    // -1 is the sentinel LimitExecutionStep reads as "unlimited": the fold must not confuse it with zero
+    assertScan(planOf("SELECT FROM Character LIMIT -1"));
+    assertThat(names("SELECT FROM Character LIMIT -1")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void limitZeroIsFoldedWhateverTheFilterSays() {
+    // a LIMIT 0 truncates the result to nothing no matter what the filter would have done, so the filter is not
+    // evaluated at all. The one thing that can tell the difference is a predicate that raises: it no longer does.
+    assertThatThrownBy(() -> names("SELECT FROM Character WHERE 1/0 = 1")).isInstanceOf(ArithmeticErrorException.class);
+
+    assertNoScan(planOf("SELECT FROM Character WHERE 1/0 = 1 LIMIT 0"));
+    assertThat(names("SELECT FROM Character WHERE 1/0 = 1 LIMIT 0")).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -86,6 +86,29 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
   }
 
   @Test
+  void aLiteralFalseFilterIsFoldedToo() {
+    // the parser answers a bare boolean literal with the BooleanExpression.FALSE/TRUE sentinels rather than a
+    // condition, so they carry their own verdict
+    assertNoScan(planOf("SELECT FROM Character WHERE false"));
+    assertNoScan(planOf("SELECT FROM Character WHERE true AND false"));
+
+    assertScan(planOf("SELECT FROM Character WHERE true"));
+    assertThat(names("SELECT FROM Character WHERE true")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+    assertThat(names("SELECT FROM Character WHERE false")).isEmpty();
+  }
+
+  @Test
+  void aNegatedConstantFilterIsReadWithItsNegation() {
+    // the hazard the NOT handling exists to avoid: reading "NOT (1=0)" as false would answer a filter that matches
+    // every record with no rows at all
+    assertScan(planOf("SELECT FROM Character WHERE NOT (1=0)"));
+    assertThat(names("SELECT FROM Character WHERE NOT (1=0)")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+
+    assertScan(planOf("SELECT FROM Character WHERE NOT (name = 'Arya')"));
+    assertThat(names("SELECT FROM Character WHERE NOT (name = 'Arya')")).containsExactlyInAnyOrder("Jon", "Tyrion");
+  }
+
+  @Test
   void aSatisfiableFilterIsStillPlannedAsAScan() {
     assertScan(planOf("SELECT FROM Character WHERE name = 'Arya'"));
     assertScan(planOf("SELECT FROM Character WHERE 1=1"));
@@ -158,6 +181,20 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
 
     assertThat(rs.hasNext()).isFalse();
     rs.close();
+  }
+
+  @Test
+  void countStarWithASkipReturnsNoRow() {
+    // the hardwired count plan replaces the whole step chain, so it has to chain the statement's SKIP itself: it
+    // used to hand back the very row it was told to skip
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM Character SKIP 1")) {
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM Character SKIP 0 LIMIT 5")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("total").intValue()).isEqualTo(3);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -234,12 +234,8 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
   @Test
   void anUnknownTargetIsStillReported() {
     // folding must not cost the statement its target validation
-    try {
-      database.query("sql", "SELECT FROM ThisTypeDoesNotExist WHERE 1=0").close();
-      org.assertj.core.api.Assertions.fail("a missing type must be reported even when the filter is constant-false");
-    } catch (final Exception e) {
-      assertThat(e.getMessage()).contains("ThisTypeDoesNotExist");
-    }
+    assertThatThrownBy(() -> database.query("sql", "SELECT FROM ThisTypeDoesNotExist WHERE 1=0").close())
+        .hasMessageContaining("ThisTypeDoesNotExist");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -20,6 +20,8 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
 
 import org.junit.jupiter.api.Test;
 
@@ -181,6 +183,22 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
 
     assertThat(rs.hasNext()).isFalse();
     rs.close();
+  }
+
+  @Test
+  void maxOnAnIndexedPropertyWithASkipReturnsNoRow() {
+    // same hazard as the count one below: MaxMinFromIndexStep also replaces the whole chain, and it is only reached
+    // when the property carries a range index
+    database.getSchema().getType("Character").createProperty("age", Type.INTEGER);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Character", "age");
+
+    try (final ResultSet rs = database.query("sql", "SELECT max(age) AS oldest FROM Character SKIP 1")) {
+      assertThat(rs.hasNext()).isFalse();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT max(age) AS oldest FROM Character")) {
+      assertThat(rs.next().<Number>getProperty("oldest").intValue()).isEqualTo(39);
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the planner fold of a filter that is false for every row ({@code WHERE 1=0}) and of {@code LIMIT 0}: the
+ * statement is knowable from its own text, so the plan must not carry a scan the filter would only drain. That is
+ * the shape Spark and several BI tools send over the Postgres wire to discover a query's schema. Issue #6174.
+ * <p>
+ * The fold is asserted on the plan shape and on the {@code readRecord} statistic, not only on the rows: the current
+ * behaviour already returns zero rows, it just reads the whole type to do it. {@code LIMIT 0} also carries a wrong
+ * answer, the SQL twin of the Cypher one fixed in #5715 - the hardwired {@code count(*)} plan returns before the
+ * {@code LIMIT} step is chained, so {@code SELECT count(*) FROM T LIMIT 0} used to return a row.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ConstantFalseFilterFoldingTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Character");
+
+    database.transaction(() -> {
+      database.newDocument("Character").set("name", "Arya").set("age", 11).save();
+      database.newDocument("Character").set("name", "Jon").set("age", 24).save();
+      database.newDocument("Character").set("name", "Tyrion").set("age", 39).save();
+    });
+  }
+
+  @Test
+  void sparkSchemaProbeDoesNotScanItsTarget() {
+    final ResultSet rs = database.query("sql", "SELECT * FROM (SELECT name FROM Character) SPARK_GEN_SUBQ_0 WHERE 1=0");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+
+    assertNoScan(plan);
+  }
+
+  @Test
+  void constantFalseFilterOnATypeDoesNotScanIt() {
+    final ResultSet rs = database.query("sql", "SELECT name FROM Character WHERE 1=0");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+
+    assertNoScan(plan);
+  }
+
+  @Test
+  void constantFalseFilterIsRecognizedThroughParenthesesAndAnd() {
+    assertNoScan(planOf("SELECT FROM Character WHERE (1=0)"));
+    assertNoScan(planOf("SELECT FROM Character WHERE 1=0 AND name = 'Arya'"));
+    assertNoScan(planOf("SELECT FROM Character WHERE name = 'Arya' AND (2=3)"));
+    assertNoScan(planOf("SELECT FROM Character WHERE 1=0 OR 'a'='b'"));
+    assertNoScan(planOf("SELECT FROM Character WHERE (1=0 AND name = 'Arya') OR (name = 'Jon' AND 2 > 3)"));
+    assertNoScan(planOf("SELECT FROM Character WHERE 1 = 1 + 1"));
+  }
+
+  @Test
+  void aSatisfiableFilterIsStillPlannedAsAScan() {
+    assertScan(planOf("SELECT FROM Character WHERE name = 'Arya'"));
+    assertScan(planOf("SELECT FROM Character WHERE 1=1"));
+    // one alternative of the OR is satisfiable, so the statement is not empty by construction
+    assertScan(planOf("SELECT FROM Character WHERE 1=0 OR name = 'Jon'"));
+
+    assertThat(names("SELECT FROM Character WHERE 1=0 OR name = 'Jon'")).containsExactly("Jon");
+    assertThat(names("SELECT FROM Character WHERE 1=0 AND name = 'Jon'")).isEmpty();
+    assertThat(names("SELECT FROM Character WHERE (1=0 AND name = 'Arya') OR (name = 'Jon' AND 2 > 3)")).isEmpty();
+  }
+
+  @Test
+  void aFilterResolvedByAParameterIsNeverFolded() {
+    // the plan is cached and reused across bindings: a fold decided on this execution's parameters would
+    // answer the next execution with the wrong rows
+    assertScan(planOf("SELECT FROM Character WHERE ? = 0", 1));
+    assertThat(names("SELECT FROM Character WHERE ? = 0", 1)).isEmpty();
+    assertThat(names("SELECT FROM Character WHERE ? = 0", 0)).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void aFilterCallingAFunctionIsNeverFolded() {
+    // nothing on SQLFunction marks a function as pure, so a comparison involving one must not be evaluated
+    // at plan time just to classify the statement
+    assertScan(planOf("SELECT FROM Character WHERE uuid() = 'not-a-uuid'"));
+    assertThat(names("SELECT FROM Character WHERE uuid() = 'not-a-uuid'")).isEmpty();
+  }
+
+  @Test
+  void limitZeroDoesNotScanItsTarget() {
+    final ResultSet rs = database.query("sql", "SELECT name FROM Character LIMIT 0");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+
+    assertNoScan(plan);
+  }
+
+  @Test
+  void aNonZeroOrParameterizedLimitIsNeverFolded() {
+    assertScan(planOf("SELECT FROM Character LIMIT 1"));
+    assertScan(planOf("SELECT FROM Character LIMIT ?", 0));
+
+    assertThat(names("SELECT FROM Character LIMIT ?", 0)).isEmpty();
+    assertThat(names("SELECT FROM Character LIMIT ?", 2)).hasSize(2);
+  }
+
+  @Test
+  void countStarWithAConstantFalseFilterStillReturnsZero() {
+    final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM Character WHERE 1=0");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("total").intValue()).isZero();
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void countStarWithAConstantFalseFilterAndGroupByReturnsNoRow() {
+    final ResultSet rs = database.query("sql", "SELECT name, count(*) AS total FROM Character WHERE 1=0 GROUP BY name");
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void countStarWithLimitZeroReturnsNoRow() {
+    final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM Character LIMIT 0");
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void anUnknownTargetIsStillReported() {
+    // folding must not cost the statement its target validation
+    try {
+      database.query("sql", "SELECT FROM ThisTypeDoesNotExist WHERE 1=0").close();
+      org.assertj.core.api.Assertions.fail("a missing type must be reported even when the filter is constant-false");
+    } catch (final Exception e) {
+      assertThat(e.getMessage()).contains("ThisTypeDoesNotExist");
+    }
+  }
+
+  @Test
+  void aConstantFalseFilterInsideTheSubqueryIsFoldedToo() {
+    final ResultSet rs = database.query("sql", "SELECT * FROM (SELECT name FROM Character WHERE 1=0)");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+
+    assertNoScan(plan);
+  }
+
+  @Test
+  void theFoldedPlanIsCacheableAndReusable() {
+    final String sql = "SELECT name FROM Character WHERE 1=0";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // the type creation in beginTest() invalidates the plan cache with a millisecond-resolution stamp the plan has
+    // to beat: see RidInScanOptimizationTest for the same guard
+    final long setupMillis = System.currentTimeMillis();
+    while (System.currentTimeMillis() == setupMillis)
+      Thread.onSpinWait();
+
+    assertThat(names(sql)).isEmpty();
+    assertThat(db.getExecutionPlanCache().contains(sql)).as("the fold depends on the statement alone, so it is cacheable")
+        .isTrue();
+
+    // reuse: the cached plan is copied, so the folded source has to survive the copy
+    assertThat(names(sql)).isEmpty();
+    assertNoScan(planOf(sql));
+  }
+
+  @Test
+  void aLetEvaluatedOncePerStatementStillRuns() {
+    // a LET that needs no record is executed once, ahead of the fetch, and its side effects are not the fold's to
+    // skip: only the per-record work disappears with the rows that were never going to come back
+    database.transaction(() -> database.command("sql",
+        "SELECT FROM Character LET $ghost = (INSERT INTO Character SET name = 'Ghost') WHERE 1=0").close());
+
+    assertThat(names("SELECT FROM Character WHERE name = 'Ghost'")).containsExactly("Ghost");
+  }
+
+  @Test
+  void aDeleteWithAConstantFalseFilterDoesNotScanItsTarget() {
+    final ResultSet rs = database.command("sql", "DELETE FROM Character WHERE 1=0");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+    rs.close();
+
+    assertNoScan(plan);
+    assertThat(names("SELECT FROM Character")).hasSize(3);
+  }
+
+  @Test
+  void aFoldedStatementReadsNoRecordAtAll() {
+    // the plan shape says the scan is not there; this says nothing reads a record when the plan runs
+    assertThat(recordsReadBy("SELECT * FROM (SELECT name FROM Character) SPARK_GEN_SUBQ_0 WHERE 1=0")).isZero();
+    assertThat(recordsReadBy("SELECT name FROM Character WHERE 1=0")).isZero();
+    assertThat(recordsReadBy("SELECT name FROM Character LIMIT 0")).isZero();
+
+    assertThat(recordsReadBy("SELECT name FROM Character")).isEqualTo(3);
+  }
+
+  @Test
+  void anUpdateWithAConstantFalseFilterDoesNotScanItsTarget() {
+    final ResultSet rs = database.command("sql", "UPDATE Character SET name = 'changed' WHERE 1=0");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+    rs.close();
+
+    assertNoScan(plan);
+    assertThat(names("SELECT FROM Character")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void orderByAndProjectionsSurviveTheFold() {
+    final ResultSet rs = database.query("sql",
+        "SELECT name.toUpperCase() AS upper FROM Character WHERE 1=0 ORDER BY name DESC LIMIT 10");
+
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  private ExecutionPlan planOf(final String sql, final Object... params) {
+    try (final ResultSet rs = params.length == 0 ? database.query("sql", sql) : database.query("sql", sql, params)) {
+      return rs.getExecutionPlan().orElseThrow();
+    }
+  }
+
+  private List<String> names(final String sql, final Object... params) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = params.length == 0 ? database.query("sql", sql) : database.query("sql", sql, params)) {
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+    }
+    return names;
+  }
+
+  /** The records the query materialized: zero when the statement was answered from its own text. */
+  private long recordsReadBy(final String query) {
+    final long before = readRecords();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        rs.next().getPropertyNames();
+    }
+    return readRecords() - before;
+  }
+
+  private long readRecords() {
+    return ((Number) database.getStats().get("readRecord")).longValue();
+  }
+
+  private static void assertNoScan(final ExecutionPlan plan) {
+    assertThat(fetchSteps(plan))
+        .as("an empty-by-construction statement must not plan a fetch step: %s", plan.prettyPrint(0, 2))
+        .isEmpty();
+  }
+
+  private static void assertScan(final ExecutionPlan plan) {
+    assertThat(fetchSteps(plan))
+        .as("a statement that can return rows must still plan a fetch step: %s", plan.prettyPrint(0, 2))
+        .isNotEmpty();
+  }
+
+  private static List<String> fetchSteps(final ExecutionPlan plan) {
+    final List<String> found = new ArrayList<>();
+    for (final ExecutionStep step : plan.getSteps())
+      collectFetchSteps(step, found);
+    return found;
+  }
+
+  private static void collectFetchSteps(final ExecutionStep step, final List<String> found) {
+    if (step.getClass().getSimpleName().startsWith("FetchFrom") || step.getClass().getSimpleName().startsWith("CountFrom"))
+      found.add(step.getClass().getSimpleName());
+
+    if (step.getSubSteps() != null)
+      for (final ExecutionStep sub : step.getSubSteps())
+        collectFetchSteps(sub, found);
+
+    if (step instanceof ExecutionStepInternal internal && internal.getSubExecutionPlans() != null)
+      for (final ExecutionPlan sub : internal.getSubExecutionPlans())
+        for (final ExecutionStep subStep : sub.getSteps())
+          collectFetchSteps(subStep, found);
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -44,16 +44,11 @@ import com.arcadedb.query.sql.executor.IteratorResultSet;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.query.sql.parser.AndBlock;
-import com.arcadedb.query.sql.parser.BaseExpression;
-import com.arcadedb.query.sql.parser.BinaryCondition;
-import com.arcadedb.query.sql.parser.BooleanExpression;
 import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.query.sql.parser.FromClause;
 import com.arcadedb.query.sql.parser.FromItem;
 import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.query.sql.parser.MatchStatement;
-import com.arcadedb.query.sql.parser.MathExpression;
 import com.arcadedb.query.sql.parser.Projection;
 import com.arcadedb.query.sql.parser.ProjectionItem;
 import com.arcadedb.query.sql.parser.SelectStatement;
@@ -1272,112 +1267,13 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   private boolean isAlwaysFalseFilter(final WhereClause where, final CommandContext context) {
-    return where != null && isAlwaysFalse(where.baseExpression, context);
+    return where != null && where.isAlwaysFalse(context);
   }
 
   private SelectStatement selectedSubQuery(final SelectStatement select) {
     final FromClause target = select.getTarget();
     final FromItem item = target != null ? target.getItem() : null;
     return item != null && item.getStatement() instanceof SelectStatement subQuery ? subQuery : null;
-  }
-
-  /**
-   * Tells whether a boolean expression is false for every row without looking at any of them, which is how a
-   * client marks a query as a schema probe ({@code WHERE 1=0}). The expression is read in the disjunctive normal
-   * form the planner itself uses, so the answer holds through parentheses, ANDs and ORs alike: the whole filter
-   * is false only when every alternative carries a term that is. Only comparisons between operands that need no
-   * record to be computed are evaluated, so nothing here can touch the database or throw on a missing row.
-   */
-  private boolean isAlwaysFalse(final BooleanExpression expression, final CommandContext context) {
-    if (expression == null)
-      return false;
-
-    final List<AndBlock> alternatives = expression.flatten();
-    if (alternatives == null || alternatives.isEmpty())
-      return false;
-
-    for (final AndBlock alternative : alternatives) {
-      final List<BooleanExpression> terms = alternative.getSubBlocks();
-      if (terms == null || terms.isEmpty())
-        return false;
-
-      boolean falseTerm = false;
-      for (final BooleanExpression term : terms) {
-        if (term instanceof BinaryCondition condition && isConstantFalseComparison(condition, context)) {
-          falseTerm = true;
-          break;
-        }
-      }
-
-      if (!falseTerm)
-        return false;
-    }
-
-    return true;
-  }
-
-  private boolean isConstantFalseComparison(final BinaryCondition condition, final CommandContext context) {
-    if (!isLiteral(condition.left) || !isLiteral(condition.right))
-      return false;
-
-    try {
-      return Boolean.FALSE.equals(condition.evaluate((Result) null, context));
-    } catch (final Exception e) {
-      return false;
-    }
-  }
-
-  /**
-   * Whether the expression is built out of literals alone - a number, a string, a boolean, null, or arithmetic
-   * over them.
-   * <p>
-   * This is deliberately narrower than {@link Expression#isEarlyCalculated}, which only asks whether an
-   * expression can be computed without a record. That admits any function call whose arguments need no record,
-   * and nothing on {@code SQLFunction} distinguishes a pure function from one with a side effect. The question
-   * being answered here - "is this filter a schema probe?" - is asked of every query that returns no rows, the
-   * vast majority of which are not probes at all, so it must never reach a function: a query filtering on
-   * {@code someStatefulFunction() = 42} would otherwise have that function invoked once more just to be
-   * classified.
-   */
-  private boolean isLiteral(final Expression expression) {
-    if (expression == null)
-      return false;
-
-    if (expression.isNull || expression.booleanValue != null)
-      return true;
-
-    // a RID, a JSON object, a nested condition or an array concatenation is never a literal comparison operand
-    if (expression.rid != null || expression.json != null || expression.whereCondition != null
-        || expression.arrayConcatExpression != null)
-      return false;
-
-    return isLiteral(expression.mathExpression);
-  }
-
-  private boolean isLiteral(final MathExpression expression) {
-    if (expression == null)
-      return false;
-
-    if (expression instanceof BaseExpression base) {
-      // a modifier is a method call or a field/index access applied to the value: no longer a bare literal
-      if (base.modifier != null)
-        return false;
-      if (base.number != null || base.string != null || base.isNull)
-        return true;
-      return base.expression != null && isLiteral(base.expression);
-    }
-
-    // a compound arithmetic expression is a literal one only when every one of its operands is
-    final List<MathExpression> operands = expression.childExpressions;
-    if (operands == null || operands.isEmpty())
-      return false;
-
-    for (final MathExpression operand : operands) {
-      if (!isLiteral(operand))
-        return false;
-    }
-
-    return true;
   }
 
   private void writeRowDescription(final Map<String, PostgresType> columns) {


### PR DESCRIPTION
Fixes #6174.

## The problem

The SQL planner had no notion of a filter that is false for every row. `WHERE 1=0` was evaluated per record like
any other condition, so

```sql
SELECT * FROM (SELECT name FROM Character) SPARK_GEN_SUBQ_0 WHERE 1=0
```

scanned every `Character`, evaluated `1=0` once per record and discarded all of them. That is the shape Spark, and
several BI tools over the Postgres wire, send to discover a query's schema - one probe per pushed-down query,
against the real target. `LIMIT 0` is the other spelling of the same intent and cost the same.

## The fix

The recognition lives on the AST, next to the `isAlwaysTrue()` that was already there:

- `BooleanExpression.isAlwaysFalse(CommandContext)` - default `false`, overridden structurally by `AndBlock` (false
  when any term is), `OrBlock` (false only when every alternative is), `ParenthesisBlock` (delegates) and
  `BinaryCondition` (folds the comparison). Structural rather than over `flatten()`'s DNF: it is O(n) instead of
  the cartesian product a DNF expansion of a wide OR produces, and it answers the same question.
- `BinaryCondition` folds only when **both** operands are literals (`Expression.isLiteral()` /
  `MathExpression.isLiteral()` / `BaseExpression.isLiteral()`), and folds by calling the very same
  `evaluate()` the filter step would have called, so the fold and the runtime can never disagree. A bound parameter
  is excluded because the plan outlives the execution that bound it; a function call is excluded because nothing on
  `SQLFunction` marks a function as pure - `isEarlyCalculated()` is not a purity check.
- `Limit.isAlwaysEmpty()` for a literal `LIMIT 0` (not a parameter, not an expression).

`SelectExecutionPlanner` reads that off the clauses as the statement wrote them (before `optimizeQuery()`
rearranges them into index searches) and, after the target has been planned, drops the fetch steps and chains an
`EmptySourceStep` instead. The rest of the plan is untouched.

Three things the fold deliberately keeps:

- **target validation**: the fetch is planned and then discarded, so `SELECT FROM ATypeThatDoesNotExist WHERE 1=0`
  still reports the missing type instead of quietly returning nothing;
- **the aggregation semantics**: everything downstream of the fetch stays and receives no row, which is exactly
  what it receives today from the filter being removed - `SELECT count(*) FROM T WHERE 1=0` still returns its one
  row with 0, and with a `GROUP BY` still returns none;
- **a `LET` evaluated once per statement**: it is chained ahead of the empty source, which pulls it exactly like
  `EmptyStep` does.

`EmptySourceStep` is a new step rather than a reuse of `EmptyStep` because `EmptyStep.canBeCached()` is
(deliberately) `false`: it encodes one execution's *data*. "This statement cannot return a row" is a property of
its *text*, so the folded plan is cacheable.

Because `DELETE`/`UPDATE` build their target through `SelectExecutionPlanner`, they are covered by the same code.

## Two behaviour changes, and a wrong answer found next to them

`SELECT count(*) FROM T LIMIT 0` used to return one row: `count(*)` on a bare type is answered by a hardwired plan
that replaces the whole step chain and returns before any `LIMIT`/`SKIP` step is chained. It now returns no rows.
This is the SQL twin of the Cypher defect fixed in #5715.

The same hole was a wrong answer for `SKIP`, on all three hardwired plans: `SELECT count(*) FROM T SKIP 1` and
`SELECT max(indexedProperty) FROM T SKIP 1` handed back the very row they were told to skip. Both now chain the
statement's SKIP/LIMIT themselves, which costs nothing on a plan that produces one row.

Finally, a `LIMIT 0` is folded whatever the `WHERE` says, so - unlike the constant-false fold, which never reaches
a function - the filter is not evaluated at all. The only way to observe that is a predicate that raises:
`SELECT * FROM T WHERE 1/0 = 1` reports a division by zero, and with `LIMIT 0` it now returns an empty result.

## Reuse over duplication

`PostgresNetworkExecutor.isAlwaysFalse` (added in #6172) is gone: the probe detection now calls
`WhereClause.isAlwaysFalse()`, removing ~90 lines that duplicated the recognition.

## Tests

New `ConstantFalseFilterFoldingTest` (24 tests), verified red on main for the folding cases. It asserts the plan
shape (no `FetchFrom*`/`CountFrom*` step anywhere, including inside sub-plans) *and* the `readRecord` statistic, not
only that zero rows come back - the current behaviour already returns zero rows, it just reads the whole type to do
it. It also pins what must NOT be folded: a bound parameter, a function call, a satisfiable OR branch, `NOT (1=0)`, `LIMIT ?` and the `LIMIT -1` "unlimited" sentinel.

Run: engine `com.arcadedb.query.**` (10947 tests), the rest of the engine module, postgresw units + integration.
