### PR TITLE
fix(#6191): a write a follower forwards is refused rather than redirected in a circle

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2576,16 +2576,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // Backstop for the isLeader() check above: leadership can move between the two, and getLeaderId()
       // can already report this node while isLeader() has not caught up. Compare the addresses too, so
       // a self-download is impossible on either side of that window (issue #6111).
-      if (raftHAServer.getLocalHttpAddress() == null)
+      // Resolved once and compared once: the same question the write-forwarding path asks before it dials a
+      // resolved leader address, through the same comparison so the two cannot drift apart (issue #6191).
+      final String localHttpAddr = raftHAServer.getLocalHttpAddress();
+      if (localHttpAddr == null)
         // The resolver degrades to null when this node's own HTTP endpoint cannot be resolved right now.
         // The check below then cannot fire, so say so rather than letting the backstop no-op invisibly:
         // only the isLeader() check above is standing between us and a self-download.
         LogManager.instance().log(this, Level.WARNING,
             "Cannot resolve this node's own HTTP address; the self-resync address check is inactive for this "
                 + "attempt and only the leader-role check guards it (issue #6111)");
-      // The same question the write-forwarding path asks before it dials a resolved leader address
-      // (issue #6191), asked through the same helper so the two cannot drift apart.
-      if (raftHAServer.isOwnHttpAddress(leaderHttpAddr)) {
+      if (RaftHAServer.isSameHttpEndpoint(localHttpAddr, leaderHttpAddr)) {
         LogManager.instance().log(this, Level.WARNING,
             "Refusing a snapshot resync: the resolved leader address %s is this node's own. "
                 + "The request stays pending until a peer holds the leadership (issue #6111)", leaderHttpAddr);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2576,15 +2576,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // Backstop for the isLeader() check above: leadership can move between the two, and getLeaderId()
       // can already report this node while isLeader() has not caught up. Compare the addresses too, so
       // a self-download is impossible on either side of that window (issue #6111).
-      final String localHttpAddr = raftHAServer.getPeerHttpAddress(raftHAServer.getLocalPeerId());
-      if (localHttpAddr == null)
-        // getPeerHttpAddress() degrades to null when this node's own HTTP endpoint cannot be resolved
-        // right now. The comparison below then cannot fire, so say so rather than letting the backstop
-        // no-op invisibly: only the isLeader() check above is standing between us and a self-download.
+      if (raftHAServer.getLocalHttpAddress() == null)
+        // The resolver degrades to null when this node's own HTTP endpoint cannot be resolved right now.
+        // The check below then cannot fire, so say so rather than letting the backstop no-op invisibly:
+        // only the isLeader() check above is standing between us and a self-download.
         LogManager.instance().log(this, Level.WARNING,
             "Cannot resolve this node's own HTTP address; the self-resync address check is inactive for this "
                 + "attempt and only the leader-role check guards it (issue #6111)");
-      if (leaderHttpAddr.equals(localHttpAddr)) {
+      // The same question the write-forwarding path asks before it dials a resolved leader address
+      // (issue #6191), asked through the same helper so the two cannot drift apart.
+      if (raftHAServer.isOwnHttpAddress(leaderHttpAddr)) {
         LogManager.instance().log(this, Level.WARNING,
             "Refusing a snapshot resync: the resolved leader address %s is this node's own. "
                 + "The request stays pending until a peer holds the leadership (issue #6111)", leaderHttpAddr);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -329,6 +329,11 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   }
 
   @Override
+  public boolean isOwnHttpAddress(final String address) {
+    return raftHAServer != null && raftHAServer.isOwnHttpAddress(address);
+  }
+
+  @Override
   public RoutingTable getRoutingTable(final ROUTING_PROTOCOL protocol) {
     return raftHAServer != null ? raftHAServer.getRoutingTable(protocol) : null;
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -378,6 +378,44 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * Returns this node's own HTTP address (host:port), or {@code null} when it cannot be resolved right
+   * now (the HTTP listener is not up yet). Resolved through the same path as every peer address, so a
+   * caller comparing the two compares like with like.
+   */
+  public String getLocalHttpAddress() {
+    return resolveHttpAddress(localPeerId);
+  }
+
+  /**
+   * True when {@code address} is the HTTP endpoint this node itself is listening on, i.e. dialing it would
+   * come straight back here. Answers the one question every automatic redirect has to ask before it
+   * redirects: an address resolved for a <em>peer</em> that turns out to be ours identifies nothing (issue
+   * #6191). It is what the derive fallback in {@link #resolveHttpAddress(RaftPeerId)} produces on a cluster
+   * whose nodes share a host and declare no {@code http} port - it combines the peer's Raft host with this
+   * node's HTTP port, so every peer collapses onto this node's own address.
+   * <p>
+   * A textual comparison, like the peer bookkeeping it reads: both sides come from the same resolver, so a
+   * derived address matches a derived one. It deliberately does not resolve hostnames - {@code localhost}
+   * and {@code 127.0.0.1} are not reported as the same endpoint - because the addresses only differ that
+   * way when they were declared explicitly, and a declared address is a statement about which node owns
+   * which port that this method has no business second-guessing.
+   */
+  public boolean isOwnHttpAddress(final String address) {
+    return isSameHttpEndpoint(getLocalHttpAddress(), address);
+  }
+
+  /**
+   * Whether two {@code host:port} addresses name the same listening socket. Case-insensitive, because host
+   * names are: the two sides can come from different entries of {@code HA_SERVER_LIST} and a difference in
+   * case would otherwise read as "a different node", which is the answer that lets a redirect loop live.
+   * Never resolves names, so {@code localhost} and {@code 127.0.0.1} are reported as different endpoints
+   * (see {@link #isOwnHttpAddress}). Package-private for testing.
+   */
+  static boolean isSameHttpEndpoint(final String address, final String other) {
+    return address != null && address.equalsIgnoreCase(other);
+  }
+
+  /**
    * Returns the HTTPS address (host:httpsPort) for a peer, or {@code null} when no HTTPS endpoint can
    * be resolved. The endpoint is taken from the explicit 5th field of the server list when present;
    * otherwise, on a homogeneous cluster, it is derived from the peer's Raft host plus this node's

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -135,7 +135,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private final    long                    quorumTimeout;
   private final    RaftGroup               raftGroup;
   private final    RaftPeerId              localPeerId;
-  private final    Map<RaftPeerId, String> httpAddresses      = new HashMap<>();
+  // Concurrent, not a plain HashMap: this is the one address map that is structurally modified while the
+  // cluster runs - RaftClusterManager puts on a peer add and removes on a peer leave - and it is read
+  // without any lock by the lag monitor, by cluster reporting, and (since issue #6191) by every write a
+  // follower forwards. A HashMap resizing under a concurrent get() is how a reader sees a stale or missing
+  // address, or spins. The siblings below are populated in the constructor and never written again, so a
+  // final field publishes them safely.
+  private final    Map<RaftPeerId, String> httpAddresses      = new ConcurrentHashMap<>();
   // Explicit HTTPS endpoints (optional 5th field in HA_SERVER_LIST). Used for encrypted
   // peer-to-peer transfers (snapshot download) when SSL is enabled.
   private final    Map<RaftPeerId, String> httpsAddresses     = new HashMap<>();
@@ -1639,6 +1645,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     return raftProperties;
   }
 
+  /**
+   * The live map of explicitly declared peer HTTP endpoints, keyed by peer id - not a copy: callers add an
+   * entry when a peer joins and drop it when one leaves. It is a {@link ConcurrentHashMap}, so writing to it
+   * while other threads resolve addresses is safe, but it rejects null keys and values.
+   */
   public Map<RaftPeerId, String> getHttpAddresses() {
     return httpAddresses;
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -302,6 +302,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private final AtomicBoolean selfForwardWarned = new AtomicBoolean(false);
 
   /**
+   * Emits the "a peer forwarded a write here and this node is not the leader either" notice only once per
+   * database. The refusal itself travels back to the caller; this is so the node that proved the address
+   * wrong also says so in its own log (issue #6191).
+   */
+  private final AtomicBoolean forwardedAgainWarned = new AtomicBoolean(false);
+
+  /**
    * Test-only fault-injection hook. Fires after Raft replication succeeds but BEFORE phase-2
    * commit runs. Set to a non-null Consumer to simulate leader crash in this narrow window.
    * Always null in production.
@@ -2598,13 +2605,24 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // arrived on a node that is not the leader either. Redirecting it once more sends it round the cycle the
     // wrong address created; refuse instead, so the peer that forwarded it (and through it the client) gets a
     // typed, retryable answer in one hop rather than a hang (issue #6191).
-    if (LeaderForwardContext.isAlreadyForwarded())
+    if (LeaderForwardContext.isAlreadyForwarded()) {
+      // Said once in this node's own log too: the refusal travels back to the peer that forwarded the write
+      // and from there to the client, so without this line the only node that can name the misconfiguration -
+      // the one that proved the address wrong by receiving the request - says nothing about it anywhere.
+      if (forwardedAgainWarned.compareAndSet(false, true))
+        LogManager.instance().log(this, Level.WARNING,
+            "A cluster peer forwarded a write to this node as the leader, but this node is not the leader (db=%s). "
+                + "That peer resolved an HTTP address for the leader which does not identify it - unless leadership "
+                + "just moved, declare every node's HTTP port explicitly with the 'host:raftPort:httpPort' syntax in "
+                + "%s. The write is refused rather than forwarded on. This notice is logged only once per database.",
+            getName(), GlobalConfiguration.HA_SERVER_LIST.getKey());
       throw new ServerIsNotTheLeaderException(
           "Refusing to forward a write that a cluster peer already forwarded to the leader: it arrived on this node, "
               + "which is not the leader. Either leadership moved while the request was in flight - retry - or the "
               + "HTTP address that peer resolved for the leader does not identify it, which is what declaring every "
               + "node's HTTP port ('host:raftPort:httpPort') in " + GlobalConfiguration.HA_SERVER_LIST.getKey()
               + " prevents", raft.getLeaderName());
+    }
 
     // During cluster startup or a leader change there is a window with no elected leader. Rather than failing
     // the forwarded write immediately (which loses the caller's transaction - issue #4728 follow-up), wait a

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2675,15 +2675,17 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
         .uri(URI.create("http://" + leaderHttpAddress + "/api/v1/command/" + getName()))
         .header("Content-Type", "application/json")
-        // One hop, and the receiving node knows it: if this address does not identify the leader, the node it
-        // does reach refuses the command instead of resolving the same wrong address and forwarding again
-        // (issue #6191).
-        .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true")
         .POST(HttpRequest.BodyPublishers.ofString(body.toString()));
 
     final String clusterToken = raftHAServer.getClusterToken();
-    if (clusterToken != null && !clusterToken.isBlank())
+    if (clusterToken != null && !clusterToken.isBlank()) {
       builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
+      // One hop, and the receiving node knows it: if this address does not identify the leader, the node it
+      // does reach refuses the command instead of resolving the same wrong address and forwarding it again
+      // (issue #6191). Sent only with the token, because that is the only form in which a receiving node
+      // trusts the marker - same pairing as PostServerCommandHandler's forward.
+      builder.header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true");
+    }
 
     String proxiedUser = proxied.getCurrentUserName();
     if (proxiedUser == null || proxiedUser.isBlank()) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -94,6 +94,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.LeaderForwardContext;
 
 import java.io.IOException;
 import java.net.URI;
@@ -292,6 +293,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * deployments that legitimately issue writes from background threads don't get log-spammed.
    */
   private final AtomicBoolean forwardAsRootWarned = new AtomicBoolean(false);
+
+  /**
+   * Emits the "the leader resolved to this node's own address" notice only once per database, so a
+   * misconfigured cluster under load reports the configuration to fix instead of one line per refused
+   * write (issue #6191).
+   */
+  private final AtomicBoolean selfForwardWarned = new AtomicBoolean(false);
 
   /**
    * Test-only fault-injection hook. Fires after Raft replication succeeds but BEFORE phase-2
@@ -2585,6 +2593,19 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private ResultSet forwardCommandToLeaderViaRaft(final String language, final String query,
       final Map<String, Object> mapArgs, final Object[] positionalArgs) {
     final RaftHAServer raft = requireRaftServer();
+
+    // This request is already the result of a peer redirecting it to what it believed was the leader, and it
+    // arrived on a node that is not the leader either. Redirecting it once more sends it round the cycle the
+    // wrong address created; refuse instead, so the peer that forwarded it (and through it the client) gets a
+    // typed, retryable answer in one hop rather than a hang (issue #6191).
+    if (LeaderForwardContext.isAlreadyForwarded())
+      throw new ServerIsNotTheLeaderException(
+          "Refusing to forward a write that a cluster peer already forwarded to the leader: it arrived on this node, "
+              + "which is not the leader. Either leadership moved while the request was in flight - retry - or the "
+              + "HTTP address that peer resolved for the leader does not identify it, which is what declaring every "
+              + "node's HTTP port ('host:raftPort:httpPort') in " + GlobalConfiguration.HA_SERVER_LIST.getKey()
+              + " prevents", raft.getLeaderName());
+
     // During cluster startup or a leader change there is a window with no elected leader. Rather than failing
     // the forwarded write immediately (which loses the caller's transaction - issue #4728 follow-up), wait a
     // bounded time for a leader to appear and forward as soon as one does. If this node becomes the leader
@@ -2594,6 +2615,27 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     if (leaderHttpAddress == null)
       throw new TransactionException("Cannot forward command to leader: leader HTTP address is not available "
           + "(no leader elected within " + leaderWaitMs + "ms; tune " + GlobalConfiguration.HA_FORWARD_LEADER_WAIT_TIMEOUT_MS.getKey() + ")");
+
+    // The address resolved for the leader is this node's own, and this node is not the leader: the POST would
+    // come back here, be forwarded again, and consume one more HTTP worker thread per hop. This is what the
+    // derive fallback produces when the peers share a host and no 'http' port is declared - it pairs the
+    // leader's Raft host with THIS node's HTTP port. Refuse with the typed error the HTTP and gRPC layers
+    // already know how to report (issue #6191). The one case where the self-address is right - this node
+    // became the leader while waiting above - is left alone: that POST executes locally and terminates.
+    if (!raft.isLeader() && raft.isOwnHttpAddress(leaderHttpAddress)) {
+      if (selfForwardWarned.compareAndSet(false, true))
+        LogManager.instance().log(this, Level.WARNING,
+            "The HTTP address resolved for the leader (%s) is this node's own, so a write forwarded to it would come "
+                + "back here and be forwarded again. Writes issued on this node are refused until the cluster can tell "
+                + "its peers' HTTP endpoints apart: declare every node's HTTP port explicitly with the "
+                + "'host:raftPort:httpPort' syntax in %s. This notice is logged only once per database.",
+            leaderHttpAddress, GlobalConfiguration.HA_SERVER_LIST.getKey());
+      throw new ServerIsNotTheLeaderException(
+          "Cannot forward the command: the HTTP address resolved for the leader (" + leaderHttpAddress
+              + ") is this node's own, and this node is not the leader. Declare every node's HTTP port explicitly with "
+              + "the 'host:raftPort:httpPort' syntax in " + GlobalConfiguration.HA_SERVER_LIST.getKey(),
+          raft.getLeaderName());
+    }
 
     final JSONObject body = new JSONObject();
     body.put("language", language);
@@ -2615,6 +2657,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
         .uri(URI.create("http://" + leaderHttpAddress + "/api/v1/command/" + getName()))
         .header("Content-Type", "application/json")
+        // One hop, and the receiving node knows it: if this address does not identify the leader, the node it
+        // does reach refuses the command instead of resolving the same wrong address and forwarding again
+        // (issue #6191).
+        .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true")
         .POST(HttpRequest.BodyPublishers.ofString(body.toString()));
 
     final String clusterToken = raftHAServer.getClusterToken();
@@ -2740,6 +2786,14 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
     if (exceptionClass == null)
       return new TransactionException(message);
+
+    // ServerIsNotTheLeaderException carries the leader address as its second constructor argument (the HTTP
+    // layer sends it as exceptionArgs), so it too is rebuilt explicitly. Without this arm a leader-side "I am
+    // not the leader either" - the answer a node gives to a write forwarded onto it by a peer whose leader
+    // address was wrong (issue #6191) - collapsed into a plain TransactionException, and the caller lost both
+    // the retryability it inherits from NeedRetryException and the leader it names.
+    if (ServerIsNotTheLeaderException.class.getName().equals(exceptionClass))
+      return new ServerIsNotTheLeaderException(detail != null ? detail : message, exceptionArgs);
 
     // DuplicatedKeyException carries structured args (index name, keys, existing RID), so it is
     // reconstructed explicitly rather than from a plain message.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -2605,6 +2605,12 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     // arrived on a node that is not the leader either. Redirecting it once more sends it round the cycle the
     // wrong address created; refuse instead, so the peer that forwarded it (and through it the client) gets a
     // typed, retryable answer in one hop rather than a hang (issue #6191).
+    //
+    // Deliberately before the leader-address wait below, unlike the self-address check that follows it: waiting
+    // would only make sense if this node might forward the request onward once a leader appears, and it must
+    // not. A leadership change in flight and an address that names the wrong node are indistinguishable from
+    // here, so the caller retries - which re-resolves the leader from scratch - rather than this node posting a
+    // non-idempotent write a second time on a path that cannot prove the first one did not execute.
     if (LeaderForwardContext.isAlreadyForwarded()) {
       // Said once in this node's own log too: the refusal travels back to the peer that forwarded the write
       // and from there to the client, so without this line the only node that can name the misconfiguration -

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -543,16 +543,19 @@ class Issue6111StaleSnapshotReadFloorTest {
    * Same refusal via the address comparison rather than the role flag: leadership can move between the
    * {@code isLeader()} check and the address resolution, and {@code getLeaderId()} can report this node
    * while {@code isLeader()} has not caught up.
+   * <p>
+   * The comparison itself moved into {@code RaftHAServer.isOwnHttpAddress} when the write-forwarding path
+   * started asking the same question (issue #6191), and is unit-tested there; what this test pins is that
+   * the resync path asks it at all when the role flag still says "follower".
    */
   @Test
   void aResolvedLeaderAddressEqualToOurOwnIsAlsoRefused(@TempDir final Path tempDir) throws Exception {
     final ArcadeStateMachine sm = newStateMachine(tempDir);
-    final RaftPeerId localId = RaftPeerId.valueOf("local-peer");
     final RaftHAServer mockRaft = mock(RaftHAServer.class);
     when(mockRaft.isLeader()).thenReturn(false); // role flag has not caught up...
     when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
-    when(mockRaft.getLocalPeerId()).thenReturn(localId);
-    when(mockRaft.getPeerHttpAddress(localId)).thenReturn("localhost:2480"); // ...but it is us
+    when(mockRaft.getLocalHttpAddress()).thenReturn("localhost:2480");
+    when(mockRaft.isOwnHttpAddress("localhost:2480")).thenReturn(true); // ...but it is us
     sm.setRaftHAServer(mockRaft);
     try {
       sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -544,9 +544,9 @@ class Issue6111StaleSnapshotReadFloorTest {
    * {@code isLeader()} check and the address resolution, and {@code getLeaderId()} can report this node
    * while {@code isLeader()} has not caught up.
    * <p>
-   * The comparison itself moved into {@code RaftHAServer.isOwnHttpAddress} when the write-forwarding path
-   * started asking the same question (issue #6191), and is unit-tested there; what this test pins is that
-   * the resync path asks it at all when the role flag still says "follower".
+   * The comparison itself moved into {@code RaftHAServer.isSameHttpEndpoint} when the write-forwarding path
+   * started asking the same question (issue #6191), and its edge cases are unit-tested there; here it runs
+   * for real against the two addresses the mock reports.
    */
   @Test
   void aResolvedLeaderAddressEqualToOurOwnIsAlsoRefused(@TempDir final Path tempDir) throws Exception {
@@ -554,8 +554,7 @@ class Issue6111StaleSnapshotReadFloorTest {
     final RaftHAServer mockRaft = mock(RaftHAServer.class);
     when(mockRaft.isLeader()).thenReturn(false); // role flag has not caught up...
     when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
-    when(mockRaft.getLocalHttpAddress()).thenReturn("localhost:2480");
-    when(mockRaft.isOwnHttpAddress("localhost:2480")).thenReturn(true); // ...but it is us
+    when(mockRaft.getLocalHttpAddress()).thenReturn("localhost:2480"); // ...but it is us
     sm.setRaftHAServer(mockRaft);
     try {
       sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
@@ -163,8 +163,8 @@ class Issue6191FollowerForwardLoopIT extends BaseRaftHATest {
 
   /**
    * The bulk-load endpoint relays to the leader too, with a whole upload buffered per hop, so it has to
-   * enforce the same one-hop rule. Driven over real HTTP because the marker is a request header: the point
-   * is that a node receiving an already-forwarded load refuses it rather than relaying it onward.
+   * enforce the same one-hop rule. Driven over real HTTP because the marker is a request header, and sent
+   * the way a peer sends it - with the cluster token, the only form in which the marker is trusted.
    */
   @Test
   @Timeout(120)
@@ -172,14 +172,16 @@ class Issue6191FollowerForwardLoopIT extends BaseRaftHATest {
     final int leader = findLeaderIndex();
     assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
     final int follower = firstFollower(leader);
+    final String clusterToken = getRaftPlugin(follower).getRaftHAServer().getClusterToken();
+    assertThat(clusterToken).as("peers authenticate to each other with a cluster token").isNotBlank();
 
     final HttpURLConnection conn = (HttpURLConnection) new URI(
         "http://127.0.0.1:" + getServer(follower).getHttpServer().getPort() + "/api/v1/batch/" + getDatabaseName())
         .toURL().openConnection();
     try {
       conn.setRequestMethod("POST");
-      conn.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(
-          ("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+      conn.setRequestProperty("X-ArcadeDB-Cluster-Token", clusterToken);
+      conn.setRequestProperty("X-ArcadeDB-Forwarded-User", "root");
       conn.setRequestProperty("Content-Type", "application/x-ndjson");
       conn.setRequestProperty(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true");
       conn.setDoOutput(true);
@@ -198,6 +200,48 @@ class Issue6191FollowerForwardLoopIT extends BaseRaftHATest {
     } finally {
       conn.disconnect();
     }
+  }
+
+  /**
+   * The gate on the marker: it is a statement one node makes to another, so it is honored only on a request
+   * that authenticated with the cluster token. A client that copies the header onto its own write - or a
+   * proxy that relays unknown {@code X-ArcadeDB-*} headers through - must not be able to turn a transparent
+   * forward-to-leader into a refusal for itself.
+   */
+  @Test
+  @Timeout(120)
+  void theMarkerFromAnOrdinaryClientDoesNotSuppressForwarding() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int follower = firstFollower(leader);
+
+    final HttpURLConnection conn = (HttpURLConnection) new URI(
+        "http://127.0.0.1:" + getServer(follower).getHttpServer().getPort() + "/api/v1/command/" + getDatabaseName())
+        .toURL().openConnection();
+    try {
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+          ("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+      conn.setRequestProperty("Content-Type", "application/json");
+      conn.setRequestProperty(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true");
+      conn.setDoOutput(true);
+      final byte[] payload = ("{\"language\":\"sql\",\"command\":\"CREATE VERTEX TYPE Issue6191ClientMarker\"}")
+          .getBytes(StandardCharsets.UTF_8);
+      try (final DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+        out.write(payload);
+      }
+
+      assertThat(conn.getResponseCode())
+          .as("a client's own header must not stop this follower from forwarding its write to the leader")
+          .isEqualTo(200);
+    } finally {
+      conn.disconnect();
+    }
+
+    waitForAllServers();
+    assertThat(getServerDatabase(leader, getDatabaseName()).getSchema().existsType("Issue6191ClientMarker"))
+        .as("the write was forwarded and executed by the leader")
+        .isTrue();
   }
 
   private int firstFollower(final int leader) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.LeaderForwardContext;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.DataOutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A write issued on a follower is forwarded to the leader over HTTP, and the address it is forwarded to is
+ * only as good as the configuration behind it. When {@code arcadedb.ha.serverList} declares no {@code http}
+ * port, the address is <em>derived</em> from the peer's Raft host plus <em>this</em> node's HTTP port - so on
+ * a cluster whose nodes differ by port rather than by host, every peer, the leader included, resolves to the
+ * node doing the resolving. The POST comes back to a follower, which is still not the leader, and is
+ * forwarded again: a cycle bounded only by HTTP timeouts and the size of the worker pool, one held request
+ * thread per hop (issue #6191).
+ * <p>
+ * Both ways out are asserted here, because neither covers the other:
+ * <ul>
+ *   <li>the <b>dial</b> side refuses before the request leaves, when the address resolved for the leader is
+ *   this node's own - the same question {@code triggerSnapshotDownload()} has asked since issue #6111;</li>
+ *   <li>the <b>receiving</b> side refuses a write that a peer already forwarded, whichever node it lands on.
+ *   That is the general bound: an address can name the wrong <em>peer</em> rather than this node, which no
+ *   local self-check can see, and the cycle is then two hops long instead of one.</li>
+ * </ul>
+ * The ambiguity is injected by emptying (or misdirecting) one follower's resolved HTTP address map for the
+ * duration of a single test, rather than by configuring the cluster without HTTP ports: it reproduces exactly
+ * the production condition at the point where it matters, without making cluster startup - which dials those
+ * same addresses to probe peers - part of what is under test.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6191FollowerForwardLoopIT extends BaseRaftHATest {
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  /**
+   * The reachable deployment: peers on one host, no {@code http} port declared. Before the fix this POSTed to
+   * itself and never returned, so the timeout is the assertion of last resort.
+   */
+  @Test
+  @Timeout(120)
+  void aFollowerRefusesAWriteWhoseLeaderAddressResolvesToItself() {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int follower = firstFollower(leader);
+
+    final RaftHAServer raft = getRaftPlugin(follower).getRaftHAServer();
+    final Map<RaftPeerId, String> httpAddresses = raft.getHttpAddresses();
+    final Map<RaftPeerId, String> declared = new HashMap<>(httpAddresses);
+    try {
+      httpAddresses.clear(); // nothing declared: every peer now derives to this node's own endpoint
+
+      final String ownAddress = "localhost:" + getServer(follower).getHttpServer().getPort();
+      assertThat(raft.getLeaderHttpAddress())
+          .as("the derived leader address is this follower's own endpoint - the defect being guarded")
+          .isEqualTo(ownAddress);
+      assertThat(raft.isOwnHttpAddress(raft.getLeaderHttpAddress())).isTrue();
+
+      assertThatThrownBy(() -> getServerDatabase(follower, getDatabaseName())
+          .command("sql", "CREATE VERTEX TYPE Issue6191SelfForward"))
+          .as("the write must be refused, not POSTed back to this node to be forwarded again")
+          .isInstanceOf(ServerIsNotTheLeaderException.class)
+          .hasMessageContaining("is this node's own")
+          .hasMessageContaining(GlobalConfiguration.HA_SERVER_LIST.getKey());
+    } finally {
+      httpAddresses.putAll(declared);
+    }
+  }
+
+  /**
+   * The cycle a local self-check cannot see: the resolved address names a real peer, just not the leader. The
+   * second node has to be the one that stops it, and the refusal has to reach the first as itself - a
+   * {@link ServerIsNotTheLeaderException} the caller can retry on, not a flattened transaction failure.
+   */
+  @Test
+  @Timeout(120)
+  void aWriteForwardedOntoAFollowerIsRefusedInsteadOfForwardedAgain() {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int follower = firstFollower(leader);
+    final int otherFollower = secondFollower(leader, follower);
+
+    final RaftHAServer raft = getRaftPlugin(follower).getRaftHAServer();
+    final Map<RaftPeerId, String> httpAddresses = raft.getHttpAddresses();
+    final Map<RaftPeerId, String> declared = new HashMap<>(httpAddresses);
+    try {
+      // This follower now believes the leader listens where the OTHER follower does.
+      httpAddresses.put(RaftPeerId.valueOf(peerIdForIndex(leader)),
+          "localhost:" + getServer(otherFollower).getHttpServer().getPort());
+
+      assertThatThrownBy(() -> getServerDatabase(follower, getDatabaseName())
+          .command("sql", "CREATE VERTEX TYPE Issue6191CrossForward"))
+          .as("the node that received the forwarded write must refuse it rather than forward it on")
+          .isInstanceOf(ServerIsNotTheLeaderException.class)
+          .hasMessageContaining("already forwarded");
+    } finally {
+      httpAddresses.putAll(declared);
+    }
+  }
+
+  /**
+   * Control: with the addresses the cluster actually has, a write issued on a follower is forwarded to the
+   * leader and executed. Without it the two tests above would also pass against a build that refused every
+   * forwarded write.
+   */
+  @Test
+  @Timeout(120)
+  void aFollowerWriteWithCorrectAddressesStillReachesTheLeader() {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int follower = firstFollower(leader);
+
+    getServerDatabase(follower, getDatabaseName()).command("sql", "CREATE VERTEX TYPE Issue6191Forwarded");
+    waitForAllServers();
+
+    assertThat(getServerDatabase(leader, getDatabaseName()).getSchema().existsType("Issue6191Forwarded"))
+        .as("the forwarded DDL must have been executed by the leader")
+        .isTrue();
+  }
+
+  /**
+   * The bulk-load endpoint relays to the leader too, with a whole upload buffered per hop, so it has to
+   * enforce the same one-hop rule. Driven over real HTTP because the marker is a request header: the point
+   * is that a node receiving an already-forwarded load refuses it rather than relaying it onward.
+   */
+  @Test
+  @Timeout(120)
+  void aBatchForwardedOntoAFollowerIsRefusedInsteadOfForwardedAgain() throws Exception {
+    final int leader = findLeaderIndex();
+    assertThat(leader).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int follower = firstFollower(leader);
+
+    final HttpURLConnection conn = (HttpURLConnection) new URI(
+        "http://127.0.0.1:" + getServer(follower).getHttpServer().getPort() + "/api/v1/batch/" + getDatabaseName())
+        .toURL().openConnection();
+    try {
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+          ("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes(StandardCharsets.UTF_8)));
+      conn.setRequestProperty("Content-Type", "application/x-ndjson");
+      conn.setRequestProperty(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true");
+      conn.setDoOutput(true);
+      final byte[] payload = "{\"@type\":\"Issue6191Batch\",\"id\":1}\n".getBytes(StandardCharsets.UTF_8);
+      conn.setRequestProperty("Content-Length", Integer.toString(payload.length));
+      try (final DataOutputStream out = new DataOutputStream(conn.getOutputStream())) {
+        out.write(payload);
+      }
+
+      assertThat(conn.getResponseCode())
+          .as("a batch that arrives already forwarded must be refused by this follower, not relayed again")
+          .isEqualTo(400);
+      assertThat(new String(conn.getErrorStream().readAllBytes(), StandardCharsets.UTF_8))
+          .contains("already forwarded")
+          .contains(GlobalConfiguration.HA_SERVER_LIST.getKey());
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private int firstFollower(final int leader) {
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leader)
+        return i;
+    throw new IllegalStateException("no follower in a " + getServerCount() + "-node cluster");
+  }
+
+  private int secondFollower(final int leader, final int firstFollower) {
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leader && i != firstFollower)
+        return i;
+    throw new IllegalStateException("no second follower in a " + getServerCount() + "-node cluster");
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
@@ -57,7 +57,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * The ambiguity is injected by emptying (or misdirecting) one follower's resolved HTTP address map for the
  * duration of a single test, rather than by configuring the cluster without HTTP ports: it reproduces exactly
  * the production condition at the point where it matters, without making cluster startup - which dials those
- * same addresses to probe peers - part of what is under test.
+ * same addresses to probe peers - part of what is under test. The map is the live one and the cluster's own
+ * background threads read it throughout; that is safe because it is a {@code ConcurrentHashMap}, which is
+ * what it has to be anyway - {@code RaftClusterManager} adds and removes entries as peers join and leave.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -106,6 +108,12 @@ class Issue6191FollowerForwardLoopIT extends BaseRaftHATest {
    * The cycle a local self-check cannot see: the resolved address names a real peer, just not the leader. The
    * second node has to be the one that stops it, and the refusal has to reach the first as itself - a
    * {@link ServerIsNotTheLeaderException} the caller can retry on, not a flattened transaction failure.
+   * <p>
+   * The <b>type</b> is the assertion that matters and it travels in the error body's {@code exception} field,
+   * which is emitted in every server mode. The message text travels in {@code detail}, which
+   * {@code AbstractServerHttpHandler.buildErrorBody} conceals when the server runs in production mode
+   * (pre-existing behaviour, not specific to this path), so the text assertion here holds because tests run
+   * in the default development mode.
    */
   @Test
   @Timeout(120)

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191FollowerForwardLoopIT.java
@@ -82,6 +82,9 @@ class Issue6191FollowerForwardLoopIT extends BaseRaftHATest {
     final int follower = firstFollower(leader);
 
     final RaftHAServer raft = getRaftPlugin(follower).getRaftHAServer();
+    // The live map, by contract (see getHttpAddresses): writing to it is how this test puts the running node
+    // into the misconfigured state. A defensive copy there would leave these tests passing while injecting
+    // nothing, so if that accessor ever starts returning one, this is the line that has to change with it.
     final Map<RaftPeerId, String> httpAddresses = raft.getHttpAddresses();
     final Map<RaftPeerId, String> declared = new HashMap<>(httpAddresses);
     try {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191SelfForwardGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191SelfForwardGuardTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The question every automatic redirect has to answer before it dials a resolved leader address: is this
+ * address my own? An address that is identifies nobody, and following it lands the request back on the node
+ * that resolved it - which resolves the same address and redirects again (issue #6191).
+ * <p>
+ * Exercised directly because the address comparison is shared by the write-forwarding path and the snapshot
+ * resync refusal ({@code ArcadeStateMachine.triggerSnapshotDownload}, issue #6111), and neither of those can
+ * show what it does with a hostname that differs only in case.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6191SelfForwardGuardTest {
+
+  @Test
+  void theSameEndpointIsRecognised() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "localhost:2480")).isTrue();
+  }
+
+  /** Host names are case-insensitive, and "a different case" must not read as "a different node". */
+  @Test
+  void hostCaseDoesNotMakeItADifferentEndpoint() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("DB0.example.com:2480", "db0.example.com:2480")).isTrue();
+  }
+
+  /** The whole point on a same-host cluster: the port is what tells the peers apart. */
+  @Test
+  void aDifferentPortIsADifferentEndpoint() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "localhost:2481")).isFalse();
+  }
+
+  @Test
+  void aDifferentHostIsADifferentEndpoint() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("db0:2480", "db1:2480")).isFalse();
+  }
+
+  /**
+   * No name resolution: the two spellings only ever differ this way when they were declared explicitly, and a
+   * declared address is a statement about which node owns which port that this comparison does not overrule.
+   */
+  @Test
+  void loopbackSpellingsAreNotUnified() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "127.0.0.1:2480")).isFalse();
+  }
+
+  /** An address that could not be resolved is not evidence of anything, in either position. */
+  @Test
+  void anUnresolvedAddressIsNeverAMatch() {
+    assertThat(RaftHAServer.isSameHttpEndpoint(null, "localhost:2480")).isFalse();
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", null)).isFalse();
+    assertThat(RaftHAServer.isSameHttpEndpoint(null, null)).isFalse();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191SelfForwardGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191SelfForwardGuardTest.java
@@ -24,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * The question every automatic redirect has to answer before it dials a resolved leader address: is this
- * address my own? An address that is identifies nobody, and following it lands the request back on the node
- * that resolved it - which resolves the same address and redirects again (issue #6191).
+ * address my own? One that is identifies nobody, and following it lands the request back on the node that
+ * resolved it - which resolves the same address and redirects again (issue #6191).
  * <p>
  * Exercised directly because the address comparison is shared by the write-forwarding path and the snapshot
  * resync refusal ({@code ArcadeStateMachine.triggerSnapshotDownload}, issue #6111), and neither of those can

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
@@ -30,6 +30,7 @@ import com.arcadedb.exception.QueryNotIdempotentException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.TransactionCommittedRemotelyException;
 import com.arcadedb.exception.TransactionException;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -109,6 +110,40 @@ class RaftReplicatedDatabaseTest {
     assertThat(dup.getIndexName()).isEqualTo("Account_PK");
     assertThat(dup.getKeys()).isEqualTo("[42]");
     assertThat(dup.getCurrentIndexedRID()).isEqualTo(new RID(7, 1L));
+  }
+
+  /**
+   * The answer a node gives to a write forwarded onto it by a peer whose leader address named the wrong node
+   * (issue #6191). It has to survive the hop as itself: collapsed into a plain TransactionException the caller
+   * loses both the retryability it inherits from NeedRetryException and the leader the message names.
+   */
+  @Test
+  void reconstructLeaderExceptionNotTheLeaderKeepsTypeAndLeader() {
+    final String body = "{\"error\":\"Cannot execute command\","
+        + "\"detail\":\"Refusing to forward a write that a cluster peer already forwarded to the leader\","
+        + "\"exception\":\"com.arcadedb.network.binary.ServerIsNotTheLeaderException\","
+        + "\"exceptionArgs\":\"ArcadeDB_0\"}";
+
+    final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(400, body);
+
+    assertThat(result).isInstanceOf(ServerIsNotTheLeaderException.class);
+    assertThat(result).isInstanceOf(NeedRetryException.class);
+    assertThat(((ServerIsNotTheLeaderException) result).getLeaderAddress()).isEqualTo("ArcadeDB_0");
+    assertThat(result.getMessage())
+        .isEqualTo("Refusing to forward a write that a cluster peer already forwarded to the leader");
+  }
+
+  /** The leader was unknown to the refusing node, so there is no address to carry: the type still is. */
+  @Test
+  void reconstructLeaderExceptionNotTheLeaderWithoutALeaderAddress() {
+    final String body = "{\"error\":\"Cannot execute command\",\"detail\":\"not the leader\","
+        + "\"exception\":\"com.arcadedb.network.binary.ServerIsNotTheLeaderException\"}";
+
+    final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(400, body);
+
+    assertThat(result).isInstanceOf(ServerIsNotTheLeaderException.class);
+    assertThat(((ServerIsNotTheLeaderException) result).getLeaderAddress()).isNull();
+    assertThat(result.getMessage()).isEqualTo("not the leader");
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -113,6 +113,19 @@ public interface HAServerPlugin extends ServerPlugin {
   String getReplicaAddresses();
 
   /**
+   * True when {@code address} is the HTTP endpoint this node is itself listening on. A leader address that
+   * answers true identifies nobody: dialing it comes straight back to the node that resolved it, which -
+   * on a path that redirects a client's write automatically - means the write is redirected to a node that
+   * will redirect it again (issue #6191). Callers refuse instead.
+   * <p>
+   * Defaults to {@code false} for implementations that cannot tell, which leaves them exactly where they
+   * were: the receiving side's one-hop rule ({@link LeaderForwardContext}) still bounds the cycle.
+   */
+  default boolean isOwnHttpAddress(final String address) {
+    return false;
+  }
+
+  /**
    * A client-facing wire protocol a routing view can be built for. Each names a per-peer endpoint a client
    * dials directly, which is never the Raft address the cluster uses to talk to itself, nor - for anything
    * but a homogeneous deployment - derivable from it. The name of a constant, lowercased, is also the field

--- a/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
+++ b/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
@@ -35,10 +35,17 @@ package com.arcadedb.server;
  * follower-to-leader redirect. {@code AbstractServerHttpHandler} publishes it onto this thread-local at the
  * request boundary and clears it in a finally block, because one of the redirect decisions is taken deep
  * inside the engine ({@code RaftReplicatedDatabase.command}) where the HTTP exchange is no longer in reach.
- * It is honored whoever sent it - a follower forwards under the cluster token, but the server-command path
- * also relays a client's own Basic/API-token credentials - because its only effect on a receiving node is to
- * refuse the redirect: a client setting the header on its own request can have that request refused, never
- * executed on a node that is not the leader.
+ * <p>
+ * It is honored <em>only</em> on a request that authenticated with the cluster token, because the marker is a
+ * statement one node makes to another. Trusting it from an ordinary client request would cost nothing in
+ * safety - its only possible effect is a refusal, never execution on a node that is not the leader - but it
+ * would let any caller (or a proxy that copies unknown {@code X-ArcadeDB-*} headers through) turn its own
+ * transparent forward-to-leader into a {@code ServerIsNotTheLeaderException}. Every follower-to-leader
+ * redirect that can loop authenticates with the cluster token, so nothing is left uncovered by the gate: the
+ * one branch that does not - a server command forwarded with a client's own Basic/API-token credentials -
+ * carries no marker at all and relies on the dial-side self-address check, which is what the reachable
+ * misconfiguration (an undeclared {@code http} port, where every peer derives to this node's own address)
+ * produces anyway.
  * <p>
  * {@code LeaderProxy} enforces the same one-hop rule for the requests it relays, reading the exchange
  * directly since it still has one.

--- a/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
+++ b/server/src/main/java/com/arcadedb/server/LeaderForwardContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+/**
+ * Records, for the duration of one HTTP request, that a cluster peer already redirected this request to
+ * what it believed to be the leader. A node serving a marked request must execute it or refuse it, never
+ * redirect it a second time (issue #6191).
+ * <p>
+ * Every follower-to-leader redirect resolves the leader's HTTP endpoint, and that endpoint is only as
+ * good as the cluster configuration behind it: when {@code arcadedb.ha.serverList} declares no {@code http}
+ * port the address is <em>derived</em> from the peer's Raft host plus <em>this</em> node's HTTP port, which
+ * on a cluster whose nodes differ by port rather than by host resolves every peer - the leader included - to
+ * the address of the node doing the resolving. The redirect then lands back on a follower, which resolves
+ * the same wrong address and redirects again. Nothing in the exchange itself says the request has been here
+ * before, so the cycle is bounded only by HTTP timeouts and the size of the worker pool.
+ * <p>
+ * The marker travels as the {@link #FORWARDED_TO_LEADER_HEADER} request header, set by every
+ * follower-to-leader redirect. {@code AbstractServerHttpHandler} publishes it onto this thread-local at the
+ * request boundary and clears it in a finally block, because one of the redirect decisions is taken deep
+ * inside the engine ({@code RaftReplicatedDatabase.command}) where the HTTP exchange is no longer in reach.
+ * It is honored whoever sent it - a follower forwards under the cluster token, but the server-command path
+ * also relays a client's own Basic/API-token credentials - because its only effect on a receiving node is to
+ * refuse the redirect: a client setting the header on its own request can have that request refused, never
+ * executed on a node that is not the leader.
+ * <p>
+ * {@code LeaderProxy} enforces the same one-hop rule for the requests it relays, reading the exchange
+ * directly since it still has one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class LeaderForwardContext {
+  /** Request header a node sets when it redirects a request to the leader on a client's behalf. */
+  public static final String FORWARDED_TO_LEADER_HEADER = "X-ArcadeDB-Forwarded-To-Leader";
+
+  private static final ThreadLocal<Boolean> ALREADY_FORWARDED = new ThreadLocal<>();
+
+  private LeaderForwardContext() {
+  }
+
+  /** Declares that the request being served on this thread was already redirected to the leader by a peer. */
+  public static void markAlreadyForwarded() {
+    ALREADY_FORWARDED.set(Boolean.TRUE);
+  }
+
+  /**
+   * True when the request being served on this thread arrived already redirected to the leader, so
+   * redirecting it again would send it round a cycle instead of to a node that can execute it.
+   */
+  public static boolean isAlreadyForwarded() {
+    return Boolean.TRUE.equals(ALREADY_FORWARDED.get());
+  }
+
+  /** Clears the marker. Must run in a finally block: HTTP worker threads are pooled and reused. */
+  public static void clear() {
+    ALREADY_FORWARDED.remove();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -274,15 +274,6 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
 
       ServerSecurityUser user = null;
 
-      // A peer already redirected this request to the leader, so this node must execute it or refuse it -
-      // redirecting it again sends it round the cycle a wrong leader address creates, and nothing else in the
-      // exchange says the request has been here before (issue #6191). Published onto a thread-local because
-      // one of the redirect decisions is taken deep in the engine, where the exchange is out of reach. It is
-      // read where the forwarding paths are, and its only effect there is to refuse: a client that sets the
-      // header on its own request can therefore only have its own write refused, never executed off-leader.
-      if (exchange.getRequestHeaders().contains(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER))
-        LeaderForwardContext.markAlreadyForwarded();
-
       // Cluster-internal forwarded auth: a follower forwarded a request on behalf of an
       // end user. The original per-node session token (Bearer AU-...) cannot be resolved on
       // the leader, so the follower substitutes X-ArcadeDB-Cluster-Token plus
@@ -294,6 +285,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
             exchange.getRequestHeaders().get("X-ArcadeDB-Forwarded-User"));
         if (user == null)
           return; // 401 already sent
+
+        // A peer already redirected this request to the leader, so this node must execute it or refuse it -
+        // redirecting it again sends it round the cycle a wrong leader address creates, and nothing else in
+        // the exchange says the request has been here before (issue #6191). Published onto a thread-local
+        // because one of the redirect decisions is taken deep in the engine, where the exchange is out of
+        // reach. Read only here, inside the cluster-token branch: the marker is a statement one node makes to
+        // another, and honoring it from an ordinary client request would let any caller turn its own
+        // transparent forward into a refusal by copying the header through.
+        if (exchange.getRequestHeaders().contains(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER))
+          LeaderForwardContext.markAlreadyForwarded();
       }
 
       if (user == null) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -30,6 +30,7 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.HAReplicatedDatabase;
+import com.arcadedb.server.LeaderForwardContext;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.HttpSessionException;
@@ -272,6 +273,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
 
       ServerSecurityUser user = null;
+
+      // A peer already redirected this request to the leader, so this node must execute it or refuse it -
+      // redirecting it again sends it round the cycle a wrong leader address creates, and nothing else in the
+      // exchange says the request has been here before (issue #6191). Published onto a thread-local because
+      // one of the redirect decisions is taken deep in the engine, where the exchange is out of reach. It is
+      // read where the forwarding paths are, and its only effect there is to refuse: a client that sets the
+      // header on its own request can therefore only have its own write refused, never executed off-leader.
+      if (exchange.getRequestHeaders().contains(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER))
+        LeaderForwardContext.markAlreadyForwarded();
 
       // Cluster-internal forwarded auth: a follower forwarded a request on behalf of an
       // end user. The original per-node session token (Bearer AU-...) cannot be resolved on
@@ -586,7 +596,18 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         realException = e.getCause();
       final ArithmeticErrorException arithmetic = arithmeticError(e);
 
-      if (realException instanceof SecurityException) {
+      if (realException instanceof ServerIsNotTheLeaderException notTheLeader) {
+        // Symmetric with the un-wrapped ServerIsNotTheLeaderException arm above, reached whenever the refusal
+        // is raised inside the auto-commit transaction wrapper in DatabaseAbstractHandler - which is where the
+        // HA write path raises it: a write issued on a follower is refused before it is forwarded when the
+        // resolved leader address names nobody (issue #6191). Without this branch the answer degraded to a 500
+        // "Error on transaction commit", which names neither the leader nor the reason, and which the
+        // forwarding peer cannot rebuild into the retryable typed exception the caller is entitled to.
+        LogManager.instance()
+                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
+                        realException.getMessage());
+        sendErrorResponse(exchange, 400, "Cannot execute command", notTheLeader, notTheLeader.getLeaderAddress());
+      } else if (realException instanceof SecurityException) {
         LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on transaction execution (%s): %s",
                 SecurityException.class.getSimpleName(), realException.getMessage());
         sendErrorResponse(exchange, 403, "Security error", realException, null);
@@ -736,6 +757,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       }
 
       ProtocolContext.clear();
+      LeaderForwardContext.clear();
       LogManager.instance().setContext(null);
       // Invariant: the correlation context stays populated until here, AFTER observation.stop() above
       // has fired the tracing/observation handlers. LogCorrelationIT relies on reading the requestId

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -604,8 +604,8 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         // "Error on transaction commit", which names neither the leader nor the reason, and which the
         // forwarding peer cannot rebuild into the retryable typed exception the caller is entitled to.
         LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
+                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s",
+                        getClass().getSimpleName(), realException.getMessage());
         sendErrorResponse(exchange, 400, "Cannot execute command", notTheLeader, notTheLeader.getLeaderAddress());
       } else if (realException instanceof SecurityException) {
         LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on transaction execution (%s): %s",

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -26,6 +26,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.LeaderForwardContext;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.batch.BatchRecord;
 import com.arcadedb.server.http.handler.batch.BatchRecordStream;
@@ -1031,10 +1032,30 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
   private ExecutionResponse forwardBatchToLeader(final HttpServerExchange exchange, final HAServerPlugin ha,
       final String databaseName, final ServerSecurityUser user, final String contentType) throws Exception {
 
+    // A peer already relayed this load to what it believed was the leader and it landed here, on a node that
+    // is not the leader either. Relaying it on would send it round the cycle that wrong address created, one
+    // held request thread and one buffered upload per hop; refuse in one hop instead (issue #6191).
+    if (LeaderForwardContext.isAlreadyForwarded())
+      return new ExecutionResponse(400,
+          "{ \"error\" : \"Refusing to forward a batch that a cluster peer already forwarded to the leader: it arrived "
+              + "on this node, which is not the leader. Either leadership moved while the request was in flight - retry - "
+              + "or the HTTP address that peer resolved for the leader does not identify it, which is what declaring "
+              + "every node's HTTP port ('host:raftPort:httpPort') in " + GlobalConfiguration.HA_SERVER_LIST.getKey()
+              + " prevents\"}");
+
     final String leaderAddress = ha.getLeaderAddress();
     if (leaderAddress == null || leaderAddress.isBlank())
       return new ExecutionResponse(503,
           "{ \"error\" : \"Cannot forward batch to leader: leader address is not available\"}");
+
+    // The address resolved for the leader is this node's own: dialing it would come straight back here. The
+    // derive fallback produces exactly this on a cluster whose peers share a host and declare no HTTP port,
+    // because it pairs the leader's Raft host with THIS node's HTTP port (issue #6191).
+    if (ha.isOwnHttpAddress(leaderAddress))
+      return new ExecutionResponse(400,
+          "{ \"error\" : \"Cannot forward batch to leader: the HTTP address resolved for the leader (" + leaderAddress
+              + ") is this node's own, and this node is not the leader. Declare every node's HTTP port explicitly with "
+              + "the 'host:raftPort:httpPort' syntax in " + GlobalConfiguration.HA_SERVER_LIST.getKey() + "\"}");
 
     final String clusterToken = ha.getClusterToken();
     if (clusterToken == null || clusterToken.isBlank())
@@ -1119,6 +1140,9 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
         .header("Content-Type", contentType)
         .header("X-ArcadeDB-Cluster-Token", clusterToken)
         .header("X-ArcadeDB-Forwarded-User", userName)
+        // One hop only: a node that receives this and is not the leader refuses it rather than resolving the
+        // same leader address - which may name nobody - and relaying it again (issue #6191).
+        .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true")
         .POST(publisher)
         .build();
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -1051,12 +1051,13 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
                 + "it: declare every node's HTTP port explicitly with the 'host:raftPort:httpPort' syntax in %s. The "
                 + "load is refused rather than relayed on. This notice is logged only once.",
             databaseName, GlobalConfiguration.HA_SERVER_LIST.getKey());
-      return new ExecutionResponse(400,
-          "{ \"error\" : \"Refusing to forward a batch that a cluster peer already forwarded to the leader: it arrived "
+      return new ExecutionResponse(400, new JSONObject()
+          .put("error", "Refusing to forward a batch that a cluster peer already forwarded to the leader: it arrived "
               + "on this node, which is not the leader. Either leadership moved while the request was in flight - "
               + "retry - or the HTTP address that peer resolved for the leader does not identify it, which is what "
               + "declaring every node's HTTP port ('host:raftPort:httpPort') in "
-              + GlobalConfiguration.HA_SERVER_LIST.getKey() + " prevents\"}");
+              + GlobalConfiguration.HA_SERVER_LIST.getKey() + " prevents")
+          .toString());
     }
 
     final String leaderAddress = ha.getLeaderAddress();
@@ -1068,10 +1069,11 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // derive fallback produces exactly this on a cluster whose peers share a host and declare no HTTP port,
     // because it pairs the leader's Raft host with THIS node's HTTP port (issue #6191).
     if (ha.isOwnHttpAddress(leaderAddress))
-      return new ExecutionResponse(400,
-          "{ \"error\" : \"Cannot forward batch to leader: the HTTP address resolved for the leader (" + leaderAddress
-              + ") is this node's own, and this node is not the leader. Declare every node's HTTP port explicitly with "
-              + "the 'host:raftPort:httpPort' syntax in " + GlobalConfiguration.HA_SERVER_LIST.getKey() + "\"}");
+      return new ExecutionResponse(400, new JSONObject()
+          .put("error", "Cannot forward batch to leader: the HTTP address resolved for the leader (" + leaderAddress
+              + ") is this node's own, and this node is not the leader. Declare every node's HTTP port explicitly "
+              + "with the 'host:raftPort:httpPort' syntax in " + GlobalConfiguration.HA_SERVER_LIST.getKey())
+          .toString());
 
     final String clusterToken = ha.getClusterToken();
     if (clusterToken == null || clusterToken.isBlank())

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -183,6 +183,12 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
   private static final int        MAX_ABANDONED_BODY_DRAIN   = 64 * 1024;
   private static final HttpClient HTTP_CLIENT                = HttpClient.newHttpClient();
 
+  /**
+   * Emits the "a peer relayed a batch here and this node is not the leader either" notice only once (issue
+   * #6191). Per handler instance, so each server in an in-process cluster still gets to say it once.
+   */
+  private final AtomicBoolean forwardedAgainWarned = new AtomicBoolean(false);
+
   public PostBatchHandler(final HttpServer httpServer) {
     super(httpServer);
   }
@@ -1035,13 +1041,23 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // A peer already relayed this load to what it believed was the leader and it landed here, on a node that
     // is not the leader either. Relaying it on would send it round the cycle that wrong address created, one
     // held request thread and one buffered upload per hop; refuse in one hop instead (issue #6191).
-    if (LeaderForwardContext.isAlreadyForwarded())
+    if (LeaderForwardContext.isAlreadyForwarded()) {
+      // Also said once in this node's log: the refusal is relayed back to the peer and from there to the
+      // client, so otherwise the only node that can name the misconfiguration never mentions it.
+      if (forwardedAgainWarned.compareAndSet(false, true))
+        LogManager.instance().log(this, Level.WARNING,
+            "A cluster peer forwarded a batch to this node as the leader, but this node is not the leader (db=%s). "
+                + "Unless leadership just moved, the HTTP address that peer resolved for the leader does not identify "
+                + "it: declare every node's HTTP port explicitly with the 'host:raftPort:httpPort' syntax in %s. The "
+                + "load is refused rather than relayed on. This notice is logged only once.",
+            databaseName, GlobalConfiguration.HA_SERVER_LIST.getKey());
       return new ExecutionResponse(400,
           "{ \"error\" : \"Refusing to forward a batch that a cluster peer already forwarded to the leader: it arrived "
-              + "on this node, which is not the leader. Either leadership moved while the request was in flight - retry - "
-              + "or the HTTP address that peer resolved for the leader does not identify it, which is what declaring "
-              + "every node's HTTP port ('host:raftPort:httpPort') in " + GlobalConfiguration.HA_SERVER_LIST.getKey()
-              + " prevents\"}");
+              + "on this node, which is not the leader. Either leadership moved while the request was in flight - "
+              + "retry - or the HTTP address that peer resolved for the leader does not identify it, which is what "
+              + "declaring every node's HTTP port ('host:raftPort:httpPort') in "
+              + GlobalConfiguration.HA_SERVER_LIST.getKey() + " prevents\"}");
+    }
 
     final String leaderAddress = ha.getLeaderAddress();
     if (leaderAddress == null || leaderAddress.isBlank())

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -36,6 +36,7 @@ import com.arcadedb.server.backup.AutoBackupSchedulerPlugin;
 import com.arcadedb.server.backup.BackupRetentionManager;
 import com.arcadedb.server.HAReplicatedDatabase;
 import com.arcadedb.server.HAServerPlugin;
+import com.arcadedb.server.LeaderForwardContext;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -1206,9 +1207,30 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (ha == null || ha.isLeader())
       return null;
 
+    // A peer already forwarded this command to what it believed was the leader and it arrived here, on a node
+    // that is not the leader either. Forwarding it on would send it round the cycle that wrong address
+    // created; refuse in one hop with the typed error instead (issue #6191).
+    if (LeaderForwardContext.isAlreadyForwarded())
+      throw new ServerIsNotTheLeaderException(
+          "Refusing to forward a server command that a cluster peer already forwarded to the leader: it arrived on "
+              + "this node, which is not the leader. Either leadership moved while the request was in flight - retry - "
+              + "or the HTTP address that peer resolved for the leader does not identify it, which is what declaring "
+              + "every node's HTTP port ('host:raftPort:httpPort') in " + GlobalConfiguration.HA_SERVER_LIST.getKey()
+              + " prevents", ha.getLeaderName());
+
     final String leaderHttpAddress = ha.getLeaderAddress();
     if (leaderHttpAddress == null)
       throw new ServerIsNotTheLeaderException("Leader address is unknown", ha.getLeaderName());
+
+    // Dialing an address that resolves to this node comes straight back here, and this node is not the
+    // leader. That is what the derive fallback produces when the peers share a host and no HTTP port is
+    // declared: it pairs the leader's Raft host with THIS node's HTTP port (issue #6191).
+    if (ha.isOwnHttpAddress(leaderHttpAddress))
+      throw new ServerIsNotTheLeaderException(
+          "Cannot forward the server command: the HTTP address resolved for the leader (" + leaderHttpAddress
+              + ") is this node's own, and this node is not the leader. Declare every node's HTTP port explicitly with "
+              + "the 'host:raftPort:httpPort' syntax in " + GlobalConfiguration.HA_SERVER_LIST.getKey(),
+          ha.getLeaderName());
 
     final HeaderValues authValues = exchange.getRequestHeaders().get("Authorization");
     final String authHeader = authValues != null ? authValues.getFirst() : null;
@@ -1216,6 +1238,9 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
         .uri(URI.create("http://" + leaderHttpAddress + "/api/v1/server"))
         .header("Content-Type", "application/json")
+        // One hop only: whichever node this address really names refuses the command if it is not the leader,
+        // instead of resolving the same address and forwarding it again (issue #6191).
+        .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true")
         .POST(HttpRequest.BodyPublishers.ofString(payload.toString()));
 
     if (authHeader != null && authHeader.startsWith("Bearer AU-")) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -1256,9 +1256,6 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
         .uri(URI.create("http://" + leaderHttpAddress + "/api/v1/server"))
         .header("Content-Type", "application/json")
-        // One hop only: whichever node this address really names refuses the command if it is not the leader,
-        // instead of resolving the same address and forwarding it again (issue #6191).
-        .header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true")
         .POST(HttpRequest.BodyPublishers.ofString(payload.toString()));
 
     if (authHeader != null && authHeader.startsWith("Bearer AU-")) {
@@ -1268,8 +1265,15 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       final String userName = user != null ? user.getName() : null;
       if (userName != null)
         builder.header("X-ArcadeDB-Forwarded-User", userName);
-      if (clusterToken != null && !clusterToken.isBlank())
+      if (clusterToken != null && !clusterToken.isBlank()) {
         builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
+        // One hop only: whichever node this address really names refuses the command if it is not the leader,
+        // instead of resolving the same address and forwarding it again (issue #6191). Sent only alongside
+        // the cluster token, because that is the only form in which the receiving node trusts it - see
+        // LeaderForwardContext. The other branch below relays the client's own credentials and carries no
+        // marker; its loop protection is the self-address check above.
+        builder.header(LeaderForwardContext.FORWARDED_TO_LEADER_HEADER, "true");
+      }
     } else if (authHeader != null) {
       // Basic or API token: stateless, forward as-is
       builder.header("Authorization", authHeader);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -65,6 +65,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -73,6 +74,13 @@ import java.util.regex.Pattern;
 
 public class PostServerCommandHandler extends AbstractServerHttpHandler {
   private static final HttpClient HTTP_CLIENT           = HttpClient.newHttpClient();
+
+  /**
+   * Emits the "a peer forwarded a server command here and this node is not the leader either" notice only
+   * once (issue #6191). Per handler instance, so each server in an in-process cluster says it once.
+   */
+  private final AtomicBoolean forwardedAgainWarned = new AtomicBoolean(false);
+
   private static final String LIST_DATABASES       = "list databases";
   private static final String SHUTDOWN             = "shutdown";
   private static final String CREATE_DATABASE      = "create database";
@@ -1210,13 +1218,23 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     // A peer already forwarded this command to what it believed was the leader and it arrived here, on a node
     // that is not the leader either. Forwarding it on would send it round the cycle that wrong address
     // created; refuse in one hop with the typed error instead (issue #6191).
-    if (LeaderForwardContext.isAlreadyForwarded())
+    if (LeaderForwardContext.isAlreadyForwarded()) {
+      // Also said once in this node's log: the refusal goes back to the peer and from there to the client, so
+      // otherwise the only node that can name the misconfiguration never mentions it.
+      if (forwardedAgainWarned.compareAndSet(false, true))
+        LogManager.instance().log(this, Level.WARNING,
+            "A cluster peer forwarded a server command to this node as the leader, but this node is not the leader. "
+                + "Unless leadership just moved, the HTTP address that peer resolved for the leader does not identify "
+                + "it: declare every node's HTTP port explicitly with the 'host:raftPort:httpPort' syntax in %s. The "
+                + "command is refused rather than forwarded on. This notice is logged only once.",
+            GlobalConfiguration.HA_SERVER_LIST.getKey());
       throw new ServerIsNotTheLeaderException(
           "Refusing to forward a server command that a cluster peer already forwarded to the leader: it arrived on "
               + "this node, which is not the leader. Either leadership moved while the request was in flight - retry - "
               + "or the HTTP address that peer resolved for the leader does not identify it, which is what declaring "
               + "every node's HTTP port ('host:raftPort:httpPort') in " + GlobalConfiguration.HA_SERVER_LIST.getKey()
               + " prevents", ha.getLeaderName());
+    }
 
     final String leaderHttpAddress = ha.getLeaderAddress();
     if (leaderHttpAddress == null)

--- a/server/src/test/java/com/arcadedb/server/LeaderForwardContextTest.java
+++ b/server/src/test/java/com/arcadedb/server/LeaderForwardContextTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The marker that stops a request being redirected to the leader twice (issue #6191). Two properties carry
+ * the whole safety of it, and both are about the pool of HTTP worker threads it lives on: a request that was
+ * not forwarded must not inherit a previous request's marker, and one thread's marker must not be visible to
+ * another.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LeaderForwardContextTest {
+
+  @AfterEach
+  void clearContext() {
+    LeaderForwardContext.clear();
+  }
+
+  @Test
+  void nothingIsMarkedByDefault() {
+    assertThat(LeaderForwardContext.isAlreadyForwarded()).isFalse();
+  }
+
+  @Test
+  void aMarkedRequestIsReported() {
+    LeaderForwardContext.markAlreadyForwarded();
+
+    assertThat(LeaderForwardContext.isAlreadyForwarded()).isTrue();
+  }
+
+  /** The finally block in the request loop: the next request served by this pooled thread starts clean. */
+  @Test
+  void clearingReleasesTheMarkerForTheNextRequestOnThisThread() {
+    LeaderForwardContext.markAlreadyForwarded();
+    LeaderForwardContext.clear();
+
+    assertThat(LeaderForwardContext.isAlreadyForwarded()).isFalse();
+  }
+
+  /** A forwarded request on one worker thread must not make a concurrent, unrelated one refuse to forward. */
+  @Test
+  void theMarkerDoesNotEscapeToAnotherThread() throws InterruptedException {
+    LeaderForwardContext.markAlreadyForwarded();
+
+    final AtomicBoolean seenElsewhere = new AtomicBoolean(true);
+    final Thread other = new Thread(() -> seenElsewhere.set(LeaderForwardContext.isAlreadyForwarded()));
+    other.start();
+    other.join();
+
+    assertThat(seenElsewhere).isFalse();
+    assertThat(LeaderForwardContext.isAlreadyForwarded()).as("and this thread keeps its own marker").isTrue();
+  }
+}


### PR DESCRIPTION
Fixes #6191.

## The defect

A follower forwards a write over HTTP to the address it resolves for the leader. That address is only as good as the configuration behind it: with no `http` port declared in `arcadedb.ha.serverList`, `RaftHAServer.resolveHttpAddress` derives it from the peer's Raft host plus **this** node's HTTP port. On a cluster whose nodes differ by port rather than by host - several nodes on one machine, `localhost:2434,localhost:2435,localhost:2436` - every peer, the leader included, resolves to the node doing the resolving.

`forwardCommandToLeaderViaRaft` then POSTs `/api/v1/command` to itself. `PostCommandHandler` runs it, `RaftReplicatedDatabase.command` sees `!isLeader()`, and forwards again. Nothing breaks the cycle; each hop holds one HTTP worker thread on a node that is already failing to make progress. Measured on the reproduction (guards disabled): **40 seconds of nested self-POSTs**, hundreds of stacked requests, ending only when the server was torn down.

Every write forwarded from a follower is affected, not only DDL - the branch is `isExecutedByTheLeader() || isDDL() || !isIdempotent()`.

## Why this is more than the issue proposed

The issue asked for a self-address check at the `/command` dial site. That is necessary but not sufficient, and it is not the only affected site:

- **A wrong address does not have to be *ours*.** Hosts A(2480), A(2481), B: on B the derived leader address names the *other* A node. B forwards to it, that node is not the leader either, resolves the same address, and forwards on. No local self-check can see that cycle.
- **`/command` is not the only path that redirects automatically.** `PostBatchHandler.forwardBatchToLeader` and `PostServerCommandHandler.forwardToLeaderIfReplica` resolve the same leader address and relay a client's request to it - the batch one buffering a whole upload per hop.

So the fix is two guards, neither of which covers the other:

1. **Dial side** - refuse when the resolved leader address is this node's own and this node is not the leader, on all three forwarding paths, through a new `RaftHAServer.isOwnHttpAddress`. `ArcadeStateMachine.triggerSnapshotDownload`'s #6111 refusal now shares that helper instead of hand-rolling the comparison, so the two cannot drift apart. The benign case the existing comment describes - this node *became* the leader while waiting, so the POST to self executes locally - is left alone.
2. **Receiving side** - a request a peer already forwarded to the leader is never forwarded again, whichever node it lands on. This is the general bound: it costs one hop regardless of which node the wrong address named. It is also the existing pattern in this module - `LeaderProxy` refuses to re-forward an already-forwarded request - generalized so the engine-level decision can use it.

The marker travels as `X-ArcadeDB-Forwarded-To-Leader` and is published onto a thread-local (`LeaderForwardContext`) by `AbstractServerHttpHandler`, because the `/command` decision is taken deep in the engine where the HTTP exchange is out of reach. It is honored whoever sent it - the server-command path relays a client's own Basic/API-token credentials rather than the cluster token - because its only possible effect on a receiving node is to **refuse**: a client that sets the header on its own request can have that request refused, never executed on a node that is not the leader.

Both refusals are `ServerIsNotTheLeaderException`, the typed error the HTTP and gRPC layers already report, with a message naming `arcadedb.ha.serverList`'s `http` field, plus a one-time WARNING next to the existing derive warning.

Two things had to be fixed for that type to survive:

- `reconstructLeaderException` had no arm for it, so a peer's "I am not the leader either" collapsed into a bare `TransactionException` and the caller lost the retryability it inherits from `NeedRetryException`;
- the wrapped arm of the HTTP error mapping had none either, so a refusal raised inside `DatabaseAbstractHandler`'s auto-commit wrapper - which is exactly where the HA write path raises it - answered 500 "Error on transaction commit". It now answers 400 with the leader named, symmetric with the un-wrapped arm.

Deliberately **not** changed: `resolveHttpAddress` itself. Unlike the routing table of #6183, HTTP addresses also feed cluster reporting (`getReplicaAddresses()`, `getStats()`) and peer-to-peer snapshot transfer, where a best-effort address is still worth showing and nothing auto-redirects onto it. The check belongs at the sites that *dial*, not at the resolver that *advertises*.

## Tests

`Issue6191FollowerForwardLoopIT` (3-node in-process cluster; the ambiguity is injected into one follower's resolved-address map for the duration of a single test, so cluster startup - which dials those same addresses to probe peers - is not part of what is under test):

- a follower whose leader address derives to its own endpoint refuses the write instead of POSTing to itself;
- a write forwarded onto a *second* follower is refused there rather than forwarded on, and reaches the first node as a `ServerIsNotTheLeaderException`, not a flattened transaction failure;
- the same for `POST /api/v1/batch`, driven over real HTTP;
- control: with the addresses the cluster actually has, a follower write is still forwarded and executed by the leader.

With both guards removed, the first test spends 40s in the loop and the second one succeeds where it must fail - neither is vacuous.

Also `Issue6191SelfForwardGuardTest` (the address comparison, including the host-case and loopback-spelling decisions), `LeaderForwardContextTest` (the marker does not leak across pooled worker threads and does not survive a request), and two `reconstructLeaderException` cases.

Green: `ha-raft` unit suite (881), `server` unit suite (735), and `Issue6191FollowerForwardLoopIT`, `RaftBatchEndpointIT`, `RaftLeaderProxyIT`, `RaftEmbeddedWriteAgainstReplicaIT`, `RaftReplicationWriteAgainstReplicaIT`, `RaftUserManagement3NodesIT`, `RaftReplicationChangeSchemaIT`, `RaftSchemaWalInstalment3NodesIT`, `Issue6183AmbiguousRoutingIT`, `Issue6183FollowerCommandRoutingIT`.
