### PR TITLE
fix(#6201, #6202): a retryable conflict is retried and reported as one, and every snapshot resync refuses the same addresses

### DIFF
--- a/.claude/skills/engine-concurrency/SKILL.md
+++ b/.claude/skills/engine-concurrency/SKILL.md
@@ -9,7 +9,10 @@ description: Use when adding, reviewing, or debugging parallelism in ArcadeDB en
 
 **Existing JDK-common-pool callers** (tagged in source with `NOTE (concurrency)` comments referencing the rule, will migrate as workloads justify it):
 - `GraphBatch.parallelSort` (`engine/...graph/GraphBatch.java`)
-- `ArcadeStateMachine.notifyInstallSnapshotFromLeader` (`ha-raft/...`)
+
+`ArcadeStateMachine.notifyInstallSnapshotFromLeader` was on this list until issue #6202 gave it a dedicated
+single-worker executor (`arcadedb-raft-snapshot-install`); a follower snapshot install is a full database
+download, i.e. the longest-running thing the HA layer does, and it no longer parks a common-pool worker for it.
 
 ## Dedicated thread pools
 
@@ -23,7 +26,8 @@ description: Use when adding, reviewing, or debugging parallelism in ArcadeDB en
 | `TimeSeriesEngine` pool | `engine` | Time-series rollup work | configurable | n/a |
 | `BackupScheduler` | `server` | Cron-style backup jobs | scheduled executor | n/a |
 | `MaterializedViewScheduler` | `server` | Cron-style MV refresh | scheduled executor | n/a |
-| Raft HA pools | `ha-raft` | Leader election, log replication, snapshot install | configurable in Raft conf | n/a |
+| Raft HA pools | `ha-raft` | Leader election, log replication | configurable in Raft conf | n/a |
+| `ArcadeStateMachine.snapshotInstallExecutor` | `ha-raft` | Leader-initiated follower snapshot install, off the Ratis state-machine thread | 1 worker, 16-deep queue (Ratis serialises installs per division) | Abort, turned into a failed future so Ratis retries - never caller-runs, which would put the download back on the Ratis thread |
 | Undertow IO + worker | `server` | HTTP request handling | hardcoded 500 worker threads | Undertow built-in |
 | `ServerMonitor` | `server` | Periodic metric collection | scheduled executor | n/a |
 

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1773,6 +1773,12 @@ peer. Neither outcome reported an error: `reconcileDatabasesFromLeader` succeede
 stale-read floor of #6111 was dropped, and the node returned to the ready set carrying whatever it had copied -
 its own incomplete databases, or a peer's that is itself behind.
 
+The two paths that re-resolve the address on **every download attempt** - `SnapshotInstaller.install` takes
+address suppliers precisely because leadership can move mid-operation - re-guard it on every attempt too, through
+both the HTTP and the HTTPS supplier. Guarding only the call site would leave the refusal a point-in-time check
+that attempt 3 walks straight past, and guarding only HTTP would leave it unreachable on an SSL cluster, where
+`downloadWithRetry` prefers the HTTPS endpoint and only falls back to HTTP when it comes back null.
+
 All six now ask one helper, so they cannot drift apart, and it refuses three things rather than two: this
 node being the leader, an address that is this node's own, and **an address that does not identify a single
 peer**. The last is the ambiguity check `selectUnambiguousRouting` makes for client routing tables (#6183),

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1752,10 +1752,18 @@ either way.
 
 ## The Ratis-initiated snapshot install makes the refusals the manual one makes (#6202)
 
-`ArcadeStateMachine` pulls a database snapshot from the leader on three paths, and only the manual one
-(`triggerSnapshotDownload()`) checked what it was about to dial. `notifyInstallSnapshotFromLeader` - the
-Ratis-initiated install, the one that runs when a follower's log is behind the leader's compacted log - and the
-targeted single-database resync both resolved an address and dialled it with no check at all.
+`ArcadeStateMachine` pulls a database snapshot from the leader on **six** paths, and only the manual one
+(`triggerSnapshotDownload()`) checked what it was about to dial. The other five resolved an address and dialled
+it with no check, or with only part of one:
+
+| Path | Guarded before |
+|---|---|
+| `triggerSnapshotDownload()` - watchdog / leader change / persistent-lag recovery | leader role + self address (#6111) |
+| `notifyInstallSnapshotFromLeader()` - the Ratis-initiated install, when a follower's log is behind the leader's compacted log | nothing |
+| `triggerDatabaseResync(String)` - targeted resync of one quarantined database | nothing |
+| `applyInstallDatabaseEntry` - the `forceSnapshot` restore flow | leader role only |
+| `installFromLeaderForBootstrap` - the bootstrap-fingerprint-mismatch reinstall | nothing |
+| `resyncDatabaseFromLeader` - operator-triggered emergency recovery | leader role + address known |
 
 The address is only as good as the configuration behind it. With no `http` port declared in
 `arcadedb.ha.serverList` a peer's HTTP endpoint is derived from that peer's Raft host plus **this** node's HTTP
@@ -1765,7 +1773,7 @@ peer. Neither outcome reported an error: `reconcileDatabasesFromLeader` succeede
 stale-read floor of #6111 was dropped, and the node returned to the ready set carrying whatever it had copied -
 its own incomplete databases, or a peer's that is itself behind.
 
-All three paths now ask one helper, so they cannot drift apart, and it refuses three things rather than two: this
+All six now ask one helper, so they cannot drift apart, and it refuses three things rather than two: this
 node being the leader, an address that is this node's own, and **an address that does not identify a single
 peer**. The last is the ambiguity check `selectUnambiguousRouting` makes for client routing tables (#6183),
 applied where it matters more - a confidently wrong routing address costs one redirect, a confidently wrong

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -1705,3 +1705,87 @@ by the negative size marker a plain collapse would replace with a positive one, 
 exactly what tells a bucket scan that a slot holds a document of its own.
 
 [#6178](https://github.com/ArcadeData/arcadedb/issues/6178)
+
+## A retryable conflict raised while a command runs is retried, and reported as retryable (#6201)
+
+`DatabaseAbstractHandler` runs `execute()` inside the engine's retrying transaction and converted **every**
+exception the handler raised into a `TransactionException`. Two dispatchers key on the exception type, and the
+wrapper broke both.
+
+`LocalDatabase.transaction(...)` decides what to retry with `catch (NeedRetryException | DuplicatedKeyException)`.
+A conflict raised while the command ran - a `save()` losing an MVCC race, an index update hitting a concurrent
+key - arrived there already wrapped, matched neither arm, fell into the generic `catch (Throwable)` and
+propagated on the first attempt. Only a conflict detected by the wrapper's own `commit()` was ever retried, so
+the `retries` a client asks for had no effect on most of the conflict surface.
+
+The HTTP error mapping keys on the type too, and the wrapped arm had no `NeedRetryException` branch, so the same
+conflict was answered `500 "Error on transaction commit"` - which names neither the reason nor that the write can
+be re-driven. `PostBatchHandler` documents the contract the other way round ("NeedRetryException -> 503, security
+-> 403, RecordNotFoundException -> 404, ... are left to the base handler"), and that was true only when no
+transaction wrapper was active. A client whose retry policy keys on 503 gave up on a write that would have
+succeeded on retry.
+
+The wrapper now rethrows a `RuntimeException` unchanged and wraps only the checked exceptions
+`TransactionScope.execute()` cannot declare. Every ArcadeDB exception is unchecked, so both dispatchers see the
+type they dispatch on.
+
+**The mapping itself is now written once.** It was three hand-written `instanceof` chains - one for an exception
+that reached the boundary as itself, one inside the `CommandExecutionException` arm and one inside the
+`TransactionException` arm - and every mapping added since had to be added to each separately: #4350 (duplicated
+key), #5064/#5075 (committed remotely), #5191 (parsing), #5219, #5602 (arithmetic), #5935 (malformed JSON), #6191
+(not the leader). The half that was missed each time took a second issue to notice, and #6201 is that second
+issue for `NeedRetryException` and `RecordNotFoundException`. A single ordered classification, applied to the
+exception and - for the generic wrappers only - to its cause, closes those two and every other asymmetry at once:
+a wrapped `IllegalArgumentException`, a wrapped `ServerSecurityException` and a wrapped `HttpSessionException`
+were each mapped by one or two of the three chains and not the rest. `Issue6201ErrorStatusParityTest` pins the
+property rather than the arms - the same exception raised inside and outside the wrapper must answer the same
+status - so a mapping added to one branch and not another fails there rather than in a future issue.
+
+One nuance the three chains had disagreed on is now stated rather than inherited: a `CommandExecutionException`
+that nothing more specific matched is reported *as itself*, because the engine raises it to say what failed
+("Backup failed for database 'x' to directory 'y'") and its cause is often just plumbing; a `TransactionException`
+is reported *as its cause*, because that wrapper is put on by the plumbing and its message says nothing the
+status label does not. Neither loses information - the error body's `detail` field renders the whole cause chain
+either way.
+
+[#6201](https://github.com/ArcadeData/arcadedb/issues/6201)
+
+## The Ratis-initiated snapshot install makes the refusals the manual one makes (#6202)
+
+`ArcadeStateMachine` pulls a database snapshot from the leader on three paths, and only the manual one
+(`triggerSnapshotDownload()`) checked what it was about to dial. `notifyInstallSnapshotFromLeader` - the
+Ratis-initiated install, the one that runs when a follower's log is behind the leader's compacted log - and the
+targeted single-database resync both resolved an address and dialled it with no check at all.
+
+The address is only as good as the configuration behind it. With no `http` port declared in
+`arcadedb.ha.serverList` a peer's HTTP endpoint is derived from that peer's Raft host plus **this** node's HTTP
+port, so on a cluster whose nodes share a host - several nodes on one machine, a compose file, a developer laptop
+- every peer collapses onto this node's own endpoint, and on a cluster with mixed ports it can name the wrong
+peer. Neither outcome reported an error: `reconcileDatabasesFromLeader` succeeded, the install was recorded, the
+stale-read floor of #6111 was dropped, and the node returned to the ready set carrying whatever it had copied -
+its own incomplete databases, or a peer's that is itself behind.
+
+All three paths now ask one helper, so they cannot drift apart, and it refuses three things rather than two: this
+node being the leader, an address that is this node's own, and **an address that does not identify a single
+peer**. The last is the ambiguity check `selectUnambiguousRouting` makes for client routing tables (#6183),
+applied where it matters more - a confidently wrong routing address costs one redirect, a confidently wrong
+snapshot source cannot be undone. Refusing leaves the follower out of the ready set and visibly behind, which is
+the state it is actually in; Ratis retries the install and the `HealthMonitor` re-arms the manual path.
+
+Two things the same method carried:
+
+- The install ran on the JDK common `ForkJoinPool` (`CompletableFuture.supplyAsync` with no executor), against
+  the rule at the head of `QueryEngineManager`'s class javadoc - that pool is shared with Gremlin and Polyglot
+  user code and with JDK internals, and a snapshot install is a full database download, the longest-running thing
+  the HA layer does. It has a dedicated single-worker executor now (`arcadedb-raft-snapshot-install`), with a
+  bounded queue and an abort policy turned into a failed future: caller-runs would put the download back on the
+  Ratis thread the offload exists to protect.
+- The single-flight `AtomicBoolean` did not serialise. The install proceeds when it *loses* the CAS - standing
+  down would report an install it never performed - so it could run concurrently with a request-driven resync
+  over one set of database directories. That was argued benign because both pull from the same leader and
+  `SnapshotInstaller` swaps atomically, but the argument is about today's installer and would outlive whoever
+  remembers it. A lock states the exclusion instead: the install waits for it (it owns its thread now), while the
+  request-driven paths fold into whatever holds it, exactly as they already fold into a lost CAS rather than
+  parking the single-threaded lifecycle executor.
+
+[#6202](https://github.com/ArcadeData/arcadedb/issues/6202)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2894,9 +2894,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return; // no unfilled gap
     if (snapshotDownloadInProgress.get())
       return; // one is genuinely running; it will clear the floor or re-arm the request
-    // Asked through the resolver triggerSnapshotDownload() itself uses, so this cheap precheck cannot pass a
-    // request the resync would then refuse - and burn a throttle slot doing it (issue #6202).
-    if (raftHA.getUnambiguousPeerHttpAddress(raftHA.getLeaderId()) == null)
+    // The same three questions resolveSnapshotSource() asks, so this cheap precheck cannot pass a request the
+    // resync would then refuse and burn a throttle slot doing it (issue #6202): the leader role is checked at the
+    // top of this method, and the resolved address must both identify a single peer and not be our own. Asked
+    // through the same two helpers rather than restated, and without resolveSnapshotSource() itself, whose
+    // unresolvable-local-address WARNING belongs to an attempt rather than to a HealthMonitor tick. When the
+    // local address cannot be resolved isOwnHttpAddress answers false, so the request goes through and that
+    // warning is emitted once by the resync, which is where it is actionable.
+    final String leaderHttpAddr = raftHA.getUnambiguousPeerHttpAddress(raftHA.getLeaderId());
+    if (leaderHttpAddr == null || raftHA.isOwnHttpAddress(leaderHttpAddr))
       return; // nowhere to download from yet; notifyLeaderChanged() drives the first attempt
 
     final long now = System.currentTimeMillis();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -68,15 +68,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
 /**
@@ -161,6 +165,31 @@ public class ArcadeStateMachine extends BaseStateMachine {
   });
 
   /**
+   * Runs a leader-initiated snapshot install off the Ratis state-machine thread, which must not block.
+   * <p>
+   * This was {@code CompletableFuture.supplyAsync(...)} with no executor, i.e. the JDK common ForkJoinPool,
+   * against the "No JDK common ForkJoinPool" rule at the head of {@code QueryEngineManager}'s class javadoc: that
+   * pool is shared with user-supplied scripts (Gremlin, Polyglot) and with JDK internals, and a snapshot install
+   * is a full database download - the longest-running thing the HA layer does. It has its own thread now
+   * (issue #6202), which is also what lets the install wait on {@link #snapshotDownloadLock} instead of racing
+   * the request-driven resyncs.
+   * <p>
+   * One worker, because Ratis serialises installs per division and {@code SnapshotInstaller} works over one set
+   * of database directories; a bounded queue and {@code AbortPolicy} rather than caller-runs, because running on
+   * the caller is precisely the outcome the offload exists to prevent - a rejection is turned into a failed
+   * future so Ratis retries the install rather than the Ratis thread carrying the download.
+   */
+  private final ThreadPoolExecutor snapshotInstallExecutor = createSnapshotInstallExecutor();
+
+  private static ThreadPoolExecutor createSnapshotInstallExecutor() {
+    return new ThreadPoolExecutor(0, 1, 30L, TimeUnit.SECONDS, new ArrayBlockingQueue<>(16), r -> {
+      final Thread t = new Thread(r, "arcadedb-raft-snapshot-install");
+      t.setDaemon(true);
+      return t;
+    }, new ThreadPoolExecutor.AbortPolicy());
+  }
+
+  /**
    * Removes dropped database directories away from the apply loop. Deliberately not the lifecycleExecutor: a
    * deletion is unbounded in the size of the database and would delay the snapshot-download triggers that
    * executor carries.
@@ -198,6 +227,20 @@ public class ArcadeStateMachine extends BaseStateMachine {
   private final AtomicBoolean needsSnapshotDownload      = new AtomicBoolean(false);
   private final AtomicBoolean snapshotDownloadInProgress = new AtomicBoolean(false);
   private final AtomicBoolean catchingUp                 = new AtomicBoolean(false);
+
+  /**
+   * Serialises the resync paths against each other (issue #6202). {@link #snapshotDownloadInProgress} was the
+   * only interlock, and it does not serialise: {@link #notifyInstallSnapshotFromLeader} proceeds when it LOSES
+   * the CAS rather than standing down, because standing down would report an install it never performed. Two
+   * downloads over one set of database directories were argued benign - both pull from the same leader and
+   * {@code SnapshotInstaller} swaps atomically - but that argument is about today's installer, not about the
+   * interlock, and it would outlive whoever remembers it. The lock states the invariant instead of deriving it.
+   * <p>
+   * The Ratis-initiated install waits for it; the two request-driven paths take it with {@code tryLock} and fold
+   * into whatever holds it, exactly as they already fold into a lost CAS - they run on the single-threaded
+   * {@link #lifecycleExecutor} and must not park it for the length of a download.
+   */
+  private final ReentrantLock snapshotDownloadLock = new ReentrantLock();
 
   // Highest Raft-log index whose data is actually present in the local databases while a flagged
   // stale-snapshot re-download is still outstanding; -1 when there is none (the normal case).
@@ -1169,8 +1212,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * downloaded from the leader. Delegates to {@link SnapshotInstaller#install} for crash-safe
    * installation with marker files and atomic directory swap.
    * <p>
-   * Runs asynchronously via {@link CompletableFuture#supplyAsync} to avoid blocking the
-   * Ratis state machine thread.
+   * Runs asynchronously on {@link #snapshotInstallExecutor} to avoid blocking the Ratis state machine thread.
    */
   @Override
   public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
@@ -1179,99 +1221,121 @@ public class ArcadeStateMachine extends BaseStateMachine {
     LogManager.instance().log(this, Level.INFO,
         "HA resync started (mode=snapshot, reason=leader snapshot install): firstLogIndex=%s", firstTermIndexInLog);
 
-    // Runs on the JDK common ForkJoinPool via supplyAsync(). Apache-ratis uses a dedicated pool
-    // to avoid blocking Ratis internal threads, so this offload IS necessary - we must not run
-    // the snapshot download synchronously on the caller. The remaining concern is the common
-    // pool itself: it is shared with user-supplied scripts (Gremlin, Polyglot), and a long
-    // snapshot download could starve user code under exceptional conditions. Snapshot installs
-    // are rare (only on follower (re)joining) and serialised inside Ratis, so this is operationally
-    // tolerable today. See QueryEngineManager class javadoc - "No JDK common ForkJoinPool" rule -
-    // for the migration target; the cleanup item is to fork onto a dedicated executor (sized via
-    // a future {@code arcadedb.haSnapshotInstallThreads} knob) once we add one.
-    return CompletableFuture.supplyAsync(() -> {
-      // Participate in the same single-flight protocol as triggerSnapshotDownload() so that
-      // isSnapshotDownloadPending() returns true during this install and the HealthMonitor's
-      // recoverFromPersistentLag() does not initiate a new concurrent triggerSnapshotDownload().
-      // We use CAS (not unconditional set) to avoid clearing a flag owned by a concurrently
-      // running triggerSnapshotDownload():
-      //  - if we win (flag false->true): we own the flag and MUST clear it in finally.
-      //  - if we lose (flag already true, another download in progress): we skip the flag and let
-      //    the other download complete; we still proceed with reconcileDatabasesFromLeader() because
-      //    the two installs both pull from the same leader and SnapshotInstaller is crash-safe with
-      //    atomic directory swaps. NOTE: the two calls are not serialized by this flag; ordering
-      //    is only guaranteed when we win the CAS. Eliminating the residual race requires a mutex
-      //    or waiting on the in-flight download, which is deferred as a future improvement.
-      final boolean acquiredSnapshotFlag = snapshotDownloadInProgress.compareAndSet(false, true);
-      try {
-        final RaftPeerId leaderId = RaftPeerId.valueOf(
-            roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getId());
-        final String leaderHttpAddr = raftHAServer.getPeerHttpAddress(leaderId);
-        final String leaderHttpsAddr = raftHAServer.getPeerHttpsAddress(leaderId);
+    try {
+      return CompletableFuture.supplyAsync(() -> installSnapshotFromLeader(roleInfoProto, firstTermIndexInLog),
+          snapshotInstallExecutor);
+    } catch (final RejectedExecutionException e) {
+      // The offload exists so the download does not run on the Ratis thread, so a rejection must not be answered
+      // by running it here. Ratis retries the install; a failed future leaves this node visibly behind until it
+      // does, which is the state it is in (issue #6202).
+      LogManager.instance().log(this, Level.SEVERE,
+          "Cannot schedule the leader-initiated snapshot install: the install executor rejected it", e);
+      return CompletableFuture.failedFuture(
+          new IllegalStateException("Snapshot install executor rejected the task", e));
+    }
+  }
 
-        if (leaderHttpAddr == null)
-          throw new RuntimeException("Cannot determine leader HTTP address for snapshot download");
+  /** The body of {@link #notifyInstallSnapshotFromLeader}, run on {@link #snapshotInstallExecutor}. */
+  private TermIndex installSnapshotFromLeader(final RaftProtos.RoleInfoProto roleInfoProto,
+      final TermIndex firstTermIndexInLog) {
+    // Participate in the same single-flight protocol as triggerSnapshotDownload() so that
+    // isSnapshotDownloadPending() returns true during this install and the HealthMonitor's
+    // recoverFromPersistentLag() does not initiate a new concurrent triggerSnapshotDownload().
+    // We use CAS (not unconditional set) to avoid clearing a flag owned by a concurrently
+    // running triggerSnapshotDownload():
+    //  - if we win (flag false->true): we own the flag and MUST clear it in finally.
+    //  - if we lose (flag already true, another download in progress): we skip the flag but still perform the
+    //    install, because standing down would report an install that never happened.
+    // Losing the CAS used to mean the two downloads ran concurrently over one set of database directories -
+    // benign only for as long as SnapshotInstaller keeps swapping atomically. snapshotDownloadLock states the
+    // exclusion outright: this path waits for it (it owns its thread and may block), while the request-driven
+    // paths fold into whatever holds it (issue #6202).
+    final boolean acquiredSnapshotFlag = snapshotDownloadInProgress.compareAndSet(false, true);
+    try {
+      // Interruptibly, so close()'s shutdownNow() can unwind a thread parked behind an in-flight resync instead
+      // of holding the shutdown open for the length of somebody else's download.
+      snapshotDownloadLock.lockInterruptibly();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      if (acquiredSnapshotFlag)
+        snapshotDownloadInProgress.set(false);
+      throw new RuntimeException("Interrupted while waiting for an in-flight resync to finish", e);
+    }
+    try {
+      final RaftPeerId leaderId = RaftPeerId.valueOf(
+          roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getId());
 
-        final String clusterToken = raftHAServer.getClusterToken();
+      // The guards the manual resync path has always made, which this one had none of (issue #6202): a derived
+      // address can name this node itself or the wrong peer, and reconcileDatabasesFromLeader would succeed,
+      // the install would be recorded, the read floor dropped, and the node would return to the ready set
+      // carrying whatever it copied. Refusing is the honest disposition - Ratis retries the install.
+      final SnapshotSource source = resolveSnapshotSource(leaderId);
+      if (source.refused())
+        throw new IllegalStateException("Refusing a leader-initiated snapshot install: " + source.refusal());
 
-        reconciler.reconcileDatabasesFromLeader(leaderHttpAddr, leaderHttpsAddr, clusterToken);
+      final String leaderHttpAddr = source.httpAddress();
+      final String leaderHttpsAddr = raftHAServer.getPeerHttpsAddress(leaderId);
+      final String clusterToken = raftHAServer.getClusterToken();
 
-        // Compute the installed snapshot TermIndex. firstTermIndexInLog is the first log entry
-        // AFTER the snapshot, so the snapshot covers all entries up to getIndex()-1.
-        // Returning firstTermIndexInLog itself (as the old code did) caused two bugs:
-        // 1. SnapshotInstallationHandler called state.reloadStateMachine(firstTermIndexInLog) which
-        //    purged log entries up to firstTermIndexInLog.getIndex() instead of getIndex()-1.
-        // 2. StateMachineUpdater.reload() calls getLatestSnapshot().getIndex() and expects it to match
-        //    the TermIndex we return; returning firstTermIndexInLog while storage was never updated
-        //    caused NullPointerException (and before that, IllegalStateException from the PAUSED check).
-        final long snapshotIndex = Math.max(0L, firstTermIndexInLog.getIndex() - 1);
-        // Use firstTermIndexInLog.getTerm() as the snapshot term. The true last-entry term inside
-        // the snapshot is opaque to us (ArcadeDB ships database files, not Ratis snapshot chunks),
-        // so we use the term of the first available log entry as a safe upper bound. This value is
-        // only used to name the marker file (snapshot.term_index) and as metadata for Ratis's
-        // snapshotIndex tracking; it does not affect data correctness.
-        final long snapshotTerm = firstTermIndexInLog.getTerm();
-        final TermIndex installedTermIndex = TermIndex.valueOf(snapshotTerm, snapshotIndex);
+      reconciler.reconcileDatabasesFromLeader(leaderHttpAddr, leaderHttpsAddr, clusterToken);
 
-        // Register the snapshot in SimpleStateMachineStorage. StateMachineUpdater.reload() calls
-        // getLatestSnapshot() immediately after reinitialize() and requires a non-null result.
-        // registerSnapshotMarker() writes the empty marker file and updates the latest-snapshot
-        // reference; see its javadoc for why a file-less, null-digest marker is safe for ArcadeDB.
-        if (!registerSnapshotMarker(snapshotTerm, snapshotIndex))
-          throw new IOException("Failed to register snapshot marker at index " + snapshotIndex);
+      // Compute the installed snapshot TermIndex. firstTermIndexInLog is the first log entry
+      // AFTER the snapshot, so the snapshot covers all entries up to getIndex()-1.
+      // Returning firstTermIndexInLog itself (as the old code did) caused two bugs:
+      // 1. SnapshotInstallationHandler called state.reloadStateMachine(firstTermIndexInLog) which
+      //    purged log entries up to firstTermIndexInLog.getIndex() instead of getIndex()-1.
+      // 2. StateMachineUpdater.reload() calls getLatestSnapshot().getIndex() and expects it to match
+      //    the TermIndex we return; returning firstTermIndexInLog while storage was never updated
+      //    caused NullPointerException (and before that, IllegalStateException from the PAUSED check).
+      final long snapshotIndex = Math.max(0L, firstTermIndexInLog.getIndex() - 1);
+      // Use firstTermIndexInLog.getTerm() as the snapshot term. The true last-entry term inside
+      // the snapshot is opaque to us (ArcadeDB ships database files, not Ratis snapshot chunks),
+      // so we use the term of the first available log entry as a safe upper bound. This value is
+      // only used to name the marker file (snapshot.term_index) and as metadata for Ratis's
+      // snapshotIndex tracking; it does not affect data correctness.
+      final long snapshotTerm = firstTermIndexInLog.getTerm();
+      final TermIndex installedTermIndex = TermIndex.valueOf(snapshotTerm, snapshotIndex);
 
-        // Advance the local applied-index to the snapshot point so that the StateMachineUpdater
-        // knows which log entries have been consumed by this install. A full state-machine install
-        // brings EVERY present database to the snapshot point, so record the snapshot index for each
-        // of them too (not just the global position) - this keeps the per-database bootstrap
-        // replay-skip honest after a full resync (issue #4824).
-        lastAppliedIndex.set(snapshotIndex);
-        updateLastAppliedTermIndex(snapshotTerm, snapshotIndex);
-        writePersistedAppliedIndexForAllDatabases(snapshotIndex);
-        // The install brought every database up to the snapshot point, so any read floor an earlier
-        // stale marker published is now satisfied. Cleared BEFORE the notify below so a woken waiter
-        // re-checks against the restored state instead of the floor (issue #6111).
-        clearStaleSnapshotFloor();
+      // Register the snapshot in SimpleStateMachineStorage. StateMachineUpdater.reload() calls
+      // getLatestSnapshot() immediately after reinitialize() and requires a non-null result.
+      // registerSnapshotMarker() writes the empty marker file and updates the latest-snapshot
+      // reference; see its javadoc for why a file-less, null-digest marker is safe for ArcadeDB.
+      if (!registerSnapshotMarker(snapshotTerm, snapshotIndex))
+        throw new IOException("Failed to register snapshot marker at index " + snapshotIndex);
 
-        // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this
-        // leader-driven snapshot install advances the applied index without going through
-        // applyTransaction(), the only other notifyApplied() call site (issue #5846).
-        final RaftHAServer raftHA = this.raftHAServer;
-        if (raftHA != null)
-          raftHA.notifyApplied();
+      // Advance the local applied-index to the snapshot point so that the StateMachineUpdater
+      // knows which log entries have been consumed by this install. A full state-machine install
+      // brings EVERY present database to the snapshot point, so record the snapshot index for each
+      // of them too (not just the global position) - this keeps the per-database bootstrap
+      // replay-skip honest after a full resync (issue #4824).
+      lastAppliedIndex.set(snapshotIndex);
+      updateLastAppliedTermIndex(snapshotTerm, snapshotIndex);
+      writePersistedAppliedIndexForAllDatabases(snapshotIndex);
+      // The install brought every database up to the snapshot point, so any read floor an earlier
+      // stale marker published is now satisfied. Cleared BEFORE the notify below so a woken waiter
+      // re-checks against the restored state instead of the floor (issue #6111).
+      clearStaleSnapshotFloor();
 
-        LogManager.instance().log(this, Level.INFO,
-            "HA resync finished (mode=snapshot, result=ok): snapshotIndex=%d", snapshotIndex);
-        clearDivergedState();
-        return installedTermIndex;
+      // Wake any threads blocked in RaftHAServer.waitForAppliedIndex()/waitForLocalApply(): this
+      // leader-driven snapshot install advances the applied index without going through
+      // applyTransaction(), the only other notifyApplied() call site (issue #5846).
+      final RaftHAServer raftHA = this.raftHAServer;
+      if (raftHA != null)
+        raftHA.notifyApplied();
 
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.SEVERE, "Error during snapshot installation from leader", e);
-        throw new RuntimeException("Error during Raft snapshot installation", e);
-      } finally {
-        if (acquiredSnapshotFlag)
-          snapshotDownloadInProgress.set(false);
-      }
-    });
+      LogManager.instance().log(this, Level.INFO,
+          "HA resync finished (mode=snapshot, result=ok): snapshotIndex=%d", snapshotIndex);
+      clearDivergedState();
+      return installedTermIndex;
+
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.SEVERE, "Error during snapshot installation from leader", e);
+      throw new RuntimeException("Error during Raft snapshot installation", e);
+    } finally {
+      snapshotDownloadLock.unlock();
+      if (acquiredSnapshotFlag)
+        snapshotDownloadInProgress.set(false);
+    }
   }
 
   public long getElectionCount() {
@@ -1843,7 +1907,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
         return;
       }
 
-      final String leaderHttpAddr = raftHAServer.getLeaderHttpAddress();
+      // Same refusals as every other path that pulls a snapshot, through the same helper (issue #6202): a
+      // derived address that names this node would "restore" the local copy from itself and report success,
+      // which is worse than the failure the caller already handles below.
+      final SnapshotSource source = resolveSnapshotSource(raftHAServer.getLeaderId());
+      if (source.refused())
+        throw new RuntimeException("Cannot reinstall database '" + databaseName + "' from the leader: "
+            + source.refusal());
+
+      final String leaderHttpAddr = source.httpAddress();
       final String leaderHttpsAddr = raftHAServer.getLeaderHttpsAddress();
       final String clusterToken = raftHAServer.getClusterToken();
       try {
@@ -2070,8 +2142,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // failed bootstrap install never leaves the database closed.
       final RaftHAServer raft = raftHAServer;
       final String clusterToken = raft != null ? raft.getClusterToken() : null;
+      // Resolved through the same guard as every other snapshot pull: the supplier answers null - which
+      // install() treats as "no leader to pull from" and retries - rather than handing back an address that
+      // names this node or no single peer (issue #6202).
       SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-          () -> raft != null ? raft.getLeaderHttpAddress() : null,
+          this::guardedLeaderHttpAddress,
           () -> raft != null ? raft.getLeaderHttpsAddress() : null,
           clusterToken, server);
       LogManager.instance().log(this, Level.INFO,
@@ -2110,9 +2185,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
       throw new ReplicationException("Cannot resync database '" + dbName
           + "' on the leader: the leader holds the authoritative copy. Run the resync on the diverged follower.");
 
-    if (raft.getLeaderHttpAddress() == null)
-      throw new ReplicationException("Cannot resync database '" + dbName
-          + "': the leader is currently unknown (election in progress?). Retry once a leader is elected.");
+    final SnapshotSource source = resolveSnapshotSource(raft.getLeaderId());
+    if (source.refused())
+      // The two checks this path used to make by hand (is this the leader, is the address known) are two of the
+      // three the helper makes, and the third - an address that identifies no single peer - is the one an
+      // operator most needs told about before a database is replaced (issue #6202).
+      throw new ReplicationException("Cannot resync database '" + dbName + "': " + source.refusal());
 
     LogManager.instance().log(this, Level.WARNING,
         "Operator-triggered resync of database '%s' from leader: dropping local copy and re-acquiring full snapshot", dbName);
@@ -2536,24 +2614,113 @@ public class ArcadeStateMachine extends BaseStateMachine {
     return raftDir != null ? raftDir.resolve("bootstrap-baselines") : null;
   }
 
+  /**
+   * The HTTP address a snapshot resync may pull from, or the reason it may not. Exactly one field is set.
+   *
+   * @param httpAddress the leader's HTTP endpoint, when the resync may proceed
+   * @param refusal     why it may not, phrased to be logged after "Refusing a snapshot resync: "
+   */
+  private record SnapshotSource(String httpAddress, String refusal) {
+    static SnapshotSource refuse(final String reason) {
+      return new SnapshotSource(null, reason);
+    }
+
+    boolean refused() {
+      return refusal != null;
+    }
+  }
+
+  /**
+   * Answers whether a snapshot resync from {@code leaderId} may be attempted, and with which address.
+   * <p>
+   * Every resync path asks it - the manual {@link #triggerSnapshotDownload()}, the targeted
+   * {@code triggerDatabaseResync(String)} and the Ratis-initiated {@link #notifyInstallSnapshotFromLeader} -
+   * because a resync that pulls from the wrong node is not recoverable and not even visible: the reconcile
+   * succeeds, the install is recorded, and the node returns to the ready set carrying whatever it copied. The
+   * Ratis-initiated path had none of these checks at all (issue #6202), and duplicating them would have made a
+   * fourth hand-maintained copy of a rule the first three already disagreed about.
+   * <p>
+   * Three refusals:
+   * <ul>
+   * <li><b>This node is the leader.</b> A node cannot repair itself from itself. {@code notifyLeaderChanged()}
+   * submits a resync unconditionally - including on the node that just WON the election - and the leader address
+   * then resolves to this node's own, so the "download" would copy this node's already-incomplete databases back
+   * onto themselves and report success. That is merely pointless on some paths, but it lets
+   * {@link #resolveStaleSnapshotFloorAfterResync} durably record the marker index as applied and drop the read
+   * floor, re-opening issue #6111 and surviving restarts.</li>
+   * <li><b>No address identifies the leader on its own.</b> With no {@code http} port declared in
+   * {@code HA_SERVER_LIST} a peer's address is derived from its Raft host plus THIS node's HTTP port, so on a
+   * cluster whose nodes differ by port rather than by host every peer collapses onto one address and it names at
+   * most one of them. {@link RaftHAServer#getUnambiguousPeerHttpAddress} withholds an address two peers claim -
+   * the ambiguity check the client-routing tables already make (issue #6183), which belongs here more, because
+   * here a confidently wrong address does durable damage rather than costing one redirect.</li>
+   * <li><b>The address is this node's own.</b> The backstop for the first refusal: leadership can move between
+   * the two checks, and {@code getLeaderId()} can already report this node while {@code isLeader()} has not
+   * caught up. The same comparison the write-forwarding path makes before it dials a resolved leader address, so
+   * the two cannot drift apart (issue #6191).</li>
+   * </ul>
+   * Refusing leaves the node visibly behind - the floor stands, {@link #isResyncInProgress()} keeps it out of the
+   * ready set, reads keep failing honestly - which is the state it is actually in. Ratis retries the install and
+   * the {@link HealthMonitor} re-arms the manual path, so a refusal is not a dead end either.
+   */
+  private SnapshotSource resolveSnapshotSource(final RaftPeerId leaderId) {
+    // Read once into a local: the field is volatile and a teardown can null it between two reads, which would
+    // turn a refusal into a NullPointerException on the install path.
+    final RaftHAServer raftHA = this.raftHAServer;
+    if (raftHA == null)
+      return SnapshotSource.refuse("the HA server is not available on this node");
+
+    if (raftHA.isLeader())
+      return SnapshotSource.refuse("this node is the leader, so there is no peer to pull from. "
+          + "The request stays pending until leadership moves elsewhere (issue #6111)");
+
+    if (leaderId == null)
+      return SnapshotSource.refuse("the leader is unknown");
+
+    final String leaderHttpAddr = raftHA.getUnambiguousPeerHttpAddress(leaderId);
+    if (leaderHttpAddr == null)
+      return SnapshotSource.refuse("no HTTP address identifies leader " + leaderId + " on its own - it is either "
+          + "unresolvable or shared with another peer, and reconciling databases from the wrong node cannot be "
+          + "undone. Declare each node's 'http' port explicitly in " + GlobalConfiguration.HA_SERVER_LIST.getKey()
+          + " (issue #6202)");
+
+    // Resolved once and compared once: reading it twice would let the two comparisons disagree.
+    final String localHttpAddr = raftHA.getLocalHttpAddress();
+    if (localHttpAddr == null)
+      // The resolver degrades to null when this node's own HTTP endpoint cannot be resolved right now. The check
+      // below then cannot fire, so say so rather than letting the backstop no-op invisibly: only the leader-role
+      // check is standing between us and a self-download.
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot resolve this node's own HTTP address; the self-resync address check is inactive for this "
+              + "attempt and only the leader-role check guards it (issue #6111)");
+    else if (RaftHAServer.isSameHttpEndpoint(localHttpAddr, leaderHttpAddr))
+      return SnapshotSource.refuse("the resolved leader address " + leaderHttpAddr + " is this node's own. "
+          + "The request stays pending until a peer holds the leadership (issue #6111)");
+
+    return new SnapshotSource(leaderHttpAddr, null);
+  }
+
+  /**
+   * The leader's HTTP address when a snapshot may be pulled from it, {@code null} when it may not. The
+   * supplier-shaped form of {@link #resolveSnapshotSource}, for {@code SnapshotInstaller.install} overloads that
+   * re-resolve the address on every retry.
+   */
+  private String guardedLeaderHttpAddress() {
+    final RaftHAServer raftHA = this.raftHAServer;
+    if (raftHA == null)
+      return null;
+    final SnapshotSource source = resolveSnapshotSource(raftHA.getLeaderId());
+    if (source.refused()) {
+      LogManager.instance().log(this, Level.WARNING, "Refusing to pull a snapshot: %s", source.refusal());
+      return null;
+    }
+    return source.httpAddress();
+  }
+
   // @VisibleForTesting
   void triggerSnapshotDownload() {
     if (raftHAServer == null || server == null)
       return;
-    // A node cannot repair itself from itself. notifyLeaderChanged() submits this unconditionally -
-    // including on the node that just WON the election - and getLeaderHttpAddress() then resolves to
-    // this node's own HTTP address, so the "download" would copy this node's already-incomplete
-    // databases back onto themselves and report success. That is merely pointless on the pre-existing
-    // paths, but it would let resolveStaleSnapshotFloorAfterResync() durably record the marker index as
-    // applied and drop the read floor, re-opening issue #6111 on a leader and surviving restarts.
-    // Refuse instead: the floor stands, isResyncInProgress() keeps the node out of the ready set, and
-    // reads keep failing honestly until leadership moves to a peer that actually holds the entries.
-    if (raftHAServer.isLeader()) {
-      LogManager.instance().log(this, Level.WARNING,
-          "Refusing a snapshot resync: this node is the leader, so there is no peer to pull from. "
-              + "The request stays pending until leadership moves elsewhere (issue #6111)");
-      return;
-    }
     // Single-flight guard: multiple recovery paths (reinitialize watchdog, notifyLeaderChanged,
     // stale-follower recovery from the HealthMonitor) can request a download. Only one may run at
     // a time; concurrent requests are dropped. The flag also feeds isSnapshotDownloadPending() so
@@ -2567,51 +2734,25 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return;
     }
     try {
-      final String leaderHttpAddr = raftHAServer.getLeaderHttpAddress();
-      if (leaderHttpAddr == null) {
-        LogManager.instance().log(this, Level.WARNING,
-            "Cannot trigger snapshot download: leader HTTP address unknown");
+      // A leader-initiated install holds the lock without owning the flag when it lost the CAS, so the flag alone
+      // does not prove nothing is running. Folded rather than awaited: this runs on the single-threaded
+      // lifecycleExecutor, which must not be parked for the length of a download (issue #6202).
+      if (!snapshotDownloadLock.tryLock()) {
+        LogManager.instance().log(this, Level.INFO,
+            "Snapshot resync already in progress (leader-initiated install); folding this request into it");
         return;
       }
-      // Backstop for the isLeader() check above: leadership can move between the two, and getLeaderId()
-      // can already report this node while isLeader() has not caught up. Compare the addresses too, so
-      // a self-download is impossible on either side of that window (issue #6111).
-      // Resolved once and compared once: the same question the write-forwarding path asks before it dials a
-      // resolved leader address, through the same comparison so the two cannot drift apart (issue #6191).
-      final String localHttpAddr = raftHAServer.getLocalHttpAddress();
-      if (localHttpAddr == null)
-        // The resolver degrades to null when this node's own HTTP endpoint cannot be resolved right now.
-        // The check below then cannot fire, so say so rather than letting the backstop no-op invisibly:
-        // only the isLeader() check above is standing between us and a self-download.
-        LogManager.instance().log(this, Level.WARNING,
-            "Cannot resolve this node's own HTTP address; the self-resync address check is inactive for this "
-                + "attempt and only the leader-role check guards it (issue #6111)");
-      if (RaftHAServer.isSameHttpEndpoint(localHttpAddr, leaderHttpAddr)) {
-        LogManager.instance().log(this, Level.WARNING,
-            "Refusing a snapshot resync: the resolved leader address %s is this node's own. "
-                + "The request stays pending until a peer holds the leadership (issue #6111)", leaderHttpAddr);
-        return;
-      }
-      final String leaderHttpsAddr = raftHAServer.getLeaderHttpsAddress();
-      final String clusterToken = raftHAServer.getClusterToken();
-      int resynced = 0;
-      for (final String dbName : server.getDatabaseNames()) {
-        // install() keeps the database open during the download and rolls back on failure, so a
-        // watchdog-triggered resync never leaves it closed.
-        if (server.existsDatabase(dbName)) {
-          SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-              leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
-          resynced++;
+      try {
+        final SnapshotSource source = resolveSnapshotSource(raftHAServer.getLeaderId());
+        if (source.refused()) {
+          LogManager.instance().log(this, Level.WARNING, "Refusing a snapshot resync: %s", source.refusal());
+          return;
         }
+        final String leaderHttpAddr = source.httpAddress();
+        downloadAllDatabasesFrom(leaderHttpAddr);
+      } finally {
+        snapshotDownloadLock.unlock();
       }
-      LogManager.instance().log(this, Level.INFO,
-          "Snapshot resync completed: reinstalled %d database(s) from the leader; diverged state cleared", resynced);
-      clearDivergedState();
-      // The databases now carry the leader's state, so a read floor published by a stale marker in
-      // reinitialize() is satisfied. Record the marker index as the persisted applied position too:
-      // without it the very same gap is re-detected on the next restart and the node re-downloads
-      // forever. Then wake the waiters this resync unblocked (issue #6111).
-      resolveStaleSnapshotFloorAfterResync(resynced);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Snapshot resync failed", e);
       // The node is still short of the entries the marker claims, so the read floor stays and the
@@ -2625,6 +2766,34 @@ public class ArcadeStateMachine extends BaseStateMachine {
     } finally {
       snapshotDownloadInProgress.set(false);
     }
+  }
+
+  /**
+   * Reinstalls every present database from {@code leaderHttpAddr} and resolves the state a full resync clears.
+   * The caller has already established that the address may be pulled from ({@link #resolveSnapshotSource}) and
+   * holds {@link #snapshotDownloadLock}.
+   */
+  private void downloadAllDatabasesFrom(final String leaderHttpAddr) throws IOException {
+    final String leaderHttpsAddr = raftHAServer.getLeaderHttpsAddress();
+    final String clusterToken = raftHAServer.getClusterToken();
+    int resynced = 0;
+    for (final String dbName : server.getDatabaseNames()) {
+      // install() keeps the database open during the download and rolls back on failure, so a
+      // watchdog-triggered resync never leaves it closed.
+      if (server.existsDatabase(dbName)) {
+        SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
+            leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
+        resynced++;
+      }
+    }
+    LogManager.instance().log(this, Level.INFO,
+        "Snapshot resync completed: reinstalled %d database(s) from the leader; diverged state cleared", resynced);
+    clearDivergedState();
+    // The databases now carry the leader's state, so a read floor published by a stale marker in
+    // reinitialize() is satisfied. Record the marker index as the persisted applied position too:
+    // without it the very same gap is re-detected on the next restart and the node re-downloads
+    // forever. Then wake the waiters this resync unblocked (issue #6111).
+    resolveStaleSnapshotFloorAfterResync(resynced);
   }
 
   /**
@@ -2694,7 +2863,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return; // no unfilled gap
     if (snapshotDownloadInProgress.get())
       return; // one is genuinely running; it will clear the floor or re-arm the request
-    if (raftHA.getLeaderHttpAddress() == null)
+    // Asked through the resolver triggerSnapshotDownload() itself uses, so this cheap precheck cannot pass a
+    // request the resync would then refuse - and burn a throttle slot doing it (issue #6202).
+    if (raftHA.getUnambiguousPeerHttpAddress(raftHA.getLeaderId()) == null)
       return; // nowhere to download from yet; notifyLeaderChanged() drives the first attempt
 
     final long now = System.currentTimeMillis();
@@ -2750,22 +2921,36 @@ public class ArcadeStateMachine extends BaseStateMachine {
           return;
         }
         try {
-          final String leaderHttpAddr = raftHAServer.getLeaderHttpAddress();
-          if (leaderHttpAddr == null) {
-            LogManager.instance().log(this, Level.WARNING,
-                "Cannot resync quarantined database '%s': leader HTTP address unknown", dbName);
+          if (!snapshotDownloadLock.tryLock()) {
+            HALog.log(this, HALog.BASIC,
+                "Snapshot download already in progress (leader-initiated install), skipping targeted resync of '%s'",
+                dbName);
             return;
           }
-          final String leaderHttpsAddr = raftHAServer.getLeaderHttpsAddress();
-          final String clusterToken = raftHAServer.getClusterToken();
-          // install() keeps the database open during the download and rolls back on failure, so a
-          // targeted resync never leaves it closed.
-          if (server.existsDatabase(dbName)) {
-            SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-                leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
-            LogManager.instance().log(this, Level.INFO,
-                "Targeted snapshot resync of quarantined database '%s' completed", dbName);
-            clearDivergedDatabase(dbName);
+          try {
+            // Same refusals as the two full-resync paths, through the same helper: a targeted resync reinstalls a
+            // whole database from the resolved address, so an address naming this node or the wrong peer does the
+            // same durable damage here (issue #6202).
+            final SnapshotSource source = resolveSnapshotSource(raftHAServer.getLeaderId());
+            if (source.refused()) {
+              LogManager.instance().log(this, Level.WARNING,
+                  "Refusing a targeted snapshot resync of quarantined database '%s': %s", dbName, source.refusal());
+              return;
+            }
+            final String leaderHttpAddr = source.httpAddress();
+            final String leaderHttpsAddr = raftHAServer.getLeaderHttpsAddress();
+            final String clusterToken = raftHAServer.getClusterToken();
+            // install() keeps the database open during the download and rolls back on failure, so a
+            // targeted resync never leaves it closed.
+            if (server.existsDatabase(dbName)) {
+              SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
+                  leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
+              LogManager.instance().log(this, Level.INFO,
+                  "Targeted snapshot resync of quarantined database '%s' completed", dbName);
+              clearDivergedDatabase(dbName);
+            }
+          } finally {
+            snapshotDownloadLock.unlock();
           }
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.SEVERE,
@@ -2908,6 +3093,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
   @Override
   public void close() throws IOException {
     lifecycleExecutor.shutdownNow();
+    snapshotInstallExecutor.shutdownNow();
     deferredDatabaseDeleter.close();
     super.close();
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -239,6 +239,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * The Ratis-initiated install waits for it; the two request-driven paths take it with {@code tryLock} and fold
    * into whatever holds it, exactly as they already fold into a lost CAS - they run on the single-threaded
    * {@link #lifecycleExecutor} and must not park it for the length of a download.
+   * <p>
+   * <b>Three of the six snapshot-pull paths are deliberately outside it</b>, and it is a choice rather than a
+   * gap. {@code applyInstallDatabaseEntry}'s {@code forceSnapshot} branch and {@link #installFromLeaderForBootstrap}
+   * run on the Ratis apply thread as part of applying a committed entry: they are already serialised against each
+   * other by that single thread, they cannot fold (skipping leaves the database absent or diverged, which is the
+   * state the entry exists to repair), and they must not park the apply loop - and with it replication for every
+   * database on this node - for the length of a download it did not start. {@link #resyncDatabaseFromLeader} runs
+   * on the operator's HTTP worker thread and reports its outcome to them synchronously, so folding would answer
+   * "done" for work it did not do. What makes an actual overlap visible rather than silent is
+   * {@code SnapshotInstaller}'s own {@code INSTALLS_IN_FLIGHT} set, which logs a WARNING naming the database when
+   * two installs share one directory - the detector for the assumption this lock cannot enforce everywhere.
    */
   private final ReentrantLock snapshotDownloadLock = new ReentrantLock();
 
@@ -2177,9 +2188,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // install() treats as "no leader to pull from" and retries - rather than handing back an address that
       // names this node or no single peer (issue #6202).
       SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-          this::guardedLeaderHttpAddress,
-          () -> raft != null ? raft.getLeaderHttpsAddress() : null,
-          clusterToken, server);
+          this::guardedLeaderHttpAddress, this::guardedLeaderHttpsAddress, clusterToken, server);
       LogManager.instance().log(this, Level.INFO,
           "Database '%s' reinstalled after bootstrap mismatch", dbName);
     } catch (final IOException e) {
@@ -2227,13 +2236,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
         "Operator-triggered resync of database '%s' from leader: dropping local copy and re-acquiring full snapshot", dbName);
 
     try {
-      // Resolve the leader address on each retry (it can change mid-operation if leadership moves).
+      // Resolve the leader address on each retry (it can change mid-operation if leadership moves) - and re-guard
+      // it on each retry with it, or the refusal above is a point-in-time check that a later attempt walks
+      // straight past onto this node's own address (issue #6202). The check above is still worth making: it turns
+      // an already-doomed request into an immediate, descriptive refusal instead of a failed download.
       // install() keeps the local copy open and serving during the download and only closes + swaps
       // once a complete snapshot is on disk, rolling back on failure. A failed resync therefore never
       // leaves the database closed (the cause of the operator-visible DatabaseIsClosedException).
       final String clusterToken = raft.getClusterToken();
       SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-          raft::getLeaderHttpAddress, raft::getLeaderHttpsAddress, clusterToken, server);
+          this::guardedLeaderHttpAddress, this::guardedLeaderHttpsAddress, clusterToken, server);
       LogManager.instance().log(this, Level.INFO, "Database '%s' resynced from leader on operator request", dbName);
     } catch (final IOException e) {
       throw new ReplicationException("Failed to resync database '" + dbName + "' from leader", e);
@@ -2733,8 +2745,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
   /**
    * The leader's HTTP address when a snapshot may be pulled from it, {@code null} when it may not. The
-   * supplier-shaped form of {@link #resolveSnapshotSource}, for {@code SnapshotInstaller.install} overloads that
-   * re-resolve the address on every retry.
+   * supplier-shaped form of {@link #resolveSnapshotSource}, for the {@code SnapshotInstaller.install} overloads
+   * that re-resolve the address on every download attempt.
+   * <p>
+   * Guarding the call site once is not enough for those: the whole reason they take a supplier is that leadership
+   * can move mid-operation, and an up-front check says nothing about the address attempt 3 will resolve. Every
+   * attempt asks again (issue #6202).
+   * <p>
+   * This is the arm that logs the refusal - see {@link #guardedLeaderHttpsAddress()} for why that is exactly one
+   * line per attempt whether or not SSL is on.
    */
   private String guardedLeaderHttpAddress() {
     final RaftHAServer raftHA = this.raftHAServer;
@@ -2746,6 +2765,22 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return null;
     }
     return source.httpAddress();
+  }
+
+  /**
+   * The leader's HTTPS address under the same guard, or {@code null}. Needed as well as the HTTP arm because
+   * {@code downloadWithRetry} prefers the HTTPS endpoint when SSL is enabled and only falls back to the HTTP one
+   * when it comes back null - so guarding HTTP alone would leave the guard unreachable on an SSL cluster.
+   * <p>
+   * Silent by design, which is what keeps the pair to one log line per attempt: a refusal makes this return null,
+   * and the caller then consults the HTTP arm, which logs. When it does NOT refuse there is nothing to log, and
+   * the HTTP arm is not consulted at all.
+   */
+  private String guardedLeaderHttpsAddress() {
+    final RaftHAServer raftHA = this.raftHAServer;
+    if (raftHA == null || resolveSnapshotSource(raftHA.getLeaderId()).refused())
+      return null;
+    return raftHA.getLeaderHttpsAddress();
   }
 
   // @VisibleForTesting

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1271,7 +1271,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // carrying whatever it copied. Refusing is the honest disposition - Ratis retries the install.
       final SnapshotSource source = resolveSnapshotSource(leaderId);
       if (source.refused())
-        throw new IllegalStateException("Refusing a leader-initiated snapshot install: " + source.refusal());
+        throw new SnapshotRefusedException(source.refusal());
 
       final String leaderHttpAddr = source.httpAddress();
       final String leaderHttpsAddr = raftHAServer.getPeerHttpsAddress(leaderId);
@@ -1328,6 +1328,14 @@ public class ArcadeStateMachine extends BaseStateMachine {
       clearDivergedState();
       return installedTermIndex;
 
+    } catch (final SnapshotRefusedException e) {
+      // A refusal is the expected, retried outcome this guard exists to produce, not a fault: Ratis re-drives
+      // the install, so on a misconfigured cluster - or in the window right after an election, before the
+      // leader-role flag catches up - it fires on every attempt. Logged at WARNING and without a stack trace,
+      // like the same refusal on the two request-driven paths; a SEVERE per retry would trip log-based alerting
+      // for a guard that is working as designed.
+      LogManager.instance().log(this, Level.WARNING, SNAPSHOT_INSTALL_REFUSED + "%s", e.reason());
+      throw new RuntimeException("Error during Raft snapshot installation", e);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error during snapshot installation from leader", e);
       throw new RuntimeException("Error during Raft snapshot installation", e);
@@ -1335,6 +1343,29 @@ public class ArcadeStateMachine extends BaseStateMachine {
       snapshotDownloadLock.unlock();
       if (acquiredSnapshotFlag)
         snapshotDownloadInProgress.set(false);
+    }
+  }
+
+  /** Prefix of both the refusal exception's message and the WARNING it is logged with. */
+  private static final String SNAPSHOT_INSTALL_REFUSED = "Refusing a leader-initiated snapshot install: ";
+
+  /**
+   * A snapshot resync that {@link #resolveSnapshotSource} refused before it started. A distinct type only so the
+   * install path can tell it apart from a genuine installation failure in its catch chain and log it at the
+   * severity its disposition deserves - the two request-driven paths return rather than throw, and never had to
+   * make the distinction.
+   */
+  private static final class SnapshotRefusedException extends IllegalStateException {
+    private final String reason;
+
+    private SnapshotRefusedException(final String reason) {
+      super(SNAPSHOT_INSTALL_REFUSED + reason);
+      this.reason = reason;
+    }
+
+    /** The refusal on its own, so the log line can carry a literal prefix rather than a fully formatted message. */
+    String reason() {
+      return reason;
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1351,6 +1351,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.SEVERE, "Error during snapshot installation from leader", e);
       throw new RuntimeException("Error during Raft snapshot installation", e);
     } finally {
+      // Released in this order on purpose: the flag is the broader signal - isSnapshotDownloadPending() feeds the
+      // HealthMonitor's decision not to start anything - so it must not read false while this install still holds
+      // the lock. The converse window it leaves (lock free, flag still true) costs a concurrent request one folded
+      // attempt, which the next retryUnfilledSnapshotGap() tick re-drives; swapping the two would only move the
+      // window, not close it, and would move it to the side where something new can be started under a held lock.
       snapshotDownloadLock.unlock();
       if (acquiredSnapshotFlag)
         snapshotDownloadInProgress.set(false);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1844,15 +1844,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    */
   static HAServerPlugin.RoutingTable selectUnambiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol,
       final String[] addresses, final boolean[] fromConfig, final int count) {
-    // address -> {peers claiming it, of which declared}. Sized for the group: this runs per ROUTE request and
-    // per refusal, never on a data path.
-    final Map<String, int[]> claims = new HashMap<>(count * 2);
-    for (int i = 0; i < count; i++) {
-      final int[] claim = claims.computeIfAbsent(addresses[i], a -> new int[2]);
-      ++claim[0];
-      if (fromConfig[i])
-        ++claim[1];
-    }
+    final Map<String, int[]> claims = claimsByAddress(addresses, fromConfig, count);
 
     if (!identifiesOnePeer(claims.get(addresses[0]), fromConfig[0]))
       return null;
@@ -1865,9 +1857,74 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     return new HAServerPlugin.RoutingTable(protocol, addresses[0], List.copyOf(readers));
   }
 
+  /**
+   * address -&gt; {peers claiming it, of which declared}. Sized for the group: every caller runs per ROUTE request,
+   * per refusal or per snapshot install, never on a data path.
+   */
+  private static Map<String, int[]> claimsByAddress(final String[] addresses, final boolean[] fromConfig,
+      final int count) {
+    final Map<String, int[]> claims = new HashMap<>(count * 2);
+    for (int i = 0; i < count; i++) {
+      final int[] claim = claims.computeIfAbsent(addresses[i], a -> new int[2]);
+      ++claim[0];
+      if (fromConfig[i])
+        ++claim[1];
+    }
+    return claims;
+  }
+
   /** True when the address this claim describes belongs to exactly one peer, or to the only one that declared it. */
   private static boolean identifiesOnePeer(final int[] claim, final boolean declared) {
     return claim[0] == 1 || (declared && claim[1] == 1);
+  }
+
+  /**
+   * The HTTP address of {@code peerId}, but only when it identifies that peer and no other; {@code null}
+   * otherwise. The same question {@link #selectUnambiguousRouting} asks of a client routing table, asked of the
+   * peer-to-peer HTTP endpoint (issue #6202).
+   * <p>
+   * With no {@code http} port declared in {@link GlobalConfiguration#HA_SERVER_LIST}, a peer's HTTP address is
+   * derived as its Raft host plus <em>this</em> node's port (see {@link #resolveHttpAddress(RaftPeerId)}), so on a
+   * cluster whose nodes differ by port rather than by host every peer collapses onto one address. Two peers can
+   * never legitimately answer on one {@code host:port} - they would be fighting over the socket - so an address
+   * two of them resolve to identifies at most one, and the resolver has no way to say which. A declared address
+   * outranks a derived one when they collide: the operator stated it, and the collision only proves the guess
+   * wrong.
+   * <p>
+   * The plain {@link #getPeerHttpAddress(RaftPeerId)} deliberately keeps returning the best-effort address for
+   * cluster reporting and for a caller that merely displays it. This variant is for the callers that act on the
+   * address unattended, where a wrong-but-plausible peer is worse than no peer at all: a follower that reconciles
+   * its databases from a node that is not the leader reports success and returns to the ready set carrying
+   * whatever it copied.
+   */
+  public String getUnambiguousPeerHttpAddress(final RaftPeerId peerId) {
+    final String address = resolveHttpAddress(peerId);
+    if (address == null)
+      return null;
+
+    final Collection<RaftPeer> peers = raftGroup.getPeers();
+    // Index 0 is always the peer asked about. The +1 is not slack: raftGroup holds the peers HA_SERVER_LIST was
+    // parsed into, so a peer that joined at runtime (addPeer, the Kubernetes auto-join) is not in getPeers() and
+    // occupies a slot beyond it - the same sizing getRoutingTable uses, for the same reason.
+    final String[] addresses = new String[peers.size() + 1];
+    final boolean[] fromConfig = new boolean[addresses.length];
+    addresses[0] = address;
+    fromConfig[0] = httpAddresses.containsKey(peerId);
+    int resolved = 1;
+
+    for (final RaftPeer peer : peers) {
+      if (peer.getId().equals(peerId))
+        continue;
+      final String other = resolveHttpAddress(peer);
+      if (other == null)
+        continue;
+      addresses[resolved] = other;
+      fromConfig[resolved] = httpAddresses.containsKey(peer.getId());
+      ++resolved;
+    }
+
+    final Map<String, int[]> claims = claimsByAddress(addresses, fromConfig, resolved);
+    return identifiesOnePeer(claims.get(address), fromConfig[0]) ? address : null;
   }
 
   /** Tells the operator, once per protocol, that peers shared an address and what to write to fix it. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java
@@ -50,14 +50,14 @@ public abstract class BaseRaftHATest extends BaseGraphServerTest {
   // thread IT) ran in the same shared, reused JVM fork (failsafe reuseForks=true/forkCount=1 for the
   // whole module). Both stalls were confirmed real via the test's own embedded log timestamps, not a
   // log-flush artifact. Not reproducible locally in isolation, nor under an emulated 4-CPU/3.9GB-heap
-  // constraint matching the CI runner - only in the full-suite adjacency. The project's own
-  // engine-concurrency skill documents ArcadeStateMachine.notifyInstallSnapshotFromLeader as a
-  // not-yet-migrated user of the JDK common ForkJoinPool, which is also shared with JDK GC/reference
-  // handler internals - exactly the "long-running [GC-heavy] work starves engine work" failure shape
-  // this looks like. This bump is a mitigation, not a fix: it only widens the ceiling on the rare
-  // stalled path (withResyncRetry()/awaitValue()/awaitCountOn() all return as soon as the condition
-  // is met), while the real fix - isolating heavy ITs into their own fork, or migrating the common-
-  // pool caller - is tracked as a follow-up rather than attempted here.
+  // constraint matching the CI runner - only in the full-suite adjacency. The suspected cause was
+  // ArcadeStateMachine.notifyInstallSnapshotFromLeader running its download on the JDK common
+  // ForkJoinPool, which is also shared with JDK GC/reference handler internals - exactly the
+  // "long-running [GC-heavy] work starves engine work" failure shape this looks like. That caller has
+  // its own executor since issue #6202, so half of the suspicion is gone; the timeout stays until a
+  // CI run shows it can come down, and the other half of the fix - isolating heavy ITs into their own
+  // fork - is still a follow-up. The bump costs nothing when nothing stalls: withResyncRetry(),
+  // awaitValue() and awaitCountOn() all return as soon as the condition is met.
   private static final long RESYNC_RETRY_TIMEOUT_MS = 120_000;
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -431,6 +431,34 @@ class Issue6111StaleSnapshotReadFloorTest {
   }
 
   /**
+   * The retry throttle allows one attempt per watchdog interval, so an attempt the resync will refuse anyway
+   * costs a whole interval of not retrying. The precheck therefore asks the same questions
+   * {@code resolveSnapshotSource()} asks, including the one it used to skip: an address that resolves to this
+   * node's own is not somewhere to download from (issue #6202).
+   */
+  @Test
+  void retryStandsDownWhenTheResolvedLeaderAddressIsOurOwn(@TempDir final Path tempDir) throws Exception {
+    final ArcadeStateMachine sm = newStateMachine(tempDir);
+    final RaftHAServer mockRaft = mock(RaftHAServer.class);
+    when(mockRaft.isLeader()).thenReturn(false);
+    when(mockRaft.getLeaderId()).thenReturn(LEADER_PEER_ID);
+    when(mockRaft.getUnambiguousPeerHttpAddress(LEADER_PEER_ID)).thenReturn("localhost:2480");
+    when(mockRaft.isOwnHttpAddress("localhost:2480")).thenReturn(true);
+    sm.setRaftHAServer(mockRaft);
+    try {
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      sm.retryUnfilledSnapshotGap();
+
+      assertThat(readLastRetryMs(sm))
+          .as("a doomed attempt must not consume the one retry slot this watchdog interval has")
+          .isZero();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /**
    * The case the backstop exists for: a floor left behind by a failed download, nothing running, a
    * leader reachable. The retry must fire - and reach {@code triggerSnapshotDownload()}, which with no
    * databases present completes and clears the floor.

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6111StaleSnapshotReadFloorTest.java
@@ -517,7 +517,7 @@ class Issue6111StaleSnapshotReadFloorTest {
     final ArcadeStateMachine sm = newStateMachine(tempDir);
     final RaftHAServer mockRaft = mock(RaftHAServer.class);
     when(mockRaft.isLeader()).thenReturn(true);
-    when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
+    when(mockRaft.getUnambiguousPeerHttpAddress(LEADER_PEER_ID)).thenReturn("localhost:2480");
     sm.setRaftHAServer(mockRaft);
     try {
       sm.writePersistedAppliedIndex(PERSISTED_APPLIED, DB_NAME);
@@ -553,7 +553,8 @@ class Issue6111StaleSnapshotReadFloorTest {
     final ArcadeStateMachine sm = newStateMachine(tempDir);
     final RaftHAServer mockRaft = mock(RaftHAServer.class);
     when(mockRaft.isLeader()).thenReturn(false); // role flag has not caught up...
-    when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
+    when(mockRaft.getLeaderId()).thenReturn(LEADER_PEER_ID);
+    when(mockRaft.getUnambiguousPeerHttpAddress(LEADER_PEER_ID)).thenReturn("localhost:2480");
     when(mockRaft.getLocalHttpAddress()).thenReturn("localhost:2480"); // ...but it is us
     sm.setRaftHAServer(mockRaft);
     try {
@@ -597,9 +598,15 @@ class Issue6111StaleSnapshotReadFloorTest {
   private static RaftHAServer followerRaftHAServerMock() {
     final RaftHAServer mockRaft = mock(RaftHAServer.class);
     when(mockRaft.isLeader()).thenReturn(false);
-    when(mockRaft.getLeaderHttpAddress()).thenReturn("localhost:2480");
+    when(mockRaft.getLeaderId()).thenReturn(LEADER_PEER_ID);
+    // The resolver every resync path now goes through: it withholds an address that does not identify one
+    // peer on its own, and refusing is the whole point of it (issue #6202).
+    when(mockRaft.getUnambiguousPeerHttpAddress(LEADER_PEER_ID)).thenReturn("peer-b:2480");
     return mockRaft;
   }
+
+  /** The peer id the mocked leader answers to. */
+  private static final RaftPeerId LEADER_PEER_ID = RaftPeerId.valueOf("peer-b_2434");
 
   private static long readLastRetryMs(final ArcadeStateMachine sm) throws Exception {
     final Field f = ArcadeStateMachine.class.getDeclaredField("lastStaleSnapshotRetryMs");

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
@@ -201,6 +201,48 @@ class Issue6202SnapshotInstallGuardTest {
   }
 
   // -----------------------------------------------------------------------------------------------
+  // A path that re-resolves the address on every retry must re-guard it on every retry
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * {@code SnapshotInstaller.install} takes address SUPPLIERS precisely because leadership can move mid-operation,
+   * so a guard applied once at the call site says nothing about the address attempt 3 resolves. The operator
+   * resync checked up front and then handed over the raw resolver, which is the same failure #6202 fixes,
+   * reopened on a later attempt.
+   * <p>
+   * Driven by making the resolver answer a good peer once - satisfying the up-front check - and this node's own
+   * address from then on, which is what a leadership change onto this node looks like to the supplier.
+   */
+  @Test
+  void everyDownloadAttemptOfAnOperatorResyncIsReGuarded(@TempDir final Path tempDir) throws Exception {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(false);
+    when(raft.getLeaderId()).thenReturn(RaftPeerId.valueOf(LEADER_PEER_ID));
+    when(raft.getLocalHttpAddress()).thenReturn(LOCAL_HTTP);
+    // First call: a genuine peer, so the up-front refusal does not fire. Every call after it: this node itself.
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID)))
+        .thenReturn("peer-b:2480", LOCAL_HTTP);
+
+    final List<LoggedLine> logged = new CopyOnWriteArrayList<>();
+    final Logger previous = installCapturingLogger(logged);
+    final ArcadeStateMachine sm = newInitializedStateMachine(tempDir);
+    sm.setRaftHAServer(raft);
+    try {
+      assertThatThrownBy(() -> sm.resyncDatabaseFromLeader("testdb"))
+          .as("the download must fail rather than pull this node's own database onto itself")
+          .isInstanceOf(ReplicationException.class)
+          .hasMessageContaining("Failed to resync database 'testdb'");
+
+      assertThat(logged.stream().map(LoggedLine::message))
+          .as("and the attempt must say it was refused, not merely that no address was known")
+          .anyMatch(m -> m.startsWith("Refusing to pull a snapshot"));
+    } finally {
+      LogManager.instance().setLogger(previous);
+      sm.close();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
   // Serialising the resync paths must not outlive the state machine
   // -----------------------------------------------------------------------------------------------
 
@@ -305,6 +347,8 @@ class Issue6202SnapshotInstallGuardTest {
     final ContextConfiguration config = new ContextConfiguration();
     config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, tempDir.resolve("databases").toString());
     config.setValue(GlobalConfiguration.HA_AUTO_ACQUIRE_DATABASES, false);
+    // No backoff to sit through: the download paths under test never reach the network, they are refused first.
+    config.setValue(GlobalConfiguration.HA_SNAPSHOT_INSTALL_RETRIES, 0);
 
     final ArcadeStateMachine sm = new ArcadeStateMachine();
     sm.setServer(new ArcadeDBServer(config));

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for issue #6202: {@code notifyInstallSnapshotFromLeader} - the Ratis-initiated resync, the one
+ * that runs when a follower's log is behind the leader's compacted log - resolved the leader's HTTP address and
+ * dialled it with no check at all, while the manual {@code triggerSnapshotDownload()} refused twice before
+ * dialling the very same kind of address.
+ * <p>
+ * The address is only as good as the configuration behind it. With no {@code http} port declared in
+ * {@code arcadedb.ha.serverList} a peer's HTTP endpoint is derived from the peer's Raft host plus THIS node's HTTP
+ * port, so on a cluster whose nodes share a host every peer collapses onto this node's own endpoint, and on one
+ * with mixed ports it can name the wrong peer. Neither outcome reported an error: the reconcile succeeded, the
+ * install was recorded, the stale-read floor was dropped and the node returned to the ready set carrying whatever
+ * it had copied - a node "repaired" from its own incomplete databases, or from a peer that is itself behind.
+ * <p>
+ * Both paths now ask the same helper, so they cannot drift apart, and the helper also refuses an address that
+ * does not identify one peer - the ambiguity check the client routing tables make (#6183), which matters more
+ * here, because a confidently wrong routing address costs one redirect while a confidently wrong snapshot source
+ * cannot be undone.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6202SnapshotInstallGuardTest {
+  private static final String LEADER_PEER_ID    = "peer-b_2434";
+  private static final String LOCAL_HTTP        = "localhost:2480";
+  private static final long   FIRST_LOG_INDEX   = 500L;
+  private static final long   SNAPSHOT_INDEX    = FIRST_LOG_INDEX - 1;
+  private static final long   PERSISTED_APPLIED = 100L;
+
+  // -----------------------------------------------------------------------------------------------
+  // The Ratis-initiated install must make the refusals the manual resync makes
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * The reachable misconfiguration: every peer derives to this node's own endpoint, so the follower "downloads"
+   * its own incomplete databases onto themselves. The manual path has refused this since #6111; this one did not.
+   */
+  @Test
+  void anInstallFromThisNodesOwnAddressIsRefused(@TempDir final Path tempDir) throws Exception {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(false);
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID))).thenReturn(LOCAL_HTTP);
+    when(raft.getLocalHttpAddress()).thenReturn(LOCAL_HTTP);
+
+    assertRefused(tempDir, raft, "is this node's own");
+  }
+
+  /**
+   * Leadership can move while an install is in flight, and a leader has no peer to pull from: "downloading" from
+   * itself would let the install drop the read floor and durably record the snapshot index as applied on state
+   * this node never had.
+   */
+  @Test
+  void anInstallOnANodeThatBelievesItIsTheLeaderIsRefused(@TempDir final Path tempDir) throws Exception {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(true);
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID))).thenReturn("peer-b:2480");
+
+    assertRefused(tempDir, raft, "this node is the leader");
+  }
+
+  /**
+   * The refusal #6202 asks for on top of the two the manual path already made: an address two peers both resolve
+   * to identifies at most one of them, and reconciling every database from the wrong node is not recoverable.
+   */
+  @Test
+  void anInstallFromAnAddressThatIdentifiesNoSinglePeerIsRefused(@TempDir final Path tempDir) throws Exception {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(false);
+    // The resolver withheld the address: it is claimed by more than one peer, or resolves to nothing.
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID))).thenReturn(null);
+    when(raft.getLocalHttpAddress()).thenReturn(LOCAL_HTTP);
+
+    assertRefused(tempDir, raft, "identifies leader");
+  }
+
+  /**
+   * Control: a genuine peer leader is still installed from, and the install still resolves the state it is
+   * supposed to. Without it the three tests above would also pass against a method that refused everything.
+   */
+  @Test
+  void aGenuinePeerLeaderIsStillInstalledFrom(@TempDir final Path tempDir) throws Exception {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(false);
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID))).thenReturn("peer-b:2480");
+    when(raft.getLocalHttpAddress()).thenReturn(LOCAL_HTTP);
+
+    final ArcadeStateMachine sm = newInitializedStateMachine(tempDir);
+    sm.setRaftHAServer(raft);
+    try {
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      final TermIndex installed = sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(), TermIndex.valueOf(9L,
+          FIRST_LOG_INDEX)).get();
+
+      assertThat(installed.getIndex())
+          .as("the snapshot covers every entry BEFORE the first one still in the log")
+          .isEqualTo(SNAPSHOT_INDEX);
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("an install from a real peer resolves the read floor")
+          .isEqualTo(-1L);
+      assertThat(sm.readPersistedAppliedIndex()).isEqualTo(SNAPSHOT_INDEX);
+    } finally {
+      sm.close();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Drives the Ratis-initiated install against {@code raft} and asserts it fails with a refusal naming
+   * {@code reasonFragment}, leaving the node visibly behind rather than recorded as caught up.
+   */
+  private void assertRefused(final Path tempDir, final RaftHAServer raft, final String reasonFragment)
+      throws Exception {
+    final ArcadeStateMachine sm = newInitializedStateMachine(tempDir);
+    sm.setRaftHAServer(raft);
+    try {
+      sm.writePersistedAppliedIndex(PERSISTED_APPLIED, "testdb");
+      setStaleSnapshotAppliedFloor(sm, PERSISTED_APPLIED);
+
+      final CompletableFuture<TermIndex> install = sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(),
+          TermIndex.valueOf(9L, FIRST_LOG_INDEX));
+
+      assertThatThrownBy(install::get)
+          .as("the install must fail so Ratis retries it, rather than record a snapshot it never installed")
+          .rootCause()
+          .hasMessageStartingWith("Refusing a leader-initiated snapshot install: ")
+          .hasMessageContaining(reasonFragment);
+
+      assertThat(sm.getStaleSnapshotAppliedFloor())
+          .as("a refused install resolves nothing, so the stale-read floor must stand")
+          .isEqualTo(PERSISTED_APPLIED);
+      assertThat(sm.readPersistedAppliedIndex())
+          .as("and the snapshot index must not be durably recorded as applied")
+          .isEqualTo(PERSISTED_APPLIED);
+      assertThat(sm.isResyncInProgress())
+          .as("the node keeps itself out of the ready set instead of pretending it caught up")
+          .isTrue();
+    } finally {
+      sm.close();
+    }
+  }
+
+  /** The Ratis role info a follower receives, naming {@link #LEADER_PEER_ID} as the installing leader. */
+  private static RaftProtos.RoleInfoProto leaderRoleInfo() {
+    return RaftProtos.RoleInfoProto.newBuilder()
+        .setFollowerInfo(RaftProtos.FollowerInfoProto.newBuilder()
+            .setLeaderInfo(RaftProtos.ServerRpcProto.newBuilder()
+                .setId(RaftProtos.RaftPeerProto.newBuilder()
+                    .setId(ByteString.copyFromUtf8(LEADER_PEER_ID)))))
+        .build();
+  }
+
+  /**
+   * A state machine with real Ratis storage (the install registers a snapshot marker through it) rooted at
+   * {@code tempDir}, and auto-acquire off so a reconcile over zero local databases needs no leader to answer.
+   */
+  private static ArcadeStateMachine newInitializedStateMachine(final Path tempDir) throws IOException {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, tempDir.resolve("databases").toString());
+    config.setValue(GlobalConfiguration.HA_AUTO_ACQUIRE_DATABASES, false);
+
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(new ArcadeDBServer(config));
+    sm.initialize(stubRaftServer(), RaftGroupId.valueOf(UUID.randomUUID()),
+        newFormattedStorage(tempDir.resolve("raft")));
+    return sm;
+  }
+
+  private static RaftStorage newFormattedStorage(final Path dir) throws IOException {
+    return RaftStorage.newBuilder()
+        .setDirectory(dir.toFile())
+        .setOption(RaftStorage.StartupOption.FORMAT)
+        .build();
+  }
+
+  private static void setStaleSnapshotAppliedFloor(final ArcadeStateMachine sm, final long floor) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("staleSnapshotAppliedFloor");
+    f.setAccessible(true);
+    ((AtomicLong) f.get(sm)).set(floor);
+  }
+
+  /**
+   * Minimal {@link RaftServer} stub: {@code BaseStateMachine.initialize()} only needs a non-null {@code getId()};
+   * nothing else is reached on this path.
+   */
+  private static RaftServer stubRaftServer() {
+    return (RaftServer) Proxy.newProxyInstance(
+        Issue6202SnapshotInstallGuardTest.class.getClassLoader(),
+        new Class<?>[] { RaftServer.class },
+        (proxy, method, args) -> {
+          if ("getId".equals(method.getName()))
+            return RaftPeerId.valueOf("test-peer");
+          if ("close".equals(method.getName()) || "start".equals(method.getName()))
+            return null;
+          throw new UnsupportedOperationException("Stub: " + method.getName());
+        });
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202SnapshotInstallGuardTest.java
@@ -20,6 +20,9 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.DefaultLogger;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.server.ArcadeDBServer;
 
 import org.apache.ratis.proto.RaftProtos;
@@ -36,9 +39,14 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -150,6 +158,96 @@ class Issue6202SnapshotInstallGuardTest {
     }
   }
 
