### PR TITLE
fix(#6180, #6176): a truncated batch upload is never served its own bytes again

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1705,3 +1705,38 @@ by the negative size marker a plain collapse would replace with a positive one, 
 exactly what tells a bucket scan that a slot holds a document of its own.
 
 [#6178](https://github.com/ArcadeData/arcadedb/issues/6178)
+
+## A truncated batch upload no longer applies its own bytes a second time (#6180, #6176)
+
+`POST /api/v1/batch` could load records the client never sent in that request: its own request head and a replay
+of records it had already committed. On a type with a unique index the replay collided with what it duplicated and
+the load was answered **409 Conflict** for a key the client had sent exactly once, instead of the **408** and the
+partial-commit counts a truncated upload is contracted to get. On a type without one - which is what a bulk load
+usually has - it duplicated rows and answered 200.
+
+The connection is what lies, and the reader is what asks it. Undertow's `UndertowInputStream` takes a buffer from
+the pool *before* the channel read that fails and does not give it back, so the buffer stays on the stream holding
+whatever the pool last left in it - on this connection, its own request head and the records already parsed. The
+next read is then served from that buffer without the channel being touched at all. What reaches the failure is
+`InputStreamReader`, which probes the stream between decodes (`StreamDecoder.inReady` calls `available()`) and
+**swallows** the `IOException`: the failure that should have ended the load disappears, and the parser is handed
+the replay as payload. Measured on `main` with a 520-record payload sent in two chunks: reads of 8192 and 8172
+bytes past the end of the upload, beginning at the very record the second chunk began with, and a total of 40284
+bytes consumed against the 23920 the client sent.
+
+The batch handler's own body stream now ends a body that has failed. The first failure is remembered, whether it
+surfaces on a read or on a probe; the probe answers -1 - Undertow's own "the body is finished", which the
+truncation check already reads - so the reader stops asking instead of swallowing anything, and every later read is
+refused with the recorded cause. A load that hits it takes the truncated-body path it was always meant to take:
+408, the counts needed to resume, and not one record the client did not send. The forwarding path a follower uses
+to relay a batch to the leader reads through the same guarded stream, so a cut upload cannot relay a replay of
+itself either.
+
+Every answer now carries `bytesRead`, not only the successful one. On a truncated load that is where a client
+learns how far the server got, and it is the number that says the server read no further than the client wrote:
+`bytesRead` equal to the bytes sent is now asserted by `Issue5470BatchStreamStallIT` in both of its truncation
+tests. The OpenAPI schemas for the batch response and the batch error were completed to match what both bodies
+have carried since #5618: `bytesRead`, `linesRead`, `linesSkipped` and `verticesWithoutId`.
+
+[#6180](https://github.com/ArcadeData/arcadedb/issues/6180)
+[#6176](https://github.com/ArcadeData/arcadedb/issues/6176)

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -78,7 +78,7 @@ import java.util.logging.Level;
  * a client that stops sending (issue #5470). A body that ends early is answered with HTTP 408 and the
  * partial-commit counts, never with a 200 carrying a truncated count: both when the read fails outright and when
  * the body simply stops before the announced {@code Content-Length}, which is what a fixed-length upload cut by a
- * proxy looks like from here. The successful response carries {@code bytesRead} for the same reason.
+ * proxy looks like from here. Every response carries {@code bytesRead} for the same reason.
  * <p>
  * Response: {@code verticesCreated}, {@code edgesCreated}, {@code elapsedMs}, {@code bytesRead} and, when temporary
  * ids were used, {@code idMapping} - replaced by {@code idMappingOmitted} / {@code idMappingSize} past
@@ -253,7 +253,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // the user thread (issue #4122).
       final HAServerPlugin ha = httpServer.getServer().getHA();
       if (ha != null && !ha.isLeader())
-        return forwardBatchToLeader(exchange, ha, databaseName, user, contentType);
+        return forwardBatchToLeader(exchange, ha, databaseName, user, contentType, inputStream);
 
       final DatabaseInternal database = httpServer.getServer().getDatabase(databaseName, false, false);
       final boolean isCsv = contentType.contains("text/csv");
@@ -397,7 +397,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // distinction is the difference between naming the offending line and reporting the load as truncated with
       // "the last record read is not part of the payload", which was untrue and unfixable: the line WAS in the file.
       if (e instanceof MalformedBatchRecordException && bodyEndedEarly(exchange, inputStream))
-        return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs,
+        return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs, inputStream,
             "only " + inputStream.getBytesRead() + " of the " + exchange.getRequestContentLength()
                 + " announced bytes were received, the last record read (" + message + ") is not part of the payload",
             null);
@@ -422,7 +422,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       error.put("verticesCreated", verticesCreated);
       error.put("edgesCreated", edgesCreated);
       error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);
-      addLineAccounting(error, stream, vertexRefs);
+      addLineAccounting(error, stream, vertexRefs, inputStream);
       return new ExecutionResponse(400, error.toString());
     } catch (final IOException e) {
       // The request body could not be read to the end: the client went away, a proxy cut the upload, or the
@@ -430,8 +430,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       // reading (issue #5470). Never let this look like a completed load: reaching the end of the loop with a
       // truncated body would answer 200 with a partial count and the client would happily move on.
       final String message = e.getMessage() != null ? e.getMessage() : e.toString();
-      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs, message,
-          e.getClass().getName());
+      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs, inputStream,
+          message, e.getClass().getName());
     }
 
     // The stream ended without an error, but the client announced more than what arrived: a connection dropped
