### PR TITLE
perf(#6133): "are this database's pages flushed?" is an O(1) per-database counter, not a walk of the JVM-wide page index

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2497,11 +2497,17 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
       open = false;
 
-      if (preserveWalForRecovery)
-        // #4928: the give-up close leaves the stuck pages in the shared flush thread's index, referencing a
-        // now-closed database - they can never be flushed once open=false (flushPage early-returns). Purge
-        // them so the JVM-wide flush thread does not leak entries; their content is safe in the preserved WAL.
-        PageManager.INSTANCE.removeModifiedPagesOfDatabase(this);
+      // #4928: the give-up close leaves the stuck pages in the shared flush thread's index, referencing a
+      // now-closed database - they can never be flushed once open=false (flushPage early-returns). Purge them
+      // so the JVM-wide flush thread does not leak entries; their content is safe in the preserved WAL.
+      // #6133: done on EVERY close, not only the give-up one. On a clean close the page purge itself is a
+      // no-op - the wait above proved this database's pipeline empty - but this call is also where the
+      // JVM-wide flush thread FORGETS the database: its suspend and replay-drain locks, its deferred batches,
+      // its flush-progress counter and its pending-page counter are all keyed by the Database instance, as is
+      // the page manager's snapshot barrier monitor. Skipping it on the common path pinned one dead
+      // LocalDatabase (and everything it references) per closed database for the lifetime of
+      // PageManager.INSTANCE, which any process cycling through databases pays forever.
+      PageManager.INSTANCE.removeModifiedPagesOfDatabase(this);
 
       PageManager.INSTANCE.removeAllReadPagesOfDatabase(this);
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2477,6 +2477,10 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       }
 
       if (drop)
+        // NOT redundant with the unconditional purge further down (#6133), and it has to stay BEFORE the wait:
+        // the files of a dropped database are about to be deleted, so its queued pages must leave the pipeline
+        // here or the wait below would sit through a backlog that nobody will ever need on disk. The later call
+        // then finds nothing left to purge and only does the forgetting, which is all a drop still needs from it.
         PageManager.INSTANCE.removeModifiedPagesOfDatabase(this);
 
       // #4928: bounded wait. When it gives up (wedged flush / unwritable disk), this close becomes

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -48,6 +48,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  * visible in the map and decremented AFTER it stops being visible. The count is therefore never lower than the number
  * of indexed pages, so {@code pendingOf() == 0} proves the pipeline is empty (what the barrier and the close path
  * need), while the opposite skew is bounded by a few instructions and costs at worst one extra poll.