+  /**
+   * A refusal is the expected outcome of a guard, and Ratis re-drives the install, so on a misconfigured cluster
+   * - or in the window after an election before the leader-role flag catches up - it fires on every attempt.
+   * Logged as the two request-driven resync paths log the same refusal: WARNING, message only. It used to fall
+   * into the install's generic {@code catch (Exception)} and come out as a SEVERE with a stack trace, which is
+   * what log-based alerting keys on.
+   */
+  @Test
+  void aRefusalIsLoggedAsAWarningAndNotAsAFault(@TempDir final Path tempDir) throws Exception {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(false);
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID))).thenReturn(LOCAL_HTTP);
+    when(raft.getLocalHttpAddress()).thenReturn(LOCAL_HTTP);
+
+    final List<LoggedLine> logged = new CopyOnWriteArrayList<>();
+    final Logger previous = installCapturingLogger(logged);
+    final ArcadeStateMachine sm = newInitializedStateMachine(tempDir);
+    sm.setRaftHAServer(raft);
+    try {
+      assertThatThrownBy(() -> sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(),
+          TermIndex.valueOf(9L, FIRST_LOG_INDEX)).get(30, TimeUnit.SECONDS)).isNotNull();
+
+      final LoggedLine refusal = logged.stream()
+          .filter(l -> l.message().startsWith("Refusing a leader-initiated snapshot install"))
+          .findFirst()
+          .orElse(null);
+      assertThat(refusal).as("the refusal must be logged, so an operator can see why the node stays behind")
+          .isNotNull();
+      assertThat(refusal.level()).isEqualTo(Level.WARNING);
+      assertThat(refusal.throwable())
+          .as("a guard firing as designed carries no stack trace worth printing")
+          .isNull();
+
+      assertThat(logged.stream().map(LoggedLine::message))
+          .as("and it must not ALSO come out of the generic failure arm as a SEVERE fault")
+          .noneMatch(m -> m.startsWith("Error during snapshot installation from leader"));
+    } finally {
+      LogManager.instance().setLogger(previous);
+      sm.close();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Serialising the resync paths must not outlive the state machine
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * The install waits for {@code snapshotDownloadLock} rather than racing whatever holds it, and it is the one
+   * resync path that may block - it owns its executor thread. That wait has to be interruptible, or a
+   * {@code close()} would be held open for the length of somebody else's download; {@code lockInterruptibly()}
+   * is what makes {@code shutdownNow()} able to unwind it, and this is the only path in the new locking code
+   * without other coverage.
+   */
+  @Test
+  void closingTheStateMachineUnwindsAnInstallParkedBehindAnInFlightResync(@TempDir final Path tempDir)
+      throws Exception {
+    final RaftHAServer raft = mock(RaftHAServer.class);
+    when(raft.isLeader()).thenReturn(false);
+    when(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf(LEADER_PEER_ID))).thenReturn("peer-b:2480");
+    when(raft.getLocalHttpAddress()).thenReturn(LOCAL_HTTP);
+
+    final ArcadeStateMachine sm = newInitializedStateMachine(tempDir);
+    sm.setRaftHAServer(raft);
+
+    // Stands in for a request-driven resync already running: the install must queue behind it, not proceed.
+    final ReentrantLock resyncLock = snapshotDownloadLock(sm);
+    resyncLock.lock();
+    try {
+      final CompletableFuture<TermIndex> install = sm.notifyInstallSnapshotFromLeader(leaderRoleInfo(),
+          TermIndex.valueOf(9L, FIRST_LOG_INDEX));
+
+      for (int i = 0; i < 500 && !resyncLock.hasQueuedThreads(); i++)
+        Thread.sleep(10);
+      assertThat(resyncLock.hasQueuedThreads())
+          .as("the install must park on the lock instead of running concurrently with the in-flight resync")
+          .isTrue();
+
+      sm.close();
+
+      // Bounded rather than get(): an install that is NOT unwound never completes, and a regression must fail
+      // this test rather than hang the module's run.
+      assertThatThrownBy(() -> install.get(30, TimeUnit.SECONDS))
+          .as("shutdownNow() must unwind the parked install rather than wait out a download it cannot see")
+          .hasRootCauseInstanceOf(InterruptedException.class)
+          .hasStackTraceContaining("Interrupted while waiting for an in-flight resync to finish");
+    } finally {
+      resyncLock.unlock();
+    }
+  }
+
   // -----------------------------------------------------------------------------------------------
   // Helpers
   // -----------------------------------------------------------------------------------------------
