### PR TITLE
fix(#6103): a rolled-back type rename puts its buckets back under the names they report

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -288,6 +288,12 @@ public class LocalDocumentType implements DocumentType {
    * the same inconsistency in the opposite direction. In the rollback it runs even when the restore failed, so the
    * map always agrees with whatever name the component ended up with; that case is reported separately through the
    * {@code corrupted} flag.
+   * <p>
+   * The guarantee is only that the key agrees with the component, not that the component agrees with the disk:
+   * {@link com.arcadedb.engine.PaginatedComponent#rename} moves the file and updates the {@code FileManager} before
+   * it assigns {@code componentName}, so a failure between those steps leaves the file under the new name while the
+   * component - and therefore this map - keeps the old one. That window predates this method and is not closed by
+   * it.
    */
   protected void rekeyBucket(final Bucket bucket, final String previousKey) {
     final String currentName = bucket.getName();

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -215,8 +215,7 @@ public class LocalDocumentType implements DocumentType {
 
         removedBuckets.add(bucket);
 
-        schema.bucketMap.remove(oldBucketName);
-        schema.bucketMap.put(bucket.getName(), (LocalBucket) bucket);
+        rekeyBucket(bucket, oldBucketName);
       }
 
       name = newName;
@@ -253,9 +252,9 @@ public class LocalDocumentType implements DocumentType {
       }
 
       for (Bucket bucket : removedBuckets) {
+        final String renamedBucketName = bucket.getName();
         try {
-          final String newBucketName = bucket.getName();
-          final String restoredName = LocalSchema.rebaseComponentName(newBucketName, newName, oldName,
+          final String restoredName = LocalSchema.rebaseComponentName(renamedBucketName, newName, oldName,
               schema.getEncoding());
           if (restoredName == null)
             corrupted = true;
@@ -263,6 +262,8 @@ public class LocalDocumentType implements DocumentType {
             ((LocalBucket) bucket).rename(restoredName);
         } catch (IOException ex) {
           corrupted = true;
+        } finally {
+          rekeyBucket(bucket, renamedBucketName);
         }
       }
 
@@ -272,6 +273,29 @@ public class LocalDocumentType implements DocumentType {
 
       throw new SchemaException("Error on renaming type '" + oldName + "' in '" + newName + "'", e);
     }
+  }
+
+  /**
+   * Moves the schema's bucket-map entry from {@code previousKey} to the name the bucket now reports.
+   * <p>
+   * The map is keyed by name and the key is not derived from the component on lookup, so renaming a bucket without
+   * re-keying leaves the bucket unreachable under its own name while the stale key resolves to a component that
+   * answers to a different one. Everything name-based then disagrees with the schema: {@code existsBucket()},
+   * {@code getBucketByName()} (hence {@code SELECT FROM BUCKET:x}), the duplicate-name guard in
+   * {@code LocalSchema.createBucket()}, and the keys of the statistics file.
+   * <p>
+   * Called from both the forward rename loop and its rollback: a rollback that restores the file but not the key is
+   * the same inconsistency in the opposite direction. In the rollback it runs even when the restore failed, so the
+   * map always agrees with whatever name the component ended up with; that case is reported separately through the
+   * {@code corrupted} flag.
+   */
+  protected void rekeyBucket(final Bucket bucket, final String previousKey) {
+    final String currentName = bucket.getName();
+    if (previousKey.equals(currentName))
+      return;
+
+    schema.bucketMap.remove(previousKey, bucket);
+    schema.bucketMap.put(currentName, (LocalBucket) bucket);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalVertexType.java
@@ -66,8 +66,7 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
 
         removedBuckets.add(bucket);
 
-        schema.bucketMap.remove(oldBucketName);
-        schema.bucketMap.put(bucket.getName(), (LocalBucket) bucket);
+        rekeyBucket(bucket, oldBucketName);
       }
 
       // SchemaException too: it is a RuntimeException, and letting it past this catch would leave the edge buckets
@@ -77,9 +76,9 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
 
       boolean corrupted = false;
       for (Bucket bucket : removedBuckets) {
+        final String renamedBucketName = bucket.getName();
         try {
-          final String newBucketName = bucket.getName();
-          final String restoredName = LocalSchema.rebaseComponentName(newBucketName, newName, oldName,
+          final String restoredName = LocalSchema.rebaseComponentName(renamedBucketName, newName, oldName,
               schema.getEncoding());
           if (restoredName == null)
             corrupted = true;
@@ -87,6 +86,8 @@ public class LocalVertexType extends LocalDocumentType implements VertexType {
             ((LocalBucket) bucket).rename(restoredName);
         } catch (IOException ex) {
           corrupted = true;
+        } finally {
+          rekeyBucket(bucket, renamedBucketName);
         }
       }
 

--- a/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.index.TypeIndex;
 import org.junit.jupiter.api.Test;
@@ -289,6 +290,136 @@ class TypeRenameComponentNamingTest extends TestHelper {
       assertThat(database.query("sql", "select from Multi where p1 = 'a3'").stream().count()).isEqualTo(1L);
       assertThat(database.query("sql", "select from Multi where p2 = 'b4'").stream().count()).isEqualTo(1L);
     });
+  }
+
+  /**
+   * The forward bucket loop re-keys {@code LocalSchema.bucketMap} as each bucket is renamed. The rollback used to
+   * restore only the file and the component's own name, so after a mid-loop failure the map still held the earlier
+   * buckets under the name the rename was going to give them, pointing at components whose {@code getName()} had
+   * gone back to the old one. Everything that resolves a bucket by name then disagrees with the schema:
+   * {@code SELECT FROM BUCKET:x}, {@code existsBucket()}, the duplicate-name guard in {@code createBucket()} and the
+   * keys of the statistics file.
+   * <p>
+   * The failure is injected the same way as {@link #aFailedIndexRenameRollsBackTheIndexesAlreadyRenamed}: a
+   * directory parked on the path the last bucket's file is about to move to, which {@code Files.move} cannot
+   * replace.
+   */
+  @Test
+  void aFailedBucketRenameRestoresTheBucketMapKeys() {
+    database.transaction(() -> database.getSchema().createDocumentType("Multi", 2).createProperty("p1", Type.STRING));
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.newDocument("Multi").set("p1", "a" + i).save();
+    });
+
+    final List<Bucket> buckets = new ArrayList<>(database.getSchema().getType("Multi").getBuckets(false));
+    assertThat(buckets).as("two buckets are needed for a mid-loop failure").hasSize(2);
+
+    final File databaseDirectory = new File(database.getDatabasePath());
+    final File parked = parkDirectoryOnRenameTarget(databaseDirectory, buckets.getLast().getName(), "Multi",
+        "renamed.Multi");
+
+    try {
+      assertThatThrownBy(() -> database.getSchema().getType("Multi").rename("renamed.Multi"))
+          .isInstanceOf(SchemaException.class);
+    } finally {
+      parked.delete();
+    }
+
+    assertBucketMapKeysMatchBucketNames();
+    assertThat(database.getSchema().existsBucket("renamed.Multi_0")).as("no leftover key under the new name").isFalse();
+    assertThat(database.getSchema().existsBucket("renamed.Multi_1")).as("no leftover key under the new name").isFalse();
+
+    // A bucket that is no longer reachable by its own name cannot be queried, and its name looks free to reuse.
+    database.transaction(() -> assertThat(database.query("sql", "select from BUCKET:Multi_0").stream().count())
+        .as("the rolled-back bucket is still addressable by name").isPositive());
+    assertThatThrownBy(() -> database.getSchema().createBucket("Multi_0"))
+        .as("the rolled-back bucket name is still taken").isInstanceOf(SchemaException.class);
+
+    assertThat(database.countType("Multi", true)).isEqualTo(10L);
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.countType("Multi", true)).isEqualTo(10L);
+    assertBucketMapKeysMatchBucketNames();
+  }
+
+  /**
+   * Same defect on the vertex-specific half of the rename: {@link LocalVertexType} renames the out/in edge buckets
+   * in a second loop, with the same per-bucket re-keying and the same rollback that used to skip it.
+   */
+  @Test
+  void aFailedEdgeBucketRenameRestoresTheBucketMapKeys() {
+    database.getSchema().createVertexType("V", 1);
+    database.getSchema().createVertexType("W", 1);
+    database.getSchema().createEdgeType("E", 1);
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        final var from = database.newVertex("V").set("k", i).save();
+        final var to = database.newVertex("W").set("k", i).save();
+        from.newEdge("E", to, true, new Object[0]);
+      }
+    });
+
+    final List<Bucket> edgeBuckets = database.getSchema().getType("V").getInvolvedBuckets().stream()
+        .filter(b -> b.getName().endsWith("_out_edges") || b.getName().endsWith("_in_edges")).toList();
+    assertThat(edgeBuckets).as("out and in edge buckets are needed for a mid-loop failure").hasSize(2);
+
+    final File databaseDirectory = new File(database.getDatabasePath());
+    final File parked = parkDirectoryOnRenameTarget(databaseDirectory, edgeBuckets.getLast().getName(), "V", "re.named");
+
+    try {
+      assertThatThrownBy(() -> database.getSchema().getType("V").rename("re.named"))
+          .isInstanceOf(SchemaException.class);
+    } finally {
+      parked.delete();
+    }
+
+    assertBucketMapKeysMatchBucketNames();
+    assertThat(database.getSchema().existsBucket("re.named_0_out_edges")).as("no leftover key under the new name")
+        .isFalse();
+    assertThat(database.getSchema().existsBucket("re.named_0")).as("no leftover key under the new name").isFalse();
+    assertThat(database.getSchema().existsBucket("V_0_out_edges")).isTrue();
+    assertThat(database.getSchema().existsBucket("V_0")).isTrue();
+
+    assertThat(database.countType("V", true)).isEqualTo(10L);
+    database.transaction(() -> assertThat(database.query("sql", "select expand(out('E')) from V").stream().count())
+        .isEqualTo(10L));
+
+    assertComponentFileNamesAreWellFormed();
+    reopen();
+
+    assertThat(database.countType("V", true)).isEqualTo(10L);
+    assertBucketMapKeysMatchBucketNames();
+    database.transaction(() -> assertThat(database.query("sql", "select expand(out('E')) from V").stream().count())
+        .isEqualTo(10L));
+  }
+
+  /**
+   * Fault injection: park a directory on the file path the rename of {@code componentName} is about to move to, so
+   * {@code Files.move} raises an {@code IOException}. A derived component name is {@code <typeName><suffix>} and the
+   * file name is that plus a {@code .fileId.pageSize.vVersion.ext} tail, both of which the rename carries over
+   * untouched, so the target file name is the same with the type-name prefix swapped.
+   */
+  private File parkDirectoryOnRenameTarget(final File directory, final String componentName, final String oldTypeName,
+      final String newTypeName) {
+    assertThat(componentName).startsWith(oldTypeName + "_");
+    final File blockedFile = fileStartingWith(directory, componentName + ".");
+    final File parked = new File(directory, newTypeName + blockedFile.getName().substring(oldTypeName.length()));
+    assertThat(parked.mkdir()).as("fault injection: park a directory on %s", parked.getName()).isTrue();
+    return parked;
+  }
+
+  /**
+   * Every bucket must be registered under the name it reports. A key that no longer matches is not merely untidy:
+   * the bucket becomes unreachable by name while the stale key resolves to a component that answers to something
+   * else.
+   */
+  private void assertBucketMapKeysMatchBucketNames() {
+    for (final Bucket bucket : database.getSchema().getBuckets())
+      assertThat(database.getSchema().getBucketByNameIfExists(bucket.getName()))
+          .as("bucket '%s' must be registered under the name it reports", bucket.getName()).isSameAs(bucket);
   }
 
   private static File fileStartingWith(final File directory, final String prefix) {

--- a/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java
@@ -330,7 +330,8 @@ class TypeRenameComponentNamingTest extends TestHelper {
     assertThat(database.getSchema().existsBucket("renamed.Multi_0")).as("no leftover key under the new name").isFalse();
     assertThat(database.getSchema().existsBucket("renamed.Multi_1")).as("no leftover key under the new name").isFalse();
 
-    // A bucket that is no longer reachable by its own name cannot be queried, and its name looks free to reuse.
+    // The two lookups a stale key would have broken: the bucket answers to its own name again, and that name is
+    // still taken, so nothing can be created over the file it already owns.
     database.transaction(() -> assertThat(database.query("sql", "select from BUCKET:Multi_0").stream().count())
         .as("the rolled-back bucket is still addressable by name").isPositive());
     assertThatThrownBy(() -> database.getSchema().createBucket("Multi_0"))


### PR DESCRIPTION
Closes #6103

## What was wrong

`LocalDocumentType.rename()` and `LocalVertexType.rename()` re-key `LocalSchema.bucketMap` as each bucket is renamed in the forward loop:

```java
schema.bucketMap.remove(oldBucketName);
schema.bucketMap.put(bucket.getName(), (LocalBucket) bucket);
```

When a later bucket failed, the `catch` restored the earlier buckets' **files** and their `componentName`, but never undid the map mutation. After a rollback the map therefore held an entry under the name the rename was *going to* give the bucket, pointing at a component whose `getName()` had gone back to the old one - and no entry at all under the name the component actually reports.

`bucketMap` is keyed by name and nothing re-derives the key on lookup, so from that point on everything name-based disagreed with the schema:

- `Schema.existsBucket(name)` / `getBucketByName(name)` - hence `SELECT FROM BUCKET:x` and `INSERT INTO BUCKET:x` - could no longer find the bucket.
- The duplicate-name guard in `LocalSchema.createBucket()` reads the same map, so the name looked free and a second bucket could be created over the existing file.
- `writeStatisticsFile()` iterates `bucketMap.entrySet()` and writes the stale key, so the cached record count and page statistics were filed under a name that does not exist on reopen.
- On `LocalVertexType`, `GraphEngine.createVertexAdditionalBuckets()` resolves the out/in edge buckets by name, so a later `addBucket()` on the type would try to create a bucket whose file is already on disk.

The index half of the same rollback was fixed in #6099 (`34e852b32`); this is the bucket half that comment https://github.com/ArcadeData/arcadedb/issues/6103#issuecomment-5273160092 narrowed the issue down to.

## The fix

Both loops now go through one helper, `LocalDocumentType.rekeyBucket(bucket, previousKey)`, which moves the map entry to whatever name the component currently reports. The forward loop calls it after the rename, and the rollback calls it in a `finally` so the map agrees with the component even when the restore itself failed - that case is still reported separately through the existing `corrupted` flag, which is what the `SchemaException` message is for.

`LocalVertexType` inherits the helper and uses it for its edge-bucket loop; its main-bucket half already went back through `super.rename(oldName)`, which is the forward path and re-keys correctly.

## Tests

Two regression tests in `engine/src/test/java/com/arcadedb/schema/TypeRenameComponentNamingTest.java`, both using the fault-injection pattern #6099 established (park a directory on the path the component file is about to move to, so `Files.move` raises a real `IOException` - no mocks):

- `aFailedBucketRenameRestoresTheBucketMapKeys` - a 2-bucket document type, the failure injected on the last bucket.
- `aFailedEdgeBucketRenameRestoresTheBucketMapKeys` - a vertex type with edges, the failure injected on the last edge bucket, which exercises `LocalVertexType`'s own loop after `super.rename()` has already succeeded.

Both assert the invariant directly (every bucket in `schema.getBuckets()` resolves under the name it reports), that no key survives under the new name, and then the user-visible consequences: `SELECT FROM BUCKET:Multi_0` still works, `createBucket("Multi_0")` is still refused as a duplicate, the type still counts and traverses, and all of it survives a reopen.

Verified red before the fix (both failed on the invariant assertion, the other 10 tests in the class passing) and green after.

## Test plan

- [ ] `mvn -o -pl engine -am -Dtest=TypeRenameComponentNamingTest test` - 12/12 green.
- [ ] `mvn -o -pl engine -am -DexcludedGroups=benchmark,slow,vector test` - no regressions in the engine unit lane.
- [ ] Manually: create a type with two buckets, make the second bucket's rename target unwritable, `ALTER TYPE ... NAME ...`, then confirm `SELECT FROM BUCKET:<firstBucket>` still resolves.