@@ -439,7 +439,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // reporting 200 with a truncated count is the worst possible outcome - the client moves on believing the load
     // completed.
     if (bodyEndedEarly(exchange, inputStream))
-      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs,
+      return truncatedBody(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs, inputStream,
           "only " + inputStream.getBytesRead() + " of the " + exchange.getRequestContentLength()
               + " announced bytes were received", null);
 
@@ -450,7 +450,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // something the user has to prove with grep into something the server states with numbers.
     final long accounted = verticesCreated + edgesCreated + stream.getLinesSkipped();
     if (accounted != stream.getLinesRead())
-      return recordsDropped(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs);
+      return recordsDropped(exchange, databaseName, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
 
     // A chunked upload announces no length, so the only thing that can prove it arrived whole is the client saying
     // how much it was going to send. Without it a body that ends early - because the producer feeding the stream
@@ -459,7 +459,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     final long records = verticesCreated + edgesCreated;
     if (expectedRecords >= 0 && records != expectedRecords)
       return recordCountMismatch(exchange, databaseName, verticesCreated, edgesCreated, expectedRecords, records,
-          stream, vertexRefs);
+          stream, vertexRefs, inputStream);
 
     final long elapsed = System.currentTimeMillis() - startTime;
 
@@ -467,10 +467,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     result.put("verticesCreated", verticesCreated);
     result.put("edgesCreated", edgesCreated);
     result.put("elapsedMs", elapsed);
-    // How much of the upload the server actually consumed: on a chunked body there is nothing to compare it with
-    // server-side, so this is what lets a client verify that its whole file arrived (issue #5470).
-    result.put("bytesRead", inputStream.getBytesRead());
-    addLineAccounting(result, stream, vertexRefs);
+    addLineAccounting(result, stream, vertexRefs, inputStream);
 
     // Include temp ID mapping if any temp IDs were used, unless the load was too big for the mapping to be worth
     // (or even possible to) send back - see MAX_ID_MAPPING_IN_RESPONSE and the 'idMapping' parameter.
@@ -572,7 +569,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    */
   private ExecutionResponse truncatedBody(final HttpServerExchange exchange, final String databaseName,
       final long verticesCreated, final long edgesCreated, final BatchRecordStream stream,
-      final VertexRefResolver vertexRefs, final String message, final String exceptionClass) {
+      final VertexRefResolver vertexRefs, final CountingInputStream inputStream, final String message,
+      final String exceptionClass) {
 
     LogManager.instance().log(this, Level.WARNING,
         "Batch load on database '%s' was interrupted after %d vertices and %d edges because the request body "
@@ -587,7 +585,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     // already gone, but when it does it carries the counts needed to resume instead of restarting.
     return partialPayloadResponse(exchange, 408,
         "Request body was truncated after " + verticesCreated + " vertices and " + edgesCreated + " edges: " + message,
-        exceptionClass, verticesCreated, edgesCreated, stream, vertexRefs);
+        exceptionClass, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
   }
 
   /**
@@ -598,7 +596,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    */
   private ExecutionResponse recordCountMismatch(final HttpServerExchange exchange, final String databaseName,
       final long verticesCreated, final long edgesCreated, final long expectedRecords, final long records,
-      final BatchRecordStream stream, final VertexRefResolver vertexRefs) {
+      final BatchRecordStream stream, final VertexRefResolver vertexRefs, final CountingInputStream inputStream) {
 
     final boolean truncated = records < expectedRecords;
 
@@ -611,7 +609,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
 
     return partialPayloadResponse(exchange, truncated ? 408 : 400,
         "Expected " + expectedRecords + " records but " + records + " were received (" + verticesCreated
-            + " vertices and " + edgesCreated + " edges)", null, verticesCreated, edgesCreated, stream, vertexRefs);
+            + " vertices and " + edgesCreated + " edges)", null, verticesCreated, edgesCreated, stream, vertexRefs,
+        inputStream);
   }
 
   /**
@@ -625,7 +624,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    */
   private ExecutionResponse recordsDropped(final HttpServerExchange exchange, final String databaseName,
       final long verticesCreated, final long edgesCreated, final BatchRecordStream stream,
-      final VertexRefResolver vertexRefs) {
+      final VertexRefResolver vertexRefs, final CountingInputStream inputStream) {
 
     final long missing = stream.getLinesRead() - stream.getLinesSkipped() - verticesCreated - edgesCreated;
 
@@ -640,7 +639,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
             + " records were dropped without an error. The load is reported as failed rather than successful; the "
             + "records already committed are counted above, so do not simply re-POST the payload - that would "
             + "duplicate them",
-        null, verticesCreated, edgesCreated, stream, vertexRefs);
+        null, verticesCreated, edgesCreated, stream, vertexRefs, inputStream);
   }
 
   /**
@@ -649,7 +648,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    */
   private ExecutionResponse partialPayloadResponse(final HttpServerExchange exchange, final int status,
       final String message, final String exceptionClass, final long verticesCreated, final long edgesCreated,
-      final BatchRecordStream stream, final VertexRefResolver vertexRefs) {
+      final BatchRecordStream stream, final VertexRefResolver vertexRefs, final CountingInputStream inputStream) {
 
     final JSONObject error = new JSONObject();
     error.put("error", message);
@@ -661,7 +660,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     error.put("verticesCreated", verticesCreated);
     error.put("edgesCreated", edgesCreated);
     error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);