@@ -220,6 +318,48 @@ class Issue6202SnapshotInstallGuardTest {
         .setDirectory(dir.toFile())
         .setOption(RaftStorage.StartupOption.FORMAT)
         .build();
+  }
+
+  /** One line the capturing logger saw. */
+  private record LoggedLine(Level level, String message, Throwable throwable) {
+  }
+
+  /**
+   * Installs a {@link Logger} that records every line, returning the previous one for restore. Restores a fresh
+   * {@link DefaultLogger} rather than the live instance, which is the sanctioned test pattern here.
+   */
+  private static Logger installCapturingLogger(final List<LoggedLine> logged) {
+    final Logger capturing = new Logger() {
+      @Override
+      public void log(final Object requester, final Level level, final String message, final Throwable throwable,
+          final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+          final Object arg5, final Object arg6, final Object arg7, final Object arg8, final Object arg9,
+          final Object arg10, final Object arg11, final Object arg12, final Object arg13, final Object arg14,
+          final Object arg15, final Object arg16, final Object arg17) {
+        if (message != null)
+          logged.add(new LoggedLine(level, message, throwable));
+      }
+
+      @Override
+      public void log(final Object requester, final Level level, final String message, final Throwable throwable,
+          final String context, final Object... args) {
+        if (message != null)
+          logged.add(new LoggedLine(level, message, throwable));
+      }
+
+      @Override
+      public void flush() {
+      }
+    };
+    final Logger previous = new DefaultLogger();
+    LogManager.instance().setLogger(capturing);
+    return previous;
+  }
+
+  private static ReentrantLock snapshotDownloadLock(final ArcadeStateMachine sm) throws Exception {
+    final Field f = ArcadeStateMachine.class.getDeclaredField("snapshotDownloadLock");
+    f.setAccessible(true);
+    return (ReentrantLock) f.get(sm);
   }
 
   private static void setStaleSnapshotAppliedFloor(final ArcadeStateMachine sm, final long floor) throws Exception {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202UnambiguousPeerHttpAddressTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6202UnambiguousPeerHttpAddressTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for the resolver every snapshot resync path goes through since issue #6202:
+ * {@link RaftHAServer#getUnambiguousPeerHttpAddress}.
+ * <p>
+ * Two peers can never legitimately answer on one {@code host:port} - they would be fighting over the socket - so
+ * an address two of them resolve to identifies at most one, and nothing can say which. The plain
+ * {@code getPeerHttpAddress} keeps returning the best-effort address for cluster reporting and for a human
+ * reading it; this variant is for the callers that act on it unattended, where reconciling every database from
+ * the wrong node cannot be undone.
+ * <p>
+ * It is the same rule {@link RaftHAServer#selectUnambiguousRouting} applies to client routing tables (#6183),
+ * now sharing its claim-counting core with it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6202UnambiguousPeerHttpAddressTest {
+
+  /** Distinct declared HTTP ports: every peer owns its address, so each one is handed out. */
+  @Test
+  void anAddressOnlyOnePeerClaimsIsReturned() {
+    final RaftHAServer raft = newDetachedServer("localhost:2434:2480,localhost:2435:2481,localhost:2436:2482");
+
+    assertThat(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf("localhost_2435"))).isEqualTo("localhost:2481");
+    assertThat(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf("localhost_2436"))).isEqualTo("localhost:2482");
+  }
+
+  /**
+   * The shape the snapshot path has to refuse: two peers resolve to one address, so it names at most one of them.
+   * A follower that reconciled from it would report success while carrying another node's - possibly its own -
+   * databases.
+   */
+  @Test
+  void anAddressTwoPeersClaimIsWithheld() {
+    final RaftHAServer raft = newDetachedServer("localhost:2434:2480,localhost:2435:2490,localhost:2436:2490");
+
+    assertThat(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf("localhost_2435")))
+        .as("both peers answer to localhost:2490, so neither is identified by it")
+        .isNull();
+    assertThat(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf("localhost_2436"))).isNull();
+    assertThat(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf("localhost_2434")))
+        .as("the unaffected peer is still identified by its own address")
+        .isEqualTo("localhost:2480");
+  }
+
+  /** An unknown peer resolves to nothing, which is a refusal rather than a best-effort guess. */
+  @Test
+  void anUnknownPeerResolvesToNothing() {
+    final RaftHAServer raft = newDetachedServer("localhost:2434:2480,localhost:2435:2481");
+
+    assertThat(raft.getUnambiguousPeerHttpAddress(RaftPeerId.valueOf("nobody_9999"))).isNull();
+    assertThat(raft.getUnambiguousPeerHttpAddress(null)).isNull();
+  }
+
+  /**
+   * A {@link RaftHAServer} built from {@code serverList} with Ratis never started: the peer group and the
+   * declared HTTP addresses are both populated by the constructor, which is all this resolver reads. The node
+   * names itself with the {@code prefix_N} convention so a same-host server list still resolves a local peer.
+   */
+  private static RaftHAServer newDetachedServer(final String serverList) {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, serverList);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getServerName()).thenReturn("ArcadeDB_0");
+
+    return new RaftHAServer(mockServer, config);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -538,6 +538,12 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // chains did, since only their wrapper arms ever consulted getCause(). Unwrapping unconditionally would
     // change what a mapping keyed on the OUTER type answers: an IllegalArgumentException that happens to carry
     // a DuplicatedKeyException cause is a 400, not a 409.
