### PR TITLE
fix(#6065): an embedding dimension is bounded, and a negative k is named instead of reaching the allocator

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -47,6 +47,18 @@ import java.util.Map;
  */
 public abstract class AbstractAlgoProcedure implements CypherProcedure {
 
+  /**
+   * Hard upper bound for every embedding-dimension-shaped parameter (`embeddingDimension`,
+   * `dimensions`, ...). These size a per-node {@code double[]} row, so the allocation grows as
+   * {@code nodeCount * dimension} with no graph-derived ceiling to clamp against - a single
+   * in-range-but-huge value is an allocation-DoS on a graph of any size.
+   * <p>
+   * 4096 sits comfortably above every dimension in practical use (the widest mainstream text
+   * embeddings are 3072-wide) while capping one embedding row at 32 KB.
+   * </p>
+   */
+  public static final int MAX_EMBEDDING_DIMENSION = 4096;
+
   // ── Embedding math utilities ─────────────────────────────────────────────
 
   /** Normalises {@code vec} to unit L2 length in-place; no-op if the vector is zero. */
@@ -168,6 +180,51 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     } catch (final ArithmeticException e) {
       throw new IllegalArgumentException(getName() + "(): " + paramName + " is out of range for an int: " + value, e);
     }
+  }
+
+  /**
+   * Narrows an embedding-dimension-shaped config value to {@code int} and bounds it to
+   * {@code [1, MAX_EMBEDDING_DIMENSION]}.
+   * <p>
+   * Unlike a top-k / result-count bound, which clamps against the graph's node count
+   * ({@code Math.min(k, n)}) because "as many as exist" is the natural reading, an embedding
+   * dimension has no graph-derived bound to clamp against: it multiplies the per-node allocation
+   * regardless of how small the graph is. A large but perfectly in-range value such as
+   * {@code {embeddingDimension: 1000000000}} therefore survives {@link #extractInt} and then asks
+   * for a {@code new double[n][1000000000]} (~8 GB even at {@code n == 1}).
+   * </p>
+   * <p>
+   * The value is rejected rather than silently clamped: there is no "correct" dimension to fall back
+   * to, and quietly returning embeddings of a different width than the caller asked for would be a
+   * worse failure than a clear error.
+   * </p>
+   */
+  protected int extractEmbeddingDimension(final Number value, final String paramName) {
+    final int dimension = extractInt(value, paramName);
+    if (dimension < 1)
+      throw new IllegalArgumentException(getName() + "(): " + paramName + " must be at least 1, got " + dimension);
+    if (dimension > MAX_EMBEDDING_DIMENSION)
+      throw new IllegalArgumentException(
+          getName() + "(): " + paramName + " must not exceed " + MAX_EMBEDDING_DIMENSION + ", got " + dimension);
+    return dimension;
+  }
+
+  /**
+   * Narrows a result-count bound (top-k, number of paths, ...) to {@code int}, saturating at the int
+   * bounds rather than wrapping, and rejects a negative value with a message naming the parameter.
+   * <p>
+   * Saturation is deliberate here - "more results than can possibly exist" has the sensible reading
+   * "as many as exist", and each caller clamps against the graph afterwards. A negative count has no
+   * such reading, and without this check it reaches an array/collection allocation and surfaces as a
+   * bare {@code NegativeArraySizeException} or {@code IllegalArgumentException: Illegal Capacity},
+   * neither of which names the offending parameter.
+   * </p>
+   */
+  protected int extractCount(final Number value, final String paramName) {
+    final int count = NumberUtils.saturateToInt(value);
+    if (count < 0)
+      throw new IllegalArgumentException(getName() + "(): " + paramName + " must not be negative, got " + count);
+    return count;
   }
 
   /** @see GraphEngine#getAllVertices(Database, String[]) */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
  *
  * <p>Config map parameters (all optional):
  * <ul>
