### PR TITLE
fix(#6198): the tag dictionary asks the header page, not a page counter that lags the flush

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -409,6 +409,20 @@ public class FileManager {
     return f;
   }
 
+  /**
+   * Looks up an already-registered file by the component name it is registered under, creating nothing.
+   * This is the read-only half of {@link #getOrCreateFile(String, String, ComponentFile.MODE)}, and the
+   * difference matters to a caller that has to decide which <em>file id</em> to build a component on:
+   * {@code getOrCreateFile} is keyed by component name, so a component that allocated a fresh id and only
+   * then asked for its file would be handed this one instead, and would go on addressing pages of an id
+   * that is not the file it holds.
+   *
+   * @return the registered file, or {@code null} when no file is registered under that component name
+   */
+  public ComponentFile getFileByComponentName(final String componentName) {
+    return fileNameMap.get(componentName);
+  }
+
   public ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.MODE mode)
       throws IOException {
     ComponentFile file = fileNameMap.get(fileName);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -211,6 +211,13 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
     final TimeSeriesTagDictionary dictionary = existingFile != null ?
         new TimeSeriesTagDictionary(database, name, existingFile.getFilePath(), existingFile.getFileId()) :
         new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + "/" + name);
+
+    // Registered BEFORE it is initialised, and it has to be: initHeaderPage() commits, and a commit
+    // resolves the component to bump its page count through schema.getFileById(), which throws on an id
+    // the schema does not know. The half-built component is not exposed by that: openOrCreate() runs from
+    // the TimeSeriesEngine constructor, under the schema DDL that creates or opens the type, before a
+    // single shard of it exists - so nothing can hold this type's dictionary id yet, and the only other
+    // caller is a test-only TimeSeriesShard constructor.
     schema.registerFile(dictionary);
 
     if (dictionary.readStoredHeader() != null)

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -206,10 +206,11 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
         new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + "/" + name);
     schema.registerFile(dictionary);
 