+    //
+    // One level is sufficient because at most one is produced: DatabaseAbstractHandler.executeInTransaction
+    // rethrows a RuntimeException unchanged rather than re-wrapping it (#6201), so a failure arrives here either
+    // as itself or under a single planner/commit wrapper. That is a coupling, not a coincidence - a change that
+    // reintroduces double-wrapping has to deepen the walk here too, or the mapping it buries silently degrades to
+    // the generic 500 this method exists to stop producing.
     final Throwable cause = e.getCause() != null && isGenericWrapper(e) ? e.getCause() : e;
 
     // ServerSecurityException is not a SecurityException (it extends ServerException), so both are probed.

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -626,15 +626,6 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       return;
     }
 
-    // The request payload is missing a property, carries a null where a value is required, or holds the wrong
-    // type for it: a malformed request, not a server fault. Without this it degraded to 500 (issue #5935).
-    final JSONException invalidJson = firstOf(e, cause, JSONException.class);
-    if (invalidJson != null) {
-      logUserError(invalidJson);
-      sendErrorResponse(exchange, 400, "Invalid JSON payload", invalidJson, null);
-      return;
-    }
-
     // The whole chain is searched here rather than only the two throwables above, because the arithmetic error
     // is wrapped differently depending on how the request arrived: directly, inside the auto-commit wrapper, or
     // with the JDK ArithmeticException it came from as its own cause. An integer overflow or a division by zero
