### PR TITLE
fix(#6203): a materialized-view refresh is one transaction, and the scheduler stops pinning an abandoned database

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1723,28 +1723,38 @@ then reported `ERROR`, or `STALE` once `MaterializedViewChangeListener` overwrot
 "the data you are looking at is old" when the data was in fact gone. It stayed gone until some later refresh
 happened to succeed, which for a MANUAL view may be never.
 
-The refresh now clears the previous snapshot with a `DELETE FROM` inside the same transaction as the repopulate,
-so the pass gets the isolation every other ArcadeDB transaction has: the deletes and the inserts stay in the
-transaction's own page buffer until commit, a concurrent reader sees the previous snapshot throughout and the new
-one afterwards, and a failure anywhere rolls the whole pass back onto the previous snapshot rather than onto
-nothing.
+The refresh now writes the defining query's rows over the previous snapshot's records inside one transaction,
+deleting only the surplus and creating only the shortfall. The pass gets the isolation every other ArcadeDB
+transaction has: every write stays in the transaction's own page buffer until commit, a concurrent reader sees the
+previous snapshot throughout and the new one afterwards, and a failure anywhere rolls the whole pass back onto the
+previous snapshot rather than onto nothing. A view's rows also keep their `@rid` across a refresh, where before
+every pass gave them new ones.
 
-Neither trigger fires on the trivial case, which is why this survived the existing tests: an unindexed view
-smaller than one truncate batch was already atomic. The regression tests cover both - an index on the backing type
-(the `dropIndex` commit, at any size) and a view larger than `arcadedb.truncateBatchSize` (the in-scan commit).
+Neither trigger fires on the trivial case, which is why this survived the existing tests: an unindexed view smaller
+than one truncate batch was already atomic. The regression tests cover both - an index on the backing type (the
+`dropIndex` commit, at any size) and a view larger than `arcadedb.truncateBatchSize` (the in-scan commit).
+
+**Rewriting in place rather than clearing and repopulating is what keeps an index on the backing type from paying
+for the atomicity**, and it makes an indexed refresh cheaper than it was before. Clearing the view would give every
+row a new RID, and `TransactionIndexContext` collapses a REMOVE followed by an ADD only on the same (key, RID), so
+each pass would leave a full set of real tombstones where the truncate used to drop the index and rebuild it empty.
+Measured over 120 refreshes of a 2000-row indexed view: a flat 256KB for the old truncate, 256KB growing to 3.9MB
+and still climbing for clear-and-repopulate, and a flat 256KB for the rewrite - because
+`DocumentIndexer.updateDocument` finds the key values unchanged for every row a stable view reproduces and skips the
+index outright. Zero index writes per pass, against a full rebuild per pass before. The backing buckets stay flat
+too, since no record is freed and reallocated. A `@Tag("slow")` soak test guards the bound.
 
 **The shadow-type swap the issue proposed was rejected.** Building into a second backing type and repointing the
 view at it reads better on paper - the swap is metadata only and the old rows are dropped as files rather than
 deleted one by one - but in this engine the swap has no cheap implementation. Renaming a type renames its buckets,
 and `PaginatedComponent.rename()` first waits for every page of the *whole database* to be flushed; paying a
-database-wide flush barrier twice per refresh, on every tick of every PERIODIC view, is a worse defect than the
-one being fixed. Repointing the view at a differently named backing type avoids the barrier but makes the view's
-own name stop being the type name, which is what makes `SELECT FROM <view>` work at all and what every record's
-`@type` reports. What the single transaction costs instead is bounded and not new: it holds the pages of the old
-rows as well as the new ones - largely the same pages, since the deletes hand their free space straight back to
-the inserts - and an index on the backing type is maintained entry by entry rather than dropped and rebuilt empty.
-The repopulate was already one unbounded transaction, so a view too large to refresh in one transaction was
-already too large to refresh.
+database-wide flush barrier twice per refresh, on every tick of every PERIODIC view, is a worse defect than the one
+being fixed. Repointing the view at a differently named backing type avoids the barrier but makes the view's own
+name stop being the type name, which is what makes `SELECT FROM <view>` work at all and what every record's `@type`
+reports. What the single transaction costs instead is bounded and not new: it holds the pages of the rows it
+rewrites, and under HA the pass is one Raft log entry rather than one per truncate batch plus one for the
+repopulate. The repopulate was already one unbounded transaction, so a view too large to refresh in one transaction
+was already too large to refresh.
 
 ### The scheduler no longer pins an abandoned database to a live thread
 

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1705,3 +1705,66 @@ by the negative size marker a plain collapse would replace with a positive one, 
 exactly what tells a bucket scan that a slot holds a document of its own.
 
 [#6178](https://github.com/ArcadeData/arcadedb/issues/6178)
+
+## A materialized-view refresh is one transaction, so a failed one no longer empties the view (#6203)
+
+A full refresh looked like a single transaction and was not one. `TRUNCATE TYPE ... UNSAFE` commits the caller's
+transaction from the inside: `schema.dropIndex()` for every index on the backing type before a single record is
+touched, then `commit(); begin()` once per `arcadedb.truncateBatchSize` records, then once more before it rebuilds
+the indexes it dropped. Wrapping that in `database.transaction()` bought nothing, and both consequences were
+silent.
+
+Every other reader saw the view empty, or holding some prefix of the new rows, for the whole runtime of the
+defining query - which for a view worth materialising is exactly the expensive case, and for a PERIODIC view is
+every tick. Nothing distinguished that from a legitimately empty or small result.
+
+Worse, a defining query that threw after the truncate had committed left the backing type with zero rows. The view
+then reported `ERROR`, or `STALE` once `MaterializedViewChangeListener` overwrote it, and both of those read as
+"the data you are looking at is old" when the data was in fact gone. It stayed gone until some later refresh
+happened to succeed, which for a MANUAL view may be never.
+
+The refresh now clears the previous snapshot with a `DELETE FROM` inside the same transaction as the repopulate,
+so the pass gets the isolation every other ArcadeDB transaction has: the deletes and the inserts stay in the
+transaction's own page buffer until commit, a concurrent reader sees the previous snapshot throughout and the new
+one afterwards, and a failure anywhere rolls the whole pass back onto the previous snapshot rather than onto
+nothing.
+
+Neither trigger fires on the trivial case, which is why this survived the existing tests: an unindexed view
+smaller than one truncate batch was already atomic. The regression tests cover both - an index on the backing type
+(the `dropIndex` commit, at any size) and a view larger than `arcadedb.truncateBatchSize` (the in-scan commit).
+
+**The shadow-type swap the issue proposed was rejected.** Building into a second backing type and repointing the
+view at it reads better on paper - the swap is metadata only and the old rows are dropped as files rather than
+deleted one by one - but in this engine the swap has no cheap implementation. Renaming a type renames its buckets,
+and `PaginatedComponent.rename()` first waits for every page of the *whole database* to be flushed; paying a
+database-wide flush barrier twice per refresh, on every tick of every PERIODIC view, is a worse defect than the
+one being fixed. Repointing the view at a differently named backing type avoids the barrier but makes the view's
+own name stop being the type name, which is what makes `SELECT FROM <view>` work at all and what every record's
+`@type` reports. What the single transaction costs instead is bounded and not new: it holds the pages of the old
+rows as well as the new ones - largely the same pages, since the deletes hand their free space straight back to
+the inserts - and an index on the backing type is maintained entry by entry rather than dropped and rebuilt empty.
+The repopulate was already one unbounded transaction, so a view too large to refresh in one transaction was
+already too large to refresh.
+
+### The scheduler no longer pins an abandoned database to a live thread
+
+`MaterializedViewScheduler` guarded against a database abandoned without `close()` by holding it through a
+`WeakReference` and cancelling the task once that cleared. It could not clear, for two independent reasons.
+
+The refresh runs a transaction on the scheduler thread, which installs a `DatabaseContext` entry keyed by the
+database path holding a strong reference to the database, and the scheduler never removed it - so after the very
+first refresh the weak reference was moot. `TimeSeriesMaintenanceScheduler.runMaintenance()` documents the same
+hazard and takes the entry back down in a `finally`; the refresh now does too, removing only a context that pass
+installed itself.
+
+The task also captured the `MaterializedViewImpl` strongly, and a view holds its own database, so the reference
+that was weak was not the only one. Both are weak now. The task keeps the view's name as a `String` and cancels
+itself when either reference clears, unregistering itself only while it is still the task registered for that view
+- a task that self-cancels after an `ALTER MATERIALIZED VIEW` or a schema reload must leave its replacement
+scheduled.
+
+Finally, the scheduler is created per `LocalSchema` but its thread was called `ArcadeDB-MV-Scheduler` with no
+discriminator, so a JVM with several open databases got several identically named threads and a thread dump could
+not say which was which. The database name is now part of it.
+
+[#6203](https://github.com/ArcadeData/arcadedb/issues/6203)

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1390,7 +1390,7 @@ public class LocalSchema implements Schema {
 
   public synchronized MaterializedViewScheduler getMaterializedViewScheduler() {
     if (materializedViewScheduler == null)
-      materializedViewScheduler = new MaterializedViewScheduler();
+      materializedViewScheduler = new MaterializedViewScheduler(database.getName());
     return materializedViewScheduler;
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -20,10 +20,14 @@ package com.arcadedb.schema;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 
 public class MaterializedViewRefresher {
@@ -83,14 +87,13 @@ public class MaterializedViewRefresher {
   }
 
   /**
-   * Clears the backing type and repopulates it from the defining query, as ONE transaction.
+   * Replaces the backing type's contents with the defining query's rows, as ONE transaction.
    * <p>
-   * The clear is a {@code DELETE FROM} rather than the {@code TRUNCATE TYPE ... UNSAFE} this used to run, and the
-   * difference is the whole point (issue #6203). {@code TRUNCATE} commits the caller's transaction from the inside -
-   * {@code schema.dropIndex()} for every index on the backing type before a single record is touched, then
-   * {@code commit(); begin()} once per {@code arcadedb.truncateBatchSize} records, then once more before it rebuilds
-   * the indexes it dropped - so the refresh was a sequence of committed transactions wearing the costume of one. Both
-   * consequences were silent:
+   * The {@code TRUNCATE TYPE ... UNSAFE} this used to start with is gone, and that is the whole point (issue #6203).
+   * {@code TRUNCATE} commits the caller's transaction from the inside - {@code schema.dropIndex()} for every index on
+   * the backing type before a single record is touched, then {@code commit(); begin()} once per
+   * {@code arcadedb.truncateBatchSize} records, then once more before it rebuilds the indexes it dropped - so the
+   * refresh was a sequence of committed transactions wearing the costume of one. Both consequences were silent:
    * <ul>
    * <li>every other reader saw the view empty, or holding some prefix of the new rows, for the whole runtime of the
    * defining query - which for a view worth materialising is exactly the expensive case, and for a PERIODIC view is
@@ -99,10 +102,10 @@ public class MaterializedViewRefresher {
    * then reported ERROR or STALE, and both of those read as "the data you are looking at is old" when the data was in
    * fact gone - until some later refresh happened to succeed, which for a MANUAL view may be never.</li>
    * </ul>
-   * As one transaction the refresh gets the isolation every other ArcadeDB transaction has: the deletes and the
-   * inserts stay in the transaction's own page buffer until commit, so a concurrent reader sees the previous snapshot
-   * throughout and the new one afterwards, and a failure anywhere rolls the whole pass back onto the previous
-   * snapshot rather than onto nothing.
+   * As one transaction the refresh gets the isolation every other ArcadeDB transaction has: every write stays in the
+   * transaction's own page buffer until commit, so a concurrent reader sees the previous snapshot throughout and the
+   * new one afterwards, and a failure anywhere rolls the whole pass back onto the previous snapshot rather than onto
+   * nothing.
    * <p>
    * The rejected alternative was to build into a shadow backing type and swap the two at the end. It reads better on
    * paper - the swap is metadata only and the old rows are dropped as files rather than deleted one by one - but in
@@ -113,11 +116,24 @@ public class MaterializedViewRefresher {
    * but makes the view's own name stop being the type name, which is what makes {@code SELECT FROM <view>} work at
    * all and what every record's {@code @type} reports.
    * <p>
-   * What this costs relative to the truncate: the transaction now holds the pages of the old rows as well as the new
-   * ones - bounded in practice by the free space the deletes hand straight back to the inserts in the same buckets -
-   * and an index on the backing type is maintained entry by entry instead of being dropped and rebuilt empty. Under
-   * HA the pass is one Raft log entry rather than one per truncate batch plus one for the repopulate. None of this is
-   * a new ceiling: the repopulate was already a single unbounded transaction, so a view too large to refresh in one
+   * The new rows are written OVER the previous snapshot's records rather than into fresh ones, and only the surplus
+   * is deleted (or the shortfall created). That is not a micro-optimisation, it is what keeps an index on the backing
+   * type from paying for the atomicity. Clearing the view with a delete and repopulating with new records would give
+   * every row a new RID, and {@code TransactionIndexContext} collapses a REMOVE followed by an ADD only on the same
+   * (key, RID) - so each pass would leave a full set of real tombstones in the index, where the truncate used to drop
+   * the index and rebuild it empty. Measured over 120 refreshes of a 2000-row indexed view: delete-and-recreate grew
+   * the index from 256KB to 3.9MB and climbing, held down only by compaction it was itself provoking, against a flat
+   * 256KB for the truncate. Rewriting in place instead means {@code DocumentIndexer.updateDocument} finds the key
+   * values unchanged for every row a stable view reproduces, and skips the index entirely: zero index writes per
+   * pass, which is better than either.
+   * <p>
+   * The RIDs are collected up front rather than iterated live. An update whose content no longer fits its slot can
+   * relocate the record, and a scan that is still walking the bucket would then meet it a second time at its new
+   * home - rewriting a row already written and losing count of what is surplus.
+   * <p>
+   * What this costs relative to the truncate: the transaction holds the pages of the rows it rewrites, and under HA
+   * the pass is one Raft log entry rather than one per truncate batch plus one for the repopulate. Neither is a new
+   * ceiling - the repopulate was already a single unbounded transaction, so a view too large to refresh in one
    * transaction was already too large to refresh.
    */
   private static void refreshOnce(final Database database, final MaterializedViewImpl view) {
@@ -129,21 +145,59 @@ public class MaterializedViewRefresher {
     // would otherwise defer the commit indefinitely.
     // See: https://github.com/ArcadeData/arcadedb/issues/3941
     database.transaction(() -> {
-      // Clear the previous snapshot inside this transaction, so it stays visible until the new one replaces it.
-      database.command("sql", "DELETE FROM `" + backingTypeName + "`").close();
+      final List<RID> previousSnapshot = collectRIDs(database, backingTypeName);
+      int reused = 0;
 
-      // Execute the defining query and insert results
+      // Execute the defining query and write its rows over the previous snapshot's records
       try (final ResultSet rs = database.query("sql", view.getQuery())) {
         while (rs.hasNext()) {
           final Result result = rs.next();
-          final MutableDocument doc = database.newDocument(backingTypeName);
-          for (final String prop : result.getPropertyNames()) {
-            if (!prop.startsWith("@"))
-              doc.set(prop, result.getProperty(prop));
-          }
+          final MutableDocument doc = reused < previousSnapshot.size() ?
+              previousSnapshot.get(reused++).asDocument(true).modify() :
+              database.newDocument(backingTypeName);
+          applyRow(doc, result);
           doc.save();
         }
       }
+
+      // Whatever the new snapshot did not need
+      for (int i = reused; i < previousSnapshot.size(); i++)
+        previousSnapshot.get(i).asDocument(true).delete();
     }, false);
+  }
+
+  /** Copies one query row onto a document, dropping any property the row does not carry. */
+  private static void applyRow(final MutableDocument doc, final Result row) {
+    // A reused document still holds the columns of the row it used to carry, and whatever this row does not
+    // reproduce has to go. Snapshot the names first: getPropertyNames() is a live view of the document, so both
+    // the writes below and the removals after would otherwise mutate what is being iterated. A newly created
+    // document has none, and skipping the copy is what keeps the create path allocating exactly as it did.
+    final Set<String> previous = doc.getPropertyNames();
+    final List<String> carriedOver = previous.isEmpty() ? null : new ArrayList<>(previous);
+
+    for (final String prop : row.getPropertyNames())
+      if (!prop.startsWith("@"))
+        doc.set(prop, row.getProperty(prop));
+
+    if (carriedOver != null)
+      for (final String prop : carriedOver)
+        if (!row.hasProperty(prop))
+          doc.remove(prop);
+  }
+
+  /**
+   * The RIDs currently holding the view, in scan order. {@code countType} is a cached counter rather than a scan and
+   * is used here only as a capacity hint - the list is filled by the scan, so a stale count costs a resize and
+   * nothing else - which spares the common case, a view whose row count barely moves between refreshes, from
+   * growing the list at all.
+   */
+  private static List<RID> collectRIDs(final Database database, final String backingTypeName) {
+    final long count = database.countType(backingTypeName, false);
+    final List<RID> rids = new ArrayList<>(count > 0 && count < Integer.MAX_VALUE ? (int) count : 16);
+    database.scanType(backingTypeName, false, record -> {
+      rids.add(record.getIdentity());
+      return true;
+    });
+    return rids;
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -82,6 +82,44 @@ public class MaterializedViewRefresher {
     }
   }
 
+  /**
+   * Clears the backing type and repopulates it from the defining query, as ONE transaction.
+   * <p>
+   * The clear is a {@code DELETE FROM} rather than the {@code TRUNCATE TYPE ... UNSAFE} this used to run, and the
+   * difference is the whole point (issue #6203). {@code TRUNCATE} commits the caller's transaction from the inside -
+   * {@code schema.dropIndex()} for every index on the backing type before a single record is touched, then
+   * {@code commit(); begin()} once per {@code arcadedb.truncateBatchSize} records, then once more before it rebuilds
+   * the indexes it dropped - so the refresh was a sequence of committed transactions wearing the costume of one. Both
+   * consequences were silent:
+   * <ul>
+   * <li>every other reader saw the view empty, or holding some prefix of the new rows, for the whole runtime of the
+   * defining query - which for a view worth materialising is exactly the expensive case, and for a PERIODIC view is
+   * every tick;</li>
+   * <li>a defining query that threw after the truncate had committed left the backing type with zero rows. The view
+   * then reported ERROR or STALE, and both of those read as "the data you are looking at is old" when the data was in
+   * fact gone - until some later refresh happened to succeed, which for a MANUAL view may be never.</li>
+   * </ul>
+   * As one transaction the refresh gets the isolation every other ArcadeDB transaction has: the deletes and the
+   * inserts stay in the transaction's own page buffer until commit, so a concurrent reader sees the previous snapshot
+   * throughout and the new one afterwards, and a failure anywhere rolls the whole pass back onto the previous
+   * snapshot rather than onto nothing.
+   * <p>
+   * The rejected alternative was to build into a shadow backing type and swap the two at the end. It reads better on
+   * paper - the swap is metadata only and the old rows are dropped as files rather than deleted one by one - but in
+   * this engine the swap has no cheap implementation. Renaming a type renames its buckets, and
+   * {@code PaginatedComponent.rename()} first waits for every page of the whole database to be flushed: paying a
+   * database-wide flush barrier twice per refresh, on every tick of every PERIODIC view, is a worse defect than the
+   * one being fixed. Repointing the view at a differently named backing type instead of renaming avoids the barrier
+   * but makes the view's own name stop being the type name, which is what makes {@code SELECT FROM <view>} work at
+   * all and what every record's {@code @type} reports.
+   * <p>
+   * What this costs relative to the truncate: the transaction now holds the pages of the old rows as well as the new
+   * ones - bounded in practice by the free space the deletes hand straight back to the inserts in the same buckets -
+   * and an index on the backing type is maintained entry by entry instead of being dropped and rebuilt empty. Under
+   * HA the pass is one Raft log entry rather than one per truncate batch plus one for the repopulate. None of this is
+   * a new ceiling: the repopulate was already a single unbounded transaction, so a view too large to refresh in one
+   * transaction was already too large to refresh.
+   */
   private static void refreshOnce(final Database database, final MaterializedViewImpl view) {
     final String backingTypeName = view.getBackingTypeName();
 
@@ -91,8 +129,8 @@ public class MaterializedViewRefresher {
     // would otherwise defer the commit indefinitely.
     // See: https://github.com/ArcadeData/arcadedb/issues/3941
     database.transaction(() -> {
-      // Truncate existing data, faster than DELETE FROM (no per-record WAL entries).
-      database.command("sql", "TRUNCATE TYPE `" + backingTypeName + "` UNSAFE").close();
+      // Clear the previous snapshot inside this transaction, so it stays visible until the new one replaces it.
+      database.command("sql", "DELETE FROM `" + backingTypeName + "`").close();
 
       // Execute the defining query and insert results
       try (final ResultSet rs = database.query("sql", view.getQuery())) {

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -19,6 +19,7 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.log.LogManager;
@@ -26,6 +27,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -145,15 +147,15 @@ public class MaterializedViewRefresher {
     // would otherwise defer the commit indefinitely.
     // See: https://github.com/ArcadeData/arcadedb/issues/3941
     database.transaction(() -> {
-      final List<RID> previousSnapshot = collectRIDs(database, backingTypeName);
+      final RecordIdentities previousSnapshot = collectIdentities(database, backingTypeName);
       int reused = 0;
 
       // Execute the defining query and write its rows over the previous snapshot's records
       try (final ResultSet rs = database.query("sql", view.getQuery())) {
         while (rs.hasNext()) {
           final Result result = rs.next();
-          final MutableDocument doc = reused < previousSnapshot.size() ?
-              previousSnapshot.get(reused++).asDocument(true).modify() :
+          final MutableDocument doc = reused < previousSnapshot.size ?
+              ((Document) database.lookupByRID(previousSnapshot.get(reused++), true)).modify() :
               database.newDocument(backingTypeName);
           applyRow(doc, result);
           doc.save();
@@ -161,8 +163,8 @@ public class MaterializedViewRefresher {
       }
 
       // Whatever the new snapshot did not need
-      for (int i = reused; i < previousSnapshot.size(); i++)
-        previousSnapshot.get(i).asDocument(true).delete();
+      for (int i = reused; i < previousSnapshot.size; i++)
+        database.lookupByRID(previousSnapshot.get(i), true).delete();
     }, false);
   }
 
@@ -186,18 +188,56 @@ public class MaterializedViewRefresher {
   }
 
   /**
-   * The RIDs currently holding the view, in scan order. {@code countType} is a cached counter rather than a scan and
-   * is used here only as a capacity hint - the list is filled by the scan, so a stale count costs a resize and
-   * nothing else - which spares the common case, a view whose row count barely moves between refreshes, from
-   * growing the list at all.
+   * The identities currently holding the view, in scan order. {@code countType} is a cached counter rather than a
+   * scan and is used here only as a capacity hint - the arrays are filled by the scan, so a stale count costs a
+   * resize and nothing else - which spares the common case, a view whose row count barely moves between refreshes,
+   * from growing them at all.
    */
-  private static List<RID> collectRIDs(final Database database, final String backingTypeName) {
+  private static RecordIdentities collectIdentities(final Database database, final String backingTypeName) {
     final long count = database.countType(backingTypeName, false);
-    final List<RID> rids = new ArrayList<>(count > 0 && count < Integer.MAX_VALUE ? (int) count : 16);
+    final RecordIdentities identities = new RecordIdentities(
+        count > 0 && count < Integer.MAX_VALUE ? (int) count : 16);
     database.scanType(backingTypeName, false, record -> {
-      rids.add(record.getIdentity());
+      identities.add(record.getIdentity());
       return true;
     });
-    return rids;
+    return identities;
+  }
+
+  /**
+   * The previous snapshot's record identities, held as the two primitives a {@link RID} is made of rather than as a
+   * {@code List<RID>}.
+   * <p>
+   * This is allocated on every refresh of every view and is proportional to the view's size, and a boxed RID per row
+   * costs several times what the pair of primitives does - a reference plus an object header plus the same two
+   * fields, against 12 bytes. Identities are rebuilt one at a time as the rewrite consumes them, so at most one is
+   * ever live, and each is handed straight to {@code lookupByRID} rather than to {@code RID.asDocument()}: the
+   * latter resolves the database from the thread's {@link com.arcadedb.database.DatabaseContext}, which this refresh
+   * has no reason to depend on.
+   */
+  private static final class RecordIdentities {
+    private int[] bucketIds;
+    private long[] positions;
+    private int   size;
+
+    private RecordIdentities(final int initialCapacity) {
+      this.bucketIds = new int[initialCapacity];
+      this.positions = new long[initialCapacity];
+    }
+
+    private void add(final RID rid) {
+      if (size == bucketIds.length) {
+        final int grown = size + (size >> 1) + 1;
+        bucketIds = Arrays.copyOf(bucketIds, grown);
+        positions = Arrays.copyOf(positions, grown);
+      }
+      bucketIds[size] = rid.getBucketId();
+      positions[size] = rid.getPosition();
+      ++size;
+    }
+
+    private RID get(final int index) {
+      return new RID(bucketIds[index], positions[index]);
+    }
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
@@ -19,6 +19,7 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.log.LogManager;
 
 import java.lang.ref.WeakReference;
@@ -31,12 +32,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public class MaterializedViewScheduler {
-  private final ScheduledExecutorService executor;
-  private final Map<String, ScheduledFuture<?>> tasks = new ConcurrentHashMap<>();
+  private final ScheduledExecutorService  executor;
+  private final Map<String, RefreshTask> tasks = new ConcurrentHashMap<>();
 
-  public MaterializedViewScheduler() {
+  /**
+   * @param databaseName names the scheduler thread. One scheduler is created per {@link LocalSchema}, so a JVM with
+   *                     several open databases has several of these threads, and an undiscriminated name leaves a
+   *                     thread dump unable to say which database a thread belongs to.
+   */
+  public MaterializedViewScheduler(final String databaseName) {
     this.executor = Executors.newSingleThreadScheduledExecutor(r -> {
-      final Thread t = new Thread(r, "ArcadeDB-MV-Scheduler");
+      final Thread t = new Thread(r, "ArcadeDB-MV-Scheduler-" + databaseName);
       t.setDaemon(true);
       return t;
     });
@@ -52,17 +58,10 @@ public class MaterializedViewScheduler {
     // as TimeSeriesMaintenanceScheduler.schedule() already does
     cancel(view.getName());
 
-    final WeakReference<Database> dbRef = new WeakReference<>(database);
-    final ScheduledFuture<?> future = executor.scheduleAtFixedRate(() -> {
-      final Database db = dbRef.get();
-      if (db == null || !db.isOpen()) {
-        cancel(view.getName());
-        return;
-      }
-      runOneRefresh(db, view);
-    }, interval, interval, TimeUnit.MILLISECONDS);
+    final RefreshTask task = new RefreshTask(database, view);
+    task.future = executor.scheduleAtFixedRate(task, interval, interval, TimeUnit.MILLISECONDS);
 
-    tasks.put(view.getName(), future);
+    tasks.put(view.getName(), task);
   }
 
   /**
@@ -85,27 +84,99 @@ public class MaterializedViewScheduler {
    * is a choice, not an oversight, and the next person to find this thread busy during an OOM should know it was
    * made on purpose.
    * <p>
+   * The refresh runs a transaction, which installs a {@link DatabaseContext} entry keyed by the database path on
+   * whichever thread runs it, and that entry holds a strong reference to the database. On the scheduler thread -
+   * which outlives every request and is never recycled - it has to be taken back down again, or a database
+   * abandoned without {@code close()} stays reachable from a live thread, with its whole page cache, for the life
+   * of the JVM, and {@link RefreshTask}'s weak references can never clear (issue #6203).
+   * {@code TimeSeriesMaintenanceScheduler.runMaintenance()} documents the same hazard. Only a context this call
+   * installed is removed: the method is package-visible so a test can drive one pass without waiting out a tick,
+   * and tearing down a caller's own context would be a side effect nobody asked for.
+   * <p>
    * Extracted from the scheduling above so the guarantee can be tested without waiting out a tick.
    */
   // @VisibleForTesting
   void runOneRefresh(final Database database, final MaterializedViewImpl view) {
+    final String databasePath = database.getDatabasePath();
+    final boolean contextInstalledHere = DatabaseContext.INSTANCE.getContextIfExists(databasePath) == null;
     try {
       MaterializedViewRefresher.fullRefresh(database, view);
     } catch (final Throwable e) {
       view.setStatus(MaterializedViewStatus.ERROR);
       LogManager.instance().log(this, Level.SEVERE,
           "Error in periodic refresh for view '%s': %s", e, view.getName(), e.getMessage());
+    } finally {
+      if (contextInstalledHere)
+        DatabaseContext.INSTANCE.removeContext(databasePath);
     }
   }
 
   public void cancel(final String viewName) {
-    final ScheduledFuture<?> future = tasks.remove(viewName);
-    if (future != null)
-      future.cancel(false);
+    final RefreshTask task = tasks.remove(viewName);
+    if (task != null)
+      task.future.cancel(false);
   }
 
   public void shutdown() {
     executor.shutdownNow();
     tasks.clear();
+  }
+
+  /**
+   * One view's periodic pass, holding nothing it does not have to.
+   * <p>
+   * Both references are weak on purpose. A database closed the normal way already stops this task -
+   * {@code LocalSchema.close()} calls {@link #shutdown()} - so they exist for exactly one case: a database
+   * abandoned without ever being closed. For them to do that job NEITHER may be strong, because the two objects are
+   * reachable from each other: {@link MaterializedViewImpl} holds its database, and the database's schema holds the
+   * view. Holding the view strongly here would pin the database just as effectively as holding the database
+   * strongly, which is why this leaked with a {@code WeakReference<Database>} already in place (issue #6203).
+   * Everything else the task needs is a {@code String}. The enclosing scheduler, captured by this inner class, has
+   * no reference of its own back to the database.
+   */
+  private final class RefreshTask implements Runnable {
+    private final String                              viewName;
+    private final WeakReference<Database>             databaseRef;
+    private final WeakReference<MaterializedViewImpl> viewRef;
+    /**
+     * Assigned by {@code schedule()} as soon as the task is scheduled, and BEFORE the task is published to
+     * {@code tasks} - so anything found in that map has one, and {@link #cancel} never has to test for it. Only
+     * {@link #cancelSelf()}, which runs from inside the task itself, can observe it unset.
+     */
+    private volatile ScheduledFuture<?> future;
+
+    private RefreshTask(final Database database, final MaterializedViewImpl view) {
+      this.viewName = view.getName();
+      this.databaseRef = new WeakReference<>(database);
+      this.viewRef = new WeakReference<>(view);
+    }
+
+    @Override
+    public void run() {
+      final Database database = databaseRef.get();
+      final MaterializedViewImpl view = viewRef.get();
+      if (database == null || view == null || !database.isOpen()) {
+        cancelSelf();
+        return;
+      }
+      runOneRefresh(database, view);
+    }
+
+    /**
+     * Cancels this task, and unregisters it only while it is still the task registered for the view. A blind
+     * {@code cancel(viewName)} would cancel whatever is registered under that name, which after a re-schedule
+     * (schema reload, ALTER MATERIALIZED VIEW) is the replacement task rather than this one - and the view would
+     * then stop refreshing with nothing saying so.
+     */
+    private void cancelSelf() {
+      final ScheduledFuture<?> mine = future;
+      if (mine == null)
+        // The first run beat schedule()'s assignment by the width of one statement, so there is nothing to cancel
+        // yet and nothing registered under this name to unregister. The field is volatile and assigned right
+        // after, so the next tick - one interval away - takes this branch's place and cancels then.
+        return;
+      tasks.remove(viewName, this);
+      mine.cancel(false);
+    }
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 
 public class MaterializedViewScheduler {
   private final ScheduledExecutorService  executor;
-  private final Map<String, RefreshTask> tasks = new ConcurrentHashMap<>();
+  private final Map<String, RefreshTask>  tasks = new ConcurrentHashMap<>();
 
   /**
    * @param databaseName names the scheduler thread. One scheduler is created per {@link LocalSchema}, so a JVM with

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewRefreshAtomicityTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewRefreshAtomicityTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.event.BeforeRecordCreateListener;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A full refresh used to be a sequence of committed transactions rather than one: {@code TRUNCATE TYPE ... UNSAFE}
+ * commits the caller's transaction from the inside - once per {@code arcadedb.truncateBatchSize} records, once more
+ * before it rebuilds the indexes it dropped, and the {@code dropIndex} itself is committed before any record is
+ * touched. So the emptied view became visible to every other reader long before the repopulate finished. Two
+ * consequences, both silent: a reader saw the view empty or half built for the whole runtime of the defining query,
+ * and a refresh that failed after the truncate destroyed the previous snapshot instead of leaving it in place.
+ * <p>
+ * Both triggers are covered below, since neither fires on the trivial case: an index on the backing type (the
+ * dropIndex commit, at any size) and a view larger than one truncate batch (the in-scan commit).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class MaterializedViewRefreshAtomicityTest extends TestHelper {
+
+  /**
+   * The data-loss half. A refresh that throws part way through the repopulate must leave the view exactly as it was,
+   * not empty: the view's status reports staleness, never "the rows are gone", so an operator has nothing to go on,
+   * and for a MANUAL view there may be no later refresh to put them back.
+   */
+  @Test
+  void aFailedRefreshOnAnIndexedViewLeavesThePreviousSnapshotIntact() {
+    createSourceWith(5);
+    createView("FailedRefreshView");
+    createIndexOn("FailedRefreshView", "NOTUNIQUE");
+
+    assertThat(countOf("FailedRefreshView")).isEqualTo(5);
+
+    // More source rows, so a successful refresh would be visibly different from the snapshot on disk.
+    insertSourceRows(5, 3);
+
+    failRefreshOnRecord("FailedRefreshView", 3);
+
+    assertThat(countOf("FailedRefreshView"))
+        .as("a failed refresh must preserve the previous snapshot, not empty the view")
+        .isEqualTo(5);
+    assertThat(idsOf("FailedRefreshView")).containsExactly(0L, 1L, 2L, 3L, 4L);
+    assertThat(idsFromIndexOf("FailedRefreshView"))
+        .as("and the index must still agree with the records")
+        .containsExactly(0L, 1L, 2L, 3L, 4L);
+
+    // ...and the view is still refreshable afterwards.
+    database.getSchema().getMaterializedView("FailedRefreshView").refresh();
+    assertThat(countOf("FailedRefreshView")).isEqualTo(8);
+    assertThat(idsFromIndexOf("FailedRefreshView")).containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L);
+  }
+
+  /**
+   * The same guarantee for the other trigger: a view bigger than one truncate batch, with no index in play.
+   */
+  @Test
+  void aFailedRefreshOnAViewLargerThanOneTruncateBatchLeavesThePreviousSnapshotIntact() {
+    final int rows = GlobalConfiguration.TRUNCATE_BATCH_SIZE.getValueAsInteger() + 100;
+    createSourceWith(rows);
+    createView("LargeFailedRefreshView");
+
+    assertThat(countOf("LargeFailedRefreshView")).isEqualTo(rows);
+
+    insertSourceRows(rows, 3);
+    failRefreshOnRecord("LargeFailedRefreshView", 3);
+
+    assertThat(countOf("LargeFailedRefreshView"))
+        .as("a failed refresh must preserve the previous snapshot, not empty the view")
+        .isEqualTo(rows);
+  }
+
+  /**
+   * The visibility half: for the whole runtime of the defining query - which for a view worth materialising is
+   * exactly the expensive case, and for a PERIODIC view is every tick - a concurrent reader must keep seeing the
+   * previous snapshot, never a prefix of the new one and never zero rows.
+   */
+  @Test
+  void aConcurrentReaderNeverSeesTheViewPartiallyBuilt() throws Exception {
+    createSourceWith(5);
+    createView("VisibilityView");
+    createIndexOn("VisibilityView", "NOTUNIQUE");
+
+    assertThat(countOf("VisibilityView")).isEqualTo(5);
+    insertSourceRows(5, 3);
+
+    final CountDownLatch refreshReachedFirstInsert = new CountDownLatch(1);
+    final CountDownLatch readerObserved = new CountDownLatch(1);
+    final DocumentType backing = database.getSchema().getType("VisibilityView");
+    final AtomicInteger created = new AtomicInteger();
+    final BeforeRecordCreateListener pause = record -> {
+      if (created.incrementAndGet() == 1) {
+        refreshReachedFirstInsert.countDown();
+        try {
+          readerObserved.await(30, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      return true;
+    };
+    backing.getEvents().registerListener(pause);
+
+    final AtomicReference<Throwable> refreshFailure = new AtomicReference<>();
+    final Thread refresher = new Thread(() -> {
+      try {
+        database.getSchema().getMaterializedView("VisibilityView").refresh();
+      } catch (final Throwable e) {
+        refreshFailure.set(e);
+      }
+    }, "mv-refresh-under-test");
+    refresher.start();
+
+    final long observed;
+    try {
+      assertThat(refreshReachedFirstInsert.await(30, TimeUnit.SECONDS))
+          .as("the refresh reached its first insert").isTrue();
+      observed = countOf("VisibilityView");
+    } finally {
+      readerObserved.countDown();
+      refresher.join(TimeUnit.SECONDS.toMillis(30));
+      backing.getEvents().unregisterListener(pause);
+    }
+
+    assertThat(refreshFailure.get()).isNull();
+    assertThat(observed)
+        .as("a reader must see the previous snapshot for the whole refresh, not an empty or half-built view")
+        .isEqualTo(5);
+    assertThat(countOf("VisibilityView")).as("and the finished refresh is visible").isEqualTo(8);
+  }
+
+  /**
+   * A UNIQUE index on the backing type is the case where clearing the view and repopulating it inside one
+   * transaction has to survive the same key being removed and re-added before the uniqueness check runs.
+   */
+  @Test
+  void aViewWithAUniqueIndexRefreshesRepeatedly() {
+    createSourceWith(5);
+    createView("UniqueIndexView");
+    createIndexOn("UniqueIndexView", "UNIQUE");
+
+    for (int pass = 0; pass < 3; pass++) {
+      database.getSchema().getMaterializedView("UniqueIndexView").refresh();
+      assertThat(idsOf("UniqueIndexView")).containsExactly(0L, 1L, 2L, 3L, 4L);
+      assertThat(idsFromIndexOf("UniqueIndexView")).containsExactly(0L, 1L, 2L, 3L, 4L);
+    }
+
+    insertSourceRows(5, 2);
+    database.getSchema().getMaterializedView("UniqueIndexView").refresh();
+    assertThat(idsFromIndexOf("UniqueIndexView")).containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L);
+  }
+
+  private void failRefreshOnRecord(final String viewName, final int failOnNthCreate) {
+    final DocumentType backing = database.getSchema().getType(viewName);
+    final AtomicInteger created = new AtomicInteger();
+    final BeforeRecordCreateListener boom = record -> {
+      if (created.incrementAndGet() == failOnNthCreate)
+        throw new IllegalStateException("simulated failure part way through the repopulate");
+      return true;
+    };
+    backing.getEvents().registerListener(boom);
+    try {
+      assertThatThrownBy(() -> database.getSchema().getMaterializedView(viewName).refresh())
+          .as("the failure still reaches the caller")
+          .isInstanceOf(IllegalStateException.class);
+    } finally {
+      backing.getEvents().unregisterListener(boom);
+    }
+  }
+
+  private void createIndexOn(final String viewName, final String uniqueness) {
+    database.command("sql", "CREATE PROPERTY `" + viewName + "`.id INTEGER").close();
+    database.command("sql", "CREATE INDEX ON `" + viewName + "` (id) " + uniqueness).close();
+  }
+
+  private void createView(final String viewName) {
+    database.transaction(() -> database.getSchema().buildMaterializedView()
+        .withName(viewName)
+        .withQuery("SELECT id FROM RefreshSource ORDER BY id")
+        .create());
+  }
+
+  private void createSourceWith(final int rows) {
+    database.transaction(() -> database.getSchema().createDocumentType("RefreshSource"));
+    insertSourceRows(0, rows);
+  }
+
+  private void insertSourceRows(final int from, final int count) {
+    database.transaction(() -> {
+      for (int i = from; i < from + count; i++)
+        database.newDocument("RefreshSource").set("id", i).save();
+    });
+  }
+
+  private long countOf(final String viewName) {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM `" + viewName + "`")) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private List<Long> idsOf(final String viewName) {
+    final List<Long> ids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", "SELECT id FROM `" + viewName + "` ORDER BY id")) {
+      while (rs.hasNext())
+        ids.add(((Number) rs.next().getProperty("id")).longValue());
+    }
+    return ids;
+  }
+
+  /**
+   * Reads through the index rather than the buckets, so an index left disagreeing with the records - stale entries
+   * for rows that were rolled back, missing entries for rows that survived - cannot pass as correct data. The plan
+   * is asserted as well as the rows: without that, a planner change that stopped choosing the index would silently
+   * turn this into a second bucket scan, and the test would keep passing while checking nothing new.
+   */
+  private List<Long> idsFromIndexOf(final String viewName) {
+    final String query = "SELECT id FROM `" + viewName + "` WHERE id >= 0 ORDER BY id";
+    final List<Long> ids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      assertThat(rs.getExecutionPlan().orElseThrow().prettyPrint(0, 3))
+          .as("the assertion is only worth making if it is served by the index")
+          .contains("FETCH FROM INDEX");
+      while (rs.hasNext())
+        ids.add(((Number) rs.next().getProperty("id")).longValue());
+    }
+    return ids;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewRefreshAtomicityTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewRefreshAtomicityTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.schema;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
 import com.arcadedb.engine.FileManager;
 import com.arcadedb.event.BeforeRecordCreateListener;
 import com.arcadedb.event.BeforeRecordUpdateListener;
@@ -190,6 +191,61 @@ class MaterializedViewRefreshAtomicityTest extends TestHelper {
   }
 
   /**
+   * Rewriting in place pairs each new row with a previous record BY POSITION, so a defining query whose order moves
+   * between passes makes the unique keys change hands: the record that held key 4 is handed key 0, while the record
+   * that held key 0 is handed key 4, all inside one transaction. Under the truncate this could not arise - the index
+   * was dropped before any row was touched and rebuilt only once every row was in place - so it is new ground, and a
+   * spurious {@code DuplicatedKeyException} here would be exactly the kind of failure that only shows up on the one
+   * view whose query has no stable sort.
+   * <p>
+   * The permutation is driven rather than hoped for: the view sorts on a column the test rewrites between passes, so
+   * every one of the five keys lands on a different record than it did before.
+   */
+  @Test
+  void aViewWithAUniqueIndexSurvivesItsRowsChangingOrderBetweenRefreshes() {
+    database.transaction(() -> database.getSchema().createDocumentType("RefreshSource"));
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++)
+        database.newDocument("RefreshSource").set("id", i).set("ord", i).save();
+    });
+    database.transaction(() -> database.getSchema().buildMaterializedView()
+        .withName("ReorderedView")
+        .withQuery("SELECT id FROM RefreshSource ORDER BY ord")
+        .create());
+    createIndexOn("ReorderedView", "UNIQUE");
+
+    assertThat(idsOf("ReorderedView")).containsExactly(0L, 1L, 2L, 3L, 4L);
+
+    // Same five keys, reversed order: every record is handed a key that another record still holds.
+    for (int pass = 0; pass < 3; pass++) {
+      final int direction = pass;
+      database.transaction(() -> {
+        try (final ResultSet rs = database.query("sql", "SELECT FROM RefreshSource")) {
+          while (rs.hasNext()) {
+            final MutableDocument doc = rs.next().getRecord().orElseThrow().asDocument().modify();
+            final int id = ((Number) doc.get("id")).intValue();
+            doc.set("ord", direction % 2 == 0 ? 4 - id : id).save();
+          }
+        }
+      });
+
+      database.getSchema().getMaterializedView("ReorderedView").refresh();
+
+      // In record order, not sorted: this is what proves the keys actually changed hands rather than the test
+      // asserting a permutation it never provoked.
+      assertThat(idsInRecordOrderOf("ReorderedView"))
+          .as("pass %d handed every record a key another record was still holding", pass)
+          .containsExactlyElementsOf(direction % 2 == 0 ?
+              List.of(4L, 3L, 2L, 1L, 0L) :
+              List.of(0L, 1L, 2L, 3L, 4L));
+      assertThat(idsOf("ReorderedView")).as("pass %d", pass).containsExactly(0L, 1L, 2L, 3L, 4L);
+      assertThat(idsFromIndexOf("ReorderedView"))
+          .as("the unique index agrees with the records after pass %d", pass)
+          .containsExactly(0L, 1L, 2L, 3L, 4L);
+    }
+  }
+
+  /**
    * The cost the atomicity is not allowed to have. The truncate this replaced dropped every index on the backing
    * type and rebuilt it empty, so an indexed view's index never grew however often it refreshed. Clearing the view
    * with a delete instead would give every row a new RID on every pass, and {@code TransactionIndexContext}
@@ -291,6 +347,16 @@ class MaterializedViewRefreshAtomicityTest extends TestHelper {
     try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM `" + viewName + "`")) {
       return ((Number) rs.next().getProperty("c")).longValue();
     }
+  }
+
+  /** The ids as the records hold them, unsorted, so a permutation of the rows is visible rather than normalised away. */
+  private List<Long> idsInRecordOrderOf(final String viewName) {
+    final List<Long> ids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", "SELECT id FROM `" + viewName + "`")) {
+      while (rs.hasNext())
+        ids.add(((Number) rs.next().getProperty("id")).longValue());
+    }
+    return ids;
   }
 
   private List<Long> idsOf(final String viewName) {

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewRefreshAtomicityTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewRefreshAtomicityTest.java
@@ -20,8 +20,14 @@ package com.arcadedb.schema;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.FileManager;
 import com.arcadedb.event.BeforeRecordCreateListener;
+import com.arcadedb.event.BeforeRecordUpdateListener;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -114,13 +120,15 @@ class MaterializedViewRefreshAtomicityTest extends TestHelper {
     assertThat(countOf("VisibilityView")).isEqualTo(5);
     insertSourceRows(5, 3);
 
-    final CountDownLatch refreshReachedFirstInsert = new CountDownLatch(1);
+    final CountDownLatch refreshReachedFirstWrite = new CountDownLatch(1);
     final CountDownLatch readerObserved = new CountDownLatch(1);
     final DocumentType backing = database.getSchema().getType("VisibilityView");
-    final AtomicInteger created = new AtomicInteger();
-    final BeforeRecordCreateListener pause = record -> {
-      if (created.incrementAndGet() == 1) {
-        refreshReachedFirstInsert.countDown();
+    final AtomicInteger written = new AtomicInteger();
+    // On the update, not the create: the refresh writes the new rows over the previous snapshot's records and only
+    // creates the shortfall, so the first write of a pass is an update whenever the view already had a row.
+    final BeforeRecordUpdateListener pause = record -> {
+      if (written.incrementAndGet() == 1) {
+        refreshReachedFirstWrite.countDown();
         try {
           readerObserved.await(30, TimeUnit.SECONDS);
         } catch (final InterruptedException e) {
@@ -143,8 +151,8 @@ class MaterializedViewRefreshAtomicityTest extends TestHelper {
 
     final long observed;
     try {
-      assertThat(refreshReachedFirstInsert.await(30, TimeUnit.SECONDS))
-          .as("the refresh reached its first insert").isTrue();
+      assertThat(refreshReachedFirstWrite.await(30, TimeUnit.SECONDS))
+          .as("the refresh reached its first write").isTrue();
       observed = countOf("VisibilityView");
     } finally {
       readerObserved.countDown();
@@ -160,8 +168,9 @@ class MaterializedViewRefreshAtomicityTest extends TestHelper {
   }
 
   /**
-   * A UNIQUE index on the backing type is the case where clearing the view and repopulating it inside one
-   * transaction has to survive the same key being removed and re-added before the uniqueness check runs.
+   * A UNIQUE index on the backing type is where rewriting the view inside one transaction has to survive the same
+   * key being written over the record that already holds it, and - once the view outgrows the previous snapshot -
+   * being added on a new record in the same transaction that carries the rest.
    */
   @Test
   void aViewWithAUniqueIndexRefreshesRepeatedly() {
@@ -180,21 +189,77 @@ class MaterializedViewRefreshAtomicityTest extends TestHelper {
     assertThat(idsFromIndexOf("UniqueIndexView")).containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L);
   }
 
-  private void failRefreshOnRecord(final String viewName, final int failOnNthCreate) {
+  /**
+   * The cost the atomicity is not allowed to have. The truncate this replaced dropped every index on the backing
+   * type and rebuilt it empty, so an indexed view's index never grew however often it refreshed. Clearing the view
+   * with a delete instead would give every row a new RID on every pass, and {@code TransactionIndexContext}
+   * collapses a REMOVE followed by an ADD only on the same (key, RID) - so each pass would leave a full set of real
+   * tombstones behind. Measured over 120 passes of this fixture: 256KB flat for the truncate, 256KB to 3.9MB and
+   * still climbing for delete-and-recreate. Writing the rows over the previous snapshot's records keeps the key
+   * values unchanged, which {@code DocumentIndexer.updateDocument} skips outright, so nothing is written to the
+   * index at all.
+   * <p>
+   * Measured on the file size rather than the mutable page count: auto-compaction saws the page count back down at
+   * {@code arcadedb.indexCompactionMinPagesSchedule}, so it hides the growth by folding it into ever more compacted
+   * series. The bound of twice the first pass's size is deliberately loose - this guards against the growth pattern
+   * coming back, it does not measure it - and delete-and-recreate is already past it by pass 60.
+   */
+  @Test
+  @Tag("slow")
+  void refreshingAnIndexedViewRepeatedlyDoesNotGrowTheIndex() throws Exception {
+    createSourceWith(2000);
+    createView("SoakView");
+    createIndexOn("SoakView", "NOTUNIQUE");
+
+    final long afterFirst = indexBytesOf("SoakView");
+    assertThat(afterFirst).as("the index is on disk to begin with").isPositive();
+
+    for (int pass = 0; pass < 60; pass++)
+      database.getSchema().getMaterializedView("SoakView").refresh();
+
+    assertThat(idsFromIndexOf("SoakView")).hasSize(2000);
+    assertThat(indexBytesOf("SoakView"))
+        .as("60 refreshes of an unchanged indexed view must not grow its index")
+        .isLessThanOrEqualTo(afterFirst * 2);
+  }
+
+  private long indexBytesOf(final String viewName) throws Exception {
+    final FileManager files = ((DatabaseInternal) database).getFileManager();
+    long bytes = 0;
+    for (final TypeIndex index : database.getSchema().getType(viewName).getAllIndexes(false))
+      for (final IndexInternal bucketIndex : index.getIndexesOnBuckets())
+        for (final int fileId : bucketIndex.getFileIds())
+          bytes += files.getFile(fileId).getSize();
+    return bytes;
+  }
+
+  /**
+   * Fails the refresh on its {@code failOnNthWrite}-th write to the backing type. Counted over creates AND updates,
+   * so the failure lands part way through the pass whether the row is written over one of the previous snapshot's
+   * records or created because the new snapshot is longer - and stays there if that balance ever changes.
+   */
+  private void failRefreshOnRecord(final String viewName, final int failOnNthWrite) {
     final DocumentType backing = database.getSchema().getType(viewName);
-    final AtomicInteger created = new AtomicInteger();
-    final BeforeRecordCreateListener boom = record -> {
-      if (created.incrementAndGet() == failOnNthCreate)
-        throw new IllegalStateException("simulated failure part way through the repopulate");
+    final AtomicInteger written = new AtomicInteger();
+    final BeforeRecordCreateListener boomOnCreate = record -> {
+      if (written.incrementAndGet() == failOnNthWrite)
+        throw new IllegalStateException("simulated failure part way through the refresh");
       return true;
     };
-    backing.getEvents().registerListener(boom);
+    final BeforeRecordUpdateListener boomOnUpdate = record -> {
+      if (written.incrementAndGet() == failOnNthWrite)
+        throw new IllegalStateException("simulated failure part way through the refresh");
+      return true;
+    };
+    backing.getEvents().registerListener(boomOnCreate);
+    backing.getEvents().registerListener(boomOnUpdate);
     try {
       assertThatThrownBy(() -> database.getSchema().getMaterializedView(viewName).refresh())
           .as("the failure still reaches the caller")
           .isInstanceOf(IllegalStateException.class);
     } finally {
-      backing.getEvents().unregisterListener(boom);
+      backing.getEvents().unregisterListener(boomOnCreate);
+      backing.getEvents().unregisterListener(boomOnUpdate);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
@@ -89,7 +89,8 @@ class MaterializedViewSchedulerTest {
     TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
       final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
       try {
-        // The backing type does not exist, so every pass fails on the TRUNCATE that starts it.
+        // Neither the backing type nor the source type exists, so every pass fails - on the scan of the backing
+        // type that collects the previous snapshot, before the defining query is even run.
         final MaterializedViewImpl view = new MaterializedViewImpl(database, "FailingView", "SELECT name FROM Source",
             "FailingView_backing", List.of("Source"), MaterializedViewRefreshMode.PERIODIC, true, 50);
 

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
@@ -20,15 +20,18 @@ package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,7 +40,7 @@ class MaterializedViewSchedulerTest {
   @Test
   void reschedulingCancelsThePreviousTask() throws Exception {
     TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
-      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
       try {
         final MaterializedViewImpl view = newPeriodicView(database);
 
@@ -59,7 +62,7 @@ class MaterializedViewSchedulerTest {
   @Test
   void cancelStopsTheScheduledTask() throws Exception {
     TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
-      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
       try {
         final MaterializedViewImpl view = newPeriodicView(database);
 
@@ -84,7 +87,7 @@ class MaterializedViewSchedulerTest {
   @Test
   void aRefreshThatKeepsFailingKeepsTheScheduleAlive() throws Exception {
     TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
-      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
       try {
         // The backing type does not exist, so every pass fails on the TRUNCATE that starts it.
         final MaterializedViewImpl view = new MaterializedViewImpl(database, "FailingView", "SELECT name FROM Source",
@@ -115,7 +118,7 @@ class MaterializedViewSchedulerTest {
   @Test
   void anErrorThrownByARefreshDoesNotEscapeTheTick() throws Exception {
     TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
-      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
       try {
         final MaterializedViewImpl view = new ThrowingRefreshView(database, "ThrowingView",
             MaterializedViewRefreshMode.PERIODIC, TimeUnit.HOURS.toMillis(1));
@@ -137,11 +140,208 @@ class MaterializedViewSchedulerTest {
         List.of("Source"), MaterializedViewRefreshMode.PERIODIC, true, TimeUnit.HOURS.toMillis(1));
   }
 
-  @SuppressWarnings("unchecked")
+  /**
+   * The scheduler thread outlives every request and is never recycled, so a {@link DatabaseContext} entry left
+   * installed on it by the refresh transaction pins the database - page cache included - for the life of the JVM,
+   * and is what made the task's weak references unable to ever clear (issue #6203). Checked on the thread that ran
+   * the pass, since the context is a ThreadLocal.
+   */
+  @Test
+  void aPassLeavesNoDatabaseContextOnTheThreadThatRanIt() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
+      try {
+        database.transaction(() -> database.getSchema().createDocumentType("ContextSource"));
+        database.transaction(() -> database.getSchema().buildMaterializedView()
+            .withName("ContextView")
+            .withQuery("SELECT id FROM ContextSource")
+            .create());
+        final MaterializedViewImpl view = (MaterializedViewImpl) database.getSchema().getMaterializedView("ContextView");
+
+        final AtomicReference<Object> leftBehind = new AtomicReference<>();
+        final Thread standIn = new Thread(() -> {
+          scheduler.runOneRefresh(database, view);
+          leftBehind.set(DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath()));
+        }, "mv-scheduler-stand-in");
+        standIn.start();
+        standIn.join(TimeUnit.SECONDS.toMillis(30));
+
+        assertThat(view.getStatus()).as("the pass itself succeeded").isEqualTo("VALID");
+        assertThat(leftBehind.get())
+            .as("the refresh must not leave the database installed on the scheduler thread")
+            .isNull();
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  /**
+   * ...but only a context the pass installed itself. {@code runOneRefresh} is package-visible so a test can drive
+   * one pass inline, and dismantling the caller's own context would be a side effect nobody asked for.
+   */
+  @Test
+  void aPassLeavesAContextItDidNotInstallAlone() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
+      try {
+        database.transaction(() -> database.getSchema().createDocumentType("KeptContextSource"));
+        database.transaction(() -> database.getSchema().buildMaterializedView()
+            .withName("KeptContextView")
+            .withQuery("SELECT id FROM KeptContextSource")
+            .create());
+        final MaterializedViewImpl view =
+            (MaterializedViewImpl) database.getSchema().getMaterializedView("KeptContextView");
+
+        // The calls above already installed this thread's context.
+        assertThat(DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath())).isNotNull();
+
+        scheduler.runOneRefresh(database, view);
+
+        assertThat(DatabaseContext.INSTANCE.getContextIfExists(database.getDatabasePath()))
+            .as("a context the pass found already installed is left where it was")
+            .isNotNull();
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  /**
+   * One scheduler is created per database, so a JVM with several open databases used to get several threads all
+   * called {@code ArcadeDB-MV-Scheduler} and a thread dump that could not say which was which.
+   */
+  @Test
+  void theSchedulerThreadIsNamedAfterItsDatabase() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
+      try {
+        final MaterializedViewImpl view = new MaterializedViewImpl(database, "NamedThreadView",
+            "SELECT name FROM Source", "NamedThreadView_backing", List.of("Source"),
+            MaterializedViewRefreshMode.PERIODIC, true, 20);
+        scheduler.schedule(database, view);
+
+        // The backing type does not exist, so every pass fails - which is enough to prove the thread ran.
+        Awaitility.await("the scheduler thread ran a pass")
+            .atMost(Duration.ofSeconds(60))
+            .pollInterval(Duration.ofMillis(20))
+            .until(() -> view.getErrorCount() >= 1);
+
+        assertThat(Thread.getAllStackTraces().keySet().stream().map(Thread::getName))
+            .anyMatch(name -> name.equals("ArcadeDB-MV-Scheduler-" + database.getName()));
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  /**
+   * The weak references exist for a database abandoned without {@code close()}: the tick has to notice and cancel
+   * itself. Driven by clearing the references rather than by waiting on {@code System.gc()}, so the cancel path is
+   * proved without the test depending on when a collection happens.
+   */
+  @Test
+  void aTaskWhoseReferencesHaveClearedCancelsItself() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
+      try {
+        final MaterializedViewImpl view = newPeriodicView(database);
+        scheduler.schedule(database, view);
+
+        final Runnable task = refreshTask(scheduler, view.getName());
+        final ScheduledFuture<?> future = scheduledTask(scheduler, view.getName());
+
+        weakReferenceField(task, "viewRef").clear();
+        task.run();
+
+        assertThat(future.isCancelled()).as("the tick cancels itself once its references have gone").isTrue();
+        assertThat((Object) refreshTask(scheduler, view.getName())).as("and unregisters itself").isNull();
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  /**
+   * ...and unregisters only itself. A task that self-cancels after the view was re-scheduled - a schema reload or
+   * an ALTER MATERIALIZED VIEW - must leave the replacement registered, or the view stops refreshing with nothing
+   * saying so.
+   */
+  @Test
+  void aSelfCancellingTaskLeavesAReplacementRegistered() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
+      try {
+        final MaterializedViewImpl view = newPeriodicView(database);
+        scheduler.schedule(database, view);
+        final Runnable stale = refreshTask(scheduler, view.getName());
+
+        // The view is re-scheduled, so the map now holds a different task under the same name.
+        scheduler.schedule(database, view);
+        final Runnable current = refreshTask(scheduler, view.getName());
+        final ScheduledFuture<?> currentFuture = scheduledTask(scheduler, view.getName());
+        assertThat((Object) current).isNotSameAs(stale);
+
+        weakReferenceField(stale, "viewRef").clear();
+        stale.run();
+
+        assertThat((Object) refreshTask(scheduler, view.getName()))
+            .as("the replacement is still the registered task").isSameAs(current);
+        assertThat(currentFuture.isCancelled()).as("and is still scheduled").isFalse();
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  /**
+   * The reachability claim itself belongs in a heap check rather than in a {@code System.gc()}-dependent test, but
+   * its precondition does not: the scheduled task must hold nothing strongly that leads back to the database. It
+   * used to hold the database weakly and the view - which holds its own database - strongly, so the weak reference
+   * could never clear and an abandoned database stayed pinned to a live thread with its page cache (issue #6203).
+   */
+  @Test
+  void aScheduledTaskHoldsNothingStrongThatLeadsBackToTheDatabase() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", database -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler(database.getName());
+      try {
+        final MaterializedViewImpl view = newPeriodicView(database);
+        scheduler.schedule(database, view);
+
+        final Runnable task = refreshTask(scheduler, view.getName());
+        for (final Field field : task.getClass().getDeclaredFields()) {
+          field.setAccessible(true);
+          assertThat(field.get(task))
+              .as("field '%s' of the scheduled task", field.getName())
+              .isNotInstanceOfAny(Database.class, MaterializedView.class);
+        }
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
   private static ScheduledFuture<?> scheduledTask(final MaterializedViewScheduler scheduler, final String viewName)
+      throws Exception {
+    final Runnable task = refreshTask(scheduler, viewName);
+    if (task == null)
+      return null;
+    final Field field = task.getClass().getDeclaredField("future");
+    field.setAccessible(true);
+    return (ScheduledFuture<?>) field.get(task);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Runnable refreshTask(final MaterializedViewScheduler scheduler, final String viewName)
       throws Exception {
     final Field field = MaterializedViewScheduler.class.getDeclaredField("tasks");
     field.setAccessible(true);
-    return ((Map<String, ScheduledFuture<?>>) field.get(scheduler)).get(viewName);
+    return ((Map<String, ? extends Runnable>) field.get(scheduler)).get(viewName);
+  }
+
+  private static WeakReference<?> weakReferenceField(final Runnable task, final String fieldName) throws Exception {
+    final Field field = task.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return (WeakReference<?>) field.get(task);
   }
 }


### PR DESCRIPTION
Fixes #6203.

## 1. A full refresh is now one transaction, so a failed one no longer empties the view

A full refresh looked like a single transaction and was not one. `TRUNCATE TYPE ... UNSAFE` commits the caller's
transaction from the inside:

* `schema.dropIndex()` for every index on the backing type, before a single record is touched;
* `commit(); begin()` once per `arcadedb.truncateBatchSize` records;
* another `commit(); begin()` before it rebuilds the indexes it dropped.

Wrapping that in `database.transaction()` bought nothing, and both consequences were silent.

**Readers saw a partially built view.** Between the truncate's first commit and the last insert, `SELECT FROM <view>`
returned zero rows or some prefix of the new ones, with nothing to distinguish that from a legitimately empty or
small result. The window is the whole runtime of the defining query - which for a view worth materialising is
exactly the expensive case, and for a PERIODIC view is every tick.

**A failed refresh destroyed the data.** A defining query that threw after the truncate had committed left the
backing type with zero rows. The view then reported `ERROR`, or `STALE` once `MaterializedViewChangeListener`
overwrote it, and both of those read as "the data you are looking at is old" when the data was in fact gone. For a
MANUAL view there may be no later refresh at all.

`refreshOnce` now writes the defining query's rows over the previous snapshot's records inside one transaction,
deleting only the surplus and creating only the shortfall. The pass then gets the isolation every other ArcadeDB
transaction has: every write stays in the transaction's own page buffer until commit, a concurrent reader sees the
previous snapshot throughout and the new one afterwards, and a failure anywhere rolls the whole pass back onto the
previous snapshot rather than onto nothing. A view's rows also keep their `@rid` across a refresh, where before
every pass gave them new ones.

### Rewriting in place, rather than clearing and repopulating

This is what keeps an index on the backing type from paying for the atomicity, and it makes an indexed refresh
cheaper than it was before. Clearing the view would give every row a new RID, and `TransactionIndexContext`
collapses a REMOVE followed by an ADD only on the same (key, RID), so each pass would leave a full set of real
tombstones where the truncate used to drop the index and rebuild it empty. Measured over 120 refreshes of a
2000-row indexed view, index bytes on disk:

| refresh strategy | after 120 passes |
| --- | --- |
| `TRUNCATE` (drop + rebuild empty), before this PR | **256KB flat** |
| `DELETE FROM` + recreate | **256KB to 3.9MB, still climbing** |
| write rows over the previous records | **256KB flat** |

`DocumentIndexer.updateDocument` finds the key values unchanged for every row a stable view reproduces and skips
the index outright: zero index writes per pass, against a full rebuild per pass before. The backing buckets stay
flat too, since no record is freed and reallocated. A `@Tag("slow")` soak test guards the bound.

The RIDs are collected up front rather than iterated live: an update whose content no longer fits its slot can
relocate the record, and a scan still walking the bucket would then meet it a second time at its new home.

### Why not the shadow-type swap the issue proposed

Building into a second backing type and swapping reads better on paper - the swap is metadata only and the old rows
are dropped as files rather than deleted one by one - but in this engine the swap has no cheap implementation:

* **Renaming is not metadata-only here.** Renaming a type renames its buckets, and `PaginatedComponent.rename()`
  first waits for every page of the *whole database* to be flushed
  (`PageManager.waitAllPagesOfDatabaseAreFlushed`). Paying a database-wide flush barrier twice per refresh, on every
  tick of every PERIODIC view, is a worse defect than the one being fixed. It also leaves a window in which the type
  does not exist at all, so a reader gets an error rather than stale data.
* **Repointing the view at a differently named backing type** avoids the barrier but makes the view's own name stop
  being the type name. That identity is what makes `SELECT FROM <view>` resolve and what every record's `@type`
  reports, so it is a user-visible change, not an internal one.

What the single transaction costs instead is bounded and not new: it holds the pages of the rows it rewrites, and
under HA the pass is one Raft log entry rather than one per truncate batch plus one for the repopulate. The
repopulate was **already** one unbounded transaction, so a view too large to refresh in one transaction was already
too large to refresh.

### Why the existing tests did not catch it

Neither trigger fires on the trivial case: an unindexed view smaller than one truncate batch was already atomic, so
every existing materialized-view test passed. The new tests drive both triggers.

## 2. The scheduler no longer pins an abandoned database to a live thread

`MaterializedViewScheduler` guarded against a database abandoned without `close()` by holding it through a
`WeakReference` and cancelling the task once that cleared. It could not clear, for **two** independent reasons - the
issue names the first:

* The refresh runs a transaction on the scheduler thread, which installs a `DatabaseContext` entry keyed by the
  database path holding a strong reference to the database, and the scheduler never removed it.
  `TimeSeriesMaintenanceScheduler.runMaintenance()` documents the same hazard and takes the entry back down in a
  `finally`. The refresh now does too - removing only a context that pass installed itself, since `runOneRefresh` is
  package-visible so a test can drive one pass inline and dismantling a caller's own context would be a side effect
  nobody asked for.
* The task also captured the `MaterializedViewImpl` strongly, and `MaterializedViewImpl` holds its own database. So
  the reference that was weak was not the only one, and fixing only the `DatabaseContext` would have left the
  mechanism just as unreachable. Both are weak now; the task keeps the view's name as a `String`.

The tick's self-cancel also used a blind `cancel(viewName)`, which after a re-schedule (schema reload,
`ALTER MATERIALIZED VIEW`) would cancel the *replacement* task rather than itself and stop the view refreshing with
nothing saying so. A task now unregisters itself only while it is still the task registered for that view.

Finally, the scheduler is created per `LocalSchema` but its thread was called `ArcadeDB-MV-Scheduler` with no
discriminator, so a JVM with several open databases got several identically named threads and a thread dump could
not say which was which. The database name is now part of it.

## Tests

New `MaterializedViewRefreshAtomicityTest` (all three of the first tests fail on `main`, verified):

* `aFailedRefreshOnAnIndexedViewLeavesThePreviousSnapshotIntact` - the `dropIndex` commit trigger. On `main` the view
  is left with 0 rows; the index is also checked, through a plan asserted to be an index fetch so the assertion
  cannot quietly become a second bucket scan.
* `aFailedRefreshOnAViewLargerThanOneTruncateBatchLeavesThePreviousSnapshotIntact` - the in-scan commit trigger. On
  `main`: `expected: 1100L but was: 100L`.
* `aConcurrentReaderNeverSeesTheViewPartiallyBuilt` - a `BeforeRecordCreateListener` parks the refresh on its first
  insert while the test thread reads the view, so the visibility window is driven exactly rather than raced for.
* `aViewWithAUniqueIndexRefreshesRepeatedly` - a guard on the new implementation: writing a key over the record
  that already holds it, and adding it on a new record in the same transaction, has to survive the uniqueness check.
* `refreshingAnIndexedViewRepeatedlyDoesNotGrowTheIndex` (`@Tag("slow")`) - 60 refreshes must not grow the index on
  disk. Fails at 2MB against its 512KB bound on the delete-and-recreate shape.

Added to `MaterializedViewSchedulerTest`:

* `aPassLeavesNoDatabaseContextOnTheThreadThatRanIt` (fails on `main`) and `aPassLeavesAContextItDidNotInstallAlone`.
* `aScheduledTaskHoldsNothingStrongThatLeadsBackToTheDatabase` - the reachability claim itself belongs in a heap
  check rather than a `System.gc()`-dependent test, but its precondition is asserted deterministically.
* `aTaskWhoseReferencesHaveClearedCancelsItself` and `aSelfCancellingTaskLeavesAReplacementRegistered` - the cancel
  path driven by clearing the references rather than by waiting on a collection.
* `theSchedulerThreadIsNamedAfterItsDatabase`.

Full `engine` unit suite including the `slow` lane: 12221 tests, 0 failures. The server/HA materialized-view ITs were not run locally (port
2480 was held by another process on this machine) and are left to CI.
