### PR TITLE
fix(#6204): localhost and 127.0.0.1 are one endpoint, so the self-forward guard fires on the cluster that needs it

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LoopbackHosts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LoopbackHosts.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import java.util.Set;
+
+/**
+ * The ways a server list can spell the loopback host, in one place. Three parts of the HA code have to
+ * recognise it - the inbound gRPC allowlist seeds itself with it, the server-list validation rejects a list
+ * that mixes it with real hosts, and the self-forward guard has to see that {@code localhost:2480} and
+ * {@code 127.0.0.1:2480} are one socket (issue #6204) - and a spelling missing from any one copy is a silent
+ * hole in that check rather than a visible failure.
+ * <p>
+ * Purely textual: no name is resolved. That keeps the recognition free of DNS on a request path and, more
+ * importantly, honest - it answers "was this written as the loopback host", which is a question about the
+ * configuration, not about what a resolver would say about it today.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class LoopbackHosts {
+
+  /** The IP literals, as they appear on the wire and in a server list. */
+  static final Set<String> IPS = Set.of("127.0.0.1", "0:0:0:0:0:0:0:1", "::1");
+
+  private LoopbackHosts() {
+  }
+
+  /**
+   * True when {@code host} is the loopback host written in any of its accepted forms: the name
+   * {@code localhost} in any case, the IPv4 literal, or the IPv6 literal with or without brackets.
+   * <p>
+   * Only <em>the</em> loopback address qualifies. {@code 127.0.0.2} is a loopback address as well, but a
+   * different one, and two nodes bound to different addresses of the range with the same port is a working
+   * single-machine cluster that must keep forwarding between its nodes.
+   */
+  static boolean isLoopback(final String host) {
+    if (host == null || host.isEmpty())
+      return false;
+
+    final String bare = host.charAt(0) == '[' && host.charAt(host.length() - 1) == ']' ?
+        host.substring(1, host.length() - 1) :
+        host;
+
+    // The IP literals carry no letters, so an exact match is already case-insensitive for them.
+    return "localhost".equalsIgnoreCase(bare) || IPS.contains(bare);
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PeerAddressAllowlistFilter.java
@@ -82,7 +82,6 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
     InetAddress[] resolve(String host) throws UnknownHostException;
   }
 
-  private static final Set<String> LOOPBACK_IPS = Set.of("127.0.0.1", "0:0:0:0:0:0:0:1", "::1");
   // Minimum spacing between miss-triggered re-resolutions. Bounds DNS load under a connection flood
   // (at startup or from a non-peer) while letting the allowlist converge within ~1s.
   private static final long        MISS_RESOLVE_FLOOR_MS = 1_000L;
@@ -252,7 +251,7 @@ final class PeerAddressAllowlistFilter extends ServerTransportFilter {
 
   private synchronized void doResolve() {
     final long now = clock.getAsLong();
-    final Set<String> effective = new HashSet<>(LOOPBACK_IPS);
+    final Set<String> effective = new HashSet<>(LoopbackHosts.IPS);
     int covered = 0;
     for (final String host : peerHosts) {
       Set<String> fresh = null;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -401,10 +401,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * node's HTTP port, so every peer collapses onto this node's own address.
    * <p>
    * A textual comparison, like the peer bookkeeping it reads: both sides come from the same resolver, so a
-   * derived address matches a derived one. It deliberately does not resolve hostnames - {@code localhost}
-   * and {@code 127.0.0.1} are not reported as the same endpoint - because the addresses only differ that
-   * way when they were declared explicitly, and a declared address is a statement about which node owns
-   * which port that this method has no business second-guessing.
+   * derived address matches a derived one. It deliberately does not resolve hostnames - a declared host name
+   * is a statement about which node owns which port that this method has no business second-guessing - with
+   * the single exception of the loopback spellings, which are one socket written two ways and are what a
+   * single-machine cluster is usually configured with (issue #6204).
    */
   public boolean isOwnHttpAddress(final String address) {
     return isSameHttpEndpoint(getLocalHttpAddress(), address);
@@ -414,11 +414,39 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * Whether two {@code host:port} addresses name the same listening socket. Case-insensitive, because host
    * names are: the two sides can come from different entries of {@code HA_SERVER_LIST} and a difference in
    * case would otherwise read as "a different node", which is the answer that lets a redirect loop live.
-   * Never resolves names, so {@code localhost} and {@code 127.0.0.1} are reported as different endpoints
-   * (see {@link #isOwnHttpAddress}). Package-private for testing.
+   * <p>
+   * Beyond the text, the one equivalence it knows is the loopback host: a hand-written server list for a
+   * single-machine cluster routinely spells one node {@code localhost} and the next {@code 127.0.0.1}, and
+   * that is precisely the deployment where the derive fallback resolves a peer onto this node's own socket
+   * (issue #6204). The equivalence is only applied when the ports are equal, which is what makes it safe -
+   * two nodes cannot both be listening on one port of one host, so "loopback on both sides, same port" is
+   * the same socket rather than an ambiguity worth preserving. It is not extended to a wildcard bind or to a
+   * different address of the loopback range: those can genuinely name another node, and answering "that is
+   * me" for one of them would refuse a write that had to be forwarded. See {@link LoopbackHosts}.
+   * <p>
+   * Package-private for testing.
    */
   static boolean isSameHttpEndpoint(final String address, final String other) {
-    return address != null && address.equalsIgnoreCase(other);
+    if (address == null || other == null)
+      return false;
+    if (address.equalsIgnoreCase(other))
+      return true;
+
+    // The last colon separates the port: an unbracketed IPv6 literal carries colons of its own, and only the
+    // last one is the separator.
+    final int addressPortAt = address.lastIndexOf(':');
+    final int otherPortAt = other.lastIndexOf(':');
+    if (addressPortAt < 0 || otherPortAt < 0)
+      return false;
+
+    // Compared in place: on a same-host cluster the port is what differs, so the common "no" costs nothing.
+    final int portLength = address.length() - addressPortAt - 1;
+    if (portLength != other.length() - otherPortAt - 1 //
+        || !address.regionMatches(addressPortAt + 1, other, otherPortAt + 1, portLength))
+      return false;
+
+    return LoopbackHosts.isLoopback(address.substring(0, addressPortAt)) //
+        && LoopbackHosts.isLoopback(other.substring(0, otherPortAt));
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
@@ -221,7 +221,7 @@ final class RaftPeerAddressResolver {
     boolean hasNonLocalhost = false;
     for (final RaftPeer peer : peers) {
       final String host = peer.getAddress().split(":")[0].trim();
-      if ("localhost".equals(host) || "127.0.0.1".equals(host))
+      if (LoopbackHosts.isLoopback(host))
         hasLocalhost = true;
       else
         hasNonLocalhost = true;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191SelfForwardGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6191SelfForwardGuardTest.java
@@ -58,12 +58,13 @@ class Issue6191SelfForwardGuardTest {
   }
 
   /**
-   * No name resolution: the two spellings only ever differ this way when they were declared explicitly, and a
-   * declared address is a statement about which node owns which port that this comparison does not overrule.
+   * A declared host name is a statement about which node owns which port, and no name resolution happens
+   * here to overrule it. The spellings of the loopback address are the one exception, in
+   * {@link Issue6204LoopbackEndpointTest}.
    */
   @Test
-  void loopbackSpellingsAreNotUnified() {
-    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "127.0.0.1:2480")).isFalse();
+  void aHostNameIsNotUnifiedWithAnIp() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("db0.example.com:2480", "10.0.0.7:2480")).isFalse();
   }
 
   /** An address that could not be resolved is not evidence of anything, in either position. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6204LoopbackEndpointTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6204LoopbackEndpointTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A single-machine cluster is the commonest way to meet the address the self-forward guard exists to catch
+ * (issue #6191), and it is also the one place where the same socket gets written two ways: one entry of
+ * {@code HA_SERVER_LIST} says {@code localhost}, the next says {@code 127.0.0.1}. The guard compares text, so
+ * before issue #6204 those two read as different nodes and the guard stayed silent on exactly the deployment
+ * that needs it.
+ * <p>
+ * The equivalence stops at the spellings of <em>the</em> loopback address. A distinct loopback address
+ * ({@code 127.0.0.2}), a wildcard bind ({@code 0.0.0.0}) and a declared host name are all still different
+ * endpoints: those can genuinely name another node, and answering "that is me" for one of them would refuse a
+ * write that had to be forwarded.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6204LoopbackEndpointTest {
+
+  @Test
+  void localhostAndTheIpv4LoopbackAreTheSameEndpoint() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "127.0.0.1:2480")).isTrue();
+    assertThat(RaftHAServer.isSameHttpEndpoint("127.0.0.1:2480", "localhost:2480")).isTrue();
+  }
+
+  @Test
+  void theIpv6LoopbackIsTheSameEndpointToo() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "[::1]:2480")).isTrue();
+    assertThat(RaftHAServer.isSameHttpEndpoint("127.0.0.1:2480", "[0:0:0:0:0:0:0:1]:2480")).isTrue();
+    // Unbracketed, which is how a hand-written server list tends to spell it: the last colon is still the
+    // port separator, so the host is read as "::1" and not as a truncated address.
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "::1:2480")).isTrue();
+  }
+
+  /** Host names are case-insensitive on both sides of the equivalence, not only when they match textually. */
+  @Test
+  void caseIsStillIgnored() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("LOCALHOST:2480", "127.0.0.1:2480")).isTrue();
+  }
+
+  /**
+   * The port is what tells apart the nodes of a same-host cluster, and it is the reason the equivalence is
+   * safe: two of them cannot be listening on one port of one host, so equal port plus loopback on both sides
+   * is the same socket.
+   */
+  @Test
+  void thePortStillDecides() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:2480", "127.0.0.1:2481")).isFalse();
+    assertThat(RaftHAServer.isSameHttpEndpoint("[::1]:2480", "localhost:2481")).isFalse();
+  }
+
+  /**
+   * {@code 127.0.0.2} is a loopback address but not the same one: binding two nodes to different addresses of
+   * the loopback range with a shared port is a legitimate way to run a cluster on one machine, and unifying
+   * them would refuse the forwarding between them.
+   */
+  @Test
+  void anotherLoopbackAddressIsADifferentSocket() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("127.0.0.1:2480", "127.0.0.2:2480")).isFalse();
+  }
+
+  /**
+   * A wildcard bind accepts connections on every local interface, so it is tempting to read it as "any
+   * address is mine". It is not: two nodes on two machines both bound to {@code 0.0.0.0:2480} would then
+   * refuse to forward to each other, turning a working cluster into a read-only one.
+   */
+  @Test
+  void theWildcardBindIsNotEveryPeer() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("0.0.0.0:2480", "db1.example.com:2480")).isFalse();
+    assertThat(RaftHAServer.isSameHttpEndpoint("0.0.0.0:2480", "127.0.0.1:2480")).isFalse();
+  }
+
+  /** A declared host name is a statement about which node owns which port, and it is not overruled here. */
+  @Test
+  void aDeclaredHostNameIsNotUnifiedWithAnIp() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("db0.example.com:2480", "127.0.0.1:2480")).isFalse();
+  }
+
+  /** Without a port there is no endpoint to compare, so the answer falls back to the text. */
+  @Test
+  void aBareHostIsNotAnEndpoint() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost", "127.0.0.1")).isFalse();
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost", "localhost")).isTrue();
+  }
+
+  @Test
+  void theLoopbackSpellingsAreRecognisedOnTheirOwn() {
+    assertThat(LoopbackHosts.isLoopback("localhost")).isTrue();
+    assertThat(LoopbackHosts.isLoopback("LocalHost")).isTrue();
+    assertThat(LoopbackHosts.isLoopback("127.0.0.1")).isTrue();
+    assertThat(LoopbackHosts.isLoopback("::1")).isTrue();
+    assertThat(LoopbackHosts.isLoopback("[::1]")).isTrue();
+    assertThat(LoopbackHosts.isLoopback("0:0:0:0:0:0:0:1")).isTrue();
+
+    assertThat(LoopbackHosts.isLoopback("127.0.0.2")).isFalse();
+    assertThat(LoopbackHosts.isLoopback("0.0.0.0")).isFalse();
+    assertThat(LoopbackHosts.isLoopback("db0")).isFalse();
+    assertThat(LoopbackHosts.isLoopback("[")).isFalse();
+    assertThat(LoopbackHosts.isLoopback("")).isFalse();
+    assertThat(LoopbackHosts.isLoopback(null)).isFalse();
+  }
+}