@@ -647,6 +638,12 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       return;
     }
 
+    // Ahead of the JSON arm below, which is the precedence the old CommandExecutionException|CommandParsingException
+    // chain had: a statement whose text failed to parse is reported as the parsing failure it is, even when the
+    // parser's own cause happens to be a JSONException. Both answer 400, so the order decides the message and the
+    // wire contract's exception field, not the status - and "the query text is invalid" is the actionable half,
+    // while how the parser tripped over it is an implementation detail.
+    //
     // A parsing/semantic validation error (malformed query, unknown variable, invalid MERGE rebind, unsupported
     // Gremlin syntax such as Groovy closures, ...) is a client error - the query text is invalid, not an
     // internal server fault. Surfaced with the real validation message so API consumers can fix the query,
@@ -655,6 +652,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     if (parsing != null) {
       logUserError(parsing);
       sendErrorResponse(exchange, 400, "Cannot execute command", parsing, null);
+      return;
+    }
+
+    // The request payload is missing a property, carries a null where a value is required, or holds the wrong
+    // type for it: a malformed request, not a server fault. Without this it degraded to 500 (issue #5935).
+    final JSONException invalidJson = firstOf(e, cause, JSONException.class);
+    if (invalidJson != null) {
+      logUserError(invalidJson);
+      sendErrorResponse(exchange, 400, "Invalid JSON payload", invalidJson, null);
       return;
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -448,266 +448,8 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         idempotencyReservation = null;
       }
 
