### PR TITLE
fix(#6179): an expression whose modifier or CASE branch reads the record is no longer "early calculated"

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2370,11 +2370,16 @@ public class SelectExecutionPlanner {
           continue;
         final int idx = idxBoxed;
 
-        if (literalSide == null || !literalSide.isEarlyCalculated(context))
-          continue;
-        // Plan-time pruning is unsafe when the literal is parameter-bound: the cached plan would
-        // reuse the first execution's bucket id for every subsequent binding.
-        if (literalSide.containsInputParameter())
+        // Only a literal is bound here, not everything Expression.isEarlyCalculated() would admit. The
+        // bucket derived below is baked into the plan, so the value it comes from must be fixed for the
+        // life of that plan and free to compute: a parameter is not (a cached plan would reuse the first
+        // execution's bucket id for every subsequent binding, which is what the isEarlyCalculated form
+        // used to exclude by hand), and a function call is neither - it would be invoked at plan time,
+        // once more than the query asked for, and a non-deterministic one would fix a bucket that its
+        // per-row value no longer agrees with. That the plan is not cached today when the WHERE holds a
+        // function is an accident of FunctionCall.isCacheable() being true only for traversals; pruning
+        // no longer leans on it. See issue #6179.
+        if (literalSide == null || !literalSide.isLiteral())
           continue;
 
         if (!bound[idx]) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayLiteralExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayLiteralExpression.java
@@ -100,6 +100,20 @@ public class ArrayLiteralExpression extends MathExpression {
     return true;
   }
 
+  /**
+   * {@code items} sit outside {@code childExpressions}; the inherited walker would miss them.
+   *
+   * @see Expression#isLiteral(boolean)
+   */
+  @Override
+  public boolean isLiteral(final boolean allowInputParameters) {
+    for (final Expression item : items) {
+      if (!item.isLiteral(allowInputParameters))
+        return false;
+    }
+    return true;
+  }
+
   @Override
   public boolean isAggregate(final CommandContext context) {
     for (final Expression item : items) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayNumberSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayNumberSelector.java
@@ -82,6 +82,13 @@ public class ArrayNumberSelector extends SimpleNode {
     return null;
   }
 
+  /**
+   * @see Expression#isEarlyCalculated(CommandContext)
+   */
+  public boolean isEarlyCalculated(final CommandContext context) {
+    return expressionValue == null || expressionValue.isEarlyCalculated(context);
+  }
+
   public ArrayNumberSelector copy() {
     final ArrayNumberSelector result = new ArrayNumberSelector();
     result.inputValue = inputValue == null ? null : inputValue.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayRangeSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayRangeSelector.java
@@ -142,6 +142,14 @@ public class ArrayRangeSelector extends SimpleNode {
     return Arrays.asList(Arrays.copyOfRange(arrayResult, lFrom, lTo));
   }
 
+  /**
+   * @see Expression#isEarlyCalculated(CommandContext)
+   */
+  public boolean isEarlyCalculated(final CommandContext context) {
+    return (fromSelector == null || fromSelector.isEarlyCalculated(context)) //
+        && (toSelector == null || toSelector.isEarlyCalculated(context));
+  }
+
   public ArrayRangeSelector copy() {
     final ArrayRangeSelector result = new ArrayRangeSelector();
     result.from = from;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySelector.java
@@ -87,6 +87,13 @@ public class ArraySelector extends SimpleNode {
     return result;
   }
 
+  /**
+   * @see Expression#isEarlyCalculated(CommandContext)
+   */
+  public boolean isEarlyCalculated(final CommandContext context) {
+    return expression == null || expression.isEarlyCalculated(context);
+  }
+
   public ArraySelector copy() {
     final ArraySelector result = new ArraySelector();
     result.rid = rid == null ? null : rid.copy();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySingleValuesSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArraySingleValuesSelector.java
@@ -135,6 +135,17 @@ public class ArraySingleValuesSelector extends SimpleNode {
     }
   }
 
+  /**
+   * @see Expression#isEarlyCalculated(CommandContext)
+   */
+  public boolean isEarlyCalculated(final CommandContext context) {
+    for (final ArraySelector item : items)
+      if (!item.isEarlyCalculated(context))
+        return false;
+
+    return true;
+  }
+
   public ArraySingleValuesSelector copy() {
     final ArraySingleValuesSelector result = new ArraySingleValuesSelector();
     result.items = items.stream().map(x -> x.copy()).collect(Collectors.toList());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -354,19 +354,16 @@ public class BaseExpression extends MathExpression {
     return identifier != null && modifier == null && identifier.isBaseIdentifier();
   }
 
+  /**
+   * @see Expression#isEarlyCalculated(CommandContext) for what "early calculated" does and does not promise.
+   */
   @Override
-  public boolean isLiteral() {
-    // a modifier is a method call or a field/index access applied to the value: no longer a bare literal
-    if (modifier != null)
+  public boolean isEarlyCalculated(final CommandContext context) {
+    // the modifier is part of the expression: `'Mr.'.append(surname)` is a literal only up to the dot, and
+    // evaluating the whole of it without a record silently resolves `surname` to null (issue #6179)
+    if (modifier != null && !modifier.isEarlyCalculated(context))
       return false;
 
-    if (number != null || string != null || isNull)
-      return true;
-
-    return expression != null && expression.isLiteral();
-  }
-
-  public boolean isEarlyCalculated(CommandContext context) {
     if (number != null || inputParam != null || string != null)
       return true;
 
@@ -374,6 +371,27 @@ public class BaseExpression extends MathExpression {
       return expression.isEarlyCalculated(context);
 
     return identifier != null && identifier.isEarlyCalculated(context);
+  }
+
+  /**
+   * @see Expression#isLiteral(boolean)
+   */
+  @Override
+  public boolean isLiteral(final boolean allowInputParameters) {
+    // a modifier is a method call or a field/index access applied to the value: no longer a bare literal
+    if (modifier != null)
+      return false;
+
+    if (number != null || string != null || isNull)
+      return true;
+
+    if (inputParam != null)
+      return allowInputParameters;
+
+    if (expression != null)
+      return expression.isLiteral(allowInputParameters);
+
+    return identifier != null && identifier.isLiteral(allowInputParameters);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
@@ -178,6 +178,15 @@ public class BaseIdentifier extends SimpleNode {
     return suffix != null && suffix.isEarlyCalculated(context);
   }
 
+  /**
+   * A suffix is a property or variable reference, never a literal.
+   *
+   * @see Expression#isLiteral(boolean)
+   */
+  public boolean isLiteral(final boolean allowInputParameters) {
+    return levelZero != null && levelZero.isLiteral(allowInputParameters);
+  }
+
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
       final BaseIdentifier result = new BaseIdentifier();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
@@ -193,6 +193,31 @@ public class CaseExpression extends MathExpression {
   }
 
   /**
+   * CASE branches sit outside {@code childExpressions}, so the inherited walker finds an empty list and answers
+   * true for a CASE that reads the record on every branch. Walk every branch explicitly instead (issue #6179).
+   * A simple-form WHEN is a {@link WhereClause}, and a boolean expression carries no record-free predicate of its
+   * own, so a CASE built that way is never assumed to be computable without a record.
+   *
+   * @see Expression#isEarlyCalculated(CommandContext)
+   */
+  @Override
+  public boolean isEarlyCalculated(final CommandContext context) {
+    if (caseExpression != null && !caseExpression.isEarlyCalculated(context))
+      return false;
+
+    for (final CaseAlternative alternative : alternatives) {
+      if (alternative.isSimpleForm())
+        return false;
+      if (alternative.getWhenExpression() == null || !alternative.getWhenExpression().isEarlyCalculated(context))
+        return false;
+      if (alternative.getThenExpression() == null || !alternative.getThenExpression().isEarlyCalculated(context))
+        return false;
+    }
+
+    return elseExpression == null || elseExpression.isEarlyCalculated(context);
+  }
+
+  /**
    * Check if two values are equal, handling nulls properly.
    */
   private boolean valuesEqual(final Object a, final Object b) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
@@ -218,6 +218,30 @@ public class CaseExpression extends MathExpression {
   }
 
   /**
+   * Same reason as above: the branches sit outside {@code childExpressions}, so the inherited walker would report
+   * a CASE built entirely of literals as non-literal. A simple-form WHEN is a {@link WhereClause} and cannot be
+   * read as a constant, so only the extended form can qualify.
+   *
+   * @see Expression#isLiteral(boolean)
+   */
+  @Override
+  public boolean isLiteral(final boolean allowInputParameters) {
+    if (caseExpression == null || !caseExpression.isLiteral(allowInputParameters))
+      return false;
+
+    for (final CaseAlternative alternative : alternatives) {
+      if (alternative.isSimpleForm())
+        return false;
+      if (alternative.getWhenExpression() == null || !alternative.getWhenExpression().isLiteral(allowInputParameters))
+        return false;
+      if (alternative.getThenExpression() == null || !alternative.getThenExpression().isLiteral(allowInputParameters))
+        return false;
+    }
+
+    return elseExpression == null || elseExpression.isLiteral(allowInputParameters);
+  }
+
+  /**
    * Check if two values are equal, handling nulls properly.
    */
   private boolean valuesEqual(final Object a, final Object b) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
@@ -112,29 +112,24 @@ public class Expression extends SimpleNode {
   }
 
   /**
-   * Whether the expression is built out of literals alone - a number, a string, a boolean, null, or arithmetic over
-   * them - so that its value is written in the statement itself and cannot change between two executions of the same
-   * plan.
+   * Whether the expression can be computed <b>without a record</b>: no property reference, no traversal, nothing
+   * that only a row can answer. It is what lets an equality be turned into an index key, or a per-record LET into
+   * a global one.
    * <p>
-   * This is deliberately narrower than {@link #isEarlyCalculated(CommandContext)}, which only asks whether an
-   * expression can be computed without a record. That admits any function call whose arguments need no record, and
-   * nothing on {@code SQLFunction} distinguishes a pure function from one with a side effect; it also admits a bound
-   * parameter, whose value belongs to one execution and must never be baked into a cached plan. Plan-time constant
-   * folding asks this question of statements that are overwhelmingly not constant at all, so it must never reach a
-   * function: {@code WHERE someStatefulFunction() = 42} would otherwise have that function invoked just to be
-   * classified.
+   * It promises nothing else. In particular it is <b>not</b> a purity, determinism or constant-ness check: any
+   * function or method whose arguments need no record qualifies, so {@code uuid()}, {@code sysdate()} and any
+   * user-defined function over literals all answer true, and an input parameter does too. There is no marker on
+   * {@link com.arcadedb.query.sql.executor.SQLFunction} that would tell a pure function from one with a side
+   * effect ({@code com.arcadedb.function.StatelessFunction} in the sibling registry means "needs no record" as
+   * well, not "pure").
+   * <p>
+   * So a caller that only wants to <i>classify</i> an expression can use this; a caller that intends to
+   * <b>evaluate</b> it at plan time - and thereby invoke whatever it contains, once more than the query itself
+   * asks for - wants {@link #isLiteral()} instead. See issue #6179.
+   *
+   * @see #isLiteral()
+   * @see #isLiteral(boolean)
    */
-  public boolean isLiteral() {
-    if (isNull || booleanValue != null)
-      return true;
-
-    // a RID, a JSON object, a nested condition or an array concatenation is never a bare literal
-    if (rid != null || json != null || whereCondition != null || arrayConcatExpression != null)
-      return false;
-
-    return mathExpression != null && mathExpression.isLiteral();
-  }
-
   public boolean isEarlyCalculated(final CommandContext context) {
     if (isNull)
       return true;
@@ -155,6 +150,51 @@ public class Expression extends SimpleNode {
     else if (value instanceof MathExpression expression)
       return expression.isEarlyCalculated(context);
 
+    return false;
+  }
+
+  /**
+   * Whether the expression is built out of literals alone - a number, a string, a boolean, {@code null}, a RID
+   * literal, a collection of them, or arithmetic over them - so that its value is written in the statement itself
+   * and cannot change between two executions of the same plan.
+   * <p>
+   * This is deliberately narrower than {@link #isEarlyCalculated(CommandContext)}, which only asks whether an
+   * expression can be computed without a record. That admits any function call whose arguments need no record, and
+   * nothing on {@code SQLFunction} distinguishes a pure function from one with a side effect; it also admits a bound
+   * parameter, whose value belongs to one execution and must never be baked into a cached plan. Constant folding
+   * asks this question of statements that are overwhelmingly not constant at all, so it must never reach a function:
+   * {@code WHERE someStatefulFunction() = 42} would otherwise have that function invoked just to be classified.
+   * <p>
+   * It is therefore the predicate to use whenever an expression is <b>evaluated</b> to decide the shape of a plan
+   * (issues #6174 and #6179), while {@code isEarlyCalculated} is for classifying one.
+   *
+   * @see #isLiteral(boolean)
+   */
+  public boolean isLiteral() {
+    return isLiteral(false);
+  }
+
+  /**
+   * @param allowInputParameters when true an input parameter counts as a literal too: it is bound before the plan
+   *                             is built and reading it invokes nothing. Only for callers whose result does not
+   *                             outlive the execution - a value baked into a <b>cached</b> plan must not depend on
+   *                             this execution's bindings, so constant folding uses {@link #isLiteral()}.
+   *
+   * @see #isLiteral()
+   */
+  public boolean isLiteral(final boolean allowInputParameters) {
+    if (isNull || booleanValue != null)
+      return true;
+    else if (rid != null)
+      // written in the statement as #<bucket>:<position>, so it is as fixed as a number is
+      return rid.legacy || (rid.expression != null && rid.expression.isLiteral(allowInputParameters));
+    else if (mathExpression != null)
+      return mathExpression.isLiteral(allowInputParameters);
+
+    // A JSON object, a nested condition and an array concatenation are never bare literals. Neither is the
+    // inherited {@code value} field, which isEarlyCalculated() above still reads for a Number or a String: that
+    // is where the pre-ANTLR executor substituted a parameter by hand, and nothing in the tree assigns it any
+    // more. The asymmetry between the two predicates is unreachable, not a gap.
     return false;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -331,6 +331,12 @@ public class FunctionCall extends SimpleNode {
     return item;
   }
 
+  /**
+   * True for <b>any</b> function whose arguments need no record - {@code uuid()}, {@code sysdate()} and any
+   * user-defined function over literals included. Nothing here says the call is pure or repeatable, so a caller
+   * that goes on to evaluate the expression at plan time invokes the function for real, once more than the query
+   * asked for. See {@link Expression#isEarlyCalculated(CommandContext)} and issue #6179.
+   */
   public boolean isEarlyCalculated(final CommandContext context) {
     if (isTraverseFunction(context))
       return false;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
@@ -191,6 +191,15 @@ public class LevelZeroIdentifier extends SimpleNode {
     return collection != null && collection.isEarlyCalculated(context);
   }
 
+  /**
+   * A function call is never a literal, whatever its arguments are.
+   *
+   * @see Expression#isLiteral(boolean)
+   */
+  public boolean isLiteral(final boolean allowInputParameters) {
+    return collection != null && collection.isLiteral(allowInputParameters);
+  }
+
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
       final LevelZeroIdentifier result = new LevelZeroIdentifier();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -1088,6 +1088,9 @@ public class MathExpression extends SimpleNode {
     return false;
   }
 
+  /**
+   * @see Expression#isEarlyCalculated(CommandContext) for what "early calculated" does and does not promise.
+   */
   public boolean isEarlyCalculated(final CommandContext context) {
     for (final MathExpression exp : childExpressions) {
       if (!exp.isEarlyCalculated(context))
@@ -1097,18 +1100,27 @@ public class MathExpression extends SimpleNode {
   }
 
   /**
-   * A compound arithmetic expression is a literal one only when every one of its operands is. Subclasses that carry
-   * their operands somewhere else than {@link #childExpressions} - an array literal, a CASE, and the arithmetic
-   * parenthesis of {@code (1) = 0} - inherit the {@code false} an empty operand list gives: see
-   * {@link Expression#isLiteral()} for why this answer stays on the safe side. Those are missed folds, not unsafe
-   * ones, and each subclass is free to answer for itself if a shape ever turns out to be worth recognizing.
+   * @see Expression#isLiteral()
    */
   public boolean isLiteral() {
+    return isLiteral(false);
+  }
+
+  /**
+   * A compound arithmetic expression is a literal one only when every one of its operands is. A subclass that keeps
+   * its operands outside {@link #childExpressions} - an array literal, a CASE, the arithmetic parenthesis of
+   * {@code (1) = 0} - would inherit the {@code false} an empty operand list gives, which is the safe answer but a
+   * missed fold; each of those overrides this and answers for itself. A node this walker cannot see into is never
+   * mistaken for a literal.
+   *
+   * @see Expression#isLiteral(boolean)
+   */
+  public boolean isLiteral(final boolean allowInputParameters) {
     if (childExpressions.isEmpty())
       return false;
 
-    for (final MathExpression operand : childExpressions) {
-      if (!operand.isLiteral())
+    for (final MathExpression exp : childExpressions) {
+      if (!exp.isLiteral(allowInputParameters))
         return false;
     }
     return true;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
@@ -196,6 +196,25 @@ public class MethodCall extends SimpleNode {
     return false;
   }
 
+  /**
+   * Whether the call can be evaluated against the value it is applied to without a record. A graph method
+   * ({@code out}, {@code in}, {@code both}, ...) walks the record's edges, and every other method resolves its
+   * arguments against the current record, so they all have to be computable on their own.
+   * <p>
+   * As with {@link Expression#isEarlyCalculated(CommandContext)}, this says nothing about the method being pure:
+   * a caller that evaluates the expression at plan time invokes it for real.
+   */
+  public boolean isEarlyCalculated(final CommandContext context) {
+    if (isGraphFunction())
+      return false;
+
+    for (final Expression param : params)
+      if (!param.isEarlyCalculated(context))
+        return false;
+
+    return true;
+  }
+
   public boolean isCacheable() {
     return isGraphFunction();
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Modifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Modifier.java
@@ -143,6 +143,34 @@ public class Modifier extends SimpleNode {
     return result;
   }
 
+  /**
+   * Whether the whole chain can be applied to an already computed value without a record.
+   * <p>
+   * A method call or an index/range selector carries expressions of its own, and those are evaluated against
+   * the current record: {@code 'Mr.'.append(surname)} and {@code ['a','b'][idx]} both reach into it. A suffix
+   * ({@code .name}) instead reads a property of the value the modifier is applied to, so it needs no record.
+   * A condition, a right binary condition and a nested projection are filters over the items of that value
+   * whose terms can still reach the record through {@code $parent} / {@code $current}, so they are never
+   * assumed to be record-free.
+   *
+   * @see Expression#isEarlyCalculated(CommandContext)
+   */
+  public boolean isEarlyCalculated(final CommandContext context) {
+    if (methodCall != null) {
+      if (!methodCall.isEarlyCalculated(context))
+        return false;
+    } else if (arrayRange != null) {
+      if (!arrayRange.isEarlyCalculated(context))
+        return false;
+    } else if (arraySingleValues != null) {
+      if (!arraySingleValues.isEarlyCalculated(context))
+        return false;
+    } else if (condition != null || rightBinaryCondition != null || nestedProjection != null)
+      return false;
+
+    return next == null || next.isEarlyCalculated(context);
+  }
+
   public Modifier copy() {
     final Modifier result = new Modifier();
     result.squareBrackets = squareBrackets;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/PCollection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/PCollection.java
@@ -103,6 +103,17 @@ public class PCollection extends SimpleNode {
     return true;
   }
 
+  /**
+   * @see Expression#isLiteral(boolean)
+   */
+  public boolean isLiteral(final boolean allowInputParameters) {
+    for (final Expression exp : expressions) {
+      if (!exp.isLiteral(allowInputParameters))
+        return false;
+    }
+    return true;
+  }
+
   public PCollection copy() {
     final PCollection result = new PCollection();
     result.expressions = expressions == null ? null : expressions.stream().map(x -> x.copy()).collect(Collectors.toList());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisExpression.java
@@ -129,6 +129,17 @@ public class ParenthesisExpression extends MathExpression {
     return expression != null && expression.isEarlyCalculated(context);
   }
 
+  /**
+   * {@code expression} is stored outside {@code childExpressions}, so the inherited walker would answer false for
+   * a literal in parentheses. Forward to it.
+   *
+   * @see Expression#isLiteral(boolean)
+   */
+  @Override
+  public boolean isLiteral(final boolean allowInputParameters) {
+    return expression != null && expression.isLiteral(allowInputParameters);
+  }
+
   @Override
   public boolean containsInputParameter() {
     // {@code expression} is stored outside {@code childExpressions}, so the inherited

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
@@ -176,12 +176,21 @@ public class WhereClause extends SimpleNode {
     return Long.MAX_VALUE;
   }
 
+  /**
+   * Collects the {@code field = value} pairs an index estimate can be taken from, by evaluating the value side.
+   * <p>
+   * Only literals and bound parameters are evaluated, never anything {@link Expression#isEarlyCalculated} would
+   * also admit: a function call there would be invoked once per planning just to sharpen a cost estimate, which
+   * is an invocation the query never asked for and nothing on the function says is free (issue #6179). A
+   * parameter is fine - it is already bound and reading it calls nothing - and the estimate it feeds lives only
+   * as long as this planning pass.
+   */
   private Map<String, Object> getEqualityOperations(final AndBlock condition, final CommandContext context) {
     final Map<String, Object> result = new HashMap<String, Object>();
     for (final BooleanExpression expression : condition.subBlocks) {
       if (expression instanceof BinaryCondition b) {
         if (b.operator instanceof EqualsCompareOperator) {
-          if (b.left.isBaseIdentifier() && b.right.isEarlyCalculated(context)) {
+          if (b.left.isBaseIdentifier() && b.right.isLiteral(true)) {
             result.put(b.left.toString(), b.right.execute((Result) null, context));
           }
         }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/PartitionPruningPlannerTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/PartitionPruningPlannerTest.java
@@ -146,6 +146,34 @@ class PartitionPruningPlannerTest extends TestHelper {
   }
 
   @Test
+  void computedPredicateDoesNotNarrowIndexFilterBuckets() {
+    // Issue #6179: only a literal binds a partition coordinate. A value that is merely "early
+    // calculated" - here a method call over a literal, but a function call over literals reads the
+    // same - must not be evaluated while planning: that would invoke it once more than the query
+    // asked for, and a non-deterministic one would fix a bucket its per-row value no longer agrees
+    // with. Before, the path was safe only because a function in the WHERE happens to make the plan
+    // non-cacheable, a coupling in an unrelated file. The rows must still come back, unpruned.
+    createPartitionedType();
+    populate();
+
+    final ResultSet rs = database.query("sql", "SELECT FROM " + TYPE_NAME + " WHERE tenant_id = 'ac'.append('me')");
+    final ExecutionPlan plan = rs.getExecutionPlan().orElseThrow();
+    final GetValueFromIndexEntryStep extract = findIndexExtract(plan);
+    assertThat(extract).isNotNull();
+    assertThat(extract.getFilterBucketIds())
+        .as("a computed value must NOT prune; every bucket must still be visible")
+        .hasSize(BUCKETS);
+
+    int count = 0;
+    while (rs.hasNext()) {
+      assertThat(rs.next().<String>getProperty("tenant_id")).isEqualTo("acme");
+      count++;
+    }
+    rs.close();
+    assertThat(count).isEqualTo(1);
+  }
+
+  @Test
   void flagSuppressesIndexFilterBucketNarrowing() {
     // With the flag set even literal queries must skip pruning; every bucket id remains visible
     // to the index extract step.

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6179EarlyCalculatedModifierTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6179EarlyCalculatedModifierTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6179: {@code BaseExpression.isEarlyCalculated()} classified an expression on its leftmost
+ * term alone and never looked at the modifier chain, so {@code 'Mr.'.append(surname)} was reported
+ * as computable without a record. The planner takes that as licence to use an index and to evaluate
+ * the expression against a {@code null} record, so the record-dependent part silently resolved to
+ * null and the query answered differently depending on whether an index existed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6179EarlyCalculatedModifierTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      final VertexType person = database.getSchema().createVertexType("Person");
+      person.createProperty("fullName", Type.STRING);
+      person.createProperty("surname", Type.STRING);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Person", "fullName");
+
+      final VertexType noIndex = database.getSchema().createVertexType("PersonNoIndex");
+      noIndex.createProperty("fullName", Type.STRING);
+      noIndex.createProperty("surname", Type.STRING);
+    });
+  }
+
+  private void createFixture() {
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Person SET fullName = 'Mr.Smith', surname = 'Smith'");
+      database.command("sql", "INSERT INTO Person SET fullName = 'Mr.Jones', surname = 'Jones'");
+      database.command("sql", "INSERT INTO PersonNoIndex SET fullName = 'Mr.Smith', surname = 'Smith'");
+      database.command("sql", "INSERT INTO PersonNoIndex SET fullName = 'Mr.Jones', surname = 'Jones'");
+    });
+  }
+
+  @Test
+  void aMethodCallOnARecordFieldIsNotEarlyCalculated() {
+    createFixture();
+
+    database.transaction(() -> {
+      // the indexed and the non-indexed type hold the same rows, so both queries must answer the same
+      try (final ResultSet indexed = database.query("sql", "SELECT fullName FROM Person WHERE fullName = 'Mr.'.append(surname)")) {
+        assertThat(indexed.stream().map(r -> r.<String>getProperty("fullName")).toList()).containsExactlyInAnyOrder("Mr.Smith",
+            "Mr.Jones");
+      }
+
+      try (final ResultSet scanned = database.query("sql",
+          "SELECT fullName FROM PersonNoIndex WHERE fullName = 'Mr.'.append(surname)")) {
+        assertThat(scanned.stream().map(r -> r.<String>getProperty("fullName")).toList()).containsExactlyInAnyOrder("Mr.Smith",
+            "Mr.Jones");
+      }
+    });
+  }
+
+  @Test
+  void anIndexIsNotUsedWhenTheRightSideDependsOnTheRecord() {
+    createFixture();
+
+    database.transaction(() -> {
+      try (final ResultSet explain = database.query("sql",
+          "EXPLAIN SELECT fullName FROM Person WHERE fullName = 'Mr.'.append(surname)")) {
+        final String plan = explain.next().getProperty("executionPlanAsString");
+        assertThat(plan).doesNotContain("FETCH FROM INDEX");
+      }
+    });
+  }
+
+  @Test
+  void aCollectionSelectorOnARecordFieldIsNotEarlyCalculated() {
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Person SET fullName = 'b', surname = 'x', idx = 1");
+      database.command("sql", "INSERT INTO PersonNoIndex SET fullName = 'b', surname = 'x', idx = 1");
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet indexed = database.query("sql", "SELECT fullName FROM Person WHERE fullName = ['a','b'][idx]")) {
+        assertThat(indexed.stream().map(r -> r.<String>getProperty("fullName")).toList()).containsExactly("b");
+      }
+
+      try (final ResultSet scanned = database.query("sql", "SELECT fullName FROM PersonNoIndex WHERE fullName = ['a','b'][idx]")) {
+        assertThat(scanned.stream().map(r -> r.<String>getProperty("fullName")).toList()).containsExactly("b");
+      }
+    });
+  }
+
+  @Test
+  void aCaseExpressionOverARecordFieldIsNotEarlyCalculated() {
+    createFixture();
+
+    database.transaction(() -> {
+      final String filter = " WHERE fullName = CASE surname WHEN 'Smith' THEN 'Mr.Smith' ELSE 'nomatch' END";
+
+      try (final ResultSet indexed = database.query("sql", "SELECT fullName FROM Person" + filter)) {
+        assertThat(indexed.stream().map(r -> r.<String>getProperty("fullName")).toList()).containsExactly("Mr.Smith");
+      }
+
+      try (final ResultSet scanned = database.query("sql", "SELECT fullName FROM PersonNoIndex" + filter)) {
+        assertThat(scanned.stream().map(r -> r.<String>getProperty("fullName")).toList()).containsExactly("Mr.Smith");
+      }
+    });
+  }
+
+  /**
+   * The other half of the contract: a function whose arguments need no record stays "early calculated", so an
+   * equality against it is still resolved through the index. Only expressions that reach the record are excluded.
+   */
+  @Test
+  void aFunctionOverLiteralsIsStillEarlyCalculated() {
+    createFixture();
+
+    database.transaction(() -> {
+      try (final ResultSet explain = database.query("sql", "EXPLAIN SELECT fullName FROM Person WHERE fullName = uuid()")) {
+        final String plan = explain.next().getProperty("executionPlanAsString");
+        assertThat(plan).contains("FETCH FROM INDEX");
+      }
+    });
+  }
+
+  @Test
+  void aModifierOverALiteralIsStillEarlyCalculated() {
+    createFixture();
+
+    database.transaction(() -> {
+      try (final ResultSet explain = database.query("sql",
+          "EXPLAIN SELECT fullName FROM Person WHERE fullName = 'Mr.'.append('Smith')")) {
+        final String plan = explain.next().getProperty("executionPlanAsString");
+        assertThat(plan).contains("FETCH FROM INDEX");
+      }
+
+      try (final ResultSet indexed = database.query("sql", "SELECT fullName FROM Person WHERE fullName = 'Mr.'.append('Smith')")) {
+        assertThat(indexed.stream().map(r -> r.<String>getProperty("fullName")).toList()).containsExactly("Mr.Smith");
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6179LiteralExpressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6179LiteralExpressionTest.java
@@ -117,6 +117,28 @@ class Issue6179LiteralExpressionTest extends AbstractParserTest {
   }
 
   @Test
+  void aCaseIsALiteralOnlyWhenEveryBranchIs() {
+    assertThat(rightOperandOf("select from Foo where a = CASE 1 WHEN 1 THEN 'x' ELSE 'y' END").isLiteral()).isTrue();
+    assertThat(rightOperandOf("select from Foo where a = CASE b WHEN 1 THEN 'x' ELSE 'y' END").isLiteral()).isFalse();
+    assertThat(rightOperandOf("select from Foo where a = CASE 1 WHEN 1 THEN b ELSE 'y' END").isLiteral()).isFalse();
+    assertThat(rightOperandOf("select from Foo where a = CASE 1 WHEN 1 THEN 'x' ELSE b END").isLiteral()).isFalse();
+    // the simple form's WHEN is a boolean expression, which carries no constant-ness of its own
+    assertThat(rightOperandOf("select from Foo where a = CASE WHEN 1 = 1 THEN 'x' ELSE 'y' END").isLiteral()).isFalse();
+  }
+
+  @Test
+  void aCaseIsEarlyCalculatedOnlyWhenNoBranchReadsTheRecord() {
+    assertThat(rightOperandOf("select from Foo where a = CASE 1 WHEN 1 THEN 'x' ELSE 'y' END").isEarlyCalculated(
+        context)).isTrue();
+    assertThat(rightOperandOf("select from Foo where a = CASE b WHEN 1 THEN 'x' ELSE 'y' END").isEarlyCalculated(
+        context)).isFalse();
+    assertThat(rightOperandOf("select from Foo where a = CASE 1 WHEN 1 THEN b ELSE 'y' END").isEarlyCalculated(
+        context)).isFalse();
+    assertThat(rightOperandOf("select from Foo where a = CASE WHEN 1 = 1 THEN 'x' ELSE 'y' END").isEarlyCalculated(
+        context)).isFalse();
+  }
+
+  @Test
   void aTraversalMethodIsNotEarlyCalculated() {
     final Expression expression = rightOperandOf("select from Foo where a = 'x'.out('E')");
     assertThat(expression.isEarlyCalculated(context)).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6179LiteralExpressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6179LiteralExpressionTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6179: {@code isEarlyCalculated()} answers "can this be computed without a record", which is not the same
+ * question as "is this a constant". These pin both predicates, and above all the cases where they disagree.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6179LiteralExpressionTest extends AbstractParserTest {
+
+  private final CommandContext context = new BasicCommandContext();
+
+  private Expression rightOperandOf(final String query) {
+    final SelectStatement statement = (SelectStatement) checkRightSyntax(query);
+    final BooleanExpression term = statement.whereClause.flatten().getFirst().subBlocks.getFirst();
+    return ((BinaryCondition) term).right;
+  }
+
+  @Test
+  void aLiteralIsBothEarlyCalculatedAndLiteral() {
+    for (final String literal : new String[] { "1", "'x'", "true", "1 + 2 * 3", "(1 + 2)", "['a', 'b']", "[]", "#12:0" }) {
+      final Expression expression = rightOperandOf("select from Foo where a = " + literal);
+      assertThat(expression.isEarlyCalculated(context)).as(literal).isTrue();
+      assertThat(expression.isLiteral()).as(literal).isTrue();
+    }
+  }
+
+  /**
+   * The one shape where the narrower predicate says yes and the wider one says no: {@code null} is a constant, but
+   * {@code BaseExpression.isEarlyCalculated} has never admitted it, and it must not start to - an index lookup on
+   * a null key is not the same question as the per-record comparison the filter would make.
+   */
+  @Test
+  void theNullLiteralIsALiteralButNotEarlyCalculated() {
+    final Expression expression = rightOperandOf("select from Foo where a = null");
+    assertThat(expression.isLiteral()).isTrue();
+    assertThat(expression.isEarlyCalculated(context)).isFalse();
+  }
+
+  @Test
+  void aPropertyIsNeither() {
+    final Expression expression = rightOperandOf("select from Foo where a = b");
+    assertThat(expression.isEarlyCalculated(context)).isFalse();
+    assertThat(expression.isLiteral()).isFalse();
+  }
+
+  /**
+   * A function call is never a literal, whatever its arguments are. That it stays "early calculated" - the point
+   * of the issue - is pinned where a database is at hand, in {@code Issue6179EarlyCalculatedModifierTest}.
+   */
+  @Test
+  void aFunctionOverLiteralsIsNotALiteral() {
+    for (final String call : new String[] { "uuid()", "sysdate()", "concat('a', 'b')" }) {
+      final Expression expression = rightOperandOf("select from Foo where a = " + call);
+      assertThat(expression.isLiteral()).as(call).isFalse();
+      assertThat(expression.isLiteral(true)).as(call).isFalse();
+    }
+  }
+
+  @Test
+  void anInputParameterIsALiteralOnlyWhenTheCallerSaysSo() {
+    final Expression expression = rightOperandOf("select from Foo where a = :p");
+    assertThat(expression.isEarlyCalculated(context)).isTrue();
+    assertThat(expression.isLiteral()).isFalse();
+    assertThat(expression.isLiteral(true)).isTrue();
+  }
+
+  @Test
+  void aCollectionIsLiteralOnlyWhenEveryItemIs() {
+    assertThat(rightOperandOf("select from Foo where a = ['x', 1]").isLiteral()).isTrue();
+    assertThat(rightOperandOf("select from Foo where a = ['x', b]").isLiteral()).isFalse();
+    assertThat(rightOperandOf("select from Foo where a = ['x', :p]").isLiteral()).isFalse();
+    assertThat(rightOperandOf("select from Foo where a = ['x', :p]").isLiteral(true)).isTrue();
+  }
+
+  @Test
+  void aModifierOverALiteralIsEarlyCalculatedButNotLiteral() {
+    for (final String modified : new String[] { "'x'.append('y')", "[1, 2][0]", "'abc'.substring(1)" }) {
+      final Expression expression = rightOperandOf("select from Foo where a = " + modified);
+      assertThat(expression.isEarlyCalculated(context)).as(modified).isTrue();
+      assertThat(expression.isLiteral()).as(modified).isFalse();
+    }
+  }
+
+  @Test
+  void aModifierReachingTheRecordIsNotEarlyCalculated() {
+    for (final String modified : new String[] { "'x'.append(b)", "[1, 2][b]", "[1, 2][b - 1]", "'x'.append('y').append(b)",
+        "'x'.append(b).append('y')" }) {
+      final Expression expression = rightOperandOf("select from Foo where a = " + modified);
+      assertThat(expression.isEarlyCalculated(context)).as(modified).isFalse();
+      assertThat(expression.isLiteral()).as(modified).isFalse();
+    }
+  }
+
+  @Test
+  void aTraversalMethodIsNotEarlyCalculated() {
+    final Expression expression = rightOperandOf("select from Foo where a = 'x'.out('E')");
+    assertThat(expression.isEarlyCalculated(context)).isFalse();
+    assertThat(expression.isLiteral()).isFalse();
+  }
+}


### PR DESCRIPTION
Closes #6179.

The issue was filed as a contract/naming trap found while implementing #6172, with the note "not a live bug as far as I can tell". It is one: two nodes answer `isEarlyCalculated()` - "can this be computed without a record" - without looking at the part of themselves that reads one.

### The bug

- **`BaseExpression`** judged the expression on its leftmost term alone and never consulted the modifier chain, so `'Mr.'.append(surname)` and `['a','b'][idx]` were reported as record-free. (`isBaseIdentifier()`, twelve lines above, already checks `modifier == null`.)
- **`CaseExpression`** keeps its branches outside `childExpressions`, so `MathExpression`'s inherited walker found an empty list and returned true for a CASE that reads the record on every branch.

The planner takes that answer as licence to resolve the equality through an index and to evaluate the expression against a `null` record, so the record-dependent part silently resolves to null. The query then answers differently depending on whether an index exists. On the fixture in the new test the indexed type returns **no rows** where the identical unindexed type returns two:

```sql
SELECT fullName FROM Person       WHERE fullName = 'Mr.'.append(surname)   -- indexed:   []
SELECT fullName FROM PersonNoIndex WHERE fullName = 'Mr.'.append(surname)  -- scan:      [Mr.Smith, Mr.Jones]
```

The same classification also promotes a per-record `LET` to a global one (`SelectExecutionPlanner.splitLet`), with the same effect.

The fix walks what was skipped: the modifier chain (method-call arguments, array range and index selectors; a suffix reads a property of the value it is applied to, so it still needs no record; a filter or nested projection is never assumed record-free) and every CASE branch. A traversal method (`.out()`, `.in()`, ...) is excluded like `FunctionCall` already excludes traversal functions.

### The contract, written down where it is read

`isEarlyCalculated` says nothing about purity, determinism or constant-ness - any function over literals qualifies, `uuid()` included - and there is no marker anywhere on `SQLFunction` that would say otherwise. That is now in its Javadoc, in `FunctionCall`'s, and in `MethodCall`'s.

A caller that intends to **evaluate** an expression while planning wants a constant instead. `Expression.isLiteral()` is that predicate, raised to the parser from the private walk `PostgresNetworkExecutor` grew in #6172 - which now calls it and drops its copy. The optional `isLiteral(true)` form admits a bound input parameter, for callers whose result does not outlive the execution.

Two plan-time evaluation sites move onto it:

- **partitioned-bucket pruning** binds a partition coordinate only from a literal now. The bucket it derives is baked into the plan, so the value must be fixed for the plan's life and free to compute; a function was neither. The path was safe only because `FunctionCall.isCacheable()` is true for traversals alone - two unrelated predicates in different files happening to line up, exactly the accident the issue flagged. Pruning no longer leans on it, so widening `isCacheable()` later cannot silently break it. The explicit `containsInputParameter()` guard goes with it: `isLiteral()` already excludes parameters.
- **the MATCH index-cost estimate** (`WhereClause.getEqualityOperations`) evaluates literals and bound parameters only, instead of invoking a user function once per planning pass just to sharpen an estimate.

### Tests

- `Issue6179EarlyCalculatedModifierTest` - indexed and unindexed types with identical rows must answer identically for a method call, a collection selector and a CASE over a record field; a modifier over a literal and a function over literals must still be resolved through the index (the contract's other half).
- `Issue6179LiteralExpressionTest` - the two predicates side by side, above all where they disagree: functions and modifiers over literals are early calculated but not literal; a parameter is a literal only for the caller that says so; `null` is the one shape that is a literal but has never been early calculated (an index lookup on a null key is not the filter's question, and must not start to be).
- `PartitionPruningPlannerTest.computedPredicateDoesNotNarrowIndexFilterBuckets` - a computed value no longer prunes, and the rows still come back.

Verified red before / green after for both the modifier and the CASE case. Full engine suite green (11931 tests); `PostgresWJdbcIT` green (44), including the #6172 probe tests that assert `uuid() = 'nomatch'` is not folded.

### Spotted while testing, not touched here

`SELECT FROM Doc WHERE @rid > :p` returns zero rows for a parameter bound either to a RID or to its string form, while the same query with a RID literal answers correctly. Pre-existing and unrelated to this change (`SelectExecutionPlanner.isRidRange` evaluates the right side unguarded); will file separately.