### PR TITLE
fix(#6177): a periodic materialized view can no longer stop refreshing silently, and its test polls instead of sampling once

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -55,7 +55,13 @@ public class MaterializedViewRefresher {
         view.setStatus(MaterializedViewStatus.VALID);
       } while (view.finishRefreshPassAndCheckPending());
 
-    } catch (final Exception e) {
+    } catch (final Throwable e) {
+      // Throwable, not Exception: refresh ownership is held from the tryBeginRefresh() above, and the only
+      // places that give it back are the two releases in this method. Letting an Error past them latched the
+      // view in RUNNING for the life of the database - every later refresh, periodic or manual or incremental,
+      // then found the state machine busy and either coalesced onto a pass that had already died or returned
+      // having done nothing, so the view silently froze at its last successful snapshot. The pass is still
+      // reported as failed and the Error still propagates to the caller; what changes is that the next one can run.
       view.recordRefreshError();
       view.setStatus(MaterializedViewStatus.ERROR);
       // Ownership is released here rather than in a finally: the success path already released it,

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
@@ -59,16 +59,34 @@ public class MaterializedViewScheduler {
         cancel(view.getName());
         return;
       }
-      try {
-        MaterializedViewRefresher.fullRefresh(db, view);
-      } catch (final Exception e) {
-        view.setStatus(MaterializedViewStatus.ERROR);
-        LogManager.instance().log(this, Level.SEVERE,
-            "Error in periodic refresh for view '%s': %s", e, view.getName(), e.getMessage());
-      }
+      runOneRefresh(db, view);
     }, interval, interval, TimeUnit.MILLISECONDS);
 
     tasks.put(view.getName(), future);