-    } catch (final ServerSecurityException e) {
-      // PASS SecurityException TO THE CLIENT
-      LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
-              SecurityException.class.getSimpleName(), e.getMessage());
-      sendErrorResponse(exchange, 403, "Security error", e, null);
-    } catch (final SecurityException e) {
-      LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
-              SecurityException.class.getSimpleName(), e.getMessage());
-      sendErrorResponse(exchange, 403, "Security error", e, null);
-    } catch (final ServerIsNotTheLeaderException e) {
-      LogManager.instance()
-              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      sendErrorResponse(exchange, 400, "Cannot execute command", e, e.getLeaderAddress());
-    } catch (final NeedRetryException e) {
-      LogManager.instance()
-              .log(this, Level.FINE, "Error on command execution (%s): %s", getClass().getSimpleName(), e.getMessage());
-      sendErrorResponse(exchange, 503, "Cannot execute command", e, null);
-    } catch (final TransactionCommittedRemotelyException e) {
-      LogManager.instance()
-              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      // 409 Conflict, NOT 5xx (#5064/#5075 review): the transaction IS durably committed cluster-wide -
-      // only the local apply failed. A 5xx would invite HTTP clients and load balancers to RETRY, which
-      // would apply the changes a second time (duplicate inserts) - the exact hazard the distinct
-      // exception type exists to prevent. Same rationale as the DuplicatedKeyException 409 below (#4350).
-      sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry", e, null);
-    } catch (final DuplicatedKeyException e) {
-      LogManager.instance()
-              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      // 409 Conflict (RFC 9110 §15.5.10): a unique-constraint violation is a client data conflict,
-      // not a transient server-availability problem. 503 told clients/load balancers the request was
-      // retry-worthy, amplifying the bad write. See issue #4350.
-      sendErrorResponse(exchange, 409, "Found duplicate key in index", e,
-              e.getIndexName() + "|" + e.getKeys() + "|" + e.getCurrentIndexedRID());
-    } catch (final RecordNotFoundException e) {
-      LogManager.instance()
-              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      sendErrorResponse(exchange, 404, "Record not found", e, null);
-    } catch (final QueryNotIdempotentException e) {
-      LogManager.instance()
-              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      sendErrorResponse(exchange, 400, "Query is not idempotent", e, null);
-    } catch (final IllegalArgumentException e) {
-      LogManager.instance()
-              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      sendErrorResponse(exchange, 400, "Cannot execute command", e, null);
-    } catch (final JSONException e) {
-      // The request payload is missing a property, carries a null where a value is required, or holds the wrong type
-      // for it: a malformed request, not a server fault. Without this arm it degraded to 500 (issue #5935).
-      LogManager.instance()
-              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      sendErrorResponse(exchange, 400, "Invalid JSON payload", e, null);
-    } catch (final CommandExecutionException | CommandParsingException e) {
-      Throwable realException = e;
-      if (e.getCause() != null)
-        realException = e.getCause();
-      // Resolved once: the arm below needs both the answer and the exception itself, and the chain walk is not worth
-      // repeating.
-      final ArithmeticErrorException arithmetic = arithmeticError(e);
-
-      if (realException instanceof QueryNotIdempotentException) {
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 400, "Query is not idempotent", realException, null);
-      } else if (realException instanceof SecurityException) {
-        LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
-                SecurityException.class.getSimpleName(), realException.getMessage());
-        sendErrorResponse(exchange, 403, "Security error", realException, null);
-      } else if (realException instanceof TransactionCommittedRemotelyException committedRemotely) {
-        // Symmetric with the un-wrapped arm (#5064/#5075): a wrapped committed-remotely outcome must keep
-        // its non-retryable 409 - degrading to 500 invites the client retry that inserts duplicates of
-        // records the cluster already committed. Same defense-in-depth as the DuplicatedKeyException
-        // branch below.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry",
-                committedRemotely, null);
-      } else if (realException instanceof DuplicatedKeyException dup) {
-        // Symmetric with the un-wrapped DuplicatedKeyException catch arm. Some code paths
-        // (e.g. script execution, command planners) wrap DuplicatedKeyException in
-        // CommandExecutionException; without this branch the response would degrade to 500.
-        // See issue #4350.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 409, "Found duplicate key in index", dup,
-                dup.getIndexName() + "|" + dup.getKeys() + "|" + dup.getCurrentIndexedRID());
-      } else if (arithmetic != null) {
-        // An integer overflow or a division by zero is decided by the values the caller supplied, not by anything
-        // wrong with the server, and Neo4j classifies the whole category as a client error
-        // (Neo.ClientError.Statement.ArithmeticError). Reported as 400 with the arithmetic message rather than the
-        // 500 it used to degrade to. See issue #5602.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        arithmetic.getMessage());
-        sendErrorResponse(exchange, 400, "Cannot execute command", arithmetic, null);
-      } else if (e instanceof CommandParsingException || realException instanceof CommandParsingException) {
-        // A parsing/semantic validation error (malformed query, unknown variable, invalid MERGE
-        // rebind, unsupported Gremlin syntax such as Groovy closures, ...) is a client error - the query
-        // text is invalid, not an internal server fault. Surface as HTTP 400 with the real validation
-        // message so API consumers can fix the query, instead of a misleading 500. The check covers a
-        // CommandParsingException wrapped as the cause of a CommandExecutionException as well as a
-        // directly-thrown CommandParsingException, even when it carries its own cause (e.g. a Gremlin
-        // ScriptException, in which case realException is that cause). See issues #5191 and #5201.
-        final Throwable reported = e instanceof CommandParsingException ? e : realException;
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        reported.getMessage());
-        sendErrorResponse(exchange, 400, "Cannot execute command", reported, null);
-      } else if (realException instanceof JSONException) {
-        // Symmetric with the un-wrapped JSONException arm above: a command planner that wraps the payload read in a
-        // CommandExecutionException must not turn the client's malformed JSON into a 500 (issue #5935).
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 400, "Invalid JSON payload", realException, null);
-      } else {
-        // UNEXPECTED INTERNAL ERROR (not a client/validation error handled above): log the FULL stack trace so
-        // an internal fault - e.g. a BufferUnderflowException from a truncated/corrupted record read - is
-        // diagnosable. Passing the throwable is what makes the logger emit the trace; without it no stack trace
-        // is ever printed, at any log level. Use realException (the actual cause) for a useful trace.
-        LogManager.instance()
-                .log(this, getInternalErrorLogLevel(), "Error on command execution (%s)", realException,
-                        getClass().getSimpleName());
-        sendErrorResponse(exchange, 500, "Cannot execute command", realException, null);
-      }
-    } catch (final HttpSessionException e) {
-      // A referenced HTTP transaction session id is no longer resolvable (committed/rolled back, expired,
-      // owned by another principal, or invalidated). Surface as an explicit 404 client error - never a 500,
-      // and never a silent implicit-transaction commit. Must precede the TransactionException arm below since
-      // HttpSessionException extends it.
-      LogManager.instance()
-              .log(this, Level.FINE, "Transaction session error on command execution (%s): %s", getClass().getSimpleName(),
-                      e.getMessage());
-      sendErrorResponse(exchange, 404, "Remote transaction session not found or expired", e, null);
-    } catch (final TransactionException e) {
-      Throwable realException = e;
-      if (e.getCause() != null)
-        realException = e.getCause();
-      final ArithmeticErrorException arithmetic = arithmeticError(e);
-
-      if (realException instanceof ServerIsNotTheLeaderException notTheLeader) {
-        // Symmetric with the un-wrapped ServerIsNotTheLeaderException arm above, reached whenever the refusal
-        // is raised inside the auto-commit transaction wrapper in DatabaseAbstractHandler - which is where the
-        // HA write path raises it: a write issued on a follower is refused before it is forwarded when the
-        // resolved leader address names nobody (issue #6191). Without this branch the answer degraded to a 500
-        // "Error on transaction commit", which names neither the leader nor the reason, and which the
-        // forwarding peer cannot rebuild into the retryable typed exception the caller is entitled to.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s",
-                        getClass().getSimpleName(), realException.getMessage());
-        sendErrorResponse(exchange, 400, "Cannot execute command", notTheLeader, notTheLeader.getLeaderAddress());
-      } else if (realException instanceof SecurityException) {
-        LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on transaction execution (%s): %s",
-                SecurityException.class.getSimpleName(), realException.getMessage());
-        sendErrorResponse(exchange, 403, "Security error", realException, null);
-      } else if (realException instanceof QueryNotIdempotentException) {
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 400, "Query is not idempotent", realException, null);
-      } else if (realException instanceof IllegalArgumentException) {
-        // Bad client input (malformed parameter, unparseable marker, etc.) wrapped by the
-        // surrounding transaction wrapper. Surface as HTTP 400 just like the un-wrapped
-        // IllegalArgumentException catch arm above so the contract is symmetric regardless of
-        // whether the request happened to run inside a transaction.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 400, "Cannot execute command", realException, null);
-      } else if (realException instanceof JSONException) {
-        // Symmetric with the un-wrapped JSONException arm above: a malformed request payload read inside the
-        // auto-commit transaction wrapper must still answer 400, not the generic 500 (issue #5935).
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 400, "Invalid JSON payload", realException, null);
-      } else if (realException instanceof TransactionCommittedRemotelyException committedRemotely) {
-        // Same as the un-wrapped committed-remotely arm above (#5064/#5075), reached when the auto-commit
-        // wrapper re-wrapped it: the non-retryable 409 must survive the wrapping.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry",
-                committedRemotely, null);
-      } else if (realException instanceof DuplicatedKeyException dup) {
-        // Same as the un-wrapped DuplicatedKeyException arm above, but reached when the
-        // exception was thrown inside the auto-commit transaction wrapper in
-        // DatabaseAbstractHandler (which wraps any Exception thrown by execute() in a
-        // TransactionException). Without this branch the response degrades to 500. See issue #4350.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 409, "Found duplicate key in index", dup,
-                dup.getIndexName() + "|" + dup.getKeys() + "|" + dup.getCurrentIndexedRID());
-      } else if (arithmetic != null) {
-        // Symmetric with the un-wrapped arithmetic arm above (#5602): the auto-commit wrapper in
-        // DatabaseAbstractHandler re-wraps the failure as a TransactionException, and without this branch the
-        // client error would degrade back to 500.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        arithmetic.getMessage());
-        sendErrorResponse(exchange, 400, "Cannot execute command", arithmetic, null);
-      } else if (realException instanceof CommandParsingException) {
-        // Symmetric with the un-wrapped CommandParsingException arm above. A Cypher/SQL validation
-        // error thrown during execution is wrapped by the auto-commit transaction wrapper in
-        // DatabaseAbstractHandler (TransactionException -> CommandParsingException cause). Without this
-        // branch the response degraded to 500 "Error on transaction commit", hiding the real
-        // client-side validation message. Surface as HTTP 400 instead. See issue #5191.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 400, "Cannot execute command", realException, null);
-      } else if (realException instanceof CommandExecutionException) {
-        // Symmetric with the un-wrapped CommandExecutionException arm above. A runtime execution error
-        // (valid query, but the command failed while running - e.g. a Gremlin `.next()` on an empty
-        // traversal raising NoSuchElementException) is wrapped by the auto-commit transaction wrapper in
-        // DatabaseAbstractHandler (TransactionException -> CommandExecutionException cause). The failure
-        // happened during execute(), not at commit, so the honest label is "Cannot execute command", not
-        // the misleading "Error on transaction commit". Keep the HTTP 500 (runtime server-side error,
-        // matching Apache TinkerPop's SERVER_ERROR_SCRIPT_EVALUATION mapping). See issue #5219.
-        LogManager.instance()
-                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
-                        realException.getMessage());
-        sendErrorResponse(exchange, 500, "Cannot execute command", realException, null);
-      } else {
-        // UNEXPECTED INTERNAL ERROR wrapped by the auto-commit transaction wrapper (the client sees the generic
-        // "Error on transaction commit"). Log the FULL stack trace of the real cause: without passing the
-        // throwable the logger never prints a trace, at any level, which is why a BufferUnderflowException on a
-        // read-only command surfaced with no diagnosable trace even at DEBUG.
-        LogManager.instance()
-                .log(this, getInternalErrorLogLevel(), "Error on transaction execution (%s)", realException,
-                        getClass().getSimpleName());
-        sendErrorResponse(exchange, 500, "Error on transaction commit", realException, null);
-      }
     } catch (final Throwable e) {
-      // Check if a SecurityException is wrapped at any depth
-      Throwable cause = e;
-      while (cause != null) {
-        if (cause instanceof SecurityException) {
-          LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
-                  SecurityException.class.getSimpleName(), cause.getMessage());
-          sendErrorResponse(exchange, 403, "Security error", cause, null);
-          return;
-        }
-        cause = cause.getCause();
-      }
-      // UNEXPECTED RAW THROWABLE (typical for non-database handlers): same treatment as the other
-      // unexpected-internal-error arms - full stack trace, visible in production mode (issue #5374).
-      LogManager.instance()
-              .log(this, getInternalErrorLogLevel(), "Error on command execution (%s)", e, getClass().getSimpleName());
-      sendErrorResponse(exchange, 500, "Internal error", e, null);
+      sendMappedErrorResponse(exchange, e);
     } finally {
       // Drop any principal this request bound onto the thread's DatabaseContext in
       // checkAuthorizationOnDatabase (GHSA-c23x-pqcj-7hfm). This runs on a pooled worker thread, so a
@@ -769,6 +511,242 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
           Integer.toString(exchange.getStatusCode()), databaseTag(exchange))
           .record(System.nanoTime() - httpStartNanos, TimeUnit.NANOSECONDS);
     }
