### PR TITLE
fix(#6087): a copied EXPORT/IMPORT statement keeps its WITH settings, and a scheduled backup can be tuned per database

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
@@ -133,6 +133,12 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
   public Statement copy() {
     final ExportDatabaseStatement result = new ExportDatabaseStatement();
     result.url = this.url;
+    // WITHOUT THESE, A COPY SILENTLY DROPS EVERY 'WITH ...' SETTING AND FALLS BACK TO THE DEFAULT FORMAT - THE SAME
+    // DEFECT BackupDatabaseStatement HAD (#6080). COPY THE WHOLE STATE, NOT THE URL ALONE, SO THE COPY STAYS CORRECT
+    // THE MOMENT THIS STATEMENT REACHES A PATH THAT COPIES IT
+    result.format = this.format;
+    result.overwrite = this.overwrite;
+    result.settings.putAll(this.settings);
     return result;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -149,6 +149,10 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
   public Statement copy() {
     final ImportDatabaseStatement result = new ImportDatabaseStatement();
     result.url = this.url;
+    // WITHOUT THIS, A COPY SILENTLY DROPS EVERY 'WITH ...' SETTING - THE SAME DEFECT BackupDatabaseStatement HAD
+    // (#6080). FOR IMPORT THE SETTINGS ARE THE STATEMENT: WITHOUT THEM AN 'IMPORT DATABASE WITH vertices=...' HAS NO
+    // SOURCE AT ALL
+    result.settings.putAll(this.settings);
     return result;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ExportDatabaseStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ExportDatabaseStatementTestParserTest.java
@@ -20,6 +20,12 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 class ExportDatabaseStatementTestParserTest extends AbstractParserTest {
 
   @Test
@@ -38,5 +44,58 @@ class ExportDatabaseStatementTestParserTest extends AbstractParserTest {
     checkWrongSyntax("export database file:///foo/bar/ foo bar");
     checkWrongSyntax("export database http://www.foo.bar asdf ");
     checkWrongSyntax("EXPORT DATABASE https://www.foo.bar asd ");
+  }
+
+  /**
+   * Regression test for issue #6087: {@code copy()} only carried the URL over, so every {@code WITH ...} setting was
+   * silently dropped by the copy. Same defect {@code BackupDatabaseStatement} had (#6080).
+   * <p>
+   * Parsed with {@link #checkSyntax(String, boolean)} rather than {@link #checkRightSyntax(String)} on purpose:
+   * the latter re-parses the node's own {@code toString()}, and {@code ExportDatabaseStatement.toString()} does not
+   * render the {@code WITH} clause, so the round-trip would hand back a statement with an empty settings map and the
+   * test would assert nothing.
+   */
+  @Test
+  void copyKeepsTheWithSettings() {
+    final SimpleNode parsed = checkSyntax("EXPORT DATABASE file://Movies.graphson.tgz WITH format = 'graphson', overwrite = true",
+        true);
+    assertThat(parsed).isInstanceOf(ExportDatabaseStatement.class);
+
+    final ExportDatabaseStatement original = (ExportDatabaseStatement) parsed;
+    assertThat(renderSettings(original)).containsOnly(entry("format", "'graphson'"), entry("overwrite", "true"));
+
+    final ExportDatabaseStatement copy = (ExportDatabaseStatement) original.copy();
+
+    assertThat(renderSettings(copy)).isEqualTo(renderSettings(original));
+    assertThat(copy.url).isEqualTo(original.url);
+  }
+
+  @Test
+  void copyOfAStatementWithoutSettingsKeepsAnEmptyMap() {
+    final SimpleNode parsed = checkSyntax("EXPORT DATABASE file://Movies.jsonl.tgz", true);
+    final ExportDatabaseStatement original = (ExportDatabaseStatement) parsed;
+    assertThat(original.settings).isEmpty();
+
+    final ExportDatabaseStatement copy = (ExportDatabaseStatement) original.copy();
+
+    assertThat(copy.settings).isEmpty();
+    assertThat(copy.url).isEqualTo(original.url);
+  }
+
+  /**
+   * Renders the settings the way {@code executeSimple} consumes them: the raw setting name held in
+   * {@code Expression.value} against the rendered value.
+   * <p>
+   * Comparing the two {@code Map<Expression, Expression>} instances directly would not work: {@code SimpleNode}
+   * derives {@code hashCode()} from a freshly allocated {@code Object[]}, so an {@code Expression} hashes to a
+   * different bucket on every call and {@code HashMap.equals} can never find a key. That is a separate, pre-existing
+   * defect - the settings map is only ever iterated in production, never looked up - and this test deliberately does
+   * not depend on it either way.
+   */
+  private static Map<String, String> renderSettings(final ExportDatabaseStatement statement) {
+    final Map<String, String> rendered = new HashMap<>();
+    for (final Map.Entry<Expression, Expression> entry : statement.settings.entrySet())
+      rendered.put(entry.getKey().value.toString(), entry.getValue().toString());
+    return rendered;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ImportDatabaseStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ImportDatabaseStatementTestParserTest.java
@@ -20,6 +20,12 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 class ImportDatabaseStatementTestParserTest extends AbstractParserTest {
 
   @Test
@@ -50,5 +56,52 @@ class ImportDatabaseStatementTestParserTest extends AbstractParserTest {
         IMPORT DATABASE WITH vertices="file://vertices.csv", verticesFileType=csv, typeIdProperty=Id, \
         edges="file://edges.csv", edgesFileType=csv, edgeFromField="From", edgeToField="To"\
         """);
+  }
+
+  /**
+   * Regression test for issue #6087: {@code copy()} only carried the URL over, so every {@code WITH ...} setting was
+   * silently dropped by the copy. Same defect {@code BackupDatabaseStatement} had (#6080).
+   */
+  @Test
+  void copyKeepsTheWithSettings() {
+    final SimpleNode parsed = checkRightSyntax("IMPORT DATABASE http://www.foo.bar WITH forceDatabaseCreate = true, commitEvery = 10000");
+    assertThat(parsed).isInstanceOf(ImportDatabaseStatement.class);
+
+    final ImportDatabaseStatement original = (ImportDatabaseStatement) parsed;
+    assertThat(renderSettings(original)).containsOnly(entry("forceDatabaseCreate", "true"), entry("commitEvery", "10000"));
+
+    final ImportDatabaseStatement copy = (ImportDatabaseStatement) original.copy();
+
+    assertThat(renderSettings(copy)).isEqualTo(renderSettings(original));
+    assertThat(copy.url).isEqualTo(original.url);
+  }
+
+  @Test
+  void copyOfAStatementWithoutSettingsKeepsAnEmptyMap() {
+    final SimpleNode parsed = checkRightSyntax("IMPORT DATABASE http://www.foo.bar");
+    final ImportDatabaseStatement original = (ImportDatabaseStatement) parsed;
+    assertThat(original.settings).isEmpty();
+
+    final ImportDatabaseStatement copy = (ImportDatabaseStatement) original.copy();
+
+    assertThat(copy.settings).isEmpty();
+    assertThat(copy.url).isEqualTo(original.url);
+  }
+
+  /**
+   * Renders the settings the way {@code executeSimple} consumes them: the raw setting name held in
+   * {@code Expression.value} against the rendered value.
+   * <p>
+   * Comparing the two {@code Map<Expression, Expression>} instances directly would not work: {@code SimpleNode}
+   * derives {@code hashCode()} from a freshly allocated {@code Object[]}, so an {@code Expression} hashes to a
+   * different bucket on every call and {@code HashMap.equals} can never find a key. That is a separate, pre-existing
+   * defect - the settings map is only ever iterated in production, never looked up - and this test deliberately does
+   * not depend on it either way.
+   */
+  private static Map<String, String> renderSettings(final ImportDatabaseStatement statement) {
+    final Map<String, String> rendered = new HashMap<>();
+    for (final Map.Entry<Expression, Expression> entry : statement.settings.entrySet())
+      rendered.put(entry.getKey().value.toString(), entry.getValue().toString());
+    return rendered;
   }
 }

--- a/integration/src/main/java/com/arcadedb/integration/backup/Backup.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/Backup.java
@@ -81,6 +81,16 @@ public class Backup {
     }
   }
 
+  /**
+   * The settings this backup will run with. Every caller that configures a {@code Backup} from another module does so
+   * through a reflective boundary (SQL's {@code BACKUP DATABASE}, the server's scheduled backup), where a mis-wired
+   * setter fails silently; this is what lets those call sites be tested against what actually reached the instance
+   * instead of against the archive it happened to produce.
+   */
+  public BackupSettings getSettings() {
+    return settings;
+  }
+
   public Backup setEncryptionAlgorithm(final String algorithm) {
     settings.encryptionAlgorithm = algorithm;
     return this;

--- a/server/src/main/java/com/arcadedb/server/backup/AutoBackupConfig.java
+++ b/server/src/main/java/com/arcadedb/server/backup/AutoBackupConfig.java
@@ -107,6 +107,9 @@ public class AutoBackupConfig {
         dbConfig.setRunOnServer(defaults.getRunOnServer());
         dbConfig.setSchedule(defaults.getSchedule());
         dbConfig.setRetention(defaults.getRetention());
+        dbConfig.setCompressionLevel(defaults.getCompressionLevel());
+        dbConfig.setCompressionThreads(defaults.getCompressionThreads());
+        dbConfig.setMaxMBPerSecond(defaults.getMaxMBPerSecond());
       }
     } else {
       // Merge database-specific config with defaults

--- a/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
+++ b/server/src/main/java/com/arcadedb/server/backup/BackupTask.java
@@ -49,6 +49,9 @@ public class BackupTask implements Runnable {
   private static volatile Constructor<?>               backupConstructor;
   private static volatile Method                       setDirectoryMethod;
   private static volatile Method                       setVerboseLevelMethod;
+  private static volatile Method                       setCompressionLevelMethod;
+  private static volatile Method                       setCompressionThreadsMethod;
+  private static volatile Method                       setMaxMBPerSecondMethod;
   private static volatile Method                       backupDatabaseMethod;
   private static volatile boolean                      reflectionInitialized;
   private static final    Object                       REFLECTION_LOCK = new Object();
@@ -191,6 +194,7 @@ public class BackupTask implements Runnable {
       final Object backup = backupConstructor.newInstance(database, backupFileName);
       setDirectoryMethod.invoke(backup, dbBackupDir);
       setVerboseLevelMethod.invoke(backup, 1);
+      applyCompressionOverrides(backup);
 
       return (String) backupDatabaseMethod.invoke(backup);
 
@@ -201,6 +205,29 @@ public class BackupTask implements Runnable {
     } catch (final InvocationTargetException e) {
       throw new BackupException("Error performing backup for database '" + databaseName + "'", e.getTargetException());
     }
+  }
+
+  /**
+   * Pushes this database's compression overrides onto the {@code Backup} instance, skipping any the configuration left
+   * unset so the corresponding {@code GlobalConfiguration} default still applies. A mixed fleet can then give a large,
+   * rarely-restored database a slow, small-archive setting overnight and a small, frequently-restored one a setting
+   * that stays out of the live workload's way (issue #6087).
+   * <p>
+   * Package-private, and called through the reflective boundary that keeps the server buildable without the
+   * integration module, so that a test can assert what actually reached the {@code Backup} instance rather than
+   * inferring it from the archive.
+   */
+  void applyCompressionOverrides(final Object backup) throws BackupException, IllegalAccessException, InvocationTargetException {
+    initializeReflection();
+
+    if (config.getCompressionLevel() != null)
+      setCompressionLevelMethod.invoke(backup, config.getCompressionLevel().intValue());
+
+    if (config.getCompressionThreads() != null)
+      setCompressionThreadsMethod.invoke(backup, config.getCompressionThreads().intValue());
+
+    if (config.getMaxMBPerSecond() != null)
+      setMaxMBPerSecondMethod.invoke(backup, config.getMaxMBPerSecond().intValue());
   }
 
   /**
@@ -216,6 +243,9 @@ public class BackupTask implements Runnable {
             backupConstructor = backupClass.getConstructor(Database.class, String.class);
             setDirectoryMethod = backupClass.getMethod("setDirectory", String.class);
             setVerboseLevelMethod = backupClass.getMethod("setVerboseLevel", Integer.TYPE);
+            setCompressionLevelMethod = backupClass.getMethod("setCompressionLevel", Integer.TYPE);
+            setCompressionThreadsMethod = backupClass.getMethod("setCompressionThreads", Integer.TYPE);
+            setMaxMBPerSecondMethod = backupClass.getMethod("setMaxMBPerSecond", Integer.TYPE);
             backupDatabaseMethod = backupClass.getMethod("backupDatabase");
             reflectionInitialized = true;
           } catch (final ClassNotFoundException | NoSuchMethodException e) {

--- a/server/src/main/java/com/arcadedb/server/backup/DatabaseBackupConfig.java
+++ b/server/src/main/java/com/arcadedb/server/backup/DatabaseBackupConfig.java
@@ -115,10 +115,15 @@ public class DatabaseBackupConfig {
     checkRange("maxMBPerSecond", maxMBPerSecond, MIN_MAX_MB_PER_SECOND, Integer.MAX_VALUE);
   }
 
+  /**
+   * The message is word-for-word the one {@code BackupSettings.checkIntSetting} raises for the same setting, so the
+   * two places that can refuse a compression value - this one when {@code backup.json} is read, that one when the
+   * value reaches the {@code Backup} - read identically in the log.
+   */
   private static void checkRange(final String name, final Integer value, final int min, final int max) {
     if (value != null && (value < min || value > max))
       throw new IllegalArgumentException(
-          "Backup setting '%s' must be between %d and %d, got: %d".formatted(name, min, max, value));
+          "Backup setting '%s' must be between %d and %d, found %d".formatted(name, min, max, value));
   }
 
   public void mergeWithDefaults(final DatabaseBackupConfig defaults) {

--- a/server/src/main/java/com/arcadedb/server/backup/DatabaseBackupConfig.java
+++ b/server/src/main/java/com/arcadedb/server/backup/DatabaseBackupConfig.java
@@ -28,11 +28,40 @@ import java.time.LocalTime;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class DatabaseBackupConfig {
+  /**
+   * Bounds for the per-database compression overrides. They repeat the ones enforced by
+   * {@code com.arcadedb.integration.backup.BackupSettings} and by the matching {@code GlobalConfiguration} entries,
+   * because the server module deliberately does not depend on the integration module at compile time - the backup is
+   * reached reflectively so that a distribution without it still starts. {@code compressionOverrideBoundsMatchTheBackupApi}
+   * in {@code DatabaseBackupConfigTest} fails if the two ever drift.
+   */
+  public static final int MIN_COMPRESSION_LEVEL   = 0;
+  public static final int MAX_COMPRESSION_LEVEL   = 9;
+  public static final int MIN_COMPRESSION_THREADS = -1;
+  public static final int MAX_COMPRESSION_THREADS = 256;
+  public static final int MIN_MAX_MB_PER_SECOND   = 0;
+
   private final String          databaseName;
   private       boolean         enabled     = true;
   private       String          runOnServer = "$leader";
   private       ScheduleConfig  schedule;
   private       RetentionConfig retention;
+  /**
+   * Deflate level, 0 (store) to 9 (smallest). {@code null} means "defer to
+   * {@code GlobalConfiguration.BACKUP_COMPRESSION_LEVEL}", the same convention {@code BackupSettings} uses, which is
+   * what keeps a {@code backup.json} written before this setting existed behaving exactly as it did.
+   */
+  private       Integer         compressionLevel;
+  /**
+   * Compression threads: -1 automatic, 0 the legacy single-threaded writer, N a pool of N. {@code null} defers to
+   * {@code GlobalConfiguration.BACKUP_COMPRESSION_THREADS}.
+   */
+  private       Integer         compressionThreads;
+  /**
+   * Read-side rate cap in MB/s, 0 for unlimited. {@code null} defers to
+   * {@code GlobalConfiguration.BACKUP_MAX_MB_PER_SECOND}.
+   */
+  private       Integer         maxMBPerSecond;
 
   public DatabaseBackupConfig(final String databaseName) {
     this.databaseName = databaseName;
@@ -53,6 +82,16 @@ public class DatabaseBackupConfig {
     if (json.has("retention"))
       config.retention = RetentionConfig.fromJSON(json.getJSONObject("retention"));
 
+    // ABSENT MEANS "DEFER TO THE GLOBAL CONFIGURATION", SO AN EXISTING backup.json KEEPS ITS EXACT BEHAVIOUR
+    if (json.has("compressionLevel"))
+      config.compressionLevel = json.getInt("compressionLevel");
+
+    if (json.has("compressionThreads"))
+      config.compressionThreads = json.getInt("compressionThreads");
+
+    if (json.has("maxMBPerSecond"))
+      config.maxMBPerSecond = json.getInt("maxMBPerSecond");
+
     // Validate the configuration
     config.validate();
 
@@ -68,6 +107,18 @@ public class DatabaseBackupConfig {
 
     if (retention != null)
       retention.validate();
+
+    // REFUSED HERE, AT LOAD TIME, RATHER THAN INSIDE THE Backup SETTER AT 3AM: AN OUT-OF-RANGE VALUE IN backup.json IS
+    // A CONFIGURATION MISTAKE AND THE OPERATOR SHOULD HEAR ABOUT IT WHEN THE SERVER READS THE FILE
+    checkRange("compressionLevel", compressionLevel, MIN_COMPRESSION_LEVEL, MAX_COMPRESSION_LEVEL);
+    checkRange("compressionThreads", compressionThreads, MIN_COMPRESSION_THREADS, MAX_COMPRESSION_THREADS);
+    checkRange("maxMBPerSecond", maxMBPerSecond, MIN_MAX_MB_PER_SECOND, Integer.MAX_VALUE);
+  }
+
+  private static void checkRange(final String name, final Integer value, final int min, final int max) {
+    if (value != null && (value < min || value > max))
+      throw new IllegalArgumentException(
+          "Backup setting '%s' must be between %d and %d, got: %d".formatted(name, min, max, value));
   }
 
   public void mergeWithDefaults(final DatabaseBackupConfig defaults) {
@@ -83,6 +134,15 @@ public class DatabaseBackupConfig {
       this.retention = defaults.retention;
     else if (defaults.retention != null)
       this.retention.mergeWithDefaults(defaults.retention);
+
+    // A DATABASE THAT SET NOTHING INHERITS THE SERVER DEFAULT; ONE THAT SET A VALUE KEEPS IT. STILL null AFTERWARDS
+    // MEANS NEITHER LEVEL EXPRESSED AN OPINION AND THE GlobalConfiguration DEFAULT APPLIES
+    if (this.compressionLevel == null)
+      this.compressionLevel = defaults.compressionLevel;
+    if (this.compressionThreads == null)
+      this.compressionThreads = defaults.compressionThreads;
+    if (this.maxMBPerSecond == null)
+      this.maxMBPerSecond = defaults.maxMBPerSecond;
   }
 
   public String getDatabaseName() {
@@ -121,6 +181,30 @@ public class DatabaseBackupConfig {
     this.retention = retention;
   }
 
+  public Integer getCompressionLevel() {
+    return compressionLevel;
+  }
+
+  public void setCompressionLevel(final Integer compressionLevel) {
+    this.compressionLevel = compressionLevel;
+  }
+
+  public Integer getCompressionThreads() {
+    return compressionThreads;
+  }
+
+  public void setCompressionThreads(final Integer compressionThreads) {
+    this.compressionThreads = compressionThreads;
+  }
+
+  public Integer getMaxMBPerSecond() {
+    return maxMBPerSecond;
+  }
+
+  public void setMaxMBPerSecond(final Integer maxMBPerSecond) {
+    this.maxMBPerSecond = maxMBPerSecond;
+  }
+
   /**
    * Converts this configuration to a JSON object.
    */
@@ -134,6 +218,17 @@ public class DatabaseBackupConfig {
 
     if (retention != null)
       json.put("retention", retention.toJSON());
+
+    // ONLY WHAT WAS ACTUALLY SET IS WRITTEN BACK: EMITTING A RESOLVED DEFAULT WOULD FREEZE TODAY'S GLOBAL VALUE INTO
+    // THE FILE AND THE DATABASE WOULD STOP FOLLOWING THE SERVER SETTING
+    if (compressionLevel != null)
+      json.put("compressionLevel", compressionLevel);
+
+    if (compressionThreads != null)
+      json.put("compressionThreads", compressionThreads);
+
+    if (maxMBPerSecond != null)
+      json.put("maxMBPerSecond", maxMBPerSecond);
 
     return json;
   }

--- a/server/src/test/java/com/arcadedb/server/backup/BackupTaskCompressionOverrideTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/BackupTaskCompressionOverrideTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.backup;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.integration.backup.Backup;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6087: a scheduled backup used to run with the server-wide {@code GlobalConfiguration} compression settings no
+ * matter what the database asked for, because {@link DatabaseBackupConfig} carried no place to say otherwise. These
+ * tests pin the wiring itself - that the values a per-database configuration holds actually reach the {@code Backup}
+ * instance {@link BackupTask} builds behind its reflective boundary, and that an unset one leaves the instance alone so
+ * the global default still decides.
+ */
+class BackupTaskCompressionOverrideTest {
+
+  @Test
+  void everyConfiguredOverrideReachesTheBackupInstance() throws Exception {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("archivedb");
+    config.setCompressionLevel(9);
+    config.setCompressionThreads(2);
+    config.setMaxMBPerSecond(64);
+
+    final Backup backup = newBackup();
+    newTask(config).applyCompressionOverrides(backup);
+
+    assertThat(backup.getSettings().compressionLevel).isEqualTo(9);
+    assertThat(backup.getSettings().compressionThreads).isEqualTo(2);
+    assertThat(backup.getSettings().maxMBPerSecond).isEqualTo(64);
+  }
+
+  /**
+   * The half that makes the change backward compatible: a {@code backup.json} that never mentions compression must
+   * leave every setting at {@code null}, which is what {@code BackupSettings} reads as "use the global configuration".
+   * Push a resolved value here instead and every existing deployment silently freezes today's global default.
+   */
+  @Test
+  void anUnsetOverrideLeavesTheBackupDeferringToTheGlobalConfiguration() throws Exception {
+    final Backup backup = newBackup();
+    newTask(new DatabaseBackupConfig("legacydb")).applyCompressionOverrides(backup);
+
+    assertThat(backup.getSettings().compressionLevel).isNull();
+    assertThat(backup.getSettings().compressionThreads).isNull();
+    assertThat(backup.getSettings().maxMBPerSecond).isNull();
+  }
+
+  @Test
+  void aPartiallyConfiguredDatabaseOverridesOnlyWhatItNamed() throws Exception {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("livedb");
+    config.setCompressionLevel(1);
+
+    final Backup backup = newBackup();
+    newTask(config).applyCompressionOverrides(backup);
+
+    assertThat(backup.getSettings().compressionLevel).isEqualTo(1);
+    assertThat(backup.getSettings().compressionThreads).isNull();
+    assertThat(backup.getSettings().maxMBPerSecond).isNull();
+  }
+
+  /**
+   * Two databases in one fleet, opposite settings: the point of the whole change. Asserting them against each other
+   * rules out a wiring that reads the value from somewhere shared rather than from the database's own configuration.
+   */
+  @Test
+  void twoDatabasesInTheSameFleetGetTheirOwnSettings() throws Exception {
+    final DatabaseBackupConfig nightly = new DatabaseBackupConfig("archivedb");
+    nightly.setCompressionLevel(9);
+
+    final DatabaseBackupConfig live = new DatabaseBackupConfig("livedb");
+    live.setCompressionLevel(1);
+
+    final Backup nightlyBackup = newBackup();
+    newTask(nightly).applyCompressionOverrides(nightlyBackup);
+
+    final Backup liveBackup = newBackup();
+    newTask(live).applyCompressionOverrides(liveBackup);
+
+    assertThat(nightlyBackup.getSettings().compressionLevel).isEqualTo(9);
+    assertThat(liveBackup.getSettings().compressionLevel).isEqualTo(1);
+  }
+
+  /**
+   * {@link DatabaseBackupConfig#validate()} refuses an out-of-range value when the file is read, but a value set
+   * programmatically bypasses it. The {@code Backup} setter is still the last line of defence, and it must not be
+   * possible to reach it with a value it silently accepts.
+   */
+  @Test
+  void anOutOfRangeOverrideSetProgrammaticallyIsStillRefusedByTheBackup() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("mydb");
+    config.setCompressionLevel(42);
+
+    final Backup backup = newBackup();
+
+    assertThatThrownBy(() -> newTask(config).applyCompressionOverrides(backup))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * The whole chain in one test: the JSON an operator writes into {@code config/backup.json}, through
+   * {@link AutoBackupConfig#getEffectiveConfig(String)}, into the {@code Backup} the scheduled task builds. The two
+   * databases here are the mixed fleet the issue describes - one tuned for the smallest archive, one tuned to stay out
+   * of the live workload's way - and a third that names nothing and keeps following the server default.
+   */
+  @Test
+  void aMixedFleetGetsItsPerDatabaseSettingsFromTheConfigFile() throws Exception {
+    final AutoBackupConfig serverConfig = AutoBackupConfig.fromJSON(new JSONObject("""
+        {
+          "version": 1,
+          "enabled": true,
+          "backupDirectory": "./backups",
+          "defaults": {
+            "enabled": true,
+            "runOnServer": "$leader"
+          },
+          "databases": {
+            "archivedb": { "compressionLevel": 9, "compressionThreads": 8 },
+            "livedb":    { "compressionLevel": 1, "maxMBPerSecond": 32 },
+            "plaindb":   { "enabled": true }
+          }
+        }
+        """));
+
+    final Backup archive = newBackup();
+    newTask(serverConfig.getEffectiveConfig("archivedb")).applyCompressionOverrides(archive);
+    assertThat(archive.getSettings().compressionLevel).isEqualTo(9);
+    assertThat(archive.getSettings().compressionThreads).isEqualTo(8);
+    assertThat(archive.getSettings().maxMBPerSecond).isNull();
+
+    final Backup live = newBackup();
+    newTask(serverConfig.getEffectiveConfig("livedb")).applyCompressionOverrides(live);
+    assertThat(live.getSettings().compressionLevel).isEqualTo(1);
+    assertThat(live.getSettings().compressionThreads).isNull();
+    assertThat(live.getSettings().maxMBPerSecond).isEqualTo(32);
+
+    final Backup plain = newBackup();
+    newTask(serverConfig.getEffectiveConfig("plaindb")).applyCompressionOverrides(plain);
+    assertThat(plain.getSettings().compressionLevel).isNull();
+    assertThat(plain.getSettings().compressionThreads).isNull();
+    assertThat(plain.getSettings().maxMBPerSecond).isNull();
+  }
+
+  /**
+   * A database with no entry of its own falls through {@code getEffectiveConfig}'s "copy the defaults" branch, which
+   * builds a fresh {@link DatabaseBackupConfig} field by field - so a setting missing from that copy is dropped in
+   * silence for exactly the databases that never asked for special treatment.
+   */
+  @Test
+  void aDatabaseWithNoEntryOfItsOwnInheritsTheServerDefaults() throws Exception {
+    final AutoBackupConfig serverConfig = AutoBackupConfig.fromJSON(new JSONObject("""
+        {
+          "version": 1,
+          "enabled": true,
+          "defaults": { "compressionLevel": 6, "compressionThreads": 4, "maxMBPerSecond": 16 }
+        }
+        """));
+
+    final Backup backup = newBackup();
+    newTask(serverConfig.getEffectiveConfig("unlisteddb")).applyCompressionOverrides(backup);
+
+    assertThat(backup.getSettings().compressionLevel).isEqualTo(6);
+    assertThat(backup.getSettings().compressionThreads).isEqualTo(4);
+    assertThat(backup.getSettings().maxMBPerSecond).isEqualTo(16);
+  }
+
+  /**
+   * A {@code Backup} that is never run: {@code backupDatabase()} is what touches the database and the filesystem, and
+   * these tests only care about what the setters recorded.
+   */
+  private static Backup newBackup() {
+    return new Backup((Database) null, "unit-test.zip");
+  }
+
+  private static BackupTask newTask(final DatabaseBackupConfig config) {
+    return new BackupTask(null, config.getDatabaseName(), config, "target/backup-override-test", null);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/backup/DatabaseBackupConfigTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/DatabaseBackupConfigTest.java
@@ -18,6 +18,9 @@
  */
 package com.arcadedb.server.backup;
 
+import com.arcadedb.database.Database;
+import com.arcadedb.integration.backup.Backup;
+import com.arcadedb.integration.backup.BackupSettings;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -749,5 +752,173 @@ class DatabaseBackupConfigTest {
     final DatabaseBackupConfig.ScheduleConfig config = new DatabaseBackupConfig.ScheduleConfig();
 
     assertThat(config.hasTimeWindow()).isFalse();
+  }
+
+  // ============ Per-database compression overrides (issue #6087) ============
+
+  @Test
+  void compressionOverridesAreUnsetByDefault() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("mydb");
+
+    // null IS THE "DEFER TO GlobalConfiguration" STATE - THE WHOLE BACKWARD-COMPATIBILITY GUARANTEE RESTS ON IT
+    assertThat(config.getCompressionLevel()).isNull();
+    assertThat(config.getCompressionThreads()).isNull();
+    assertThat(config.getMaxMBPerSecond()).isNull();
+  }
+
+  @Test
+  void fromJsonWithCompressionOverrides() {
+    final JSONObject json = new JSONObject()
+        .put("compressionLevel", 9)
+        .put("compressionThreads", 2)
+        .put("maxMBPerSecond", 64);
+
+    final DatabaseBackupConfig config = DatabaseBackupConfig.fromJSON("archivedb", json);
+
+    assertThat(config.getCompressionLevel()).isEqualTo(9);
+    assertThat(config.getCompressionThreads()).isEqualTo(2);
+    assertThat(config.getMaxMBPerSecond()).isEqualTo(64);
+  }
+
+  /**
+   * A {@code backup.json} written before this setting existed must load and behave exactly as it did: every override
+   * stays unset, so the global configuration still decides.
+   */
+  @Test
+  void fromJsonWithoutCompressionOverridesLeavesThemUnset() {
+    final JSONObject json = new JSONObject()
+        .put("enabled", true)
+        .put("runOnServer", "$leader");
+
+    final DatabaseBackupConfig config = DatabaseBackupConfig.fromJSON("legacydb", json);
+
+    assertThat(config.getCompressionLevel()).isNull();
+    assertThat(config.getCompressionThreads()).isNull();
+    assertThat(config.getMaxMBPerSecond()).isNull();
+  }
+
+  @Test
+  void toJsonOmitsUnsetCompressionOverrides() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("mydb");
+    config.setCompressionLevel(6);
+
+    final JSONObject json = config.toJSON();
+
+    assertThat(json.has("compressionLevel")).isTrue();
+    assertThat(json.getInt("compressionLevel")).isEqualTo(6);
+    // WRITING A RESOLVED DEFAULT BACK WOULD FREEZE TODAY'S GLOBAL VALUE INTO THE FILE
+    assertThat(json.has("compressionThreads")).isFalse();
+    assertThat(json.has("maxMBPerSecond")).isFalse();
+  }
+
+  @Test
+  void compressionOverridesSurviveAJsonRoundTrip() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("mydb");
+    config.setCompressionLevel(1);
+    config.setCompressionThreads(0);
+    config.setMaxMBPerSecond(0);
+
+    final DatabaseBackupConfig reloaded = DatabaseBackupConfig.fromJSON("mydb", config.toJSON());
+
+    assertThat(reloaded.getCompressionLevel()).isEqualTo(1);
+    assertThat(reloaded.getCompressionThreads()).isZero();
+    assertThat(reloaded.getMaxMBPerSecond()).isZero();
+  }
+
+  @Test
+  void mergeWithDefaultsFillsOnlyTheUnsetCompressionOverrides() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("mydb");
+    config.setCompressionLevel(9);
+
+    final DatabaseBackupConfig defaults = new DatabaseBackupConfig("_defaults");
+    defaults.setCompressionLevel(1);
+    defaults.setCompressionThreads(4);
+    defaults.setMaxMBPerSecond(32);
+
+    config.mergeWithDefaults(defaults);
+
+    assertThat(config.getCompressionLevel()).isEqualTo(9); // the database's own value wins
+    assertThat(config.getCompressionThreads()).isEqualTo(4);
+    assertThat(config.getMaxMBPerSecond()).isEqualTo(32);
+  }
+
+  @Test
+  void mergeWithDefaultsLeavesEverythingUnsetWhenNeitherLevelSaysAnything() {
+    final DatabaseBackupConfig config = new DatabaseBackupConfig("mydb");
+
+    config.mergeWithDefaults(new DatabaseBackupConfig("_defaults"));
+
+    assertThat(config.getCompressionLevel()).isNull();
+    assertThat(config.getCompressionThreads()).isNull();
+    assertThat(config.getMaxMBPerSecond()).isNull();
+  }
+
+  @Test
+  void validateRejectsAnOutOfRangeCompressionLevel() {
+    assertThatThrownBy(() -> DatabaseBackupConfig.fromJSON("mydb", new JSONObject().put("compressionLevel", 10)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compressionLevel");
+
+    assertThatThrownBy(() -> DatabaseBackupConfig.fromJSON("mydb", new JSONObject().put("compressionLevel", -1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compressionLevel");
+  }
+
+  @Test
+  void validateRejectsAnOutOfRangeCompressionThreadCount() {
+    assertThatThrownBy(() -> DatabaseBackupConfig.fromJSON("mydb", new JSONObject().put("compressionThreads", -2)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compressionThreads");
+
+    assertThatThrownBy(() -> DatabaseBackupConfig.fromJSON("mydb",
+        new JSONObject().put("compressionThreads", DatabaseBackupConfig.MAX_COMPRESSION_THREADS + 1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("compressionThreads");
+  }
+
+  @Test
+  void validateRejectsANegativeMaxMBPerSecond() {
+    assertThatThrownBy(() -> DatabaseBackupConfig.fromJSON("mydb", new JSONObject().put("maxMBPerSecond", -1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxMBPerSecond");
+  }
+
+  @Test
+  void validateAcceptsTheBoundaryValues() {
+    final JSONObject json = new JSONObject()
+        .put("compressionLevel", DatabaseBackupConfig.MAX_COMPRESSION_LEVEL)
+        .put("compressionThreads", DatabaseBackupConfig.MIN_COMPRESSION_THREADS)
+        .put("maxMBPerSecond", DatabaseBackupConfig.MIN_MAX_MB_PER_SECOND);
+
+    final DatabaseBackupConfig config = DatabaseBackupConfig.fromJSON("mydb", json);
+
+    assertThat(config.getCompressionLevel()).isEqualTo(9);
+    assertThat(config.getCompressionThreads()).isEqualTo(-1);
+    assertThat(config.getMaxMBPerSecond()).isZero();
+  }
+
+  /**
+   * The server module reaches the backup reflectively and so cannot reference {@code BackupSettings} in production
+   * code; the bounds are repeated in {@link DatabaseBackupConfig} instead. This is the guard that they never drift -
+   * without it, a config accepted here could still be refused by {@code Backup.setCompressionThreads} at 3am.
+   */
+  @Test
+  void compressionOverrideBoundsMatchTheBackupApi() {
+    assertThat(DatabaseBackupConfig.MAX_COMPRESSION_THREADS).isEqualTo(BackupSettings.MAX_COMPRESSION_THREADS);
+
+    // THE Backup SETTERS ARE THE AUTHORITY: ASK THEM DIRECTLY RATHER THAN RESTATING THEIR LITERALS HERE
+    final Backup backup = new Backup((Database) null, "bounds.zip");
+    backup.setCompressionLevel(DatabaseBackupConfig.MIN_COMPRESSION_LEVEL);
+    backup.setCompressionLevel(DatabaseBackupConfig.MAX_COMPRESSION_LEVEL);
+    backup.setCompressionThreads(DatabaseBackupConfig.MIN_COMPRESSION_THREADS);
+    backup.setCompressionThreads(DatabaseBackupConfig.MAX_COMPRESSION_THREADS);
+    backup.setMaxMBPerSecond(DatabaseBackupConfig.MIN_MAX_MB_PER_SECOND);
+
+    assertThatThrownBy(() -> backup.setCompressionLevel(DatabaseBackupConfig.MAX_COMPRESSION_LEVEL + 1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> backup.setCompressionThreads(DatabaseBackupConfig.MIN_COMPRESSION_THREADS - 1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> backup.setMaxMBPerSecond(DatabaseBackupConfig.MIN_MAX_MB_PER_SECOND - 1))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/server/src/test/java/com/arcadedb/server/backup/DatabaseBackupConfigTest.java
+++ b/server/src/test/java/com/arcadedb/server/backup/DatabaseBackupConfigTest.java
@@ -28,6 +28,7 @@ import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Unit tests for DatabaseBackupConfig and its nested configuration classes.
@@ -920,5 +921,25 @@ class DatabaseBackupConfigTest {
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> backup.setMaxMBPerSecond(DatabaseBackupConfig.MIN_MAX_MB_PER_SECOND - 1))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * A compression value can be refused in two places - here when {@code backup.json} is read, and inside the
+   * {@code Backup} setter when it is pushed through - and an operator grepping the log should not have to know which
+   * one spoke. Pins the two messages to each other rather than to a literal, so aligning one and forgetting the other
+   * fails instead of merely reading oddly.
+   */
+  @Test
+  void aRefusedValueReadsTheSameWhicheverLayerRefusedIt() {
+    final int outOfRange = DatabaseBackupConfig.MAX_COMPRESSION_THREADS + 1;
+
+    final Throwable fromConfig = catchThrowable(
+        () -> DatabaseBackupConfig.fromJSON("mydb", new JSONObject().put("compressionThreads", outOfRange)));
+    final Throwable fromBackup = catchThrowable(
+        () -> new Backup((Database) null, "wording.zip").setCompressionThreads(outOfRange));
+
+    assertThat(fromConfig).isNotNull();
+    assertThat(fromBackup).isNotNull();
+    assertThat(fromConfig).hasMessage(fromBackup.getMessage());
   }
 }


### PR DESCRIPTION
Closes #6087

Item 2 of the issue (the deferred-RAM gauge) already shipped in #6116 / PR #6122, so this PR covers the two that were left open: `copy()` dropping settings on `EXPORT`/`IMPORT DATABASE`, and the absence of a per-database compression override for scheduled backups.

## 1. `ExportDatabaseStatement.copy()` / `ImportDatabaseStatement.copy()` dropped the settings map

Both carried only `url` over, so a copy lost every `WITH ...` setting - the identical defect `BackupDatabaseStatement` had and that #6080 fixed. As the issue notes, this is latent rather than live today: neither top-level admin statement is on a path that copies whole statements. It is fixed anyway because it is one edit away from becoming live, and because a silent drop is the worst possible failure mode for these two - `IMPORT DATABASE WITH vertices=...` has no source at all without its settings.

`ExportDatabaseStatement.copy()` also dropped `format` and `overwrite`, which are statement state in exactly the same way, so the fix copies the whole object rather than just the map the issue named.

**Adjacent gaps deliberately left alone** (neither is a regression, both are worth a look separately):

- `ExportDatabaseStatement.toString()` does not render the `WITH` clause, so a parse -> `toString()` -> re-parse round-trip is lossy. `BackupDatabaseStatement.toString()` has the same gap; `ImportDatabaseStatement.toString()` does not. This is why the new export test parses with `checkSyntax(...)` rather than `checkRightSyntax(...)` - the latter re-parses `toString()` output and would have handed back an empty settings map, i.e. a test that could not fail.
- `SimpleNode.hashCode()` computes `Objects.hashCode(getIdentityElements())`, and `getIdentityElements()` returns a freshly allocated `Object[]` on every call, so it is the array's *identity* hash: a node hashes to a different value on every invocation while `equals()` is content-based. Measured directly - three consecutive `hashCode()` calls on one `Expression` returned 1175962212, 2055281021, 1554547125. Consequence: any `SimpleNode` used as a `HashMap` key can never be looked up, and `Map.equals` over a settings map always returns false. Production impact appears to be nil (these maps are only ever iterated, and a `put` collision needs the two random hashes to match exactly, not merely the bucket), but the fix is a one-word `Arrays.hashCode`, and it touches every AST node, so it does not belong in this PR. The new tests compare the *rendered* `name -> value` pairs instead, and say so in a comment, so they do not depend on it in either direction.

## 2. No per-database compression override for scheduled backups

`DatabaseBackupConfig` gains three optional settings - `compressionLevel`, `compressionThreads`, `maxMBPerSecond` - mirroring `BackupSettings`'s `null` = "defer to the global configuration" convention. `BackupTask` threads them into the reflective `Backup` construction alongside the existing `setDirectory`/`setVerboseLevel` calls, skipping any the configuration left unset. A mixed fleet can now give a large, rarely-restored database `compressionLevel: 9` overnight while a small, frequently-restored one keeps `compressionLevel: 1` and stays out of the live workload's way.

```json
{
  "version": 1,
  "databases": {
    "archivedb": { "compressionLevel": 9, "compressionThreads": 8 },
    "livedb":    { "compressionLevel": 1, "maxMBPerSecond": 32 }
  }
}
```

They work in the `defaults` block too, and `mergeWithDefaults` fills only what the database left unset.

**Three decisions worth flagging:**

- **No `version` bump.** The issue offered "a version bump / backward-compat default of unset"; this takes the second. The fields are purely additive and absent is a valid, meaning-preserving state, so a version-1 `backup.json` loads and behaves byte-for-byte as it did. Nothing in the codebase gates on `version` - `AutoBackupConfig` reads it, stores it and never compares it - so bumping it would signal a migration that does not exist while changing no behavior.
- **Bounds are re-stated in the server module**, because `server` deliberately does not depend on `integration` at compile time (the backup is reached reflectively so a distribution without it still starts). `GlobalConfiguration.BACKUP_COMPRESSION_THREADS` already repeats the same literal for the same reason. `compressionOverrideBoundsMatchTheBackupApi` is the drift guard: it asserts against `BackupSettings.MAX_COMPRESSION_THREADS` and then asks the real `Backup` setters where they draw the line, rather than restating their literals a third time.
- **Out-of-range values are refused at load time**, in `validate()`, next to the existing cron and `maxFiles` checks - same shape, same exception, same call site - rather than being left to surface from inside a `Backup` setter during the 3am backup window.
- **`Backup.getSettings()`** is new and public. Every cross-module caller configures a `Backup` through a reflective boundary where a mis-wired setter fails silently; this is what lets the wiring be asserted against what actually reached the instance rather than inferred from the archive it happened to produce.

## Test plan

- [x] `ExportDatabaseStatementTestParserTest`, `ImportDatabaseStatementTestParserTest` - `copyKeepsTheWithSettings` **verified failing before the fix** ("Expecting actual not to be empty" on both), passing after. `copyOfAStatementWithoutSettingsKeepsAnEmptyMap` guards the empty case.
- [x] `BackupTaskCompressionOverrideTest` (7 tests, new) - every override reaches the `Backup`; an unset one leaves it `null` so the global default still decides; a partially configured database overrides only what it named; two databases in one fleet get their own settings; an out-of-range value set programmatically is still refused by the `Backup`; and the full chain from a `backup.json` string through `AutoBackupConfig.getEffectiveConfig` into the `Backup`, including the "no entry of its own" branch that copies the defaults field by field.
- [x] **Sabotage check**: with `applyCompressionOverrides`'s level branch forced to `if (false)`, 4 of the 5 tests then written went red. The tests detect the wiring, they do not merely accompany it.
- [x] `DatabaseBackupConfigTest` - 11 new tests for defaults, JSON parse, round-trip, `toJSON` omitting unset values, merge precedence, range refusals, boundary acceptance, and the bounds drift guard. 70 tests total, green.
- [x] `mvn -o -pl engine -am test -Dtest='com.arcadedb.query.sql.parser.**,DatabaseAdminStatementsTest'` - 371 tests, 0 failures.
- [x] `mvn -o -pl integration -am test -Dtest='com.arcadedb.integration.backup.**'` - 82 tests, 0 failures.
- [x] `mvn -o -pl server -am test -Dtest='com.arcadedb.server.backup.**'` - 160 tests, 0 failures.
- [x] `mvn -o test-compile -pl '!studio'` - BUILD SUCCESS across the reactor including all test sources. (`studio` fails on an unrelated offline npm cache miss for `xmldoc`, no Java involved.)