### PR DESCRIPTION
Closes #6204. Follow-up to #6191 / #6195.

### The gap

The self-forward guard asks one question - "is this resolved leader address my own?" - and answers it by comparing text. The deployment where the derive fallback really does collapse a peer onto this node's own socket is a cluster whose nodes share a host, and that is also the deployment whose `HA_SERVER_LIST` is hand-written and routinely spells one node `localhost` and the next `127.0.0.1`. Written that way, the guard saw two different nodes:

- the write-forwarding refusal did not fire, so the request was bounded only by the second guard, the one-hop `X-ArcadeDB-Forwarded-To-Leader` marker - correct, but one wasted round trip and one wasted worker thread later than it should be;
- `ArcadeStateMachine.triggerSnapshotDownload`'s self-resync backstop did not fire either, and there nothing else stands behind it except the `isLeader()` check the backstop exists *because* it can be stale (#6111). A self-resync copies this node's incomplete databases onto themselves and reports success.

### The change

`isSameHttpEndpoint` now unifies the spellings of the loopback host - `localhost`, `127.0.0.1`, `::1`, `0:0:0:0:0:0:0:1`, bracketed or not - **and only when the ports are equal**. The port condition is what makes the equivalence safe rather than a guess: two nodes cannot both be listening on one port of one host, so loopback on both sides with the same port is the same socket, not an ambiguity worth preserving.