+  }
+
+  /**
+   * Turns any exception raised while serving a request into an HTTP status, a client-facing message and the
+   * structured {@code exceptionArgs} of the wire contract. The <b>single</b> place that decision is taken.
+   * <p>
+   * It used to be three: a chain of typed {@code catch} arms for an exception that reached the boundary as
+   * itself, plus one hand-written {@code instanceof} mirror of it inside the {@code CommandExecutionException}
+   * arm and another inside the {@code TransactionException} arm, for the same exception wrapped. The mirrors
+   * were maintained by hand and were never complete, and every gap needed its own issue to be noticed - #4350
+   * (duplicated key), #5064/#5075 (committed remotely), #5935 (malformed JSON), #5191 (parsing), #5602
+   * (arithmetic), #6191 (not the leader) each added one arm to one or two of the three. #6201 closed the
+   * remaining pair the same way it closed the wrapping that produced them: {@code NeedRetryException} (503) and
+   * {@code RecordNotFoundException} (404) existed only un-wrapped, so a retryable conflict raised inside the
+   * auto-commit wrapper was answered 500 "Error on transaction commit" - opaque to a client whose retry policy
+   * keys on 503, and the exact opposite of the contract {@code PostBatchHandler} documents.
+   * <p>
+   * The classification below is therefore written once and applied to both shapes. Order is significant only
+   * where one type extends another, which is called out at each such arm.
+   *
+   * @param e the exception that reached the request boundary
+   */
+  private void sendMappedErrorResponse(final HttpServerExchange exchange, final Throwable e) {
+    // Exactly one level of unwrapping, and only for the generic wrappers - which is what the three former
+    // chains did, since only their wrapper arms ever consulted getCause(). Unwrapping unconditionally would
+    // change what a mapping keyed on the OUTER type answers: an IllegalArgumentException that happens to carry
+    // a DuplicatedKeyException cause is a 400, not a 409.
+    final Throwable cause = e.getCause() != null && isGenericWrapper(e) ? e.getCause() : e;
+
+    // ServerSecurityException is not a SecurityException (it extends ServerException), so both are probed.
+    Throwable security = firstOf(e, cause, ServerSecurityException.class);
+    if (security == null)
+      security = firstOf(e, cause, SecurityException.class);
+    if (security != null) {
+      // PASS SecurityException TO THE CLIENT
+      LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
+              SecurityException.class.getSimpleName(), security.getMessage());
+      sendErrorResponse(exchange, 403, "Security error", security, null);
+      return;
+    }
+
+    // Before the NeedRetryException arm below, which it extends: the refusal names the leader the caller has to
+    // dial instead of merely saying "try again", and the forwarding peer rebuilds the typed exception from it
+    // (issue #6191).
+    final ServerIsNotTheLeaderException notTheLeader = firstOf(e, cause, ServerIsNotTheLeaderException.class);
+    if (notTheLeader != null) {
+      logUserError(notTheLeader);
+      sendErrorResponse(exchange, 400, "Cannot execute command", notTheLeader, notTheLeader.getLeaderAddress());
+      return;
+    }
+
+    // Before the TransactionException arm below, which it extends. A referenced HTTP transaction session id is
+    // no longer resolvable (committed/rolled back, expired, owned by another principal, or invalidated):
+    // an explicit 404 client error - never a 500, and never a silent implicit-transaction commit.
+    final HttpSessionException sessionGone = firstOf(e, cause, HttpSessionException.class);
+    if (sessionGone != null) {
+      LogManager.instance()
+              .log(this, Level.FINE, "Transaction session error on command execution (%s): %s",
+                      getClass().getSimpleName(), sessionGone.getMessage());
+      sendErrorResponse(exchange, 404, "Remote transaction session not found or expired", sessionGone, null);
+      return;
+    }
+
+    // Before the TransactionException arm below, which it extends. 409 Conflict, NOT 5xx (#5064/#5075): the
+    // transaction IS durably committed cluster-wide - only the local apply failed. A 5xx would invite HTTP
+    // clients and load balancers to RETRY, applying the changes a second time (duplicate inserts) - the exact
+    // hazard the distinct exception type exists to prevent. Same rationale as the DuplicatedKeyException 409.
+    final TransactionCommittedRemotelyException committedRemotely = firstOf(e, cause,
+            TransactionCommittedRemotelyException.class);
+    if (committedRemotely != null) {
+      logUserError(committedRemotely);
+      sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry",
+              committedRemotely, null);
+      return;
+    }
+
+    // 409 Conflict (RFC 9110 15.5.10): a unique-constraint violation is a client data conflict, not a transient
+    // server-availability problem. 503 told clients/load balancers the request was retry-worthy, amplifying the
+    // bad write. See issue #4350.
+    final DuplicatedKeyException dup = firstOf(e, cause, DuplicatedKeyException.class);
+    if (dup != null) {
+      logUserError(dup);
+      sendErrorResponse(exchange, 409, "Found duplicate key in index", dup,
+              dup.getIndexName() + "|" + dup.getKeys() + "|" + dup.getCurrentIndexedRID());
+      return;
+    }
+
+    // 503: the conflict is transient and the same request can succeed as issued. Reached from inside the
+    // auto-commit wrapper as well since #6201, which is where the engine raises most of them.
+    final NeedRetryException retryable = firstOf(e, cause, NeedRetryException.class);
+    if (retryable != null) {
+      LogManager.instance()
+              .log(this, Level.FINE, "Error on command execution (%s): %s", getClass().getSimpleName(),
+                      retryable.getMessage());
+      sendErrorResponse(exchange, 503, "Cannot execute command", retryable, null);
+      return;
+    }
+
+    final RecordNotFoundException notFound = firstOf(e, cause, RecordNotFoundException.class);
+    if (notFound != null) {
+      logUserError(notFound);
+      sendErrorResponse(exchange, 404, "Record not found", notFound, null);
+      return;
+    }
+
+    final QueryNotIdempotentException notIdempotent = firstOf(e, cause, QueryNotIdempotentException.class);
+    if (notIdempotent != null) {
+      logUserError(notIdempotent);
+      sendErrorResponse(exchange, 400, "Query is not idempotent", notIdempotent, null);
+      return;
+    }
+
+    // The request payload is missing a property, carries a null where a value is required, or holds the wrong
+    // type for it: a malformed request, not a server fault. Without this it degraded to 500 (issue #5935).
+    final JSONException invalidJson = firstOf(e, cause, JSONException.class);
+    if (invalidJson != null) {
+      logUserError(invalidJson);
+      sendErrorResponse(exchange, 400, "Invalid JSON payload", invalidJson, null);
+      return;
+    }
+
+    // The whole chain is searched here rather than only the two throwables above, because the arithmetic error
+    // is wrapped differently depending on how the request arrived: directly, inside the auto-commit wrapper, or
+    // with the JDK ArithmeticException it came from as its own cause. An integer overflow or a division by zero
+    // is decided by the values the caller supplied, not by anything wrong with the server, and Neo4j classifies
+    // the whole category as a client error (Neo.ClientError.Statement.ArithmeticError). See issue #5602.
+    final ArithmeticErrorException arithmetic = arithmeticError(e);
+    if (arithmetic != null) {
+      logUserError(arithmetic);
+      sendErrorResponse(exchange, 400, "Cannot execute command", arithmetic, null);
+      return;
+    }
+
+    // A parsing/semantic validation error (malformed query, unknown variable, invalid MERGE rebind, unsupported
+    // Gremlin syntax such as Groovy closures, ...) is a client error - the query text is invalid, not an
+    // internal server fault. Surfaced with the real validation message so API consumers can fix the query,
+    // instead of a misleading 500. See issues #5191 and #5201.
+    final CommandParsingException parsing = firstOf(e, cause, CommandParsingException.class);
+    if (parsing != null) {
+      logUserError(parsing);
+      sendErrorResponse(exchange, 400, "Cannot execute command", parsing, null);
+      return;
+    }
+
+    // Bad client input (malformed parameter, unparseable marker, ...).
+    final IllegalArgumentException badArgument = firstOf(e, cause, IllegalArgumentException.class);
+    if (badArgument != null) {
+      logUserError(badArgument);
+      sendErrorResponse(exchange, 400, "Cannot execute command", badArgument, null);
+      return;
+    }
+
+    // From here on nothing identified the failure as a client error, so the two generic wrappers answer for
+    // whatever they carry. UNEXPECTED INTERNAL ERROR: log the FULL stack trace - passing the throwable is what
+    // makes the logger emit one, and without it a BufferUnderflowException from a truncated record read was not
+    // diagnosable at any log level.
+    final CommandExecutionException commandFailure = firstOf(e, cause, CommandExecutionException.class);
+    if (commandFailure != null) {
+      // The failure happened during execute(), not at commit, so the honest label is "Cannot execute command".
+      // The 500 stands: a runtime server-side error, matching Apache TinkerPop's SERVER_ERROR_SCRIPT_EVALUATION
+      // mapping (issue #5219).
+      //
+      // Reported as itself and not as its cause, unlike the TransactionException arm below: this type is raised
+      // BY the engine to say what failed, so its message is the diagnosis - "Backup failed for database 'x' to
+      // directory 'y'" over a bare reflection failure - and dropping it would leave the client with the plumbing
+      // and none of the context. Nothing is lost either way, since the error body's detail field renders the
+      // whole cause chain and the logger prints it as "Caused by".
+      LogManager.instance()
+              .log(this, getInternalErrorLogLevel(), "Error on command execution (%s)", commandFailure,
+                      getClass().getSimpleName());
+      sendErrorResponse(exchange, 500, "Cannot execute command", commandFailure, null);
+      return;
+    }
+
+    if (firstOf(e, cause, TransactionException.class) != null) {
+      // Reported as its CAUSE, unlike the arm above: this wrapper is put on by the plumbing rather than raised by
+      // it, so its message ("Error on executing command") says nothing the label does not, while the cause is the
+      // real fault - and the wire contract's exception field is what a customer report is diagnosed from.
+      LogManager.instance()
+              .log(this, getInternalErrorLogLevel(), "Error on transaction execution (%s)", cause,
+                      getClass().getSimpleName());
+      sendErrorResponse(exchange, 500, "Error on transaction commit", cause, null);
+      return;
+    }
+
+    // Last resort, and the only place the cause chain is walked to any depth for a SecurityException: a
+    // security failure buried under an unrecognised wrapper must still be answered as one. Deliberately below
+    // every arm above, so a recognised mapping keeps deciding - which is where this walk already sat, in the
+    // catch-Throwable arm.
+    for (Throwable deep = e; deep != null; deep = deep.getCause())
+      if (deep instanceof SecurityException) {
+        LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
+                SecurityException.class.getSimpleName(), deep.getMessage());
+        sendErrorResponse(exchange, 403, "Security error", deep, null);
+        return;
+      }
+
+    // UNEXPECTED RAW THROWABLE (typical for non-database handlers): same treatment as the other
+    // unexpected-internal-error arms - full stack trace, visible in production mode (issue #5374).
+    LogManager.instance()
+            .log(this, getInternalErrorLogLevel(), "Error on command execution (%s)", e, getClass().getSimpleName());
+    sendErrorResponse(exchange, 500, "Internal error", e, null);
+  }
+
+  /**
+   * The exceptions {@link #sendMappedErrorResponse} looks through rather than at: they carry no classification
+   * of their own beyond "something failed while executing/committing", and the failure that matters is their
+   * cause. Every other type is answered as itself, cause or no cause.
+   */
+  private static boolean isGenericWrapper(final Throwable e) {
+    return e instanceof TransactionException || e instanceof CommandExecutionException
+            || e instanceof CommandParsingException;
+  }
+
+  /**
+   * The first of {@code e} and its unwrapped {@code cause} that is an instance of {@code type}, or {@code null}
+   * when neither is. {@code e} is tested first so a mapping reports the outermost throwable of its own type,
+   * which is the one carrying the message and the structured arguments the client is given.
+   */
+  private static <T> T firstOf(final Throwable e, final Throwable cause, final Class<T> type) {
+    if (type.isInstance(e))
+      return type.cast(e);
+    if (type.isInstance(cause))
+      return type.cast(cause);
+    return null;
+  }
+
+  /**
+   * Logs a failure the caller caused. Demoted under flood protection in production mode
+   * ({@link #getUserSevereErrorLogLevel()}) and without a stack trace: the message is the diagnosis, and the
+   * client is being told what went wrong anyway.
+   */
+  private void logUserError(final Throwable e) {
+    LogManager.instance()
+            .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
+                    e.getMessage());
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -546,10 +546,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // the generic 500 this method exists to stop producing.
     final Throwable cause = e.getCause() != null && isGenericWrapper(e) ? e.getCause() : e;
 
-    // ServerSecurityException is not a SecurityException (it extends ServerException), so both are probed.
-    Throwable security = firstOf(e, cause, ServerSecurityException.class);
-    if (security == null)
-      security = firstOf(e, cause, SecurityException.class);
+    final Throwable security = isSecurityFailure(e) ? e : isSecurityFailure(cause) ? cause : null;
     if (security != null) {
       // PASS SecurityException TO THE CLIENT
       LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
@@ -702,12 +699,14 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       return;
     }
 
-    // Last resort, and the only place the cause chain is walked to any depth for a SecurityException: a
-    // security failure buried under an unrecognised wrapper must still be answered as one. Deliberately below
-    // every arm above, so a recognised mapping keeps deciding - which is where this walk already sat, in the
-    // catch-Throwable arm.
+    // Last resort, and the only place the cause chain is walked to any depth for a security failure: one buried
+    // under an unrecognised wrapper must still be answered as one. Deliberately below every arm above, so a
+    // recognised mapping keeps deciding - which is where this walk already sat, in the catch-Throwable arm. It
+    // asks isSecurityFailure like the shallow probe does: the walk used to test only SecurityException, so a
+    // ServerSecurityException buried two levels deep came out as a generic 500 while the same exception one
+    // level up came out as 403.
     for (Throwable deep = e; deep != null; deep = deep.getCause())
-      if (deep instanceof SecurityException) {
+      if (isSecurityFailure(deep)) {
         LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
                 SecurityException.class.getSimpleName(), deep.getMessage());
         sendErrorResponse(exchange, 403, "Security error", deep, null);
@@ -719,6 +718,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     LogManager.instance()
             .log(this, getInternalErrorLogLevel(), "Error on command execution (%s)", e, getClass().getSimpleName());
     sendErrorResponse(exchange, 500, "Internal error", e, null);
+  }
+
+  /**
+   * Whether {@code e} is a security refusal the client must be told about as a 403. Two unrelated types express
+   * one thing: {@link ServerSecurityException} extends {@code ServerException}, NOT {@link SecurityException}, so
+   * neither {@code instanceof} implies the other and asking for one of them is always a half-answer. Written once
+   * so the shallow probe and the last-resort cause walk cannot disagree about what counts.
+   */
+  private static boolean isSecurityFailure(final Throwable e) {
+    return e instanceof SecurityException || e instanceof ServerSecurityException;
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/DatabaseAbstractHandler.java
@@ -152,28 +152,16 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
       if (activeSession != null) {
         // EXECUTE THE CODE LOCKING THE CURRENT SESSION. THIS AVOIDS USING THE SAME SESSION FROM MULTIPLE THREADS AT THE SAME TIME
         activeSession.execute(user, () -> {
-          if (finalAtomicTransaction) {
-            database.transaction(() -> {
-              try {
-                response.set(execute(exchange, user, database, payload));
-              } catch (Exception e) {
-                throw new TransactionException("Error on executing command", e);
-              }
-            }, false, retries);
-          } else
+          if (finalAtomicTransaction)
+            executeInTransaction(exchange, user, database, payload, response, retries);
+          else
             response.set(execute(exchange, user, database, payload));
           return null;
         });
       } else {
-        if (finalAtomicTransaction) {
-          database.transaction(() -> {
-            try {
-              response.set(execute(exchange, user, database, payload));
-            } catch (Exception e) {
-              throw new TransactionException("Error on executing command", e);
-            }
-          }, false, retries);
-        } else
+        if (finalAtomicTransaction)
+          executeInTransaction(exchange, user, database, payload, response, retries);
+        else
           response.set(execute(exchange, user, database, payload));
       }
 
@@ -205,6 +193,41 @@ public abstract class DatabaseAbstractHandler extends AbstractServerHttpHandler 
     }
 
     return response.get();