-    addLineAccounting(error, stream, vertexRefs);
+    addLineAccounting(error, stream, vertexRefs, inputStream);
     return new ExecutionResponse(status, error.toString());
   }
 
@@ -672,11 +671,18 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    * checked it (the server does, see {@link #recordsDropped}), and can compare it with the line count of its own
    * file - which is what issue #5618 had to be diagnosed with, by hand, after the fact.
    * <p>
+   * {@code bytesRead} is on every answer for the same reason. On a chunked body there is nothing to compare it with
+   * server-side, so it is what lets a client verify that its whole file arrived (issue #5470); on a truncated one it
+   * is how far the server got, and - since issue #6180 - the number that says the server read no further than the
+   * client wrote, which it must never do whatever the connection hands it (see
+   * {@link CountingInputStream#available()}).
+   * <p>
    * {@code verticesWithoutId} is reported only when it is not zero: those vertices are loaded and durable, but no
    * edge of the payload can ever point at them, and today the only symptom is an "unknown temporary ID" much later.
    */
   private void addLineAccounting(final JSONObject json, final BatchRecordStream stream,
-      final VertexRefResolver vertexRefs) {
+      final VertexRefResolver vertexRefs, final CountingInputStream inputStream) {
+    json.put("bytesRead", inputStream.getBytesRead());
     json.put("linesRead", stream.getLinesRead());
     json.put("linesSkipped", stream.getLinesSkipped());
 
@@ -703,11 +709,19 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
   /**
    * Counts the bytes handed to the parser, so the handler can compare them with the announced
    * {@code Content-Length} - and makes sure that giving up on a load never means reading the rest of it first.
+   * <p>
+   * It is also where a request body that has FAILED stops being a request body (issue #6180). The first failure -
+   * whether it surfaces on a read or on an {@link #available()} probe - is remembered, and every later read of the
+   * same body is refused with it instead of being attempted again. See {@link #available()} for what that prevents.
    */
-  private static class CountingInputStream extends FilterInputStream {
+  // Package-private, not private: PostBatchHandlerBodyFailureTest drives it directly, which is the only way to
+  // reproduce a request body that fails on a probe and then offers bytes anyway (issue #6180).
+  static class CountingInputStream extends FilterInputStream {
     private final HttpServerExchange exchange;
     private       long              bytesRead;
     private       boolean           endOfBody;
+    /** The failure that ended this body, or {@code null} while it is still readable. */
+    private       IOException       bodyFailure;
 
     CountingInputStream(final HttpServerExchange exchange, final InputStream in) {
       super(in);
@@ -716,7 +730,14 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
 
     @Override
     public int read() throws IOException {
-      final int read = super.read();
+      refuseIfBodyFailed();
+      final int read;
+      try {
+        read = super.read();
+      } catch (final IOException e) {
+        bodyFailure = e;
+        throw e;
+      }
       if (read >= 0)
         ++bytesRead;
       else
@@ -726,12 +747,69 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
 
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
-      final int read = super.read(b, off, len);
+      refuseIfBodyFailed();
+      final int read;
+      try {
+        read = super.read(b, off, len);
+      } catch (final IOException e) {
+        bodyFailure = e;
+        throw e;
+      }
       if (read > 0)
         bytesRead += read;
       else if (read < 0)
         endOfBody = true;
       return read;
+    }
+
+    /**
+     * Whether the request body has already failed. A load that reaches this has read every byte the client managed
+     * to send: whatever the stream would hand over now is not payload.
+     */
+    boolean hasBodyFailed() {
+      return bodyFailure != null;
+    }
+
+    /**
+     * Refuses a read of a body that has already failed, with the failure itself rather than a wrapper: it is the
+     * reason this read cannot happen, its stack trace points at where the body really ended, and the load is
+     * answered with exactly the message it would have carried had the failure surfaced on this read in the first
+     * place.
+     */
+    private void refuseIfBodyFailed() throws IOException {
+      if (bodyFailure != null)
+        throw bodyFailure;
+    }
+
+    /**
+     * How much of the body has already arrived, and - the part that matters here - the ONE place a failed body is
+     * allowed to be probed without the failure being lost.
+     * <p>
+     * {@code InputStreamReader} probes the stream between decodes ({@code StreamDecoder.inReady}) and SWALLOWS the
+     * {@link IOException} it may raise. That is what made a cut upload apply records the client never sent (issue
+     * #6180): the probe reaches {@code UndertowInputStream.readIntoBufferNonBlocking}, which allocates a pooled
+     * buffer before the channel read that throws and does not release it, so the buffer stays on the stream holding
+     * whatever the POOL last left in it - for a connection whose first read filled it, the request head and the very
+     * records already loaded. The next read is then served from that buffer without touching the channel, and the
+     * parser is handed a replay of the payload: on a type with a unique index it surfaces as a 409 duplicate key
+     * ({@code Issue5470BatchStreamStallIT} on {@code main}), and on one without it as silently duplicated rows and a
+     * 200 (issue #6176).
+     * <p>
+     * So the failure is recorded here rather than raised: the probe answers -1, which is exactly the "the body is
+     * finished" convention {@link #drainAlreadyBuffered} already reads from Undertow, the decoder stops asking, and
+     * the next read is refused by {@link #refuseIfBodyFailed} - which sends the load down the truncated-body path it
+     * was always meant to take, with the counts the client needs to resume.
+     */
+    @Override
+    public int available() {
+      if (bodyFailure != null)
+        return -1;
+      try {
+        return super.available();
+      } catch (final IOException e) {
+        bodyFailure = e;
+        return -1;
+      }
     }
 
     /**
@@ -762,7 +840,9 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
      */
     @Override
     public void close() {
-      if (endOfBody || drainAlreadyBuffered(MAX_ABANDONED_BODY_DRAIN) == BufferedDrain.END_OF_BODY)
+      // A body that FAILED is not a body that ended: there is nothing to drain and the connection carrying it is
+      // gone, so it is retired below rather than handed back for the next request (issue #6180).
+      if (bodyFailure == null && (endOfBody || drainAlreadyBuffered(MAX_ABANDONED_BODY_DRAIN) == BufferedDrain.END_OF_BODY))
         return;
 
       // Retiring a connection is invisible from the outside, and it is also where an unexpected cost would show up
@@ -1036,7 +1116,8 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
    * by {@code RaftReplicatedDatabase.command()} for SQL writes.
    */
   private ExecutionResponse forwardBatchToLeader(final HttpServerExchange exchange, final HAServerPlugin ha,
-      final String databaseName, final ServerSecurityUser user, final String contentType) throws Exception {
+      final String databaseName, final ServerSecurityUser user, final String contentType,
+      final CountingInputStream body) throws Exception {
 
     // A peer already relayed this load to what it believed was the leader and it landed here, on a node that
     // is not the leader either. Relaying it on would send it round the cycle that wrong address created, one
@@ -1089,8 +1170,10 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
     if (queryString != null && !queryString.isEmpty())
       url += "?" + queryString;
 
+    // The body travels through the same guarded stream the leader-side load would use, so a cut upload cannot
+    // relay a replay of its own bytes on to the leader either (issue #6180).
     final HttpRequest request = buildForwardRequest(url, contentType, clusterToken, user.getName(),
-        exchange.getRequestContentLength(), exchange.getInputStream());
+        exchange.getRequestContentLength(), body);
 
     try {
       final HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -584,8 +584,7 @@ public class CoreApiSpec implements OpenApiContributor {
     schema.addProperty("verticesCreated", SpecBuilders.integer("Vertices created"));
     schema.addProperty("edgesCreated", SpecBuilders.integer("Edges created"));
     schema.addProperty("elapsedMs", SpecBuilders.integer("Elapsed time in milliseconds"));
-    schema.addProperty("bytesRead", SpecBuilders.integer(
-        "Bytes of the upload the server consumed, so a client can verify its whole file arrived"));
+    addLoadAccounting(schema);
     schema.addProperty("idMapping", SpecBuilders.object(
         "Temporary id to RID mapping, present only when temporary ids were used and the mapping was small enough to echo"));
     schema.addProperty("idMappingOmitted", SpecBuilders.bool(
@@ -616,7 +615,25 @@ public class CoreApiSpec implements OpenApiContributor {
     schema.addProperty("partialCommit", SpecBuilders.bool("""
         True when earlier chunks are durably committed. Retrying the whole payload then duplicates \
         the already-committed vertices, because temporary ids are not keys."""));
+    addLoadAccounting(schema);
     return schema;
+  }
+
+  /**
+   * What the load did with the payload, on the successful answer and the failing ones alike: a client reconciling a
+   * partial load needs them exactly where it needs the counts.
+   */
+  private void addLoadAccounting(final Schema<Object> schema) {
+    schema.addProperty("bytesRead", SpecBuilders.integer("""
+        Bytes of the upload the server consumed, so a client can verify its whole file arrived - and, on a \
+        truncated load, how far the server got. Never more than the client sent."""));
+    schema.addProperty("linesRead", SpecBuilders.integer(
+        "Lines the parser read, so 'linesRead' minus 'linesSkipped' can be checked against the records created"));
+    schema.addProperty("linesSkipped", SpecBuilders.integer(
+        "Lines that carried no record: blank lines, plus CSV headers and '---' separators"));
+    schema.addProperty("verticesWithoutId", SpecBuilders.integer("""
+        Vertices created without an '@id' under refMode=id. They are loaded and durable, but no edge can \
+        reference them. Absent when zero."""));
   }
 
   private Schema<?> createProgressResponseSchema() {

--- a/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
@@ -73,6 +73,12 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
   private static final int CLIENT_SO_TIMEOUT_MS = STREAMING_BUDGET_MS + 30_000;
   /** More than one server-side vertex batch (PostBatchHandler flushes every 10,000 vertices). */
   private static final int TOTAL_VERTICES   = 25_000;
+  /**
+   * Long enough that the server reads each half of the payload on its own, so a pooled buffer holding only whole
+   * records is what goes back to the pool - see {@link #aTruncatedUploadIsNotServedItsOwnBytesAgain}. Far below the
+   * socket read timeout, which is what bounds it.
+   */
+  private static final int CHUNK_PAUSE_MS   = 300;
 
   @Override
   public void setTestConfiguration() {
@@ -229,10 +235,90 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
       final JSONObject result = new JSONObject(payload);
       assertThat(result.getLong("verticesCreated")).isEqualTo(vertices);
       assertThat(result.getBoolean("partialCommit")).isTrue();
+      assertThat(result.getLong("bytesRead"))
+          .as("the server may not read a byte past the last one the client sent")
+          .isEqualTo(sent.length);
 
       final JSONObject count = executeCommand(0, "sql", "SELECT count(*) as total FROM V1 WHERE id >= 3000000");
       assertThat(count.getJSONObject("result").getJSONArray("records").getJSONObject(0).getLong("total"))
           .as("only the records the client sent may be loaded")
+          .isEqualTo(vertices);
+    }
+  }
+
+  /**
+   * The same truncation, with the payload sent in two record-aligned chunks - which is what turns the defect of
+   * issue #6180 from an oddity into duplicated rows.
+   * <p>
+   * The pause makes the server read each chunk into a pooled buffer of its own, so a buffer holding NOTHING but
+   * whole records goes back to the pool. When the peer then goes away, the probe {@code InputStreamReader} makes
+   * between decodes fails inside {@code UndertowInputStream.readIntoBufferNonBlocking}, which has already taken a
+   * buffer from that pool and does not give it back: the next read is served from it without touching the
+   * connection, and the parser is handed a replay of records it has already loaded. Measured on {@code main}
+   * before the fix: reads of 8192 and 8172 bytes past the end of the payload, starting at the very record the
+   * second chunk started with, and a {@code bytesRead} of 40284 against the 23920 bytes the client sent. On a type
+   * with a unique index the replay surfaces as a 409 duplicate key rather than the 408 this asserts (issue #6176);
+   * on one without it, as silently duplicated rows and a 200.
+   * <p>
+   * Which buffer the pool hands back is not under a test's control, so this one is the SHAPE and not the detector:
+   * it caught the defect running on its own and passed against a defective handler running fourth in this class.
+   * {@link #aBodyShorterThanItsContentLengthIsNotReportedAsSuccess} is what fails every time without the fix - the
+   * replay there is the request head rather than records, which the parser rejects, so the load still ends in a 408
+   * and only {@code bytesRead} tells the two apart. Both assert the same invariant: the server reads no further
+   * than the client wrote.
+   */
+  @Test
+  void aTruncatedUploadIsNotServedItsOwnBytesAgain() throws Exception {
+    final int vertices = 520;
+    final StringBuilder body = new StringBuilder();
+    for (int i = 0; i < vertices; i++)
+      body.append("{\"@type\":\"vertex\",\"@class\":\"V1\",\"id\":").append(4_000_000 + i).append("}\n");
+
+    final byte[] sent = body.toString().getBytes(StandardCharsets.UTF_8);
+    final String auth = Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
+
+    try (final Socket socket = new Socket("127.0.0.1", 2480)) {
+      socket.setSoTimeout(CLIENT_SO_TIMEOUT_MS);
+
+      final OutputStream out = socket.getOutputStream();
+      out.write(("POST /api/v1/batch/" + getDatabaseName() + "?vertexBatchSize=1 HTTP/1.1\r\n"
+          + "Host: 127.0.0.1:2480\r\n"
+          + "Authorization: Basic " + auth + "\r\n"
+          + "Content-Type: application/x-ndjson\r\n"
+          + "Content-Length: 1000000\r\n"
+          + "\r\n").getBytes(StandardCharsets.UTF_8));
+
+      // Halfway is a record boundary: every record of this payload is the same length.
+      final int half = sent.length / 2;
+      out.write(sent, 0, half);
+      out.flush();
+      Thread.sleep(CHUNK_PAUSE_MS);
+      out.write(sent, half, sent.length - half);
+      out.flush();
+      Thread.sleep(CHUNK_PAUSE_MS);
+      socket.shutdownOutput();
+
+      final BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+      final String statusLine = in.readLine();
+
+      String payload = null;
+      for (String l = in.readLine(); l != null; l = in.readLine())
+        if (l.startsWith("{"))
+          payload = l;
+
+      assertThat(statusLine).as("a truncated upload is a 408, never a 409 for a key the client sent once").contains("408");
+      assertThat(payload).isNotNull();
+
+      final JSONObject result = new JSONObject(payload);
+      assertThat(result.getLong("bytesRead"))
+          .as("the parser was handed bytes the client never sent")
+          .isEqualTo(sent.length);
+      assertThat(result.getLong("verticesCreated")).isEqualTo(vertices);
+      assertThat(result.getLong("linesRead")).isEqualTo(vertices);
+
+      final JSONObject count = executeCommand(0, "sql", "SELECT count(*) as total FROM V1 WHERE id >= 4000000");
+      assertThat(count.getJSONObject("result").getJSONArray("records").getJSONObject(0).getLong("total"))
+          .as("a record the client sent once is loaded once")
           .isEqualTo(vertices);
     }
   }

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostBatchHandlerBodyFailureTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostBatchHandlerBodyFailureTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.server.http.handler.PostBatchHandler.CountingInputStream;
+import io.undertow.server.HttpServerExchange;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression for issue #6180: a request body that has FAILED must never hand the batch parser another byte.
+ * <p>
+ * The stream under test is what stands between the parser and a connection that lies. Undertow's
+ * {@code UndertowInputStream} allocates a pooled buffer before the channel read that fails and does not release it,
+ * so the next read is served from that buffer - which holds whatever the POOL last left in it, on this connection
+ * usually its own request head and the records already loaded. {@code InputStreamReader} is what reaches it, because
+ * it probes with {@code available()} between decodes ({@code StreamDecoder.inReady}) and swallows the
+ * {@link IOException} - so the failure that should have ended the load disappears and the replay is parsed as
+ * payload. {@link FailsOnProbeThenOffersStaleBytes} is that connection, in the small.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostBatchHandlerBodyFailureTest {
+
+  private static final String SENT  = "{\"@type\":\"vertex\",\"@class\":\"V1\",\"id\":1}\n";
+  /** What a poisoned pooled buffer offers after the failure: bytes of this connection the parser already handled. */
+  private static final String STALE = "POST /api/v1/batch/graph HTTP/1.1\r\n" + SENT + SENT;
+
+  @Test
+  void aProbeThatFailsEndsTheBodyInsteadOfPoisoningIt() throws IOException {
+    final FailsOnProbeThenOffersStaleBytes connection = new FailsOnProbeThenOffersStaleBytes();
+    final CountingInputStream body = new CountingInputStream(new HttpServerExchange(null), connection);
+
+    assertThat(readFully(body, SENT.length())).isEqualTo(SENT);
+
+    // The probe InputStreamReader makes between decodes: -1 is Undertow's own "the body is finished", which is what
+    // the handler's truncation check reads, and it must not surface as an exception the decoder would swallow.
+    assertThat(body.available()).as("a failed probe reports the end of the body, it does not throw").isEqualTo(-1);
+    assertThat(body.hasBodyFailed()).isTrue();
+
+    // Refused with the failure itself: the load is answered with the same reason it would have carried had the
+    // read been the first thing to fail, which is what the 408 says.
+    assertThatThrownBy(() -> body.read(new byte[64], 0, 64))
+        .as("no byte may be read from a body that failed")
+        .isInstanceOf(IOException.class)
+        .hasMessage("peer closed the connection");
+    assertThatThrownBy(body::read).isInstanceOf(IOException.class).hasMessage("peer closed the connection");
+
+    assertThat(body.getBytesRead())
+        .as("the load consumed exactly what the client sent")
+        .isEqualTo(SENT.length());
+    assertThat(connection.readsAfterFailure).as("the poisoned connection is never read again").isZero();
+  }
+
+  /**
+   * The whole point, end to end over the very reader the batch parser uses: on a body that fails on the probe, a
+   * {@link BufferedReader} must reach the end of the payload and then fail - never return the replayed lines. Without
+   * the guard this reads the request line and the two records again, which on a unique index is the 409 duplicate key
+   * {@code Issue5470BatchStreamStallIT} sees instead of a 408 (issues #6180 and #6176).
+   */
+  @Test
+  void aReaderOverAFailedBodyNeverSeesTheReplayedLines() throws IOException {
+    final FailsOnProbeThenOffersStaleBytes connection = new FailsOnProbeThenOffersStaleBytes();
+    final BufferedReader reader = new BufferedReader(
+        new InputStreamReader(new CountingInputStream(new HttpServerExchange(null), connection),
+            StandardCharsets.UTF_8));
+
+    assertThat(reader.readLine()).isEqualTo(SENT.strip());
+    assertThatThrownBy(reader::readLine).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void aReadThatFailsIsNotAttemptedASecondTime() throws IOException {
+    final InputStream connection = new InputStream() {
+      private int reads;
+
+      @Override
+      public int read() throws IOException {
+        if (++reads == 1)
+          throw new IOException("connection reset");
+        return 'x';
+      }
+    };
+    final CountingInputStream body = new CountingInputStream(new HttpServerExchange(null), connection);
+
+    assertThatThrownBy(body::read).isInstanceOf(IOException.class).hasMessage("connection reset");
+    // Refused rather than attempted again: a second attempt would have succeeded and returned the 'x' below.
+    assertThatThrownBy(body::read).isInstanceOf(IOException.class).hasMessage("connection reset");
+    assertThat(body.getBytesRead()).isZero();
+  }
+
+  @Test
+  void anIntactBodyIsUnaffected() throws IOException {
+    final CountingInputStream body = new CountingInputStream(new HttpServerExchange(null),
+        new ByteArrayInputStream(SENT.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(body.available()).isEqualTo(SENT.length());
+    assertThat(readFully(body, SENT.length())).isEqualTo(SENT);
+    assertThat(body.read()).isEqualTo(-1);
+    assertThat(body.isEndOfBody()).isTrue();
+    assertThat(body.hasBodyFailed()).isFalse();
+    assertThat(body.getBytesRead()).isEqualTo(SENT.length());
+  }
+
+  private static String readFully(final InputStream in, final int length) throws IOException {
+    final byte[] buffer = new byte[length];
+    int read = 0;
+    while (read < length) {
+      final int n = in.read(buffer, read, length - read);
+      if (n < 0)
+        break;
+      read += n;
+    }
+    return new String(buffer, 0, read, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * A request body that delivers what the client sent, fails on the next probe, and - as a pooled buffer Undertow
+   * leaked on that failure does - would happily serve unrelated bytes to whoever asks again.
+   */
+  private static class FailsOnProbeThenOffersStaleBytes extends InputStream {
+    private final byte[] sent  = SENT.getBytes(StandardCharsets.UTF_8);
+    private final byte[] stale = STALE.getBytes(StandardCharsets.UTF_8);
+    private       int    position;
+    private       boolean failed;
+    private       int     readsAfterFailure;
+
+    @Override
+    public int available() throws IOException {
+      if (position < sent.length)
+        return sent.length - position;
+      failed = true;
+      throw new IOException("peer closed the connection");
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) {
+      if (failed) {
+        ++readsAfterFailure;
+        final int copied = Math.min(len, stale.length);
+        System.arraycopy(stale, 0, b, off, copied);
+        return copied;
+      }
+      final int copied = Math.min(len, sent.length - position);
+      System.arraycopy(sent, position, b, off, copied);
+      position += copied;
+      return copied;
+    }
+
+    @Override
+    public int read() {
+      final byte[] one = new byte[1];
+      return read(one, 0, 1) <= 0 ? -1 : one[0] & 0xFF;
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -73,7 +73,8 @@ class CoreApiSpecTest {
   void batchResponseCarriesTheCountsAndIdMapping() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("BatchResponse");
     assertThat(schema.getProperties().keySet()).containsExactlyInAnyOrder(
-        "verticesCreated", "edgesCreated", "elapsedMs", "bytesRead",
+        "verticesCreated", "edgesCreated", "elapsedMs",
+        "bytesRead", "linesRead", "linesSkipped", "verticesWithoutId",
         "idMapping", "idMappingOmitted", "idMappingSize");
   }
 
@@ -81,7 +82,8 @@ class CoreApiSpecTest {
   void batchFailuresCarryThePartialCommitCountsNotTheGenericError() {
     final Schema<?> schema = openAPI.getComponents().getSchemas().get("BatchError");
     assertThat(schema.getProperties().keySet()).containsExactlyInAnyOrder(
-        "error", "exception", "requestId", "verticesCreated", "edgesCreated", "partialCommit");
+        "error", "exception", "requestId", "verticesCreated", "edgesCreated", "partialCommit",
+        "bytesRead", "linesRead", "linesSkipped", "verticesWithoutId");
 
     final Operation post = openAPI.getPaths().get("/api/v1/batch/{database}").getPost();
     for (final String code : List.of("400", "408")) {


### PR DESCRIPTION
Two issues, one defect: `POST /api/v1/batch` could apply records the client never sent in that request.

## What was happening

`Issue5470BatchStreamStallIT.aBodyShorterThanItsContentLengthIsNotReportedAsSuccess` has been red on `main` with
**409 Conflict** where it expects 408. #6180 read that correctly: 409 is the duplicate-key mapping, and the ids in
that payload are unique within it and unique in a fresh database, so reaching it means the records were inserted
twice. #6176 filed the same failure from the status-code end.

Measured before changing anything, by instrumenting the handler's body stream on a 100-record upload cut after
4600 bytes:

```
read  before=0    read=4600  head=[{"@type":"vertex",...,"id":3000000}|...]     <- the payload
available() threw java.io.IOException: UT000128: Remote peer closed connection before all data could be read
    at java.base/sun.nio.cs.StreamDecoder.inReady(StreamDecoder.java:430)
read  before=4600 read=8192  head=[POST /api/v1/batch/graph?vertexBatchSize=1 HTTP/1.1|Host: 1]
```

The second read is the connection's own request head. The chain:

1. `UndertowInputStream.readIntoBufferNonBlocking` allocates a pooled buffer **before** the channel read that
   throws, and does not release it on the way out. The buffer stays on the stream, holding whatever the pool last
   left in it - identified here by object identity as the very buffer that held this connection's request head and
   body (`limit 16364 = capacity`, zeros past byte 4801).
2. The next `read()` sees a non-null buffer and is served from it without touching the channel at all.
3. What reaches the failure is `InputStreamReader`: it probes with `available()` between decodes
   (`StreamDecoder.inReady`) and **swallows** the `IOException`. The failure that should have ended the load
   disappears, and the replay is parsed as payload.

Sent in two record-aligned chunks, the replay is whole records: reads of 8192 and 8172 bytes past the end of the
upload, starting at the exact record the second chunk started with, and 40284 bytes consumed against the 23920 the
client sent. On a type with a unique index those re-applied records collide and the load is answered 409 for a key
the client sent once. On a type without one - what a bulk load usually has - they duplicate rows and the load is
answered 200.

**One correction to #6176's second claim**: the "interrupted after 0 vertices and 0 edges" log line quoted there
belongs to the sibling test `stalledClientIsCutOffAndAnswered`, which legitimately reports 0 - it sends a single
vertex with the default `vertexBatchSize`, so nothing has been flushed when the client goes silent. The resume
counts were never lost.

## The fix

`PostBatchHandler.CountingInputStream` ends a body that has failed:

- the first failure is remembered, whether it surfaces on a read or on a probe;
- the probe answers `-1` - Undertow's own "the body is finished", which `bodyEndedEarly`/`drainAlreadyBuffered`
  already read - so the decoder stops asking instead of swallowing anything;
- every later read is refused with the recorded failure itself, so the load takes the truncated-body path it was
  always meant to take: 408, the counts needed to resume, and not one record the client did not send.

The follower-to-leader forwarding path now reads through the same guarded stream, so a cut upload cannot relay a
replay of itself to the leader either.

Every answer carries `bytesRead` now, not only the successful one: on a truncated load that is where a client
learns how far the server got, and it is the number that says the server read no further than the client wrote.
The OpenAPI batch response and error schemas were completed to match what both bodies have carried since #5618
(`bytesRead`, `linesRead`, `linesSkipped`, `verticesWithoutId`).

## Verification

- `PostBatchHandlerBodyFailureTest` (new, 4 tests) drives the stream directly - the only way to reproduce a body
  that fails on a probe and then offers bytes anyway. **3 of the 4 go red with the guard removed**; the fourth is
  the intact-body control.
- `Issue5470BatchStreamStallIT`: the existing truncation test now asserts `bytesRead`, and **fails without the fix
  with 20964 bytes read against the 4600 sent**. A new test covers the record-aligned shape, where the replay
  carries whole records; its javadoc says plainly that it is the shape and not the detector, because which buffer
  the pool hands back is not under a test's control.
- Green: `Issue5470BatchStreamStallIT`, `Issue5470BatchErrorDeliveryIT`, `PostBatchHandlerIT`,
  `Issue5618BatchLineAccountingIT` (48 tests); `RemoteGraphBatchIT`, `OpenApiSpecGenerationIT`,
  `UngatedHandlerCrossDatabaseIT`, `UngatedHandlerPerTypeAclIT` (33); `PostBatchHandlerBodyFailureTest`,
  `PostBatchHandlerForwardRequestTest`, `CoreApiSpecTest` (19).

Closes #6180, closes #6176.