- *   <li>{@code dimensions} (int, default 128) – embedding vector size</li>
+ *   <li>{@code dimensions} (int, default 128, max {@value AbstractAlgoProcedure#MAX_EMBEDDING_DIMENSION}) – embedding vector size</li>
  *   <li>{@code iterations} (int, default 4) – propagation depth</li>
  *   <li>{@code normalization} (double, default 0.0) – degree-normalization exponent α:
  *       weight of neighbour j contributing to node i is proportional to
@@ -97,7 +97,7 @@ public class AlgoFastRP extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int dimensions = config != null && config.get("dimensions") instanceof Number n ? extractInt(n, "dimensions") : 128;
+    final int dimensions = config != null && config.get("dimensions") instanceof Number n ? extractEmbeddingDimension(n, "dimensions") : 128;
     final int iterations = config != null && config.get("iterations") instanceof Number n ? extractInt(n, "iterations") : 4;
     final double normStrength = config != null && config.get("normalization") instanceof Number n ? n.doubleValue() : 0.0;
     final double selfInfluence = config != null && config.get("selfInfluence") instanceof Number n ? n.doubleValue() : 0.0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  *
  * <p>Config map parameters (all optional):
  * <ul>
- *   <li>{@code embeddingDimension} (int, default 64) – output embedding size per layer</li>
+ *   <li>{@code embeddingDimension} (int, default 64, max {@value AbstractAlgoProcedure#MAX_EMBEDDING_DIMENSION}) – output embedding size per layer</li>
  *   <li>{@code layers} (int, default 2) – number of aggregation layers</li>
  *   <li>{@code relTypes} (String, default all) – comma-separated edge type names</li>
  *   <li>{@code direction} (String, default BOTH)</li>
@@ -94,7 +94,7 @@ public class AlgoGraphSAGE extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int outDim = config != null && config.get("embeddingDimension") instanceof Number n ? extractInt(n, "embeddingDimension") : 64;
+    final int outDim = config != null && config.get("embeddingDimension") instanceof Number n ? extractEmbeddingDimension(n, "embeddingDimension") : 64;
     final int layers = config != null && config.get("layers") instanceof Number n ? extractInt(n, "layers") : 2;
     final long seed = config != null && config.get("seed") instanceof Number n ? n.longValue() : -1L;
     final String[] relTypes = config != null ? extractRelTypes(config.get("relTypes")) : null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
  *
  * <p>Config map parameters (all optional):
  * <ul>
- *   <li>{@code embeddingDimension} (int, default 128) – output embedding size</li>
+ *   <li>{@code embeddingDimension} (int, default 128, max {@value AbstractAlgoProcedure#MAX_EMBEDDING_DIMENSION}) – output embedding size</li>
  *   <li>{@code iterations} (int, default 4) – number of message-passing rounds</li>
  *   <li>{@code relTypes} (String, default all) – comma-separated edge type names</li>
  *   <li>{@code direction} (String, default BOTH)</li>
@@ -93,7 +93,7 @@ public class AlgoHashGNN extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int embDim = config != null && config.get("embeddingDimension") instanceof Number n ? extractInt(n, "embeddingDimension") : 128;
+    final int embDim = config != null && config.get("embeddingDimension") instanceof Number n ? extractEmbeddingDimension(n, "embeddingDimension") : 128;
     final int iterations = config != null && config.get("iterations") instanceof Number n ? extractInt(n, "iterations") : 4;
     final long seed = config != null && config.get("seed") instanceof Number n ? n.longValue() : -1L;
     final String[] relTypes = config != null ? extractRelTypes(config.get("relTypes")) : null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
@@ -23,7 +23,6 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -91,7 +90,7 @@ public class AlgoKNN extends AbstractAlgoProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final int rawK             = args.length > 0 && args[0] instanceof Number num ? NumberUtils.saturateToInt(num) : 10;
+    final int rawK             = args.length > 0 && args[0] instanceof Number num ? extractCount(num, "k") : 10;
     final String[] relTypes    = args.length > 1 ? extractRelTypes(args[1]) : null;
     final Vertex.DIRECTION dir = args.length > 2 ? parseDirection(extractString(args[2], "direction")) : Vertex.DIRECTION.BOTH;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -27,7 +27,6 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,7 +89,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
 
     final Vertex startNode        = extractVertex(args[0], "startNode");
     final Vertex endNode          = extractVertex(args[1], "endNode");
-    final int k                   = NumberUtils.saturateToInt((Number) args[2]);
+    final int k                   = extractCount((Number) args[2], "k");
     final String[] relTypes       = args.length > 3 ? extractRelTypes(args[3]) : null;
     final String weightProperty   = args.length > 4 ? extractString(args[4], "weightProperty") : null;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
@@ -45,7 +45,8 @@ import java.util.stream.Stream;
  *
  * <p>Parameters:
  * <ul>
- *   <li>{@code k} (int, required) – number of partitions (k ≥ 2)</li>
+ *   <li>{@code k} (int, required) – number of partitions (k ≥ 2; clamped to the node count, since a
+ *       cut into more parts than there are nodes can only leave the surplus parts empty)</li>
  *   <li>{@code config} (map, optional):
  *     <ul>
  *       <li>{@code maxIterations} (int, default 100) – local-search passes per restart</li>

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
@@ -101,9 +101,9 @@ public class AlgoMaxKCut extends AbstractAlgoProcedure {
   public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
     validateArgs(args);
 
-    final int k = args[0] instanceof Number kn ? extractInt(kn, "k") : 2;
-    if (k < 2)
-      throw new IllegalArgumentException(getName() + "(): k must be ≥ 2, got " + k);
+    final int rawK = args[0] instanceof Number kn ? extractInt(kn, "k") : 2;
+    if (rawK < 2)
+      throw new IllegalArgumentException(getName() + "(): k must be ≥ 2, got " + rawK);
 
     final Map<String, Object> config = args.length > 1 ? extractMap(args[1], "config") : null;
     final int maxIter = config != null && config.get("maxIterations") instanceof Number n ? extractInt(n, "maxIterations") : 100;
@@ -119,6 +119,11 @@ public class AlgoMaxKCut extends AbstractAlgoProcedure {
     final int n = graph.nodeCount;
     if (n == 0)
       return Stream.empty();
+    // Clamp to the graph size, same as AlgoHierarchicalClustering's numClusters: a cut into more
+    // parts than there are nodes can only leave the surplus parts empty, and the per-node gain array
+    // (`new double[k]`, allocated once per node per pass per restart) would otherwise be sized off an
+    // unclamped k - a multi-GB allocation attempt for e.g. algo.maxKCut(2000000000) on a tiny graph.
+    final int k = Math.min(rawK, n);
     final int[][] adj = graph.adjacency(dir, relTypes);
 
     // Build weighted adjacency (null weightProperty → all weights = 1.0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
@@ -123,7 +123,10 @@ public class AlgoMaxKCut extends AbstractAlgoProcedure {
     // parts than there are nodes can only leave the surplus parts empty, and the per-node gain array
     // (`new double[k]`, allocated once per node per pass per restart) would otherwise be sized off an
     // unclamped k - a multi-GB allocation attempt for e.g. algo.maxKCut(2000000000) on a tiny graph.
-    final int k = Math.min(rawK, n);
+    // The floor of 2 keeps the clamp from undercutting the k >= 2 contract validated above: on a
+    // single-node graph a bare Math.min would hand the local search k = 1, i.e. a "cut" into one
+    // partition, which is not the degenerate-but-valid answer to what the caller asked for.
+    final int k = Math.max(2, Math.min(rawK, n));
     final int[][] adj = graph.adjacency(dir, relTypes);
 
     // Build weighted adjacency (null weightProperty → all weights = 1.0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoNode2Vec.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoNode2Vec.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
  *
  * <p>Config map parameters (all optional):
  * <ul>
- *   <li>{@code embeddingDimension} (int, default 128) – embedding size</li>
+ *   <li>{@code embeddingDimension} (int, default 128, max {@value AbstractAlgoProcedure#MAX_EMBEDDING_DIMENSION}) – embedding size</li>
  *   <li>{@code walkLength} (int, default 80) – steps per random walk</li>
  *   <li>{@code walksPerNode} (int, default 10) – walks generated per node</li>
  *   <li>{@code iterations} (int, default 1) – training epochs over all walks</li>
@@ -99,7 +99,7 @@ public class AlgoNode2Vec extends AbstractAlgoProcedure {
     validateArgs(args);
 
     final Map<String, Object> config = args.length > 0 ? extractMap(args[0], "config") : null;
-    final int dim = config != null && config.get("embeddingDimension") instanceof Number n ? extractInt(n, "embeddingDimension") : 128;
+    final int dim = config != null && config.get("embeddingDimension") instanceof Number n ? extractEmbeddingDimension(n, "embeddingDimension") : 128;
     final int walkLen = config != null && config.get("walkLength") instanceof Number n ? extractInt(n, "walkLength") : 80;
     final int walksPerNode = config != null && config.get("walksPerNode") instanceof Number n ? extractInt(n, "walksPerNode") : 10;
     final int epochs = config != null && config.get("iterations") instanceof Number n ? extractInt(n, "iterations") : 1;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -157,17 +157,31 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
    * through {@link Integer#parseInt}, which threw a bare {@code NumberFormatException} for exactly
    * the same magnitudes the {@link Number} branch next to it accepted - the two branches now agree.
    * </p>
+   * <p>
+   * A negative {@code k} has no such reading and is rejected by name, mirroring
+   * {@code AbstractAlgoProcedure.extractCount()}. {@code LSMVectorIndex.findNeighborsFromVector}
+   * clamps with {@code Math.min(k, candidateCount)}, which leaves a negative value negative, so
+   * without this check it reaches {@code new ArrayList<>(k)} and surfaces as a bare
+   * {@code IllegalArgumentException: Illegal Capacity} that never mentions {@code k}.
+   * </p>
    */
   private static int extractLimit(final Object arg) {
+    final int limit;
     if (arg instanceof Number n)
-      return NumberUtils.saturateToInt(n);
-
-    final String text = arg.toString().trim();
-    try {
-      return NumberUtils.saturateToInt(new BigDecimal(text));
-    } catch (final NumberFormatException e) {
-      throw new CommandSQLParsingException("db.index.vector.queryNodes(): k must be a number, got '" + text + "'", e);
+      limit = NumberUtils.saturateToInt(n);
+    else {
+      final String text = arg.toString().trim();
+      try {
+        limit = NumberUtils.saturateToInt(new BigDecimal(text));
+      } catch (final NumberFormatException e) {
+        throw new CommandSQLParsingException("db.index.vector.queryNodes(): k must be a number, got '" + text + "'", e);
+      }
     }
+
+    if (limit < 0)
+      throw new CommandSQLParsingException("db.index.vector.queryNodes(): k must not be negative, got " + limit);
+
+    return limit;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -35,6 +35,7 @@ import com.arcadedb.utility.NumberUtils;
 import com.arcadedb.utility.Pair;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -99,7 +100,7 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
     validateArgs(args);
 
     final String indexSpec = args[0].toString();
-    final int limit = args[1] instanceof Number n ? NumberUtils.saturateToInt(n) : Integer.parseInt(args[1].toString());
+    final int limit = extractLimit(args[1]);
 
     Object key = args[2];
     if (key == null)
@@ -145,6 +146,28 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
     }
 
     return results.stream();
+  }
+
+  /**
+   * Narrows the {@code k} argument to an {@code int}, saturating at the int bounds instead of
+   * failing, whether it arrives as a {@link Number} or as a numeric string.
+   * <p>
+   * A result-count bound has a sensible "as many as exist" reading, so a value above
+   * {@link Integer#MAX_VALUE} saturates rather than being rejected. The string fallback used to go
+   * through {@link Integer#parseInt}, which threw a bare {@code NumberFormatException} for exactly
+   * the same magnitudes the {@link Number} branch next to it accepted - the two branches now agree.
+   * </p>
+   */
+  private static int extractLimit(final Object arg) {
+    if (arg instanceof Number n)
+      return NumberUtils.saturateToInt(n);
+
+    final String text = arg.toString().trim();
+    try {
+      return NumberUtils.saturateToInt(new BigDecimal(text));
+    } catch (final NumberFormatException e) {
+      throw new CommandSQLParsingException("db.index.vector.queryNodes(): k must be a number, got '" + text + "'", e);
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCallVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCallVectorNeighborsTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for calling vector search from Cypher via CALL.
@@ -229,6 +230,27 @@ class CypherCallVectorNeighborsTest extends TestHelper {
 
       assertThat(names).hasSize(2);
     }
+  }
+
+  @Test
+  void queryNodesRejectsANegativeKWithAMessageNamingTheParameter() {
+    // Raised in cycle 3 of the PR #6214 review: this is the third numeric-count entry point the PR
+    // touches, and it had the same failure mode Part B1 closes for algo.knn / algo.kShortestPaths.
+    // LSMVectorIndex.findNeighborsFromVector clamps with Math.min(k, candidateCount), which leaves a
+    // negative k negative, so it reached `new ArrayList<>(k)` as a bare
+    // "IllegalArgumentException: Illegal Capacity: -5" that never mentioned k.
+    final Map<String, Object> params = new HashMap<>();
+    params.put("vec", new float[]{0.0f, 0.0f, 1.0f});
+    params.put("k", -5);
+
+    assertThatThrownBy(() -> {
+      try (ResultSet results = database.query("opencypher",
+          "CALL db.index.vector.queryNodes('Doc[embedding]', $k, $vec) YIELD node, score RETURN node.name AS name",
+          params)) {
+        while (results.hasNext())
+          results.next();
+      }
+    }).hasStackTraceContaining("db.index.vector.queryNodes(): k must not be negative");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCallVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCallVectorNeighborsTest.java
@@ -191,6 +191,47 @@ class CypherCallVectorNeighborsTest extends TestHelper {
   }
 
   @Test
+  void queryNodesKAsANumericStringAboveIntRangeSaturatesLikeTheNumberBranch() {
+    // Issue #6065 Part B2: `k` is read as `args[1] instanceof Number ? saturateToInt(n) : <string fallback>`.
+    // Since #5924 the Number branch saturates, but the string fallback was still Integer.parseInt, so
+    // the very same magnitude that returned all 5 neighbours as a Long threw a bare
+    // NumberFormatException as a String. The two branches now agree.
+    final Map<String, Object> params = new HashMap<>();
+    params.put("vec", new float[]{0.0f, 0.0f, 1.0f});
+    params.put("k", "2147483648");
+
+    try (ResultSet results = database.query("opencypher",
+        "CALL db.index.vector.queryNodes('Doc[embedding]', $k, $vec) YIELD node, score RETURN node.name AS name, score",
+        params)) {
+
+      final List<String> names = new ArrayList<>();
+      while (results.hasNext())
+        names.add(results.next().getProperty("name"));
+
+      assertThat(names).hasSize(5);
+    }
+  }
+
+  @Test
+  void queryNodesKAsAnOrdinaryNumericStringStillWorks() {
+    // Guards the saturation above against over-reach: an in-range numeric string is unchanged.
+    final Map<String, Object> params = new HashMap<>();
+    params.put("vec", new float[]{1.0f, 0.0f, 0.0f});
+    params.put("k", "2");
+
+    try (ResultSet results = database.query("opencypher",
+        "CALL db.index.vector.queryNodes('Doc[embedding]', $k, $vec) YIELD node, score RETURN node.name AS name, score",
+        params)) {
+
+      final List<String> names = new ArrayList<>();
+      while (results.hasNext())
+        names.add(results.next().getProperty("name"));
+
+      assertThat(names).hasSize(2);
+    }
+  }
+
+  @Test
   void queryNodesWithReturnPattern() {
     // Exact Neo4j pattern from the user's benchmark query
     final Map<String, Object> params = new HashMap<>();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6065NumericParameterBoundsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6065NumericParameterBoundsTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6065 (follow-up to #5924 / PR #6055).
+ * <p>
+ * Part A: an embedding-dimension-shaped parameter has no graph-derived bound to clamp against the way
+ * a top-k parameter does, so a large but perfectly in-range {@code int} survived the #5924 overflow
+ * check and went straight into a per-node {@code double[]} allocation - {@code new double[1][1000000000]}
+ * is ~8 GB on a one-node graph. These are now bounded by
+ * {@link AbstractAlgoProcedure#MAX_EMBEDDING_DIMENSION} and rejected, not silently clamped: there is no
+ * "correct" dimension to fall back to.
+ * </p>
+ * <p>
+ * Part B: a literal negative {@code k} used to reach the array/collection allocation and surface as a
+ * bare {@code NegativeArraySizeException} / {@code IllegalArgumentException: Illegal Capacity} that
+ * never named the offending parameter.
+ * </p>
+ */
+class Issue6065NumericParameterBoundsTest {
+  /** Comfortably in-range for an int, comfortably out of range for a heap. */
+  private static final long HUGE_DIMENSION = 1_000_000_000L;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6065-numeric-bounds");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // Tiny path graph A -> B -> C -> D, plus the shortcut A -> D so kShortestPaths has two routes.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      final MutableVertex d = database.newVertex("Node").set("name", "D").save();
+      a.newEdge("LINK", b, true, (Object[]) null).save();
+      b.newEdge("LINK", c, true, (Object[]) null).save();
+      c.newEdge("LINK", d, true, (Object[]) null).save();
+      a.newEdge("LINK", d, true, (Object[]) null).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  // ── Part A: embedding-dimension-shaped parameters are bounded ────────────────
+
+  @Test
+  void node2vecRejectsAnEmbeddingDimensionAboveTheCap() {
+    assertThatThrownBy(() -> drain(
+        "CALL algo.node2vec({embeddingDimension: $dim, walkLength: 3, walksPerNode: 1, seed: 1}) YIELD node RETURN node",
+        Map.of("dim", HUGE_DIMENSION)))
+        .hasStackTraceContaining("embeddingDimension")
+        .hasStackTraceContaining(String.valueOf(AbstractAlgoProcedure.MAX_EMBEDDING_DIMENSION));
+  }
+
+  @Test
+  void fastRPRejectsADimensionsValueAboveTheCap() {
+    assertThatThrownBy(() -> drain(
+        "CALL algo.fastrp({dimensions: $dim, iterations: 1, seed: 1}) YIELD node RETURN node",
+        Map.of("dim", HUGE_DIMENSION)))
+        .hasStackTraceContaining("dimensions")
+        .hasStackTraceContaining(String.valueOf(AbstractAlgoProcedure.MAX_EMBEDDING_DIMENSION));
+  }
+
+  @Test
+  void graphSageRejectsAnEmbeddingDimensionAboveTheCap() {
+    assertThatThrownBy(() -> drain(
+        "CALL algo.graphsage({embeddingDimension: $dim, layers: 1, seed: 1}) YIELD node RETURN node",
+        Map.of("dim", HUGE_DIMENSION)))
+        .hasStackTraceContaining("embeddingDimension")
+        .hasStackTraceContaining(String.valueOf(AbstractAlgoProcedure.MAX_EMBEDDING_DIMENSION));
+  }
+
+  @Test
+  void hashGnnRejectsAnEmbeddingDimensionAboveTheCap() {
+    assertThatThrownBy(() -> drain(
+        "CALL algo.hashgnn({embeddingDimension: $dim, iterations: 1, seed: 1}) YIELD node RETURN node",
+        Map.of("dim", HUGE_DIMENSION)))
+        .hasStackTraceContaining("embeddingDimension")
+        .hasStackTraceContaining(String.valueOf(AbstractAlgoProcedure.MAX_EMBEDDING_DIMENSION));
+  }
+
+  @Test
+  void aZeroEmbeddingDimensionIsRejectedRatherThanProducingEmptyVectors() {
+    assertThatThrownBy(() -> drain(
+        "CALL algo.fastrp({dimensions: 0, iterations: 1, seed: 1}) YIELD node RETURN node", Map.of()))
+        .hasStackTraceContaining("dimensions")
+        .hasStackTraceContaining("at least 1");
+  }
+
+  @Test
+  void anEmbeddingDimensionExactlyAtTheCapIsStillAccepted() {
+    // The cap must not narrow what already worked: 4096 doubles per node is 32 KB per row.
+    final List<Result> results = drain(
+        "CALL algo.fastrp({dimensions: $dim, iterations: 1, seed: 1}) YIELD node, embedding RETURN node, embedding",
+        Map.of("dim", AbstractAlgoProcedure.MAX_EMBEDDING_DIMENSION));
+
+    assertThat(results).hasSize(4);
+    for (final Result r : results)
+      assertThat((List<?>) r.getProperty("embedding")).hasSize(AbstractAlgoProcedure.MAX_EMBEDDING_DIMENSION);
+  }
+
+  // ── Part B: a negative result-count bound is named, not thrown from an allocator ──
+
+  @Test
+  void knnRejectsANegativeKWithAMessageNamingTheParameter() {
+    assertThatThrownBy(() -> drain("CALL algo.knn($k, 'LINK', 'BOTH') YIELD node1, node2 RETURN node1, node2",
+        Map.of("k", -5)))
+        .hasStackTraceContaining("algo.knn(): k must not be negative");
+  }
+
+  @Test
+  void kShortestPathsRejectsANegativeKWithAMessageNamingTheParameter() {
+    assertThatThrownBy(() -> drain("""
+        MATCH (a:Node {name: 'A'}), (d:Node {name: 'D'}) \
+        CALL algo.kShortestPaths(a, d, $k) YIELD path, weight, rank \
+        RETURN rank, weight""", Map.of("k", -5)))
+        .hasStackTraceContaining("algo.kShortestPaths(): k must not be negative");
+  }
+
+  @Test
+  void kShortestPathsStillHonoursAPositiveK() {
+    // Guards the negative-k rejection against over-reach: 2 is still 2.
+    final List<Result> results = drain("""
+        MATCH (a:Node {name: 'A'}), (d:Node {name: 'D'}) \
+        CALL algo.kShortestPaths(a, d, 2) YIELD path, weight, rank \
+        RETURN rank, weight""", Map.of());
+
+    assertThat(results).hasSize(2);
+  }
+
+  private List<Result> drain(final String cypher, final Map<String, Object> params) {
+    final List<Result> results = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", cypher, params)) {
+      while (rs.hasNext())
+        results.add(rs.next());
+    }
+    return results;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6065NumericParameterBoundsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6065NumericParameterBoundsTest.java
@@ -142,6 +142,33 @@ class Issue6065NumericParameterBoundsTest {
       assertThat((List<?>) r.getProperty("embedding")).hasSize(AbstractAlgoProcedure.MAX_EMBEDDING_DIMENSION);
   }
 
+  @Test
+  void maxKCutClampsAHugeKAgainstTheGraphSizeInsteadOfAllocatingForIt() {
+    // Raised in review of PR #6214: issue #6065 asserted algo.maxKCut's k "already clamps against n
+    // downstream" - it did not. Only `k < 2` was rejected, and `new double[k]` is allocated once per
+    // node per local-search pass per restart, so a huge k was the same allocation-DoS shape this
+    // issue closes for embeddingDimension. A k-cut into more parts than there are nodes can only
+    // leave the surplus parts empty, so clamping (rather than rejecting) is the honest reading here.
+    final List<Result> results = drain(
+        "CALL algo.maxKCut($k, {seed: 42, restarts: 1, maxIterations: 1}) YIELD node, community RETURN node, community",
+        Map.of("k", 2_000_000_000));
+
+    assertThat(results).hasSize(4);
+    for (final Result r : results)
+      assertThat(((Number) r.getProperty("community")).intValue()).isBetween(0, 3);
+  }
+
+  @Test
+  void maxKCutStillHonoursASmallK() {
+    // Guards the clamp against over-reach: k below the node count is untouched.
+    final List<Result> results = drain(
+        "CALL algo.maxKCut(2, {seed: 42}) YIELD node, community RETURN node, community", Map.of());
+
+    assertThat(results).hasSize(4);
+    for (final Result r : results)
+      assertThat(((Number) r.getProperty("community")).intValue()).isBetween(0, 1);
+  }
+
   // ── Part B: a negative result-count bound is named, not thrown from an allocator ──
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6065NumericParameterBoundsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6065NumericParameterBoundsTest.java
@@ -169,6 +169,41 @@ class Issue6065NumericParameterBoundsTest {
       assertThat(((Number) r.getProperty("community")).intValue()).isBetween(0, 1);
   }
 
+  @Test
+  void maxKCutOnASingleNodeGraphStillHonoursTheMinimumOfTwoPartitions() {
+    // Raised in cycle 2 of the PR #6214 review: the clamp added in cycle 1 must not undercut the
+    // k >= 2 contract that algo.maxKCut validates a few lines above it. On a one-node graph a bare
+    // Math.min(rawK, n) yields k = 1 - a "cut" into a single partition - so the clamp carries a
+    // floor of 2. The allocation stays bounded either way: max(2, min(rawK, n)).
+    // algo.maxKCut loads the whole graph, so the single-node case needs its own database.
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6065-single-node");
+    if (factory.exists())
+      factory.open().drop();
+    final Database single = factory.create();
+    try {
+      single.getSchema().createVertexType("Node");
+      single.transaction(() -> single.newVertex("Node").set("name", "solo").save());
+
+      final List<Result> results = new ArrayList<>();
+      try (final ResultSet rs = single.query("opencypher",
+          "CALL algo.maxKCut($k, {seed: 42, restarts: 1, maxIterations: 1}) YIELD node, community RETURN node, community",
+          Map.of("k", 2_000_000_000))) {
+        while (rs.hasNext())
+          results.add(rs.next());
+      }
+
+      // The assertion has to be exact, not a range: the only observable of a one-node cut is the
+      // single community id, and `isBetween(0, 1)` would pass for k = 1 too, so it could never fail.
+      // The node's partition is the first draw of the seeded RNG, `new Random(42).nextInt(k)`, which
+      // is 1 for k = 2 and can only ever be 0 for k = 1. Asserting 1 is therefore exactly the
+      // assertion that distinguishes the floor being present from it being absent.
+      assertThat(results).hasSize(1);
+      assertThat(((Number) results.getFirst().getProperty("community")).intValue()).isEqualTo(1);
+    } finally {
+      single.drop();
+    }
+  }
+
   // ── Part B: a negative result-count bound is named, not thrown from an allocator ──
 
   @Test


### PR DESCRIPTION
Closes #6065

## Summary

Follow-up to #5924 / PR #6055, which fixed the unchecked-numeric-*narrowing* family in the OpenCypher procedures package. The two gaps that fix deliberately left open are not narrowing bugs, which is why an overflow check alone could never catch them.

**Part A - embedding-dimension-shaped parameters now have an upper bound.** A top-k-shaped parameter has a natural graph-derived ceiling and every one of them clamps against it (`Math.min(k, n)`). An embedding dimension has none: it multiplies the per-node allocation regardless of how small the graph is. So a large but perfectly in-range `int` sailed through `extractInt()`/`NumberUtils.toIntExact()` and went straight into the allocation - `CALL algo.node2Vec({embeddingDimension: 1000000000})` on a one-node graph asks for `new double[1][1000000000]`, about 8 GB. This is the same allocation-DoS shape PR #6055 closed for `AlgoKNN`/`AlgoKShortestPaths`/`LSMVectorIndex`, reached by a valid value instead of an overflowing one.

`AbstractAlgoProcedure.extractEmbeddingDimension()` bounds the value to `[1, MAX_EMBEDDING_DIMENSION]` and is wired into the four affected sites: `AlgoNode2Vec.embeddingDimension`, `AlgoFastRP.dimensions`, `AlgoGraphSAGE.embeddingDimension`, `AlgoHashGNN.embeddingDimension`. The value is **rejected, not silently clamped**: there is no "correct" dimension to fall back to the way `Math.min(k, n)` has one for top-k, and quietly returning embeddings of a width the caller did not ask for would be the worse failure. `MAX_EMBEDDING_DIMENSION = 4096` sits comfortably above every dimension in practical use (the widest mainstream text embeddings are 3072-wide) while capping one embedding row at 32 KB. `AlgoHierarchicalClustering.numClusters` is untouched: it already clamps against `n` downstream. `AlgoMaxKCut.k` did NOT, contrary to what the issue states - see the review-cycle note below.

**Part B1 - a negative `k` is named instead of reaching the allocator.** `algo.knn(-5)` used to die in `new double[k]` with a bare `NegativeArraySizeException`, and `algo.kShortestPaths(a, b, -5)` in `new ArrayList<>(...)` with `IllegalArgumentException: Illegal Capacity`. Neither mentioned `k`. `AbstractAlgoProcedure.extractCount()` keeps the deliberate saturation ("more results than can exist" reads as "as many as exist") and adds the negative check at the same site the extraction already happens. Pre-existing behaviour, not a regression.

**Part B2 - `db.index.vector.queryNodes`' numeric-string fallback saturates.** `args[1] instanceof Number n ? saturateToInt(n) : Integer.parseInt(...)` meant the exact magnitude the `Number` branch happily saturated (`2147483648`) threw a `NumberFormatException` when it arrived as a string. Both branches now go through `NumberUtils.saturateToInt`, and a genuinely non-numeric argument gets a `CommandSQLParsingException` naming `k` rather than a raw `NumberFormatException`.

## Verification

New `Issue6065NumericParameterBoundsTest` (12 tests) plus 2 methods added to `CypherCallVectorNeighborsTest`. The regression tests were confirmed to fail against the unfixed sources: with the main-source changes stashed, **8 of the 11 new tests go red** (all four dimension caps, the zero-dimension rejection, both negative-`k` messages, and the numeric-string `k`). The other three are deliberate over-reach guards - a dimension exactly at the cap, a positive `k`, an ordinary numeric string - and pass both before and after by design.

Two of the red-run failures are the bug itself rather than an assertion mismatch: `hashGnnRejects...` took 8.2 s and `graphSageRejects...` 3.9 s before dying, because they really did try to allocate.

Full `com.arcadedb.query.opencypher.**` unit suite after cycle 3: **4391 tests, 0 failures, 0 errors, 13 skipped**.

## Review cycle 1 - `AlgoMaxKCut.k` was not clamped after all

The review disproved a claim issue #6065 made, and that the first revision of this description repeated: that `AlgoMaxKCut.k` "already clamps against `n` downstream". Checked against `AlgoMaxKCut.java`, it did not. `k` was only lower-bounded (`k < 2` rejected) and `new double[k]` is allocated **once per node per local-search pass per restart**, so `CALL algo.maxKCut(2000000000)` on a tiny graph is exactly the allocation shape this PR exists to close.

Fixed by clamping to `Math.min(rawK, n)` after the graph loads, matching `AlgoHierarchicalClustering.numClusters`. Clamping rather than rejecting is the honest reading here: a cut into more parts than there are nodes can only leave the surplus parts empty, so there *is* a correct fallback - unlike an embedding dimension. Two tests added (`maxKCutClampsAHugeKAgainstTheGraphSizeInsteadOfAllocatingForIt` plus an over-reach guard that a small `k` is untouched); the clamp test was confirmed sensitive by running it against the unclamped code with `k = 10 > n = 4`, where it fails on a community id outside `[0, 3]`.

## Test plan

- [ ] `mvn -o -pl engine -am -Dtest='Issue6065NumericParameterBoundsTest' test` - all 9 green
- [ ] `mvn -o -pl engine -am -Dtest='CypherCallVectorNeighborsTest' test` - all 9 green (7 pre-existing + 2 new)
- [ ] `mvn -o -pl engine -am -Dtest='com.arcadedb.query.opencypher.**.*Test' -DexcludedGroups=benchmark,vector,slow test` - no regression across the package
- [ ] Manual: `CALL algo.node2vec({embeddingDimension: 1000000000})` returns `algo.node2vec(): embeddingDimension must not exceed 4096, got 1000000000` promptly instead of stalling on an 8 GB allocation
- [ ] Manual: `CALL algo.knn(-5)` returns `algo.knn(): k must not be negative, got -5`
- [ ] Manual: `CALL db.index.vector.queryNodes('Doc[embedding]', '2147483648', $vec)` returns every neighbour, matching the `Number` form

## Notes for review

- `MAX_EMBEDDING_DIMENSION` is `public` on `AbstractAlgoProcedure` so the tests bind to the production constant rather than a copied literal; if the cap is ever retuned the tests follow it.
- The four procedure javadocs now state the cap via `{@value}`, so it cannot drift from the constant.
- `AlgoHashGNN` derives `numFeatures = Math.max(embDim * 4, 64)`; that multiplication would overflow `int` above ~536 M, which the 4096 cap now makes unreachable.

## Review cycle 2 - the maxKCut clamp needed a floor

The review pointed out that on a single-node graph the cycle-1 clamp `Math.min(rawK, n)` hands the local search `k = 1`, a "cut" into one partition, silently contradicting the `k >= 2` validation a few lines above it. The clamp is now `Math.max(2, Math.min(rawK, n))`; the allocation stays bounded by the node count for every graph of two nodes or more, which is the only case where the bound matters.

The regression test for it needs its own one-node database, because `algo.maxKCut` loads the whole graph. It asserts the community id **exactly** rather than by range: the only observable of a one-node cut is that single id, and `isBetween(0, 1)` would pass for `k = 1` too, so it could never fail. `new Random(42).nextInt(2)` is `1` while `nextInt(1)` can only ever be `0`, so asserting `1` is precisely the assertion that separates the floor being present from absent - verified by removing the floor and watching it go red.

**Not actioned, deliberately:** the review's style note about converging `AlgoMaxKCut`'s pre-existing `k must be ≥ 2` Unicode message on the ASCII wording the new messages use. The review itself called it non-blocking and not introduced here, and rewording a validation message that other tests may match on is unrelated churn in a fix PR.

## Review cycle 3 - the third numeric-count entry point

The review found that `db.index.vector.queryNodes` still let a negative `k` reach a bare allocator exception, the exact failure mode Part B1 closes for `algo.knn`/`algo.kShortestPaths`. Confirmed against `LSMVectorIndex.findNeighborsFromVector`: its clamp is `Math.min(k, candidateCount)` and `candidateCount` is never negative, so `-5` stays `-5` all the way to `new ArrayList<>(k)` and surfaces as `IllegalArgumentException: Illegal Capacity: -5` without ever naming `k`. `extractLimit()` now rejects it by name, mirroring `extractCount()`, with a test confirmed red when the check is removed.

`AlgoMaxKCut`'s class javadoc now documents the clamp, as suggested, mirroring the four embedding-dimension procedures.

**Not actioned, deliberately:** the review's closing note that `walksPerNode`/`walkLength`/`windowSize`/`negSamples` (`AlgoNode2Vec`), `restarts`/`maxIterations` (`AlgoMaxKCut`) and `simulations` (`AlgoInfluenceMaximization`) are unbounded multiplicative knobs of a similar shape. The review framed it as a possible follow-up rather than a request, and unlike an embedding dimension these scale CPU work rather than a single allocation, so picking a ceiling ("what is a sane maximum iteration count?") is a design decision that deserves its own issue rather than being smuggled into a fix PR. Recommend filing it as a follow-up.