+ * <p>
+ * <b>The one thing that rule does NOT cover, and what covers it instead:</b> {@link #removeAllOfDatabase} drops a
+ * database's counter outright, so a {@link #putAll} for that same database running concurrently with it could leave a
+ * page indexed under a counter that is no longer there - undercounting to zero, the "a backup stamps its t0 over a
+ * half-written batch" failure. Nothing in this class prevents that; the exclusion is external and pre-existing.
+ * {@code LocalDatabase.close()/drop()} reaches the purge inside {@code executeInWriteLock}, while every commit that
+ * reaches {@code scheduleFlushOfPages} holds the matching read lock, so no page of a database can enter the index
+ * while that database is being purged from it. Do not call {@link #removeAllOfDatabase} from anywhere that does not
+ * hold that write lock.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -145,7 +154,12 @@ class FlushPageIndex {
     return removed[0];
   }
 
-  /** Drops every pending page of a database, and its counter with them (the database is closing or being dropped). */
+  /**
+   * Drops every pending page of a database, and its counter with them (the database is closing or being dropped).
+   * <p>
+   * Callers must hold the database's exclusive lock - see the class javadoc for why this one method cannot be made
+   * safe against a concurrent {@link #putAll} from inside this class.
+   */
   void removeAllOfDatabase(final BasicDatabase database) {
     pages.keySet().removeIf(pageId -> database.equals(pageId.getDatabase()));
     // Dropped AFTER the pages, never before: the other order would let a page indexed in between survive with a
@@ -175,6 +189,15 @@ class FlushPageIndex {
 
   boolean hasPendingOf(final BasicDatabase database) {
     return pendingOf(database) > 0;
+  }
+
+  /**
+   * Whether a per-database counter is still held for this database: {@code true} between its first pending page and
+   * the {@link #removeAllOfDatabase} of its close or drop. Exists so the regression test of issue #6133 can prove a
+   * clean close forgets the database instead of pinning it as a map key forever.
+   */
+  boolean isTracked(final BasicDatabase database) {
+    return pending.containsKey(database);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -167,7 +167,16 @@ class FlushPageIndex {
     pending.remove(database);
   }
 
-  /** Drops every pending page of a single dropped file. */
+  /**
+   * Drops every pending page of a single dropped file.
+   * <p>
+   * This one still walks the whole JVM-wide index - the shape #6133 removed from the pending count - and that is
+   * deliberate: every caller of {@code PageManager.deleteFile} is a one-off structural operation (dropping a bucket,
+   * an index, a bloom filter, a time-series shard, or the source files of a finished LSM compaction), never a
+   * per-record or per-page path, and the same method goes on to walk the read cache, which is larger than this index
+   * by orders of magnitude. Keep it that way: a caller that dropped files frequently would want a per-database view
+   * here, not this walk.
+   */
   void removeAllOfFile(final BasicDatabase database, final int fileId) {
     // Walked (weakly consistent, never throws) rather than removeIf'd so each removal goes through the accounting.
     for (final PageId pageId : pages.keySet())

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.BasicDatabase;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The index of the pages sitting in the asynchronous flush pipeline: {@code pageId} to the most recent
+ * {@link MutablePage} waiting in the flush queue, deferred by a suspension, or currently being written.
+ * <p>
+ * It answers two questions, and owning both in one place is the whole point of the class (issue #6133):
+ * <ul>
+ * <li><b>"is this exact page pending?"</b> - O(1) on a flat JVM-wide map, the read path of
+ * {@code getCachedPageFromMutablePageInQueue};</li>
+ * <li><b>"does this database still have pages in the pipeline?"</b> - O(1) on a per-database counter, instead of the
+ * walk of the whole JVM-wide map it used to be. That question is polled every 10 ms for the whole duration of a drain
+ * by every close, rename, index compaction, backup suspension and snapshot t0 barrier, and the barrier polls it with
+ * the JVM-wide page-manager lock held, so its cost used to scale with the backlog of every OTHER open database
+ * exactly when that backlog was at its largest.</li>
+ * </ul>
+ * <b>The counter cannot drift, because nothing outside this class can touch the map.</b> That is the reason the index
+ * became a class rather than staying a bare {@code ConcurrentHashMap} with a counter bolted onto its call sites: a
+ * count that drifts HIGH hangs {@code close()} forever on a pipeline that is in fact empty, and one that drifts LOW
+ * lets a backup stamp its t0 over a half-written batch. Every mutation - schedule, flush, dropped file, dropped
+ * database, replay detach - goes through the methods below.
+ * <p>
+ * <b>Ordering rule, where the two are not one atomic step:</b> the counter is incremented BEFORE a page becomes
+ * visible in the map and decremented AFTER it stops being visible. The count is therefore never lower than the number
+ * of indexed pages, so {@code pendingOf() == 0} proves the pipeline is empty (what the barrier and the close path
+ * need), while the opposite skew is bounded by a few instructions and costs at worst one extra poll.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class FlushPageIndex {
+  private final ConcurrentHashMap<PageId, MutablePage>          pages   = new ConcurrentHashMap<>();
+  /**
+   * Number of {@link #pages} entries per database. An entry is created with the database's first pending page and
+   * dropped by {@link #removeAllOfDatabase} (close/drop), so it is bounded by the number of open databases.
+   */
+  private final ConcurrentHashMap<BasicDatabase, AtomicInteger> pending = new ConcurrentHashMap<>();
+
+  /** @return the most recent {@link MutablePage} pending for the page, or {@code null} when none is. */
+  MutablePage get(final PageId pageId) {
+    return pages.get(pageId);
+  }
+
+  boolean containsKey(final PageId pageId) {
+    return pages.containsKey(pageId);
+  }
+
+  /** @return {@code true} when NO database has a page in the pipeline. */
+  boolean isEmpty() {
+    return pages.isEmpty();
+  }
+
+  /** Indexes a batch about to be enqueued. The counter is resolved once for the batch, which is single-database. */
+  void putAll(final List<MutablePage> batch) {
+    BasicDatabase lastDatabase = null;
+    AtomicInteger counter = null;
+    for (int i = 0; i < batch.size(); i++) {
+      final MutablePage page = batch.get(i);
+      final PageId pageId = page.getPageId();
+      final BasicDatabase database = pageId.getDatabase();
+      // Reference comparison on purpose: a batch carries the pages of ONE transaction, so this resolves the map
+      // once per batch, while still staying correct for a hypothetical mixed batch instead of miscounting it.
+      if (database != lastDatabase) {
+        counter = counterOf(database);
+        lastDatabase = database;
+      }
+      counter.incrementAndGet();
+      if (pages.put(pageId, page) != null)
+        // REPLACED A COPY THAT WAS ALREADY COUNTED (A LATER TX SUPERSEDING A PAGE STILL QUEUED, ISSUE #4544)
+        counter.decrementAndGet();
+    }
+  }
+
+  /** Indexes a single page. */
+  void put(final MutablePage page) {
+    final PageId pageId = page.getPageId();
+    final AtomicInteger counter = counterOf(pageId.getDatabase());
+    counter.incrementAndGet();
+    if (pages.put(pageId, page) != null)
+      counter.decrementAndGet();
+  }
+
+  /** @return the {@link MutablePage} that was indexed for the page, or {@code null} when none was. */
+  MutablePage remove(final PageId pageId) {
+    final MutablePage removed = pages.remove(pageId);
+    if (removed != null)
+      release(pageId.getDatabase());
+    return removed;
+  }
+
+  /** Removes every page of a batch, used to roll back an indexing whose enqueue failed. */
+  void removeAll(final List<MutablePage> batch) {
+    for (int i = 0; i < batch.size(); i++)
+      remove(batch.get(i).getPageId());
+  }
+
+  /**
+   * Removes a just-flushed page, but ONLY if the indexed value is still the exact same instance that was flushed. A
+   * later transaction may have queued a NEWER {@link MutablePage} for the same {@link PageId}; that newer entry must
+   * survive so reads keep seeing the latest version.
+   * <p>
+   * Reference identity ({@code indexed == page}) is used here on purpose instead of {@code remove(key, value)}:
+   * {@link BasePage#equals} keys on the mutable {@code version} field, which is an unreliable discriminator for a
+   * hash-map value (issue #4544). The atomic {@code computeIfPresent} guarantees the check-and-remove happens as a
+   * single operation under the same concurrency guarantees as {@code remove(key, value)}.
+   *
+   * @return {@code true} when this instance was the indexed one and was removed.
+   */
+  boolean removeIfSame(final MutablePage page) {
+    final PageId pageId = page.getPageId();
+    // computeIfPresent returns null both when the key was absent and when the mapping was removed, and only the
+    // second may release a count: the holder distinguishes them from inside the map's own atomic section.
+    final boolean[] removed = new boolean[1];
+    pages.computeIfPresent(pageId, (id, indexed) -> {
+      if (indexed != page)
+        return indexed;
+      removed[0] = true;
+      return null;
+    });
+    if (removed[0])
+      release(pageId.getDatabase());
+    return removed[0];
+  }
+
+  /** Drops every pending page of a database, and its counter with them (the database is closing or being dropped). */
+  void removeAllOfDatabase(final BasicDatabase database) {
+    pages.keySet().removeIf(pageId -> database.equals(pageId.getDatabase()));
+    // Dropped AFTER the pages, never before: the other order would let a page indexed in between survive with a
+    // fresh counter that the purge then empties, leaving a count above zero that hangs the close forever.
+    pending.remove(database);
+  }
+
+  /** Drops every pending page of a single dropped file. */
+  void removeAllOfFile(final BasicDatabase database, final int fileId) {
+    // Walked (weakly consistent, never throws) rather than removeIf'd so each removal goes through the accounting.
+    for (final PageId pageId : pages.keySet())
+      if (pageId.getFileId() == fileId && database.equals(pageId.getDatabase()))
+        remove(pageId);
+  }
+
+  /**
+   * How many pages of the database are in the flush pipeline, in O(1) - the point of the whole class.
+   * <p>
+   * Deliberately NOT clamped at zero: a negative value would mean the accounting has a bug, and clamping it would
+   * hide exactly what the regression test of #6133 is there to catch. Every caller treats {@code <= 0} as drained,
+   * so a hypothetical negative behaves like an empty pipeline rather than like a hang.
+   */
+  int pendingOf(final BasicDatabase database) {
+    final AtomicInteger counter = pending.get(database);
+    return counter != null ? counter.get() : 0;
+  }
+
+  boolean hasPendingOf(final BasicDatabase database) {
+    return pendingOf(database) > 0;
+  }
+
+  /**
+   * The same question {@link #pendingOf} answers, computed the expensive way by walking the whole index. Exists only
+   * so the regression test of issue #6133 can prove the counter agrees with the map after every kind of mutation.
+   */
+  int scanPendingOf(final BasicDatabase database) {
+    int count = 0;
+    for (final PageId pageId : pages.keySet())
+      if (database.equals(pageId.getDatabase()))
+        ++count;
+    return count;
+  }
+
+  private AtomicInteger counterOf(final BasicDatabase database) {
+    final AtomicInteger counter = pending.get(database);
+    return counter != null ? counter : pending.computeIfAbsent(database, k -> new AtomicInteger());
+  }
+
+  private void release(final BasicDatabase database) {
+    final AtomicInteger counter = pending.get(database);
+    if (counter != null)
+      counter.decrementAndGet();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -78,12 +78,14 @@ public class PageManagerFlushThread extends Thread {
   private final        ConcurrentHashMap<Database, Object>                      replayDrainLocks    = new ConcurrentHashMap<>();
 
   /**
-   * O(1) index: pageId → most recent MutablePage in the flush queue or currently being flushed.
+   * O(1) index: pageId → most recent MutablePage in the flush queue or currently being flushed, plus the O(1)
+   * per-database count of those entries the drains poll (issue #6133 - see {@link FlushPageIndex}).
    * <p>
-   * Package-private (instead of private) so the white-box regression test for issue #4544 can set up
-   * and assert on entries directly.
+   * Package-private (instead of private) so the white-box regression tests for issues #4544 and #6133 can set up
+   * and assert on entries directly. Every mutation must go through its methods: the pending-page count is
+   * maintained there and nowhere else.
    */
-  final                ConcurrentHashMap<PageId, MutablePage> pageIndex = new ConcurrentHashMap<>();
+  final                FlushPageIndex                         pageIndex = new FlushPageIndex();
 
   /**
    * Maximum bytes of dirty pages that may sit deferred (in {@link #deferredByDatabase}) while flushing is
@@ -149,8 +151,7 @@ public class PageManagerFlushThread extends Thread {
 
     // Index pages BEFORE enqueueing so that getCachedPageFromMutablePageInQueue()
     // can find them even if the queue.offer() hasn't completed yet.
-    for (final MutablePage page : pages)
-      pageIndex.put(page.getPageId(), page);
+    pageIndex.putAll(pages);
 
     // TRY TO INSERT THE PAGE IN THE QUEUE UNTIL THE THREAD IS STILL RUNNING
     while (running) {
@@ -159,8 +160,7 @@ public class PageManagerFlushThread extends Thread {
     }
 
     // Failed to enqueue (shutdown in progress) — remove from index
-    for (final MutablePage page : pages)
-      pageIndex.remove(page.getPageId());
+    pageIndex.removeAll(pages);
 
     LogManager.instance()
         .log(this, Level.SEVERE, "Error on flushing pages %s during shutdown of the database (running=%s queue=%d)", pages, running,
@@ -213,9 +213,9 @@ public class PageManagerFlushThread extends Thread {
     long lastFlushed = flushedCounter.get();
     long lastProgressAt = System.currentTimeMillis();
     while (true) {
-      final int pending = countPendingPagesOfDatabase(database, false);
+      final int pending = pageIndex.pendingOf(database);
 
-      if (pending == 0)
+      if (pending <= 0)
         return true;
 
       final long now = System.currentTimeMillis();
@@ -372,7 +372,7 @@ public class PageManagerFlushThread extends Thread {
    * committer can queue a page.
    */
   boolean hasPendingPagesOfDatabase(final Database database) {
-    return countPendingPagesOfDatabase(database, true) > 0;
+    return pageIndex.hasPendingOf(database);
   }
 
   /**
@@ -385,10 +385,12 @@ public class PageManagerFlushThread extends Thread {
    * flush thread wedged on a dead disk must not be able to hold the global lock for the 60 s the progress-based
    * timeout allows, which would stall every committer of every database in the JVM.
    * <p>
-   * Polls at 1 ms rather than spinning, deliberately: {@link #countPendingPagesOfDatabase} walks the JVM-WIDE
-   * {@link #pageIndex}, so a spin loop would turn one cheap check into hundreds of O(n) scans of a map whose size
-   * grows with exactly the backlog that makes this wait non-trivial in the first place - and all of them under the
-   * global lock. One extra millisecond in the rare case where a page IS in flight is the better trade.
+   * Polls at 1 ms rather than spinning. The check itself is now O(1) (issue #6133 - it used to walk the JVM-wide
+   * {@link #pageIndex}, so a spin turned one cheap check into hundreds of scans of a map whose size grows with
+   * exactly the backlog that makes this wait non-trivial, all of them under the global lock), but what a spin would
+   * be waiting for has not changed: a page reaching the disk, which is a synchronous file write away and orders of
+   * magnitude longer than any sane spin. One extra millisecond in the rare case where a page IS in flight is still
+   * the better trade than burning a core under a JVM-wide lock.
    *
    * @return {@code true} when the pipeline emptied, {@code false} when the deadline expired first (the caller
    *     proceeds with a t0 that may sit slightly behind the last committed transaction, and says so).
@@ -439,22 +441,6 @@ public class PageManagerFlushThread extends Thread {
           Thread.currentThread().interrupt();
       }
     }
-  }
-
-  /**
-   * Pages of the database still anywhere in the flush pipeline.
-   *
-   * @param stopAtFirst return as soon as one is found, for the callers that only need the boolean
-   */
-  private int countPendingPagesOfDatabase(final Database database, final boolean stopAtFirst) {
-    int pending = 0;
-    for (final PageId key : pageIndex.keySet())
-      if (database.equals(key.getDatabase())) {
-        ++pending;
-        if (stopAtFirst)
-          return pending;
-      }
-    return pending;
   }
 
   public void waitForCurrentFlushToComplete(final Database database) throws InterruptedException {
@@ -680,16 +666,10 @@ public class PageManagerFlushThread extends Thread {
 
   /**
    * Removes a just-flushed page from the {@link #pageIndex}, but ONLY if the indexed value is still the
-   * exact same instance that was flushed. A later transaction may have queued a NEWER {@link MutablePage}
-   * for the same {@link PageId}; that newer entry must survive so reads keep seeing the latest version.
-   * <p>
-   * Reference identity ({@code indexed == page}) is used here on purpose instead of {@code remove(key, value)}:
-   * {@link BasePage#equals} keys on the mutable {@code version} field, which is an unreliable discriminator
-   * for a hash-map value (issue #4544). The atomic {@code computeIfPresent} guarantees the check-and-remove
-   * happens as a single operation under the same concurrency guarantees as {@code remove(key, value)}.
+   * exact same instance that was flushed (issue #4544 - see {@link FlushPageIndex#removeIfSame}).
    */
   void removeFromFlushIndex(final MutablePage page) {
-    pageIndex.computeIfPresent(page.getPageId(), (id, indexed) -> indexed == page ? null : indexed);
+    pageIndex.removeIfSame(page);
   }
 
   /** Sum of the in-RAM size of every page in a deferred batch, used to bound the deferred backlog (issue #4728). */
@@ -722,8 +702,8 @@ public class PageManagerFlushThread extends Thread {
           pagesToFlush.pages.clear();
         }
 
-    // Also clean index entries for pages currently being flushed
-    pageIndex.entrySet().removeIf(e -> database.equals(e.getKey().getDatabase()));
+    // Also clean index entries for pages currently being flushed, and forget the database's pending count with them
+    pageIndex.removeAllOfDatabase(database);
 
     // Forget the per-database suspend bookkeeping so the dropped Database instance (and the resources it
     // pins) can be garbage collected instead of being retained for the flush thread's lifetime as a map key.
@@ -755,8 +735,7 @@ public class PageManagerFlushThread extends Thread {
         deferredRAMBytes.addAndGet(-removePagesOfFileFromBatch(pagesToFlush, database, fileId));
 
     // Finally clean any index entry for a page currently being flushed.
-    pageIndex.entrySet()
-        .removeIf(e -> database.equals(e.getKey().getDatabase()) && e.getKey().getFileId() == fileId);
+    pageIndex.removeAllOfFile(database, fileId);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/FlushRobustnessTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FlushRobustnessTest.java
@@ -82,8 +82,8 @@ class FlushRobustnessTest extends TestHelper {
     final int healthyPageNum = healthyBucket.getTotalPages();
     final PageId healthyPageId = new PageId(db, healthyBucket.getFileId(), healthyPageNum);
     final MutablePage healthyPage = new MutablePage(healthyPageId, pageSize, new byte[pageSize], 0, 0);
-    flush.pageIndex.put(brokenPageId, brokenPage);
-    flush.pageIndex.put(healthyPageId, healthyPage);
+    flush.pageIndex.put(brokenPage);
+    flush.pageIndex.put(healthyPage);
     flush.queue.offer(new PagesToFlush(List.of(brokenPage, healthyPage)));
 
     // #4928: the broken page's IOException must be contained: the batch continues, the healthy page reaches
@@ -95,7 +95,7 @@ class FlushRobustnessTest extends TestHelper {
     // re-reading getTotalPages() here would inflate the expectation past what was written.
     assertThat(healthyOnDisk.getSize()).as("the healthy page of the batch must still be flushed (#4928)")
         .isGreaterThanOrEqualTo((long) (healthyPageNum + 1) * pageSize);
-    assertThat(flush.pageIndex).as("no page may leak in the flush index (#4928)").isEmpty();
+    assertThat(flush.pageIndex.isEmpty()).as("no page may leak in the flush index (#4928)").isTrue();
 
     // #4930: the reopen path must NOT have re-created the dropped file on disk.
     assertThat(brokenOsFile).as("a dropped file must not be resurrected by the channel-reopen path (#4930)")
@@ -109,7 +109,7 @@ class FlushRobustnessTest extends TestHelper {
     final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, db.getConfiguration());
     // A pending entry that nothing will ever flush (the thread is never started): zero progress by design.
     final PageId stuckPageId = new PageId(db, 0, 3_000_000);
-    flush.pageIndex.put(stuckPageId, new MutablePage(stuckPageId, 1024, new byte[1024], 0, 0));
+    flush.pageIndex.put(new MutablePage(stuckPageId, 1024, new byte[1024], 0, 0));
 
     // The no-progress window is read per call from the database's own configuration.
     db.getConfiguration().setValue(GlobalConfiguration.FLUSH_ALL_PAGES_TIMEOUT, 300L);
@@ -144,8 +144,7 @@ class FlushRobustnessTest extends TestHelper {
       // Wedge the close: a pending page nothing will ever flush, and a short no-progress window.
       db.getConfiguration().setValue(GlobalConfiguration.FLUSH_ALL_PAGES_TIMEOUT, 300L);
       stuckPageId = new PageId(db, 0, 3_000_000);
-      PageManager.INSTANCE.getFlushThread().pageIndex
-          .put(stuckPageId, new MutablePage(stuckPageId, 1024, new byte[1024], 0, 0));
+      PageManager.INSTANCE.getFlushThread().pageIndex.put(new MutablePage(stuckPageId, 1024, new byte[1024], 0, 0));
 
       // #4928: the close must COMPLETE (bounded wait), and because pages could not be flushed it must be
       // crash-equivalent: WAL files and lock file preserved so the next open recovers.

--- a/engine/src/test/java/com/arcadedb/engine/Issue4544FlushIndexIdentityTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4544FlushIndexIdentityTest.java
@@ -59,7 +59,7 @@ class Issue4544FlushIndexIdentityTest extends TestHelper {
     final MutablePage newer = new MutablePage(pageId, 1024, new byte[1024], 6, 0);
 
     // A later transaction has queued the newer page: it is the current value in the flush index.
-    flush.pageIndex.put(pageId, newer);
+    flush.pageIndex.put(newer);
 
     // Both pages share the same PageId, so they always compare equal under BasePage.equals (which keys on
     // pageId only, see #4722). A value-based remove(key, value) would therefore happily evict the newer entry
@@ -83,7 +83,7 @@ class Issue4544FlushIndexIdentityTest extends TestHelper {
     final PageId pageId = new PageId(database, 4, 2);
     final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 9, 0);
 
-    flush.pageIndex.put(pageId, page);
+    flush.pageIndex.put(page);
     flush.removeFromFlushIndex(page);
 
     assertThat(flush.pageIndex.containsKey(pageId)).isFalse();

--- a/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
@@ -77,7 +77,7 @@ class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
     // Reproduce the state a page is in between commit and flush: published in the flush thread's index (so reads
     // resolve it from there) while the disk still holds the same version.
     final MutablePage pending = page.modify();
-    pageManager.getFlushThread().pageIndex.put(pageId, pending);
+    pageManager.getFlushThread().pageIndex.put(pending);
 
     // Replicated/recovery WAL entry bumping the page by one version.
     final WALFile.WALPage walPage = new WALFile.WALPage();

--- a/engine/src/test/java/com/arcadedb/engine/Issue6133PendingPagesPerDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6133PendingPagesPerDatabaseTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6133.
+ * <p>
+ * "Does this database still have pages in the flush pipeline?" used to be answered by walking the JVM-WIDE flush index
+ * and comparing every key's database, so the cost of the question scaled with the backlog of every OTHER open database
+ * - and the question is polled every 10 ms for the whole duration of a drain by close, rename, index compaction,
+ * backup suspension and the snapshot t0 barrier, the last of which polls it holding the JVM-wide page-manager lock.
+ * The answer is now an O(1) per-database counter maintained inside {@link FlushPageIndex}.
+ * <p>
+ * A counter is only as good as its exactness, which is what this test is about: one that drifts HIGH hangs
+ * {@code close()} forever on a pipeline that is in fact empty, and one that drifts LOW lets a backup stamp its t0 over
+ * a half-written batch. Every route a page can take OUT of the pipeline is exercised below - flushed (with and without
+ * a newer instance superseding it), explicitly removed by the replay detach, purged with its file, purged with its
+ * database - and after each one the counter is compared against the brute-force scan it replaced.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6133PendingPagesPerDatabaseTest extends TestHelper {
+  private static final int PAGE_SIZE = 1024;
+
+  /**
+   * Every mutation of the index keeps the per-database count in agreement with the map, and the two databases account
+   * for their pages independently.
+   */
+  @Test
+  void everyRouteOutOfThePipelineKeepsTheCountExact() {
+    final DatabaseInternal db1 = (DatabaseInternal) database;
+    final Database db2 = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-sibling");
+    try {
+      final FlushPageIndex index = new FlushPageIndex();
+
+      // db1: 5 pages on file 7, 3 on file 8. db2: 4 pages on file 7 - a same-numbered file of another database must
+      // not be confused with db1's, which is the whole point of keying the count by database.
+      final List<MutablePage> file7 = pages(db1, 7, 5);
+      final List<MutablePage> file8 = pages(db1, 8, 3);
+      final List<MutablePage> sibling = pages((DatabaseInternal) db2, 7, 4);
+      index.putAll(file7);
+      index.putAll(file8);
+      index.putAll(sibling);
+      assertCountsAgree(index, db1, 8);
+      assertCountsAgree(index, db2, 4);
+
+      // A later transaction supersedes a page still queued (the two-instance case of #4544): the index holds ONE
+      // entry for that pageId, so the count must not grow.
+      final MutablePage superseded = file7.getFirst();
+      final MutablePage newer = new MutablePage(superseded.getPageId(), PAGE_SIZE, new byte[PAGE_SIZE], 1, 0);
+      index.put(newer);
+      assertCountsAgree(index, db1, 8);
+
+      // The superseded copy reaching the disk must NOT release the entry - it still belongs to the newer instance,
+      // which is still pending - nor its count.
+      assertThat(index.removeIfSame(superseded)).as("a superseded copy must not evict the newer entry").isFalse();
+      assertCountsAgree(index, db1, 8);
+
+      // The indexed instance reaching the disk releases both.
+      assertThat(index.removeIfSame(newer)).isTrue();
+      assertCountsAgree(index, db1, 7);
+
+      // Flushing a page that is not indexed at all (already superseded AND already dropped) releases nothing.
+      assertThat(index.removeIfSame(newer)).isFalse();
+      assertCountsAgree(index, db1, 7);
+
+      // The replay detach takes a copy out by pageId.
+      assertThat(index.remove(file8.getFirst().getPageId())).isSameAs(file8.getFirst());
+      assertCountsAgree(index, db1, 6);
+      assertThat(index.remove(file8.getFirst().getPageId())).as("a second detach of the same page finds nothing").isNull();
+      assertCountsAgree(index, db1, 6);
+
+      // A dropped file purges its pages, and only its own: db2's file 7 is a different file.
+      index.removeAllOfFile(db1, 7);
+      assertCountsAgree(index, db1, 2);
+      assertCountsAgree(index, db2, 4);
+
+      // A dropped/closed database purges the rest, and forgets its counter with them.
+      index.removeAllOfDatabase(db1);
+      assertCountsAgree(index, db1, 0);
+      assertCountsAgree(index, db2, 4);
+      assertThat(index.isEmpty()).isFalse();
+
+      index.removeAllOfDatabase(db2);
+      assertCountsAgree(index, db2, 0);
+      assertThat(index.isEmpty()).as("the index is empty once both databases are gone").isTrue();
+    } finally {
+      db2.drop();
+    }
+  }
+
+  /**
+   * The count a drain polls is this database's own: a sibling database with a large backlog in the same JVM-wide
+   * pipeline must neither be counted into it nor make the drain wait for it.
+   */
+  @Test
+  void aSiblingBacklogIsNeitherCountedNorWaitedFor() throws Exception {
+    final DatabaseInternal db1 = (DatabaseInternal) database;
+    final Database db2 = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-backlog");
+    try {
+      // Constructing the flush thread directly does NOT start the background thread (that happens in
+      // PageManager.startup()), so the pipeline can be loaded up deterministically and never drains.
+      final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, db1.getConfiguration());
+
+      final int backlog = 50_000;
+      flush.pageIndex.putAll(pages((DatabaseInternal) db2, 3, backlog));
+
+      assertThat(flush.pageIndex.pendingOf(db2)).isEqualTo(backlog);
+      assertThat(flush.hasPendingPagesOfDatabase(db2)).isTrue();
+      assertThat(flush.pageIndex.pendingOf(db1)).as("a sibling's backlog is not this database's").isZero();
+      assertThat(flush.hasPendingPagesOfDatabase(db1)).isFalse();
+
+      // The drain of db1 returns immediately even though the pipeline is far from empty.
+      assertThat(flush.waitAllPagesOfDatabaseAreFlushed(db1)).isTrue();
+      assertThat(flush.waitPendingPagesOfDatabaseUntil(db1, System.currentTimeMillis() + 1_000)).isTrue();
+
+      // One page of db1 in flight is enough for the same drain to report the pipeline busy.
+      final MutablePage own = pages(db1, 3, 1).getFirst();
+      flush.pageIndex.put(own);
+      assertThat(flush.hasPendingPagesOfDatabase(db1)).isTrue();
+      assertThat(flush.waitPendingPagesOfDatabaseUntil(db1, System.currentTimeMillis() + 50)).isFalse();
+
+      flush.removeFromFlushIndex(own);
+      assertThat(flush.hasPendingPagesOfDatabase(db1)).isFalse();
+
+      flush.pageIndex.removeAllOfDatabase(db2);
+      assertThat(flush.pageIndex.isEmpty()).isTrue();
+    } finally {
+      db2.drop();
+    }
+  }
+
+  /**
+   * The accounting survives real contention. Each thread owns a disjoint page range and drives it through the whole
+   * life cycle - queued, superseded by a later transaction, flushed, detached - so any lost update in the counter
+   * shows up as a disagreement with the map once the threads are joined and the index is quiescent again. It is
+   * asserted quiescent on purpose: a comparison sampled WHILE the mutations run proves nothing either way, because
+   * the two reads straddle other threads' mutations.
+   */
+  @Test
+  void theCountSurvivesConcurrentMutation() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final FlushPageIndex index = new FlushPageIndex();
+
+    final int threads = 8;
+    final int perThread = 2_000;
+    final CountDownLatch start = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread[] workers = new Thread[threads];
+
+    for (int t = 0; t < threads; t++) {
+      final int id = t;
+      workers[t] = new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < perThread; i++) {
+            final PageId pageId = new PageId(db, 100 + id, i);
+            final MutablePage queued = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+            index.put(queued);
+            // A later transaction supersedes it while it is still queued: one entry, still one page pending.
+            final MutablePage newer = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 1, 0);
+            index.put(newer);
+            // The superseded copy reaches the disk first and must release nothing...
+            index.removeIfSame(queued);
+            // ...then the indexed one leaves, by the flush on even pages and by the replay detach on odd ones.
+            if (i % 2 == 0)
+              index.removeIfSame(newer);
+            else
+              index.remove(pageId);
+          }
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6133-mutator-" + t);
+      workers[t].start();
+    }
+
+    start.countDown();
+    for (final Thread worker : workers)
+      worker.join(TimeUnit.MINUTES.toMillis(2));
+
+    assertThat(failure.get()).isNull();
+    assertCountsAgree(index, db, 0);
+    assertThat(index.isEmpty()).isTrue();
+  }
+
+  /**
+   * The end-to-end invariant on the real pipeline: after a burst of concurrent commits the count settles at exactly
+   * zero, in agreement with the map. A count left ABOVE zero here is a close() that would never return; one left
+   * BELOW is a backup free to stamp its t0 over a page still on its way to the disk.
+   */
+  @Test
+  void theCountSettlesAtZeroAfterConcurrentCommits() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getSchema().createDocumentType("Doc");
+
+    final FlushPageIndex index = PageManager.INSTANCE.getFlushThread().pageIndex;
+
+    final Thread[] writers = new Thread[4];
+    for (int t = 0; t < writers.length; t++) {
+      final int id = t;
+      writers[t] = new Thread(() -> {
+        for (int i = 0; i < 250; i++) {
+          final int value = i;
+          db.transaction(() -> db.newDocument("Doc").set("writer", id).set("v", value).save());
+        }
+      }, "issue6133-writer-" + t);
+      writers[t].start();
+    }
+    for (final Thread writer : writers)
+      writer.join(TimeUnit.MINUTES.toMillis(2));
+
+    assertThat(PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
+    assertThat(index.pendingOf(db)).as("everything reached the disk, so nothing is pending").isZero();
+    assertThat(index.scanPendingOf(db)).isZero();
+  }
+
+  private static List<MutablePage> pages(final DatabaseInternal database, final int fileId, final int total) {
+    final List<MutablePage> pages = new ArrayList<>(total);
+    for (int i = 0; i < total; i++) {
+      final PageId pageId = new PageId(database, fileId, 1_000_000 + i);
+      pages.add(new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0));
+    }
+    return pages;
+  }
+
+  private static void assertCountsAgree(final FlushPageIndex index, final Database database, final int expected) {
+    assertThat(index.pendingOf(database)).as("pending count of '%s'", database.getName()).isEqualTo(expected);
+    assertThat(index.scanPendingOf(database)).as("scan of the index for '%s'", database.getName()).isEqualTo(expected);
+  }
+
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6133PendingPagesPerDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6133PendingPagesPerDatabaseTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.engine;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import org.junit.jupiter.api.Test;
 
@@ -242,6 +243,43 @@ class Issue6133PendingPagesPerDatabaseTest extends TestHelper {
     assertThat(PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(db)).isTrue();
     assertThat(index.pendingOf(db)).as("everything reached the disk, so nothing is pending").isZero();
     assertThat(index.scanPendingOf(db)).isZero();
+  }
+
+  /**
+   * A plain, successful close must make the JVM-wide flush thread forget the database, not just drain it.
+   * <p>
+   * The purge that clears the per-database bookkeeping - the pending-page counter added here, and with it the
+   * pre-existing suspend locks, deferred batches and flush-progress counter - used to run only when the close was a
+   * DROP or when the flush wait gave up. On the common path nothing cleared them, so every closed database stayed
+   * pinned as a map key for the life of {@code PageManager.INSTANCE}: one dead {@code LocalDatabase}, and everything
+   * it references, per close, without bound.
+   */
+  @Test
+  void aCleanCloseForgetsTheDatabase() {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-close";
+    final PageManagerFlushThread flush = PageManager.INSTANCE.getFlushThread();
+
+    final DatabaseInternal closed = (DatabaseInternal) TestHelper.createDatabase(path);
+    try {
+      closed.getSchema().createDocumentType("Doc");
+      closed.transaction(() -> closed.newDocument("Doc").set("v", 1).save());
+      // Both entries exist now: the counter from the commit, the progress counter from the wait below.
+      assertThat(PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(closed)).isTrue();
+      assertThat(flush.pageIndex.isTracked(closed)).isTrue();
+      assertThat(flush.flushedPagesPerDatabase).containsKey(closed);
+
+      closed.close();
+
+      assertThat(flush.pageIndex.isTracked(closed))
+          .as("a clean close must release the pending-page counter, not pin the closed database as its key").isFalse();
+      assertThat(flush.flushedPagesPerDatabase)
+          .as("and the flush-progress counter with it").doesNotContainKey(closed);
+      assertThat(flush.pageIndex.scanPendingOf(closed)).isZero();
+    } finally {
+      if (closed.isOpen())
+        closed.close();
+      new DatabaseFactory(path).open().drop();
+    }
   }
 
   private static List<MutablePage> pages(final DatabaseInternal database, final int fileId, final int total) {

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
@@ -59,7 +59,7 @@ class PageManagerFlushSuspendBackpressureTest extends TestHelper {
     for (int i = 0; i < batches; i++) {
       final PageId pageId = new PageId(database, 9, i);
       final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
-      flush.pageIndex.put(pageId, page);
+      flush.pageIndex.put(page);
       flush.queue.offer(new PagesToFlush(List.of(page)));
     }
 
@@ -91,7 +91,7 @@ class PageManagerFlushSuspendBackpressureTest extends TestHelper {
     for (int i = 0; i < batches; i++) {
       final PageId pageId = new PageId(database, 9, i);
       final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
-      flush.pageIndex.put(pageId, page);
+      flush.pageIndex.put(page);
       flush.queue.offer(new PagesToFlush(List.of(page)));
     }
 

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendDeferRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendDeferRaceTest.java
@@ -91,7 +91,7 @@ class PageManagerFlushSuspendDeferRaceTest extends TestHelper {
     final PageId pageId = new PageId(database, 999_888, 1);
     final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 0, 0);
     final PagesToFlush batch = new PagesToFlush(List.of(page));
-    flush.pageIndex.put(pageId, page);
+    flush.pageIndex.put(page);
     flush.queue.offer(batch);
 
     final Thread flusher = new Thread(() -> {

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
@@ -179,7 +179,7 @@ class PageManagerFlushSuspendRefCountTest extends TestHelper {
       final PageId pageId = new PageId(database, 999_888, 0);
       final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 0, 0);
       final PagesToFlush batch = new PagesToFlush(List.of(page));
-      flush.pageIndex.put(pageId, page);
+      flush.pageIndex.put(page);
       flush.queue.offer(batch);
       flush.flushPagesFromQueueToDisk(null, 1_000L);
       assertThat(flush.queue).isEmpty(); // THE BATCH WAS DEFERRED, NOT LEFT IN THE QUEUE

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushThreadInterruptTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushThreadInterruptTest.java
@@ -60,7 +60,7 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
 
     final PageId pageId = new PageId(db, fileId, pageNum);
     final MutablePage page = new MutablePage(pageId, pageSize, new byte[pageSize], 0, 0);
-    flush.pageIndex.put(pageId, page);
+    flush.pageIndex.put(page);
     flush.queue.offer(new PagesToFlush(List.of(page)));
 
     // Occupy the page's I/O slot so the flush thread spins inside concurrentPageAccess (where the interrupt
@@ -95,7 +95,7 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
     assertThat(file.getSize()).as("interrupted flush must still write the page before shutting down")
         .isGreaterThanOrEqualTo((long) (pageNum + 1) * pageSize);
-    assertThat(flush.pageIndex).as("no page may leak in the flush index").isEmpty();
+    assertThat(flush.pageIndex.isEmpty()).as("no page may leak in the flush index").isTrue();
   }
 
   @Test
@@ -121,8 +121,8 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
     final MutablePage blockedPage = new MutablePage(blockedPageId, pageSize, new byte[pageSize], 0, 0);
     final PageId freePageId = new PageId(db, fileId, pageNum);
     final MutablePage freePage = new MutablePage(freePageId, pageSize, new byte[pageSize], 0, 0);
-    flush.pageIndex.put(blockedPageId, blockedPage);
-    flush.pageIndex.put(freePageId, freePage);
+    flush.pageIndex.put(blockedPage);
+    flush.pageIndex.put(freePage);
     flush.queue.offer(new PagesToFlush(List.of(blockedPage, freePage)));
 
     final Field pendingField = PageManager.class.getDeclaredField("pendingFlushPages");
@@ -152,7 +152,7 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
     assertThat(file.getSize()).as("the rest of the batch must still be flushed after a double fault")
         .isGreaterThanOrEqualTo((long) (pageNum + 1) * pageSize);
-    assertThat(flush.pageIndex).as("no page may leak in the flush index (a leak hangs the database close)").isEmpty();
+    assertThat(flush.pageIndex.isEmpty()).as("no page may leak in the flush index (a leak hangs the database close)").isTrue();
   }
 
   /**
@@ -184,7 +184,7 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
 
     final PageId pageId = new PageId(db, fileId, pageNum);
     final MutablePage page = new MutablePage(pageId, pageSize, new byte[pageSize], 0, 0);
-    flush.pageIndex.put(pageId, page);
+    flush.pageIndex.put(page);
     flush.queue.offer(new PagesToFlush(List.of(page)));
 
     // Drive the (unstarted) flush thread by hand: with the database suspended, the batch is deferred.
@@ -204,6 +204,6 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
     assertThat(file.getSize()).as("deferred page must still be written despite the caller's interrupt")
         .isGreaterThanOrEqualTo((long) (pageNum + 1) * pageSize);
-    assertThat(flush.pageIndex).as("no page may leak in the flush index").isEmpty();
+    assertThat(flush.pageIndex.isEmpty()).as("no page may leak in the flush index").isTrue();
   }
 }


### PR DESCRIPTION
Fixes #6133.

## The problem

`PageManagerFlushThread.countPendingPagesOfDatabase` answered "does this database still have pages in the flush pipeline?" by walking the **JVM-wide** `pageIndex` - every pending page of every open database - and comparing each key's database.

`waitAllPagesOfDatabaseAreFlushed` calls it in a 10 ms poll loop for the whole duration of the drain, with `stopAtFirst = false` so it never short-circuits, and every close, rename, index compaction, backup suspension and (since #6125) snapshot t0 barrier goes through that loop. The cost of asking the question therefore scaled with the total backlog across all databases, and the answer is needed most often exactly when that backlog is large. The barrier's residual drain polls it with the JVM-wide page-manager lock held, so every committer of every database in the process waits behind those scans.

## The fix

The index becomes a class, `FlushPageIndex`, that owns the flat `pageId -> MutablePage` map **and** a per-database count of its entries. `pendingOf(database)` is one `ConcurrentHashMap.get` plus one `AtomicInteger.get`.

**Why a class and not a counter bolted onto the call sites.** The issue calls out the real risk: a count that drifts HIGH hangs `close()` forever on a pipeline that is in fact empty, and one that drifts LOW lets a backup stamp its t0 over a half-written batch. The removal sites are spread across `removeFromFlushIndex` (conditional on reference identity, the #4544 two-instance case), `removeAllPagesOfDatabase`, `removeAllPagesOfFile`, `removePagesOfFileFromBatch` and `detachPendingPages`, plus the white-box tests that fabricate pipeline state directly. Making the map private to a class means the counter cannot drift by construction: there is no way to mutate the index that does not go through the accounting.

**Ordering, where the map mutation and the count are not one atomic step.** The count is raised BEFORE a page becomes visible in the map and lowered AFTER it stops being visible. It is therefore never below the number of indexed pages, so `pendingOf() == 0` proves the pipeline is empty - which is what the barrier and the close path actually need - while the opposite skew is bounded by a few instructions and costs at worst one extra 10 ms poll. It is deliberately not clamped at zero either: a negative value would mean the accounting has a bug, and clamping would hide precisely what the regression test exists to catch. Every caller reads `<= 0` as drained, so a hypothetical negative degrades to "empty pipeline", never to a hang.

The 1 ms poll in `waitPendingPagesOfDatabaseUntil` is kept: the check is now cheap, but what a spin would be waiting for is a synchronous file write, so burning a core under the JVM-wide lock is still the wrong trade. Its javadoc is updated to say that rather than the old (now stale) reason.

## Alternatives considered

- **The cheaper intermediate suggested in the issue** - a `hasPendingPagesOfDatabase` fast path that avoids the iterator allocation on the empty-pipeline case - fixes only the boolean callers and leaves `waitAllPagesOfDatabaseAreFlushed`, the one that polls in a loop and needs the full count for its progress signal, exactly as it was.
- **Per-database sub-maps** (`Map<Database, Map<PageId, MutablePage>>`) make the count `size()` and drift structurally impossible without any ordering rule, but they put a second hash lookup on `getCachedPageFromMutablePageInQueue`, which is on the page read path. The counter keeps that path a single lookup and buys the same drift-freedom from encapsulation instead.
- **Folding the count into the existing `flushedPagesPerDatabase` record** was tempting (one map, one lookup) but the two signals are not the same: a superseded copy reaching the disk is progress even though it releases no index entry, and losing that would let a healthy-but-repeatedly-superseded page trip the no-progress timeout and turn a clean close into a crash-equivalent one.

## Verification

New `Issue6133PendingPagesPerDatabaseTest`:

1. `everyRouteOutOfThePipelineKeepsTheCountExact` - drives two databases through every mutation route (queued, superseded by a later transaction, superseded copy flushed, indexed copy flushed, replay detach, dropped file, dropped database) and compares the counter against the brute-force scan it replaced after each one. A same-numbered file in the other database proves the count is keyed by database and not by file.
2. `aSiblingBacklogIsNeitherCountedNorWaitedFor` - 50 000 pending pages of a sibling database are neither counted into this one nor waited for by its drain, and one page of its own is enough to make the same drain report the pipeline busy.
3. `theCountSurvivesConcurrentMutation` - 8 threads x 2 000 pages through the full life cycle, asserted quiescent after the join (a comparison sampled while the mutations run proves nothing either way, since the two reads straddle other threads' mutations).
4. `theCountSettlesAtZeroAfterConcurrentCommits` - end to end on the real pipeline: after 1 000 concurrent commits the count settles at exactly zero, in agreement with the map.

All four fail when the accounting is deliberately broken (verified by suppressing the release in `removeIfSame`) - and #4 fails by reproducing the symptom itself: `No flush progress for 60000 ms with 999 pages still pending`, i.e. the close that never returns.

Existing coverage: the whole `arcadedb-engine` unit suite (11 962 tests) is green, including the white-box flush tests that had to move to the new API (`Issue4544FlushIndexIdentityTest`, `Issue5326ApplyChangesPendingFlushTest`, `FlushRobustnessTest`, `PageManagerFlushThreadInterruptTest`, `PageManagerFlushSuspend*`), plus `PageSnapshotTest` and `Issue6125SnapshotBarrierAndCapTest` which exercise the barrier this loop sits in.

## Files

- `engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java` (new)
- `engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java`
- `engine/src/test/java/com/arcadedb/engine/Issue6133PendingPagesPerDatabaseTest.java` (new)
- `engine/src/test/java/com/arcadedb/engine/{Issue4544FlushIndexIdentityTest,Issue5326ApplyChangesPendingFlushTest,FlushRobustnessTest,PageManagerFlushThreadInterruptTest,PageManagerFlushSuspendBackpressureTest,PageManagerFlushSuspendDeferRaceTest,PageManagerFlushSuspendRefCountTest}.java`