### PR TITLE
perf(#6086): the restore is parallel per entry, and stops reading the archive 512 bytes at a time

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2035,4 +2035,10 @@ every entry name up front and refuses a hostile archive before writing a single 
 learns a name when it reaches it, so it stops at the bad entry with the good ones already on disk - the
 pre-existing behaviour, now pinned by a test so the difference is a recorded decision rather than an accident.
 
+A failure *during* extraction carries one guarantee that a naive pool would not give: when the extractor throws,
+no worker is still writing. Interrupting a thread does not come back out of a `FileOutputStream.write()`, so
+shutting the pool down is not enough on its own - and the caller's very next move is usually to delete the
+destination, which would then race the workers still filling it. The extractor therefore waits for its workers
+before propagating the failure.
+
 [#6086](https://github.com/ArcadeData/arcadedb/issues/6086)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1962,3 +1962,77 @@ reads from.
 already left behind.
 
 [#6090](https://github.com/ArcadeData/arcadedb/issues/6090)
+
+## The restore is now the fast half of a recovery too: parallel per entry, and no longer reading the archive 512 bytes at a time (#6086)
+
+Making the backup 27x faster (#6072) moved the bottleneck rather than removing it. On the same 1.25 GB database
+the backup took 0.68 s and the restore that undoes it 2.9 s, so the number that actually matters when someone is
+recovering - the RTO - had barely moved.
+
+### What the measurement said, and what it contradicted
+
+The issue proposed two candidate diagnoses and asked for the numbers before any code. `RestoreParallelBenchmark`
+times the two halves of a restore separately, and they are not close: on that 1.25 GB database, inflating every
+entry and throwing the bytes away takes **2.96 s** while writing the same bytes with no inflation takes **0.93 s**.
+The restore is inflate-bound, and the "the 8 KB copy buffer is suspiciously small" hypothesis is the wrong one -
+raising that buffer to 256 KB is worth 1%.
+
+The read side, however, was worth a great deal, and for a reason no one had looked at: `ZipInputStream` fills its
+inflater **512 bytes at a time**, a size its constructor hardcodes with no overload to change it, and the restore
+handed it an unbuffered `FileInputStream`. That is one read syscall per 512 compressed bytes for the whole
+archive. A 256 KB `BufferedInputStream` underneath it takes the same restore from 5.16 s to 3.96 s, and it is the
+only speedup available to the two input sources that cannot be parallel at all.
+
+### Parallel per entry
+
+ZIP entries are independent and each becomes its own file, so they are inflated and written concurrently, largest
+first (the duration of a set of very uneven independent tasks is decided by when the biggest one starts). This
+needs random access to the archive - `ZipFile` rather than `ZipInputStream` - which turns out to be the larger
+half of the win even at one thread, because `ZipFile`'s reader does not have the 512-byte fill.
+
+`arcadedb.restore.threads` sizes the pool: `-1` (the default) is the available processors capped at 8, `0` selects
+the sequential walk, `N` a pool of N. It is also settable per restore, on the command line (`-restoreThreads`) and
+through the `Restore` API. Unlike a backup, which halves the cores because it runs alongside the workload it is
+already throttling, a restore has no such neighbour - the database it is producing is not open yet - so the
+automatic sizing takes whole cores.
+
+**The archive format did not change**, and no part of this reads anything the backup did not already write. Old
+archives, including single-threaded level-9 ones written before #6072, restore through the parallel path unchanged.
+
+### The numbers
+
+1.25 GB database, 8 threads, macOS/NVMe. Two shapes, because the shape is what decides what per-entry parallelism
+can possibly buy:
+
+| configuration | one dominant entry (1 type) | several comparable entries (8 types) |
+|---|---|---|
+| before #6086 | 5.16 s (248 MB/s) | 4.51 s (258 MB/s) |
+| + buffered read, sequential | 3.96 s (1.30x) | 4.17 s (1.08x) |
+| parallel, 1 thread | 2.60 s (1.99x) | 2.63 s (1.71x) |
+| parallel, 8 threads | **2.51 s (2.05x)** | **0.49 s (9.15x)** |
+
+A database made of one dominant file cannot be split - a ZIP entry is a single deflate stream and has to be
+inflated serially - so there the whole win is the reader change and the threads add 4%. This is stated rather
+than averaged away because it is the honest shape of the result: intra-entry parallelism, the mirror of what the
+backup does, is not available without recording the backup's chunk boundaries in the archive, which would be the
+format change this deliberately avoids. On a database spread over several types the restore goes to 0.49 s -
+faster than the 0.68 s backup it undoes, which is where the issue wanted it.
+
+Peak heap is bounded by construction and does not move: 11.0 MB in every configuration above, sequential and
+parallel alike. One 256 KB copy buffer per pool thread, taken from a pool of exactly that many, plus the JDK
+inflater's own buffer per entry in flight - under 3 MB of buffers at 8 threads.
+
+### What stays sequential, and why it is not optional
+
+Per-entry parallelism needs to open the archive at random, which two of the three input sources cannot support: an
+archive read over `http(s)` is a one-shot stream, and an encrypted one is a single `CipherInputStream` that only
+decrypts front to back. Both fall back to the sequential walk automatically, whatever the thread setting says - a
+restore must never fail because of a performance setting - and both are covered by tests that assert the fallback
+was taken, not merely that the restore worked.
+
+One thing the parallel path does strictly better: it reads the central directory before it starts, so it validates
+every entry name up front and refuses a hostile archive before writing a single file. The sequential walk only
+learns a name when it reaches it, so it stops at the bad entry with the good ones already on disk - the
+pre-existing behaviour, now pinned by a test so the difference is a recorded decision rather than an accident.
+
+[#6086](https://github.com/ArcadeData/arcadedb/issues/6086)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -613,6 +613,23 @@ public enum GlobalConfiguration {
       invalid.""",
       Integer.class, 0),
 
+  RESTORE_THREADS("arcadedb.restore.threads", SCOPE.JVM,
+      """
+      Number of threads used to restore a full backup. ZIP entries are independent files, so they are inflated and \
+      written concurrently, one entry per thread. -1 (the default) sizes the pool automatically at the available \
+      processors capped at 8; 0 selects the legacy single-threaded stream walk, kept as an escape hatch. Unlike a \
+      backup, a restore does not run alongside the database it is working on - that database does not exist yet - \
+      which is why the automatic sizing claims whole cores rather than half of them. The parallel path needs random \
+      access to the archive and is therefore used only for a plain local file: an archive read over http(s) is a \
+      one-shot stream and an encrypted one is a single cipher stream, and both fall back to the sequential walk \
+      automatically, whatever this setting says. Peak heap is bounded by construction at one copy buffer per thread \
+      (256 KB) plus the JDK inflater's own buffer, so under 3 MB at 8 threads. Parallelism is per entry: a database \
+      made of one dominant file cannot be split, because a ZIP entry is a single deflate stream that has to be \
+      inflated serially.""",
+      // SAME BOUND AS RestoreSettings.MAX_RESTORE_THREADS, WHICH THE CLI AND THE Restore API VALIDATE AGAINST. THE
+      // ENGINE CANNOT DEPEND ON THE INTEGRATION MODULE, SO THE LITERAL IS REPEATED: CHANGE ONE AND CHANGE THE OTHER
+      Integer.class, -1, integerRangeAsStrings(-1, 256)),
+
   // SQL
   SQL_STATEMENT_CACHE("arcadedb.sqlStatementCache", SCOPE.DATABASE, "Maximum number of parsed statements to keep in cache",
       Integer.class, 300),

--- a/integration/src/main/java/com/arcadedb/integration/importer/ConsoleLogger.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ConsoleLogger.java
@@ -25,8 +25,17 @@ package com.arcadedb.integration.importer;
  * @author Luca Garulli
  */
 public class ConsoleLogger {
-  private final int         verboseLevel;
-  private       LogListener listener;
+  private final int          verboseLevel;
+  /**
+   * Serializes the notifications, because a listener is written once and called from wherever the logger is used, and
+   * since #6086 that includes several threads at a time: a parallel restore logs one line per archive entry from its
+   * worker pool. The listeners in the tree write those lines to a stream nobody synchronizes - the server's SSE
+   * progress channel writes straight to the exchange's output stream - so two lines arriving at once would interleave
+   * into a corrupt event rather than merely arriving out of order. Serializing here keeps that guarantee in one place
+   * instead of asking every implementation of a one-method interface to remember it.
+   */
+  private final Object       listenerLock = new Object();
+  private volatile LogListener listener;
 
   @FunctionalInterface
   public interface LogListener {
@@ -48,8 +57,7 @@ public class ConsoleLogger {
 
     final String msg = args.length == 0 ? text : text.formatted(args);
     System.out.println(msg);
-    if (listener != null)
-      listener.onLogLine(msg);
+    notifyListener(msg);
   }
 
   public void log(final int level, final String text, final Object... args) {
@@ -65,8 +73,16 @@ public class ConsoleLogger {
   public void errorLine(final String text, final Object... args) {
     final String msg = args.length == 0 ? text : text.formatted(args);
     System.out.println(msg);
-    if (listener != null)
-      listener.onLogLine(msg);
+    notifyListener(msg);
+  }
+
+  private void notifyListener(final String msg) {
+    final LogListener current = listener;
+    if (current == null)
+      return;
+    synchronized (listenerLock) {
+      current.onLogLine(msg);
+    }
   }
 
   public int getVerboseLevel() {

--- a/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
@@ -70,6 +70,17 @@ public class Restore {
     return this;
   }
 
+  /**
+   * Restore threads: -1 automatic, 0 the legacy single-threaded stream walk, N a pool of N. Overrides
+   * {@link com.arcadedb.GlobalConfiguration#RESTORE_THREADS}. Ignored, with a fallback to the sequential walk, when
+   * the archive cannot be opened for random access: an http(s) URL or an encrypted archive.
+   */
+  public Restore setRestoreThreads(final int restoreThreads) {
+    settings.restoreThreads = RestoreSettings.checkIntSetting("restoreThreads", restoreThreads, -1,
+        RestoreSettings.MAX_RESTORE_THREADS);
+    return this;
+  }
+
   public Restore setLogger(final ConsoleLogger logger) {
     this.logger = logger;
     return this;

--- a/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
@@ -24,6 +24,18 @@ import java.util.Locale;
 import java.util.Map;
 
 public class RestoreSettings {
+  /**
+   * Upper bound on the restore thread count, matching the allowed-value set of
+   * {@link com.arcadedb.GlobalConfiguration#RESTORE_THREADS} so the CLI, the API and the global configuration all
+   * reject the same values. Far above any core count that makes sense; the point is to bound the pool, not to be a
+   * useful setting up there.
+   * <p>
+   * The engine module cannot depend on this one, so {@code RESTORE_THREADS} repeats the literal instead of
+   * referencing this constant. Change one and change the other; {@code restoreThreadBoundMatchesTheGlobalConfiguration}
+   * fails if they drift.
+   */
+  public static final int MAX_RESTORE_THREADS = 256;
+
   public       String              format               = "full";
   public       String              inputFileURL;
   public       String              databaseDirectory;
@@ -31,6 +43,11 @@ public class RestoreSettings {
   public       int                 verboseLevel         = 2;
   public       String              encryptionAlgorithm  = "AES";
   public       String              encryptionKey;
+  /**
+   * Restore threads: -1 automatic, 0 the legacy single-threaded stream walk, N a pool of N. {@code null} defers to
+   * {@link com.arcadedb.GlobalConfiguration#RESTORE_THREADS}.
+   */
+  public       Integer             restoreThreads;
   public final Map<String, String> options              = new HashMap<>();
 
   protected void parseParameters(final String[] args) {
@@ -66,6 +83,10 @@ public class RestoreSettings {
           databaseDirectory = value;
         yield 2;
       }
+      case "restoreThreads" -> {
+        restoreThreads = parseIntSetting(name, value, -1, MAX_RESTORE_THREADS);
+        yield 2;
+      }
       case "o" -> {
         overwriteDestination = true;
         yield 1;
@@ -90,5 +111,26 @@ public class RestoreSettings {
 
     if (inputFileURL.contains("..") || inputFileURL.startsWith(File.separator))
       throw new IllegalArgumentException("Invalid backup file: cannot contain '..' or start with '/'");
+  }
+
+  /**
+   * Rejects an out-of-range or non-numeric value at parse time instead of letting it reach the executor, where an
+   * invalid thread count would surface as an opaque {@code IllegalArgumentException} from the JDK.
+   */
+  public static int parseIntSetting(final String name, final String value, final int min, final int max) {
+    final int parsed;
+    try {
+      parsed = Integer.parseInt(value != null ? value.trim() : null);
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException("Restore setting '%s' requires an integer, found '%s'".formatted(name, value), e);
+    }
+    return checkIntSetting(name, parsed, min, max);
+  }
+
+  public static int checkIntSetting(final String name, final int value, final int min, final int max) {
+    if (value < min || value > max)
+      throw new IllegalArgumentException(
+          "Restore setting '%s' must be between %d and %d, found %d".formatted(name, min, max, value));
+    return value;
   }
 }

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.integration.restore.format;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.integration.importer.ConsoleLogger;
 import com.arcadedb.integration.restore.RestoreException;
@@ -43,18 +44,28 @@ import java.util.zip.ZipInputStream;
 
 public class FullRestoreFormat extends AbstractRestoreFormat {
   private interface RestoreCallback {
-    void restore(ZipInputStream zipFile) throws Exception;
+    ParallelZipExtractor.ExtractStats restore(ZipInputStream zipFile) throws Exception;
   }
 
-  private final byte[] BUFFER = new byte[8192];
+  private final byte[] BUFFER = new byte[ParallelZipExtractor.BUFFER_SIZE];
 
-  private static class RestoreInputSource {
-    public final InputStream inputStream;
-    public final long        fileSize;
+  /**
+   * Where the archive is, and how it can be read. Exactly one of the two is set: a local {@code File}, or an already
+   * opened remote stream. The local stream is opened lazily, because the parallel path never wants one.
+   */
+  private record RestoreInputSource(File localFile, InputStream remoteStream, long fileSize) {
+    InputStream openStream() throws IOException {
+      return remoteStream != null ? remoteStream : new FileInputStream(localFile);
+    }
 
-    public RestoreInputSource(final InputStream inputStream, final long fileSize) {
-      this.inputStream = inputStream;
-      this.fileSize = fileSize;
+    /**
+     * The archive as something that can be opened for random access, or {@code null} when it cannot be - which is
+     * the precondition of the parallel path. A directory or a named pipe passes {@code exists()} but is not a plain
+     * file, so it keeps the sequential path and fails there the way it always did, rather than failing differently
+     * inside {@code ZipFile}.
+     */
+    File randomAccessArchive() {
+      return remoteStream == null && localFile.isFile() ? localFile : null;
     }
   }
 
@@ -81,15 +92,50 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
       throw new RestoreException(
           "Error on restoring database: the database directory '%s' cannot be created".formatted(settings.databaseDirectory));
 
-    logger.logLine(0, "Executing full restore of database from file '%s' to '%s'...", settings.inputFileURL,
-        settings.databaseDirectory);
+    // THE PARALLEL PATH NEEDS RANDOM ACCESS TO THE ARCHIVE. NEITHER OF THE OTHER TWO INPUT SOURCES CAN GIVE IT: AN
+    // http(s) ARCHIVE IS A ONE-SHOT STREAM, AND AN ENCRYPTED ONE IS A SINGLE CIPHER STREAM THAT ONLY DECRYPTS FRONT TO
+    // BACK. BOTH FALL BACK TO THE SEQUENTIAL WALK RATHER THAN BEING REFUSED - A RESTORE MUST NEVER FAIL BECAUSE OF A
+    // PERFORMANCE SETTING
+    final int threads = resolveThreads();
+    final File randomAccessArchive = settings.encryptionKey == null ? inputSource.randomAccessArchive() : null;
+    final boolean parallel = threads > 0 && randomAccessArchive != null;
 
-    decryptFile(inputSource.inputStream, zipFile -> {
-      final long beginTime = System.currentTimeMillis();
+    logger.logLine(0, "Executing full restore of database from file '%s' to '%s' (%s)...", settings.inputFileURL,
+        settings.databaseDirectory, parallel ? threads + " threads" : "single threaded");
 
+    final long beginTime = System.currentTimeMillis();
+
+    final ParallelZipExtractor.ExtractStats stats = parallel ?
+        new ParallelZipExtractor(threads, logger).extract(randomAccessArchive, databaseDirectory) :
+        restoreSequentially(inputSource, databaseDirectory);
+
+    final long elapsedInSecs = (System.currentTimeMillis() - beginTime) / 1000;
+
+    if (stats.files() == 0)
+      throw new RestoreException("Unable to perform restore");
+
+    logger.logLine(0, "Full restore completed in %d seconds %s -> %s (%,d%% compression)", elapsedInSecs,
+        FileUtils.getSizeAsString(inputSource.fileSize()), FileUtils.getSizeAsString(stats.uncompressedSize()),
+        stats.uncompressedSize() > 0 ? (stats.uncompressedSize() - inputSource.fileSize()) * 100 / stats.uncompressedSize() : 0);
+  }
+
+  /**
+   * The one-thread stream walk, which is both the pre-#6086 path and the only one available for an http(s) or an
+   * encrypted archive.
+   */
+  private ParallelZipExtractor.ExtractStats restoreSequentially(final RestoreInputSource inputSource,
+      final File databaseDirectory) throws Exception {
+    // THE BufferedInputStream IS NOT A DETAIL, AND IT IS THE ONLY SPEEDUP THE http AND ENCRYPTED ARCHIVES CAN HAVE.
+    // ZipInputStream FILLS ITS INFLATER 512 BYTES AT A TIME (THE SIZE ITS CONSTRUCTOR HARDCODES, WITH NO OVERLOAD TO
+    // CHANGE IT), SO WITHOUT A BUFFER UNDERNEATH IT THAT IS ONE read() AGAINST THE FILE - OR AGAINST THE SOCKET, OR
+    // THROUGH THE CIPHER - PER 512 COMPRESSED BYTES. MEASURED ON A 1.25 GB DATABASE: 5.16 s WITHOUT IT, 3.96 s WITH
+    // IT, FOR A CHANGE THAT COSTS ONE 256 KB BUFFER. THE COPY BUFFER ABOVE IT IS WORTH ALMOST NOTHING BY COMPARISON
+    // (3.96 s AT 8 KB AGAINST 3.92 s AT 256 KB), WHICH IS WHY THE ISSUE'S "THE 8 KB BUFFER IS SUSPICIOUSLY SMALL"
+    // HYPOTHESIS WAS THE WRONG ONE: THE RESTORE IS INFLATE-BOUND, NOT WRITE-BOUND
+    return decryptFile(new BufferedInputStream(inputSource.openStream(), ParallelZipExtractor.BUFFER_SIZE), zipFile -> {
+      int restoredFiles = 0;
       long databaseOrigSize = 0L;
 
-      int restoredFiles = 0;
       ZipEntry compressedFile = zipFile.getNextEntry();
       while (compressedFile != null) {
         databaseOrigSize += uncompressFile(zipFile, compressedFile, databaseDirectory);
@@ -99,15 +145,36 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
 
       zipFile.close();
 
-      final long elapsedInSecs = (System.currentTimeMillis() - beginTime) / 1000;
-
-      if (restoredFiles == 0)
-        throw new RestoreException("Unable to perform restore");
-
-      logger.logLine(0, "Full restore completed in %d seconds %s -> %s (%,d%% compression)", elapsedInSecs,
-          FileUtils.getSizeAsString(inputSource.fileSize), FileUtils.getSizeAsString(databaseOrigSize),
-          databaseOrigSize > 0 ? (databaseOrigSize - inputSource.fileSize) * 100 / databaseOrigSize : 0);
+      return new ParallelZipExtractor.ExtractStats(restoredFiles, databaseOrigSize);
     });
+  }
+
+  /**
+   * -1 sizes the pool automatically, 0 selects the sequential walk, N a pool of N. The setting is read from the JVM
+   * configuration rather than from a database one because a restore has no database to read it from: the database it
+   * is producing does not exist yet.
+   */
+  private int resolveThreads() {
+    final int configured = settings.restoreThreads != null ?
+        settings.restoreThreads :
+        GlobalConfiguration.RESTORE_THREADS.getValueAsInteger();
+    if (configured >= 0)
+      return configured;
+    return autoRestoreThreads(Runtime.getRuntime().availableProcessors());
+  }
+
+  /**
+   * The automatic thread count: the available processors, capped at 8, never below 1. Unlike a backup - which runs
+   * next to the live workload it is already throttling, and therefore takes only half the cores - a restore does not
+   * compete with the database it is restoring, because that database is not open yet. The cap is there because the
+   * unit of parallelism is one archive entry: past a handful of threads the limit is the entry count and the disk,
+   * not the core count.
+   * <p>
+   * Package-private and taking the core count as an argument so the boundaries can be pinned by a test rather than
+   * depending on whatever the machine running the suite happens to have.
+   */
+  static int autoRestoreThreads(final int availableProcessors) {
+    return Math.max(1, Math.min(availableProcessors, 8));
   }
 
   private long uncompressFile(final ZipInputStream inputFile, final ZipEntry compressedFile, final File databaseDirectory)
@@ -151,7 +218,7 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
       connection.setDoOutput(true);
       connection.connect();
 
-      return new RestoreInputSource(connection.getInputStream(), 0);
+      return new RestoreInputSource(null, connection.getInputStream(), 0);
     }
 
     String path = settings.inputFileURL;
@@ -165,10 +232,11 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
       throw new RestoreException("The backup file '%s' does not exist (local path=%s)".formatted(//
           settings.inputFileURL, new File(".").getAbsolutePath()));
 
-    return new RestoreInputSource(new FileInputStream(file), file.length());
+    return new RestoreInputSource(file, null, file.length());
   }
 
-  private void decryptFile(final InputStream fis, final FullRestoreFormat.RestoreCallback callback) throws Exception {
+  private ParallelZipExtractor.ExtractStats decryptFile(final InputStream fis,
+      final FullRestoreFormat.RestoreCallback callback) throws Exception {
     final ZipInputStream zipFile;
     if (settings.encryptionKey != null) {
       // Read salt from the beginning of the file (16 bytes)
@@ -203,7 +271,7 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
       zipFile = new ZipInputStream(fis, StandardCharsets.UTF_8);
 
     try {
-      callback.restore(zipFile);
+      return callback.restore(zipFile);
     } finally {
       zipFile.close();
     }

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
@@ -89,13 +89,20 @@ public class ParallelZipExtractor {
    */
   public static final int BUFFER_SIZE = 256 * 1024;
 
+  /**
+   * How long a failed extraction waits for the workers that are still writing an entry. A worker cannot be
+   * interrupted out of a file write, so this is sized for the largest single entry a database can hold rather than
+   * for a typical one; it is a degradation bound, not a timeout anyone should reach.
+   */
+  private static final int TERMINATION_TIMEOUT_SECONDS = 60;
+
   /** What the restore needs back to log the same summary line the sequential path logs. */
   public record ExtractStats(int files, long uncompressedSize) {
   }
 
-  private final int                            threads;
-  private final ConsoleLogger                  logger;
-  private final ArrayBlockingQueue<byte[]>     bufferPool;
+  private final int                        threads;
+  private final ConsoleLogger              logger;
+  private final ArrayBlockingQueue<byte[]> bufferPool;
 
   public ParallelZipExtractor(final int threads, final ConsoleLogger logger) {
     if (threads < 1)
@@ -154,8 +161,27 @@ public class ParallelZipExtractor {
 
         return new ExtractStats(entries.size(), databaseOrigSize);
       } finally {
+        // shutdownNow() ALONE IS NOT ENOUGH ON THE FAILURE PATH. IT DRAINS THE QUEUE, SO NO FURTHER ENTRY STARTS, BUT
+        // THE INTERRUPT IT SENDS DOES NOT COME BACK OUT OF A FileOutputStream.write() OR A ZipFile READ - NEITHER IS
+        // INTERRUPTIBLE - SO UP TO poolSize-1 WORKERS WOULD STILL BE WRITING FILES AFTER THIS METHOD HAD ALREADY
+        // THROWN TO ITS CALLER. THAT MATTERS BECAUSE OF WHAT CALLERS DO NEXT: THE SERVER'S RESTORE HANDLER DELETES
+        // THE DESTINATION DIRECTORY WHEN A RESTORE FAILS, AND DELETING A TREE THAT THREADS ARE STILL WRITING INTO IS
+        // A RACE THAT LEAVES FILES BEHIND. WAITING HERE MAKES ONE GUARANTEE THE CALLER CAN RELY ON: WHEN extract()
+        // RETURNS OR THROWS, NOTHING IS STILL WRITING. THE WAIT IS BOUNDED ONLY SO A PATHOLOGICAL CASE DEGRADES TO A
+        // WARNING RATHER THAN A HANG; ON THE SUCCESS PATH EVERY TASK IS ALREADY DONE AND IT RETURNS AT ONCE
         executor.shutdownNow();
+        awaitTermination(executor, databaseDirectory);
       }
+    }
+  }
+
+  private void awaitTermination(final ThreadPoolExecutor executor, final File databaseDirectory) {
+    try {
+      if (!executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        logger.errorLine("Restore workers did not stop within %d seconds: files may still be written into '%s'",
+            TERMINATION_TIMEOUT_SECONDS, databaseDirectory.getAbsolutePath());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.restore.format;
+
+import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.integration.restore.RestoreException;
+import com.arcadedb.utility.FileUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Multi-threaded extractor for the full restore (issue #6086).
+ * <p>
+ * <b>Why.</b> Once the backup became parallel (#6072) the restore was the slow half of a recovery: on the same 1.25 GB
+ * database the backup took 0.68 s and the restore that undoes it 2.9 s. The restore was a single thread alternating
+ * between inflating into an 8 KB buffer and writing that buffer out, for the whole archive.
+ * <p>
+ * <b>How the parallelism works.</b> A ZIP entry is one deflate stream and has to be inflated serially, and the chunk
+ * boundaries the backup writer used are not recorded anywhere in the archive - recording them would be an archive
+ * format change, which is out of scope precisely because old backups have to keep restoring. So the split is
+ * <i>between</i> entries, which needs no format change at all: every entry becomes its own output file, so N entries
+ * can be inflated and written at once. Entries are handed out largest first, because the makespan of a set of
+ * independent tasks of very different sizes is decided by when the biggest one starts.
+ * <p>
+ * <b>What this cannot do.</b> Per-entry parallelism needs random access to the archive ({@link ZipFile}), which the
+ * two remote-ish input sources cannot provide: an archive read over http(s) is a one-shot stream, and an encrypted one
+ * is a single cipher stream that only decrypts front to back. Both keep the sequential walk in
+ * {@link FullRestoreFormat}, which is therefore not legacy code but the fallback for those two cases - and the
+ * escape hatch for anyone who sets the thread count to 0.
+ * <p>
+ * <b>Concurrency.</b> Per the {@code engine-concurrency} skill this never touches {@code ForkJoinPool.commonPool()}.
+ * It uses a dedicated {@link ThreadPoolExecutor} whose lifetime is exactly one restore: a restore is a rare, one-off
+ * operation, so a permanently resident pool would hold idle threads for the whole life of the process, and there is no
+ * steady-state pool for {@code PoolMetrics} to report on. The queue holds nothing but entry references, so it cannot
+ * be the thing that runs the heap up; peak heap is bounded by construction at one copy buffer per pool thread, taken
+ * from a pool of exactly that many, plus the JDK inflater's own buffer per entry in flight.
+ * <p>
+ * <b>Note on {@code ZipFile} and threads.</b> Concurrent {@code getInputStream} readers serialize only on the raw read
+ * of compressed bytes (the JDK synchronizes on the shared source), which is the cheap part: inflating and writing, the
+ * two that dominate, stay parallel. Opening one {@code ZipFile} per thread would not remove even that, because the JDK
+ * caches and shares the underlying source between instances that name the same file.
+ */
+public class ParallelZipExtractor {
+  /**
+   * Copy buffer per worker thread, also used as the read-ahead buffer of the sequential path.
+   * <p>
+   * Its size is worth almost nothing on the write side and a great deal on the read side, which is the opposite of
+   * what the issue expected: raising the copy buffer from 8 KB to 256 KB moved a 1.25 GB restore from 3.96 s to
+   * 3.92 s, while putting a buffer of that size <i>under</i> the {@code ZipInputStream} of the sequential path moved
+   * it from 5.16 s to 3.96 s. A restore is inflate-bound - measured at 2.96 s of inflating against 0.93 s of writing
+   * for that database - and the write side was never the problem.
+   */
+  public static final int BUFFER_SIZE = 256 * 1024;
+
+  /** What the restore needs back to log the same summary line the sequential path logs. */
+  public record ExtractStats(int files, long uncompressedSize) {
+  }
+
+  private final int                            threads;
+  private final ConsoleLogger                  logger;
+  private final ArrayBlockingQueue<byte[]>     bufferPool;
+
+  public ParallelZipExtractor(final int threads, final ConsoleLogger logger) {
+    if (threads < 1)
+      throw new IllegalArgumentException("At least one restore thread is required");
+    this.threads = threads;
+    this.logger = logger;
+    this.bufferPool = new ArrayBlockingQueue<>(threads);
+  }
+
+  public ExtractStats extract(final File archive, final File databaseDirectory) throws IOException {
+    try (final ZipFile zipFile = new ZipFile(archive, StandardCharsets.UTF_8)) {
+      final List<ZipEntry> entries = new ArrayList<>();
+      final Enumeration<? extends ZipEntry> enumeration = zipFile.entries();
+      while (enumeration.hasMoreElements())
+        entries.add(enumeration.nextElement());
+
+      // VALIDATE EVERY NAME BEFORE ANY THREAD HAS WRITTEN ANYTHING, SO A HOSTILE ARCHIVE IS REFUSED WITHOUT LEAVING
+      // BEHIND THE FILES THAT PRECEDED THE BAD ENTRY. THE SEQUENTIAL PATH CANNOT DO THIS - IT ONLY LEARNS AN ENTRY'S
+      // NAME WHEN IT REACHES IT - BUT THE CENTRAL DIRECTORY GIVES THIS ONE EVERY NAME UP FRONT.
+      //
+      // THE DUPLICATE CHECK IS PART OF THAT AND IS NOT PEDANTRY: TWO ENTRIES OF THE SAME NAME ARE HARMLESS WHEN THEY
+      // ARE WRITTEN ONE AFTER THE OTHER (THE SECOND WINS, WHICH IS WHAT THE SEQUENTIAL WALK DOES) AND ARE TWO
+      // THREADS WRITING ONE FILE HERE. NO ARCADEDB BACKUP CAN PRODUCE ONE - A DATABASE DIRECTORY HAS UNIQUE FILE
+      // NAMES - SO REFUSING IS BETTER THAN INVENTING A LOCKING RULE FOR AN ARCHIVE NOBODY SHOULD BE RESTORING
+      final Set<String> names = new HashSet<>(entries.size());
+      for (final ZipEntry entry : entries) {
+        resolveTarget(entry, databaseDirectory);
+        if (!names.add(entry.getName()))
+          throw new IOException("The backup archive contains two entries named '%s'".formatted(entry.getName()));
+      }
+
+      // LARGEST FIRST: WITH ENTRIES THIS UNEVEN (A DATABASE IS A FEW BIG PAGE FILES AND A HANDFUL OF TINY ONES) THE
+      // DURATION IS DECIDED BY HOW LATE THE BIGGEST ENTRY STARTS
+      entries.sort(Comparator.comparingLong(ParallelZipExtractor::entryWeight).reversed());
+
+      final int poolSize = Math.min(threads, entries.size());
+      if (poolSize < 1)
+        return new ExtractStats(0, 0L);
+
+      final AtomicInteger threadId = new AtomicInteger();
+      final ThreadPoolExecutor executor = new ThreadPoolExecutor(poolSize, poolSize, 0L, TimeUnit.MILLISECONDS,
+          new LinkedBlockingQueue<>(), r -> {
+        final Thread thread = new Thread(r, "arcadedb-restore-inflater-" + threadId.incrementAndGet());
+        thread.setDaemon(true);
+        return thread;
+      });
+
+      try {
+        final List<Future<Long>> results = new ArrayList<>(entries.size());
+        for (final ZipEntry entry : entries)
+          results.add(executor.submit(uncompressEntry(zipFile, entry, databaseDirectory)));
+
+        long databaseOrigSize = 0L;
+        for (final Future<Long> result : results)
+          databaseOrigSize += drain(result);
+
+        return new ExtractStats(entries.size(), databaseOrigSize);
+      } finally {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  private Callable<Long> uncompressEntry(final ZipFile zipFile, final ZipEntry entry, final File databaseDirectory) {
+    return () -> {
+      final File uncompressedFile = resolveTarget(entry, databaseDirectory);
+      final byte[] buffer = acquireBuffer();
+      long origSize = 0L;
+      try (final InputStream in = zipFile.getInputStream(entry);
+           final OutputStream out = new FileOutputStream(uncompressedFile)) {
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+          out.write(buffer, 0, len);
+          origSize += len;
+        }
+      } finally {
+        bufferPool.offer(buffer);
+      }
+
+      final long compressedSize = entry.getCompressedSize();
+      // ONE CALL, NOT THE log()+logLine() PAIR THE SEQUENTIAL PATH USES: SEVERAL THREADS LOG HERE AND A HALF-LINE
+      // FOLLOWED LATER BY ITS OTHER HALF WOULD INTERLEAVE INTO NONSENSE
+      if (compressedSize > -1)
+        logger.logLine(2, "- File '%s'... %s -> %s (%,d%% compression)", entry.getName(),
+            FileUtils.getSizeAsString(compressedSize), FileUtils.getSizeAsString(origSize),
+            origSize > 0 ? (origSize - compressedSize) * 100 / origSize : 0);
+      else
+        logger.logLine(2, "- File '%s'... uncompressed to %s", entry.getName(), FileUtils.getSizeAsString(origSize));
+
+      return origSize;
+    };
+  }
+
+  private byte[] acquireBuffer() {
+    final byte[] buffer = bufferPool.poll();
+    return buffer != null ? buffer : new byte[BUFFER_SIZE];
+  }
+
+  private static long drain(final Future<Long> result) throws IOException {
+    try {
+      return result.get();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RestoreException("Interrupted while restoring the database", e);
+    } catch (final ExecutionException e) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof IOException ioException)
+        throw ioException;
+      if (cause instanceof RuntimeException runtimeException)
+        throw runtimeException;
+      throw new RestoreException("Error while restoring the database", cause);
+    }
+  }
+
+  /**
+   * The same two checks the sequential path makes, in the same order: the name must be a plain file name, and the
+   * resolved path must stay inside the database directory.
+   */
+  private static File resolveTarget(final ZipEntry entry, final File databaseDirectory) throws IOException {
+    final String fileName = entry.getName();
+
+    FileUtils.checkValidName(fileName);
+
+    final File uncompressedFile = new File(databaseDirectory, fileName);
+    if (!uncompressedFile.toPath().normalize().startsWith(databaseDirectory.toPath().normalize()))
+      throw new IOException("Bad zip entry");
+
+    return uncompressedFile;
+  }
+
+  /** Uncompressed size when the central directory carries it, the compressed size otherwise. */
+  private static long entryWeight(final ZipEntry entry) {
+    final long size = entry.getSize();
+    return size >= 0 ? size : Math.max(entry.getCompressedSize(), 0);
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
@@ -100,6 +100,15 @@ public class ParallelZipExtractor {
   public record ExtractStats(int files, long uncompressedSize) {
   }
 
+  /**
+   * An entry and the file it will become. The target is resolved once, in the validation pass, and carried from
+   * there: the checks that produce it are the ones that decide whether the archive is acceptable at all, so
+   * recomputing them in the worker would mean the bytes are written against a second, later answer to a question
+   * already settled.
+   */
+  private record PlannedEntry(ZipEntry entry, File target) {
+  }
+
   private final int                        threads;
   private final ConsoleLogger              logger;
   private final ArrayBlockingQueue<byte[]> bufferPool;
@@ -128,21 +137,29 @@ public class ParallelZipExtractor {
       // THREADS WRITING ONE FILE HERE. NO ARCADEDB BACKUP CAN PRODUCE ONE - A DATABASE DIRECTORY HAS UNIQUE FILE
       // NAMES - SO REFUSING IS BETTER THAN INVENTING A LOCKING RULE FOR AN ARCHIVE NOBODY SHOULD BE RESTORING
       final Set<String> names = new HashSet<>(entries.size());
+      final List<PlannedEntry> plan = new ArrayList<>(entries.size());
       for (final ZipEntry entry : entries) {
-        resolveTarget(entry, databaseDirectory);
+        plan.add(new PlannedEntry(entry, resolveTarget(entry, databaseDirectory)));
         if (!names.add(entry.getName()))
           throw new IOException("The backup archive contains two entries named '%s'".formatted(entry.getName()));
       }
 
       // LARGEST FIRST: WITH ENTRIES THIS UNEVEN (A DATABASE IS A FEW BIG PAGE FILES AND A HANDFUL OF TINY ONES) THE
       // DURATION IS DECIDED BY HOW LATE THE BIGGEST ENTRY STARTS
-      entries.sort(Comparator.comparingLong(ParallelZipExtractor::entryWeight).reversed());
+      plan.sort(Comparator.comparingLong(planned -> -entryWeight(planned.entry())));
 
-      final int poolSize = Math.min(threads, entries.size());
+      final int poolSize = Math.min(threads, plan.size());
       if (poolSize < 1)
         return new ExtractStats(0, 0L);
 
       final AtomicInteger threadId = new AtomicInteger();
+      // THE QUEUE IS UNBOUNDED, WHERE THE #6072 BACKUP WRITER THIS OTHERWISE MIRRORS USES A BOUNDED ONE WITH
+      // CallerRunsPolicy, AND THE DIFFERENCE IS DELIBERATE. THERE, WORK IS PRODUCED CONTINUOUSLY WHILE THE FILE IS
+      // READ, SO THE QUEUE IS THE BACKPRESSURE THAT KEEPS CHUNK BUFFERS - MEGABYTES EACH - FROM PILING UP. HERE THE
+      // WHOLE WORKLIST IS KNOWN BEFORE THE POOL EXISTS AND IS SUBMITTED IN ONE CLOSED LOOP: ITS LENGTH IS THE NUMBER
+      // OF FILES IN A DATABASE, AND WHAT IS QUEUED IS AN ENTRY REFERENCE, NOT A BUFFER. A BOUNDED QUEUE WOULD ALSO
+      // COST SOMETHING REAL - CallerRunsPolicy WOULD MAKE THE SUBMITTING THREAD EXTRACT AN ENTRY, TAKING A BUFFER
+      // POOLED FOR THE WORKERS AND BREAKING THE "ONE BUFFER PER POOL THREAD" HEAP BOUND
       final ThreadPoolExecutor executor = new ThreadPoolExecutor(poolSize, poolSize, 0L, TimeUnit.MILLISECONDS,
           new LinkedBlockingQueue<>(), r -> {
         final Thread thread = new Thread(r, "arcadedb-restore-inflater-" + threadId.incrementAndGet());
@@ -151,15 +168,15 @@ public class ParallelZipExtractor {
       });
 
       try {
-        final List<Future<Long>> results = new ArrayList<>(entries.size());
-        for (final ZipEntry entry : entries)
-          results.add(executor.submit(uncompressEntry(zipFile, entry, databaseDirectory)));
+        final List<Future<Long>> results = new ArrayList<>(plan.size());
+        for (final PlannedEntry planned : plan)
+          results.add(executor.submit(uncompressEntry(zipFile, planned)));
 
         long databaseOrigSize = 0L;
         for (final Future<Long> result : results)
           databaseOrigSize += drain(result);
 
-        return new ExtractStats(entries.size(), databaseOrigSize);
+        return new ExtractStats(plan.size(), databaseOrigSize);
       } finally {
         // shutdownNow() ALONE IS NOT ENOUGH ON THE FAILURE PATH. IT DRAINS THE QUEUE, SO NO FURTHER ENTRY STARTS, BUT
         // THE INTERRUPT IT SENDS DOES NOT COME BACK OUT OF A FileOutputStream.write() OR A ZipFile READ - NEITHER IS
@@ -185,9 +202,10 @@ public class ParallelZipExtractor {
     }
   }
 
-  private Callable<Long> uncompressEntry(final ZipFile zipFile, final ZipEntry entry, final File databaseDirectory) {
+  private Callable<Long> uncompressEntry(final ZipFile zipFile, final PlannedEntry planned) {
     return () -> {
-      final File uncompressedFile = resolveTarget(entry, databaseDirectory);
+      final ZipEntry entry = planned.entry();
+      final File uncompressedFile = planned.target();
       final byte[] buffer = acquireBuffer();
       long origSize = 0L;
       try (final InputStream in = zipFile.getInputStream(entry);

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/ParallelZipExtractor.java
@@ -206,6 +206,17 @@ public class ParallelZipExtractor {
     return () -> {
       final ZipEntry entry = planned.entry();
       final File uncompressedFile = planned.target();
+
+      // THE FILESYSTEM'S OWN ANSWER TO "IS THIS THE SAME FILE?", WHICH COMPARING NAMES CANNOT GIVE: ON A
+      // CASE-INSENSITIVE FILESYSTEM - THE DEFAULT ON macOS AND WINDOWS - 'Doc_0.bucket' AND 'doc_0.bucket' ARE TWO
+      // DISTINCT ENTRY NAMES AND ONE FILE, WHICH IS THE VERY RACE THE DUPLICATE-NAME CHECK EXISTS TO PREVENT. IT
+      // CANNOT BE DECIDED UP FRONT WITHOUT GUESSING AT THE FILESYSTEM (AND GUESSING WRONG WOULD REFUSE AN ARCHIVE
+      // THAT RESTORES PERFECTLY WELL ON A CASE-SENSITIVE ONE), SO IT IS ASKED HERE, WHERE THE ANSWER IS AUTHORITATIVE.
+      // THE DESTINATION IS ALWAYS A FRESHLY CREATED DIRECTORY, SO NOTHING ELSE CAN MAKE THIS FAIL
+      if (!uncompressedFile.createNewFile())
+        throw new IOException(
+            "Cannot restore entry '%s': '%s' already exists".formatted(entry.getName(), uncompressedFile));
+
       final byte[] buffer = acquireBuffer();
       long origSize = 0L;
       try (final InputStream in = zipFile.getInputStream(entry);

--- a/integration/src/test/java/com/arcadedb/integration/importer/ConsoleLoggerConcurrencyTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/ConsoleLoggerConcurrencyTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A {@code LogListener} is a one-method interface, written once and called from wherever the logger happens to be
+ * used - and since the parallel restore of issue #6086 that is several threads at a time. The listeners in this tree
+ * write to streams that are not safe for concurrent use (the server's SSE progress channel writes straight to the
+ * exchange's output stream), so two overlapping callbacks would produce a corrupt event rather than merely
+ * out-of-order ones. The guarantee has to live in the logger, which is what this pins.
+ */
+class ConsoleLoggerConcurrencyTest {
+  @Test
+  void listenerCallbacksNeverOverlap() throws Exception {
+    final AtomicInteger inside = new AtomicInteger();
+    final AtomicInteger overlaps = new AtomicInteger();
+    final AtomicInteger delivered = new AtomicInteger();
+
+    final ConsoleLogger logger = new ConsoleLogger(0, message -> {
+      if (inside.incrementAndGet() > 1)
+        overlaps.incrementAndGet();
+      // WIDE ENOUGH THAT AN UNSERIALIZED SECOND CALLER WOULD BE SEEN, NOT MERELY POSSIBLE IN THEORY
+      try {
+        Thread.sleep(1);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      delivered.incrementAndGet();
+      inside.decrementAndGet();
+    });
+
+    final int threads = 8;
+    final int linesPerThread = 20;
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(threads);
+
+    for (int t = 0; t < threads; t++) {
+      final int id = t;
+      final Thread thread = new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < linesPerThread; i++)
+            logger.logLine(0, "thread %d line %d", id, i);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          done.countDown();
+        }
+      }, "ConsoleLoggerConcurrencyTest-" + t);
+      thread.setDaemon(true);
+      thread.start();
+    }
+
+    start.countDown();
+    assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(delivered.get()).isEqualTo(threads * linesPerThread);
+    assertThat(overlaps.get()).as("two threads were inside the listener at once").isZero();
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
@@ -337,6 +337,36 @@ class Issue6086ParallelRestoreIT {
     }
   }
 
+  /**
+   * Two names that differ only in case are one file on a case-insensitive filesystem (the default on macOS and
+   * Windows) and two files on a case-sensitive one, so the up-front name comparison cannot answer this and must not
+   * try: guessing "collision" would refuse an archive that restores perfectly well on Linux, where two ArcadeDB types
+   * named {@code Doc} and {@code doc} give exactly such a pair of bucket files. The filesystem is asked instead, at
+   * the moment the file is created, so this test asserts whichever answer the filesystem it runs on gives.
+   */
+  @Test
+  void twoNamesDifferingOnlyInCaseFollowTheFilesystem() throws Exception {
+    final String archive = "target/parallel-restore-case.zip";
+    final File destination = new File(RESTORED_PATH);
+    try {
+      writeArchive(archive, "Cased.bin", "cased.bin");
+      FileUtils.deleteRecursively(destination);
+      assertThat(destination.mkdirs()).isTrue();
+
+      if (isCaseInsensitive(destination))
+        assertThatThrownBy(() -> new ParallelZipExtractor(2, new ConsoleLogger(0)).extract(new File(archive), destination))
+            .isInstanceOf(IOException.class).hasMessageContaining("already exists");
+      else {
+        assertThat(new ParallelZipExtractor(2, new ConsoleLogger(0)).extract(new File(archive), destination).files())
+            .isEqualTo(2);
+        assertThat(destination.list()).containsExactlyInAnyOrder("Cased.bin", "cased.bin");
+      }
+    } finally {
+      new File(archive).delete();
+      FileUtils.deleteRecursively(destination);
+    }
+  }
+
   /** An archive with no entries at all is not a restore, on either path. */
   @ParameterizedTest
   @ValueSource(ints = { 0, 8 })
@@ -414,6 +444,17 @@ class Issue6086ParallelRestoreIT {
       Arrays.fill(b, off, off + produced, (byte) 0);
       remaining -= produced;
       return produced;
+    }
+  }
+
+  /** Asks the filesystem under {@code directory} whether it distinguishes two names by case. */
+  private static boolean isCaseInsensitive(final File directory) throws IOException {
+    final File probe = new File(directory, "CaseProbe");
+    try {
+      assertThat(probe.createNewFile()).isTrue();
+      return new File(directory, "caseprobe").exists();
+    } finally {
+      probe.delete();
     }
   }
 

--- a/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
@@ -28,6 +28,7 @@ import com.arcadedb.integration.backup.Backup;
 import com.arcadedb.integration.backup.IoThrottler;
 import com.arcadedb.integration.backup.format.ParallelZipArchiveWriter;
 import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.integration.restore.format.ParallelZipExtractor;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
@@ -45,11 +46,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -290,6 +294,49 @@ class Issue6086ParallelRestoreIT {
     }
   }
 
+  /**
+   * The failure that the up-front validation cannot catch: an entry that fails <b>while it is being extracted</b>,
+   * with other workers mid-write beside it. The guarantee this pins is the one a caller needs in order to clean up -
+   * the server's restore handler deletes the destination directory when a restore fails, and deleting a tree that
+   * threads are still writing into is a race - so when {@code extract} throws, no worker may still be writing.
+   * <p>
+   * The failure is injected where it is deterministic and portable: a directory planted at the target path of the
+   * largest entry, which makes that entry's {@code FileOutputStream} throw the moment it opens. Largest, because
+   * entries are handed out largest first, so it fails while the others have only just started their megabytes.
+   * The extractor is driven directly rather than through {@code Restore}, which would delete the planted directory
+   * along with the rest of the destination before extracting.
+   */
+  @Test
+  void aFailureMidExtractionLeavesNoWorkerStillWriting() throws Exception {
+    final String archive = "target/parallel-restore-failing.zip";
+    final File destination = new File(RESTORED_PATH);
+    try {
+      // THE PAYLOAD IS ALL ZEROES, WHICH IS THE POINT: IT COSTS A FEW HUNDRED KB OF ARCHIVE AND STILL MAKES THE
+      // SURVIVING WORKER WRITE 192 MB, SO "IS ANYTHING STILL WRITING?" IS A QUESTION WITH A STABLE ANSWER RATHER
+      // THAN A RACE THAT HAPPENS TO GO THE TEST'S WAY. THE POISONED ENTRY IS DECLARED LARGER SO IT IS HANDED OUT
+      // FIRST AND FAILS WHILE THE OTHER WORKER IS AT THE START OF ITS OWN
+      try (final FileOutputStream out = new FileOutputStream(archive)) {
+        final ParallelZipArchiveWriter writer = new ParallelZipArchiveWriter(out, 1, 2, new IoThrottler(0));
+        writer.addEntry("poisoned.bin", System.currentTimeMillis(), new ZeroInputStream(256L * 1024 * 1024));
+        writer.addEntry("payload.bin", System.currentTimeMillis(), new ZeroInputStream(192L * 1024 * 1024));
+        writer.close();
+      }
+
+      FileUtils.deleteRecursively(destination);
+      assertThat(new File(destination, "poisoned.bin").mkdirs()).isTrue();
+
+      assertThatThrownBy(() -> new ParallelZipExtractor(2, new ConsoleLogger(0)).extract(new File(archive), destination))
+          .isInstanceOf(IOException.class);
+
+      assertThat(liveRestoreThreads()).as("a worker was still running when extract() threw").isEmpty();
+      // AND THE FILE IT WAS WRITING IS WHOLE, NOT A PREFIX A LATE WORKER WAS STILL EXTENDING
+      assertThat(new File(destination, "payload.bin")).hasSize(192L * 1024 * 1024);
+    } finally {
+      new File(archive).delete();
+      FileUtils.deleteRecursively(destination);
+    }
+  }
+
   /** An archive with no entries at all is not a restore, on either path. */
   @ParameterizedTest
   @ValueSource(ints = { 0, 8 })
@@ -344,6 +391,36 @@ class Issue6086ParallelRestoreIT {
     for (final String name : expectedNames)
       assertThat(Files.mismatch(new File(expected, name).toPath(), new File(actual, name).toPath())).as(name)
           .isEqualTo(-1L);
+  }
+
+  /** A large entry that costs neither heap nor archive: a stream of zeroes, of a length the test picks. */
+  private static final class ZeroInputStream extends InputStream {
+    private long remaining;
+
+    private ZeroInputStream(final long length) {
+      this.remaining = length;
+    }
+
+    @Override
+    public int read() {
+      return remaining-- > 0 ? 0 : -1;
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) {
+      if (remaining <= 0)
+        return -1;
+      final int produced = (int) Math.min(len, remaining);
+      Arrays.fill(b, off, off + produced, (byte) 0);
+      remaining -= produced;
+      return produced;
+    }
+  }
+
+  /** The extractor's own workers, by the name it gives them, that are still alive. */
+  private static List<String> liveRestoreThreads() {
+    return Thread.getAllStackTraces().keySet().stream().filter(Thread::isAlive)
+        .map(Thread::getName).filter(name -> name.startsWith("arcadedb-restore-inflater-")).toList();
   }
 
   /** A hand-built archive: the restore has to defend itself against ZIPs no ArcadeDB backup would ever produce. */

--- a/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.restore;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseComparator;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.integration.backup.Backup;
+import com.arcadedb.integration.backup.IoThrottler;
+import com.arcadedb.integration.backup.format.ParallelZipArchiveWriter;
+import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.FileUtils;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end coverage of the parallel restore introduced by issue #6086. The contract being defended is that the
+ * thread count changes nothing but the duration: whatever it is set to, and whichever of the three input sources the
+ * archive comes from, the restored database is the same one - and the two sources that cannot be read at random,
+ * http(s) and encrypted, keep working by falling back rather than by failing.
+ */
+class Issue6086ParallelRestoreIT {
+  private static final String DATABASE_PATH  = "target/databases/parallel-restore";
+  private static final String RESTORED_PATH  = "target/databases/parallel-restore-restored";
+  private static final String BACKUP_FILE    = "target/parallel-restore.zip";
+  private static final String ENCRYPTED_FILE = "target/parallel-restore-encrypted.zip";
+  private static final String LEGACY_FILE    = "target/parallel-restore-legacy.zip";
+  private static final String ENCRYPTION_KEY = "AnotherTestWithHard2GuessPassword";
+  private static final int    RECORDS        = 20_000;
+
+  /** What was logged, and by which thread - the thread is what tells the two restore paths apart. */
+  private record LogLine(String thread, String message) {
+  }
+
+  @BeforeAll
+  static void buildTheArchives() throws Exception {
+    clean();
+    try (final Database database = createDatabase()) {
+      new Backup(database, BACKUP_FILE).setVerboseLevel(0).backupDatabase();
+      new Backup(database, ENCRYPTED_FILE).setVerboseLevel(0).setEncryptionKey(ENCRYPTION_KEY).backupDatabase();
+      // THE SHAPE EVERY BACKUP HAD BEFORE #6072: THE SINGLE-THREADED WRITER AT LEVEL 9
+      new Backup(database, LEGACY_FILE).setVerboseLevel(0).setCompressionThreads(0).setCompressionLevel(9).backupDatabase();
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  @AfterAll
+  static void clean() {
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    new File(BACKUP_FILE).delete();
+    new File(ENCRYPTED_FILE).delete();
+    new File(LEGACY_FILE).delete();
+  }
+
+  /**
+   * The whole point of the issue, and the only assertion that can catch a restore that is fast and wrong: whatever the
+   * thread count - the legacy sequential walk, one worker, several, or the automatic sizing - the database that comes
+   * out is the one that went in.
+   */
+  @ParameterizedTest
+  @ValueSource(ints = { 0, 1, 2, 8, -1 })
+  void restoresTheSameDatabaseWhateverTheThreadCount(final int threads) throws Exception {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+    final List<LogLine> log = restore(BACKUP_FILE, RESTORED_PATH, threads, null);
+
+    assertThat(header(log)).contains(threads == 0 ? "single threaded" : "threads");
+
+    try (final Database source = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY);
+         final Database restored = new DatabaseFactory(RESTORED_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+      new DatabaseComparator().compare(source, restored);
+      assertThat(restored.countType("Doc", true)).isEqualTo(RECORDS);
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /**
+   * "The same database" as {@code DatabaseComparator} understands it is a strong claim, but it is a claim about
+   * contents, not about bytes. The files the parallel path writes have to be identical to the ones the sequential path
+   * writes, byte for byte, because that is what makes the two paths interchangeable rather than merely equivalent.
+   */
+  @Test
+  void theParallelPathWritesTheSameBytesAsTheSequentialOne() throws Exception {
+    final String sequentialPath = RESTORED_PATH + "_sequential";
+    try {
+      FileUtils.deleteRecursively(new File(sequentialPath));
+      FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+      final List<LogLine> sequentialLog = restore(BACKUP_FILE, sequentialPath, 0, null);
+      final List<LogLine> parallelLog = restore(BACKUP_FILE, RESTORED_PATH, 8, null);
+
+      // PROVE THE TWO RUNS REALLY TOOK DIFFERENT PATHS, OR THIS TEST WOULD BE COMPARING A PATH WITH ITSELF
+      assertThat(header(sequentialLog)).contains("single threaded");
+      assertThat(header(parallelLog)).contains("8 threads");
+      assertThat(entryLines(parallelLog)).isNotEmpty()
+          .allMatch(line -> line.thread().startsWith("arcadedb-restore-inflater-"));
+      assertThat(entryLines(sequentialLog)).isEmpty();
+
+      assertSameFiles(new File(sequentialPath), new File(RESTORED_PATH));
+    } finally {
+      FileUtils.deleteRecursively(new File(sequentialPath));
+    }
+  }
+
+  /**
+   * The two input sources that cannot be opened for random access. Neither may fail, and neither may silently take the
+   * parallel path: a {@code CipherInputStream} only decrypts front to back and an http body is a one-shot stream, so
+   * both have to be recognised before the archive is opened, not after.
+   */
+  @Test
+  void anEncryptedArchiveFallsBackToTheSequentialWalk() throws Exception {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+    final List<LogLine> log = restore(ENCRYPTED_FILE, RESTORED_PATH, 8, ENCRYPTION_KEY);
+
+    assertThat(header(log)).contains("single threaded");
+
+    try (final Database source = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY);
+         final Database restored = new DatabaseFactory(RESTORED_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+      new DatabaseComparator().compare(source, restored);
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  @Test
+  void anArchiveReadOverHttpFallsBackToTheSequentialWalk() throws Exception {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+    final HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    final byte[] archive = Files.readAllBytes(new File(BACKUP_FILE).toPath());
+    server.createContext("/backup.zip", exchange -> {
+      exchange.sendResponseHeaders(200, archive.length);
+      try (final OutputStream out = exchange.getResponseBody()) {
+        out.write(archive);
+      }
+    });
+    server.start();
+    try {
+      final String url = "http://localhost:" + server.getAddress().getPort() + "/backup.zip";
+      final List<LogLine> log = restore(url, RESTORED_PATH, 8, null);
+
+      assertThat(header(log)).contains("single threaded");
+
+      try (final Database source = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY);
+           final Database restored = new DatabaseFactory(RESTORED_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+        new DatabaseComparator().compare(source, restored);
+      }
+    } finally {
+      server.stop(0);
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  /** An archive written the way every archive was written before #6072 has to restore through the new path unchanged. */
+  @Test
+  void aLegacySingleThreadedArchiveRestoresThroughTheParallelPath() throws Exception {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+    final List<LogLine> log = restore(LEGACY_FILE, RESTORED_PATH, 8, null);
+    assertThat(header(log)).contains("8 threads");
+
+    try (final Database source = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY);
+         final Database restored = new DatabaseFactory(RESTORED_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+      new DatabaseComparator().compare(source, restored);
+    }
+    TestHelper.checkActiveDatabases();
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "0, single threaded", "3, 3 threads" })
+  void theGlobalConfigurationDecidesWhenTheSettingIsNotGiven(final int configured, final String expected)
+      throws Exception {
+    final int old = GlobalConfiguration.RESTORE_THREADS.getValueAsInteger();
+    try {
+      GlobalConfiguration.RESTORE_THREADS.setValue(configured);
+      FileUtils.deleteRecursively(new File(RESTORED_PATH));
+
+      final List<LogLine> log = restore(BACKUP_FILE, RESTORED_PATH, null, null);
+      assertThat(header(log)).contains(expected);
+
+      try (final Database source = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY);
+           final Database restored = new DatabaseFactory(RESTORED_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+        new DatabaseComparator().compare(source, restored);
+      }
+    } finally {
+      GlobalConfiguration.RESTORE_THREADS.setValue(old);
+      TestHelper.checkActiveDatabases();
+    }
+  }
+
+  /**
+   * Zip-slip, on both paths. The parallel path can do strictly better than the sequential one and has to: it reads the
+   * central directory before it starts, so it knows every entry name up front and can refuse the archive before a
+   * single file has been written. The sequential walk only learns a name when it reaches it, so it stops at the bad
+   * entry with the good ones already on disk - which is the pre-existing behaviour, asserted here so that the
+   * difference is a recorded decision rather than an accident.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "../escaped.txt", "sub/escaped.txt", ".." })
+  void aHostileEntryNameIsRefusedBeforeAnythingIsWritten(final String hostileName) throws Exception {
+    final String hostileArchive = "target/parallel-restore-hostile.zip";
+    final File destination = new File(RESTORED_PATH);
+    try {
+      writeArchive(hostileArchive, "innocent.txt", hostileName);
+
+      FileUtils.deleteRecursively(destination);
+      assertThatThrownBy(() -> restore(hostileArchive, RESTORED_PATH, 8, null)).isInstanceOf(RestoreException.class);
+      assertThat(destination.list()).as("the parallel path refuses the archive before writing anything").isEmpty();
+
+      FileUtils.deleteRecursively(destination);
+      assertThatThrownBy(() -> restore(hostileArchive, RESTORED_PATH, 0, null)).isInstanceOf(RestoreException.class);
+    } finally {
+      new File(hostileArchive).delete();
+      FileUtils.deleteRecursively(destination);
+    }
+  }
+
+  /**
+   * Two entries of the same name are harmless when they are written one after the other - the second wins, which is
+   * what the sequential walk does - and are two threads writing one file on the parallel path. No ArcadeDB backup can
+   * produce such an archive, so it is refused up front rather than given a locking rule of its own.
+   */
+  @Test
+  void twoEntriesOfTheSameNameAreRefused() throws Exception {
+    final String duplicateArchive = "target/parallel-restore-duplicate.zip";
+    try {
+      // ZipOutputStream REFUSES TO WRITE A DUPLICATE NAME, SO THE ARCHIVE IS BUILT WITH ARCADEDB'S OWN WRITER, WHICH
+      // DOES NOT CHECK - WHICH IS ALSO WHY THE CHECK BELONGS ON THE READING SIDE
+      try (final FileOutputStream out = new FileOutputStream(duplicateArchive)) {
+        final ParallelZipArchiveWriter writer = new ParallelZipArchiveWriter(out, 1, 1, new IoThrottler(0));
+        for (int i = 0; i < 2; i++)
+          writer.addEntry("twice.txt", System.currentTimeMillis(),
+              new ByteArrayInputStream(("copy " + i).getBytes(StandardCharsets.UTF_8)));
+        writer.close();
+      }
+
+      FileUtils.deleteRecursively(new File(RESTORED_PATH));
+      assertThatThrownBy(() -> restore(duplicateArchive, RESTORED_PATH, 8, null)).isInstanceOf(RestoreException.class)
+          .hasRootCauseMessage("The backup archive contains two entries named 'twice.txt'");
+      assertThat(new File(RESTORED_PATH).list()).isEmpty();
+    } finally {
+      new File(duplicateArchive).delete();
+      FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    }
+  }
+
+  /** An archive with no entries at all is not a restore, on either path. */
+  @ParameterizedTest
+  @ValueSource(ints = { 0, 8 })
+  void anEmptyArchiveIsRefused(final int threads) throws Exception {
+    final String emptyArchive = "target/parallel-restore-empty.zip";
+    try {
+      writeArchive(emptyArchive);
+
+      FileUtils.deleteRecursively(new File(RESTORED_PATH));
+      assertThatThrownBy(() -> restore(emptyArchive, RESTORED_PATH, threads, null))
+          .isInstanceOf(RestoreException.class).hasMessageContaining("Error during restore");
+    } finally {
+      new File(emptyArchive).delete();
+      FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    }
+  }
+
+  // ------------------------------------------------------------------------------------------------------- HELPERS
+
+  private static List<LogLine> restore(final String archive, final String destination, final Integer threads,
+      final String encryptionKey) {
+    final List<LogLine> log = Collections.synchronizedList(new ArrayList<>());
+
+    final Restore restore = encryptionKey != null ?
+        new Restore(("-f " + archive + " -d " + destination + " -o -encryptionKey " + encryptionKey).split(" ")) :
+        new Restore(archive, destination);
+    if (threads != null)
+      restore.setRestoreThreads(threads);
+
+    restore.setLogger(new ConsoleLogger(2, message -> log.add(new LogLine(Thread.currentThread().getName(), message))));
+    restore.restoreDatabase();
+    return log;
+  }
+
+  /** The single level-0 line the restore opens with, which states which path it took. */
+  private static String header(final List<LogLine> log) {
+    return log.stream().map(LogLine::message).filter(message -> message.startsWith("Executing full restore")).findFirst()
+        .orElseThrow(() -> new AssertionError("the restore logged no header line: " + log));
+  }
+
+  /** The per-entry lines, which only the parallel path emits as a whole line (and from a worker thread). */
+  private static List<LogLine> entryLines(final List<LogLine> log) {
+    return log.stream().filter(line -> line.message().startsWith("- File '")).toList();
+  }
+
+  private static void assertSameFiles(final File expected, final File actual) throws Exception {
+    final String[] expectedNames = expected.list();
+    final String[] actualNames = actual.list();
+    assertThat(expectedNames).isNotNull();
+    assertThat(actualNames).containsExactlyInAnyOrder(expectedNames);
+
+    for (final String name : expectedNames)
+      assertThat(Files.mismatch(new File(expected, name).toPath(), new File(actual, name).toPath())).as(name)
+          .isEqualTo(-1L);
+  }
+
+  /** A hand-built archive: the restore has to defend itself against ZIPs no ArcadeDB backup would ever produce. */
+  private static void writeArchive(final String path, final String... entryNames) throws Exception {
+    try (final ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(path), StandardCharsets.UTF_8)) {
+      for (final String entryName : entryNames) {
+        zip.putNextEntry(new ZipEntry(entryName));
+        zip.write(("content of " + entryName).getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+      }
+    }
+  }
+
+  private static Database createDatabase() {
+    final Database database = new DatabaseFactory(DATABASE_PATH).create();
+    database.transaction(() -> {
+      final VertexType type = database.getSchema().createVertexType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("payload", Type.STRING);
+      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+    });
+
+    database.begin();
+    for (int i = 0; i < RECORDS; i++) {
+      database.newVertex("Doc").set("id", i).set("payload", "record-" + i + "-" + "x".repeat(200)).save();
+      if (i % 1000 == 0) {
+        database.commit();
+        database.begin();
+      }
+    }
+    database.commit();
+    return database;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/restore/RestoreParallelBenchmark.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/RestoreParallelBenchmark.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.restore;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.integration.backup.Backup;
+import com.arcadedb.integration.restore.format.ParallelZipExtractor;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Before/after measurements required by issue #6086, in the same shape as the #6072 backup table so the two can be
+ * read together. Two questions have to be answered with numbers rather than intuition:
+ * <ol>
+ *   <li><b>Is the restore inflate-bound or write-bound?</b> {@link #whereTheRestoreSpendsItsTime()} answers it by
+ *       timing the two halves separately - inflating every entry and throwing the bytes away, then writing the same
+ *       number of bytes with no inflation - against the whole restore.</li>
+ *   <li><b>What does the parallelism buy, and at what heap?</b> {@link #restoreThreadSweep()} times the pre-#6086
+ *       path (a single thread and an 8 KB buffer, reimplemented here so "before" is measured rather than
+ *       remembered), the same walk with the larger buffer, and the parallel path from 1 to 8 threads.</li>
+ * </ol>
+ * Excluded from the normal build ({@code @Tag("benchmark")}). Run it explicitly:
+ * <pre>
+ *   mvn -o -pl integration -am test -Dtest=RestoreParallelBenchmark -Darcadedb.restore.benchmark.sizesMB=256,1024
+ * </pre>
+ */
+@Tag("benchmark")
+class RestoreParallelBenchmark {
+  private static final String DATABASE_PATH = "target/databases/restore-benchmark";
+  private static final String RESTORED_PATH = "target/databases/restore-benchmark-restored";
+  private static final String BACKUP_FILE   = "target/restore-benchmark.zip";
+  private static final String LEGACY_FILE   = "target/restore-benchmark-legacy.zip";
+  private static final int    PAYLOAD_SIZE  = 512;
+  private static final int    LEGACY_BUFFER = 8192;
+
+  private record Measurement(String label, long elapsedMs, long peakHeapBytes) {
+  }
+
+  @Test
+  void restoreThreadSweep() throws Exception {
+    for (final int types : types())
+      for (final int sizeMB : sizes()) {
+        final long databaseSize = buildFixture(sizeMB, types);
+        final List<Measurement> measurements = new ArrayList<>();
+
+        // WARM THE PAGE CACHE AND THE JIT SO THE FIRST CONFIGURATION IS NOT PENALISED
+        measure("warmup", () -> sequentialRestore(new File(BACKUP_FILE), LEGACY_BUFFER, false));
+
+        measurements.add(measure("sequential, 8KB buffer, unbuffered read (before #6086)",
+            () -> sequentialRestore(new File(BACKUP_FILE), LEGACY_BUFFER, false)));
+        measurements.add(measure("sequential, 8KB buffer, buffered read",
+            () -> sequentialRestore(new File(BACKUP_FILE), LEGACY_BUFFER, true)));
+        measurements.add(measure("sequential, 256KB buffer, buffered read",
+            () -> sequentialRestore(new File(BACKUP_FILE), ParallelZipExtractor.BUFFER_SIZE, true)));
+        measurements.add(measure("restore, threads=0 (sequential path)", () -> restore(BACKUP_FILE, 0)));
+
+        for (final int threads : new int[] { 1, 2, 4, 8 })
+          measurements.add(measure("restore, threads=" + threads, () -> restore(BACKUP_FILE, threads)));
+
+        measurements.add(measure("legacy level-9 archive, threads=0", () -> restore(LEGACY_FILE, 0)));
+        measurements.add(measure("legacy level-9 archive, threads=8", () -> restore(LEGACY_FILE, 8)));
+
+        report(sizeMB, types, databaseSize, measurements);
+      }
+  }
+
+  /**
+   * The measurement the issue asks for first, because the two answers point at different fixes: if the restore is
+   * write-bound the buffer size is most of the win, and if it is inflate-bound only real parallelism helps.
+   */
+  @Test
+  void whereTheRestoreSpendsItsTime() throws Exception {
+    for (final int sizeMB : sizes()) {
+      final long databaseSize = buildFixture(sizeMB, 1);
+
+      final long inflateOnly = time(() -> inflateEverything(new File(BACKUP_FILE)));
+      final long writeOnly = time(() -> writeEverything(new File(BACKUP_FILE)));
+      final long whole = time(() -> sequentialRestore(new File(BACKUP_FILE), LEGACY_BUFFER, false));
+
+      System.out.printf("%n[restore-benchmark] %,d MB target, %s on disk: inflate-only %,d ms, write-only %,d ms, "
+              + "whole sequential restore %,d ms (sum of the halves %,d ms)%n", sizeMB,
+          FileUtils.getSizeAsString(databaseSize), inflateOnly, writeOnly, whole, inflateOnly + writeOnly);
+    }
+  }
+
+  // ------------------------------------------------------------------------------------------------------- HELPERS
+
+  private static int[] sizes() {
+    return intList("arcadedb.restore.benchmark.sizesMB", "256,1024");
+  }
+
+  /**
+   * How many vertex types the fixture is spread over, which is what decides how much the per-entry parallelism can
+   * possibly buy: one type is one dominant archive entry and therefore the worst case for it, several types are
+   * several entries of comparable size and therefore the case it was built for. Both are real database shapes and the
+   * numbers are only meaningful when both are reported.
+   */
+  private static int[] types() {
+    return intList("arcadedb.restore.benchmark.types", "1,8");
+  }
+
+  private static int[] intList(final String property, final String fallback) {
+    final String[] parts = System.getProperty(property, fallback).split(",");
+    final int[] values = new int[parts.length];
+    for (int i = 0; i < parts.length; i++)
+      values[i] = Integer.parseInt(parts[i].trim());
+    return values;
+  }
+
+  /**
+   * Builds a database of roughly {@code sizeMB} spread over {@code types} vertex types, its default archive and a
+   * pre-#6072 one, and returns its size on disk.
+   */
+  private static long buildFixture(final int sizeMB, final int types) throws Exception {
+    clean();
+
+    try (final Database database = new DatabaseFactory(DATABASE_PATH).create()) {
+      database.transaction(() -> {
+        for (int t = 0; t < types; t++) {
+          final VertexType type = database.getSchema().createVertexType("Doc" + t);
+          type.createProperty("id", Type.LONG);
+          type.createProperty("payload", Type.STRING);
+          type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+        }
+      });
+
+      final long records = (long) sizeMB * 1024 * 1024 / (PAYLOAD_SIZE + 64);
+      final Random random = new Random(17);
+      long id = 0;
+      while (id < records) {
+        final long from = id;
+        database.transaction(() -> {
+          for (int i = 0; i < 5_000; i++)
+            database.newVertex("Doc" + ((from + i) % types)).set("id", from + i).set("payload", payload(random)).save();
+        });
+        id += 5_000;
+      }
+
+      new Backup(database, BACKUP_FILE).setVerboseLevel(0).backupDatabase();
+      new Backup(database, LEGACY_FILE).setVerboseLevel(0).setCompressionThreads(0).setCompressionLevel(9)
+          .backupDatabase();
+    }
+
+    return directorySize(new File(DATABASE_PATH));
+  }
+
+  private static void clean() {
+    FileUtils.deleteRecursively(new File(DATABASE_PATH));
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    new File(BACKUP_FILE).delete();
+    new File(LEGACY_FILE).delete();
+  }
+
+  private interface Work {
+    void run() throws Exception;
+  }
+
+  private static void restore(final String archive, final int threads) {
+    new Restore(archive, RESTORED_PATH).setVerboseLevel(0).setRestoreThreads(threads).restoreDatabase();
+  }
+
+  private static Measurement measure(final String label, final Work work) throws Exception {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    System.gc();
+
+    final HeapSampler sampler = new HeapSampler();
+    sampler.start();
+    final long elapsed = time(work);
+    sampler.stop();
+
+    return new Measurement(label, elapsed, sampler.peak());
+  }
+
+  private static long time(final Work work) throws Exception {
+    FileUtils.deleteRecursively(new File(RESTORED_PATH));
+    final long begin = System.currentTimeMillis();
+    work.run();
+    return System.currentTimeMillis() - begin;
+  }
+
+  /**
+   * The pre-#6086 restore, reimplemented so the "before" column is a measurement and not a memory: one thread
+   * alternating between inflating into a fixed buffer and writing it out. {@code bufferedRead} controls the other
+   * half of the story - {@code ZipInputStream} fills its inflater 512 bytes at a time, so whether there is a buffer
+   * under it matters more than how big the copy buffer above it is.
+   */
+  private static void sequentialRestore(final File archive, final int bufferSize, final boolean bufferedRead)
+      throws IOException {
+    final File directory = new File(RESTORED_PATH);
+    directory.mkdirs();
+
+    final InputStream source = bufferedRead ?
+        new BufferedInputStream(new FileInputStream(archive), ParallelZipExtractor.BUFFER_SIZE) :
+        new FileInputStream(archive);
+
+    final byte[] buffer = new byte[bufferSize];
+    try (final ZipInputStream zip = new ZipInputStream(source)) {
+      ZipEntry entry = zip.getNextEntry();
+      while (entry != null) {
+        try (final OutputStream out = new FileOutputStream(new File(directory, entry.getName()))) {
+          int len;
+          while ((len = zip.read(buffer)) > 0)
+            out.write(buffer, 0, len);
+        }
+        entry = zip.getNextEntry();
+      }
+    }
+  }
+
+  /** Inflates every entry and throws the bytes away: the inflate half of the restore, with no writing at all. */
+  private static long inflateEverything(final File archive) throws IOException {
+    final byte[] buffer = new byte[LEGACY_BUFFER];
+    long total = 0;
+    try (final ZipInputStream zip = new ZipInputStream(new FileInputStream(archive))) {
+      ZipEntry entry = zip.getNextEntry();
+      while (entry != null) {
+        int len;
+        while ((len = zip.read(buffer)) > 0)
+          total += len;
+        entry = zip.getNextEntry();
+      }
+    }
+    return total;
+  }
+
+  /**
+   * The write half of the restore with no inflation at all: the same files, of the same sizes, written in the same
+   * 8 KB units, but fed from one already-resident buffer instead of from a {@code ZipInputStream}. Holding a whole
+   * entry in heap to write its real bytes would be the wrong measurement anyway - what is being timed here is the
+   * filesystem, and the filesystem does not care what the bytes are. Entry sizes come from the central directory,
+   * which is why this one uses {@link ZipFile}: reading them is free there.
+   */
+  private static void writeEverything(final File archive) throws IOException {
+    final File directory = new File(RESTORED_PATH);
+    directory.mkdirs();
+
+    try (final ZipFile zip = new ZipFile(archive)) {
+      final byte[] buffer = new byte[LEGACY_BUFFER];
+      final Enumeration<? extends ZipEntry> entries = zip.entries();
+      while (entries.hasMoreElements()) {
+        final ZipEntry entry = entries.nextElement();
+        long remaining = entry.getSize();
+        if (remaining < 0)
+          try (final InputStream in = zip.getInputStream(entry)) {
+            remaining = in.readAllBytes().length;
+          }
+        try (final OutputStream out = new FileOutputStream(new File(directory, entry.getName()))) {
+          while (remaining > 0) {
+            final int chunk = (int) Math.min(buffer.length, remaining);
+            out.write(buffer, 0, chunk);
+            remaining -= chunk;
+          }
+        }
+      }
+    }
+  }
+
+  private static void report(final int sizeMB, final int types, final long databaseSize,
+      final List<Measurement> measurements) {
+    final Measurement reference = measurements.getFirst();
+    System.out.printf("%n[restore-benchmark] %,d MB target over %d type(s), database on disk: %s%n", sizeMB, types,
+        FileUtils.getSizeAsString(databaseSize));
+    System.out.printf("%-46s %10s %10s %10s %10s%n", "configuration", "seconds", "MB/s", "vs before", "peak heap");
+    for (final Measurement m : measurements) {
+      final double seconds = m.elapsedMs() / 1000.0;
+      System.out.printf("%-46s %10.2f %10.1f %9.2fx %10s%n", m.label(), seconds,
+          seconds > 0 ? databaseSize / 1024.0 / 1024.0 / seconds : 0,
+          m.elapsedMs() > 0 ? reference.elapsedMs() / (double) m.elapsedMs() : 0,
+          FileUtils.getSizeAsString(m.peakHeapBytes()));
+    }
+  }
+
+  private static final class HeapSampler {
+    private final AtomicLong    peak    = new AtomicLong();
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private       Thread        thread;
+
+    void start() {
+      thread = new Thread(() -> {
+        while (running.get()) {
+          peak.accumulateAndGet(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed(), Math::max);
+          try {
+            Thread.sleep(25);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+        }
+      }, "restore-benchmark-heap-sampler");
+      thread.setDaemon(true);
+      thread.start();
+    }
+
+    void stop() throws InterruptedException {
+      running.set(false);
+      thread.join();
+    }
+
+    long peak() {
+      return peak.get();
+    }
+  }
+
+  private static String payload(final Random random) {
+    final StringBuilder builder = new StringBuilder(PAYLOAD_SIZE);
+    // HALF STRUCTURED, HALF RANDOM: PAGES THAT COMPRESS LIKE REAL DATA RATHER THAN LIKE A BEST OR WORST CASE
+    while (builder.length() < PAYLOAD_SIZE / 2)
+      builder.append("field").append(builder.length()).append("=value;");
+    while (builder.length() < PAYLOAD_SIZE)
+      builder.append((char) ('a' + random.nextInt(26)));
+    return builder.toString();
+  }
+
+  private static long directorySize(final File directory) {
+    long size = 0;
+    final File[] files = directory.listFiles();
+    if (files != null)
+      for (final File file : files)
+        size += file.isDirectory() ? directorySize(file) : file.length();
+    return size;
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/restore/RestoreSettingsTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/RestoreSettingsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.restore;
+
+import com.arcadedb.GlobalConfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Command-line and API surface of the restore-thread setting added by issue #6086. A bad value has to be rejected
+ * where the user typed it, not several frames later inside a {@code ThreadPoolExecutor} constructor.
+ */
+class RestoreSettingsTest {
+  @Test
+  void parsesTheThreadParameter() {
+    final RestoreSettings settings = new RestoreSettings();
+    settings.parseParameter("restoreThreads", "4");
+
+    assertThat(settings.restoreThreads).isEqualTo(4);
+  }
+
+  @Test
+  void leavesItUnsetSoTheGlobalConfigurationApplies() {
+    assertThat(new RestoreSettings().restoreThreads).isNull();
+  }
+
+  @Test
+  void acceptsTheTwoSpecialThreadValues() {
+    final RestoreSettings settings = new RestoreSettings();
+    settings.parseParameter("restoreThreads", "0");
+    assertThat(settings.restoreThreads).isZero();
+
+    settings.parseParameter("restoreThreads", "-1");
+    assertThat(settings.restoreThreads).isEqualTo(-1);
+  }
+
+  @Test
+  void rejectsOutOfRangeAndNonNumericValues() {
+    final RestoreSettings settings = new RestoreSettings();
+
+    assertThatThrownBy(() -> settings.parseParameter("restoreThreads", "-2"))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("restoreThreads");
+    assertThatThrownBy(() -> settings.parseParameter("restoreThreads", String.valueOf(RestoreSettings.MAX_RESTORE_THREADS + 1)))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("restoreThreads");
+    assertThatThrownBy(() -> settings.parseParameter("restoreThreads", "all"))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("integer");
+  }
+
+  @Test
+  void parsesTheWholeCommandLine() {
+    final Restore restore = new Restore("-f target/x.zip -d target/db -o -restoreThreads 2".split(" "));
+
+    assertThat(restore.settings.restoreThreads).isEqualTo(2);
+  }
+
+  @Test
+  void theApiValidatesTheSameWayTheCommandLineDoes() {
+    assertThatThrownBy(() -> new Restore("target/x.zip", "target/db").setRestoreThreads(-2))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("restoreThreads");
+
+    assertThat(new Restore("target/x.zip", "target/db").setRestoreThreads(0).settings.restoreThreads).isZero();
+  }
+
+  /**
+   * A value can also arrive straight from a system property, a configuration file or {@code setValue}, all of which
+   * bypass the CLI and the API, so the bound has to live on the setting itself.
+   */
+  @Test
+  void globalConfigurationRejectsOutOfRangeValues() {
+    final int oldThreads = GlobalConfiguration.RESTORE_THREADS.getValueAsInteger();
+    try {
+      assertThatThrownBy(() -> GlobalConfiguration.RESTORE_THREADS.setValue(-2))
+          .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("arcadedb.restore.threads");
+
+      // A REJECTED VALUE MUST NOT BE LEFT BEHIND
+      assertThat(GlobalConfiguration.RESTORE_THREADS.getValueAsInteger()).isEqualTo(oldThreads);
+
+      GlobalConfiguration.RESTORE_THREADS.setValue(0);
+      assertThat(GlobalConfiguration.RESTORE_THREADS.getValueAsInteger()).isZero();
+    } finally {
+      GlobalConfiguration.RESTORE_THREADS.setValue(oldThreads);
+    }
+  }
+
+  /**
+   * The thread bound exists twice - {@link RestoreSettings#MAX_RESTORE_THREADS} for the CLI and the API, and a
+   * repeated literal in {@code GlobalConfiguration} because the engine module cannot depend on this one. A comment
+   * asking the next editor to change both is not enforcement; this is. It fails the moment they drift.
+   */
+  @Test
+  void restoreThreadBoundMatchesTheGlobalConfiguration() {
+    final int oldThreads = GlobalConfiguration.RESTORE_THREADS.getValueAsInteger();
+    try {
+      GlobalConfiguration.RESTORE_THREADS.setValue(RestoreSettings.MAX_RESTORE_THREADS);
+      assertThat(GlobalConfiguration.RESTORE_THREADS.getValueAsInteger()).isEqualTo(RestoreSettings.MAX_RESTORE_THREADS);
+
+      assertThatThrownBy(() -> GlobalConfiguration.RESTORE_THREADS.setValue(RestoreSettings.MAX_RESTORE_THREADS + 1))
+          .isInstanceOf(IllegalArgumentException.class);
+    } finally {
+      GlobalConfiguration.RESTORE_THREADS.setValue(oldThreads);
+    }
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/restore/format/FullRestoreFormatThreadSizingTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/format/FullRestoreFormatThreadSizingTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.restore.format;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the automatic restore-thread count of issue #6086, and with it the one place where the restore deliberately
+ * differs from the backup: a backup halves the cores because it runs alongside the workload it is already throttling,
+ * while a restore has no such neighbour - the database it is producing is not open yet - so it takes whole cores.
+ * A one-character edit could turn one into the other without anything else failing.
+ */
+class FullRestoreFormatThreadSizingTest {
+  @ParameterizedTest
+  @CsvSource({
+      "1, 1",
+      "2, 2",
+      "3, 3",
+      "4, 4",
+      "8, 8",
+      "16, 8",   // THE CAP: PAST A HANDFUL OF THREADS THE LIMIT IS THE ENTRY COUNT AND THE DISK, NOT THE CORES
+      "64, 8",
+      "128, 8" })
+  void autoSizingTakesTheWholeCoresAndCapsAtEight(final int availableProcessors, final int expected) {
+    assertThat(FullRestoreFormat.autoRestoreThreads(availableProcessors)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "0", "-1" })
+  void neverReturnsAnUnusableThreadCount(final int availableProcessors) {
+    assertThat(FullRestoreFormat.autoRestoreThreads(availableProcessors)).isEqualTo(1);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -703,10 +703,19 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       exchange.startBlocking();
   }
 
+  /**
+   * An SSE event is two writes plus a flush, and the stream it goes to is the exchange's own - shared, and not safe
+   * for concurrent use. More than one thread reaches here: the import path polls {@code ImporterContext} for progress
+   * on a thread of its own while the importer logs on another, and since #6086 a parallel restore logs one line per
+   * archive entry from its worker pool. Without the lock two events interleave into a single corrupt {@code data:}
+   * frame - which the client cannot parse - rather than merely arriving in an unexpected order.
+   */
   private static void sendSSE(final OutputStream out, final JSONObject data) {
     try {
-      out.write(("data: " + data + "\n\n").getBytes(StandardCharsets.UTF_8));
-      out.flush();
+      synchronized (out) {
+        out.write(("data: " + data + "\n\n").getBytes(StandardCharsets.UTF_8));
+        out.flush();
+      }
     } catch (final IOException ignored) {
       // Client disconnected
     }


### PR DESCRIPTION
Closes #6086

Backup phase 1 (#6072) made the full backup 27x faster and thereby moved the bottleneck: on the same 1.25 GB database the backup took 0.68 s and the restore that undoes it 2.9 s. This makes the restore inflate entries in parallel, one entry per thread, and fixes the read pattern that was costing more than the parallelism buys on a single-file database. The archive format is untouched: nothing here reads anything the backup did not already write, and pre-#6072 single-threaded level-9 archives restore through the new path unchanged.

## Measure first, as the issue asked

`RestoreParallelBenchmark` (`@Tag("benchmark")`, never runs in CI) times the two halves of a restore separately. On the 1.25 GB fixture: **inflating every entry and discarding the bytes takes 2.96 s, writing the same bytes with no inflation takes 0.93 s**. The restore is inflate-bound, so the issue's "the 8 KB copy buffer is suspiciously small" hypothesis is the wrong one - raising that buffer to 256 KB is worth about 1%.

The read side was worth a great deal, for a reason nobody had looked at: `ZipInputStream` fills its inflater **512 bytes at a time** (a size its constructor hardcodes, with no overload) and the restore handed it an unbuffered `FileInputStream` - one read syscall per 512 compressed bytes for the whole archive. A 256 KB `BufferedInputStream` under it takes the sequential restore from 5.16 s to 3.96 s, and it is the only speedup available to the two input sources that cannot be parallel at all.

## The change

- **`ParallelZipExtractor`** (new): opens the archive with `ZipFile`, hands entries to a dedicated pool largest-first (the makespan of uneven independent tasks is decided by when the biggest one starts), and writes each entry to its own file. No `ForkJoinPool.commonPool()`; the pool's lifetime is exactly one restore, and peak heap is bounded by construction at one 256 KB copy buffer per pool thread taken from a pool of exactly that many.
- **`arcadedb.restore.threads`**: `-1` (default) = available processors capped at 8, `0` = the sequential walk, `N` = a pool of N. Also `-restoreThreads` on the command line and `Restore.setRestoreThreads(int)` in the API, all validated against the same bound (a test fails if the two copies of that bound drift). Unlike a backup, which halves the cores because it runs beside the workload it is already throttling, a restore has no such neighbour - the database it produces is not open yet - so the automatic sizing takes whole cores.
- **The sequential walk stays**, buffered, as the fallback for the two sources that cannot be opened at random: an `http(s)` archive is a one-shot stream and an encrypted one is a single `CipherInputStream`. The fallback is automatic whatever the setting says; a restore must never fail because of a performance setting.
- **Two hostile-archive refusals the parallel path can make and the sequential one cannot**: reading the central directory first means every entry name is validated (zip-slip, `..`, embedded separators) *before any file is written*, and an archive with two entries of the same name - two threads writing one file - is refused rather than given a locking rule of its own.

## The numbers

1.25 GB database, 8 threads, macOS/NVMe. Two shapes, because the shape is what decides what per-entry parallelism can buy:

| configuration | one dominant entry (1 type) | several comparable entries (8 types) |
|---|---|---|
| before | 5.16 s (248 MB/s) | 4.51 s (258 MB/s) |
| + buffered read, sequential | 3.96 s (1.30x) | 4.17 s (1.08x) |
| parallel, 1 thread | 2.60 s (1.99x) | 2.63 s (1.71x) |
| parallel, 8 threads | **2.51 s (2.05x)** | **0.49 s (9.15x)** |

Smaller database, same shape (322 MB, 1 type): 1.15 s before, 0.64 s at 8 threads.
Legacy level-9 archive, 8 types: 3.90 s before, 0.45 s at 8 threads (10.1x).

**Stated rather than averaged away:** a database made of one dominant file cannot be split - a ZIP entry is a single deflate stream and has to be inflated serially - so there the whole win is the reader change and the threads add 4%. Intra-entry parallelism, the mirror of what the backup does, would need the backup's chunk boundaries recorded in the archive, which is the format change this deliberately avoids. On a database spread over several types the restore lands at 0.49 s, faster than the 0.68 s backup it undoes, which is where the issue wanted it.

**Peak heap does not move:** 11.0 MB in every configuration above, sequential and parallel alike.

## Test plan

- [ ] `mvn -o -pl integration -am verify -DskipITs=false -Dit.test=Issue6086ParallelRestoreIT` - 17 tests: the round trip at threads 0/1/2/8/-1 compared against the source with `DatabaseComparator`; the parallel and sequential paths compared **byte for byte**; the encrypted and `http` archives asserted to have taken the fallback (by the path each restore logs, and by the thread each per-entry line was logged from - not merely by having succeeded); a pre-#6072 level-9 archive through the parallel path; the global-configuration default; zip-slip (`../x`, `sub/x`, `..`) refused with the destination directory left empty; duplicate entry names refused; an empty archive refused on both paths.
- [ ] `mvn -o -pl integration -am test -Dtest='RestoreSettingsTest,FullRestoreFormatThreadSizingTest'` - 18 tests: CLI/API/global-configuration validation of the new setting, the shared bound, and the automatic sizing boundaries.
- [ ] `mvn -o -pl integration verify -DskipITs=false` - the whole integration module, 100 ITs green, including `BackupCompressionIT`, `FullBackupIT` and `Issue6075SnapshotBackupIT`, which restore through the changed path.
- [ ] `mvn -o -pl engine test -Dtest='ConfigurationTest,GlobalConfigurationTest,ContextConfigurationTest'` - 44 tests, for the new `GlobalConfiguration` entry.
- [ ] The tests were checked to be able to fail: with the parallel path forced off, 10 of the 17 ITs go red, so they genuinely reach the new branch rather than passing on a silent fallback.
- [ ] Not run locally: the `server` module ITs, because port 2480 is held by another process on this machine. The server calls `Restore` reflectively through the unchanged `(String, String)` constructor and `restoreDatabase()`, so no signature it depends on moved - but CI should be read for that lane.
