### PR TITLE
fix(#6199, #6200): the flush drains wake on the page, and one suspended database's backlog is its own

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -472,10 +472,12 @@ public enum GlobalConfiguration {
       """
       Maximum amount of RAM (in MB) of dirty pages the page-flush thread may defer in memory while flushing \
       is suspended (during an HA snapshot ship or a full backup, when the on-disk files must stay stable). \
-      Once the deferred backlog crosses this cap the flush thread stops draining its bounded queue, so \
-      committing threads are throttled instead of the deferred backlog growing without limit and exhausting \
-      the heap (issue #4728: a busy leader shipping a multi-GB snapshot OOM'd). Set to 0 to disable the cap \
-      (unbounded, pre-4728 behavior).""",
+      Once the deferred backlog crosses this cap the committing threads of the SUSPENDED databases are \
+      throttled, instead of the deferred backlog growing without limit and exhausting the heap (issue #4728: \
+      a busy leader shipping a multi-GB snapshot OOM'd). The cap is JVM-wide because the heap it bounds is, \
+      but the throttling is not: a database that is not suspended is never held by it, since its pages go \
+      straight to disk and relieve the backlog rather than add to it (issue #6200). Set to 0 to disable the \
+      cap (unbounded, pre-4728 behavior).""",
       Long.class, 512),
 
   PAGE_SNAPSHOT_ENABLED("arcadedb.pageSnapshotEnabled", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -49,6 +49,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  * of indexed pages, so {@code pendingOf() == 0} proves the pipeline is empty (what the barrier and the close path
  * need), while the opposite skew is bounded by a few instructions and costs at worst one extra poll.
  * <p>
+ * <b>The drain signal (issue #6199).</b> Because {@link #release} is the ONE place a database's count goes down, it
+ * is also the one place that can tell a waiter "your pipeline just emptied". {@link #awaitDrain} parks on the
+ * database's own counter instead of sleeping, so the two drains ({@code waitAllPagesOfDatabaseAreFlushed} and the
+ * snapshot barrier's {@code waitPendingPagesOfDatabaseUntil}) wake the moment the last page lands rather than at the
+ * next poll boundary. That matters most for the barrier, which polls with the JVM-wide page-manager lock held: every
+ * millisecond it sleeps there is a millisecond in which no committer of ANY database can publish a page.
+ * <p>
  * <b>The one thing that rule does NOT cover, and what covers it instead:</b> {@link #removeAllOfDatabase} drops a
  * database's counter outright, so a {@link #putAll} for that same database running concurrently with it could leave a
  * page indexed under a counter that is no longer there - undercounting to zero, the "a backup stamps its t0 over a
@@ -65,6 +72,12 @@ class FlushPageIndex {
   /**
    * Number of {@link #pages} entries per database. An entry is created with the database's first pending page and
    * dropped by {@link #removeAllOfDatabase} (close/drop), so it is bounded by the number of open databases.
+   * <p>
+   * The counter object doubles as the monitor {@link #awaitDrain} parks on and {@link #release} notifies (issue
+   * #6199). Reusing it rather than adding a parallel map of lock objects is not a shortcut: it removes the window in
+   * which a waiter could resolve a monitor that the signaller has not published yet, and it keeps the signalling
+   * path down to the counter the decrement already has in hand. The object never escapes this class - every accessor
+   * returns an {@code int} - so no foreign code can hold this monitor.
    */
   private final ConcurrentHashMap<BasicDatabase, AtomicInteger> pending = new ConcurrentHashMap<>();
 
@@ -164,7 +177,13 @@ class FlushPageIndex {
     pages.keySet().removeIf(pageId -> database.equals(pageId.getDatabase()));
     // Dropped AFTER the pages, never before: the other order would let a page indexed in between survive with a
     // fresh counter that the purge then empties, leaving a count above zero that hangs the close forever.
-    pending.remove(database);
+    final AtomicInteger counter = pending.remove(database);
+    // A waiter parked on that counter would otherwise sleep out its whole fallback interval for a database that no
+    // longer has an entry at all: pendingOf() answers 0 for it from here on, so wake it to observe that (#6199).
+    if (counter != null)
+      synchronized (counter) {
+        counter.notifyAll();
+      }
   }
 
   /**
@@ -221,6 +240,42 @@ class FlushPageIndex {
     return count;
   }
 
+  /**
+   * Parks until the database's pipeline is empty, or until {@code maxWaitMillis} elapses - the poll-free form of the
+   * drains of issue #6199.
+   * <p>
+   * <b>Standard guarded wait, and the guard is the whole point:</b> the count is re-read HERE, with the monitor
+   * already held, and not by the caller before the call. A caller that read a positive count and then asked to park
+   * would race the last {@link #release}: the decrement and its {@code notifyAll} could both land in the gap, and
+   * the wait would then be woken only by its own timeout. Re-reading under the monitor closes that gap in both
+   * directions - either this read sees the drained count and returns without parking, or it happens before the
+   * decrement, in which case the signaller cannot enter its {@code synchronized} block until this thread is already
+   * inside {@code wait()} and has released the monitor.
+   * <p>
+   * The bounded wait is a safety net, not the mechanism: it keeps the callers' timeout machinery (the no-progress
+   * window of {@code waitAllPagesOfDatabaseAreFlushed}, the hard deadline of the snapshot barrier) periodically
+   * re-evaluated, and degrades a hypothetical lost notification to the polling this used to be rather than to a
+   * hang. Callers therefore must keep their own loop and re-check their own condition on return.
+   *
+   * @param maxWaitMillis upper bound of the park. {@code <= 0} returns immediately - it never means "park forever",
+   *                      which is what a bare {@code Object.wait(0)} would do.
+   */
+  void awaitDrain(final BasicDatabase database, final long maxWaitMillis) throws InterruptedException {
+    if (maxWaitMillis <= 0)
+      return;
+
+    final AtomicInteger counter = pending.get(database);
+    if (counter == null)
+      // NEVER HAD A PENDING PAGE, OR THE DATABASE WAS ALREADY FORGOTTEN: pendingOf() ANSWERS 0, NOTHING TO WAIT FOR
+      return;
+
+    synchronized (counter) {
+      if (counter.get() <= 0)
+        return;
+      counter.wait(maxWaitMillis);
+    }
+  }
+
   private AtomicInteger counterOf(final BasicDatabase database) {
     final AtomicInteger counter = pending.get(database);
     return counter != null ? counter : pending.computeIfAbsent(database, k -> new AtomicInteger());
@@ -228,7 +283,11 @@ class FlushPageIndex {
 
   private void release(final BasicDatabase database) {
     final AtomicInteger counter = pending.get(database);
-    if (counter != null)
-      counter.decrementAndGet();
+    // The monitor is taken ONLY on the transition to drained, so the hot flush path pays a volatile decrement and a
+    // comparison per page exactly as before, and a lock acquisition only on the page that empties the pipeline.
+    if (counter != null && counter.decrementAndGet() <= 0)
+      synchronized (counter) {
+        counter.notifyAll();
+      }
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -182,6 +182,13 @@ class FlushPageIndex {
     // longer has an entry at all: pendingOf() answers 0 for it from here on, so wake it to observe that (#6199).
     if (counter != null)
       synchronized (counter) {
+        // ZEROED, not merely notified, and inside the monitor. A waiter that resolved this counter BEFORE the
+        // remove above can enter the monitor AFTER the notifyAll has already fired, and what it re-reads there is
+        // the counter object itself - the drained map entry it would otherwise consult is already gone. So the
+        // object has to carry the drained state, or that waiter parks through a signal it can never be sent again.
+        // Bounded rather than fatal (its fallback interval still expires, and its next call resolves no counter at
+        // all), but it is precisely the wake-up this notification exists to deliver.
+        counter.set(0);
         counter.notifyAll();
       }
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -901,7 +901,8 @@ public class PageManager extends LockContext {
   /**
    * Bytes of dirty pages currently held in memory because flushing is suspended on some database (a full backup, an HA
    * snapshot ship, an HA verify). Once this crosses {@link com.arcadedb.GlobalConfiguration#FLUSH_SUSPEND_MAX_DEFERRED_RAM}
-   * the flush thread stops draining its queue and committing threads are throttled instead, so this is the direct
+   * the committing threads OF THE SUSPENDED DATABASES are throttled (issue #6200 - before it, the flush thread stopped
+   * draining its queue altogether, which throttled the committers of every open database), so this is the direct
    * measure of how much a long suspension is costing writers.
    *
    * @return 0 when no suspension is in progress, or when the page manager is closed.
@@ -909,6 +910,28 @@ public class PageManager extends LockContext {
   public long getDeferredRAMBytes() {
     final PageManagerFlushThread thread = flushThread;
     return thread != null ? thread.deferredRAMBytes.get() : 0L;
+  }
+
+  /**
+   * The same backlog as {@link #getDeferredRAMBytes}, for a single database (issue #6200): the number that says WHICH
+   * suspension is costing the heap, which the JVM-wide total cannot.
+   *
+   * @return 0 when that database has nothing deferred, or when the page manager is closed.
+   */
+  public long getDeferredRAMBytesOf(final BasicDatabase database) {
+    final PageManagerFlushThread thread = flushThread;
+    return thread != null ? thread.getDeferredRAMBytesOf(database) : 0L;
+  }
+
+  /**
+   * Holds the caller while the deferred backlog of ITS database is over the cap (issue #4728). A no-op unless that
+   * database is currently suspended - see {@link PageManagerFlushThread#awaitDeferredBacklogUnderCap}, and note that
+   * this must never be called with the page-manager lock held (issue #6200).
+   */
+  private void awaitDeferredBacklogUnderCap(final List<MutablePage> pages) throws InterruptedException {
+    if (flushThread == null || pages == null || pages.isEmpty())
+      return;
+    flushThread.awaitDeferredBacklogUnderCap(pages.getFirst().getPageId().getDatabase());
   }
 
   /**
@@ -1101,13 +1124,20 @@ public class PageManager extends LockContext {
    */
   public void publishPages(final List<MutablePage> pagesToWrite, final Map<PageId, MutablePage> newPages,
       final boolean asyncFlush) throws IOException, InterruptedException {
+    // OUTSIDE THE LOCK, AND THAT IS THE ENTIRE POINT (issue #6200): while a database is suspended its dirty pages
+    // pile up in RAM, and the cap that bounds that backlog is served by holding ITS committers here. Held one line
+    // lower - inside lock() - the wait would be served while holding a JVM-WIDE lock, so throttling the committers
+    // of the one suspended database would stall the committers of every other database with them.
+    if (asyncFlush)
+      awaitDeferredBacklogUnderCap(pagesToWrite);
+
     lock();
     try {
       // Write pages (and put in readCache) BEFORE updating pageCount, otherwise concurrent
       // transactions can observe pageCount > readCache state and treat the new page as a
       // pre-existing empty page (sparse-file semantics), allowing two records' chunk chains
       // to land on the same physical slot.
-      writePages(pagesToWrite, asyncFlush);
+      writePagesNoBackpressure(pagesToWrite, asyncFlush);
 
       if (newPages != null)
         for (final MutablePage p : newPages.values()) {
@@ -1321,6 +1351,19 @@ public class PageManager extends LockContext {
   }
 
   public void writePages(final List<MutablePage> updatedPages, final boolean asyncFlush) throws IOException, InterruptedException {
+    // Entry point of the asynchronous writers that do NOT go through publishPages (LSM index compaction): they hold
+    // no page-manager lock, so the deferred-backlog cap of #4728 can be served right here (issue #6200).
+    if (asyncFlush)
+      awaitDeferredBacklogUnderCap(updatedPages);
+    writePagesNoBackpressure(updatedPages, asyncFlush);
+  }
+
+  /**
+   * {@link #writePages} without the deferred-backlog wait, for the one caller that has already served it before
+   * taking the page-manager lock: {@link #publishPages} (issue #6200).
+   */
+  private void writePagesNoBackpressure(final List<MutablePage> updatedPages, final boolean asyncFlush)
+      throws IOException, InterruptedException {
     if (asyncFlush) {
       for (final MutablePage page : updatedPages)
         putPageInReadCache(new CachedPage(page, true));

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -927,6 +927,12 @@ public class PageManager extends LockContext {
    * Holds the caller while the deferred backlog of ITS database is over the cap (issue #4728). A no-op unless that
    * database is currently suspended - see {@link PageManagerFlushThread#awaitDeferredBacklogUnderCap}, and note that
    * this must never be called with the page-manager lock held (issue #6200).
+   * <p>
+   * ASSUMPTION, shared with {@code PagesToFlush} and therefore with the whole flush pipeline: a batch carries the
+   * pages of ONE database, so the first page names it. Every caller satisfies it - a publication is one
+   * transaction's pages, and the direct {@code writePages} callers (LSM compaction, bloom filter, sparse segment
+   * builder) write one component of one database - and a mixed batch would already mis-key the deferral, the
+   * per-database pending count and the suspension check long before it reached here. Do not introduce one.
    */
   private void awaitDeferredBacklogUnderCap(final List<MutablePage> pages) throws InterruptedException {
     if (flushThread == null || pages == null || pages.isEmpty())

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -144,8 +144,9 @@ public class PageManagerFlushThread extends Thread {
    * SUSPENDED databases are ever deferred - so this is the number that actually explains a backlog, and the one
    * {@code arcadedb.pagemanager.deferred_ram_bytes} needs to be tagged by database (item 2 of #6087), which the
    * single JVM-wide total could not express. An entry is created with a database's first deferred batch and dropped
-   * when the whole backlog drains ({@link #resetDeferredRAMIfDrained}) or when the database is purged, so it is
-   * bounded by the number of open databases and empty whenever nothing is deferred anywhere.
+   * when its backlog ends - its last suspender resumed, or it was closed or dropped, both through
+   * {@link #releaseResidualDeferredRAM} - so it is bounded by the number of open databases and empty whenever
+   * nothing is deferred anywhere.
    */
   final ConcurrentHashMap<BasicDatabase, AtomicLong> deferredRAMByDatabase = new ConcurrentHashMap<>();
 
@@ -153,6 +154,13 @@ public class PageManagerFlushThread extends Thread {
    * Monitor of the committer-side backpressure of issue #4728: waiters park here while the deferred backlog is over
    * the cap, and {@link #addDeferredRAM} notifies them when it drops back under. Bounded waits, so a suspension
    * released without freeing any RAM (nothing was deferred) still lets its committers out.
+   * <p>
+   * ONE monitor for every suspended database, not one per database, because the condition they are all waiting on is
+   * one number: the JVM-wide total, which any database's release can move under the cap. Splitting it per database
+   * would mean notifying every one of them on every release anyway - the same wake-ups through more monitors. The
+   * herd is bounded by construction: the signal fires only on the DOWNWARD crossing of the cap (not per released
+   * page), on a resume, on a purge and on shutdown, and every woken committer re-reads the total and either
+   * proceeds or parks again.
    */
   private final Object deferredRAMLock = new Object();
 
@@ -857,10 +865,13 @@ public class PageManagerFlushThread extends Thread {
       // a long suspension throttles many of them, and the point is to name the database whose backlog is doing it.
       if (!reported && System.currentTimeMillis() - beginTime > DEFERRED_BACKLOG_WARN_MILLIS) {
         reported = true;
+        // Both numbers, and the JVM-wide one named as such: the cap is on the total across every suspended
+        // database, so the backlog holding this database's committers is very often NOT its own - which is the
+        // whole subject of #6200, and precisely what an operator reading a single figure would misread.
         LogManager.instance().log(this, Level.WARNING,
-            "Commits on database '%s' have been throttled for over %d ms: page flushing is suspended (backup or HA snapshot) and the deferred backlog is %s, at or above the '%s' cap",
+            "Commits on database '%s' have been throttled for over %d ms: page flushing is suspended (backup or HA snapshot) and the JVM-wide deferred backlog is %s, of which %s is this database's own, at or above the '%s' cap",
             null, db.getName(), DEFERRED_BACKLOG_WARN_MILLIS, FileUtils.getSizeAsString(deferredRAMBytes.get()),
-            GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM.getKey());
+            FileUtils.getSizeAsString(getDeferredRAMBytesOf(db)), GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM.getKey());
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -609,14 +609,17 @@ public class PageManagerFlushThread extends Thread {
       final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.remove(database);
       if (deferred != null) {
         for (final PagesToFlush batch : deferred) {
-          if (!batch.database.isOpen())
-            continue;
           synchronized (batch.pages) {
             for (final MutablePage page : batch.pages) {
-              if (!batch.database.isOpen())
-                break;
               try {
-                pageManager.flushPage(page);
+                // A page whose database closed mid-unsuspend is NOT written - there is nothing left to write it
+                // to - but it still leaves the backlog through the finally below. Skipping it (which is what the
+                // `continue`/`break` here used to do) stranded its bytes in the deferred accounting for the life
+                // of the process, and every LATER suspension would then be throttled by that much: the drift the
+                // blanket "reset the counter when nothing is deferred anywhere" net existed to absorb. Releasing
+                // it at the source is exact, and per database, so no reset can ever wipe a sibling's live count.
+                if (batch.database.isOpen())
+                  pageManager.flushPage(page);
               } catch (final DatabaseMetadataException e) {
                 // FILE DELETED, CONTINUE WITH THE NEXT PAGES
                 LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
@@ -686,9 +689,14 @@ public class PageManagerFlushThread extends Thread {
       }
     }
 
-    // Safety net: once nothing is deferred for any database the backlog is provably empty, so reset the counters
-    // to absorb any drift from edge cases above (a batch skipped because its database closed mid-unsuspend).
-    resetDeferredRAMIfDrained();
+    // Phase 4: this database's backlog has provably ended, so release whatever is still charged to it - and ONLY
+    // to it. The suspension was cleared under suspendLock in Phase 2 and resumingDatabases keeps a new suspender
+    // out until the caller's finally, so nothing can defer another of its batches behind us (the same argument
+    // Phase 2 rests on). With Phase 1 now releasing every page it skips, this should always find zero; it stays as
+    // the per-database safety net that the old blanket "if nothing is deferred anywhere, zero the counters" reset
+    // was - that one read `deferredByDatabase.isEmpty()` on this thread while the flush thread could be deferring
+    // the FIRST batch of an unrelated database, and would then wipe that database's fresh charge (review of #6200).
+    releaseResidualDeferredRAM(database);
 
     if (restoreCallerInterrupt)
       // Consumed once during Phase 1: restore it so the caller still observes its own cancellation.
@@ -739,19 +747,22 @@ public class PageManagerFlushThread extends Thread {
     if (delta == 0)
       return;
 
-    if (database != null) {
-      if (delta > 0)
-        deferredRAMByDatabase.computeIfAbsent(database, k -> new AtomicLong()).addAndGet(delta);
-      else {
-        // A release NEVER creates an entry: the only way to reach one here without a matching deferral is a database
-        // whose bookkeeping was already purged by its close, and re-creating it with a negative value would both
-        // report a nonsensical gauge and re-pin the closed instance as a map key.
-        final AtomicLong bytes = deferredRAMByDatabase.get(database);
-        if (bytes != null)
-          bytes.addAndGet(delta);
-      }
+    if (delta > 0)
+      deferredRAMByDatabase.computeIfAbsent(database, k -> new AtomicLong()).addAndGet(delta);
+    else {
+      // A release NEVER creates an entry: the only way to reach one here without a matching deferral is a database
+      // whose bookkeeping was already purged by its close, and re-creating it with a negative value would both
+      // report a nonsensical gauge and re-pin the closed instance as a map key.
+      final AtomicLong bytes = deferredRAMByDatabase.get(database);
+      if (bytes != null)
+        bytes.addAndGet(delta);
     }
 
+    addDeferredRAMTotal(delta);
+  }
+
+  /** Moves the JVM-wide total alone, for the residual release that has already zeroed the per-database part. */
+  private void addDeferredRAMTotal(final long delta) {
     final long previous = deferredRAMBytes.getAndAdd(delta);
     // Signal only on the DOWNWARD crossing of the cap, so a resume that writes thousands of deferred pages takes the
     // monitor once instead of once per page, and a backlog that is growing never touches it at all.
@@ -760,16 +771,28 @@ public class PageManagerFlushThread extends Thread {
   }
 
   /**
-   * Safety net for the deferred accounting: once nothing is deferred for ANY database the backlog is provably empty,
-   * so both the total and the per-database split are zeroed to absorb any drift from the edge cases that skip a
-   * batch (a database closed mid-unsuspend). Guarded by {@code deferredByDatabase.isEmpty()}, so it can never zero
-   * another database's live accounting.
+   * Releases whatever a database is STILL charged for once its backlog has provably ended - its last suspender
+   * resumed, or it was closed or dropped - and forgets its entry.
+   * <p>
+   * Strictly per database, which is the point: the blanket reset this replaces zeroed the total and the whole split
+   * whenever {@code deferredByDatabase} was observed empty, a check made on the resuming thread while the flush
+   * thread could be deferring the FIRST batch of an unrelated database, and that database's fresh charge was then
+   * wiped - its cap defeated until its next mutation (review of #6200). Nothing here can touch another database.
+   * <p>
+   * With the accounting now exact at the source (every path that takes a page out of the backlog releases its bytes,
+   * including the pages skipped because their database closed mid-unsuspend) this should always find zero. It stays
+   * because the alternative to healing a hypothetical drift is a total stuck above the cap, which would throttle the
+   * committers of every later suspension in the process.
    */
-  private void resetDeferredRAMIfDrained() {
-    if (deferredByDatabase.isEmpty()) {
-      deferredRAMBytes.set(0);
-      deferredRAMByDatabase.clear();
-      signalDeferredRAM();
+  private void releaseResidualDeferredRAM(final BasicDatabase database) {
+    final AtomicLong bytes = deferredRAMByDatabase.remove(database);
+    if (bytes == null)
+      return;
+    final long residual = bytes.getAndSet(0);
+    if (residual != 0) {
+      LogManager.instance().log(this, Level.FINE,
+          "Released %d residual deferred bytes of database '%s' whose backlog ended", null, residual, database.getName());
+      addDeferredRAMTotal(-residual);
     }
   }
 
@@ -874,13 +897,15 @@ public class PageManagerFlushThread extends Thread {
     resumingDatabases.remove(database);
     flushedPagesPerDatabase.remove(database);
     final ConcurrentLinkedQueue<PagesToFlush> droppedDeferred = deferredByDatabase.remove(database);
-    if (droppedDeferred != null) {
+    if (droppedDeferred != null)
       for (final PagesToFlush batch : droppedDeferred)
         addDeferredRAM(database, -batchRAM(batch));
-      resetDeferredRAMIfDrained();
-    }
-    // The database is gone: drop its per-database backlog entry with the rest of its bookkeeping (#6200).
-    deferredRAMByDatabase.remove(database);
+
+    // The database is gone: drop its per-database backlog entry with the rest of its bookkeeping, taking whatever
+    // it was still charged for out of the JVM-wide total with it - dropping the entry alone would leave the total
+    // inflated by that much forever, throttling every later suspension (#6200).
+    releaseResidualDeferredRAM(database);
+
     // Its committers cannot be throttled by a database that no longer exists, and neither can anyone else be by ITS
     // backlog: wake every waiter so they re-read a total that just lost this database's share.
     signalDeferredRAM();

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -164,6 +164,14 @@ public class PageManagerFlushThread extends Thread {
    */
   private final Object deferredRAMLock = new Object();
 
+  /**
+   * How many times {@link #repairNegativeDeferredRAM} had to reset a negative total. Reported once (a drift of this
+   * kind repeats), and package-private because the repair would otherwise HIDE the very bugs the regression tests of
+   * #6200 exist to catch: a double release lands on zero after the clamp, indistinguishable from correct accounting.
+   * The tests assert this stays at zero.
+   */
+  final AtomicLong deferredRAMDriftRepairs = new AtomicLong();
+
   public static class PagesToFlush {
     public final BasicDatabase     database;
     public final List<MutablePage> pages;
@@ -747,9 +755,10 @@ public class PageManagerFlushThread extends Thread {
    * per-database split and the derived total in step (issue #6200), and releases the committers waiting on the cap
    * when the total drops back under it.
    * <p>
-   * The two counters are not updated atomically with respect to each other, and do not need to be: the total is what
-   * the cap is read from and it is a single {@code AtomicLong}, while the per-database value is a gauge. A reader
-   * that catches the pair mid-update sees a per-database sum off by one batch from the total for a few instructions.
+   * The two counters are not updated atomically with respect to each other, and do not need to be: a reader that
+   * catches the pair mid-update sees a per-database sum off by one batch from the total for a few instructions.
+   * What they DO have to agree on is the amount that moves, which is why a release takes from the per-database
+   * counter first and moves only what it actually got - see the release branch.
    */
   private void addDeferredRAM(final BasicDatabase database, final long delta) {
     if (delta == 0)
@@ -762,8 +771,33 @@ public class PageManagerFlushThread extends Thread {
       // whose bookkeeping was already purged by its close, and re-creating it with a negative value would both
       // report a nonsensical gauge and re-pin the closed instance as a map key.
       final AtomicLong bytes = deferredRAMByDatabase.get(database);
-      if (bytes != null)
-        bytes.addAndGet(delta);
+      if (bytes == null)
+        // AND IT RELEASES NOTHING FROM THE TOTAL EITHER, which is why this returns rather than falling through.
+        return;
+
+      // THE PER-DATABASE COUNTER IS THE AUTHORITY ON WHAT MAY BE RELEASED: the take is atomic and clamped at zero,
+      // and only what the counter actually still held moves off the JVM-wide total.
+      //
+      // Without that the same bytes are released twice. releaseResidualDeferredRAM takes a database's whole
+      // remaining charge in ONE getAndSet(0) plus subtraction, and it is not mutually exclusive with the per-page
+      // releases of that same database's resume: Phase 1 walks the deferred batches holding only replayDrainLock,
+      // while the purge (close/drop) takes neither that nor anything else Phase 1 holds. So a purge landing
+      // mid-resume takes bytes Phase 1 has not released yet, and Phase 1 then releases them again. A null check
+      // alone does NOT cover it - this reference can be read BEFORE the purge removes the entry and used after -
+      // which is why the guard is on the VALUE rather than on the entry.
+      //
+      // Getting it wrong drives the JVM-wide total NEGATIVE, and that total is what the cap is read from, so the
+      // #4728 backpressure would be silently disabled for every OTHER suspended database in the process until
+      // enough new deferrals pushed it back over the cap.
+      final long releasing = -delta;
+      final long before = bytes.getAndAccumulate(releasing, (current, amount) -> current - Math.min(current, amount));
+      final long applied = Math.min(before, releasing);
+      if (applied <= 0)
+        // ALREADY TAKEN, BY THE RESIDUAL RELEASE OR BY A RACING ONE: NOTHING OF THIS CHARGE IS LEFT TO MOVE
+        return;
+
+      addDeferredRAMTotal(-applied);
+      return;
     }
 
     addDeferredRAMTotal(delta);
@@ -776,6 +810,36 @@ public class PageManagerFlushThread extends Thread {
     // monitor once instead of once per page, and a backlog that is growing never touches it at all.
     if (delta < 0 && maxDeferredRAM > 0 && previous >= maxDeferredRAM && previous + delta < maxDeferredRAM)
       signalDeferredRAM();
+
+    if (previous + delta < 0)
+      repairNegativeDeferredRAM();
+  }
+
+  /**
+   * Last-resort guard on the ONE number the #4728 cap is read from.
+   * <p>
+   * Every release is of bytes a matching deferral put there, so with correct accounting the total cannot go below
+   * zero - not even transiently, since a page has to be deferred before it can be released. A negative value is
+   * therefore a bug, and unlike the per-database gauge (which {@link #getDeferredRAMBytesOf} merely clamps for
+   * display) it is not cosmetic: the cap test is {@code total >= maxDeferredRAM}, so a total left below zero
+   * DISABLES the backpressure for every suspended database in the process until enough new deferrals climb back
+   * over the cap - the OOM this whole mechanism exists to prevent, silently re-enabled.
+   * <p>
+   * So it is both reported - once per process, because a drift of this kind repeats - and repaired. Reporting alone
+   * would leave the protection off; repairing alone would hide the bug that turned it off.
+   */
+  private void repairNegativeDeferredRAM() {
+    // getAndAccumulate, so the value REPORTED is the negative one that was found rather than the zero it became,
+    // and so a total another thread has already repaired is left alone instead of being re-reported.
+    final long negative = deferredRAMBytes.getAndAccumulate(0, (current, ignored) -> current < 0 ? 0 : current);
+    if (negative >= 0)
+      // ANOTHER THREAD GOT THERE FIRST: NOTHING WAS FOUND NEGATIVE HERE, SO NOTHING IS COUNTED OR SAID
+      return;
+
+    if (deferredRAMDriftRepairs.getAndIncrement() == 0)
+      LogManager.instance().log(this, Level.WARNING,
+          "The deferred page-flush backlog accounting went negative (%d bytes) and was reset to zero: this is a bug in the accounting, please report it. Until the reset the '%s' cap could not throttle the committers of a suspended database",
+          null, negative, GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM.getKey());
   }
 
   /**
@@ -847,6 +911,9 @@ public class PageManagerFlushThread extends Thread {
    * database left suspended cannot keep a committer parked past {@code closeAndJoin}.
    */
   public void awaitDeferredBacklogUnderCap(final BasicDatabase database) throws InterruptedException {
+    // The instanceof is a cast, not a filter: every page in the flush pipeline comes from a local Database (that is
+    // what owns a PageManager at all), and the suspension bookkeeping this reads is keyed by Database. A
+    // BasicDatabase that is not one has never been deferred and so can never be over the cap.
     if (maxDeferredRAM <= 0 || !(database instanceof final Database db) || !isSuspended(db))
       // NOT SUSPENDED: THE COMMON CASE, AND TWO MAP READS AWAY FROM THE PUBLICATION IT MUST NOT SLOW DOWN
       return;

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -618,105 +618,116 @@ public class PageManagerFlushThread extends Thread {
     // end of the method, so the caller still observes its own cancellation and the re-enqueue phase below runs
     // interrupt-free.
     boolean restoreCallerInterrupt = false;
-    // Serialized against detachPendingPages: the detach must either see these batches (and take its page out of
-    // them) or run after they have all reached the disk. Otherwise a superseded copy written here could land after
-    // a replicated write and roll the page version backwards.
-    synchronized (replayDrainLock(database)) {
-      final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.remove(database);
-      if (deferred != null) {
-        for (final PagesToFlush batch : deferred) {
-          synchronized (batch.pages) {
-            for (final MutablePage page : batch.pages) {
-              try {
-                // A page whose database closed mid-unsuspend is NOT written - there is nothing left to write it
-                // to - but it still leaves the backlog through the finally below. Skipping it (which is what the
-                // `continue`/`break` here used to do) stranded its bytes in the deferred accounting for the life
-                // of the process, and every LATER suspension would then be throttled by that much: the drift the
-                // blanket "reset the counter when nothing is deferred anywhere" net existed to absorb. Releasing
-                // it at the source is exact, and per database, so no reset can ever wipe a sibling's live count.
-                if (batch.database.isOpen())
-                  pageManager.flushPage(page);
-              } catch (final DatabaseMetadataException e) {
-                // FILE DELETED, CONTINUE WITH THE NEXT PAGES
-                LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
-              } catch (final InterruptedIOException e) {
-                // Don't drop the deferred dirty page, its WAL entry was already acked: consume the flag and
-                // retry the write once.
-                restoreCallerInterrupt = true;
-                Thread.interrupted();
+    try {
+      // Serialized against detachPendingPages: the detach must either see these batches (and take its page out of
+      // them) or run after they have all reached the disk. Otherwise a superseded copy written here could land after
+      // a replicated write and roll the page version backwards.
+      synchronized (replayDrainLock(database)) {
+        final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.remove(database);
+        if (deferred != null) {
+          for (final PagesToFlush batch : deferred) {
+            synchronized (batch.pages) {
+              for (final MutablePage page : batch.pages) {
                 try {
-                  pageManager.flushPage(page);
-                } catch (final DatabaseMetadataException | IOException e2) {
-                  // Contain every retry failure (file dropped, re-interrupt, real I/O error): letting it escape
-                  // would skip the unsuspend phases below, leaving the database suspended with batches stranded
-                  // in the deferred map. An unflushed page is recovered from the WAL (its entry was never acked).
-                  // A fresh re-interrupt set the flag again: clear it so the remaining pages flush cleanly.
-                  LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e2, page);
+                  // A page whose database closed mid-unsuspend is NOT written - there is nothing left to write it
+                  // to - but it still leaves the backlog through the finally below. Skipping it (which is what the
+                  // `continue`/`break` here used to do) stranded its bytes in the deferred accounting for the life
+                  // of the process, and every LATER suspension would then be throttled by that much: the drift the
+                  // blanket "reset the counter when nothing is deferred anywhere" net existed to absorb. Releasing
+                  // it at the source is exact, and per database, so no reset can ever wipe a sibling's live count.
+                  if (batch.database.isOpen())
+                    pageManager.flushPage(page);
+                } catch (final DatabaseMetadataException e) {
+                  // FILE DELETED, CONTINUE WITH THE NEXT PAGES
+                  LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
+                } catch (final InterruptedIOException e) {
+                  // Don't drop the deferred dirty page, its WAL entry was already acked: consume the flag and
+                  // retry the write once.
+                  restoreCallerInterrupt = true;
                   Thread.interrupted();
+                  try {
+                    pageManager.flushPage(page);
+                  } catch (final DatabaseMetadataException | IOException e2) {
+                    // Contain every retry failure (file dropped, re-interrupt, real I/O error): letting it escape
+                    // would skip the unsuspend phases below, leaving the database suspended with batches stranded
+                    // in the deferred map. An unflushed page is recovered from the WAL (its entry was never acked).
+                    // A fresh re-interrupt set the flag again: clear it so the remaining pages flush cleanly.
+                    LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e2, page);
+                    Thread.interrupted();
+                  }
+                } catch (final IOException e) {
+                  LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
+                } finally {
+                  // The page leaves the deferred backlog (flushed to disk), so release its reserved RAM (issue #4728).
+                  addDeferredRAM(database, -page.getPhysicalSize());
+                  removeFromFlushIndex(page);
+                  bumpFlushProgress(page);
                 }
-              } catch (final IOException e) {
-                LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
-              } finally {
-                // The page leaves the deferred backlog (flushed to disk), so release its reserved RAM (issue #4728).
-                addDeferredRAM(database, -page.getPhysicalSize());
-                removeFromFlushIndex(page);
-                bumpFlushProgress(page);
               }
             }
           }
         }
       }
-    }
 
-    // Phase 2 + Phase 3a: under the per-database lock, clear the suspension refcount AND atomically detach
-    // any batches deferred during Phase 1. Holding the lock makes this transition mutually exclusive with
-    // the suspended-check + defer in flushPagesFromQueueToDisk: once the flag is cleared no further batch
-    // can be added to deferredByDatabase for this database, and every batch deferred up to that point is
-    // detached exactly once. A single detach therefore suffices - nothing can repopulate the map behind us.
-    // New suspenders are still gated out by resumingDatabases (removed by the caller AFTER Phase 3b), so
-    // the count going 1 to 0 here cannot interleave with a concurrent acquire.
-    final ConcurrentLinkedQueue<PagesToFlush> newDeferred;
-    synchronized (suspendLock(database)) {
-      suspended.remove(database);
-      newDeferred = deferredByDatabase.remove(database);
-    }
+      } finally {
+      // PHASES 2 TO 4 RUN EVEN IF PHASE 1 THREW. Its per-page loop contains every failure it expects (a dropped
+      // file, an interrupt, an I/O error), but an UNEXPECTED exception escaping it used to abort the rest of the
+      // resume outright: the batches deferred during Phase 1 stayed undetached - their pages pinned in pageIndex
+      // forever, so the next close of that database would wait for a drain that can never happen - and its RAM
+      // charge stayed on the cap. The caller's own finally heals the suspension COUNT, but nothing healed those.
+      // Pre-existing shape, flagged in review of #6223 and closed here rather than left open, because the phases
+      // below are pure bookkeeping: they cannot fail, and the exception still propagates after them.
 
-    // Phase 3b: re-enqueue the detached batches into the main queue so the background thread picks them up.
-    // They are appended to the tail of the queue, so if any post-unsuspend commits have already been
-    // enqueued they will be flushed first. WAL-based recovery guarantees correctness even if the flush order
-    // differs from commit order. This blocking re-enqueue is deliberately done OUTSIDE the lock: queue.offer
-    // can block when the queue is full, and the only consumer that drains the queue (the flush thread) needs
-    // the same per-database lock to make progress, so holding it across the offer would deadlock.
-    if (newDeferred != null) {
-      for (final PagesToFlush batch : newDeferred) {
-        // The batch moves back to the main queue and leaves the deferred backlog accounting (issue #4728).
-        addDeferredRAM(database, -batchRAM(batch));
-        while (running) {
-          try {
-            if (queue.offer(batch, 1, TimeUnit.SECONDS))
+      // Phase 2 + Phase 3a: under the per-database lock, clear the suspension refcount AND atomically detach
+      // any batches deferred during Phase 1. Holding the lock makes this transition mutually exclusive with
+      // the suspended-check + defer in flushPagesFromQueueToDisk: once the flag is cleared no further batch
+      // can be added to deferredByDatabase for this database, and every batch deferred up to that point is
+      // detached exactly once. A single detach therefore suffices - nothing can repopulate the map behind us.
+      // New suspenders are still gated out by resumingDatabases (removed by the caller AFTER Phase 3b), so
+      // the count going 1 to 0 here cannot interleave with a concurrent acquire.
+      final ConcurrentLinkedQueue<PagesToFlush> newDeferred;
+      synchronized (suspendLock(database)) {
+        suspended.remove(database);
+        newDeferred = deferredByDatabase.remove(database);
+      }
+
+      // Phase 3b: re-enqueue the detached batches into the main queue so the background thread picks them up.
+      // They are appended to the tail of the queue, so if any post-unsuspend commits have already been
+      // enqueued they will be flushed first. WAL-based recovery guarantees correctness even if the flush order
+      // differs from commit order. This blocking re-enqueue is deliberately done OUTSIDE the lock: queue.offer
+      // can block when the queue is full, and the only consumer that drains the queue (the flush thread) needs
+      // the same per-database lock to make progress, so holding it across the offer would deadlock.
+      if (newDeferred != null) {
+        for (final PagesToFlush batch : newDeferred) {
+          // The batch moves back to the main queue and leaves the deferred backlog accounting (issue #4728).
+          addDeferredRAM(database, -batchRAM(batch));
+          while (running) {
+            try {
+              if (queue.offer(batch, 1, TimeUnit.SECONDS))
+                break;
+              LogManager.instance().log(this, Level.WARNING,
+                  "Page flush queue is full while re-enqueueing deferred batch for database '%s'; retrying", database.getName());
+            } catch (final InterruptedException e) {
+              Thread.currentThread().interrupt();
               break;
-            LogManager.instance().log(this, Level.WARNING,
-                "Page flush queue is full while re-enqueueing deferred batch for database '%s'; retrying", database.getName());
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            break;
+            }
           }
         }
       }
+
+      // Phase 4: this database's backlog has provably ended, so release whatever is still charged to it - and ONLY
+      // to it. The suspension was cleared under suspendLock in Phase 2 and resumingDatabases keeps a new suspender
+      // out until the caller's finally, so nothing can defer another of its batches behind us (the same argument
+      // Phase 2 rests on). With Phase 1 now releasing every page it skips, this should always find zero; it stays as
+      // the per-database safety net that the old blanket "if nothing is deferred anywhere, zero the counters" reset
+      // was - that one read `deferredByDatabase.isEmpty()` on this thread while the flush thread could be deferring
+      // the FIRST batch of an unrelated database, and would then wipe that database's fresh charge (review of #6200).
+      releaseResidualDeferredRAM(database);
+
+      if (restoreCallerInterrupt)
+        // Consumed once during Phase 1: restore it so the caller still observes its own cancellation.
+        Thread.currentThread().interrupt();
     }
-
-    // Phase 4: this database's backlog has provably ended, so release whatever is still charged to it - and ONLY
-    // to it. The suspension was cleared under suspendLock in Phase 2 and resumingDatabases keeps a new suspender
-    // out until the caller's finally, so nothing can defer another of its batches behind us (the same argument
-    // Phase 2 rests on). With Phase 1 now releasing every page it skips, this should always find zero; it stays as
-    // the per-database safety net that the old blanket "if nothing is deferred anywhere, zero the counters" reset
-    // was - that one read `deferredByDatabase.isEmpty()` on this thread while the flush thread could be deferring
-    // the FIRST batch of an unrelated database, and would then wipe that database's fresh charge (review of #6200).
-    releaseResidualDeferredRAM(database);
-
-    if (restoreCallerInterrupt)
-      // Consumed once during Phase 1: restore it so the caller still observes its own cancellation.
-      Thread.currentThread().interrupt();
   }
 
   public boolean isSuspended(final Database database) {
@@ -932,12 +943,14 @@ public class PageManagerFlushThread extends Thread {
       // a long suspension throttles many of them, and the point is to name the database whose backlog is doing it.
       if (!reported && System.currentTimeMillis() - beginTime > DEFERRED_BACKLOG_WARN_MILLIS) {
         reported = true;
-        // Both numbers, and the JVM-wide one named as such: the cap is on the total across every suspended
+        // Both backlogs, and the JVM-wide one named as such: the cap is on the total across every suspended
         // database, so the backlog holding this database's committers is very often NOT its own - which is the
-        // whole subject of #6200, and precisely what an operator reading a single figure would misread.
+        // whole subject of #6200, and precisely what an operator reading a single figure would misread. The
+        // elapsed hold is reported rather than the threshold that triggered the report: the threshold is a
+        // constant, while how long this committer has actually been held is the number the operator came for.
         LogManager.instance().log(this, Level.WARNING,
-            "Commits on database '%s' have been throttled for over %d ms: page flushing is suspended (backup or HA snapshot) and the JVM-wide deferred backlog is %s, of which %s is this database's own, at or above the '%s' cap",
-            null, db.getName(), DEFERRED_BACKLOG_WARN_MILLIS, FileUtils.getSizeAsString(deferredRAMBytes.get()),
+            "Commits on database '%s' have been throttled for %d ms: page flushing is suspended (backup or HA snapshot) and the JVM-wide deferred backlog is %s, of which %s is this database's own, at or above the '%s' cap",
+            null, db.getName(), System.currentTimeMillis() - beginTime, FileUtils.getSizeAsString(deferredRAMBytes.get()),
             FileUtils.getSizeAsString(getDeferredRAMBytesOf(db)), GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM.getKey());
       }
     }

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -982,6 +982,11 @@ public class PageManagerFlushThread extends Thread {
    * the database was dropped) or when this database stops being suspended. It is bounded per round so a suspension
    * released without freeing any RAM still lets its committers out, and it stops waiting during shutdown so a
    * database left suspended cannot keep a committer parked past {@code closeAndJoin}.
+   * <p>
+   * <b>Only the ASYNCHRONOUS writers reach this</b>, and nothing is missing by it: what the cap bounds is
+   * {@link #deferredByDatabase}, and {@link #flushPagesFromQueueToDisk} is the single place anything is ever put
+   * there. A synchronous {@code writePages} goes straight to {@code flushPage} without passing through this thread
+   * at all, so it cannot add a byte to the backlog and has nothing to be held for.
    */
   public void awaitDeferredBacklogUnderCap(final BasicDatabase database) throws InterruptedException {
     // The instanceof is a cast, not a filter: every page in the flush pipeline comes from a local Database (that is

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.BasicDatabase;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.DatabaseMetadataException;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.FileUtils;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -60,8 +61,31 @@ public class PageManagerFlushThread extends Thread {
   // its suspension window can never overlap the resume's page writes (issue #5068).
   private final        Set<Database>                                            resumingDatabases   = ConcurrentHashMap.newKeySet();
   private final static PagesToFlush                                             SHUTDOWN_THREAD     = new PagesToFlush(null);
-  /** Poll interval of {@link #waitAllPagesOfDatabaseAreFlushed(Database)} for callers that expect to wait. */
+  /** Fallback wake-up interval of {@link #waitAllPagesOfDatabaseAreFlushed(Database)} - see {@link #flushWaitPollMillis}. */
   private final static long                                                     DEFAULT_FLUSH_WAIT_POLL_MILLIS = 10;
+  /**
+   * Fallback wake-up interval of the RESIDUAL drain, {@link #waitPendingPagesOfDatabaseUntil}. Deliberately shorter
+   * than the bulk one: that wait runs with the JVM-wide page-manager lock held, so its worst case - the interval
+   * itself, reached only if a drain notification is ever lost - is a stall of every committer in the process.
+   */
+  private final static long                                                     RESIDUAL_DRAIN_WAIT_POLL_MILLIS = 1;
+  /**
+   * Fallback wake-up interval of {@link #awaitDeferredBacklogUnderCap}. The release of the cap is signalled, so this
+   * only bounds how often a parked committer re-reads the conditions that are NOT signalled: its database ceasing to
+   * be suspended, and the shutdown flag.
+   */
+  private final static long                                                     DEFERRED_BACKLOG_WAIT_POLL_MILLIS = 100;
+  /** How long a committer may be held by the deferred-backlog cap before saying so, once, at WARNING. */
+  private final static long                                                     DEFERRED_BACKLOG_WARN_MILLIS      = 10_000;
+  /**
+   * Fallback wake-up interval of {@link #waitAllPagesOfDatabaseAreFlushed(Database)}, per instance so the
+   * regression test of issue #6199 can stretch it far enough to prove the wait is released by the drain
+   * notification of {@link FlushPageIndex#awaitDrain} and not by the interval elapsing.
+   * <p>
+   * Since #6199 this is NOT the latency of the wait: a drained pipeline wakes the waiter immediately. It only
+   * bounds how often the no-progress timeout below is re-evaluated, and how long a lost notification would cost.
+   */
+  long                                                                          flushWaitPollMillis = DEFAULT_FLUSH_WAIT_POLL_MILLIS;
   // Package-private so the white-box regression test for issue #5068 can fabricate an in-flight batch and
   // deterministically exercise an interrupt during waitForCurrentFlushToComplete.
   final                AtomicReference<PagesToFlush>                            nextPagesToFlush    = new AtomicReference<>();
@@ -89,8 +113,8 @@ public class PageManagerFlushThread extends Thread {
 
   /**
    * Maximum bytes of dirty pages that may sit deferred (in {@link #deferredByDatabase}) while flushing is
-   * suspended, before the flush thread stops draining its bounded queue and lets {@code scheduleFlushOfPages}
-   * throttle the committing threads. {@code 0} disables the cap (unbounded, pre-#4728 behavior).
+   * suspended, before the committing threads OF THE SUSPENDED DATABASES are throttled in
+   * {@link #awaitDeferredBacklogUnderCap}. {@code 0} disables the cap (unbounded, pre-#4728 behavior).
    */
   private final        long                                   maxDeferredRAM;
 
@@ -108,8 +132,29 @@ public class PageManagerFlushThread extends Thread {
   /**
    * Running total of bytes currently deferred across all suspended databases. Package-private so the white-box
    * regression test for issue #4728 can assert the backlog stays bounded.
+   * <p>
+   * Derived, never assigned outside {@link #addDeferredRAM}: it is the sum of {@link #deferredRAMByDatabase}, kept
+   * incrementally because the cap is read on the commit path and iterating a map there to re-derive it would put an
+   * O(open databases) walk in front of every publication.
    */
   final                AtomicLong                             deferredRAMBytes = new AtomicLong();
+
+  /**
+   * The same total, split by database (issue #6200). The backlog is strictly per-database - only the batches of
+   * SUSPENDED databases are ever deferred - so this is the number that actually explains a backlog, and the one
+   * {@code arcadedb.pagemanager.deferred_ram_bytes} needs to be tagged by database (item 2 of #6087), which the
+   * single JVM-wide total could not express. An entry is created with a database's first deferred batch and dropped
+   * when the whole backlog drains ({@link #resetDeferredRAMIfDrained}) or when the database is purged, so it is
+   * bounded by the number of open databases and empty whenever nothing is deferred anywhere.
+   */
+  final ConcurrentHashMap<BasicDatabase, AtomicLong> deferredRAMByDatabase = new ConcurrentHashMap<>();
+
+  /**
+   * Monitor of the committer-side backpressure of issue #4728: waiters park here while the deferred backlog is over
+   * the cap, and {@link #addDeferredRAM} notifies them when it drops back under. Bounded waits, so a suspension
+   * released without freeing any RAM (nothing was deferred) still lets its committers out.
+   */
+  private final Object deferredRAMLock = new Object();
 
   public static class PagesToFlush {
     public final BasicDatabase     database;
@@ -237,7 +282,11 @@ public class PageManagerFlushThread extends Thread {
       }
 
       try {
-        Thread.sleep(DEFAULT_FLUSH_WAIT_POLL_MILLIS);
+        // Parks on the database's drain signal rather than sleeping (#6199): the wait ends the moment the last page
+        // of this database leaves the pipeline, and the interval only bounds how often the timeout above is
+        // re-evaluated. On a process cycling through many databases the old sleep rounded every close, rename,
+        // compaction and backup suspension up to the next poll boundary even when the pipeline was already empty.
+        pageIndex.awaitDrain(database, flushWaitPollMillis);
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         return false;
@@ -246,18 +295,15 @@ public class PageManagerFlushThread extends Thread {
   }
 
   protected void flushPagesFromQueueToDisk(final Database database, final long timeout) throws InterruptedException, IOException {
-    // Backpressure (issue #4728): while a database is suspended (HA snapshot ship / full backup) its dirty
-    // pages cannot be written to disk and pile up in the unbounded deferredByDatabase map. On a busy leader
-    // shipping a multi-GB snapshot this exhausted the heap. Once the deferred backlog crosses the cap, stop
-    // draining the bounded queue: it fills up and scheduleFlushOfPages() throttles the committing threads, so
-    // the dirty pages stay in the (separately bounded) page cache instead of growing the deferred map forever.
-    // Gate on `running`: during shutdown the queue must still be drained to reach the SHUTDOWN_THREAD marker,
-    // otherwise a database left suspended with a full backlog would spin the run loop forever and block join().
-    if (running && maxDeferredRAM > 0 && deferredRAMBytes.get() >= maxDeferredRAM) {
-      Thread.sleep(timeout);
-      return;
-    }
-
+    // NO CAP CHECK HERE ANY MORE (issue #6200). The backpressure of #4728 used to live at this exact point: once
+    // the deferred backlog crossed the cap the flush thread stopped polling ALTOGETHER, so the bounded queue filled
+    // and scheduleFlushOfPages throttled the committing threads - of EVERY open database, not just of the suspended
+    // one whose backlog it was, and (because publishPages holds the JVM-wide page-manager lock across the enqueue)
+    // by blocking them inside that lock. A leader shipping a multi-GB snapshot of database A therefore stalled the
+    // committers of unrelated databases B and C, whose pages could have been written to disk immediately and whose
+    // flushing would have RELIEVED the heap rather than added to it. The cap now throttles the committers of the
+    // suspended databases directly, before that lock is taken - see awaitDeferredBacklogUnderCap - and this thread
+    // always drains.
     final PagesToFlush pagesToFlush = queue.poll(timeout, TimeUnit.MILLISECONDS);
 
     if (pagesToFlush != null) {
@@ -281,7 +327,7 @@ public class PageManagerFlushThread extends Thread {
               synchronized (suspendLock(db)) {
                 if (isSuspended(db)) {
                   deferredByDatabase.computeIfAbsent(db, k -> new ConcurrentLinkedQueue<>()).offer(pagesToFlush);
-                  deferredRAMBytes.addAndGet(batchRAM(pagesToFlush));
+                  addDeferredRAM(db, batchRAM(pagesToFlush));
                   return;
                 }
               }
@@ -385,12 +431,14 @@ public class PageManagerFlushThread extends Thread {
    * flush thread wedged on a dead disk must not be able to hold the global lock for the 60 s the progress-based
    * timeout allows, which would stall every committer of every database in the JVM.
    * <p>
-   * Polls at 1 ms rather than spinning. The check itself is now O(1) (issue #6133 - it used to walk the JVM-wide
-   * {@link #pageIndex}, so a spin turned one cheap check into hundreds of scans of a map whose size grows with
-   * exactly the backlog that makes this wait non-trivial, all of them under the global lock), but what a spin would
-   * be waiting for has not changed: a page reaching the disk, which is a synchronous file write away and orders of
-   * magnitude longer than any sane spin. One extra millisecond in the rare case where a page IS in flight is still
-   * the better trade than burning a core under a JVM-wide lock.
+   * <b>Parks on the drain signal rather than polling (issue #6199).</b> It used to sleep 1 ms per round, and it does
+   * that under the JVM-wide lock, so every one of those milliseconds was a millisecond in which no committer of any
+   * database in the process could publish a page - a cost paid even when the pages had landed 999 us earlier. The
+   * lock hold is now the time the writes actually take. Neither a spin nor a shorter sleep was the answer: what the
+   * wait is waiting for is a synchronous file write, orders of magnitude longer than any sane spin, and a shorter
+   * sleep would burn a core under a JVM-wide lock to improve the average without touching the worst case.
+   * {@link #RESIDUAL_DRAIN_WAIT_POLL_MILLIS} survives as the bound on a hypothetical lost notification, which is why
+   * it stays at the 1 ms this used to sleep: the worst case is unchanged, the common case is immediate.
    *
    * @return {@code true} when the pipeline emptied, {@code false} when the deadline expired first (the caller
    *     proceeds with a t0 that may sit slightly behind the last committed transaction, and says so).
@@ -398,9 +446,10 @@ public class PageManagerFlushThread extends Thread {
   boolean waitPendingPagesOfDatabaseUntil(final Database database, final long deadlineMillis)
       throws InterruptedException {
     while (hasPendingPagesOfDatabase(database)) {
-      if (System.currentTimeMillis() >= deadlineMillis)
+      final long remaining = deadlineMillis - System.currentTimeMillis();
+      if (remaining <= 0)
         return false;
-      Thread.sleep(1);
+      pageIndex.awaitDrain(database, Math.min(remaining, RESIDUAL_DRAIN_WAIT_POLL_MILLIS));
     }
     return true;
   }
@@ -538,6 +587,9 @@ public class PageManagerFlushThread extends Thread {
         resumingDatabases.remove(database);
         lock.notifyAll();
       }
+      // The database is no longer suspended, so its committers are no longer subject to the deferred-backlog cap
+      // even if the backlog of some OTHER suspended database is still over it (issue #6200).
+      signalDeferredRAM();
     }
     return true;
   }
@@ -587,7 +639,7 @@ public class PageManagerFlushThread extends Thread {
                 LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
               } finally {
                 // The page leaves the deferred backlog (flushed to disk), so release its reserved RAM (issue #4728).
-                deferredRAMBytes.addAndGet(-page.getPhysicalSize());
+                addDeferredRAM(database, -page.getPhysicalSize());
                 removeFromFlushIndex(page);
                 bumpFlushProgress(page);
               }
@@ -619,7 +671,7 @@ public class PageManagerFlushThread extends Thread {
     if (newDeferred != null) {
       for (final PagesToFlush batch : newDeferred) {
         // The batch moves back to the main queue and leaves the deferred backlog accounting (issue #4728).
-        deferredRAMBytes.addAndGet(-batchRAM(batch));
+        addDeferredRAM(database, -batchRAM(batch));
         while (running) {
           try {
             if (queue.offer(batch, 1, TimeUnit.SECONDS))
@@ -634,10 +686,9 @@ public class PageManagerFlushThread extends Thread {
       }
     }
 
-    // Safety net: once nothing is deferred for any database the backlog is provably empty, so reset the counter
+    // Safety net: once nothing is deferred for any database the backlog is provably empty, so reset the counters
     // to absorb any drift from edge cases above (a batch skipped because its database closed mid-unsuspend).
-    if (deferredByDatabase.isEmpty())
-      deferredRAMBytes.set(0);
+    resetDeferredRAMIfDrained();
 
     if (restoreCallerInterrupt)
       // Consumed once during Phase 1: restore it so the caller still observes its own cancellation.
@@ -660,6 +711,9 @@ public class PageManagerFlushThread extends Thread {
 
   public void closeAndJoin() throws InterruptedException {
     running = false;
+    // Release any committer parked on the deferred-backlog cap: its database may still be suspended, and the
+    // backlog is only relieved by a resume that shutdown is not going to wait for (issue #6200).
+    signalDeferredRAM();
     queue.offer(SHUTDOWN_THREAD);
     join();
   }
@@ -670,6 +724,113 @@ public class PageManagerFlushThread extends Thread {
    */
   void removeFromFlushIndex(final MutablePage page) {
     pageIndex.removeIfSame(page);
+  }
+
+  /**
+   * Moves {@code delta} bytes into (positive) or out of (negative) the deferred backlog of a database, keeping the
+   * per-database split and the derived total in step (issue #6200), and releases the committers waiting on the cap
+   * when the total drops back under it.
+   * <p>
+   * The two counters are not updated atomically with respect to each other, and do not need to be: the total is what
+   * the cap is read from and it is a single {@code AtomicLong}, while the per-database value is a gauge. A reader
+   * that catches the pair mid-update sees a per-database sum off by one batch from the total for a few instructions.
+   */
+  private void addDeferredRAM(final BasicDatabase database, final long delta) {
+    if (delta == 0)
+      return;
+
+    if (database != null) {
+      if (delta > 0)
+        deferredRAMByDatabase.computeIfAbsent(database, k -> new AtomicLong()).addAndGet(delta);
+      else {
+        // A release NEVER creates an entry: the only way to reach one here without a matching deferral is a database
+        // whose bookkeeping was already purged by its close, and re-creating it with a negative value would both
+        // report a nonsensical gauge and re-pin the closed instance as a map key.
+        final AtomicLong bytes = deferredRAMByDatabase.get(database);
+        if (bytes != null)
+          bytes.addAndGet(delta);
+      }
+    }
+
+    final long previous = deferredRAMBytes.getAndAdd(delta);
+    // Signal only on the DOWNWARD crossing of the cap, so a resume that writes thousands of deferred pages takes the
+    // monitor once instead of once per page, and a backlog that is growing never touches it at all.
+    if (delta < 0 && maxDeferredRAM > 0 && previous >= maxDeferredRAM && previous + delta < maxDeferredRAM)
+      signalDeferredRAM();
+  }
+
+  /**
+   * Safety net for the deferred accounting: once nothing is deferred for ANY database the backlog is provably empty,
+   * so both the total and the per-database split are zeroed to absorb any drift from the edge cases that skip a
+   * batch (a database closed mid-unsuspend). Guarded by {@code deferredByDatabase.isEmpty()}, so it can never zero
+   * another database's live accounting.
+   */
+  private void resetDeferredRAMIfDrained() {
+    if (deferredByDatabase.isEmpty()) {
+      deferredRAMBytes.set(0);
+      deferredRAMByDatabase.clear();
+      signalDeferredRAM();
+    }
+  }
+
+  private void signalDeferredRAM() {
+    synchronized (deferredRAMLock) {
+      deferredRAMLock.notifyAll();
+    }
+  }
+
+  /** Bytes of dirty pages currently deferred for a single database (issue #6200, gauge of item 2 of #6087). */
+  public long getDeferredRAMBytesOf(final BasicDatabase database) {
+    final AtomicLong bytes = deferredRAMByDatabase.get(database);
+    return bytes != null ? Math.max(0L, bytes.get()) : 0L;
+  }
+
+  /**
+   * The committer-side half of the #4728 backpressure, and the reason the flush thread no longer has to stop
+   * draining for everybody (issue #6200).
+   * <p>
+   * While a database is suspended (HA snapshot ship, full backup) its dirty pages cannot be written to disk and pile
+   * up in {@link #deferredByDatabase}; on a busy leader shipping a multi-GB snapshot that exhausted the heap. The cap
+   * that bounds it has to be JVM-wide, because heap is: what does NOT follow is that the RESPONSE should be. Only
+   * the batches of suspended databases are ever deferred, so only their committers can grow the backlog, and only
+   * they are held here. A database that is not suspended is never delayed by this: its pages go straight to the
+   * disk, which strictly RELIEVES the heap pressure the cap exists to bound.
+   * <p>
+   * <b>This must be called BEFORE the page-manager lock is taken</b>, which is why it is a separate step of
+   * {@code PageManager.publishPages} rather than a check inside {@code scheduleFlushOfPages}. Publication holds that
+   * JVM-wide lock across both the page write and the flush enqueue, so a committer parked while holding it stalls
+   * every committer of every database - the very coupling this method removes.
+   * <p>
+   * The wait ends when the backlog drops under the cap (the suspension resumed and wrote its deferred batches, or
+   * the database was dropped) or when this database stops being suspended. It is bounded per round so a suspension
+   * released without freeing any RAM still lets its committers out, and it stops waiting during shutdown so a
+   * database left suspended cannot keep a committer parked past {@code closeAndJoin}.
+   */
+  public void awaitDeferredBacklogUnderCap(final BasicDatabase database) throws InterruptedException {
+    if (maxDeferredRAM <= 0 || !(database instanceof final Database db) || !isSuspended(db))
+      // NOT SUSPENDED: THE COMMON CASE, AND TWO MAP READS AWAY FROM THE PUBLICATION IT MUST NOT SLOW DOWN
+      return;
+
+    final long beginTime = System.currentTimeMillis();
+    boolean reported = false;
+    while (true) {
+      synchronized (deferredRAMLock) {
+        if (!running || deferredRAMBytes.get() < maxDeferredRAM || !isSuspended(db))
+          return;
+        deferredRAMLock.wait(DEFERRED_BACKLOG_WAIT_POLL_MILLIS);
+      }
+
+      // Reported from OUTSIDE the monitor: a log write is a file write, and holding this monitor across it would
+      // make the resume that is releasing the backlog queue behind it. Once per held committer, not once per round:
+      // a long suspension throttles many of them, and the point is to name the database whose backlog is doing it.
+      if (!reported && System.currentTimeMillis() - beginTime > DEFERRED_BACKLOG_WARN_MILLIS) {
+        reported = true;
+        LogManager.instance().log(this, Level.WARNING,
+            "Commits on database '%s' have been throttled for over %d ms: page flushing is suspended (backup or HA snapshot) and the deferred backlog is %s, at or above the '%s' cap",
+            null, db.getName(), DEFERRED_BACKLOG_WARN_MILLIS, FileUtils.getSizeAsString(deferredRAMBytes.get()),
+            GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM.getKey());
+      }
+    }
   }
 
   /** Sum of the in-RAM size of every page in a deferred batch, used to bound the deferred backlog (issue #4728). */
@@ -715,10 +876,14 @@ public class PageManagerFlushThread extends Thread {
     final ConcurrentLinkedQueue<PagesToFlush> droppedDeferred = deferredByDatabase.remove(database);
     if (droppedDeferred != null) {
       for (final PagesToFlush batch : droppedDeferred)
-        deferredRAMBytes.addAndGet(-batchRAM(batch));
-      if (deferredByDatabase.isEmpty())
-        deferredRAMBytes.set(0);
+        addDeferredRAM(database, -batchRAM(batch));
+      resetDeferredRAMIfDrained();
     }
+    // The database is gone: drop its per-database backlog entry with the rest of its bookkeeping (#6200).
+    deferredRAMByDatabase.remove(database);
+    // Its committers cannot be throttled by a database that no longer exists, and neither can anyone else be by ITS
+    // backlog: wake every waiter so they re-read a total that just lost this database's share.
+    signalDeferredRAM();
   }
 
   /** Drops every pending {@link MutablePage} of a single dropped file from the queue, the deferred batches and the index. */
@@ -732,7 +897,7 @@ public class PageManagerFlushThread extends Thread {
     if (deferred != null)
       for (final PagesToFlush pagesToFlush : deferred)
         // These pages leave the deferred backlog, so release their reserved RAM accounting (issue #4728).
-        deferredRAMBytes.addAndGet(-removePagesOfFileFromBatch(pagesToFlush, database, fileId));
+        addDeferredRAM(database, -removePagesOfFileFromBatch(pagesToFlush, database, fileId));
 
     // Finally clean any index entry for a page currently being flushed.
     pageIndex.removeAllOfFile(database, fileId);
@@ -794,7 +959,7 @@ public class PageManagerFlushThread extends Thread {
       if (deferred != null)
         for (final PagesToFlush batch : deferred)
           // The copies leave the deferred backlog, so release their reserved RAM accounting (issue #4728).
-          deferredRAMBytes.addAndGet(-removePagesOfPageIdFromBatch(batch, pageId, detached));
+          addDeferredRAM(database, -removePagesOfPageIdFromBatch(batch, pageId, detached));
 
       // The indexed copy is missing from every batch only in the mid-enqueue window ruled out above, but adding it
       // here keeps the caller's contract - "the pipeline no longer holds this page" - true without relying on it.

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -184,6 +184,25 @@ public class PageManagerFlushThread extends Thread {
       // the common path.
       this.pages = pages == null || pages instanceof ArrayList ? pages : new ArrayList<>(pages);
       this.database = pages == null || pages.isEmpty() ? null : pages.getFirst().pageId.getDatabase();
+      // A BATCH CARRIES THE PAGES OF ONE DATABASE, and from here on the whole pipeline reads that off the FIRST
+      // page: the suspension check that decides whether to defer, the deferred map's key, the per-database RAM
+      // charge and the committer-side cap all key on `database` above (review of #6223). A mixed batch would not
+      // throw anywhere - it would silently charge one database for another's pages and throttle the wrong
+      // committers, which is the exact class of quiet accounting drift this class spent #6200 removing. Asserted
+      // rather than checked: every caller satisfies it today (one transaction's pages, or one component's), and an
+      // unconditional scan would put an O(batch) walk on the publication path to defend against a bug that has to
+      // be introduced here first. Assertions are on in the test lanes, which is where such a bug would be written.
+      assert isSingleDatabase(this.pages) : "a flush batch must carry the pages of ONE database, got " + this.pages;
+    }
+
+    private static boolean isSingleDatabase(final List<MutablePage> pages) {
+      if (pages == null || pages.isEmpty())
+        return true;
+      final BasicDatabase first = pages.getFirst().pageId.getDatabase();
+      for (int i = 1; i < pages.size(); i++)
+        if (!first.equals(pages.get(i).pageId.getDatabase()))
+          return false;
+      return true;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -618,6 +618,8 @@ public class PageManagerFlushThread extends Thread {
     // end of the method, so the caller still observes its own cancellation and the re-enqueue phase below runs
     // interrupt-free.
     boolean restoreCallerInterrupt = false;
+    // The FIRST unexpected failure of the page loop below, re-raised once the whole backlog has been drained.
+    Throwable unexpected = null;
     try {
       // Serialized against detachPendingPages: the detach must either see these batches (and take its page out of
       // them) or run after they have all reached the disk. Otherwise a superseded copy written here could land after
@@ -657,6 +659,18 @@ public class PageManagerFlushThread extends Thread {
                   }
                 } catch (final IOException e) {
                   LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
+                } catch (final Throwable e) {
+                  // ONE PAGE'S UNEXPECTED FAILURE MUST NOT ABANDON THE REST OF THE BACKLOG (review of #6223). Letting
+                  // it escape this loop left every page after it in the batch without the finally below: still in
+                  // pageIndex, so this database's pending count stays above zero and the next close waits out the
+                  // whole flushAllPagesTimeout before giving up. Contained like the I/O failures above - the page is
+                  // recovered from the WAL, its ack was never given - and re-raised once the backlog is drained, so
+                  // the caller still learns that the resume failed.
+                  if (unexpected == null)
+                    unexpected = e;
+                  LogManager.instance().log(this, Level.SEVERE,
+                      "Unexpected error on flushing deferred page '%s' to disk, the page will be recovered from the WAL on restart",
+                      e, page);
                 } finally {
                   // The page leaves the deferred backlog (flushed to disk), so release its reserved RAM (issue #4728).
                   addDeferredRAM(database, -page.getPhysicalSize());
@@ -669,7 +683,7 @@ public class PageManagerFlushThread extends Thread {
         }
       }
 
-      } finally {
+    } finally {
       // PHASES 2 TO 4 RUN EVEN IF PHASE 1 THREW. Its per-page loop contains every failure it expects (a dropped
       // file, an interrupt, an I/O error), but an UNEXPECTED exception escaping it used to abort the rest of the
       // resume outright: the batches deferred during Phase 1 stayed undetached - their pages pinned in pageIndex
@@ -677,6 +691,14 @@ public class PageManagerFlushThread extends Thread {
       // charge stayed on the cap. The caller's own finally heals the suspension COUNT, but nothing healed those.
       // Pre-existing shape, flagged in review of #6223 and closed here rather than left open, because the phases
       // below are pure bookkeeping: they cannot fail, and the exception still propagates after them.
+      //
+      // THE ONE CASE THIS DOES NOT COVER, and the reason it is an accepted residual rather than an oversight: the
+      // per-page finally itself throwing. Every failure of the WRITE is contained per page now, so the loop always
+      // reaches the end of the backlog; a finally that fails abandons the pages after it, which keep their pageIndex
+      // entry, so this database's pending count stays above zero and its next close waits out
+      // arcadedb.flushAllPagesTimeout before giving up - preserving the WAL, so those pages are recovered on the
+      // next open rather than lost. Covering it would put a try/finally around the release of every deferred page,
+      // on the resume path of every one of them, to defend against three field reads on a MutablePage.
 
       // Phase 2 + Phase 3a: under the per-database lock, clear the suspension refcount AND atomically detach
       // any batches deferred during Phase 1. Holding the lock makes this transition mutually exclusive with
@@ -727,6 +749,17 @@ public class PageManagerFlushThread extends Thread {
       if (restoreCallerInterrupt)
         // Consumed once during Phase 1: restore it so the caller still observes its own cancellation.
         Thread.currentThread().interrupt();
+    }
+
+    if (unexpected != null) {
+      // Raised only now, with the backlog drained and the suspension cleared: the caller must still learn that its
+      // resume failed, but not at the price of a pipeline left holding pages nothing will ever take out of it.
+      if (unexpected instanceof final RuntimeException runtime)
+        throw runtime;
+      if (unexpected instanceof final Error error)
+        throw error;
+      throw new RuntimeException("Error on flushing the deferred pages of database '" + database.getName() + "'",
+          unexpected);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -802,6 +802,15 @@ public class PageManagerFlushThread extends Thread {
     }
   }
 
+  /**
+   * Whether a deferred-batch queue is still held for this database. Exists so the regression test of issue #6200
+   * can prove that purging a SUSPENDED database leaves no queue behind - one nothing would ever resume, pinning the
+   * closed instance as a map key and its pages in RAM for the life of the process.
+   */
+  boolean hasDeferredBatches(final BasicDatabase database) {
+    return deferredByDatabase.containsKey(database);
+  }
+
   /** Bytes of dirty pages currently deferred for a single database (issue #6200, gauge of item 2 of #6087). */
   public long getDeferredRAMBytesOf(final BasicDatabase database) {
     final AtomicLong bytes = deferredRAMByDatabase.get(database);
@@ -891,12 +900,29 @@ public class PageManagerFlushThread extends Thread {
 
     // Forget the per-database suspend bookkeeping so the dropped Database instance (and the resources it
     // pins) can be garbage collected instead of being retained for the flush thread's lifetime as a map key.
+    //
+    // The suspension flag and the deferred batches are dropped UNDER the database's own suspend monitor - the same
+    // one flushPagesFromQueueToDisk holds across its isSuspended check AND its deferredByDatabase.offer, and the
+    // same argument Phase 2 of the resume rests on. Without it the flush thread could observe "suspended" just
+    // before this method runs and offer its batch just after, re-creating a deferred queue for a database this
+    // method has already forgotten: nothing would ever resume it, so the batch, the map entry pinning the closed
+    // instance and its RAM charge would all leak for the life of the process - and that leaked charge would
+    // throttle the committers of every later suspension in the JVM. Ordering the flag before the detach matters
+    // for the same reason it does in Phase 2: once it is clear, no further batch can be deferred (review of #6200).
+    final ConcurrentLinkedQueue<PagesToFlush> droppedDeferred;
+    synchronized (suspendLock(database)) {
+      suspended.remove(database);
+      resumingDatabases.remove(database);
+      droppedDeferred = deferredByDatabase.remove(database);
+    }
+    // Only now, or a defer racing the block above would resolve a FRESH monitor and be excluded by nothing.
     suspendLocks.remove(database);
     replayDrainLocks.remove(database);
-    suspended.remove(database);
-    resumingDatabases.remove(database);
     flushedPagesPerDatabase.remove(database);
-    final ConcurrentLinkedQueue<PagesToFlush> droppedDeferred = deferredByDatabase.remove(database);
+
+    // Deliberately outside that monitor: batchRAM takes each batch's own monitor, and the one nesting this class
+    // allows is suspendLock BEFORE batch.pages (what the defer path does). These batches are already detached, so
+    // no one else can be looking at them, and keeping the accounting out here avoids widening that nesting.
     if (droppedDeferred != null)
       for (final PagesToFlush batch : droppedDeferred)
         addDeferredRAM(database, -batchRAM(batch));

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -951,11 +951,13 @@ public class PageManagerFlushThread extends Thread {
    * <p>
    * <b>And it must hold nothing the resume needs</b>, since the resume is what releases the backlog it waits for.
    * Checked for both entry points (review of #6223): a committer arrives through {@code publishPages}, before its
-   * {@code lock()}, and index compaction arrives through {@code writePages}, after {@code updatePageVersion} has
-   * taken and released that same lock - neither holds it here. Nothing outside this class can hold
-   * {@link #suspendLock} or {@link #replayDrainLock} at all, the resume takes no database lock, and a waiter parked
-   * below has released {@link #deferredRAMLock} by definition. So the only thing a parked caller holds is its own
-   * transaction's file locks, which the resume never asks for.
+   * {@code lock()}; index compaction arrives through {@code writePages}, and cannot hold that lock at all, because
+   * {@code LockContext.lock()} is PROTECTED and {@code com.arcadedb.index.lsm} neither shares the package nor
+   * subclasses {@link PageManager} - a structural bar, not a property of the path it happens to take today (the
+   * {@code updatePageVersion} it calls first does NOT lock; only {@code validateAndBumpVersions} wraps that).
+   * Nothing outside this class can hold {@link #suspendLock} or {@link #replayDrainLock} at all, the resume takes no
+   * database lock, and a waiter parked below has released {@link #deferredRAMLock} by definition. So the only thing
+   * a parked caller holds is its own transaction's file locks, which the resume never asks for.
    * <p>
    * The wait ends when the backlog drops under the cap (the suspension resumed and wrote its deferred batches, or
    * the database was dropped) or when this database stops being suspended. It is bounded per round so a suspension

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -949,6 +949,14 @@ public class PageManagerFlushThread extends Thread {
    * JVM-wide lock across both the page write and the flush enqueue, so a committer parked while holding it stalls
    * every committer of every database - the very coupling this method removes.
    * <p>
+   * <b>And it must hold nothing the resume needs</b>, since the resume is what releases the backlog it waits for.
+   * Checked for both entry points (review of #6223): a committer arrives through {@code publishPages}, before its
+   * {@code lock()}, and index compaction arrives through {@code writePages}, after {@code updatePageVersion} has
+   * taken and released that same lock - neither holds it here. Nothing outside this class can hold
+   * {@link #suspendLock} or {@link #replayDrainLock} at all, the resume takes no database lock, and a waiter parked
+   * below has released {@link #deferredRAMLock} by definition. So the only thing a parked caller holds is its own
+   * transaction's file locks, which the resume never asks for.
+   * <p>
    * The wait ends when the backlog drops under the cap (the suspension resumed and wrote its deferred batches, or
    * the database was dropped) or when this database stops being suspended. It is bounded per round so a suspension
    * released without freeing any RAM still lets its committers out, and it stops waiting during shutdown so a

--- a/engine/src/test/java/com/arcadedb/database/Issue5279ConcurrentUpdateTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5279ConcurrentUpdateTest.java
@@ -313,8 +313,13 @@ class Issue5279ConcurrentUpdateTest extends BucketPageLayoutTestSupport {
     assertThat(conflicts.get()).as("connecting two vertices of one's own must not conflict").isLessThanOrEqualTo(1);
 
     database.transaction(() -> {
+      // Every vertex transaction retries until it commits, so all of them are there...
       assertThat(database.countType("Node", false)).isEqualTo(2L + 2L * threadCount * edgesPerThread);
-      assertThat(database.countType("Link", false)).isEqualTo(1L + (long) threadCount * edgesPerThread);
+      // ...but the edge transaction runs at attempts=1, so a conflict tolerated above means that edge was NOT
+      // created. Counting the conflicts out is what makes the two assertions agree: expecting the full total while
+      // allowing one conflict asserts both that a conflict may happen and that it may not, and the run where one
+      // DOES happen then fails here (160 against 161) instead of at the tolerance meant to absorb it.
+      assertThat(database.countType("Link", false)).isEqualTo(1L + (long) threadCount * edgesPerThread - conflicts.get());
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue5326ApplyChangesPendingFlushTest.java
@@ -145,12 +145,7 @@ class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
           db.newDocument("TestType").set("name", "deferred-" + i).save();
       });
 
-      // Wait for the flush thread to move the committed batch into the deferred backlog. The deadline only bounds a
-      // hang: the flush thread polls its queue on a 1s timeout, so 60s is orders of magnitude above the worst-case
-      // deferral latency even on the loaded runners that made #5326 visible in the first place.
-      final long deadline = System.currentTimeMillis() + 60_000;
-      while (flushThread.deferredRAMBytes.get() == 0 && System.currentTimeMillis() < deadline)
-        Thread.sleep(10);
+      awaitEveryCommittedBatchDeferred(flushThread);
 
       final MutablePage pending = flushThread.pageIndex.get(pageId);
       assertThat(pending).as("the committed page must still be pending in the flush pipeline").isNotNull();
@@ -227,9 +222,7 @@ class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
         });
       }
 
-      final long deadline = System.currentTimeMillis() + 60_000;
-      while (flushThread.deferredRAMBytes.get() == 0 && System.currentTimeMillis() < deadline)
-        Thread.sleep(10);
+      awaitEveryCommittedBatchDeferred(flushThread);
 
       final MutablePage newest = flushThread.pageIndex.get(pageId);
       assertThat(newest).as("the twice-committed page must still be pending in the flush pipeline").isNotNull();
@@ -273,5 +266,25 @@ class Issue5326ApplyChangesPendingFlushTest extends TestHelper {
     pageManager.removePageFromCache(pageId);
     final ImmutablePage reloaded = pageManager.getImmutablePage(pageId, pageSize, false, true);
     assertThat(reloaded.getVersion()).isEqualTo(replicatedVersion);
+  }
+
+  /**
+   * Waits until EVERY batch committed while suspended has been polled out of the flush queue and parked in the
+   * deferred backlog.
+   * <p>
+   * The condition is the drained pipeline, not {@code deferredRAMBytes > 0}: with more than one commit, the first
+   * deferral says nothing about the second batch, which can still be sitting in the queue - and a copy of the page
+   * that is in the QUEUE rather than in the deferred map is detached without touching the deferred accounting, so
+   * the "both copies left the backlog" assertion would see one page's worth and fail, blaming the detach for a race
+   * in the wait. The deadline only bounds a hang: the flush thread polls on a 1 s timeout, so 60 s is orders of
+   * magnitude above the worst-case deferral latency even on the loaded runners that made #5326 visible.
+   */
+  private static void awaitEveryCommittedBatchDeferred(final PageManagerFlushThread flushThread) throws InterruptedException {
+    final long deadline = System.currentTimeMillis() + 60_000;
+    while (System.currentTimeMillis() < deadline) {
+      if (flushThread.deferredRAMBytes.get() > 0 && flushThread.queue.isEmpty() && flushThread.nextPagesToFlush.get() == null)
+        return;
+      Thread.sleep(10);
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * is what makes a "this database just drained" signal possible at all, and the waits now park on it.
  * <p>
  * <b>How these tests can tell a notification from a poll</b>, given that both end the wait: the fallback interval is
- * stretched to a minute. A wait that returns in well under that was released by the signal; one released by the
+ * stretched to ten minutes. A wait that returns in well under that was released by the signal; one released by the
  * interval would blow the assertion's own timeout. The fallback is deliberately kept (a bounded {@code wait}, not an
  * unbounded park) so the callers' timeout machinery still gets re-evaluated and a hypothetical lost notification
  * degrades to the polling this used to be - which is why it has to be stretched here to be excluded.
@@ -52,8 +52,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Issue6199DrainWakeupTest extends TestHelper {
   private static final int  PAGE_SIZE             = 1024;
   /** Far longer than any assertion below waits: a wait that ends inside the timeouts was NOT ended by this. */
-  private static final long LONG_FALLBACK_MILLIS  = TimeUnit.MINUTES.toMillis(1);
-  private static final long ASSERTION_TIMEOUT_SEC = 15;
+  private static final long LONG_FALLBACK_MILLIS  = TimeUnit.MINUTES.toMillis(10);
+  /**
+   * Generous on purpose, and it costs nothing: it bounds only the waits that are expected to SUCCEED, so a longer
+   * bound cannot turn a passing run red - while a short one can, as this class already learned when a 15 s bound
+   * met a 24 s stop-the-world pause in the shared 12000-test JVM. What the tests actually rest on is the gap
+   * between this and the fallback above, which stays an order of magnitude wide.
+   */
+  private static final long ASSERTION_TIMEOUT_SEC = 60;
 
   /**
    * The last page leaving the pipeline releases a waiter immediately, instead of at the next poll boundary.
@@ -183,12 +189,17 @@ class Issue6199DrainWakeupTest extends TestHelper {
    * map entry it would otherwise consult is already gone. If the purge only notified without zeroing it, that
    * waiter would re-read a stale positive count and park through a signal it can never be sent again.
    * <p>
-   * The window is a handful of instructions, so it is reached by alignment and repetition rather than forced: the
-   * waiters and the purge are released from one gate, and measured against a purge that notifies WITHOUT zeroing
-   * the counter this fails about one run in three. A single UNALIGNED waiter per round caught nothing at all in
-   * three runs, which is why the gate is here; and the round is deliberately small (12 waiters, not the 24 that
-   * reproduced at the same rate), because this runs in the shared engine-suite JVM where thread churn is a cost
-   * every other test pays.
+   * <b>A probabilistic guard, and worth being exact about how probabilistic.</b> The window is a handful of
+   * instructions, so it is reached by alignment and repetition rather than forced: the waiters and the purge are
+   * released from one gate. Measured against a purge that notifies WITHOUT zeroing the counter, it reproduced the
+   * miss in 1 run out of 12 on a loaded machine and 2 out of 6 on an idle one - samples that small do not
+   * distinguish the two, so rely on the lower figure. A single UNALIGNED waiter per round reproduced NOTHING in
+   * three runs, which is why the gate is here at all.
+   * <p>
+   * The round is deliberately no larger (12 waiters, 80 rounds) although a larger one reproduces more often: this
+   * runs in the shared engine-suite JVM where thread churn is a cost every other test pays, and the guarantee rests
+   * on the argument written into {@code FlushPageIndex.removeAllOfDatabase} rather than on this test catching a
+   * regression of it every time.
    */
   @Test
   void aPurgeRacingTheParkIsNeverMissed() throws Exception {

--- a/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
@@ -176,6 +176,62 @@ class Issue6199DrainWakeupTest extends TestHelper {
   }
 
   /**
+   * The same purge, racing the park instead of following it.
+   * <p>
+   * The purge drops the map entry and then signals ONCE, so a waiter that resolved the counter just before the
+   * removal and enters the monitor just after the signal has to find the drained state on the counter OBJECT: the
+   * map entry it would otherwise consult is already gone. If the purge only notified without zeroing it, that
+   * waiter would re-read a stale positive count and park through a signal it can never be sent again.
+   * <p>
+   * The window is a handful of instructions, so it is reached by alignment and repetition rather than forced: the
+   * waiters and the purge are released from one gate, and measured against a purge that notifies WITHOUT zeroing
+   * the counter this fails about one run in three. A single UNALIGNED waiter per round caught nothing at all in
+   * three runs, which is why the gate is here; and the round is deliberately small (12 waiters, not the 24 that
+   * reproduced at the same rate), because this runs in the shared engine-suite JVM where thread churn is a cost
+   * every other test pays.
+   */
+  @Test
+  void aPurgeRacingTheParkIsNeverMissed() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int waitersPerRound = 12;
+
+    for (int round = 0; round < 80; round++) {
+      final FlushPageIndex index = new FlushPageIndex();
+      index.put(page(db, 8, round));
+
+      // One gate for the waiters AND the purge, so they are released within microseconds of each other: the window
+      // is a handful of instructions wide, and nothing but alignment plus repetition can land inside it.
+      final CountDownLatch gate = new CountDownLatch(1);
+      final CountDownLatch returned = new CountDownLatch(waitersPerRound);
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final Thread[] waiters = new Thread[waitersPerRound];
+      for (int w = 0; w < waitersPerRound; w++) {
+        waiters[w] = new Thread(() -> {
+          try {
+            gate.await();
+            while (index.hasPendingOf(db))
+              index.awaitDrain(db, LONG_FALLBACK_MILLIS);
+            returned.countDown();
+          } catch (final Throwable e) {
+            failure.compareAndSet(null, e);
+          }
+        }, "issue6199-purge-racer-" + round + "-" + w);
+        waiters[w].start();
+      }
+
+      gate.countDown();
+      index.removeAllOfDatabase(db);
+
+      assertThat(returned.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+          "round %d: a purge racing the park must not leave a waiter asleep on a signal that already fired", round)
+          .isTrue();
+      for (final Thread waiter : waiters)
+        waiter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+      assertThat(failure.get()).isNull();
+    }
+  }
+
+  /**
    * The bulk drain - the one every close, rename, index compaction and backup suspension goes through - is released
    * by the page landing and not by its own interval, which is stretched to a minute here to make the two
    * distinguishable.
@@ -229,8 +285,13 @@ class Issue6199DrainWakeupTest extends TestHelper {
     final long begin = System.currentTimeMillis();
     assertThat(flush.waitPendingPagesOfDatabaseUntil(db, begin + 200)).as("a page that never lands expires the deadline")
         .isFalse();
-    assertThat(System.currentTimeMillis() - begin).as("the deadline must bound the wait, not the fallback interval")
-        .isLessThan(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    // A TRIPWIRE, NOT A LATENCY ASSERTION, and its bound says so. What it can catch is a wait that came back only
+    // because something else eventually ended it; what it must NOT do is measure how promptly a 200 ms deadline
+    // expires, because this runs in the shared engine-suite JVM after ~12000 other tests, where a stop-the-world
+    // pause of tens of seconds is not exotic - a 15 s bound here failed on exactly that, at 24 s, with the code
+    // behaving correctly. The deadline being honoured is asserted above, by the return value.
+    assertThat(System.currentTimeMillis() - begin).as("the wait must be bounded by the deadline rather than unbounded")
+        .isLessThan(TimeUnit.MINUTES.toMillis(1));
 
     assertThat(flush.waitPendingPagesOfDatabaseUntil(db, System.currentTimeMillis())).as(
         "an expired deadline must return at once instead of parking").isFalse();

--- a/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6199.
+ * <p>
+ * Both drains of the flush pipeline used to discover that it had emptied by SLEEPING and asking again, so the latency
+ * they paid was set by the poll interval rather than by when the pages actually landed: 10 ms for the bulk drain that
+ * every close, rename, index compaction and backup suspension goes through, and 1 ms for the snapshot t0 barrier's
+ * residual drain - which polls with BOTH the database's apply write lock and the JVM-wide page-manager lock held, so
+ * each of those sleeps was a millisecond in which no committer of any database in the process could publish a page.
+ * <p>
+ * Since #6133 there is exactly one place a database's pending count goes down ({@code FlushPageIndex.release}), which
+ * is what makes a "this database just drained" signal possible at all, and the waits now park on it.
+ * <p>
+ * <b>How these tests can tell a notification from a poll</b>, given that both end the wait: the fallback interval is
+ * stretched to a minute. A wait that returns in well under that was released by the signal; one released by the
+ * interval would blow the assertion's own timeout. The fallback is deliberately kept (a bounded {@code wait}, not an
+ * unbounded park) so the callers' timeout machinery still gets re-evaluated and a hypothetical lost notification
+ * degrades to the polling this used to be - which is why it has to be stretched here to be excluded.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6199DrainWakeupTest extends TestHelper {
+  private static final int  PAGE_SIZE             = 1024;
+  /** Far longer than any assertion below waits: a wait that ends inside the timeouts was NOT ended by this. */
+  private static final long LONG_FALLBACK_MILLIS  = TimeUnit.MINUTES.toMillis(1);
+  private static final long ASSERTION_TIMEOUT_SEC = 15;
+
+  /**
+   * The last page leaving the pipeline releases a waiter immediately, instead of at the next poll boundary.
+   */
+  @Test
+  void theLastPageLeavingThePipelineReleasesTheWaiter() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final FlushPageIndex index = new FlushPageIndex();
+
+    final MutablePage first = page(db, 3, 0);
+    final MutablePage last = page(db, 3, 1);
+    index.put(first);
+    index.put(last);
+
+    final CountDownLatch started = new CountDownLatch(1);
+    final CountDownLatch returned = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread waiter = new Thread(() -> {
+      try {
+        started.countDown();
+        while (index.hasPendingOf(db))
+          index.awaitDrain(db, LONG_FALLBACK_MILLIS);
+        returned.countDown();
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "issue6199-waiter");
+    waiter.start();
+
+    assertThat(started.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).isTrue();
+    // Long enough that the waiter is parked rather than still on its way there; the racing case is covered below.
+    Thread.sleep(100);
+
+    // The first page is not the last one: the pipeline is not empty yet, so no wake-up may end the wait.
+    assertThat(index.removeIfSame(first)).isTrue();
+    assertThat(returned.await(200, TimeUnit.MILLISECONDS)).as("the wait must not end while a page is still pending")
+        .isFalse();
+
+    assertThat(index.removeIfSame(last)).isTrue();
+    assertThat(returned.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+        "the drain must be released by the last page landing, not by the fallback interval").isTrue();
+
+    waiter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    assertThat(failure.get()).isNull();
+  }
+
+  /**
+   * The notification cannot be missed between the count reaching zero and the waiter parking: the guard is re-read
+   * with the monitor already held, so a release that lands in that window is observed instead of slept through.
+   * Run repeatedly with the release racing the park, since the losing interleaving is the one that hangs.
+   */
+  @Test
+  void aReleaseRacingTheParkIsNeverMissed() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final FlushPageIndex index = new FlushPageIndex();
+
+    for (int i = 0; i < 300; i++) {
+      final MutablePage page = page(db, 4, i);
+      index.put(page);
+
+      final CountDownLatch returned = new CountDownLatch(1);
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final Thread waiter = new Thread(() -> {
+        try {
+          while (index.hasPendingOf(db))
+            index.awaitDrain(db, LONG_FALLBACK_MILLIS);
+          returned.countDown();
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6199-racer-" + i);
+      waiter.start();
+
+      // NO handshake on purpose: the release lands wherever it lands - before the guard read, between it and the
+      // park, or after - and every one of those must end the wait.
+      assertThat(index.removeIfSame(page)).isTrue();
+
+      assertThat(returned.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+          "iteration %d: a release racing the park must not be slept through", i).isTrue();
+      waiter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+      assertThat(failure.get()).isNull();
+    }
+
+    assertThat(index.isEmpty()).isTrue();
+  }
+
+  /**
+   * A database purged from the index (close or drop) releases its waiters too: their counter is gone, so nothing
+   * else would ever signal them and they would sleep out the whole fallback interval for a database that no longer
+   * has pages at all.
+   */
+  @Test
+  void purgingTheDatabaseReleasesItsWaiters() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final FlushPageIndex index = new FlushPageIndex();
+    index.put(page(db, 5, 0));
+
+    final CountDownLatch started = new CountDownLatch(1);
+    final CountDownLatch returned = new CountDownLatch(1);
+    final Thread waiter = new Thread(() -> {
+      try {
+        started.countDown();
+        while (index.hasPendingOf(db))
+          index.awaitDrain(db, LONG_FALLBACK_MILLIS);
+        returned.countDown();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }, "issue6199-purge-waiter");
+    waiter.start();
+
+    assertThat(started.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).isTrue();
+    Thread.sleep(100);
+
+    index.removeAllOfDatabase(db);
+
+    assertThat(returned.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+        "a purged database must release the waiters parked on its counter").isTrue();
+    waiter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+  }
+
+  /**
+   * The bulk drain - the one every close, rename, index compaction and backup suspension goes through - is released
+   * by the page landing and not by its own interval, which is stretched to a minute here to make the two
+   * distinguishable.
+   */
+  @Test
+  void theBulkDrainIsReleasedByTheFlushAndNotByItsInterval() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    // Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when
+    // this test moves it.
+    final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, db.getConfiguration());
+    flush.flushWaitPollMillis = LONG_FALLBACK_MILLIS;
+
+    final MutablePage page = page(db, 6, 0);
+    flush.pageIndex.put(page);
+
+    final CountDownLatch started = new CountDownLatch(1);
+    final AtomicBoolean drained = new AtomicBoolean();
+    final CountDownLatch returned = new CountDownLatch(1);
+    final Thread waiter = new Thread(() -> {
+      started.countDown();
+      drained.set(flush.waitAllPagesOfDatabaseAreFlushed(db));
+      returned.countDown();
+    }, "issue6199-bulk-drain");
+    waiter.start();
+
+    assertThat(started.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).isTrue();
+    Thread.sleep(100);
+    assertThat(returned.getCount()).as("the drain must still be waiting while its page is pending").isEqualTo(1);
+
+    flush.removeFromFlushIndex(page);
+
+    assertThat(returned.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+        "the bulk drain must wake on the flush, not %d ms later", LONG_FALLBACK_MILLIS).isTrue();
+    assertThat(drained).isTrue();
+    waiter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+  }
+
+  /**
+   * The residual drain of the snapshot t0 barrier - the one that runs under the JVM-wide page-manager lock - keeps
+   * its hard deadline: a page that never lands must not hold that lock past it, and an already-expired deadline must
+   * not park at all (a {@code wait(0)} would park forever, the shape this rewrite has to avoid).
+   */
+  @Test
+  void theResidualDrainKeepsItsHardDeadline() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, db.getConfiguration());
+
+    final MutablePage page = page(db, 7, 0);
+    flush.pageIndex.put(page);
+
+    final long begin = System.currentTimeMillis();
+    assertThat(flush.waitPendingPagesOfDatabaseUntil(db, begin + 200)).as("a page that never lands expires the deadline")
+        .isFalse();
+    assertThat(System.currentTimeMillis() - begin).as("the deadline must bound the wait, not the fallback interval")
+        .isLessThan(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+
+    assertThat(flush.waitPendingPagesOfDatabaseUntil(db, System.currentTimeMillis())).as(
+        "an expired deadline must return at once instead of parking").isFalse();
+
+    // And it returns as soon as the page does land.
+    final CountDownLatch returned = new CountDownLatch(1);
+    final AtomicBoolean settled = new AtomicBoolean();
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread waiter = new Thread(() -> {
+      try {
+        settled.set(flush.waitPendingPagesOfDatabaseUntil(db, System.currentTimeMillis() + LONG_FALLBACK_MILLIS));
+        returned.countDown();
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "issue6199-residual-drain");
+    waiter.start();
+
+    Thread.sleep(100);
+    flush.removeFromFlushIndex(page);
+
+    assertThat(returned.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).isTrue();
+    assertThat(settled).isTrue();
+    waiter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    assertThat(failure.get()).isNull();
+  }
+
+  private static MutablePage page(final DatabaseInternal database, final int fileId, final int pageNumber) {
+    return new MutablePage(new PageId(database, fileId, pageNumber), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -54,7 +54,12 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
   private static final int  CAP_MB                = 1;            // 1 MB deferred cap -> 4 pages fit exactly
   private static final long CAP_BYTES             = (long) CAP_MB * 1024 * 1024;
   private static final int  FILE_ID               = 9;
-  private static final long ASSERTION_TIMEOUT_SEC = 15;
+  /**
+   * Bounds only the waits expected to SUCCEED - the short windows asserting "not released yet" are written
+   * inline - so a generous value cannot turn a passing run red, while a tight one can under the stop-the-world
+   * pauses the shared 12000-test JVM produces late in a run.
+   */
+  private static final long ASSERTION_TIMEOUT_SEC = 60;
 
   /**
    * The heart of the issue: while one suspended database sits over the cap, the batches of the OTHER databases must

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.PageManagerFlushThread.PagesToFlush;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6200.
+ * <p>
+ * The deferred-flush backpressure of #4728 bounds a JVM-wide resource (heap) and was therefore right to use a JVM-wide
+ * ceiling - but its RESPONSE to crossing that ceiling was JVM-wide too: the flush thread stopped draining its bounded
+ * queue altogether, so the queue filled and the committing threads of EVERY open database were throttled, not just
+ * those of the suspended database whose backlog it was. A leader shipping a multi-GB snapshot of database A stalled
+ * the committers of unrelated databases B and C, whose pages could have gone straight to disk - which would have
+ * RELIEVED the heap the cap exists to protect, since only the batches of suspended databases are ever deferred.
+ * <p>
+ * The cap is now served on the committer side, before the JVM-wide page-manager lock is taken, and only for the
+ * databases that are actually suspended. The flush thread always drains.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
+  private static final int  PAGE_SIZE             = 256 * 1024;   // 256 KB per page
+  private static final int  CAP_MB                = 1;            // 1 MB deferred cap -> 4 pages fit exactly
+  private static final long CAP_BYTES             = (long) CAP_MB * 1024 * 1024;
+  private static final int  FILE_ID               = 9;
+  private static final long ASSERTION_TIMEOUT_SEC = 15;
+
+  /**
+   * The heart of the issue: while one suspended database sits over the cap, the batches of the OTHER databases must
+   * still be polled and written. Before the fix the flush thread returned without polling at all, so a batch queued
+   * behind the over-cap database's backlog was never reached, whatever database it belonged to.
+   */
+  @Test
+  void aDatabaseOverTheCapDoesNotStopTheDrainForTheOthers() throws Exception {
+    final DatabaseInternal suspendedDb = (DatabaseInternal) database;
+    final Database otherDb = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-other");
+    try {
+      final PageManagerFlushThread flush = cappedFlushThread();
+      flush.setSuspended(suspendedDb, true);
+      try {
+        // Six batches of the suspended database - twice what fits under the cap - and one batch of a database that
+        // is NOT suspended, queued behind all of them.
+        for (int i = 0; i < 6; i++)
+          enqueue(flush, suspendedDb, i);
+        final MutablePage otherPage = enqueue(flush, (DatabaseInternal) otherDb, 0);
+
+        for (int i = 0; i < 7; i++)
+          flush.flushPagesFromQueueToDisk(null, 20L);
+
+        assertThat(flush.queue).as("the flush thread must keep draining while a suspended database is over the cap")
+            .isEmpty();
+        assertThat(flush.pageIndex.pendingOf(otherDb)).as(
+            "the batch of the database that is not suspended must have been flushed, not left behind the backlog")
+            .isZero();
+        assertThat(flush.pageIndex.get(otherPage.getPageId())).isNull();
+
+        // The suspended database's own batches are all deferred, and all charged to IT.
+        assertThat(flush.pageIndex.pendingOf(suspendedDb)).isEqualTo(6);
+        assertThat(flush.getDeferredRAMBytesOf(suspendedDb)).isEqualTo(6L * PAGE_SIZE);
+        assertThat(flush.getDeferredRAMBytesOf(otherDb)).as("a database that is not suspended defers nothing").isZero();
+        assertThat(flush.deferredRAMBytes.get()).isEqualTo(6L * PAGE_SIZE);
+      } finally {
+        flush.setSuspended(suspendedDb, false);
+      }
+    } finally {
+      otherDb.drop();
+    }
+  }
+
+  /**
+   * The cap still throttles the committers of the database it applies to - that is #4728's whole point, and the
+   * bound on the backlog now rests on it entirely - and releases them when the backlog is written out.
+   */
+  @Test
+  void theSuspendedDatabaseOwnCommittersAreHeldUntilTheBacklogDrains() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = cappedFlushThread();
+    flush.setSuspended(db, true);
+
+    // Defer exactly the cap: 4 pages of 256 KB.
+    for (int i = 0; i < 4; i++)
+      enqueue(flush, db, i);
+    for (int i = 0; i < 4; i++)
+      flush.flushPagesFromQueueToDisk(null, 20L);
+    assertThat(flush.deferredRAMBytes.get()).isEqualTo(CAP_BYTES);
+
+    final CountDownLatch released = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread committer = new Thread(() -> {
+      try {
+        flush.awaitDeferredBacklogUnderCap(db);
+        released.countDown();
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "issue6200-committer");
+    committer.start();
+
+    assertThat(released.await(500, TimeUnit.MILLISECONDS)).as(
+        "a committer of the suspended database must be held while its backlog is at the cap").isFalse();
+
+    // The suspension ends: the deferred pages are written out and the committer is released.
+    flush.setSuspended(db, false);
+
+    assertThat(released.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+        "the committer must be released once the backlog is written out").isTrue();
+    committer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    assertThat(failure.get()).isNull();
+    assertThat(flush.deferredRAMBytes.get()).isZero();
+    assertThat(flush.getDeferredRAMBytesOf(db)).isZero();
+  }
+
+  /**
+   * The other half of the same rule: a database that is NOT suspended is never held by the cap, however far over it
+   * another database's backlog is. Its pages go straight to the disk, so committing them can only relieve the heap.
+   */
+  @Test
+  void aDatabaseThatIsNotSuspendedIsNeverHeldByAnotherDatabaseBacklog() throws Exception {
+    final DatabaseInternal suspendedDb = (DatabaseInternal) database;
+    final Database otherDb = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-free");
+    try {
+      final PageManagerFlushThread flush = cappedFlushThread();
+      flush.setSuspended(suspendedDb, true);
+      try {
+        for (int i = 0; i < 8; i++)
+          enqueue(flush, suspendedDb, i);
+        for (int i = 0; i < 8; i++)
+          flush.flushPagesFromQueueToDisk(null, 20L);
+        assertThat(flush.deferredRAMBytes.get()).as("the backlog is far over the cap").isGreaterThan(CAP_BYTES);
+
+        final long begin = System.currentTimeMillis();
+        flush.awaitDeferredBacklogUnderCap(otherDb);
+        assertThat(System.currentTimeMillis() - begin).as(
+            "a database that is not suspended must not wait on another database's backlog").isLessThan(1_000);
+      } finally {
+        flush.setSuspended(suspendedDb, false);
+      }
+    } finally {
+      otherDb.drop();
+    }
+  }
+
+  /**
+   * The backlog is accounted per database and not only as one JVM-wide total, which is what makes it possible to say
+   * WHICH suspension is holding the heap - and what the per-database {@code deferred_ram_bytes} gauge of item 2 of
+   * #6087 needs. The total stays the exact sum of the parts.
+   */
+  @Test
+  void theBacklogIsAccountedPerDatabaseAndSumsToTheTotal() throws Exception {
+    final DatabaseInternal db1 = (DatabaseInternal) database;
+    final Database db2 = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-split");
+    try {
+      final PageManagerFlushThread flush = cappedFlushThread();
+      flush.setSuspended(db1, true);
+      flush.setSuspended(db2, true);
+      try {
+        for (int i = 0; i < 3; i++)
+          enqueue(flush, db1, i);
+        for (int i = 0; i < 2; i++)
+          enqueue(flush, (DatabaseInternal) db2, i);
+        for (int i = 0; i < 5; i++)
+          flush.flushPagesFromQueueToDisk(null, 20L);
+
+        assertThat(flush.getDeferredRAMBytesOf(db1)).isEqualTo(3L * PAGE_SIZE);
+        assertThat(flush.getDeferredRAMBytesOf(db2)).isEqualTo(2L * PAGE_SIZE);
+        assertThat(flush.deferredRAMBytes.get()).as("the total is the sum of the per-database parts")
+            .isEqualTo(flush.getDeferredRAMBytesOf(db1) + flush.getDeferredRAMBytesOf(db2));
+      } finally {
+        flush.setSuspended(db1, false);
+        flush.setSuspended(db2, false);
+      }
+
+      // Both suspensions released and both backlogs written: the accounting returns to zero on every axis.
+      assertThat(flush.deferredRAMBytes.get()).isZero();
+      assertThat(flush.getDeferredRAMBytesOf(db1)).isZero();
+      assertThat(flush.getDeferredRAMBytesOf(db2)).isZero();
+    } finally {
+      db2.drop();
+    }
+  }
+
+  /**
+   * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
+   * test moves it.
+   */
+  private PageManagerFlushThread cappedFlushThread() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM, (long) CAP_MB);
+    return new PageManagerFlushThread(PageManager.INSTANCE, cfg);
+  }
+
+  private static MutablePage enqueue(final PageManagerFlushThread flush, final DatabaseInternal database,
+      final int pageNumber) {
+    final MutablePage page = new MutablePage(new PageId(database, FILE_ID, pageNumber), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+    flush.pageIndex.put(page);
+    flush.queue.offer(new PagesToFlush(List.of(page)));
+    return page;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -291,6 +291,90 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
   }
 
   /**
+   * Purging a database that is STILL suspended takes its whole backlog with it - the deferred queue, its share of
+   * the total, and the suspension flag - and leaves the databases that are still suspended untouched.
+   * <p>
+   * Nothing ever resumes a database that is gone, so anything left behind here is permanent: a queue pinning the
+   * closed instance as a map key with its pages in RAM, and a charge on the JVM-wide total that would throttle the
+   * committers of every LATER suspension in the process.
+   */
+  @Test
+  void purgingASuspendedDatabaseTakesItsWholeBacklogWithIt() throws Exception {
+    final DatabaseInternal purgedDb = (DatabaseInternal) database;
+    final Database survivingDb = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-purge");
+    try {
+      final PageManagerFlushThread flush = cappedFlushThread();
+      flush.setSuspended(purgedDb, true);
+      flush.setSuspended(survivingDb, true);
+      try {
+        enqueue(flush, purgedDb, 0);
+        enqueue(flush, (DatabaseInternal) survivingDb, 0);
+        flush.flushPagesFromQueueToDisk(null, 20L);
+        flush.flushPagesFromQueueToDisk(null, 20L);
+        assertThat(flush.deferredRAMBytes.get()).isEqualTo(2L * PAGE_SIZE);
+
+        flush.removeAllPagesOfDatabase(purgedDb);
+
+        assertThat(flush.hasDeferredBatches(purgedDb)).as("no deferred queue may outlive the database").isFalse();
+        assertThat(flush.getDeferredRAMBytesOf(purgedDb)).isZero();
+        assertThat(flush.isSuspended(purgedDb)).as("a database that is gone cannot be suspended").isFalse();
+
+        assertThat(flush.getDeferredRAMBytesOf(survivingDb)).as("and the sibling keeps its own backlog")
+            .isEqualTo(PAGE_SIZE);
+        assertThat(flush.deferredRAMBytes.get()).isEqualTo((long) PAGE_SIZE);
+      } finally {
+        flush.setSuspended(survivingDb, false);
+      }
+    } finally {
+      survivingDb.drop();
+    }
+  }
+
+  /**
+   * The same purge, racing the flush thread's poll of one of that database's batches.
+   * <p>
+   * The defer is decided under the database's suspend monitor, so the purge has to drop the suspension flag and
+   * detach the deferred queue under that SAME monitor: otherwise the flush thread can read "suspended" just before
+   * the purge and offer its batch just after it, re-creating a queue for a database the purge already forgot.
+   * <p>
+   * The interleaving is a few instructions wide, so this stresses it rather than forcing it: measured against the
+   * unguarded version it fails about one run in three, around iteration 100. What it pins deterministically is the
+   * invariant either order must leave - no queue, no charge - which is also what a future refactor would break.
+   */
+  @Test
+  void aBatchPolledWhileTheDatabaseIsPurgedIsNeverLeftDeferredForIt() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = cappedFlushThread();
+
+    for (int i = 0; i < 200; i++) {
+      flush.setSuspended(db, true);
+      enqueue(flush, db, i);
+
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final Thread poller = new Thread(() -> {
+        try {
+          flush.flushPagesFromQueueToDisk(null, 100L);
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6200-poller-" + i);
+      final Thread purger = new Thread(() -> flush.removeAllPagesOfDatabase(db), "issue6200-purger-" + i);
+
+      poller.start();
+      purger.start();
+      poller.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+      purger.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+
+      assertThat(failure.get()).isNull();
+      assertThat(flush.hasDeferredBatches(db)).as("iteration %d: a purged database must be left with no deferred queue", i)
+          .isFalse();
+      assertThat(flush.getDeferredRAMBytesOf(db)).as("iteration %d", i).isZero();
+      assertThat(flush.deferredRAMBytes.get()).as("iteration %d: nothing may stay charged to a purged database", i)
+          .isZero();
+    }
+  }
+
+  /**
    * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
    * test moves it.
    */

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -32,7 +32,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #6200.
@@ -499,6 +502,40 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
           round).isZero();
       assertThat(flush.deferredRAMDriftRepairs.get()).as(
           "round %d: and it must get there by accounting, not by the drift repair", round).isZero();
+    }
+  }
+
+  /**
+   * The invariant the whole per-database accounting rests on, made loud instead of silent.
+   * <p>
+   * Everything downstream reads the owning database off a batch's FIRST page: the suspension check that decides
+   * whether to defer, the key of the deferred map, the per-database RAM charge, and the committer-side cap. A mixed
+   * batch would throw nowhere; it would charge one database for another's pages and hold the wrong committers - the
+   * quiet accounting drift #6200 spent its review rounds removing. This test exists so the assert that guards it is
+   * known to FIRE rather than assumed to: an assertion nobody has seen trip is worth what a test nobody has seen
+   * fail is worth.
+   */
+  @Test
+  void aBatchMixingTwoDatabasesIsRejectedLoudly() {
+    boolean assertionsEnabled = false;
+    // A deliberate side effect inside an assert: the only portable way to ask whether -ea is on.
+    assert assertionsEnabled = true;
+    assumeTrue(assertionsEnabled, "assertions are disabled (-da), so the guard under test is not active");
+
+    final DatabaseInternal db1 = (DatabaseInternal) database;
+    final Database db2 = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-mixed");
+    try {
+      final MutablePage ownPage = new MutablePage(new PageId(db1, FILE_ID, 0), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+      final List<MutablePage> mixed = List.of(ownPage,
+          new MutablePage(new PageId((DatabaseInternal) db2, FILE_ID, 0), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0));
+
+      assertThatThrownBy(() -> new PagesToFlush(mixed)).isInstanceOf(AssertionError.class)
+          .hasMessageContaining("ONE database");
+
+      // ...and the single-database batch it is contrasted with is built without complaint.
+      assertThat(new PagesToFlush(List.of(ownPage)).database).isEqualTo(db1);
+    } finally {
+      db2.drop();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.PageManagerFlushThread.PagesToFlush;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -375,6 +376,58 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
   }
 
   /**
+   * A purge landing in the middle of its OWN database's resume must not release the same bytes twice.
+   * <p>
+   * The resume walks the deferred batches holding only {@code replayDrainLock}, releasing them page by page; the
+   * purge takes neither that lock nor anything else the resume holds, and its {@code releaseResidualDeferredRAM}
+   * takes the database's whole remaining charge out of the JVM-wide total in one subtraction. The straggling
+   * per-page releases that follow must then subtract NOTHING - they were already covered by that bulk one.
+   * <p>
+   * Getting it wrong drives the total negative, and the total is what the cap is read from: {@code total >= cap}
+   * answers false for every suspended database in the process until enough new deferrals climb back over it, so the
+   * #4728 OOM protection would be off for databases that have nothing to do with the one that was purged. That is
+   * why this asserts the total is exactly zero and never negative, on every iteration.
+   */
+  @Test
+  void aPurgeRacingItsOwnResumeReleasesTheSameBytesOnlyOnce() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = cappedFlushThread();
+
+    for (int i = 0; i < 100; i++) {
+      flush.setSuspended(db, true);
+      // ONE long batch rather than many short ones: the window is inside Phase 1's per-page loop, so the loop has
+      // to be long enough for the purge to land in it.
+      enqueueBatch(flush, db, i, 400);
+      flush.flushPagesFromQueueToDisk(null, 20L);
+      assertThat(flush.deferredRAMBytes.get()).isPositive();
+
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final Thread resumer = new Thread(() -> {
+        try {
+          flush.setSuspended(db, false);
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6200-resumer-" + i);
+      final Thread purger = new Thread(() -> flush.removeAllPagesOfDatabase(db), "issue6200-purge-resume-" + i);
+
+      resumer.start();
+      purger.start();
+      resumer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+      purger.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+
+      assertThat(failure.get()).isNull();
+      // The drift counter, NOT just the total: the negative-total repair would otherwise hide exactly this bug, by
+      // clamping a double release back to the zero a correct run also ends on.
+      assertThat(flush.deferredRAMDriftRepairs.get()).as(
+          "iteration %d: the JVM-wide total must never be released twice for the same bytes - a negative total silently disables the cap for every other suspended database",
+          i).isZero();
+      assertThat(flush.deferredRAMBytes.get()).as("iteration %d", i).isZero();
+      assertThat(flush.getDeferredRAMBytesOf(db)).as("iteration %d", i).isZero();
+    }
+  }
+
+  /**
    * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
    * test moves it.
    */
@@ -390,5 +443,16 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
     flush.pageIndex.put(page);
     flush.queue.offer(new PagesToFlush(List.of(page)));
     return page;
+  }
+
+  /** One batch of {@code pages} small pages, for the races whose window is inside a per-page loop. */
+  private static void enqueueBatch(final PageManagerFlushThread flush, final DatabaseInternal database, final int round,
+      final int pages) {
+    final int pageSize = 1024;
+    final List<MutablePage> batch = new ArrayList<>(pages);
+    for (int i = 0; i < pages; i++)
+      batch.add(new MutablePage(new PageId(database, FILE_ID, round * pages + i), pageSize, new byte[pageSize], 0, 0));
+    flush.pageIndex.putAll(batch);
+    flush.queue.offer(new PagesToFlush(batch));
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -210,6 +210,87 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
   }
 
   /**
+   * One database's backlog ending must not touch another's. The reset this replaced zeroed the total AND the whole
+   * per-database split whenever it observed {@code deferredByDatabase} empty - a check made on the resuming thread
+   * while the flush thread could be deferring the FIRST batch of an unrelated database, whose fresh charge was then
+   * wiped, defeating the cap for it until its next mutation (review of #6200).
+   */
+  @Test
+  void oneDatabaseResumingDoesNotWipeAnotherDatabaseBacklog() throws Exception {
+    final DatabaseInternal resumingDb = (DatabaseInternal) database;
+    final Database otherDb = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-survivor");
+    try {
+      final PageManagerFlushThread flush = cappedFlushThread();
+      flush.setSuspended(resumingDb, true);
+      flush.setSuspended(otherDb, true);
+      try {
+        // Both databases defer a batch, then only the first one resumes.
+        enqueue(flush, resumingDb, 0);
+        enqueue(flush, (DatabaseInternal) otherDb, 0);
+        flush.flushPagesFromQueueToDisk(null, 20L);
+        flush.flushPagesFromQueueToDisk(null, 20L);
+        assertThat(flush.deferredRAMBytes.get()).isEqualTo(2L * PAGE_SIZE);
+
+        flush.setSuspended(resumingDb, false);
+
+        assertThat(flush.getDeferredRAMBytesOf(resumingDb)).as("the resumed database wrote its backlog out").isZero();
+        assertThat(flush.getDeferredRAMBytesOf(otherDb)).as(
+            "a sibling's resume must not wipe the backlog of a database that is still suspended").isEqualTo(PAGE_SIZE);
+        assertThat(flush.deferredRAMBytes.get()).as("and the total must still hold the sibling's share")
+            .isEqualTo((long) PAGE_SIZE);
+      } finally {
+        flush.setSuspended(otherDb, false);
+      }
+      assertThat(flush.deferredRAMBytes.get()).isZero();
+    } finally {
+      otherDb.drop();
+    }
+  }
+
+  /**
+   * Shutdown releases a committer that is still parked on the cap. Its database may well be left suspended - the
+   * backlog is only relieved by a resume that {@code closeAndJoin} is not going to wait for - so without the signal
+   * there the committer would sit out its fallback interval against a condition that can never become true.
+   */
+  @Test
+  void shutdownReleasesACommitterParkedOnAStillSuspendedDatabase() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = cappedFlushThread();
+    flush.setSuspended(db, true);
+    try {
+      for (int i = 0; i < 4; i++)
+        enqueue(flush, db, i);
+      for (int i = 0; i < 4; i++)
+        flush.flushPagesFromQueueToDisk(null, 20L);
+      assertThat(flush.deferredRAMBytes.get()).isGreaterThanOrEqualTo(CAP_BYTES);
+
+      final CountDownLatch released = new CountDownLatch(1);
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final Thread committer = new Thread(() -> {
+        try {
+          flush.awaitDeferredBacklogUnderCap(db);
+          released.countDown();
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6200-shutdown-committer");
+      committer.start();
+
+      assertThat(released.await(300, TimeUnit.MILLISECONDS)).as("held while the backlog is at the cap").isFalse();
+
+      // The thread was never started, so closeAndJoin's join() returns at once: what is under test is the signal.
+      flush.closeAndJoin();
+
+      assertThat(released.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+          "shutdown must release a committer parked on a database that is still suspended").isTrue();
+      committer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+      assertThat(failure.get()).isNull();
+    } finally {
+      flush.setSuspended(db, false);
+    }
+  }
+
+  /**
    * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
    * test moves it.
    */

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -428,6 +428,76 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
   }
 
   /**
+   * An UNEXPECTED exception out of the resume's page-writing phase must not strand the rest of it.
+   * <p>
+   * Phase 1 contains every failure it expects - a dropped file, an interrupt, an I/O error - per page. Anything else
+   * escaping it used to abort Phases 2 to 4 outright: the batches deferred during Phase 1 stayed undetached, their
+   * pages pinned in the flush index forever (so the next close of that database waits for a drain that can never
+   * happen), and its charge stayed on the cap that throttles every suspended database. The caller's own finally
+   * heals the suspension COUNT, which is what makes the rest easy to miss.
+   * <p>
+   * A {@code null} slipped into a deferred batch stands in for "something the per-page handlers do not catch"; what
+   * the assertions are about is the state the resume leaves behind, not the exception itself.
+   * <p>
+   * The batch that has to survive is one deferred WHILE Phase 1 runs - Phase 1 detaches the pre-existing backlog on
+   * entry, so only a batch that arrives afterwards depends on Phase 2 - which is why this runs the resume on its own
+   * thread and feeds the flush thread's defer path underneath it. The first attempt at this test did it all on one
+   * thread and passed against the unfixed code, proving nothing.
+   */
+  @Test
+  void anUnexpectedFailureWhileWritingTheBacklogStillFinishesTheResume() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    for (int round = 0; round < 20; round++) {
+      final PageManagerFlushThread flush = cappedFlushThread();
+      flush.setSuspended(db, true);
+
+      // Long enough that the defer below lands inside Phase 1's write loop, with the trap at the very end so the
+      // exception comes after that window rather than before it.
+      final int pageSize = 1024;
+      final List<MutablePage> pages = new ArrayList<>();
+      for (int i = 0; i < 600; i++)
+        pages.add(new MutablePage(new PageId(db, FILE_ID, i), pageSize, new byte[pageSize], 0, 0));
+      final PagesToFlush trapped = new PagesToFlush(pages);
+      flush.pageIndex.putAll(pages);
+      flush.queue.offer(trapped);
+      flush.flushPagesFromQueueToDisk(null, 20L);
+      assertThat(flush.getDeferredRAMBytesOf(db)).isEqualTo((long) 600 * pageSize);
+
+      // Booby-trapped AFTER the deferral accounted for it, so the failure lands in Phase 1's write loop rather than
+      // in the defer that charged it.
+      trapped.pages.add(null);
+
+      final AtomicReference<Throwable> resumeFailure = new AtomicReference<>();
+      final Thread resumer = new Thread(() -> {
+        try {
+          flush.setSuspended(db, false);
+        } catch (final Throwable e) {
+          resumeFailure.set(e);
+        }
+      }, "issue6200-failing-resume-" + round);
+      resumer.start();
+
+      // A batch deferred while Phase 1 is still grinding: this is the one only Phase 2 can detach.
+      enqueue(flush, db, 5_000 + round);
+      flush.flushPagesFromQueueToDisk(null, 20L);
+
+      resumer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+      assertThat(resumeFailure.get()).as("round %d: the failure must still reach the caller", round).isNotNull();
+
+      assertThat(flush.isSuspended(db)).as("round %d: the suspension must not survive a failed resume", round).isFalse();
+      assertThat(flush.hasDeferredBatches(db)).as(
+          "round %d: Phase 2 must still detach what was deferred during Phase 1, or those pages stay pinned in the flush index and the next close waits for a drain that can never happen",
+          round).isFalse();
+      assertThat(flush.getDeferredRAMBytesOf(db)).as(
+          "round %d: Phase 4 must still release the charge, or it throttles every later suspension in the process",
+          round).isZero();
+      assertThat(flush.deferredRAMDriftRepairs.get()).as(
+          "round %d: and it must get there by accounting, not by the drift repair", round).isZero();
+    }
+  }
+
+  /**
    * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
    * test moves it.
    */

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
@@ -26,6 +26,8 @@ import com.arcadedb.engine.PageManagerFlushThread.PagesToFlush;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,13 +36,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  * accumulated without bound in {@link PageManagerFlushThread}'s deferred map while page flushing was suspended.
  * <p>
  * The fix caps the deferred backlog ({@code arcadedb.flushSuspendMaxDeferredRAM}). Once the cap is reached the
- * flush thread stops draining its bounded queue, which then fills and backpressures the committing threads
- * instead of letting the deferred map grow until the heap is exhausted.
+ * committing threads of the suspended database are throttled, instead of the deferred map growing until the heap
+ * is exhausted.
+ * <p>
+ * <b>Where that throttling happens moved in #6200</b>, and this test moved with it. It used to be the flush thread
+ * that stopped draining its bounded queue, which then filled and backpressured the committers - all of them, of
+ * every open database, and inside the JVM-wide page-manager lock that publication holds. The cap is now served on
+ * the committer side of the suspended database only ({@code awaitDeferredBacklogUnderCap}), before that lock is
+ * taken, and the flush thread always drains. The bound this test exists for is unchanged and is asserted below in
+ * its new form: past the cap, no further page of the suspended database can be published.
  */
 class PageManagerFlushSuspendBackpressureTest extends TestHelper {
 
-  private static final int PAGE_SIZE = 256 * 1024;          // 256 KB per page
-  private static final int CAP_MB    = 1;                   // 1 MB deferred cap -> 4 pages fit exactly
+  private static final int  PAGE_SIZE = 256 * 1024;          // 256 KB per page
+  private static final int  CAP_MB    = 1;                   // 1 MB deferred cap -> 4 pages fit exactly
+  private static final long CAP_BYTES = (long) CAP_MB * 1024 * 1024;
 
   @Test
   void deferredBacklogStaysBoundedWhileSuspended() throws Exception {
@@ -53,28 +63,45 @@ class PageManagerFlushSuspendBackpressureTest extends TestHelper {
 
     final Database db = (Database) database;
     flush.setSuspended(db, true);
+    try {
+      // Enqueue 4 single-page batches: exactly what fits under the 1 MB cap.
+      final int batches = 4;
+      for (int i = 0; i < batches; i++) {
+        final PageId pageId = new PageId(database, 9, i);
+        final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+        flush.pageIndex.put(page);
+        flush.queue.offer(new PagesToFlush(List.of(page)));
+      }
 
-    // Enqueue 6 single-page batches: 4 fit under the 1 MB cap, the remaining 2 must stay in the queue.
-    final int batches = 6;
-    for (int i = 0; i < batches; i++) {
-      final PageId pageId = new PageId(database, 9, i);
-      final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
-      flush.pageIndex.put(page);
-      flush.queue.offer(new PagesToFlush(List.of(page)));
+      // Drive the flush thread by hand: with the database suspended every batch is deferred, never written.
+      for (int i = 0; i < batches; i++)
+        flush.flushPagesFromQueueToDisk(null, 20L);
+
+      assertThat(flush.deferredRAMBytes.get()).isEqualTo(4L * PAGE_SIZE);
+      assertThat(flush.deferredRAMBytes.get()).isGreaterThanOrEqualTo(CAP_BYTES);
+
+      // The backlog is at the cap, so the next committer of THIS database is held before it can publish anything
+      // more into it - which is what keeps the deferred map from growing until the heap is exhausted.
+      final CountDownLatch published = new CountDownLatch(1);
+      final Thread committer = new Thread(() -> {
+        try {
+          flush.awaitDeferredBacklogUnderCap(db);
+          published.countDown();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }, "issue4728-committer");
+      committer.start();
+      try {
+        assertThat(published.await(500, TimeUnit.MILLISECONDS)).as(
+            "past the cap no further page of the suspended database may be published").isFalse();
+      } finally {
+        committer.interrupt();
+        committer.join(TimeUnit.SECONDS.toMillis(10));
+      }
+    } finally {
+      flush.setSuspended(db, false);
     }
-
-    // Drive the flush thread by hand. Each call either defers one batch (under cap) or, once the cap is hit,
-    // returns without polling. A short timeout keeps the over-cap sleeps fast.
-    for (int i = 0; i < batches + 4; i++)
-      flush.flushPagesFromQueueToDisk(null, 20L);
-
-    final long capBytes = (long) CAP_MB * 1024 * 1024;
-    // The deferred backlog never exceeds the cap...
-    assertThat(flush.deferredRAMBytes.get()).isLessThanOrEqualTo(capBytes);
-    // ...and exactly the 4 pages that fit were deferred.
-    assertThat(flush.deferredRAMBytes.get()).isEqualTo(4L * PAGE_SIZE);
-    // ...leaving the remaining 2 batches stuck in the queue (this is the writer backpressure signal).
-    assertThat(flush.queue).hasSize(2);
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -158,7 +158,11 @@ public final class EngineMetricsBinder implements MeterBinder {
         "snapshotOldestWindowAge");
 
     // #6087: the companion reading for the OTHER path. While a reader freezes the files with a flush suspension,
-    // dirty pages pile up here; crossing arcadedb.flushSuspendMaxDeferredRAM throttles committing threads outright.
+    // dirty pages pile up here; crossing arcadedb.flushSuspendMaxDeferredRAM throttles the committing threads of the
+    // SUSPENDED databases (since #6200 - before it the flush thread stopped draining its queue altogether, so the
+    // committers of every OPEN database were throttled with them). This reading stays JVM-wide because the cap is,
+    // and the per-database split that item 2 of #6087 wants to tag it by now exists as
+    // PageManager.getDeferredRAMBytesOf.
     gauge(registry, "arcadedb.engine.flush.deferred.bytes", "Dirty page bytes deferred by a flush suspension",
         "deferredRAM");
   }


### PR DESCRIPTION
Fixes #6199, fixes #6200. Both are follow-ups of #6133.

## #6199 - the drains stop polling

Both waits on the flush pipeline discovered that it had emptied by **sleeping and asking again**, so the latency they paid was set by the poll interval rather than by when the pages actually landed:

- `waitAllPagesOfDatabaseAreFlushed` polls every 10 ms, and every `close()`, `rename()`, index compaction, backup suspension and the snapshot barrier's first drain goes through it;
- `waitPendingPagesOfDatabaseUntil` polls every **1 ms**, and its caller (`PageManager.openSnapshot`, step 2 of the t0 barrier) runs it with **both the database's apply write lock and the JVM-wide page-manager lock held**. Every one of those `Thread.sleep(1)` calls was a millisecond in which no committer of *any* database in the process could publish a page - paid even when the pages had landed 999 us earlier.

Since #6133, `FlushPageIndex.release()` is the only path on which a database's pending count goes down, so a "this database just drained" signal has exactly one hook. The per-database counter now doubles as the monitor: `release()` notifies on the transition to zero (and `removeAllOfDatabase` notifies on a purge), and both waits call `FlushPageIndex.awaitDrain` instead of sleeping.

The guard is re-read **inside** the monitor, so a release landing between the caller's check and the park cannot be slept through. The bounded `wait` is kept, not as the mechanism but as the bound on a hypothetical lost notification and to keep the callers' timeout machinery re-evaluated - which is why the residual drain's fallback stays at the 1 ms it used to sleep: **worst case unchanged, common case immediate**.

Rejected, as the issue suggests: shortening the poll interval. It burns a core under a JVM-wide lock to improve the average without touching the worst case.

## #6200 - the cap stops charging one database's backlog to everyone

The cap of #4728 bounds **heap**, which is JVM-wide, so a global ceiling is the right thing to measure. What did not follow is that the *response* should be global too, and it was: once one suspended database's backlog crossed the cap, `flushPagesFromQueueToDisk` returned **without polling at all**. The bounded queue then filled and `scheduleFlushOfPages` throttled the committing threads - of every open database, not just of the suspended one - and, because `publishPages` holds the JVM-wide page-manager lock across the enqueue, it throttled them *inside that lock*. A leader shipping a multi-GB snapshot of database A stalled the committers of unrelated databases B and C, whose pages could have gone straight to disk, which strictly **relieves** the heap the cap protects.

### What this PR does instead of the issue's proposal

The issue proposed keeping the gate on the drain side and making the back-off selective (poll as usual, flush non-suspended batches, put the over-cap suspended batch back). That would have to re-queue the held batch, and a batch put back at the tail is **reordered against the other batches of its own database**: two commits can leave two `MutablePage` copies of the same `PageId` pending at once (the #4544 case), and deferring the newer one first means the older one is written over it at resume. It also cannot bound the heap on its own - the pages weigh exactly the same in the queue as in the deferred map, so moving them around does not stop the growth; only holding the producers does.

So the throttle moved to the producer side, where it belongs, and the drain-side gate is gone entirely:

- `PageManagerFlushThread.awaitDeferredBacklogUnderCap(database)` holds a committer while the backlog is at or over the cap **and its own database is suspended**. A database that is not suspended never enters it - its pages cannot grow the backlog.
- It is called **before the page-manager lock is taken**: as a separate step of `publishPages`, and directly in `writePages` for the asynchronous compaction writes that do not go through `publishPages`. This is the whole point - held one line lower, the wait would be served inside a JVM-wide lock and we would be back to stalling everybody.
- The flush thread always drains, so B's and C's batches are polled and written while A sits over the cap.
- `deferredRAMBytes` is split into a per-database counter plus the derived total (`getDeferredRAMBytesOf`), which is what item 2 of #6087 needs for a gauge tagged by database - not expressible before, because the number did not exist per database.
- A committer held for more than 10 s says so once, at WARNING, naming the database whose backlog is holding it.

The heap bound is unchanged in the worst case (cap plus whatever was already admitted), and tighter in practice: while a database is suspended, deferring a batch is a map insert with no I/O, so the queue does not build up and the total tracks the cap closely.

## Tests

- `Issue6199DrainWakeupTest` (new) - stretches the fallback interval to a minute so a wait that ends inside the assertion timeout can only have been ended by the signal; races the release against the park 300 times to pin the guarded-wait shape; covers the purge wake-up and the barrier's hard deadline (including the `wait(0)` trap an expired deadline would otherwise be). Verified to fail on the pre-fix behaviour: 3 of 5 tests red with the notify removed.
- `Issue6200PerDatabaseDeferredBacklogTest` (new) - a second database's batch is flushed while the first sits at twice the cap; the suspended database's own committers are held and then released by the resume; a non-suspended database is never held; the accounting splits per database and sums to the total. Verified to fail on the pre-fix behaviour: 3 of 4 tests red with the drain-side gate restored.
- `PageManagerFlushSuspendBackpressureTest` - #4728's own bound, re-asserted where the enforcement moved: past the cap, no further page of the suspended database can be published.
- Full `engine` module suite green (11998 tests), including `Issue6133PendingPagesPerDatabaseTest`, `Issue6125SnapshotBarrierAndCapTest`, `PageManagerFlushSuspendDeferRaceTest`, `PageManagerFlushSuspendRefCountTest`, `Issue5326ApplyChangesPendingFlushTest`, `FlushRobustnessTest` and `PageSnapshotTest`.