+  }
+
+  /**
+   * Runs {@link #execute(HttpServerExchange, ServerSecurityUser, Database, JSONObject)} inside the auto-commit
+   * transaction, retrying it up to {@code retries} times.
+   * <p>
+   * A {@link RuntimeException} is rethrown <b>unchanged</b>. Wrapping it - which this block used to do for every
+   * exception alike - broke the two contracts the wrapper itself depends on (issue #6201):
+   * <ul>
+   * <li>{@code LocalDatabase.transaction(...)} decides what to retry by type
+   * ({@code catch (NeedRetryException | DuplicatedKeyException)}). A conflict raised while {@code execute()} runs -
+   * a {@code save()} losing an MVCC race, an index update hitting a concurrent key - arrived there already wrapped,
+   * matched neither arm and propagated on the first attempt, so {@code retries} had no effect on anything but a
+   * conflict detected by the wrapper's own {@code commit()}.</li>
+   * <li>The HTTP error mapping in {@link AbstractServerHttpHandler} keys on the exception type, so a retryable
+   * conflict was answered as an opaque 500 "Error on transaction commit" rather than the documented 503, and a
+   * client whose retry policy keys on 503 gave up on a write that would have succeeded on retry.</li>
+   * </ul>
+   * Only a CHECKED exception still needs the wrapper, because {@code TransactionScope.execute()} declares none;
+   * every ArcadeDB exception is unchecked and therefore reaches both dispatchers as itself.
+   * <p>
+   * Package-private for direct unit testing.
+   */
+  void executeInTransaction(final HttpServerExchange exchange, final ServerSecurityUser user,
+      final DatabaseInternal database, final JSONObject payload, final AtomicReference<ExecutionResponse> response,
+      final int retries) {
+    database.transaction(() -> {
+      try {
+        response.set(execute(exchange, user, database, payload));
+      } catch (final RuntimeException e) {
+        throw e;
+      } catch (final Exception e) {
+        throw new TransactionException("Error on executing command", e);
+      }
+    }, false, retries);
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6201AutoCommitRetryTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6201AutoCommitRetryTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.exception.TransactionException;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import io.undertow.server.HttpServerExchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for the first half of issue #6201: the {@code retries} the auto-commit wrapper passes to the
+ * engine had no effect on anything raised while the command ran.
+ * <p>
+ * {@code DatabaseAbstractHandler} used to convert <b>every</b> exception the handler raised into a
+ * {@code TransactionException} from inside the transaction block. {@code LocalDatabase.transaction(...)} decides
+ * what to retry by type - {@code catch (NeedRetryException | DuplicatedKeyException)} - so a conflict raised
+ * during {@code execute()} arrived there already wrapped, matched neither arm, fell into the generic
+ * {@code catch (Throwable)} and propagated on the first attempt. Only a conflict detected by the wrapper's own
+ * {@code commit()} was ever retried.
+ * <p>
+ * The wrapper now rethrows a {@link RuntimeException} unchanged and wraps only the checked exceptions
+ * {@code TransactionScope} cannot declare, which is what these tests pin.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6201AutoCommitRetryTest {
+  private static final String DATABASE_PATH = "./target/databases/Issue6201AutoCommitRetryTest";
+
+  private DatabaseInternal database;
+
+  @BeforeEach
+  void createDatabase() {
+    final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    database = (DatabaseInternal) factory.create();
+  }
+
+  @AfterEach
+  void dropDatabase() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void aConflictRaisedWhileTheCommandRunsIsRetried() {
+    final AtomicInteger attempts = new AtomicInteger();
+    final CountingHandler handler = new CountingHandler(attempts,
+        attempt -> attempt < 3
+            ? new ConcurrentModificationException("Record #1:1 modified by another transaction")
+            : null);
+
+    final AtomicReference<ExecutionResponse> response = new AtomicReference<>();
+    handler.executeInTransaction(null, null, database, null, response, 5);
+
+    assertThat(attempts.get())
+        .as("the engine retries a NeedRetryException raised inside the transaction block, so the command runs "
+            + "again until it succeeds")
+        .isEqualTo(3);
+    assertThat(response.get()).isNotNull();
+    assertThat(response.get().getCode()).isEqualTo(200);
+  }
+
+  /**
+   * A duplicated key is deterministic and fails identically on every attempt, so the engine allows it exactly one
+   * retry (#4959) - the retry only exists to disambiguate a concurrency-induced duplicate. What matters here is
+   * that it is classified at all: before the fix it was wrapped out of the classification and never retried once.
+   */
+  @Test
+  void aDuplicatedKeyRaisedWhileTheCommandRunsIsRetriedOnce() {
+    final AtomicInteger attempts = new AtomicInteger();
+    final CountingHandler handler = new CountingHandler(attempts,
+        attempt -> new DuplicatedKeyException("Idx", "[1]", new RID(1, 1)));
+
+    assertThatThrownBy(
+        () -> handler.executeInTransaction(null, null, database, null, new AtomicReference<>(), 5))
+        .isInstanceOf(DuplicatedKeyException.class);
+
+    assertThat(attempts.get()).isEqualTo(2);
+  }
+
+  /**
+   * The other half of #6201: the exception reaching the HTTP error mapping must still be the typed one, so the
+   * mapping answers 503 rather than the opaque 500 the wrapper produced. Exhausting the retries must not put the
+   * wrapper back on.
+   */
+  @Test
+  void anExhaustedConflictPropagatesAsItselfAndNotWrapped() {
+    final AtomicInteger attempts = new AtomicInteger();
+    final CountingHandler handler = new CountingHandler(attempts,
+        attempt -> new ConcurrentModificationException("Record #1:1 modified by another transaction"));
+
+    assertThatThrownBy(
+        () -> handler.executeInTransaction(null, null, database, null, new AtomicReference<>(), 3))
+        .isInstanceOf(ConcurrentModificationException.class);
+
+    assertThat(attempts.get()).isEqualTo(3);
+  }
+
+  /**
+   * A CHECKED exception is the one case that still needs the wrapper: {@code TransactionScope.execute()} declares
+   * none, so it cannot travel out of the block as itself.
+   */
+  @Test
+  void aCheckedExceptionIsStillWrapped() {
+    final CountingHandler handler = new CountingHandler(new AtomicInteger(), attempt -> null) {
+      @Override
+      protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+          final Database database, final JSONObject payload) throws IOException {
+        throw new IOException("simulated I/O failure");
+      }
+    };
+
+    assertThatThrownBy(
+        () -> handler.executeInTransaction(null, null, database, null, new AtomicReference<>(), 1))
+        .isInstanceOf(TransactionException.class)
+        .hasMessage("Error on executing command")
+        .hasCauseInstanceOf(IOException.class);
+  }
+
+  /** Decides what the n-th (1-based) attempt throws; {@code null} means "succeed". */
+  @FunctionalInterface
+  private interface AttemptOutcome {
+    RuntimeException failureFor(int attempt);
+  }
+
+  /**
+   * A handler whose {@code execute()} counts its invocations and fails according to {@code outcome}, standing in
+   * for a command losing an MVCC race on a record it saves.
+   */
+  private static class CountingHandler extends DatabaseAbstractHandler {
+    private final AtomicInteger  attempts;
+    private final AttemptOutcome outcome;
+
+    private CountingHandler(final AtomicInteger attempts, final AttemptOutcome outcome) {
+      super(null);
+      this.attempts = attempts;
+      this.outcome = outcome;
+    }
+
+    @Override
+    protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+        final Database database, final JSONObject payload) throws Exception {
+      final RuntimeException failure = outcome.failureFor(attempts.incrementAndGet());
+      if (failure != null)
+        throw failure;
+      return new ExecutionResponse(200, "{}");
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.exception.QueryNotIdempotentException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.exception.TransactionCommittedRemotelyException;
+import com.arcadedb.exception.TransactionException;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.serializer.json.JSONException;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import io.micrometer.observation.ObservationRegistry;
+import io.undertow.io.Sender;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.Methods;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for issue #6201: the HTTP status a failure is answered with must not depend on whether the
+ * failure happened to be raised inside a transaction wrapper.
+ * <p>
+ * {@code DatabaseAbstractHandler} runs {@code execute()} inside the engine's retrying transaction, and the error
+ * mapping in {@link AbstractServerHttpHandler} used to be three hand-written {@code instanceof} chains - one for
+ * an exception that arrived as itself, one inside the {@code CommandExecutionException} arm and one inside the
+ * {@code TransactionException} arm. They were mirrors maintained by hand and were never complete: every new
+ * mapping (#4350, #5064, #5191, #5602, #5935, #6191) had to be added to each chain separately, and the half that
+ * was missed took a second issue to notice. {@code NeedRetryException} (503) and {@code RecordNotFoundException}
+ * (404) were the pair still missing when #6201 was filed, so a retryable conflict raised while a command ran was
+ * answered as an opaque 500 "Error on transaction commit" - and a client whose retry policy keys on 503 gave up
+ * on a write that would have succeeded on retry.
+ * <p>
+ * This test pins the property rather than the individual arms: for every mapped exception, the bare exception and
+ * the same exception wrapped in each of the two generic wrappers must produce the SAME status. A future mapping
+ * added to only one branch of the classification fails here.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6201ErrorStatusParityTest {
+
+  /** One mapped failure: how to build it, and the status the contract says it is answered with. */
+  private record MappedFailure(String name, int expectedStatus, Supplier<RuntimeException> factory) {
+  }
+
+  private static final List<MappedFailure> MAPPED_FAILURES = List.of(
+      // The pair #6201 was filed for: both existed only on the un-wrapped chain.
+      new MappedFailure("ConcurrentModificationException", 503,
+          () -> new ConcurrentModificationException("Record modified by another transaction")),
+      new MappedFailure("RecordNotFoundException", 404,
+          () -> new RecordNotFoundException("Record not found", new RID(1, 1))),
+      // The mappings each earlier issue had to add to two or three chains by hand.
+      new MappedFailure("DuplicatedKeyException", 409, () -> new DuplicatedKeyException("Idx", "[1]", new RID(1, 1))),
+      new MappedFailure("TransactionCommittedRemotelyException", 409,
+          () -> new TransactionCommittedRemotelyException("committed cluster-wide, do not retry",
+              new IllegalStateException("simulated local apply failure"))),
+      new MappedFailure("ServerIsNotTheLeaderException", 400,
+          () -> new ServerIsNotTheLeaderException("Not the leader", "192.168.0.1:2480")),
+      new MappedFailure("SecurityException", 403, () -> new SecurityException("Not allowed")),
+      new MappedFailure("QueryNotIdempotentException", 400,
+          () -> new QueryNotIdempotentException("Query is not idempotent")),
+      new MappedFailure("JSONException", 400, () -> new JSONException("Missing property 'command'")),
+      new MappedFailure("IllegalArgumentException", 400, () -> new IllegalArgumentException("Unparseable limit")),
+      new MappedFailure("CommandParsingException", 400, () -> new CommandParsingException("Unknown variable 'x'")));
+
+  /**
+   * The property itself: bare, wrapped in {@code TransactionException} (what the auto-commit wrapper produced),
+   * and wrapped in {@code CommandExecutionException} (what a script or a command planner produces) must all
+   * answer the same status.
+   */
+  @TestFactory
+  Stream<DynamicTest> statusIsTheSameWrappedAndUnwrapped() {
+    return MAPPED_FAILURES.stream().map(failure -> DynamicTest.dynamicTest(failure.name(), () -> {
+      final HandledResponse bare = handle(failure.factory().get());
+      assertThat(bare.statusCode)
+          .as("%s raised directly must answer %d (body=%s)", failure.name(), failure.expectedStatus(), bare.body)
+          .isEqualTo(failure.expectedStatus());
+
+      final HandledResponse inTransaction = handle(
+          new TransactionException("Error on executing command", failure.factory().get()));
+      assertThat(inTransaction.statusCode)
+          .as("%s raised INSIDE the auto-commit transaction wrapper must answer the same %d, not a generic 500"
+              + " (body=%s)", failure.name(), failure.expectedStatus(), inTransaction.body)
+          .isEqualTo(failure.expectedStatus());
+
+      final HandledResponse inCommand = handle(
+          new CommandExecutionException("Error on command execution", failure.factory().get()));
+      assertThat(inCommand.statusCode)
+          .as("%s wrapped by a command planner must answer the same %d (body=%s)", failure.name(),
+              failure.expectedStatus(), inCommand.body)
+          .isEqualTo(failure.expectedStatus());
+    }));
+  }
+
+  /**
+   * The concrete defect reported in #6201: a lost MVCC race inside the auto-commit wrapper answered 500
+   * "Error on transaction commit", which tells a client neither that the write can be re-driven nor why it
+   * failed. {@code PostBatchHandler} documents the contract as "NeedRetryException -> 503".
+   */
+  @Test
+  void aConflictInsideTheAutoCommitWrapperIsReportedAsRetryable() {
+    final HandledResponse response = handle(new TransactionException("Error on executing command",
+        new ConcurrentModificationException("Record #1:1 modified by another transaction")));
+
+    assertThat(response.statusCode).isEqualTo(503);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.getString("error")).isEqualTo("Cannot execute command");
+    // The typed exception survives too: the remote Java driver and the HA leader-exception reconstruction both
+    // rebuild the retryable type from this field, and a generic TransactionException is not retryable.
+    assertThat(json.getString("exception")).isEqualTo(ConcurrentModificationException.class.getName());
+  }
+
+  /**
+   * The un-wrapped fallbacks the classification still has to distinguish once nothing more specific matched, so
+   * collapsing the three chains into one did not collapse the three generic 500s into one message.
+   */
+  @Test
+  void theGenericWrappersKeepTheirOwnUnrecognisedFailureMessage() {
+    assertThat(new JSONObject(handle(new TransactionException("Error on commit")).body).getString("error"))
+        .isEqualTo("Error on transaction commit");
+    assertThat(new JSONObject(handle(new CommandExecutionException("boom", new IllegalStateException("x"))).body)
+        .getString("error")).isEqualTo("Cannot execute command");
+    assertThat(new JSONObject(handle(new IllegalStateException("unexpected internal state")).body).getString("error"))
+        .isEqualTo("Internal error");
+  }
+
+  private record HandledResponse(int statusCode, String body) {
+  }
+
+  /**
+   * Runs the real {@link AbstractServerHttpHandler#handleRequest} against a handler whose {@code execute()}
+   * throws the given exception, and captures the status code and JSON body the classification produces.
+   */
+  private HandledResponse handle(final RuntimeException toThrow) {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getObservationRegistry()).thenReturn(ObservationRegistry.create());
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    when(server.getServerName()).thenReturn("test");
+
+    final HttpServer httpServer = mock(HttpServer.class);
+    when(httpServer.getServer()).thenReturn(server);
+
+    final Sender sender = mock(Sender.class);
+    final HttpServerExchange exchange = mock(HttpServerExchange.class);
+    final int[] statusCode = { 200 };
+    when(exchange.setStatusCode(anyInt())).thenAnswer(invocation -> {
+      statusCode[0] = invocation.getArgument(0);
+      return exchange;
+    });
+    when(exchange.getStatusCode()).thenAnswer(invocation -> statusCode[0]);
+    when(exchange.getRequestHeaders()).thenReturn(new HeaderMap());
+    when(exchange.getResponseHeaders()).thenReturn(new HeaderMap());
+    when(exchange.getRequestMethod()).thenReturn(Methods.POST);
+    when(exchange.getRelativePath()).thenReturn("/command/graph");
+    when(exchange.getResponseSender()).thenReturn(sender);
+
+    new ThrowingHandler(httpServer, toThrow).handleRequest(exchange);
+
+    final ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+    verify(sender).send(body.capture());
+    return new HandledResponse(statusCode[0], body.getValue());
+  }
+
+  /** Handler whose execute() throws, standing in for a command that fails while running. */
+  private static final class ThrowingHandler extends AbstractServerHttpHandler {
+    private final RuntimeException toThrow;
+
+    private ThrowingHandler(final HttpServer httpServer, final RuntimeException toThrow) {
+      super(httpServer);
+      this.toThrow = toThrow;
+    }
+
+    @Override
+    protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+        final JSONObject payload) {
+      throw toThrow;
+    }
+
+    @Override
+    public boolean isRequireAuthentication() {
+      // Skip the Authorization machinery: this test targets the error classification only.
+      return false;
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
@@ -170,6 +170,43 @@ class Issue6201ErrorStatusParityTest {
   }
 
   /**
+   * Collapsing three orderings into one means the surviving order has to be the right one where they disagreed.
+   * A statement whose text failed to parse is reported as the parsing failure it is, even when the parser's own
+   * cause is a {@code JSONException} - which is what the {@code CommandExecutionException|CommandParsingException}
+   * chain did, and which is the actionable half for a client: the query text is invalid, and how the parser
+   * tripped over it is an implementation detail. Both answer 400, so this pins the message and the wire
+   * contract's {@code exception} field rather than the status.
+   */
+  @Test
+  void aParseFailureIsReportedAsOneEvenWhenItsCauseIsMalformedJson() {
+    final HandledResponse response = handle(
+        new CommandParsingException("Unknown variable 'x'", new JSONException("Missing property 'command'")));
+
+    assertThat(response.statusCode).isEqualTo(400);
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.getString("error")).isEqualTo("Cannot execute command");
+    assertThat(json.getString("exception")).isEqualTo(CommandParsingException.class.getName());
+  }
+
+  /**
+   * The other side of that order: a malformed payload that is NOT a parse failure still answers as one, so
+   * moving the parsing arm ahead of the JSON arm did not swallow the #5935 mapping.
+   */
+  @Test
+  void aMalformedPayloadIsStillReportedAsInvalidJson() {
+    for (final RuntimeException malformed : List.of(
+        new JSONException("Missing property 'command'"),
+        new CommandExecutionException("Error on command execution", new JSONException("Missing property 'command'")),
+        new TransactionException("Error on executing command", new JSONException("Missing property 'command'")))) {
+      final HandledResponse response = handle(malformed);
+      assertThat(response.statusCode).isEqualTo(400);
+      assertThat(new JSONObject(response.body).getString("error"))
+          .as("shape=%s", malformed.getClass().getSimpleName())
+          .isEqualTo("Invalid JSON payload");
+    }
+  }
+
+  /**
    * The un-wrapped fallbacks the classification still has to distinguish once nothing more specific matched, so
    * collapsing the three chains into one did not collapse the three generic 500s into one message.
    */

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue6201ErrorStatusParityTest.java
@@ -33,6 +33,7 @@ import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 
 import io.micrometer.observation.ObservationRegistry;
@@ -95,6 +96,8 @@ class Issue6201ErrorStatusParityTest {
       new MappedFailure("ServerIsNotTheLeaderException", 400,
           () -> new ServerIsNotTheLeaderException("Not the leader", "192.168.0.1:2480")),
       new MappedFailure("SecurityException", 403, () -> new SecurityException("Not allowed")),
+      // Not a SecurityException - it extends ServerException - so asking for either type alone is a half-answer.
+      new MappedFailure("ServerSecurityException", 403, () -> new ServerSecurityException("Not allowed")),
       new MappedFailure("QueryNotIdempotentException", 400,
           () -> new QueryNotIdempotentException("Query is not idempotent")),
       new MappedFailure("JSONException", 400, () -> new JSONException("Missing property 'command'")),
@@ -146,6 +149,24 @@ class Issue6201ErrorStatusParityTest {
     // The typed exception survives too: the remote Java driver and the HA leader-exception reconstruction both
     // rebuild the retryable type from this field, and a generic TransactionException is not retryable.
     assertThat(json.getString("exception")).isEqualTo(ConcurrentModificationException.class.getName());
+  }
+
+  /**
+   * The last-resort walk: a security refusal buried under wrappers the classification does not recognise is still
+   * a 403, and it must not matter which of the two unrelated security types it is. The walk used to test only
+   * {@code SecurityException}, so the same refusal answered 403 one level up and a generic 500 two levels down.
+   */
+  @Test
+  void aSecurityFailureBuriedUnderUnrecognisedWrappersIsStill403() {
+    for (final RuntimeException buried : List.of(
+        new IllegalStateException("outer", new RuntimeException("middle", new SecurityException("Not allowed"))),
+        new IllegalStateException("outer", new RuntimeException("middle", new ServerSecurityException("Not allowed"))))) {
+      final HandledResponse response = handle(buried);
+      assertThat(response.statusCode)
+          .as("a security refusal at depth 2 must still be 403 (body=%s)", response.body)
+          .isEqualTo(403);
+      assertThat(new JSONObject(response.body).getString("error")).isEqualTo("Security error");
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #6201, closes #6202.

## #6201 - the auto-commit wrapper defeated both dispatchers that key on the exception type

`DatabaseAbstractHandler` runs `execute()` inside the engine's retrying transaction and converted **every**
exception the handler raised into a `TransactionException`. Two dispatchers key on the type:

- `LocalDatabase.transaction(...)` decides what to retry with `catch (NeedRetryException | DuplicatedKeyException)`.
  A conflict raised while the command ran - a `save()` losing an MVCC race, an index update hitting a concurrent
  key - arrived already wrapped, matched neither arm, fell into the generic `catch (Throwable)` and propagated on
  the first attempt. Only a conflict detected by the wrapper's own `commit()` was ever retried, so the `retries` a
  client asks for had no effect on most of the conflict surface.
- The HTTP error mapping keys on the type too, and the wrapped arm had no `NeedRetryException` branch, so the same
  conflict was answered `500 "Error on transaction commit"`. `PostBatchHandler` documents the contract the other
  way round ("NeedRetryException -> 503, security -> 403, RecordNotFoundException -> 404, ... are left to the base
  handler") - true only when no transaction wrapper was active. A client whose retry policy keys on 503 gave up on
  a write that would have succeeded on retry.

The wrapper now rethrows a `RuntimeException` unchanged and wraps only the checked exceptions
`TransactionScope.execute()` cannot declare. Every ArcadeDB exception is unchecked, so both dispatchers see the
type they dispatch on.

**The mapping is now written once.** It was three hand-written `instanceof` chains - one for an exception that
reached the boundary as itself, one inside the `CommandExecutionException` arm, one inside the
`TransactionException` arm - and every mapping added since had to be added to each separately (#4350, #5064/#5075,
#5191, #5219, #5602, #5935, #6191). The half that was missed each time took a second issue to notice, and #6201 is
that second issue for `NeedRetryException` and `RecordNotFoundException`. A single ordered classification -
applied to the exception and, for the generic wrappers only, to its cause - closes those two and three more
asymmetries at once (a wrapped `IllegalArgumentException`, `ServerSecurityException` and `HttpSessionException`
were each mapped by one or two of the three chains and not the rest).

One nuance the three chains had disagreed on is now stated rather than inherited: a `CommandExecutionException`
that nothing more specific matched is reported *as itself* (the engine raises it to say what failed - "Backup
failed for database 'x' to directory 'y'" - and its cause is often just plumbing), a `TransactionException` is
reported *as its cause* (that wrapper is put on by the plumbing). Neither loses information: the error body's
`detail` field renders the whole cause chain either way.

## #6202 - only one of six snapshot-resync paths checked what it was about to dial

`ArcadeStateMachine` pulls a database snapshot from the leader on six paths. Only `triggerSnapshotDownload()`
refused anything. `notifyInstallSnapshotFromLeader` - the Ratis-initiated install, the one that runs when a
follower's log is behind the leader's compacted log - resolved the address and dialled it with no check at all,
and so did the targeted single-database resync, the `forceSnapshot` restore, the bootstrap-mismatch reinstall and
the operator-triggered resync.

With no `http` port declared in `arcadedb.ha.serverList` a peer's HTTP endpoint is derived from that peer's Raft
host plus **this** node's HTTP port, so on a cluster whose nodes share a host every peer collapses onto this
node's own endpoint, and on one with mixed ports it can name the wrong peer. Neither outcome reported an error:
`reconcileDatabasesFromLeader` succeeded, the install was recorded, the #6111 stale-read floor was dropped, and
the node returned to the ready set carrying whatever it had copied.

All six now ask one helper, so they cannot drift apart, and it refuses **three** things rather than two: this node
being the leader, an address that is this node's own, and an address that does not identify a single peer. The
last is the ambiguity check `selectUnambiguousRouting` makes for client routing tables (#6183), applied where it
matters more - a confidently wrong routing address costs one redirect, a confidently wrong snapshot source cannot
be undone. Refusing leaves the follower out of the ready set and visibly behind, which is the state it is actually
in; Ratis retries the install and the `HealthMonitor` re-arms the manual path.

Two things the same method carried, both named in the issue:

- The install ran on the JDK common `ForkJoinPool` (`supplyAsync` with no executor), against the rule at the head
  of `QueryEngineManager`'s class javadoc. It has a dedicated single-worker executor now
  (`arcadedb-raft-snapshot-install`) with a bounded queue and an abort policy turned into a failed future -
  caller-runs would put the download back on the Ratis thread the offload exists to protect.
- The single-flight `AtomicBoolean` did not serialise: the install proceeds when it *loses* the CAS, because
  standing down would report an install it never performed. A lock states the exclusion instead - the install
  waits for it (it owns its thread now), the request-driven paths fold into whatever holds it rather than parking
  the single-threaded lifecycle executor.

## Verification

New tests, each confirmed to fail against the pre-fix code:

- `Issue6201ErrorStatusParityTest` - pins the property rather than the arms: for ten mapped exceptions, bare and
  wrapped in each generic wrapper must answer the same status. 5 of 12 fail before the fix.
- `Issue6201AutoCommitRetryTest` - a conflict raised during `execute()` is actually retried, an exhausted one
  propagates as itself, a checked exception is still wrapped. 3 of 4 fail before the fix.
- `Issue6202SnapshotInstallGuardTest` - the leader-initiated install refuses this node's own address, a node that
  believes it is the leader, and an address identifying no single peer, with a control that a genuine peer leader
  is still installed from. All three refusals fail before the fix.
- `Issue6202UnambiguousPeerHttpAddressTest` - the resolver itself.

Existing suites run green: server unit (750) and IT (669 + 84 + 17), ha-raft unit (890), and the snapshot resync
ITs (`RaftFullSnapshotResyncIT`, `RaftForceResyncIT`, `RaftDivergedFollowerRecoveryIT`, `SnapshotAcquireNewDatabaseIT`,
`Issue4749SnapshotInstallClosesRegisteredDatabaseIT`, `SnapshotInstallerIntegrationIT`). `BackupHttpErrorHandlingIT`
caught the reporting nuance above during the first IT pass and is green after it.

Also updated: the `engine-concurrency` skill's common-pool list and pool table, and the `BaseRaftHATest` comment
that named the common-pool caller as the suspected cause of its 120s resync timeout.