Deliberately not unified, because each can genuinely name another node and a false "that is me" refuses a write that had to be forwarded:

- a wildcard bind (`0.0.0.0:2480`), which would otherwise match every peer on that port and turn a two-machine cluster read-only;
- another address of the loopback range (`127.0.0.2`), which is a legitimate way to run two nodes on one machine with one port;
- a declared host name against an IP - that still needs resolution, and the path stays free of it.

The last colon is taken as the port separator so an unbracketed IPv6 literal parses correctly, and the port is compared in place with `regionMatches`: on a same-host cluster the port is what differs, so the common "no" allocates nothing.

`localhost` and the loopback literals were already spelled out in two places - the inbound gRPC allowlist seed and the server-list validation that rejects a list mixing loopback with real hosts - so they move into `LoopbackHosts` and both existing call sites read from it rather than a third copy appearing. The validation gains the `::1` spellings and case-insensitivity from that; its behaviour is otherwise unchanged.

### Verification

`Issue6204LoopbackEndpointTest` (9 cases) covers both directions of the equivalence, the IPv6 forms bracketed and bare, case, and every negative above; the case in `Issue6191SelfForwardGuardTest` that asserted the old behaviour is replaced by one that pins what is still not unified (a host name against an IP). Every assertion in the new class fails against the previous one-line implementation.

Run locally, all green: `Issue6204LoopbackEndpointTest`, `Issue6191SelfForwardGuardTest`, `PeerAddressAllowlistFilterTest`, `RaftHAServerTest`, `RaftHAServerAddressParsingTest`, `RaftHAServerValidatePeerAddressTest`, `Issue4836K8sScaleUpTest`, `RaftReplicatedDatabaseTest`, `Issue6111StaleSnapshotReadFloorTest` - 217 tests.

`Issue6191FollowerForwardLoopIT` was **not** re-run locally: it binds 2480 and up, and port 2480 is currently held by another server on this machine, which turns that class red for reasons unrelated to the change. It cannot be affected either way - its three nodes differ by port, and the equivalence only ever applies to two addresses whose ports are equal - but CI will run it.
