### PR TITLE
test(#6217): the chunked-merge tests count commit conflicts, and say which mechanism produced one

### DIFF
--- a/engine/src/test/java/com/arcadedb/database/Issue6129ChunkedSlotMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6129ChunkedSlotMergeTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.database;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.PageManager;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,9 +58,10 @@ class Issue6129ChunkedSlotMergeTest extends BucketPageLayoutTestSupport {
   void updatesOfChunkedRecordsSharingAPageNeverConflict() throws Exception {
     final RID[][] owned = createAndSpillRecords("Chunked");
 
-    final AtomicInteger conflicts = runConcurrentUpdates(owned, this::fixedSizePayload);
+    final ConcurrentUpdateOutcome outcome = runConcurrentUpdates(owned, this::fixedSizePayload);
 
-    assertThat(conflicts.get()).as("updating chunked records owned by different threads must not conflict").isZero();
+    assertThat(outcome.commitConflicts())
+        .as("updating chunked records owned by different threads must not conflict: %s", outcome).isZero();
 
     verifyContent(owned, this::fixedSizePayload);
     checkDatabase();
@@ -72,14 +73,21 @@ class Issue6129ChunkedSlotMergeTest extends BucketPageLayoutTestSupport {
    * rebasable - they are poisoned by the chunk writer - so what this pins down is that the head chunk's merge still
    * carries the whole write when the chain grows underneath it, and that a record's continuation chunks landing next
    * to another thread's do not bring the conflict back.
+   * <p>
+   * "Conflict" here means one the COMMIT raised. A read of a chunked record can also fail, on a mechanism of its own:
+   * {@code readMultiPageRecord} re-validates the page VERSION of everything its chain touched, and the continuation
+   * chunks of all 40 records of this fixture live on one page, so an unrelated rewrite invalidates a reader that
+   * touched nothing of that record. That is issue #6217, it is counted separately by {@link ConcurrentUpdateOutcome},
+   * and until this class distinguished the two it was what made this test fail on a loaded machine.
    */
   @Test
   void growingUpdatesOfChunkedRecordsSharingAPageNeverConflict() throws Exception {
     final RID[][] owned = createAndSpillRecords("ChunkedGrowing");
 
-    final AtomicInteger conflicts = runConcurrentUpdates(owned, this::growingPayload);
+    final ConcurrentUpdateOutcome outcome = runConcurrentUpdates(owned, this::growingPayload);
 
-    assertThat(conflicts.get()).as("extending the chunk chain of one's own record must not conflict").isZero();
+    assertThat(outcome.commitConflicts())
+        .as("extending the chunk chain of one's own record must not conflict: %s", outcome).isZero();
 
     verifyContent(owned, this::growingPayload);
     checkDatabase();
@@ -561,11 +569,15 @@ class Issue6129ChunkedSlotMergeTest extends BucketPageLayoutTestSupport {
     throw new AssertionError("Not every record of " + typeName + " spilled into a chunk chain: " + bucketStats(typeName));
   }
 
-  private AtomicInteger runConcurrentUpdates(final RID[][] owned, final PayloadOf payloadOf) throws InterruptedException {
+  private ConcurrentUpdateOutcome runConcurrentUpdates(final RID[][] owned, final PayloadOf payloadOf)
+      throws InterruptedException {
     final List<Throwable> errors = new CopyOnWriteArrayList<>();
-    final AtomicInteger conflicts = new AtomicInteger();
+    final List<String> conflicts = new CopyOnWriteArrayList<>();
     final CountDownLatch start = new CountDownLatch(1);
     final List<Thread> threads = new ArrayList<>();
+
+    final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+    final PageManager.PPageManagerStats before = pageManager.getStats();
 
     for (int t = 0; t < THREADS; t++) {
       final int id = t;
@@ -579,7 +591,7 @@ class Issue6129ChunkedSlotMergeTest extends BucketPageLayoutTestSupport {
               try {
                 database.transaction(() -> rid.asDocument(true).modify().set("payload", payload).save(), true, 1);
               } catch (final ConcurrentModificationException e) {
-                conflicts.incrementAndGet();
+                conflicts.add(rid + " round " + round + ": " + e.getMessage());
               }
             }
         } catch (final Throwable e) {
@@ -596,7 +608,59 @@ class Issue6129ChunkedSlotMergeTest extends BucketPageLayoutTestSupport {
 
     if (!errors.isEmpty())
       throw new AssertionError(errors.size() + " thread(s) failed, first: " + errors.getFirst(), errors.getFirst());
-    return conflicts;
+
+    final PageManager.PPageManagerStats after = pageManager.getStats();
+    return new ConcurrentUpdateOutcome(conflicts,
+        after.concurrentModificationExceptions - before.concurrentModificationExceptions,
+        after.txPageSlotMerges - before.txPageSlotMerges,
+        after.mergesDeclinedByCoverage - before.mergesDeclinedByCoverage);
+  }
+
+  /**
+   * A conflict raised while READING the record, not while committing it: {@code readMultiPageRecord} re-validates
+   * the version of every page its chain touched and gives up after {@code TX_RETRIES} attempts. It is a different
+   * mechanism from the one these tests are about - the reader's own chunks are unchanged, what moved is another
+   * record's chunk sharing the page - and it is tracked as its own defect (#6217). Counting it as a merge failure is
+   * what made this class fail on a loaded machine with a bare "expected 0 but was 2": measured by shrinking the read
+   * budget to zero, where these very runs produce exactly this message and nothing else.
+   */
+  private static boolean isReadSideConflict(final String message) {
+    return message != null && message.contains("was modified during read");
+  }
+
+  /**
+   * What a run of {@link #runConcurrentUpdates} ended with. The counters are here because a failure of these tests
+   * is a statement about the MERGE, and the merge already counts what it did: a version clash the merge absorbed
+   * ({@code merged}) is the normal case - all but a handful of the transactions in these runs hit one - so the
+   * question a failure has to answer is which of the two ways to lose it took. {@code declinedByCoverage} above zero
+   * means a write on the page carried no declaration, which is a defect in the engine and not in the fixture;
+   * {@code declinedByCoverage} at zero means the page was POISONED, i.e. a chunk of some record's chain lives on it.
+   * Without them a failure here is a bare "expected 0 but was 2", which is where this test's own flakiness
+   * investigation started.
+   */
+  private record ConcurrentUpdateOutcome(List<String> conflicts, long versionClashes, long merged,
+                                         long declinedByCoverage) {
+    /**
+     * Conflicts the COMMIT raised, which is what these tests assert on. A read-side chain revalidation
+     * ({@link #isReadSideConflict}) is not one of them.
+     */
+    int commitConflicts() {
+      return (int) conflicts.stream().filter(c -> !isReadSideConflict(c)).count();
+    }
+
+    @Override
+    public String toString() {
+      final long readSide = conflicts.stream().filter(Issue6129ChunkedSlotMergeTest::isReadSideConflict).count();
+      final String counters = commitConflicts() + " commit conflict(s) and " + readSide
+          + " read-side chain revalidation(s) out of " + versionClashes + " page-version clashes, " + merged
+          + " absorbed by the slot merge, " + declinedByCoverage + " merges declined for missing coverage";
+      if (commitConflicts() == 0)
+        return counters;
+      return counters + ". " + (declinedByCoverage > 0
+          ? "A decline means a write on the page carried no declaration - an engine defect, not a fixture one."
+          : "No decline, so the page could not be merged because it was POISONED: a chunk of a chain lives on it.")
+          + " " + conflicts;
+    }
   }
 
   private void verifyContent(final RID[][] owned, final PayloadOf payloadOf) {


### PR DESCRIPTION
`Issue6129ChunkedSlotMergeTest.growingUpdatesOfChunkedRecordsSharingAPageNeverConflict` fails on a loaded machine with a bare `expected 0 but was 2` - once in four full `engine` lane runs, never in isolation nor when its own package runs alone. The conflicts it counted were not the mechanism it tests.

**What they actually were.** A read of a chunked record has a failure of its own: `readMultiPageRecord` re-validates the page VERSION of every page its chain touched, and a page version moves when any record on it moves. The continuation chunks of all 40 records of this fixture live on one page - measured by instrumenting the allocator, every one of the 40 placements is `headPage=0 avoid=0 -> page=1` - so an unrelated rewrite invalidates a reader that touched nothing of that record. After `TX_RETRIES` attempts it raises `Multi-page record #1:26 was modified during read after N retries`, which the harness counted like any other conflict.

Measured rather than inferred: with the read budget lowered to zero (`database.getConfiguration().setValue(TX_RETRIES, 0)`) these very runs produce exactly that message and nothing else, in 2 of 3 repetitions, with no commit-side conflict at all. With the default budget of 3, the same race needs four consecutive losses - which is what a loaded machine produces every few runs. The defect itself is #6217: the read-path half of the false conflicts #5381/#6129/#6175 removed from the write path.

**This PR.** The assertions count COMMIT conflicts, which is what these tests are about, and a failure now carries the counters the merge already keeps - version clashes, absorbed by the merge, declined for missing coverage, and how many conflicts were read-side revalidations. All but a handful of the 320 transactions in these runs hit a version clash and are absorbed, so a failure's real question is which way it lost: a decline above zero means a write carried no declaration (an engine defect), zero means the page was poisoned. Without that, the next reader of this failure starts the same investigation from nothing.

No production code changes. `Issue6129ChunkedSlotMergeTest` green (9 tests), and the full `engine` unit lane green (11978 tests) on the runs where the race did not fire.

Related: #6217.