-    if (dictionary.getTotalPages() > 0)
-      // The component was absent from the schema but its file is on disk. Adopt what is there:
-      // writing a fresh header would silently reset the id space and orphan every id already stored
-      // in a data page.
+    if (dictionary.readStoredHeader() != null)
+      // The component was absent from the schema but its file already carries an initialised header.
+      // Adopt what is there: writing a fresh header would silently reset the id space and orphan every
+      // id already stored in a data page. The test is on the header itself and not on getTotalPages(),
+      // which under-reports for as long as the pages sit in the flush queue (issue #6198).
       dictionary.load();
     else {
       dictionary.initHeaderPage();
@@ -268,10 +269,16 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   }
 
   public synchronized void load() throws IOException {
-    if (getTotalPages() == 0) {
+    final int[] header = readStoredHeader();
+    if (header == null) {
+      // No initialised header, so nothing has ever been stored in this file. Note this is decided by
+      // reading page 0 and not by getTotalPages(): see readStoredHeader().
       loaded = true;
       return;
     }
+
+    final int storedEntries = header[0];
+    final int pages = header[1];
 
     // A read transaction of our own, so this can be called from inside a scan. It must be the only one
     // rolled back at the end: load() is reachable from resolveMiss() mid-query, and discarding the
@@ -279,9 +286,6 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
     database.begin();
     try {
       final TransactionContext tx = database.getTransaction();
-      final BasePage headerPage = tx.getPage(new PageId(database, fileId, 0), pageSize);
-      final int storedEntries = headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET);
-      final int pages = headerPage.readInt(HEADER_DATA_PAGE_COUNT);
 
       final String[] values = new String[storedEntries + 1];
       values[EMPTY_ID] = "";
@@ -291,11 +295,14 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       // absent - which on the ingest path means interning a second id for a value that already has one.
       final ConcurrentHashMap<String, Integer> rebuilt = new ConcurrentHashMap<>();
       int id = 1;
-      for (int pageNum = 1; pageNum <= pages; pageNum++) {
+      for (int pageNum = 1; pageNum <= pages && id <= storedEntries; pageNum++) {
         final BasePage page = tx.getPage(new PageId(database, fileId, pageNum), pageSize);
         final int pageEntries = page.readInt(DATA_ENTRY_COUNT_OFFSET);
         int offset = DATA_ENTRIES_OFFSET;
-        for (int i = 0; i < pageEntries; i++) {
+        // Bounded by the entry count the header declared, not by the page's own counter alone: the header
+        // is read before the pages, so an append that commits in between would otherwise hand this walk
+        // more entries than the array it is filling has room for.
+        for (int i = 0; i < pageEntries && id <= storedEntries; i++) {
           final int len = page.readShort(offset) & 0xFFFF;
           final byte[] bytes = new byte[len];
           if (len > 0)
@@ -320,6 +327,12 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       if (database.isTransactionActive())
         database.rollback();
     }
+
+    // The file demonstrably holds these pages, whatever this instance's counter was seeded with. Keeping
+    // it in step matters beyond reporting: appendEntries() allocates a data page as new when the counter
+    // says the page number is past the end, which over an under-reported counter would overwrite a page
+    // that already holds entries.
+    updatePageCount(pages + 1);
   }
 
   /**
@@ -363,17 +376,19 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
     if (id < 0 || id <= entryCount)
       return null;
 
-    // Reload only when the pages really do hold the id, which is what tells a stale map apart from a
-    // corrupt id: without this a scan carrying a corrupt id would re-read every page on every row.
-    // The test is against the count stored in the header - one already-cached page read - and not
-    // against the last reload, because a leader interns for as long as it ingests: keying on the
-    // reload would self-heal for the first wave of ids and then never again.
-    if (id > peekStoredEntryCount())
-      return null;
-
     try {
+      // Reload only when the pages really do hold the id, which is what tells a stale map apart from a
+      // corrupt id: without this a scan carrying a corrupt id would re-read every page on every row.
+      // The test is against the count stored in the header - one already-cached page read - and not
+      // against the last reload, because a leader interns for as long as it ingests: keying on the
+      // reload would self-heal for the first wave of ids and then never again.
+      final int[] header = readStoredHeader();
+      if (header == null || id > header[0])
+        return null;
+
       load();
     } catch (final IOException e) {
+      // A read path declines the value rather than failing the scan around it.
       LogManager.instance().log(this, Level.WARNING,
           "Error reloading TimeSeries tag dictionary '%s' while resolving id %d: %s", e, getName(), id, e.getMessage());
       return null;
@@ -384,27 +399,36 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   }
 
   /**
-   * Entry count as stored in the header page, which is what an id arriving from outside this instance
-   * has to be measured against. Read in a transaction of its own, like {@link #load()}, since this is
-   * reachable from inside a scan. A header that cannot be read degrades to the in-RAM count, so the
-   * caller declines to reload rather than reloading once per row.
+   * Reads the header page and returns {@code { stored entry count, data page count }}, or {@code null}
+   * when this file carries no initialised header - which is the only thing that means "nothing has ever
+   * been stored here".
+   * <p>
+   * <b>The header page is the authority, not {@link #getTotalPages()}</b> (issue #6198). That counter is
+   * per-instance: it is seeded from the physical file size at construction and afterwards only the
+   * component <em>registered with the schema</em> gets it bumped at commit. So an instance built over a
+   * file whose committed pages are still in the flush queue reads zero pages for a file that holds
+   * several, and gating on it conflated "this instance has loaded nothing" with "the file holds
+   * nothing" - disabling the self-heal in {@link #resolveMiss} exactly in the state it exists for, and
+   * letting {@link #openOrCreate} write a fresh header over a populated file. Reading page 0 has neither
+   * blind spot: the read cache and the flush queue sit in front of the disk, so a committed page is
+   * visible whether or not it has reached the file, and the magic tells an initialised header from a
+   * page that is not there at all.
+   * <p>
+   * Read straight through the page manager rather than in a transaction of its own: this is reachable
+   * from inside a scan, where opening one is both a cost and a hazard, and the page is never fabricated
+   * ({@code createIfNotExists} false), so probing a file that has no page 0 leaves no phantom behind.
+   * <p>
+   * A failure to read a header that is there is not "there is no header": it is thrown, so a caller that
+   * cannot cope with an empty dictionary ({@link #load()}, {@link #openOrCreate}) fails loudly instead of
+   * publishing an empty mapping over the real one. {@link #resolveMiss} is the caller that does cope, and
+   * it catches.
    */
-  private int peekStoredEntryCount() {
-    if (getTotalPages() == 0)
-      return entryCount;
-
-    database.begin();
-    try {
-      return database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize)
-          .readInt(HEADER_ENTRY_COUNT_OFFSET);
-    } catch (final IOException e) {
-      LogManager.instance().log(this, Level.WARNING,
-          "Error reading the header of TimeSeries tag dictionary '%s': %s", e, getName(), e.getMessage());
-      return entryCount;
-    } finally {
-      if (database.isTransactionActive())
-        database.rollback();
-    }
+  private int[] readStoredHeader() throws IOException {
+    final BasePage headerPage = database.getPageManager()
+        .getImmutablePage(new PageId(database, fileId, 0), pageSize, true, false);
+    if (headerPage == null || headerPage.readInt(HEADER_MAGIC_OFFSET) != MAGIC_VALUE)
+      return null;
+    return new int[] { headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET), headerPage.readInt(HEADER_DATA_PAGE_COUNT) };
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -202,7 +202,14 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       return dictionary;
     }
 
-    final TimeSeriesTagDictionary dictionary =
+    // A file already registered under this component name is what this dictionary must be BUILT ON, id and
+    // all. The id-allocating constructor would take a fresh file id from the manager and then be handed
+    // this very file anyway - getOrCreateFile() is keyed by the component name - leaving the component
+    // addressing pages of an id that is not the file it holds, which is unusable in either direction.
+    final ComponentFile existingFile = database.getFileManager().getFileByComponentName(name);
+
+    final TimeSeriesTagDictionary dictionary = existingFile != null ?
+        new TimeSeriesTagDictionary(database, name, existingFile.getFilePath(), existingFile.getFileId()) :
         new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + "/" + name);
     schema.registerFile(dictionary);
 
@@ -269,10 +276,13 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   }
 
   public synchronized void load() throws IOException {
+    // Header first (see readStoredHeader()), pages after, in two steps rather than one. What makes that
+    // safe is that the format is strictly append-only: the counts are a lower bound that an append
+    // landing in between can only raise, and the bytes of the entries they cover never change. So the
+    // walk below rebuilds a valid prefix, and the entries it missed are picked up by the next reload.
     final int[] header = readStoredHeader();
     if (header == null) {
-      // No initialised header, so nothing has ever been stored in this file. Note this is decided by
-      // reading page 0 and not by getTotalPages(): see readStoredHeader().
+      // No initialised header, so nothing has ever been stored in this file
       loaded = true;
       return;
     }
@@ -299,9 +309,8 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
         final BasePage page = tx.getPage(new PageId(database, fileId, pageNum), pageSize);
         final int pageEntries = page.readInt(DATA_ENTRY_COUNT_OFFSET);
         int offset = DATA_ENTRIES_OFFSET;
-        // Bounded by the entry count the header declared, not by the page's own counter alone: the header
-        // is read before the pages, so an append that commits in between would otherwise hand this walk
-        // more entries than the array it is filling has room for.
+        // Bounded by the declared entry count and not by the page's own counter alone: that is what keeps
+        // an append committing between the two steps from overrunning the array sized for the first one.
         for (int i = 0; i < pageEntries && id <= storedEntries; i++) {
           final int len = page.readShort(offset) & 0xFFFF;
           final byte[] bytes = new byte[len];
@@ -328,10 +337,10 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
         database.rollback();
     }
 
-    // The file demonstrably holds these pages, whatever this instance's counter was seeded with. Keeping
-    // it in step matters beyond reporting: appendEntries() allocates a data page as new when the counter
-    // says the page number is past the end, which over an under-reported counter would overwrite a page
-    // that already holds entries.
+    // The file demonstrably holds these pages, whatever this instance's counter was seeded with. This
+    // matters beyond reporting: appendEntries() allocates a data page as new when the counter says the
+    // page number is past the end, which over an under-reported counter would overwrite a populated page.
+    // updatePageCount() only ever raises the counter, so this cannot pull back an instance already ahead.
     updatePageCount(pages + 1);
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -220,12 +220,13 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
     // caller is a test-only TimeSeriesShard constructor.
     schema.registerFile(dictionary);
 
-    if (dictionary.readStoredHeader() != null)
+    final StoredHeader header = dictionary.readStoredHeader();
+    if (header != null)
       // The component was absent from the schema but its file already carries an initialised header.
       // Adopt what is there: writing a fresh header would silently reset the id space and orphan every
       // id already stored in a data page. The test is on the header itself and not on getTotalPages(),
       // which under-reports for as long as the pages sit in the flush queue (issue #6198).
-      dictionary.load();
+      dictionary.load(header);
     else {
       dictionary.initHeaderPage();
       dictionary.loaded = true;
@@ -283,19 +284,29 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   }
 
   public synchronized void load() throws IOException {
-    // Header first (see readStoredHeader()), pages after, in two steps rather than one. What makes that
-    // safe is that the format is strictly append-only: the counts are a lower bound that an append
-    // landing in between can only raise, and the bytes of the entries they cover never change. So the
-    // walk below rebuilds a valid prefix, and the entries it missed are picked up by the next reload.
-    final int[] header = readStoredHeader();
+    load(readStoredHeader());
+  }
+
+  /**
+   * Rebuilds from a header already read, so a caller that had to read it to decide whether to reload -
+   * {@link #resolveMiss} - does not pay for a second lookup. Passing the checked header also ties the
+   * rebuild to it: the walk is guaranteed to cover the id that header was measured against.
+   *
+   * @param header the header page contents, or {@code null} when the file carries none
+   */
+  private synchronized void load(final StoredHeader header) throws IOException {
     if (header == null) {
       // No initialised header, so nothing has ever been stored in this file
       loaded = true;
       return;
     }
 
-    final int storedEntries = header[0];
-    final int pages = header[1];
+    // Header first (see readStoredHeader()), pages after, in two steps rather than one. What makes that
+    // safe is that the format is strictly append-only: the counts are a lower bound that an append
+    // landing in between can only raise, and the bytes of the entries they cover never change. So the
+    // walk below rebuilds a valid prefix, and the entries it missed are picked up by the next reload.
+    final int storedEntries = header.entryCount();
+    final int pages = header.dataPageCount();
 
     // A read transaction of our own, so this can be called from inside a scan. It must be the only one
     // rolled back at the end: load() is reachable from resolveMiss() mid-query, and discarding the
@@ -398,11 +409,11 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       // The test is against the count stored in the header - one already-cached page read - and not
       // against the last reload, because a leader interns for as long as it ingests: keying on the
       // reload would self-heal for the first wave of ids and then never again.
-      final int[] header = readStoredHeader();
-      if (header == null || id > header[0])
+      final StoredHeader header = readStoredHeader();
+      if (header == null || id > header.entryCount())
         return null;
 
-      load();
+      load(header);
     } catch (final IOException e) {
       // A read path declines the value rather than failing the scan around it.
       LogManager.instance().log(this, Level.WARNING,
@@ -439,12 +450,19 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
    * publishing an empty mapping over the real one. {@link #resolveMiss} is the caller that does cope, and
    * it catches.
    */
-  private int[] readStoredHeader() throws IOException {
+  private StoredHeader readStoredHeader() throws IOException {
     final BasePage headerPage = database.getPageManager()
         .getImmutablePage(new PageId(database, fileId, 0), pageSize, true, false);
     if (headerPage == null || headerPage.readInt(HEADER_MAGIC_OFFSET) != MAGIC_VALUE)
       return null;
-    return new int[] { headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET), headerPage.readInt(HEADER_DATA_PAGE_COUNT) };
+    return new StoredHeader(headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET), headerPage.readInt(HEADER_DATA_PAGE_COUNT));
+  }
+
+  /**
+   * What the header page says the file holds: the two counters every decision in this class is made
+   * against, named rather than carried as a pair of positional ints.
+   */
+  private record StoredHeader(int entryCount, int dataPageCount) {
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -208,6 +209,54 @@ class TimeSeriesTagDictionaryTest extends TestHelper {
     // ...and a third wave, to prove the trigger is the growth and not the reload count
     writer.internAll(List.of("host_e"));
     assertThat(follower.getById(5)).isEqualTo("host_e");
+  }
+
+  /**
+   * The self-heal must not be gated on this instance's page counter (issue #6198). That counter is seeded
+   * from the physical file size and afterwards only the schema-registered component gets it bumped at
+   * commit, so a second instance built while the writer's committed pages are still in the flush queue
+   * reads zero pages for a file that already holds a header and a data page. Gating on it made the
+   * lookup answer {@code null} in exactly the state the self-heal exists for - which is why the sibling
+   * test above passed alone and failed in a full-suite run, where the flush queue is behind.
+   * <p>
+   * The flush is suspended here to pin that state down instead of racing the flusher for it.
+   */
+  @Test
+  void anIdIsResolvedWhileTheWriterPagesAreStillInTheFlushQueue() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final AtomicReference<TimeSeriesTagDictionary> followerRef = new AtomicReference<>();
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    // suspendFlushAndExecute() swallows whatever the callback throws, so nothing is asserted in here:
+    // the fixture is built, any failure is carried out, and the assertions run below.
+    db.getPageManager().suspendFlushAndExecute(db, () -> {
+      try {
+        final TimeSeriesTagDictionary writer = createDictionary("tags_unflushed");
+        writer.internAll(List.of("host_a", "host_b", "host_c"));
+        followerRef.set(new TimeSeriesTagDictionary(db, "tags_unflushed",
+            db.getDatabasePath() + "/tags_unflushed", writer.getFileId()));
+      } catch (final Throwable t) {
+        failure.set(t);
+      }
+    });
+
+    if (failure.get() != null)
+      throw new IllegalStateException("Failed to build the unflushed-writer fixture", failure.get());
+
+    final TimeSeriesTagDictionary follower = followerRef.get();
+    assertThat(follower).isNotNull();
+    // The fixture: not one page of this file had reached the disk when the follower was built
+    assertThat(follower.getTotalPages()).isZero();
+    assertThat(follower.size()).isZero();
+
+    assertThat(follower.getById(2)).isEqualTo("host_b");
+    assertThat(follower.size()).isEqualTo(3);
+    assertThat(follower.getById(1)).isEqualTo("host_a");
+    assertThat(follower.getById(3)).isEqualTo("host_c");
+    // The reload also brought the page counter in step, so a later append cannot allocate over a page
+    // that already holds entries
+    assertThat(follower.getTotalPages()).isEqualTo(2);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.engine.timeseries;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -257,6 +258,58 @@ class TimeSeriesTagDictionaryTest extends TestHelper {
     // The reload also brought the page counter in step, so a later append cannot allocate over a page
     // that already holds entries
     assertThat(follower.getTotalPages()).isEqualTo(2);
+  }
+
+  /**
+   * The highest-stakes reader of the same page counter is {@link TimeSeriesTagDictionary#openOrCreate}:
+   * it decides between adopting a file that is already on disk and writing a fresh header over it, and
+   * the wrong answer there resets the id space and orphans every id already stored in a data page. This
+   * drives that branch in the state the counter gets wrong - a populated file, none of it flushed - and
+   * asserts the ids survived and the sequence continues rather than restarting.
+   */
+  @Test
+  void openOrCreateAdoptsAPopulatedFileWhoseComponentIsAbsentFromTheSchema() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final LocalSchema schema = (LocalSchema) db.getSchema();
+    final List<ColumnDefinition> columns = List.of(
+        new ColumnDefinition("time", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+        new ColumnDefinition("host", Type.STRING, ColumnDefinition.ColumnRole.TAG));
+
+    final AtomicReference<TimeSeriesTagDictionary> adoptedRef = new AtomicReference<>();
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    db.getPageManager().suspendFlushAndExecute(db, () -> {
+      try {
+        final TimeSeriesTagDictionary writer = createDictionary("Adopted" + TimeSeriesTagDictionary.NAME_SUFFIX);
+        writer.internAll(List.of("host_a", "host_b", "host_c"));
+
+        // Drop the component from the schema while leaving its file registered with the file manager:
+        // that is the state the adopt branch exists for, and not one page of it has reached the disk.
+        schema.removeFile(writer.getFileId());
+
+        adoptedRef.set(TimeSeriesTagDictionary.openOrCreate(db, "Adopted", columns,
+            TimeSeriesBucket.VERSION_DICTIONARY_TAGS));
+      } catch (final Throwable t) {
+        failure.set(t);
+      }
+    });
+
+    if (failure.get() != null)
+      throw new IllegalStateException("Failed to build the unflushed-adopt fixture", failure.get());
+
+    final TimeSeriesTagDictionary adopted = adoptedRef.get();
+    assertThat(adopted).isNotNull();
+
+    // Adopted, not re-initialised: every id already assigned still resolves to the value it was given
+    assertThat(adopted.size()).isEqualTo(3);
+    assertThat(adopted.getById(1)).isEqualTo("host_a");
+    assertThat(adopted.getById(2)).isEqualTo("host_b");
+    assertThat(adopted.getById(3)).isEqualTo("host_c");
+    assertThat(adopted.getId("host_b")).isEqualTo(2);
+
+    // ...and the id space continues where it left off instead of restarting and colliding with them
+    assertThat(adopted.intern("host_d")).isEqualTo(4);
+    assertThat(adopted.getById(4)).isEqualTo("host_d");
   }
 
   /**


### PR DESCRIPTION
Closes #6198.

## What was happening

`TimeSeriesTagDictionaryTest.anIdWrittenByAnotherInstanceIsResolvedByReloading` failed only in a full-suite run, with `expected: "host_b" but was: null`.

The self-heal in `resolveMiss()` was gated on `peekStoredEntryCount()`, which opened with:

```java
if (getTotalPages() == 0)
  return entryCount;
```

`getTotalPages()` is **per instance**. `PaginatedComponent` seeds it from the *physical file size* at construction, and after that only the component **registered with the schema** gets it bumped at commit (`TransactionContext.commit` and `PageManager.publishPages` both resolve the component by file id). So a second instance built over a file whose committed pages are still in the flush queue reads **zero pages for a file that holds two** - and the degraded answer it falls back to, the in-RAM `entryCount`, is the very number the guard exists to validate. Every positive id then tripped `id > 0` and the lookup returned `null` instead of reloading.

Run alone, the flusher had already written the file before the follower instance was built, which is why the test passed in isolation and failed under a full suite where the flush queue is behind. So the answer to the issue's first question is yes: the zero-page read is legitimate, and the guard was measuring the wrong thing.

## The fix

The header page is the authority and has neither blind spot: the read cache and the flush queue sit in front of the disk, so a committed page is visible whether or not it has reached the file, and the `TSTD` magic tells an initialised header from a page that is not there at all.

`readStoredHeader()` reads page 0 straight through the page manager - no transaction of its own (this is reachable from inside a scan), and `createIfNotExists=false` so probing a file that has no page 0 leaves no phantom page behind. `load()`, `resolveMiss()` and `openOrCreate()` all go through it, which also covers the second degraded branch the issue points at: a header that cannot be read is now thrown rather than silently answered with the in-RAM count, so a caller that cannot cope with an empty dictionary fails loudly instead of publishing an empty mapping over the real one.

`openOrCreate()` is the call site that mattered most. It decided "adopt the file already on disk" against "write a fresh header" on that same stale counter - and the wrong answer there resets the id space and orphans every id already stored in a data page, which is precisely what the comment on that branch warns about.

## Two further defects found in the same code

- `load()` read the header and *then* the data pages, so an append committing in between fed the walk more entries than the array sized from the header had room for (`ArrayIndexOutOfBoundsException`). The walk is now bounded by the entry count the header declared.
- `load()` left the instance page counter untouched, so `appendEntries()` on such an instance would allocate a data page as *new* over one that already holds entries. It now updates the counter from what it just read.

## Verification

New regression test `anIdIsResolvedWhileTheWriterPagesAreStillInTheFlushQueue` pins the state down with `PageManager.suspendFlushAndExecute()` instead of racing the flusher for it, so it is deterministic. Without the fix it fails with exactly the reported `expected: "host_b" but was: null`. Note `suspendFlushAndExecute()` swallows whatever its callback throws, so the fixture is built inside it and every assertion runs outside - otherwise the test would be vacuous.

Full `engine` module run (`-DexcludedGroups=slow,benchmark,vector`): **12059 tests, 0 failures**, including the originally failing test.

## Files changed

- `engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java`
- `engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java`