### PR TITLE
fix(#6212): the mixed-loopback error names what it rejected, and an empty port is not a port

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -440,8 +440,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       return false;
 
     // Compared in place: on a same-host cluster the port is what differs, so the common "no" costs nothing.
+    // A zero-length port would compare equal to another zero-length port and satisfy the condition the whole
+    // equivalence rests on without there being a port at all, so it is refused first (issue #6212).
     final int portLength = address.length() - addressPortAt - 1;
-    if (portLength != other.length() - otherPortAt - 1 //
+    if (portLength == 0 //
+        || portLength != other.length() - otherPortAt - 1 //
         || !address.regionMatches(addressPortAt + 1, other, otherPortAt + 1, portLength))
       return false;
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
@@ -216,21 +216,30 @@ final class RaftPeerAddressResolver {
         peerNames.put(peer.getId(), peerName);
     }
 
-    // Validate: mixing localhost/127.0.0.1 with non-localhost addresses is a misconfiguration
-    boolean hasLocalhost = false;
-    boolean hasNonLocalhost = false;
+    // Validate: mixing the loopback host with real hosts is a misconfiguration. A loopback address names a
+    // different machine on every node that reads it, so it identifies no peer.
+    String loopbackPeer = null;
+    String remotePeer = null;
     for (final RaftPeer peer : peers) {
-      final String host = peer.getAddress().split(":")[0].trim();
-      if (LoopbackHosts.isLoopback(host))
-        hasLocalhost = true;
-      else
-        hasNonLocalhost = true;
+      final String address = peer.getAddress();
+      // Split on the last colon, not the first: the host of an object-form entry can be a bracketed IPv6
+      // literal, and splitting on every colon would hand this check a fragment instead of a host (issue #6212).
+      final int portAt = address.lastIndexOf(':');
+      final String host = (portAt < 0 ? address : address.substring(0, portAt)).trim();
+      if (LoopbackHosts.isLoopback(host)) {
+        if (loopbackPeer == null)
+          loopbackPeer = address;
+      } else if (remotePeer == null)
+        remotePeer = address;
     }
-    if (hasLocalhost && hasNonLocalhost)
+    // Names both offenders: every spelling of the loopback host trips this check, so naming one of them in the
+    // message describes the wrong list to whoever wrote another (issue #6212), and a long list does not say
+    // by itself which entry to look at.
+    if (loopbackPeer != null && remotePeer != null)
       throw new ServerException(
-          """
-          Found a localhost (127.0.0.1) in the server list among non-localhost servers. \
-          Please fix the server list configuration.""");
+          "Found a loopback address ('" + loopbackPeer + "') in the server list among servers on other hosts ('"
+              + remotePeer + "'): a loopback address resolves to a different machine on every node that reads it, "
+              + "so it cannot identify a peer. Please fix the server list configuration.");
 
     return new ParsedPeerList(
         Collections.unmodifiableList(peers),

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6204LoopbackEndpointTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6204LoopbackEndpointTest.java
@@ -104,6 +104,19 @@ class Issue6204LoopbackEndpointTest {
     assertThat(RaftHAServer.isSameHttpEndpoint("localhost", "localhost")).isTrue();
   }
 
+  /**
+   * A trailing colon leaves an empty port on both sides, and an empty port matches an empty port - which would
+   * satisfy the "same port" condition the whole equivalence rests on without there being a port at all (issue
+   * #6212). A hand-written server list is exactly where a trailing colon comes from.
+   */
+  @Test
+  void anEmptyPortIsNotAPort() {
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:", "127.0.0.1:")).isFalse();
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:", "localhost:2480")).isFalse();
+    // Identical text stays a match: there the caller is comparing one address with itself, whatever it is.
+    assertThat(RaftHAServer.isSameHttpEndpoint("localhost:", "localhost:")).isTrue();
+  }
+
   @Test
   void theLoopbackSpellingsAreRecognisedOnTheirOwn() {
     assertThat(LoopbackHosts.isLoopback("localhost")).isTrue();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAConfigurationIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAConfigurationIT.java
@@ -32,7 +32,26 @@ class RaftHAConfigurationIT {
     // Mix non-localhost IPs with localhost - this should be rejected
     assertThatThrownBy(() -> RaftPeerAddressResolver.parsePeerList("192.168.0.1:2434,192.168.0.1:2435,localhost:2434", 2434))
         .isInstanceOf(ServerException.class)
-        .hasMessageContaining("Found a localhost");
+        .hasMessageContaining("Found a loopback address")
+        // Both offenders are named: the list can be long, and "fix the configuration" does not say where (issue #6212).
+        .hasMessageContaining("localhost:2434")
+        .hasMessageContaining("192.168.0.1:2434");
+  }
+
+  /**
+   * The check reads {@link LoopbackHosts}, so every spelling of the loopback host trips it - not only the two
+   * the message used to name (issue #6212).
+   */
+  @Test
+  void everyLoopbackSpellingIsRejectedAmongRealHosts() {
+    assertThatThrownBy(() -> RaftPeerAddressResolver.parsePeerList("192.168.0.1:2434,LOCALHOST:2435", 2434))
+        .isInstanceOf(ServerException.class)
+        .hasMessageContaining("Found a loopback address");
+
+    // The IPv6 literal only survives parsing in the object form: the colon form splits on ':'.
+    assertThatThrownBy(() -> RaftPeerAddressResolver.parsePeerList("192.168.0.1:2434,[::1]:{raft:2435}", 2434))
+        .isInstanceOf(ServerException.class)
+        .hasMessageContaining("Found a loopback address");
   }
 
   @Test


### PR DESCRIPTION
Closes #6212. The two notes from the #6205 review, which merged before they were applied.

### An empty port is not a port

`isSameHttpEndpoint` compared the port regions in place and accepted a zero-length port on both sides: `localhost:` and `127.0.0.1:` were reported as the same endpoint, because an empty port matches an empty port and that satisfied the condition the whole loopback equivalence rests on - *the ports are equal, and two nodes cannot both listen on one port of one host* - without there being a port at all.

Not reachable from `resolveHttpAddress`, which always appends a real port. It is fixed anyway because this comparison is the shared answer to "is this address my own?" behind the write-forwarding refusal (#6191) and the snapshot self-resync backstop (#6111), and a guard whose correctness rests on a caller's invariant should hold the invariant itself. A trailing colon is also exactly what a hand-written `HA_SERVER_LIST` produces.

Identical text still matches: there the caller is comparing one address with itself, whatever it is.

### The mixed-loopback error names what it rejected

`RaftPeerAddressResolver` refuses a server list that mixes the loopback host with hosts on other machines. Since #6204 the test is `LoopbackHosts.isLoopback`, so `LOCALHOST` and a bracketed `[::1]` trip it too, but the message still read:

> Found a localhost (127.0.0.1) in the server list among non-localhost servers. Please fix the server list configuration.

An operator who wrote neither of the two named spellings was told their list contains one of them. It now names the class of address, both offending entries, and why the address cannot identify a peer:

> Found a loopback address ('localhost:2434') in the server list among servers on other hosts ('192.168.0.1:2434'): a loopback address resolves to a different machine on every node that reads it, so it cannot identify a peer. Please fix the server list configuration.

The host extraction in that check also split on the *first* colon, so an object-form entry with a bracketed IPv6 host (`[::1]:{raft:2435}`) reached the check as the fragment `[` and slipped past it. It now splits on the last colon, the same rule `isSameHttpEndpoint` uses.

### Verification

`Issue6204LoopbackEndpointTest.anEmptyPortIsNotAPort` (both empty, one empty, and the identical-text case) and two cases in `RaftHAConfigurationIT`: the existing mixed-list test now also asserts both entries are named, and a new one covers `LOCALHOST` and the object-form `[::1]`. The IPv6 case fails against the previous host extraction, so it pins that half rather than just documenting it.

183 tests green locally: `Issue6204LoopbackEndpointTest`, `Issue6191SelfForwardGuardTest`, `RaftHAConfigurationIT`, `RaftHAServerTest`, `RaftHAServerAddressParsingTest`, `RaftHAServerValidatePeerAddressTest`, `Issue4836K8sScaleUpTest`, `PeerAddressAllowlistFilterTest`.
