### PR TITLE
fix(#6090): CHECK DATABASE reports an orphan edge record, and can reclaim one on request

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1938,6 +1938,11 @@ The probe is now **direction-aware**, and what it establishes is reported:
 `missingReferenceBack` is deliberately untouched - both probes still run and it is still bumped once per side
 that holds no reference - so anything parsing today's result keeps reading the same number.
 
+The three new counters are **not disjoint**, which matters if you render them as a summary: one orphaned
+bidirectional edge increments all three. Each answers "how many edges have this defect" independently, so
+summing them double-counts. `unreachableEdgeRecords` is the orphan total; the other two are the per-direction
+detail behind it, plus the half-linked edges that are still reachable from one side.
+
 Reclaiming them is a new, explicit clause: **`CHECK DATABASE FIX DELETE ORPHANS`**. It is not folded into plain
 `FIX`, and the reason is a data-loss path rather than a taste for options. The detection cannot distinguish
 "this record is garbage a failed bulk load left behind" from "this vertex lost its head-chunk pointer, so its

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1910,3 +1910,50 @@ Two things the same method carried:
   parking the single-threaded lifecycle executor.
 
 [#6202](https://github.com/ArcadeData/arcadedb/issues/6202)
+
+## `CHECK DATABASE` now reports an orphan edge record, and can reclaim one on request (#6090)
+
+An **orphan edge record** is an edge record that exists physically in an edge-type bucket, whose `@out`/`@in`
+name valid vertices, but which no vertex's edge list points back at: `countType()` counts it, no traversal
+reaches it. `GraphDatabaseChecker.checkEdges` already scanned every edge record and already probed both
+endpoints for a back-reference - the scan and the direction were both right - and then discarded the answer.
+Both call sites did nothing but `missingReferenceBack.incrementAndGet()`. No warning named the record, nothing
+entered `corruptedRecords`, and so `CHECK DATABASE FIX` never reclaimed one.
+
+The published counter could not stand in for the finding either, because it is not edge-type aware. A
+perfectly healthy **unidirectional** edge is legitimately absent from its target's IN list and bumps it by 1; a
+genuinely orphaned bidirectional edge bumps it by 2. One aggregate, no breakdown, no RIDs - on a database that
+uses unidirectional edge types at all, the signal is buried. The honest way to answer "does my database hold
+any?" was to run a full traversal yourself and compare it against `countType`.
+
+The probe is now **direction-aware**, and what it establishes is reported:
+
+- an edge absent from its OUT vertex's OUT list is a defect for every edge type - no outgoing traversal reaches
+  it - and is counted under `edgesMissingOutReference`;
+- an edge absent from its IN vertex's IN list is a defect only when the type is BIDIRECTIONAL, counted under
+  `edgesMissingInReference`;
+- an edge **neither** list names is an orphan record: warned with its RID and both endpoints, counted under
+  `unreachableEdgeRecords` and named in `unreachableEdgeRecordsFound`.
+
+`missingReferenceBack` is deliberately untouched - both probes still run and it is still bumped once per side
+that holds no reference - so anything parsing today's result keeps reading the same number.
+
+Reclaiming them is a new, explicit clause: **`CHECK DATABASE FIX DELETE ORPHANS`**. It is not folded into plain
+`FIX`, and the reason is a data-loss path rather than a taste for options. The detection cannot distinguish
+"this record is garbage a failed bulk load left behind" from "this vertex lost its head-chunk pointer, so its
+perfectly good edges look unreferenced" - a null head chunk reads exactly like a vertex with no edges. In the
+second case the edge records are the only surviving description of that adjacency and the thing `RESTORE
+VERTEX` rebuilds it from, so a repair that deleted them by default would turn a recoverable database into an
+unrecoverable one. Reporting is therefore always on; removing is always asked for, and `DELETE ORPHANS` without
+`FIX` is refused rather than silently implying it.
+
+The classification is conservative by construction: an edge is called unreachable only when **both** probes
+positively established the absence. A far endpoint that could not be loaded is already reported as a dangling
+link, and one whose list could not be walked is left to `checkVertices`, which runs after this pass and
+rebuilds the chain from the surviving edge records - neither may be answered by deleting the record that repair
+reads from.
+
+#6089 stopped `GraphBatch` from creating orphans on a failed flush; this is what finds the ones an older build
+already left behind.
+
+[#6090](https://github.com/ArcadeData/arcadedb/issues/6090)

--- a/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLLexer.g4
+++ b/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLLexer.g4
@@ -211,6 +211,9 @@ LANGUAGE: L A N G U A G E;
 TRIGGER: T R I G G E R;
 FAIL: F A I L;
 FIX: F I X;
+// Issue #6090: CHECK DATABASE ... FIX DELETE ORPHANS. Also listed among the keywords usable as an identifier, so
+// a schema that already has a type or property called "orphans" keeps parsing.
+ORPHANS: O R P H A N S;
 SLEEP: S L E E P;
 CONSOLE: C O N S O L E;
 START: S T A R T;

--- a/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4
+++ b/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4
@@ -1101,6 +1101,9 @@ checkDatabaseStatement
       (BUCKET (identifier | INTEGER_LITERAL) (COMMA (identifier | INTEGER_LITERAL))*)?
       (RECORD rid (COMMA rid)*)?
       (FIX)?
+      // Issue #6090: opt-in reclaim of ORPHAN EDGE RECORDS (edge records no vertex's edge list references).
+      // Deliberately its own clause rather than part of FIX - see DatabaseChecker.setDeleteOrphanEdgeRecords.
+      (DELETE ORPHANS)?
       (COMPRESS)?
     ;
 
@@ -1697,6 +1700,7 @@ identifier
     | REFERENCES
     | ADDBUCKET
     | REMOVEBUCKET
+    | ORPHANS
     | FORCE
     | OPTIMIZE
     | INVERSE

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -68,6 +68,8 @@ public class DatabaseChecker {
   private       int                 verboseLevel = 1;
   private       boolean             fix          = false;
   private       boolean             compress     = false;
+  /** #6090: see {@link #setDeleteOrphanEdgeRecords(boolean)} for why this is not part of {@link #fix}. */
+  private       boolean             deleteOrphanEdgeRecords = false;
   private       Set<Object>         buckets      = Collections.emptySet();
   private       Set<String>         types        = Collections.emptySet();
   /**
@@ -151,6 +153,15 @@ public class DatabaseChecker {
     result.put("prunedDanglingEntries", 0L);
     result.put("reconnectedEdges", 0L);
     result.put("invalidLinks", 0L);
+    // Issue #6090: the ORPHAN EDGE RECORD findings, seeded so a clean run publishes zeros rather than omitting the
+    // keys - "does this database hold any?" must be answerable from the result of every run, not only from one that
+    // happened to find some. unreachableEdgeRecords is the orphan count (an edge record no adjacency list
+    // references, so no traversal reaches it though countType counts it); the two edgesMissing* keys are the
+    // per-side breakdown, IN only for a bidirectional edge type. missingReferenceBack is left exactly as it was.
+    result.put("unreachableEdgeRecords", 0L);
+    result.put("edgesMissingOutReference", 0L);
+    result.put("edgesMissingInReference", 0L);
+    result.put("unreachableEdgeRecordsFound", new LinkedHashSet<RID>());
     result.put("warnings", new LinkedHashSet<>());
     // Issue #6143: files this node holds that no schema component claims. Report-only, always present so a clean
     // run says "none" rather than saying nothing, and empty under a RECORD scope, which cannot answer the question.
@@ -494,6 +505,17 @@ public class DatabaseChecker {
    * always removed by the bucket pass; once the arms could remove it first, the same repair stopped listing the
    * same record. Reported by whichever pass performs it, or the field cannot be read at all.
    */
+  /**
+   * Unions one edge scan's ORPHAN EDGE RECORD RIDs into the cross-type list (issue #6090). Merged by hand rather
+   * than through {@link #updateStats}, which only folds {@code Long} values - the same reason
+   * {@code corruptedRecords} is merged here. The count beside it stays exact even when this set hit its cap.
+   */
+  private void mergeUnreachableEdgeRecords(final Map<String, Object> stats) {
+    final Collection<RID> unreachable = (Collection<RID>) stats.get("unreachableEdgeRecordsFound");
+    if (unreachable != null)
+      ((LinkedHashSet<RID>) result.get("unreachableEdgeRecordsFound")).addAll(unreachable);
+  }
+
   private void mergeDeletedRecords(final Map<String, Object> stats) {
     final Collection<RID> deleted = (Collection<RID>) stats.get("deletedRecordsAfterFix");
     if (deleted != null)
@@ -751,7 +773,7 @@ public class DatabaseChecker {
 
       final Map<String, Object> stats;
       if (type instanceof LocalEdgeType)
-        stats = graphChecker.checkEdges(type.getName(), rids, fix, verboseLevel,
+        stats = graphChecker.checkEdges(type.getName(), rids, fix, deleteOrphanEdgeRecords, verboseLevel,
             Math.max(0, maxWarnings - currentWarnings), Math.max(0, maxWarnings - currentCorrupted));
       else
         stats = graphChecker.checkVertices(type.getName(), rids, fix, verboseLevel,
@@ -760,6 +782,7 @@ public class DatabaseChecker {
       updateStats(stats);
       ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
       ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+      mergeUnreachableEdgeRecords(stats);
       mergeDeletedRecords(stats);
       mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
           (Map<RID, String>) stats.get("missingReferenceErrors"));
@@ -868,13 +891,14 @@ public class DatabaseChecker {
       final int currentCorrupted = ((LinkedHashSet<RID>) result.get("corruptedRecords")).size();
       final Map<String, Object> stats = new GraphDatabaseChecker(database)
           .setProgress(progressCallback, "Checking edges '" + type.getName() + "'", currentStep, totalSteps)
-          .checkEdges(type.getName(), fix, verboseLevel,
+          .checkEdges(type.getName(), null, fix, deleteOrphanEdgeRecords, verboseLevel,
               Math.max(0, maxWarnings - currentWarnings), Math.max(0, maxWarnings - currentCorrupted));
 
       updateStats(stats);
 
       ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
       ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+      mergeUnreachableEdgeRecords(stats);
       mergeDeletedRecords(stats);
       mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
           (Map<RID, String>) stats.get("missingReferenceErrors"));
@@ -968,6 +992,23 @@ public class DatabaseChecker {
 
   public DatabaseChecker setCompress(final boolean compress) {
     this.compress = compress;
+    return this;
+  }
+
+  /**
+   * Opt-in for reclaiming ORPHAN EDGE RECORDS (issue #6090): edge records no vertex's adjacency list references.
+   * Only meaningful together with {@link #setFix(boolean)}, which performs the removal.
+   * <p>
+   * SEPARATE FROM {@code FIX} ON PURPOSE, and the reason is a data-loss path rather than a taste for options. The
+   * detection cannot distinguish "this record is garbage a failed load left behind" from "this vertex lost its
+   * head-chunk pointer, so its perfectly good edges look unreferenced" - a null head chunk reads exactly like a
+   * vertex with no edges. In the second case the edge records are the ONLY surviving description of that
+   * adjacency and the thing {@code RESTORE VERTEX} rebuilds it from, so a repair that deletes them by default
+   * would turn a recoverable database into an unrecoverable one. Reporting is therefore always on; removing is
+   * always asked for.
+   */
+  public DatabaseChecker setDeleteOrphanEdgeRecords(final boolean deleteOrphanEdgeRecords) {
+    this.deleteOrphanEdgeRecords = deleteOrphanEdgeRecords;
     return this;
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -158,6 +158,14 @@ public class DatabaseChecker {
     // happened to find some. unreachableEdgeRecords is the orphan count (an edge record no adjacency list
     // references, so no traversal reaches it though countType counts it); the two edgesMissing* keys are the
     // per-side breakdown, IN only for a bidirectional edge type. missingReferenceBack is left exactly as it was.
+    //
+    // THE THREE ARE NOT DISJOINT, which matters to anything rendering them as a summary (Studio, an HTTP client):
+    // an orphaned BIDIRECTIONAL edge is one record that increments all three, and an orphaned unidirectional one
+    // increments unreachableEdgeRecords and edgesMissingOutReference. They answer "how many edges have this
+    // defect", each independently, not "which bucket does each defective edge fall into", so summing them
+    // double-counts. unreachableEdgeRecords is the one to show as the orphan total; the other two are the
+    // per-direction detail behind it plus the half-linked edges that are still reachable from one side.
+
     result.put("unreachableEdgeRecords", 0L);
     result.put("edgesMissingOutReference", 0L);
     result.put("edgesMissingInReference", 0L);
@@ -497,15 +505,6 @@ public class DatabaseChecker {
   }
 
   /**
-   * Merges the records a sub-check actually deleted into {@code deletedRecordsAfterFix}.
-   * <p>
-   * Absent before, which made the field answer a different question depending on which pass did the removing: the
-   * bucket-wide {@code LocalBucket.check} listed what it deleted, while the vertex and edge arms deleted silently
-   * and reported only an {@code autoFix} count. The distinction was invisible while a broken-chain record was
-   * always removed by the bucket pass; once the arms could remove it first, the same repair stopped listing the
-   * same record. Reported by whichever pass performs it, or the field cannot be read at all.
-   */
-  /**
    * Unions one edge scan's ORPHAN EDGE RECORD RIDs into the cross-type list (issue #6090). Merged by hand rather
    * than through {@link #updateStats}, which only folds {@code Long} values - the same reason
    * {@code corruptedRecords} is merged here. The count beside it stays exact even when this set hit its cap.
@@ -516,6 +515,15 @@ public class DatabaseChecker {
       ((LinkedHashSet<RID>) result.get("unreachableEdgeRecordsFound")).addAll(unreachable);
   }
 
+  /**
+   * Merges the records a sub-check actually deleted into {@code deletedRecordsAfterFix}.
+   * <p>
+   * Absent before, which made the field answer a different question depending on which pass did the removing: the
+   * bucket-wide {@code LocalBucket.check} listed what it deleted, while the vertex and edge arms deleted silently
+   * and reported only an {@code autoFix} count. The distinction was invisible while a broken-chain record was
+   * always removed by the bucket pass; once the arms could remove it first, the same repair stopped listing the
+   * same record. Reported by whichever pass performs it, or the field cannot be read at all.
+   */
   private void mergeDeletedRecords(final Map<String, Object> stats) {
     final Collection<RID> deleted = (Collection<RID>) stats.get("deletedRecordsAfterFix");
     if (deleted != null)

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -872,14 +872,14 @@ public class GraphBatch implements AutoCloseable {
    * {@code commitEvery > 0}. So a connect pass that dies part-way leaves records that are durable and reachable
    * from nothing: {@code countType()} counts them and no traversal finds them.
    * <p>
-   * CHECK DATABASE does not rescue them. Its {@code checkEdges} pass does scan every edge record and probe both
-   * endpoints for a back-reference, but a miss only increments the aggregate {@code missingReferenceBack}
-   * counter - no warning naming the record, no entry in {@code corruptedRecords}, and therefore nothing for the
-   * {@code FIX} variant to delete. That same counter is raised by a perfectly healthy UNIDIRECTIONAL edge, which
-   * is legitimately absent from its target's IN list, so it cannot be read as an orphan count either. ({@code FIX}
-   * does reclaim orphaned edge SEGMENTS, but those are the internal linked-list chunks, not the edge records at
-   * issue here.) Nothing else will ever clean these up, so the flush cleans up after itself, before the failure
-   * propagates.
+   * CHECK DATABASE does not rescue them on its own. Since #6090 its {@code checkEdges} pass does REPORT them - it
+   * names each one and counts them under {@code unreachableEdgeRecords} - but removing them is an explicit opt-in
+   * ({@code CHECK DATABASE FIX DELETE ORPHANS}), never part of a plain {@code FIX}, because the same shape is what
+   * a vertex that merely lost its head-chunk pointer looks like. Before that the finding was discarded entirely
+   * into the aggregate {@code missingReferenceBack} counter, which a perfectly healthy UNIDIRECTIONAL edge also
+   * raises. ({@code FIX} does reclaim orphaned edge SEGMENTS, but those are the internal linked-list chunks, not
+   * the edge records at issue here.) So nothing cleans these up unattended, and the flush cleans up after itself,
+   * before the failure propagates.
    * <p>
    * Deletion goes through {@code database.deleteRecord} rather than a direct bucket delete: an edge record may
    * carry index entries (issue #4113) and EXTERNAL property values, and this flush creates them by two different

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1407,15 +1407,64 @@ public class GraphDatabaseChecker {
     return checkEdges(typeName, null, fix, verboseLevel, maxWarnings, maxCorrupted);
   }
 
+  public Map<String, Object> checkEdges(final String typeName, final Collection<RID> scopedRecords,
+      final boolean fix, final int verboseLevel, final int maxWarnings, final int maxCorrupted) {
+    return checkEdges(typeName, scopedRecords, fix, false, verboseLevel, maxWarnings, maxCorrupted);
+  }
+
   /**
    * #5680: same check restricted to {@code scopedRecords} when it is non-null - the {@code CHECK DATABASE RECORD}
    * scope. Per-edge work is identical; only the enumeration changes, from two passes over every bucket of the
    * type to a lookup per listed RID.
+   * <p>
+   * #6090 - THE BACK-REFERENCE PROBE IS DIRECTION-AWARE, and what it finds is now reported rather than folded into
+   * one opaque number. The scan already visited every edge record and already asked both endpoints whether their
+   * adjacency list names it; both answers were thrown away into {@code missingReferenceBack}, a counter that
+   * cannot be read because a healthy UNIDIRECTIONAL edge is legitimately absent from its target's IN list and
+   * bumps it by 1, while a genuinely orphaned bidirectional edge bumps it by 2.
+   * <p>
+   * Which side is allowed to hold no reference is a property of the EDGE TYPE:
+   * <ul>
+   *   <li>the OUT vertex's OUT list must name the edge, for every edge type there is - an edge absent from it is
+   *   unreachable by an outgoing traversal, which is a defect in all cases;</li>
+   *   <li>the IN vertex's IN list must name it only when the type is BIDIRECTIONAL. For a unidirectional type the
+   *   absence is the design.</li>
+   * </ul>
+   * An edge neither side names is an ORPHAN EDGE RECORD: {@code countType()} counts it, no traversal reaches it.
+   * That is the finding {@code unreachableEdgeRecords} counts and {@code unreachableEdgeRecordsFound} names.
+   * <p>
+   * {@code missingReferenceBack} is deliberately UNCHANGED - still one bump per side that holds no reference,
+   * still both probes run - so anything parsing today's result keeps reading the same number. The new keys are
+   * additive.
+   * <p>
+   * CONSERVATIVE BY CONSTRUCTION, because {@code deleteOrphans} turns the finding into a deletion: an edge is
+   * called unreachable only when BOTH probes positively established the absence. A far endpoint that could not be
+   * loaded, or whose list could not be walked, leaves the edge unclassified - the first is already reported as a
+   * dangling link, and the second is left to {@code checkVertices}, which runs after this pass and rebuilds the
+   * chain from the surviving edge records. Neither may be answered by deleting the record that repair reads from.
+   *
+   * @param deleteOrphans when true (and {@code fix} is on), an edge record no adjacency list references is flagged
+   *                      corrupted and removed by the repair loop below, which also puts its bucket into the
+   *                      caller's {@code affectedBuckets} so the indexes on it are rebuilt. NEVER implied by
+   *                      {@code fix}: see {@code CheckDatabaseStatement} for why it is its own clause
    */
   public Map<String, Object> checkEdges(final String typeName, final Collection<RID> scopedRecords,
-      final boolean fix, final int verboseLevel, final int maxWarnings, final int maxCorrupted) {
+      final boolean fix, final boolean deleteOrphans, final int verboseLevel, final int maxWarnings,
+      final int maxCorrupted) {
     final AtomicLong autoFix = new AtomicLong();
     final AtomicLong missingReferenceBack = new AtomicLong();
+    /** #6090: edge records reachable from NO adjacency list - the orphan count. Exact, never capped. */
+    final AtomicLong unreachableEdgeRecords = new AtomicLong();
+    /** #6090: edges absent from their OUT vertex's OUT list. A defect for every edge type. */
+    final AtomicLong edgesMissingOutReference = new AtomicLong();
+    /** #6090: BIDIRECTIONAL edges absent from their IN vertex's IN list. Not a defect for a unidirectional type. */
+    final AtomicLong edgesMissingInReference = new AtomicLong();
+    /**
+     * #6090: the RIDs behind {@code unreachableEdgeRecords}, so an operator can answer "which ones?" without
+     * re-deriving them from a full traversal. Bounded by the same cap as the corrupted set - the count beside it
+     * stays exact.
+     */
+    final Set<RID> unreachableEdgeRecordsFound = new LinkedHashSet<>();
     // CheckReport keeps corruptedRecords as a Set (matching checkVertices) so the same RID flagged on both sides of
     // an edge is recorded once, and totalCorrupted - which counts only genuinely new entries, see
     // CollectionUtils.addBounded - stays aligned with its size.
@@ -1456,6 +1505,14 @@ public class GraphDatabaseChecker {
             ++report.invalidLinks;
 
           } else {
+            // #6090: the two probes below record WHAT THEY ESTABLISHED, not just that something was missing.
+            // "Probed" means the far vertex loaded and its list was walked to a conclusion; only then may the
+            // absence be believed. See the class-level note on why that distinction is load-bearing here.
+            boolean outProbed = false;
+            boolean outUnreferenced = false;
+            boolean inProbed = false;
+            boolean inUnreferenced = false;
+
             Vertex inVertex = null;
             try {
               inVertex = edge.getInVertex().asVertex(true);
@@ -1477,9 +1534,15 @@ public class GraphDatabaseChecker {
             if (inVertex != null)
               try {
                 final EdgeLinkedList inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) inVertex, Vertex.DIRECTION.IN);
-                if (inEdges == null || !inEdges.containsEdge(edgeRID))
-                  // UNI DIRECTIONAL EDGE
+                inProbed = true;
+                if (inEdges == null || !inEdges.containsEdge(edgeRID)) {
+                  // LEGITIMATE FOR A UNIDIRECTIONAL EDGE TYPE, a defect for a bidirectional one - which is why the
+                  // raw counter below cannot be read as a defect count and #6090 added ones that can. Bumped here
+                  // unconditionally, exactly as before, so its published meaning does not shift under existing
+                  // readers; the classification happens once both sides have answered.
                   missingReferenceBack.incrementAndGet();
+                  inUnreferenced = true;
+                }
               } catch (final Exception e) {
                 // The vertex record is FINE but its edge LIST is unreadable: neither the edge nor the vertex is
                 // at fault, so NOTHING is flagged corrupted here (before this guard the vertex was deleted by
@@ -1510,15 +1573,54 @@ public class GraphDatabaseChecker {
             if (outVertex != null)
               try {
                 final EdgeLinkedList outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) outVertex, Vertex.DIRECTION.OUT);
-                if (outEdges == null || !outEdges.containsEdge(edgeRID))
-                  // UNI DIRECTIONAL EDGE
+                outProbed = true;
+                if (outEdges == null || !outEdges.containsEdge(edgeRID)) {
+                  // ALWAYS A DEFECT, for every edge type: no outgoing traversal can reach the record. Same
+                  // unconditional bump of the legacy counter as the incoming side, for the same reason.
                   missingReferenceBack.incrementAndGet();
+                  outUnreferenced = true;
+                }
               } catch (final Exception e) {
                 // Same as the incoming side: an unreadable LIST is not a corrupted edge or vertex.
                 if (unreadableListVertices.add(outVertex.getIdentity()))
                   report.warn("vertex " + outVertex.getIdentity() + " outgoing edge list is unreadable (error: " + describe(e)
                           + "), left to the vertex check to rebuild");
               }
+
+            // #6090: classify what the two probes established, and report it.
+            if (outProbed && outUnreferenced) {
+              edgesMissingOutReference.incrementAndGet();
+
+              // UNREACHABLE means BOTH lists were walked and neither names the record. The IN side is required
+              // even for a unidirectional type: the type could have been created bidirectional and altered since,
+              // and a record some list still names must never be called an orphan.
+              if (inProbed && inUnreferenced) {
+                unreachableEdgeRecords.incrementAndGet();
+                CollectionUtils.addBounded(unreachableEdgeRecordsFound, maxCorrupted, edgeRID);
+                report.warn("edge " + edgeRID + " is an ORPHAN RECORD: the outgoing vertex " + edge.getOut()
+                    + " does not reference it from its OUT list" + (isBidirectional(edge) ?
+                    " and neither does the incoming vertex " + edge.getIn() + " from its IN list" :
+                    ", and the type is unidirectional so the incoming vertex " + edge.getIn() + " holds no reference "
+                        + "either") + ", so no traversal reaches it"
+                    + (fix && deleteOrphans ? ", removing it" : " (run CHECK DATABASE FIX DELETE ORPHANS to reclaim it)"));
+                if (fix && deleteOrphans)
+                  // Flagged corrupted ONLY under the explicit opt-in: that is what hands the RID to the repair
+                  // loop below AND puts its bucket into the caller's affectedBuckets, so the raw bucket delete
+                  // used there does not leave the edge type's indexes pointing at a record that is gone.
+                  report.corrupt(edgeRID);
+              } else
+                report.warn("edge " + edgeRID + " is not referenced back by its outgoing vertex " + edge.getOut()
+                    + ": it is missing from that vertex's OUT list");
+            }
+
+            // A bidirectional edge absent from its target's IN list is a defect even when the OUT side is intact -
+            // an incoming traversal misses it. Reported apart from the orphan case, which already named both sides.
+            if (inProbed && inUnreferenced && isBidirectional(edge)) {
+              edgesMissingInReference.incrementAndGet();
+              if (!(outProbed && outUnreferenced))
+                report.warn("edge " + edgeRID + " is not referenced back by its incoming vertex " + edge.getIn()
+                    + ": it is missing from that vertex's IN list");
+            }
           }
 
         } catch (final Throwable e) {
@@ -1608,6 +1710,11 @@ public class GraphDatabaseChecker {
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("invalidLinks", report.invalidLinks);
       stats.put("missingReferenceBack", missingReferenceBack.get());
+      // #6090: the readable form of the counter above - see the method Javadoc for what each one means.
+      stats.put("unreachableEdgeRecords", unreachableEdgeRecords.get());
+      stats.put("edgesMissingOutReference", edgesMissingOutReference.get());
+      stats.put("edgesMissingInReference", edgesMissingInReference.get());
+      stats.put("unreachableEdgeRecordsFound", unreachableEdgeRecordsFound);
       stats.put("warnings", report.warnings);
       stats.put("totalWarnings", report.totalWarnings);
       stats.put("totalCorruptedRecords", report.totalCorrupted);
@@ -1636,6 +1743,21 @@ public class GraphDatabaseChecker {
     stats.put("removedRecords", removedRecords);
     stats.put("prunedDanglingEntries", prunedDanglingEntries);
     stats.put("reconnectedEdges", reconnectedEdges);
+  }
+
+  /**
+   * Whether the edge's own type stores a back-reference in the target vertex's IN list (issue #6090).
+   * <p>
+   * Read from the RECORD's type rather than from the {@code typeName} the scan was given: the {@code RECORD} scope
+   * hands this method edges of several types in one call, and a per-record answer is free anyway - {@code getType()}
+   * is a field read on the materialised document, not a schema lookup.
+   * <p>
+   * Defaults to TRUE for anything that is not an {@link EdgeType}, which is the conservative direction: a
+   * bidirectional type is the one whose IN list is expected to name the edge, so an unexpected type shape produces
+   * a reported defect rather than a silently accepted absence.
+   */
+  private static boolean isBidirectional(final Edge edge) {
+    return !(edge.getType() instanceof EdgeType edgeType) || edgeType.isBidirectional();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1453,6 +1453,12 @@ public class GraphDatabaseChecker {
       final int maxCorrupted) {
     final AtomicLong autoFix = new AtomicLong();
     final AtomicLong missingReferenceBack = new AtomicLong();
+    // The three #6090 counters below, and the two above, are AtomicLong for CAPTURE, not for concurrency. This
+    // scan is strictly single-threaded - CheckReport says so on its own plain-long fields, and the sets beside
+    // these are not thread-safe either - but they are incremented from inside the checkEndpoints lambda, and a
+    // local a lambda mutates has to be a mutable box. CheckReport could drop its atomics precisely because they
+    // became FIELDS of an object; these are locals of the method, so a box is what there is. Do not read them as
+    // a claim that anything here runs in parallel.
     /** #6090: edge records reachable from NO adjacency list - the orphan count. Exact, never capped. */
     final AtomicLong unreachableEdgeRecords = new AtomicLong();
     /** #6090: edges absent from their OUT vertex's OUT list. A defect for every edge type. */

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -1591,9 +1591,13 @@ public class GraphDatabaseChecker {
             if (outProbed && outUnreferenced) {
               edgesMissingOutReference.incrementAndGet();
 
-              // UNREACHABLE means BOTH lists were walked and neither names the record. The IN side is required
-              // even for a unidirectional type: the type could have been created bidirectional and altered since,
-              // and a record some list still names must never be called an orphan.
+              // UNREACHABLE means BOTH lists were walked and neither names the record - required even for a
+              // unidirectional type, whose IN list is not expected to name the edge at all. NOT because the flag
+              // can be flipped under us: LocalEdgeType.bidirectional is final, unlike lightweight/unique, so
+              // ALTER TYPE cannot change it. It is because "no list references this record" is the claim the
+              // deletion rests on, and only a walk can establish it - a type dropped and recreated over the same
+              // data, or an entry an older build left in an IN list, both make the record reachable while the
+              // schema says it should not be. Costs one probe that already ran for missingReferenceBack anyway.
               if (inProbed && inUnreferenced) {
                 unreachableEdgeRecords.incrementAndGet();
                 CollectionUtils.addBounded(unreachableEdgeRecordsFound, maxCorrupted, edgeRID);
@@ -1609,6 +1613,11 @@ public class GraphDatabaseChecker {
                   // used there does not leave the edge type's indexes pointing at a record that is gone.
                   report.corrupt(edgeRID);
               } else
+                // DELIBERATELY NOT SUPPRESSED for an edge the endpoint checks above already flagged corrupted (a
+                // dangling link whose OUT list happens not to name it either): the two findings are different -
+                // "its target is gone" and "its source does not list it" - and the second is what tells an
+                // operator the adjacency is damaged too, rather than only the far end. Reachable only when both
+                // hold, so it is not a warning per dangling edge.
                 report.warn("edge " + edgeRID + " is not referenced back by its outgoing vertex " + edge.getOut()
                     + ": it is missing from that vertex's OUT list");
             }

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -7330,6 +7330,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       stmt.fix = true;
     }
 
+    // Parse DELETE ORPHANS flag (#6090): opt-in reclaim of edge records no vertex's edge list references.
+    // ORPHANS alone identifies the clause - it is the only place the token appears in this statement.
+    if (checkCtx.ORPHANS() != null) {
+      stmt.deleteOrphans = true;
+    }
+
     // Parse COMPRESS flag
     if (checkCtx.COMPRESS() != null) {
       stmt.compress = true;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CheckDatabaseStatement.java
@@ -51,6 +51,22 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
   public final Set<Rid>              records  = new LinkedHashSet<>();
   public       boolean               fix      = false;
   public       boolean               compress = false;
+  /**
+   * #6090: {@code DELETE ORPHANS}. Reclaims ORPHAN EDGE RECORDS - edge records whose {@code @out}/{@code @in} name
+   * valid vertices but which no vertex's edge list references, so {@code countType()} counts them and no traversal
+   * reaches them.
+   * <p>
+   * A CLAUSE OF ITS OWN rather than part of {@code FIX}, because the detection cannot tell garbage from a vertex
+   * that merely lost its head-chunk pointer; the full argument is on
+   * {@link DatabaseChecker#setDeleteOrphanEdgeRecords(boolean)}. Reporting the finding needs no clause at all - it
+   * is on for every run.
+   */
+  public       boolean               deleteOrphans = false;
+
+  /** Shared with the grammar's own diagnostics: {@code DELETE ORPHANS} is a repair and has nothing to do without FIX. */
+  public static final String DELETE_ORPHANS_WITHOUT_FIX_ERROR =
+      "CHECK DATABASE DELETE ORPHANS removes records, so it requires FIX: write CHECK DATABASE FIX DELETE ORPHANS. "
+          + "Without it the orphan edge records are still reported, under the unreachableEdgeRecords key";
 
   public CheckDatabaseStatement() {
   }
@@ -69,6 +85,11 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
       // whose actual problem is the clause combination. Diagnose the outer mistake first.
       throw new IllegalArgumentException(DatabaseChecker.RECORD_SCOPE_CONFLICT_ERROR);
 
+    if (deleteOrphans && !fix)
+      // Refused rather than silently implying FIX: a statement that removes records must say so, and a caller who
+      // only wanted the finding already has it without any clause at all.
+      throw new IllegalArgumentException(DELETE_ORPHANS_WITHOUT_FIX_ERROR);
+
     final DatabaseChecker checker = createChecker(context);
     checker.setVerboseLevel(0);
     checker.setBuckets(buckets.stream().map(x -> x.getValue()).collect(Collectors.toSet()));
@@ -81,6 +102,7 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
     checker.setRecords(records.stream().map(x -> x.toRecordId((Result) null, context))
         .collect(Collectors.toCollection(LinkedHashSet::new)));
     checker.setFix(fix);
+    checker.setDeleteOrphanEdgeRecords(deleteOrphans);
     checker.setCompress(compress);
 
     // PUBLISH LIVE PROGRESS (issue #5372): pollable while the check runs via the progress HTTP endpoint,
@@ -147,6 +169,9 @@ public class CheckDatabaseStatement extends SimpleExecStatement {
 
     if (fix)
       builder.append(" FIX");
+
+    if (deleteOrphans)
+      builder.append(" DELETE ORPHANS");
 
     if (compress)
       builder.append(" COMPRESS");

--- a/engine/src/test/java/com/arcadedb/graph/Issue6090OrphanEdgeRecordCheckTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6090OrphanEdgeRecordCheckTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6090.
+ * <p>
+ * An ORPHAN EDGE RECORD is an edge record that exists physically in an edge-type bucket, whose {@code @out}/
+ * {@code @in} name valid vertices, but which no vertex's edge list points back at: {@code countType()} counts it,
+ * no traversal reaches it. {@code CHECK DATABASE} used to observe the condition - {@code checkEdges} probes both
+ * endpoints for a back-reference - and then throw the finding away: both call sites did nothing but bump
+ * {@code missingReferenceBack}, so no warning named the record, nothing entered {@code corruptedRecords} and
+ * {@code FIX} never reclaimed it.
+ * <p>
+ * These tests pin the three things that changed: the probe is direction-aware (a healthy UNIDIRECTIONAL edge is
+ * legitimately absent from its target's IN list and must not be reported), a genuine miss is warned and counted
+ * under its own keys while {@code missingReferenceBack} keeps its old meaning, and reclaiming the records is an
+ * explicit opt-in that plain {@code FIX} never performs.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6090OrphanEdgeRecordCheckTest extends TestHelper {
+
+  private static final String VERTEX_TYPE       = "Issue6090Node";
+  private static final String BIDIRECTIONAL_EDGE = "Issue6090BiLink";
+  private static final String UNIDIRECTIONAL_EDGE = "Issue6090UniLink";
+
+  /**
+   * Every test here deliberately leaves an unreachable edge record behind - that is the state under measurement -
+   * and the finding is now a warning, which is exactly what the shared teardown check refuses. Each test asserts
+   * the check result itself, so the blanket teardown run would only re-assert the same database with the opposite
+   * expectation.
+   */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().buildEdgeType().withName(BIDIRECTIONAL_EDGE).withBidirectional(true).create();
+      database.getSchema().buildEdgeType().withName(UNIDIRECTIONAL_EDGE).withBidirectional(false).create();
+    });
+  }
+
+  /**
+   * The headline case: a bidirectional edge record no list references at all. Before the fix the run reported a
+   * bare {@code missingReferenceBack} of 2 and nothing else - no warning, no RID, no way to tell it from two
+   * healthy unidirectional edges.
+   */
+  @Test
+  void anOrphanBidirectionalEdgeRecordIsNamedAndCounted() {
+    final RID orphan = createOrphanEdge(BIDIRECTIONAL_EDGE);
+
+    final Result check = checkDatabase("CHECK DATABASE");
+
+    assertThat(check.<Long>getProperty("unreachableEdgeRecords")).as("the orphan must be counted").isEqualTo(1L);
+    assertThat(rids(check, "unreachableEdgeRecordsFound")).as("and named").containsExactly(orphan);
+    assertThat(warnings(check)).as("and warned about, naming the record")
+        .anyMatch(w -> w.contains(orphan.toString()) && w.contains("ORPHAN RECORD"));
+
+    // Both sides are genuine defects for a bidirectional type.
+    assertThat(check.<Long>getProperty("edgesMissingOutReference")).isEqualTo(1L);
+    assertThat(check.<Long>getProperty("edgesMissingInReference")).isEqualTo(1L);
+
+    // The pre-existing counter keeps its exact previous meaning: one bump per side that holds no reference.
+    assertThat(check.<Long>getProperty("missingReferenceBack")).isEqualTo(2L);
+  }
+
+  /**
+   * The reason the old counter could not be read as an orphan count: a perfectly healthy unidirectional edge is
+   * legitimately absent from its target's IN list and bumps {@code missingReferenceBack} by 1. The new keys must
+   * stay at zero for it, which is what makes them usable.
+   */
+  @Test
+  void aHealthyUnidirectionalEdgeIsNotAFinding() {
+    database.transaction(() -> {
+      final MutableVertex source = database.newVertex(VERTEX_TYPE).set("name", "source").save();
+      final MutableVertex target = database.newVertex(VERTEX_TYPE).set("name", "target").save();
+      source.newEdge(UNIDIRECTIONAL_EDGE, target);
+    });
+
+    final Result check = checkDatabase("CHECK DATABASE");
+
+    assertThat(check.<Long>getProperty("unreachableEdgeRecords")).isZero();
+    assertThat(check.<Long>getProperty("edgesMissingOutReference")).isZero();
+    assertThat(check.<Long>getProperty("edgesMissingInReference"))
+        .as("a unidirectional edge is not expected in its target's IN list").isZero();
+    assertThat(warnings(check)).isEmpty();
+
+    // Unchanged, and this is the value that made the old counter unreadable.
+    assertThat(check.<Long>getProperty("missingReferenceBack")).isEqualTo(1L);
+  }
+
+  /** The same detection must work when the type is unidirectional: only the OUT list can hold the reference. */
+  @Test
+  void anOrphanUnidirectionalEdgeRecordIsNamedAndCounted() {
+    final RID orphan = createOrphanEdge(UNIDIRECTIONAL_EDGE);
+
+    final Result check = checkDatabase("CHECK DATABASE");
+
+    assertThat(check.<Long>getProperty("unreachableEdgeRecords")).isEqualTo(1L);
+    assertThat(rids(check, "unreachableEdgeRecordsFound")).containsExactly(orphan);
+    assertThat(check.<Long>getProperty("edgesMissingOutReference")).isEqualTo(1L);
+    assertThat(check.<Long>getProperty("edgesMissingInReference"))
+        .as("the IN side is not a reference holder for a unidirectional type, so it is not a defect").isZero();
+  }
+
+  /**
+   * A HALF-linked edge - reachable from its source, missing only from its target's IN list - is a defect of the
+   * incoming adjacency, not an orphan record. Reporting it as one would have {@code DELETE ORPHANS} destroy an
+   * edge a traversal still reaches.
+   */
+  @Test
+  void anEdgeStillReachableFromItsSourceIsNotAnOrphan() {
+    final RID[] edge = new RID[1];
+    final RID[] target = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex source = database.newVertex(VERTEX_TYPE).set("name", "source").save();
+      final MutableVertex destination = database.newVertex(VERTEX_TYPE).set("name", "target").save();
+      edge[0] = source.newEdge(BIDIRECTIONAL_EDGE, destination).getIdentity();
+      target[0] = destination.getIdentity();
+    });
+
+    // Drop ONLY the target's IN list, leaving the source's OUT list intact.
+    database.transaction(() -> {
+      final MutableVertex destination = target[0].asVertex(true).modify();
+      destination.setInEdgesHeadChunk(null);
+      destination.save();
+    });
+
+    final Result check = checkDatabase("CHECK DATABASE");
+
+    assertThat(check.<Long>getProperty("unreachableEdgeRecords")).as("an OUT traversal still reaches it").isZero();
+    assertThat(rids(check, "unreachableEdgeRecordsFound")).isEmpty();
+    assertThat(check.<Long>getProperty("edgesMissingInReference")).isEqualTo(1L);
+    assertThat(check.<Long>getProperty("edgesMissingOutReference")).isZero();
+    assertThat(warnings(check)).anyMatch(w -> w.contains(edge[0].toString()) && w.contains("IN list"));
+  }
+
+  /**
+   * Plain {@code FIX} must leave the record alone. Deleting a record nothing references is destructive - a vertex
+   * whose head-chunk pointer was lost looks exactly like a source of orphans, and its edge records are the only
+   * thing {@code RESTORE VERTEX} could rebuild the adjacency from - so it stays opt-in.
+   */
+  @Test
+  void plainFixDoesNotDeleteAnOrphanEdgeRecord() {
+    final RID orphan = createOrphanEdge(BIDIRECTIONAL_EDGE);
+
+    final Result check = checkDatabase("CHECK DATABASE FIX");
+
+    assertThat(check.<Long>getProperty("unreachableEdgeRecords")).as("still reported").isEqualTo(1L);
+    assertThat(countType(BIDIRECTIONAL_EDGE)).as("but never removed by a plain FIX").isEqualTo(1L);
+    assertThat(rids(check, "deletedRecordsAfterFix")).doesNotContain(orphan);
+  }
+
+  /** The explicit opt-in reclaims it, and the type stops over-reporting the record. */
+  @Test
+  void fixDeleteOrphansReclaimsTheOrphanEdgeRecord() {
+    final RID orphan = createOrphanEdge(BIDIRECTIONAL_EDGE);
+
+    final Result check = checkDatabase("CHECK DATABASE FIX DELETE ORPHANS");
+
+    assertThat(check.<Long>getProperty("unreachableEdgeRecords")).isEqualTo(1L);
+    assertThat(rids(check, "deletedRecordsAfterFix")).contains(orphan);
+    assertThat(countType(BIDIRECTIONAL_EDGE)).as("the record is gone").isZero();
+
+    // And a second run has nothing left to find.
+    final Result second = checkDatabase("CHECK DATABASE");
+    assertThat(second.<Long>getProperty("unreachableEdgeRecords")).isZero();
+    assertThat(warnings(second)).isEmpty();
+  }
+
+  /** A healthy edge must survive the opt-in: the option reclaims orphans, not edges. */
+  @Test
+  void fixDeleteOrphansKeepsAReachableEdge() {
+    database.transaction(() -> {
+      final MutableVertex source = database.newVertex(VERTEX_TYPE).set("name", "source").save();
+      final MutableVertex target = database.newVertex(VERTEX_TYPE).set("name", "target").save();
+      source.newEdge(BIDIRECTIONAL_EDGE, target);
+    });
+
+    final Result check = checkDatabase("CHECK DATABASE FIX DELETE ORPHANS");
+
+    assertThat(check.<Long>getProperty("unreachableEdgeRecords")).isZero();
+    assertThat(countType(BIDIRECTIONAL_EDGE)).isEqualTo(1L);
+  }
+
+  /** {@code DELETE ORPHANS} is a repair, so it is meaningless - and refused - without {@code FIX}. */
+  @Test
+  void deleteOrphansWithoutFixIsRefused() {
+    assertThatThrownBy(() -> database.command("sql", "CHECK DATABASE DELETE ORPHANS"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("DELETE ORPHANS");
+  }
+
+  /**
+   * The clause must survive alongside the rest of the statement, COMPRESS included - the grammar puts it between
+   * {@code FIX} and {@code COMPRESS}, which is the one place an added optional clause can break a parse.
+   * The grammar and {@code toString} round trip are pinned separately by
+   * {@code Issue6090CheckDatabaseDeleteOrphansParserTest}.
+   */
+  @Test
+  void theClauseCombinesWithTheRestOfTheStatement() {
+    final RID orphan = createOrphanEdge(BIDIRECTIONAL_EDGE);
+
+    final Result check = checkDatabase("CHECK DATABASE FIX DELETE ORPHANS COMPRESS");
+
+    assertThat(check.<String>getProperty("operation")).isEqualTo("check database");
+    assertThat(rids(check, "deletedRecordsAfterFix")).contains(orphan);
+  }
+
+  /**
+   * Builds one edge record that no vertex references: a lone edge between two otherwise edge-less vertices, whose
+   * endpoints then lose their head-chunk pointers. The record keeps valid {@code @out}/{@code @in} links, which is
+   * what distinguishes an orphan from the dangling-link corruption the checker already reported.
+   */
+  private RID createOrphanEdge(final String edgeType) {
+    final RID[] edge = new RID[1];
+    final RID[] source = new RID[1];
+    final RID[] target = new RID[1];
+
+    database.transaction(() -> {
+      final MutableVertex from = database.newVertex(VERTEX_TYPE).set("name", "source").save();
+      final MutableVertex to = database.newVertex(VERTEX_TYPE).set("name", "target").save();
+      edge[0] = from.newEdge(edgeType, to).getIdentity();
+      source[0] = from.getIdentity();
+      target[0] = to.getIdentity();
+    });
+
+    database.transaction(() -> {
+      final MutableVertex from = source[0].asVertex(true).modify();
+      from.setOutEdgesHeadChunk(null);
+      from.save();
+
+      final MutableVertex to = target[0].asVertex(true).modify();
+      to.setInEdgesHeadChunk(null);
+      to.save();
+    });
+
+    return edge[0];
+  }
+
+  private Result checkDatabase(final String command) {
+    try (final ResultSet rs = database.command("sql", command)) {
+      return rs.next();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Collection<String> warnings(final Result check) {
+    return (Collection<String>) check.getProperty("warnings");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Collection<RID> rids(final Result check, final String key) {
+    return (Collection<RID>) check.getProperty(key);
+  }
+
+  private long countType(final String typeName) {
+    final long[] count = new long[1];
+    database.transaction(() -> count[0] = database.countType(typeName, true));
+    return count[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6090CheckDatabaseDeleteOrphansParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6090CheckDatabaseDeleteOrphansParserTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Grammar coverage for the {@code DELETE ORPHANS} clause of {@code CHECK DATABASE} (issue #6090).
+ * <p>
+ * {@code checkRightSyntax} parses, renders the AST back to SQL through {@code toString} and re-parses that, so
+ * these also pin the round trip the statement cache depends on.
+ */
+class Issue6090CheckDatabaseDeleteOrphansParserTest extends AbstractParserTest {
+
+  @Test
+  void deleteOrphansClause() {
+    checkRightSyntax("CHECK DATABASE FIX DELETE ORPHANS");
+    checkRightSyntax("check database fix delete orphans");
+    checkRightSyntax("check database fix delete orphans compress");
+    checkRightSyntax("check database type Customer fix delete orphans");
+    checkRightSyntax("check database record #12:3 fix delete orphans");
+    // Accepted by the GRAMMAR; refused at execution because it removes records - see
+    // Issue6090OrphanEdgeRecordCheckTest.deleteOrphansWithoutFixIsRefused.
+    checkRightSyntax("check database delete orphans");
+
+    checkWrongSyntax("check database fix delete");
+    checkWrongSyntax("check database fix orphans");
+    checkWrongSyntax("check database delete orphans fix");
+  }
+
+  /** The rendered form must carry the clause, or the statement cache would replay a plain FIX. */
+  @Test
+  void theClauseSurvivesToString() {
+    final StringBuilder rendered = new StringBuilder();
+    checkRightSyntax("CHECK DATABASE FIX DELETE ORPHANS COMPRESS").toString(null, rendered);
+    assertThat(rendered.toString()).isEqualTo("CHECK DATABASE FIX DELETE ORPHANS COMPRESS");
+  }
+
+  /**
+   * {@code ORPHANS} is a new lexer token, so it is also listed among the keywords usable as an identifier: a
+   * schema that already has a type or property by that name must keep parsing.
+   */
+  @Test
+  void orphansIsStillUsableAsAnIdentifier() {
+    checkRightSyntax("select from orphans");
+    checkRightSyntax("select orphans from Customer");
+    checkRightSyntax("create document type orphans");
+  }
+}


### PR DESCRIPTION
Closes #6090

## The gap

An **orphan edge record** is an edge record that exists physically in an edge-type bucket, whose `@out`/`@in` name valid vertices, but which no vertex's edge list points back at: `countType()` counts it, no traversal reaches it.

`GraphDatabaseChecker.checkEdges` already had everything needed to find one - it scans every edge record and probes both endpoints for a back-reference - and then discarded the answer. Both call sites did nothing but `missingReferenceBack.incrementAndGet()`, under a `// UNI DIRECTIONAL EDGE` comment. No `report.warn` naming the record, no entry in `report.corruptedRecords`, so `CHECK DATABASE FIX` never reclaimed one.

The published counter could not stand in for the finding either, because it is not edge-type aware: a healthy **unidirectional** edge is legitimately absent from its target's IN list and bumps it by 1, a genuinely orphaned bidirectional edge bumps it by 2. One aggregate, no breakdown, no RIDs.

## The change

**1. The probe is direction-aware.** Which side is allowed to hold no reference is a property of the edge type:

| condition | defect? | new key |
|---|---|---|
| absent from the OUT vertex's OUT list | always - no outgoing traversal reaches it | `edgesMissingOutReference` |
| absent from the IN vertex's IN list | only when the type is BIDIRECTIONAL | `edgesMissingInReference` |
| absent from **both** | orphan record | `unreachableEdgeRecords` + `unreachableEdgeRecordsFound` |

`isBidirectional()` reads the **record's** own type, not the `typeName` the scan was given, because the `RECORD` scope hands one call edges of several types; it is a field read on the materialised document, not a schema lookup, so it costs nothing on the per-record path.

**2. The finding is reported.** One warning per defective edge, naming the edge RID, the endpoint and which list is missing it. The three counters above are seeded in `DatabaseChecker.check()` so a clean run publishes zeros rather than omitting the keys - "does this database hold any?" has to be answerable from every run's result, not only from one that found some. `unreachableEdgeRecordsFound` is bounded by the same cap as `corruptedRecords`; the count beside it stays exact.

`missingReferenceBack` is **deliberately unchanged**: both probes still run and it is still bumped once per side that holds no reference, so anything parsing today's result keeps reading the same number. Skipping the IN probe for unidirectional types would have been a small win and would have silently changed it.

**3. Reclaiming them is an explicit opt-in: `CHECK DATABASE FIX DELETE ORPHANS`.** Not folded into plain `FIX`, and the reason is a data-loss path rather than a taste for options. The detection cannot distinguish "garbage a failed bulk load left behind" from "this vertex lost its head-chunk pointer, so its perfectly good edges look unreferenced" - a null head chunk reads exactly like a vertex with no edges, and unlike an *unreadable* chain it is never registered for rebuild. In that second case the edge records are the only surviving description of the adjacency and the thing `RESTORE VERTEX` rebuilds it from, so deleting them by default would turn a recoverable database into an unrecoverable one. `DELETE ORPHANS` without `FIX` is refused rather than silently implying it.

Under the opt-in the orphan RID goes through `report.corrupt(...)`, which is what hands it to the existing repair loop **and** puts its bucket into `affectedBuckets` - the delete there is a raw bucket delete, so without that the edge type's indexes would keep pointing at a record that is gone.

## Why the classification is conservative

An edge is called unreachable only when **both** probes positively established the absence (`outProbed && outUnreferenced && inProbed && inUnreferenced`). Two cases deliberately fall outside it:

- a far endpoint that could not be **loaded** - already reported as a dangling link, and its edge is already flagged corrupted;
- a far endpoint whose list could not be **walked** - the existing `catch` leaves it to `checkVertices`, which runs *after* this pass and rebuilds the chain from the surviving edge records. Deleting the record that repair reads from would be the worst possible answer.

The IN-side probe is required even for a unidirectional type: a type created bidirectional and altered since can still have a list naming the edge, and a record something references must never be called an orphan.

## Test plan

- [x] `engine` `Issue6090OrphanEdgeRecordCheckTest` (9 tests) - orphan bidirectional and unidirectional records are named + counted; a **healthy unidirectional edge** is not a finding while still bumping `missingReferenceBack` by 1 (the case that made the old counter unreadable); a **half-linked** edge still reachable from its source is reported as an IN-side defect and *not* as an orphan; plain `FIX` leaves the record alone; `FIX DELETE ORPHANS` removes it and a second run is clean; a reachable edge survives the opt-in; `DELETE ORPHANS` without `FIX` is refused.
- [x] `engine` `Issue6090CheckDatabaseDeleteOrphansParserTest` (3 tests) - grammar accepts the clause in every position (`FIX DELETE ORPHANS`, with `TYPE`, with `RECORD`, before `COMPRESS`), rejects the partial forms, the clause survives `toString` (the statement cache re-parses that), and `orphans` is still usable as an identifier since it is a new lexer token.
- [x] **Proven to fail without the fix**: with only the two test files applied on top of `main`, 9/9 fail (6 failures + 3 errors). With the fix, 9/9 pass.
- [x] Full `engine` unit lane green: **11987 tests, 0 failures, 0 errors** (`-DexcludedGroups=benchmark,slow,vector`).
- [x] Re-ran the directly affected classes after the final polish: `CheckDatabaseTest`, `CheckDatabaseRecordScopeTest`, `CheckDatabaseSinglePassTest`, `CheckDatabaseAutoFixAccountingTest`, `GraphDatabaseCheckerOrphanReclaimTest`, `Issue6083OrphanEdgeRecordTest`, `CheckDatabaseStatementTestParserTest` + both new classes - 62 tests, all green.

## Notes

- `GraphBatch`'s Javadoc on `reclaimOrphanEdgeRecords` documented the old "CHECK DATABASE does not rescue them" state; updated to say what is now true (it reports them; removing is opt-in), so #6089's rationale for cleaning up after itself still reads correctly.
- Release note added to `docs/release-26.9.1.md`.