+  }
+
+  /**
+   * Runs one periodic pass, and lets nothing out.
+   * <p>
+   * {@code scheduleAtFixedRate} cancels a task PERMANENTLY the first time it throws - no further execution, ever,
+   * and nothing says so - so anything escaping here would stop this view refreshing for the life of the database
+   * while it kept reporting the status of its last successful pass. {@code Throwable} rather than {@code Exception}
+   * because "this view silently stopped refreshing" is a strictly worse outcome than a logged failure, whatever
+   * class the failure belongs to, and because a guard that has to be re-argued every time the refresh path changes
+   * is not a guard. The status is set here as well as in the refresher: an {@code Error} bypasses the refresher's
+   * own bookkeeping in versions of it that do not catch one.
+   * <p>
+   * Extracted from the scheduling above so the guarantee can be tested without waiting out a tick.
+   */
+  // @VisibleForTesting
+  void runOneRefresh(final Database database, final MaterializedViewImpl view) {
+    try {
+      MaterializedViewRefresher.fullRefresh(database, view);
+    } catch (final Throwable e) {
+      view.setStatus(MaterializedViewStatus.ERROR);
+      LogManager.instance().log(this, Level.SEVERE,
+          "Error in periodic refresh for view '%s': %s", e, view.getName(), e.getMessage());
+    }
   }
 
   public void cancel(final String viewName) {

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
@@ -73,8 +73,17 @@ public class MaterializedViewScheduler {
    * while it kept reporting the status of its last successful pass. {@code Throwable} rather than {@code Exception}
    * because "this view silently stopped refreshing" is a strictly worse outcome than a logged failure, whatever
    * class the failure belongs to, and because a guard that has to be re-argued every time the refresh path changes
-   * is not a guard. The status is set here as well as in the refresher: an {@code Error} bypasses the refresher's
-   * own bookkeeping in versions of it that do not catch one.
+   * is not a guard. The status is set here as well as in the refresher because the refresher's own bookkeeping
+   * starts only once it owns the refresh: a failure in the state-machine handover that precedes it - or in any
+   * future work that lands before that try - would otherwise leave the view reporting VALID after a pass that
+   * never ran.
+   * <p>
+   * The deliberate part of the tradeoff: a {@link VirtualMachineError} is swallowed here like anything else, so a
+   * view whose refresh keeps dying of memory pressure keeps retrying every refresh interval and logging, rather
+   * than failing loudly once. That is the intended order of preference - a task cancelled forever with nothing
+   * saying so is the worse outcome, and the retry is paced by the view's own interval rather than a spin - but it
+   * is a choice, not an oversight, and the next person to find this thread busy during an OOM should know it was
+   * made on purpose.
    * <p>
    * Extracted from the scheduling above so the guarantee can be tested without waiting out a tick.
    */

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewConcurrentRefreshTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * A refresh requested while another is already running used to be dropped, which left the view
@@ -100,6 +101,26 @@ class MaterializedViewConcurrentRefreshTest extends TestHelper {
     } finally {
       view.endRefresh();
     }
+  }
+
+  /**
+   * The refresher owns the state machine from {@code tryBeginRefresh()} to one of its two releases, and both used
+   * to sit behind {@code catch (Exception)}. A pass that failed with an {@link Error} therefore left the view
+   * latched in RUNNING for the life of the database: every later refresh found the machine busy and did nothing,
+   * so the view froze at its last successful snapshot while still reporting that snapshot's contents.
+   */
+  @Test
+  void aPassThatFailsWithAnErrorStillReleasesOwnership() {
+    final MaterializedViewImpl view = new ThrowingRefreshView(database, "ErrorPassView",
+        MaterializedViewRefreshMode.MANUAL, 0);
+
+    assertThatThrownBy(() -> MaterializedViewRefresher.fullRefresh(database, view))
+        .as("the failure still reaches the caller").isInstanceOf(ThrowingRefreshView.RefreshFailure.class);
+
+    assertThat(view.getErrorCount()).as("the failed pass is counted").isEqualTo(1);
+    assertThat(view.getStatus()).isEqualTo("ERROR");
+    assertThat(view.tryBeginRefresh()).as("a later refresh must be able to take ownership").isTrue();
+    view.endRefresh();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewEdgeCaseTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewEdgeCaseTest.java
@@ -22,7 +22,10 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -220,7 +223,7 @@ class MaterializedViewEdgeCaseTest extends TestHelper {
   }
 
   @Test
-  void periodicRefreshUpdatesView() throws Exception {
+  void periodicRefreshUpdatesView() {
     database.transaction(() -> {
       database.getSchema().createDocumentType("PeriodicSrc");
       database.getSchema().getType("PeriodicSrc").createProperty("val", Type.INTEGER);
@@ -241,16 +244,39 @@ class MaterializedViewEdgeCaseTest extends TestHelper {
       assertThat(rs.stream().count()).isEqualTo(1);
     }
 
+    final MaterializedView view = database.getSchema().getMaterializedView("PeriodicView");
+    final long refreshesBeforeTheInsert = view.getRefreshCount();
+
     // Add data after view creation
     database.transaction(() ->
       database.newDocument("PeriodicSrc").set("val", 2).save());
 
-    // Wait for the scheduler to trigger a refresh (interval = 200ms, wait 1s)
-    Thread.sleep(1_000);
+    // Wait for the scheduler to pick the row up on its own. A single sample taken a fixed time after the insert
+    // asserts on where the wall clock happened to land: on a loaded runner every one of the refresh periods it
+    // allowed for could pass without the scheduler thread being run, and the test then failed on a condition that
+    // was true a moment later (issue #6177). Polling to a deadline keeps what the test means - the PERIODIC
+    // scheduler refreshes without being asked - and reaches it as soon as it is true, so the generous ceiling
+    // costs nothing on a healthy run.
+    Awaitility.await("the periodic scheduler refreshes the view without being asked")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> {
+          try (final ResultSet rs = database.query("sql", "SELECT FROM PeriodicView")) {
+            assertThat(rs.stream().count())
+                .as("rows in PeriodicView after %d scheduled refresh(es), status=%s, errors=%d",
+                    view.getRefreshCount() - refreshesBeforeTheInsert, view.getStatus(), view.getErrorCount())
+                .isEqualTo(2);
+          }
+        });
 
-    try (final ResultSet rs = database.query("sql", "SELECT FROM PeriodicView")) {
-      assertThat(rs.stream().count()).isEqualTo(2);
-    }
+    // The row arrived because the scheduler ran a refresh, not because something else wrote the backing type:
+    // without this the test would still pass if PERIODIC silently degraded to INCREMENTAL.
+    assertThat(view.getRefreshCount())
+        .as("the scheduler must have run at least one refresh of its own")
+        .isGreaterThan(refreshesBeforeTheInsert);
+    // Not the status: refreshes keep firing every 200ms, so a sample can legitimately land on a BUILDING pass.
+    // The error counter only ever moves on a failed pass, so it says the same thing without the race.
+    assertThat(view.getErrorCount()).as("no scheduled refresh may fail").isZero();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
@@ -20,9 +20,11 @@ package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
@@ -68,6 +70,61 @@ class MaterializedViewSchedulerTest {
 
         assertThat(task.isCancelled()).isTrue();
         assertThat((Object) scheduledTask(scheduler, view.getName())).isNull();
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  /**
+   * {@code scheduleAtFixedRate} cancels a task permanently the first time it throws, so a single failed pass used
+   * to be able to stop a view refreshing for the life of the database with nothing saying so. The tick must
+   * therefore let nothing out, whatever the refresh throws.
+   */
+  @Test
+  void aRefreshThatKeepsFailingKeepsTheScheduleAlive() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      try {
+        // The backing type does not exist, so every pass fails on the TRUNCATE that starts it.
+        final MaterializedViewImpl view = new MaterializedViewImpl(database, "FailingView", "SELECT name FROM Source",
+            "FailingView_backing", List.of("Source"), MaterializedViewRefreshMode.PERIODIC, true, 50);
+
+        scheduler.schedule(database, view);
+        final ScheduledFuture<?> task = scheduledTask(scheduler, view.getName());
+
+        Awaitility.await("the failing refresh runs more than once")
+            .atMost(Duration.ofSeconds(60))
+            .pollInterval(Duration.ofMillis(20))
+            .until(() -> view.getErrorCount() >= 3);
+
+        assertThat(task.isCancelled()).as("a failed pass must not cancel the schedule").isFalse();
+        assertThat(task.isDone()).as("the task must still be pending its next run").isFalse();
+        // Not the status: with a 50ms interval the sample can legitimately land on a pass that has just set
+        // BUILDING. The error counter only ever moves on a failed pass, and it is what the wait above is on.
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  /**
+   * The same guarantee for the failure classes {@code catch (Exception)} never covered, checked without waiting
+   * out a tick.
+   */
+  @Test
+  void anErrorThrownByARefreshDoesNotEscapeTheTick() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      try {
+        final MaterializedViewImpl view = new ThrowingRefreshView(database, "ThrowingView",
+            MaterializedViewRefreshMode.PERIODIC, TimeUnit.HOURS.toMillis(1));
+
+        scheduler.runOneRefresh(database, view);
+
+        assertThat(view.getErrorCount()).as("the failed pass is still counted").isEqualTo(1);
+        assertThat(view.getStatus()).isEqualTo("ERROR");
+        assertThat(view.tryBeginRefresh()).as("the next pass can still take ownership").isTrue();
       } finally {
         scheduler.shutdown();
       }

--- a/engine/src/test/java/com/arcadedb/schema/ThrowingRefreshView.java
+++ b/engine/src/test/java/com/arcadedb/schema/ThrowingRefreshView.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.database.Database;
+
+import java.util.List;
+
+/**
+ * A materialized view whose refresh always fails with an {@link Error}, so the failure walks straight past any
+ * {@code catch (Exception)} on the refresh path. The refresher takes ownership of the view's refresh state machine
+ * before it reads the backing type name, so throwing from there exercises a failure that happens while ownership is
+ * held - the shape that used to leave the view latched as refreshing for the life of the database.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ThrowingRefreshView extends MaterializedViewImpl {
+  /** An {@link Error} rather than an {@link Exception}, which is the whole point of the fixture. */
+  static final class RefreshFailure extends Error {
+    RefreshFailure() {
+      super("refresh failed with an Error");
+    }
+  }
+
+  ThrowingRefreshView(final Database database, final String name, final MaterializedViewRefreshMode refreshMode,
+      final long refreshInterval) {
+    super(database, name, "SELECT value FROM Source", name + "_backing", List.of("Source"), refreshMode, true,
+        refreshInterval);
+  }
+
+  @Override
+  public String getBackingTypeName() {
+    throw new RefreshFailure();
+  }
+}


### PR DESCRIPTION
Closes #6177.

## The flake

`MaterializedViewEdgeCaseTest.periodicRefreshUpdatesView` created a PERIODIC view with a 200ms refresh interval, inserted a row, slept once for 1s and asserted the view held 2 rows. Five refresh periods of slack is generous right up until the runner is loaded enough (this lane runs the whole reactor) that the scheduler thread is not run in any of them, and the test then fails on a condition that is true a moment later.

It now polls to a 60s deadline and returns as soon as the condition holds, so the ceiling costs nothing on a healthy run. Two things improve beyond just removing the flake:

- the failure message carries what it saw - how many scheduled refreshes ran, the view status, the error count - instead of only `expected: 2L but was: 1L`, which is what made triaging the original CI failure cost a round trip;
- it asserts the refresh counter actually moved, so the test can no longer pass on a PERIODIC view that silently degraded into being refreshed by something else.

The rest of the class is MANUAL/INCREMENTAL and has no other wall-clock dependency; `MaterializedViewConcurrentRefreshTest` already polls to a deadline.

## The two ways "not yet" could have been "never"

Chasing what could make a periodic refresh actually not happen turned up two silent single points of failure, both on the same theme - the view stops refreshing and keeps reporting the contents of its last successful pass:

- **`MaterializedViewScheduler`'s tick caught `Exception`.** `scheduleAtFixedRate` cancels a task PERMANENTLY the first time it throws - no further execution, ever, and nothing says so. Anything not an `Exception` escaping the tick therefore stopped that view refreshing for the life of the database. The tick body moves into `runOneRefresh()`, guarded against `Throwable` and callable from a test without waiting out a tick - the shape `HAReplicationMetrics.runGuarded` already uses for the same hazard.

- **`MaterializedViewRefresher.fullRefresh` released refresh ownership only for `Exception`.** It owns the view's refresh state machine from `tryBeginRefresh()` to one of its two releases, both of which sat inside `catch (Exception)`. A pass failing with an `Error` left the view latched in RUNNING for good: every later refresh - periodic, manual or incremental - found the machine busy and either coalesced onto a pass that had already died, or returned having done nothing. The failed pass is still counted, still logged and still rethrown to the caller; what changes is that the next one can run.

## Tests

New, and each verified to fail with the production change reverted (except the first, which is a regression guard for the `Exception` case that already worked):

- `MaterializedViewSchedulerTest.aRefreshThatKeepsFailingKeepsTheScheduleAlive` - a view whose every pass fails keeps its `ScheduledFuture` alive and keeps ticking.
- `MaterializedViewSchedulerTest.anErrorThrownByARefreshDoesNotEscapeTheTick`.
- `MaterializedViewConcurrentRefreshTest.aPassThatFailsWithAnErrorStillReleasesOwnership`.

`ThrowingRefreshView` is the shared fixture for the last two.

Run green: all 7 `MaterializedView*Test` classes (65 tests) including the `slow` lane, the full `com.arcadedb.schema` package (424 tests), and `HTTPMaterializedViewIT`, `Issue3941AsyncRefreshMaterializedViewIT`, `RemoteMaterializedViewIT` under `-Pintegration`. The flaky test was run 8 times consecutively; the class now takes ~0.8s where the single sleep alone cost 1s.

## Follow-up worth its own issue

`MaterializedViewScheduler` holds the database through a `WeakReference` so that an abandoned (never closed) database lets its periodic task self-cancel. Once a refresh has run, the scheduler thread's `DatabaseContext` ThreadLocal holds a strong reference to that database, and a live thread is a GC root - so `dbRef.get()` can never return null again and that path is unreachable in practice. `TimeSeriesMaintenanceScheduler.runMaintenance` removes its context in a `finally` for a related reason. Not touched here: it is a different defect from the one this issue is about.