### PR TITLE
fix(#6260): a wall-clock bound measures the code, not the JVM's stop-the-world pauses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,19 @@ General design principles:
   - The tags are a partition, not a set of overlapping labels: CI selects each lane with `-Dgroups`/`-DexcludedGroups` such that every test runs in exactly one lane. Tagging a class `vector` and one of its methods `slow` is fine, but do not expect that method in the slow lane
   - Required imports: `import org.junit.jupiter.api.Tag;`
   - A JUnit tag on a Cucumber `@Suite` does not work: Surefire's `groups`/`excludedGroups` reach the scenarios inside the suite rather than the suite class. Route a suite to a lane with `-Dsurefire.includes` instead, as `.github/workflows/mvn-test.yml` does for the openCypher TCK
+- Never assert on raw wall-clock elapsed time. A full-suite run shares one JVM, and a stop-the-world pause of tens of
+  seconds late in a 12,000-test run turns any bound with less headroom than that into a coin flip on the JVM's mood
+  (#6260). Measure with `com.arcadedb.utility.StallAwareStopwatch` (engine test-jar) instead: it discounts the JVM-wide
+  stall observed inside the measured window, so the bound can stay tight AND stop flaking. Pick the assertion that says
+  what the number is for, because the message is what stops the next person from "fixing" a red run by loosening it:
+  - `assertGaveUpWithin(bound, whatItSeparates)` when the bound is a tripwire between a bounded operation and an
+    unbounded one. Generous is free here: a wider bound cannot turn a passing run red
+  - `assertStayedUnder(bound, claim)` when the bound IS the assertion - a complexity claim with no other practical
+    expression (a regex that must not backtrack exponentially, one deadline shared across rows rather than charged per
+    row). Loosening it deletes the test
+  - a short wait expected to TIME OUT needs neither, and neither does a lower bound (`isGreaterThan`): a stall only
+    makes those more true
+  - `@Timeout` is plain wall clock and cannot be discounted, so size it as a hang detector, not as a latency bound
 - don't add Claude as author of any source code
 
 ## Build and Development Commands

--- a/engine/src/test/java/com/arcadedb/database/Issue5587TxRetryExponentialBackoffTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5587TxRetryExponentialBackoffTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.database;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -58,20 +59,29 @@ public class Issue5587TxRetryExponentialBackoffTest extends TestHelper {
     database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY_BASE, BASE_MS);
     try {
       final List<Long> failureTimestampsNanos = new ArrayList<>();
+      // #6260: a stop-the-world pause landing inside one gap would corrupt the comparison below in whichever
+      // direction it fell, so each gap is measured with the JVM's own stalls taken out of it.
+      final List<Long> failureStallNanos = new ArrayList<>();
       final AtomicInteger attempt = new AtomicInteger();
 
       database.transaction(() -> {
         if (attempt.incrementAndGet() < ATTEMPTS)
           throw new ConcurrentModificationException("forced retry");
-      }, false, ATTEMPTS, null, e -> failureTimestampsNanos.add(System.nanoTime()));
+      }, false, ATTEMPTS, null, e -> {
+        failureTimestampsNanos.add(System.nanoTime());
+        failureStallNanos.add(StallAwareStopwatch.jvmStallNanos());
+      });
 
       assertThat(attempt.get()).isEqualTo(ATTEMPTS);
       // one error callback per failed attempt, i.e. every attempt but the last
       assertThat(failureTimestampsNanos).hasSize(ATTEMPTS - 1);
 
       final List<Long> gapsMs = new ArrayList<>();
-      for (int i = 1; i < failureTimestampsNanos.size(); i++)
-        gapsMs.add((failureTimestampsNanos.get(i) - failureTimestampsNanos.get(i - 1)) / 1_000_000);
+      for (int i = 1; i < failureTimestampsNanos.size(); i++) {
+        final long spanNanos = failureTimestampsNanos.get(i) - failureTimestampsNanos.get(i - 1);
+        final long stalledNanos = failureStallNanos.get(i) - failureStallNanos.get(i - 1);
+        gapsMs.add(Math.max(0L, spanNanos - stalledNanos) / 1_000_000);
+      }
 
       final int half = gapsMs.size() / 2;
       final long earlyGapsSumMs = gapsMs.subList(0, half).stream().mapToLong(Long::longValue).sum();
@@ -95,16 +105,15 @@ public class Issue5587TxRetryExponentialBackoffTest extends TestHelper {
     database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 0);
     try {
       final AtomicInteger attempt = new AtomicInteger();
-      final long start = System.nanoTime();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
 
       database.transaction(() -> {
         if (attempt.incrementAndGet() < ATTEMPTS)
           throw new ConcurrentModificationException("forced retry");
       }, false, ATTEMPTS);
 
-      final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
       assertThat(attempt.get()).isEqualTo(ATTEMPTS);
-      assertThat(elapsedMs).isLessThan(1_000);
+      stopwatch.assertStayedUnder(1_000, "10 retries with the delay disabled, not 10 retries that each sleep");
     } finally {
       database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, savedCap);
     }

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -101,7 +102,10 @@ class AsyncShutdownDrainTest extends TestHelper {
   }
 
   @Test
-  @Timeout(30)
+  // #6260: JUnit's timeout is plain wall clock and cannot be discounted for a stop-the-world pause the way the
+  // assertion below is, so it has to be wide enough that only a genuine hang trips it. Pre-fix, close() returns
+  // when the 60s wedge ends: this leaves the assertion room to fail with its own explanation instead.
+  @Timeout(120)
   void closeDoesNotHangOnAWedgedAsyncWorker() throws Exception {
     // #5080: database.close()/drop() drained the async executor via an UNBOUNDED waitCompletion(), so a
     // worker wedged inside a user task (here a 60s sleep, standing in for an infinite loop or stuck I/O)
@@ -123,18 +127,20 @@ class AsyncShutdownDrainTest extends TestHelper {
       async.setTransactionUseWAL(true);
 
       final CountDownLatch blockerStarted = new CountDownLatch(1);
-      // Wedged far longer than both the 1s close timeout and the 30s test timeout: pre-fix, the unbounded
-      // waitCompletion() would block close() until it finished (~60s), tripping @Timeout.
+      // Wedged far longer than the 1s close timeout and than the bound below: pre-fix, the unbounded
+      // waitCompletion() would block close() until it finished (~60s).
       async.scheduleTask(0, blockerTask(blockerStarted, 60_000), true, 0);
       assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
-      final long begin = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       db.close();
-      final long elapsed = System.currentTimeMillis() - begin;
 
-      assertThat(elapsed)
-          .as("close() must give up the async drain after ASYNC_CLOSE_TIMEOUT instead of hanging on a wedged worker")
-          .isLessThan(15_000L);
+      // #6260: this measured 27,396ms in a full-suite run with the code behaving correctly - the JVM had
+      // simply stopped the world for most of the window. The bound is a tripwire between a ~3s bounded
+      // shutdown and the 60s wedge, so it is discounted for JVM stalls rather than widened towards the 60s
+      // it has to stay clear of.
+      stopwatch.assertGaveUpWithin(15_000L,
+          "a close() that gives up the async drain after ASYNC_CLOSE_TIMEOUT from one that hangs on the 60s wedged worker");
     } finally {
       // #5105 review: drop even if the assertion failed, so a failure does not leak the wedged worker's
       // 60s thread or the DB directory. The bounded close config above keeps this final close bounded too.
@@ -147,7 +153,9 @@ class AsyncShutdownDrainTest extends TestHelper {
   }
 
   @Test
-  @Timeout(30)
+  // #6260: same reasoning as above - the method's own budget is a 10s await, so a 24s stop-the-world pause
+  // would trip a 30s timeout on a run where nothing was wrong.
+  @Timeout(120)
   void forceShutdownStillInterruptsWorkerWhenCallerThreadIsInterrupted() throws Exception {
     // #5105 review (finding 1): when close() drains from an already-interrupted thread, waitCompletion
     // returns false and re-sets the interrupt flag. async.close()'s shutdown uses interruptible steps, so

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownEscalationTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownEscalationTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.database.async;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -91,9 +92,9 @@ class AsyncShutdownEscalationTest extends TestHelper {
       // Let worker 0 enter the helping loop before shutting down.
       Thread.sleep(300);
 
-      final long start = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       async.close();
-      assertThat(System.currentTimeMillis() - start).as("close() must stay bounded").isLessThan(15_000);
+      stopwatch.assertGaveUpWithin(15_000, "a bounded close() from one that waits out the interrupt-swallowing wedge");
 
       // The escalation must not leave worker 0 behind: without it, worker 0 kept looping in
       // offerHelping (forceShutdown set but unchecked until the hand-off resolves, and the wedged

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownPromptHelpingBailTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownPromptHelpingBailTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.database.async;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -94,16 +95,14 @@ class AsyncShutdownPromptHelpingBailTest extends TestHelper {
       // The wedge stays in place for the whole shutdown: worker 0 is handled first by close() and
       // must exit on the consumed FORCE_EXIT alone (worker 1 is only interrupted afterwards, via
       // the offer-failed path, and honors it).
-      final long start = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       async.close();
-      final long elapsed = System.currentTimeMillis() - start;
 
       // Without the bail: worker 0 sat in the helping loop for the full 8s grace period before the
       // escalation interrupt. With it: worker 0 exits within one offer window of consuming the
       // marker.
-      assertThat(elapsed)
-          .as("close() must not pay the full grace period for a worker that already consumed FORCE_EXIT")
-          .isLessThan(5_000);
+      stopwatch.assertGaveUpWithin(5_000,
+          "one offer window from the full 8s grace period a worker that already consumed FORCE_EXIT used to pay");
     } finally {
       releaseWedge.countDown();
       proceed.countDown();

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncWaitCompletionTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncWaitCompletionTimeoutTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.database.async;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -38,7 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AsyncWaitCompletionTimeoutTest extends TestHelper {
 
   @Test
-  @Timeout(30)
+  // #6260: JUnit's timeout is plain wall clock and cannot be discounted for a stop-the-world pause the way the
+  // assertion below is; the method's own budget is already ~16s of latches, so 30s was a coin flip on a loaded JVM.
+  @Timeout(120)
   void waitCompletionHonorsTimeoutWhileQueueIsFull() throws Exception {
     final DatabaseInternal db = (DatabaseInternal) database;
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
@@ -56,12 +59,11 @@ class AsyncWaitCompletionTimeoutTest extends TestHelper {
     for (int i = 0; i < 2; i++)
       assertThat(async.scheduleTask(0, noOpTask(), false, 0)).isTrue();
 
-    final long start = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     final boolean flushed = async.waitCompletion(700);
-    final long elapsed = System.currentTimeMillis() - start;
 
     assertThat(flushed).as("waitCompletion must report the timeout instead of a flush").isFalse();
-    assertThat(elapsed).as("the timeout budget must also bound the enqueue phase").isLessThan(5_000);
+    stopwatch.assertGaveUpWithin(5_000, "a 700ms budget spanning the enqueue phase from a wait that outlives the blocking task");
 
     release.countDown();
     assertThat(async.waitCompletion(10_000)).isTrue();

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.database.async;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.utility.StallAwareStopwatch;
 import com.arcadedb.exception.DatabaseOperationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -79,14 +80,13 @@ class AsyncWedgedWorkerStallTest extends TestHelper {
       for (int i = 0; i < 2; i++)
         assertThat(async.scheduleTask(0, noOpTask(), false, 0)).isTrue();
 
-      final long start = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       assertThatThrownBy(() -> async.scheduleTask(0, noOpTask(), true, 0))
           .as("a producer must not hang forever on a worker wedged in user code")
           .isInstanceOf(DatabaseOperationException.class)
           .hasMessageContaining("stalled");
-      assertThat(System.currentTimeMillis() - start)
-          .as("the backstop must fire after the configured no-progress bound, not the wedge duration")
-          .isLessThan(10_000);
+      stopwatch.assertGaveUpWithin(10_000,
+          "the backstop firing after the configured no-progress bound from a producer that waits out the wedge");
     } finally {
       release.countDown();
     }

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
@@ -44,7 +44,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class AsyncWedgedWorkerStallTest extends TestHelper {
 
   @Test
-  @Timeout(30)
+  // #6260: the body below already bounds the backstop with a stall-discounted 10s assertion, so this outer
+  // bound is only a hang detector and must be sized as one. JUnit's timeout is plain wall clock with no way to
+  // discount a stop-the-world pause, and pauses of 24s and 27s are what #6260 was filed on - against ~1-2s of
+  // honest work, 30s here was close enough to fail a run where nothing was wrong.
+  @Timeout(120)
   void producerBlockedOnWedgedWorkerEventuallyThrows() throws Exception {
     final DatabaseInternal db = (DatabaseInternal) database;
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);

--- a/engine/src/test/java/com/arcadedb/engine/FlushRobustnessTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FlushRobustnessTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.PageManagerFlushThread.PagesToFlush;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -114,13 +115,17 @@ class FlushRobustnessTest extends TestHelper {
     // The no-progress window is read per call from the database's own configuration.
     db.getConfiguration().setValue(GlobalConfiguration.FLUSH_ALL_PAGES_TIMEOUT, 300L);
     try {
-      final long start = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       final boolean flushed = flush.waitAllPagesOfDatabaseAreFlushed(db);
-      final long elapsed = System.currentTimeMillis() - start;
       assertThat(flushed).as("the wait must report that it gave up (#4928)").isFalse();
-      assertThat(elapsed)
-          .as("the wait must give up loudly after the no-progress window instead of spinning forever (#4928)")
-          .isBetween(250L, 10_000L);
+      // The floor keeps the test honest - it proves the wait really did block on the no-progress window rather
+      // than failing instantly for some unrelated reason. It reads raw wall clock on purpose: a JVM stall only
+      // makes "at least this long" more true, so there is nothing to discount.
+      assertThat(stopwatch.elapsedMs())
+          .as("the wait must actually block on the no-progress window (#4928)")
+          .isGreaterThanOrEqualTo(250L);
+      stopwatch.assertGaveUpWithin(10_000L,
+          "giving up after the 300ms no-progress window from spinning forever on a page nothing will flush");
     } finally {
       db.getConfiguration().setValue(GlobalConfiguration.FLUSH_ALL_PAGES_TIMEOUT, 60_000L);
       flush.pageIndex.remove(stuckPageId);

--- a/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6125SnapshotBarrierAndCapTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.exception.PageSnapshotException;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -337,18 +338,18 @@ class Issue6125SnapshotBarrierAndCapTest extends TestHelper {
     // POLLS A REAL BATCH, AND THIS DATABASE IS QUIET, SO THE FABRICATED VALUE STANDS
     flushThread.nextPagesToFlush.set(new PageManagerFlushThread.PagesToFlush(new ArrayList<>(List.of(page))));
     try {
-      final long begin = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       assertThatThrownBy(() -> pageManager.openSnapshot(db))
           .as("the barrier must abandon the window rather than wait out a flush that never lands")
           .isInstanceOf(PageSnapshotException.class);
-      final long elapsed = System.currentTimeMillis() - begin;
 
-      // BOTH ENDS MATTER. The upper bound is the property under test - generous enough for a loaded CI runner, far
-      // below the forever the unbounded wait would have taken. The lower one keeps the test honest: it proves the
-      // barrier really did block on the fabricated batch and time out, rather than failing instantly for some
-      // unrelated reason that would make the ceiling assertion pass vacuously
-      assertThat(elapsed).as("the barrier must block on the in-flight batch and then give up within its budget")
-          .isBetween(1_000L, 60_000L);
+      // BOTH ENDS MATTER. The upper bound is the property under test - far below the forever the unbounded wait
+      // would have taken, and discounted for JVM stalls (#6260) rather than widened. The lower one keeps the test
+      // honest: it proves the barrier really did block on the fabricated batch and time out, rather than failing
+      // instantly for some unrelated reason that would make the ceiling assertion pass vacuously. It reads raw
+      // wall clock on purpose - a stall only makes "at least this long" more true
+      assertThat(stopwatch.elapsedMs()).as("the barrier must block on the in-flight batch").isGreaterThanOrEqualTo(1_000L);
+      stopwatch.assertGaveUpWithin(60_000L, "the barrier's own budget from waiting out a flush that never lands");
 
       // AND IT MUST HAVE LET GO: A FAILED BARRIER THAT KEPT THE GLOBAL LOCK WOULD BE WORSE THAN THE HANG IT REPLACES
       final AtomicBoolean acquired = new AtomicBoolean();

--- a/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6199DrainWakeupTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.engine;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -294,6 +295,7 @@ class Issue6199DrainWakeupTest extends TestHelper {
     flush.pageIndex.put(page);
 
     final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThat(flush.waitPendingPagesOfDatabaseUntil(db, begin + 200)).as("a page that never lands expires the deadline")
         .isFalse();
     // A TRIPWIRE, NOT A LATENCY ASSERTION, and its bound says so. What it can catch is a wait that came back only
@@ -301,8 +303,10 @@ class Issue6199DrainWakeupTest extends TestHelper {
     // expires, because this runs in the shared engine-suite JVM after ~12000 other tests, where a stop-the-world
     // pause of tens of seconds is not exotic - a 15 s bound here failed on exactly that, at 24 s, with the code
     // behaving correctly. The deadline being honoured is asserted above, by the return value.
-    assertThat(System.currentTimeMillis() - begin).as("the wait must be bounded by the deadline rather than unbounded")
-        .isLessThan(TimeUnit.MINUTES.toMillis(1));
+    //
+    // #6260: the stopwatch discounts that pause, so the tripwire no longer has to be widened out to a minute to
+    // survive it. 5 s is still far above the honest ~200 ms and far below the forever an unbounded wait takes.
+    stopwatch.assertGaveUpWithin(5_000L, "a wait bounded by its 200ms deadline from one that never ends on its own");
 
     assertThat(flush.waitPendingPagesOfDatabaseUntil(db, System.currentTimeMillis())).as(
         "an expired deadline must return at once instead of parking").isFalse();

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.PageManagerFlushThread.PagesToFlush;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -167,10 +168,10 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
           flush.flushPagesFromQueueToDisk(null, 20L);
         assertThat(flush.deferredRAMBytes.get()).as("the backlog is far over the cap").isGreaterThan(CAP_BYTES);
 
-        final long begin = System.currentTimeMillis();
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
         flush.awaitDeferredBacklogUnderCap(otherDb);
-        assertThat(System.currentTimeMillis() - begin).as(
-            "a database that is not suspended must not wait on another database's backlog").isLessThan(1_000);
+        stopwatch.assertStayedUnder(1_000,
+            "a free database returning at once, not waiting on another database's over-cap backlog");
       } finally {
         flush.setSuspended(suspendedDb, false);
       }

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/promql/PromQLEvaluatorIntegrationTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.TimeSeriesTypeBuilder;
 import com.arcadedb.schema.Type;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.junit.jupiter.api.Test;
 
@@ -222,13 +223,12 @@ class PromQLEvaluatorIntegrationTest extends TestHelper {
     final String wildcardPattern = "a*".repeat(20) + "c";
     final PromQLExpr expr = new PromQLParser(typeName + "{host=~\"" + wildcardPattern + "\"}").parse();
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> evaluator.evaluateInstant(expr, 6000L)).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // Generous upper bound: proves the scan was aborted near the configured deadline rather than merely
     // being slow (the unbounded match takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded match");
   }
 
   @Test
@@ -257,14 +257,13 @@ class PromQLEvaluatorIntegrationTest extends TestHelper {
     // TimeBoundRegex, so the reproducer here has to be the sequential-a*-without-nesting shape instead.
     final PromQLExpr expr = new PromQLParser(typeName + "{host=~\"" + "a*".repeat(20) + "c\"}").parse();
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     // startMs=1000, endMs=10000, stepMs=1000 -> 10 steps, every one of which sees the ts=0 data point.
     assertThatThrownBy(() -> evaluator.evaluateRange(expr, 1000L, 10_000L, 1000L)).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-step budgets would take >= 2000ms; a shared deadline keeps the whole range
     // query close to the single configured 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one deadline shared by the whole range query, not one 200ms budget per step");
   }
 
   @Test
@@ -385,14 +384,13 @@ class PromQLEvaluatorIntegrationTest extends TestHelper {
     final String wildcardPattern = "a*".repeat(20) + "c";
     final String promqlExpr = typeName + "{host=~\"" + wildcardPattern + "\"}";
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> database.command("sql", "RETURN promql('" + promqlExpr + "', 6000)").close())
         .isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // Generous upper bound: proves the call was aborted near the configured deadline rather than merely being
     // slow (the unbounded match takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded match");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/function/text/TextRegexReplaceTest.java
+++ b/engine/src/test/java/com/arcadedb/function/text/TextRegexReplaceTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.text;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -56,15 +57,14 @@ class TextRegexReplaceTest extends TestHelper {
 
     final String pathological = "a".repeat(40) + "!";
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(
         () -> database.query("sql", "SELECT text.regexReplace('" + pathological + "', '(.*a){20}$', 'x') AS r").next())
         .isInstanceOf(IllegalArgumentException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // Generous upper bound: proves the call was aborted near the configured deadline rather than merely being
     // slow (the unbounded replaceAll takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded replaceAll");
   }
 
   @Test
@@ -83,17 +83,16 @@ class TextRegexReplaceTest extends TestHelper {
         database.command("sql", "INSERT INTO RegexReplaceMultiRow SET name = '" + pathological + "'");
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT text.regexReplace(name, '(.*a){20}$', 'x') AS r FROM RegexReplaceMultiRow");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(IllegalArgumentException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-row budgets would take >= 2000ms; a shared deadline keeps the whole query close
     // to the single configured 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one 200ms budget shared by the whole query, not one per row");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextQueryExecutorTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextQueryExecutorTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -539,13 +540,12 @@ class FullTextQueryExecutorTest extends TestHelper {
       final LSMTreeFullTextIndex ftIndex = (LSMTreeFullTextIndex) index.getIndexesOnBuckets()[0];
       final FullTextQueryExecutor executor = new FullTextQueryExecutor(ftIndex);
 
-      final long begin = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       assertThatThrownBy(() -> executor.search("/(.*a){20}$/", -1)).isInstanceOf(TimeoutException.class);
-      final long elapsedMillis = System.currentTimeMillis() - begin;
 
       // Generous upper bound: proves the scan was aborted near the configured deadline rather than merely
       // being slow (the unbounded match takes tens of seconds).
-      assertThat(elapsedMillis).isLessThan(5000);
+      stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded scan");
     });
   }
 
@@ -576,11 +576,10 @@ class FullTextQueryExecutorTest extends TestHelper {
 
       final String wildcardPattern = "a" + "*a".repeat(19) + "*b";
 
-      final long begin = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       assertThatThrownBy(() -> executor.search(wildcardPattern, -1)).isInstanceOf(TimeoutException.class);
-      final long elapsedMillis = System.currentTimeMillis() - begin;
 
-      assertThat(elapsedMillis).isLessThan(5000);
+      stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded scan");
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngineBackpressureTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngineBackpressureTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.index.sparsevector;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -58,13 +59,10 @@ class PaginatedSparseVectorEngineBackpressureTest extends TestHelper {
       // to acquire it, so the call must return without observable delay.
       mutatorLock.lock();
       try {
-        final long t0 = System.nanoTime();
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
         engine.put(0, new RID(0, 1L), 0.5f);
-        final long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
         assertThat(engine.memtablePostings()).isEqualTo(1L);
-        assertThat(elapsedMs)
-            .as("put below the hard limit must not contend the mutator lock")
-            .isLessThan(50L);
+        stopwatch.assertStayedUnder(50L, "a put that never touches the held mutator lock, not one that blocks on it");
       } finally {
         mutatorLock.unlock();
       }

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LSMVectorIndexMetadata;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.StallAwareStopwatch;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
@@ -440,13 +441,12 @@ class LSMVectorIndexRebuildTest extends TestHelper {
     assertThat(stats.get("mutationsSinceRebuild")).isGreaterThanOrEqualTo((long) lowThreshold);
 
     // Search should return immediately (async rebuild starts in background)
-    final long startTime = System.nanoTime();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     results = lsmIndex.findNeighborsFromVector(queryVector, 10);
-    final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
     assertThat(results).isNotEmpty();
 
     // Search should have returned very fast (not blocked by rebuild)
-    assertThat(elapsedMs).as("Search should not block on async rebuild").isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "a bounded search from one that waits out the background rebuild");
 
     // Wait for the async rebuild to complete. Polled rather than slept: the rebuild runs on a background thread, so
     // any fixed wait is a bet on how loaded the machine is (issue #5765).

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -446,7 +446,7 @@ class LSMVectorIndexRebuildTest extends TestHelper {
     assertThat(results).isNotEmpty();
 
     // Search should have returned very fast (not blocked by rebuild)
-    stopwatch.assertGaveUpWithin(5000, "a bounded search from one that waits out the background rebuild");
+    stopwatch.assertStayedUnder(5000, "a search served from the graph it already has, not one that waits for the rebuild");
 
     // Wait for the async rebuild to complete. Polled rather than slept: the rebuild runs on a background thread, so
     // any fixed wait is a bet on how loaded the machine is (issue #5765).

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMatchEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMatchEnhancementsTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -805,7 +806,7 @@ public class OpenCypherMatchEnhancementsTest {
       final String sourceId = ids[0];
       final String targetId = ids[1];
 
-      final long startTime = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
 
       db.transaction(() -> {
         final ResultSet rs = db.command("opencypher",
@@ -826,10 +827,7 @@ public class OpenCypherMatchEnhancementsTest {
             .isEqualTo(1);
       });
 
-      final long duration = System.currentTimeMillis() - startTime;
-      assertThat(duration)
-          .as("Query should execute quickly when filtering by specific IDs")
-          .isLessThan(5000);
+      stopwatch.assertStayedUnder(5000, "a lookup driven by the ID filter, not a full scan of the type");
     } finally {
       db.drop();
     }
@@ -855,7 +853,7 @@ public class OpenCypherMatchEnhancementsTest {
       row.put("target_id", targetId);
       batch.add(row);
 
-      final long startTime = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
 
       db.transaction(() -> {
         final ResultSet rs = db.command("opencypher",
@@ -877,10 +875,7 @@ public class OpenCypherMatchEnhancementsTest {
             .isEqualTo(1);
       });
 
-      final long duration = System.currentTimeMillis() - startTime;
-      assertThat(duration)
-          .as("UNWIND + MATCH query should execute quickly when filtering by specific IDs")
-          .isLessThan(5000);
+      stopwatch.assertStayedUnder(5000, "a lookup driven by the ID filter, not a full scan of the type per unwound row");
     } finally {
       db.drop();
     }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMergeTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -1345,7 +1346,7 @@ class OpenCypherMergeTest {
       });
 
       // Run a batch of MERGEs scoped to parentA; each must NOT touch parentB's edges.
-      final long start = System.nanoTime();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       db.transaction(() -> {
         for (int i = 0; i < 30; i++) {
           db.command("opencypher",
@@ -1353,7 +1354,6 @@ class OpenCypherMergeTest {
                   + "MERGE (n:CHUNK {name:'A_unique_" + i + "'})-[:in]->(a)");
         }
       });
-      final long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
 
       final ResultSet underA = db.query("opencypher",
           "MATCH (n:CHUNK)-[:in]->(:DOCUMENT {name:'parentA'}) RETURN count(n) AS cnt");
@@ -1365,9 +1365,7 @@ class OpenCypherMergeTest {
       // the anchor's 0..N incoming edges per MERGE and finishes in well under
       // 1 s.  The 2 s threshold is loose enough to absorb GC pauses yet tight
       // enough to catch a regression to the buggy O(edges-of-type) path.
-      assertThat(elapsedMs)
-          .as("MERGE with bound anchor should not scale with noise edge count (elapsed: " + elapsedMs + "ms)")
-          .isLessThan(2000L);
+      stopwatch.assertStayedUnder(2000L, "the anchor's own incoming edges, not the 200k noise edges of the same type");
     }
 
     // Issue #4226: Sanity check - the "match by bound first" pattern (a)-[:in]->(n) with anchor on the source continues to work after the fix.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherOptionalMatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherOptionalMatchTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -374,7 +375,7 @@ class OpenCypherOptionalMatchTest {
         }
       });
 
-      long startTime = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       long startMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 
       database.transaction(() -> {
@@ -412,7 +413,6 @@ class OpenCypherOptionalMatchTest {
         assertThat(rs.hasNext()).isFalse();
       });
 
-      long duration = System.currentTimeMillis() - startTime;
       long endMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
       long memoryUsed = endMemory - startMemory;
 
@@ -420,9 +420,7 @@ class OpenCypherOptionalMatchTest {
       //System.out.println("Memory used: " + (memoryUsed / 1024 / 1024) + "MB");
 
       // The query should complete in reasonable time and memory
-      assertThat(duration)
-          .as("Query should not take excessive time due to Cartesian product")
-          .isLessThan(5000); // 5 seconds max
+      stopwatch.assertStayedUnder(5000, "an aggregation over the matched rows, not over their Cartesian product");
     }
 
     /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherWhereClauseTest.java
@@ -39,6 +39,7 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 ;
 
@@ -225,15 +226,14 @@ public class OpenCypherWhereClauseTest {
 
     final String pathologicalInput = "a".repeat(40) + "!";
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> database.query("opencypher", "RETURN $input =~ '(.*a){20}$' AS result",
         Map.of("input", pathologicalInput)).next())
         .isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // Generous upper bound: proves the query was aborted near the configured deadline rather than
     // merely being slow (the unbounded match takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded match");
   }
 
   @Test
@@ -253,15 +253,14 @@ public class OpenCypherWhereClauseTest {
         database.command("opencypher", "CREATE (p:PerRowPathological {name: $name})", Map.of("name", pathological));
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(
         () -> database.query("opencypher", "MATCH (p:PerRowPathological) WHERE p.name =~ '(.*a){20}$' RETURN p.name").next())
         .isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-row budgets would take >= 2000ms; a query-wide shared deadline keeps the whole
     // scan close to the single configured 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one query-wide deadline, not one 200ms budget per row");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/ParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/ParameterTest.java
@@ -30,6 +30,7 @@ import com.arcadedb.schema.VertexType;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -322,7 +323,7 @@ class ParameterTest {
           .as("the optimization must yield primitive float[] for the vector field")
           .isInstanceOf(float[].class);
 
-      final long start = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       database.transaction(() -> database.command("opencypher",
           """
           UNWIND $batch AS BatchEntry \
@@ -330,7 +331,6 @@ class ParameterTest {
           CREATE (p:CHUNK_EMBEDDING {vector: BatchEntry.vector}) \
           CREATE (p)-[:embb]->(b)""",
           params));
-      final long elapsed = System.currentTimeMillis() - start;
 
       database.transaction(() -> {
         try (final ResultSet rs = database.query("sql", "SELECT count(*) AS cnt FROM CHUNK_EMBEDDING")) {
@@ -352,9 +352,8 @@ class ParameterTest {
         }
       });
 
-      assertThat(elapsed)
-          .as("HTTP-path Cypher batch (%d entries x dim %d) took %d ms", batchSize, vectorDim, elapsed)
-          .isLessThan(maxElapsedMs);
+      stopwatch.assertStayedUnder(maxElapsedMs,
+          "a primitive float[] batch of " + batchSize + " entries x dim " + vectorDim + ", not a boxed List<Double> one");
     } finally {
       database.drop();
       FileUtils.deleteRecursively(new File(databasePath));

--- a/engine/src/test/java/com/arcadedb/query/opencypher/WithAndUnwindTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/WithAndUnwindTest.java
@@ -465,12 +465,10 @@ class WithAndUnwindTest {
         Map.of("src", "18", "dst", "19")
     );
 
-    final long startInline = System.nanoTime();
     database.transaction(() ->
       database.command("opencypher",
           "UNWIND $batch AS e MATCH (a:BenchNode {uid: e.src}), (b:BenchNode {uid: e.dst}) CREATE (a)-[:BENCH_EDGE]->(b)",
           Map.of("batch", batch2)));
-    final long inlineTimeMs = (System.nanoTime() - startInline) / 1_000_000;
 
     // Verify total edges
     final ResultSet countResult2 = database.query("opencypher",

--- a/engine/src/test/java/com/arcadedb/query/opencypher/WithAndUnwindTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/WithAndUnwindTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -442,12 +443,11 @@ class WithAndUnwindTest {
     );
 
     // Query using WHERE clause (was slow before fix)
-    final long startWhere = System.nanoTime();
+    final StallAwareStopwatch whereStopwatch = StallAwareStopwatch.start();
     database.transaction(() ->
       database.command("opencypher",
           "UNWIND $batch AS e MATCH (a:BenchNode), (b:BenchNode) WHERE a.uid = e.src AND b.uid = e.dst CREATE (a)-[:BENCH_EDGE]->(b)",
           Map.of("batch", batch)));
-    final long whereTimeMs = (System.nanoTime() - startWhere) / 1_000_000;
 
     // Verify edges were created
     final ResultSet countResult = database.query("opencypher",
@@ -483,8 +483,7 @@ class WithAndUnwindTest {
     // With 200 nodes, without pushdown it would do 200*200 = 40000 comparisons per UNWIND row
     // With pushdown it does ~200 comparisons per UNWIND row
     // Allow generous margin but ensure it's not catastrophically slow
-    assertThat(whereTimeMs).as("WHERE clause version should complete within 10 seconds (was timing out before fix)")
-        .isLessThan(10000);
+    whereStopwatch.assertStayedUnder(10000, "~200 comparisons per UNWIND row with the pushdown, not 200*200 without it");
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6216AlgoWorkKnobBoundsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6216AlgoWorkKnobBoundsTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -390,11 +391,10 @@ class Issue6216AlgoWorkKnobBoundsTest {
     // unguarded run has to grind through 200 million x 128 operations before it can notice the deadline.
     database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 1L);
 
-    final long start = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> drain("CALL algo.node2vec({embeddingDimension: 128, walkLength: 2, walksPerNode: 1, "
         + "windowSize: 1, negSamples: 200000000, iterations: 1, seed: 17}) YIELD node RETURN node"))
         .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
-    final long elapsed = System.currentTimeMillis() - start;
 
     // The bound comes from measurement, not taste: the whole test method runs in 0.33 s with the checkpoint
     // in place and 24.0 s with it removed, so 5 s sits roughly 16x above the passing case and 5x below the
@@ -406,8 +406,7 @@ class Issue6216AlgoWorkKnobBoundsTest {
     // passing case reach 5 s (where the failing case would be at 360 s), or 5x faster to bring the failing
     // case under it. If it ever does flake, raise the bound rather than dropping the assertion - "it throws"
     // alone passes with the checkpoint removed, which is how the first version of this test was wrong.
-    assertThat(elapsed).as("the deadline must be observed inside the sampling loop, not after it")
-        .isLessThan(5_000L);
+    stopwatch.assertStayedUnder(5_000L, "the deadline observed inside the sampling loop, not after it");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -388,13 +389,12 @@ public class SelectExecutionTest extends TestHelper {
     final SelectCompiled select = database.select().fromType("LikePathological")//
         .where().property("name").like().value("%a".repeat(20) + "c").compile();
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     Assertions.assertThatThrownBy(() -> select.vertices().toList()).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // Generous upper bound: proves the query was aborted near the configured deadline rather than merely
     // being slow (the unbounded match takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded match");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/MatchesConditionTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -184,17 +185,16 @@ class MatchesConditionTest extends TestHelper {
       database.command("sql", "INSERT INTO Pathological SET name = '" + "a".repeat(40) + "!'");
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT FROM Pathological WHERE name MATCHES '(.*a){20}$'");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // Generous upper bound: proves the query was aborted near the configured deadline rather than
     // merely being slow (the unbounded match takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded match");
   }
 
   @Test
@@ -217,17 +217,16 @@ class MatchesConditionTest extends TestHelper {
       database.command("sql", "INSERT INTO MultiPathological SET tags = " + list);
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT FROM MultiPathological WHERE tags MATCHES '(.*a){20}$'");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-item budgets would take >= 2000ms; a shared deadline keeps the whole evaluation
     // close to the single configured 200ms bound instead. 1000ms leaves generous CI-runner slack on both sides.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one 200ms budget shared by the whole evaluation, not one per row");
   }
 
   @Test
@@ -246,16 +245,15 @@ class MatchesConditionTest extends TestHelper {
         database.command("sql", "INSERT INTO PerRowPathological SET name = '" + pathological + "'");
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT FROM PerRowPathological WHERE name MATCHES '(.*a){20}$'");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-row budgets would take >= 2000ms; a query-wide shared deadline keeps the whole
     // scan close to the single configured 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one 200ms budget shared by the whole evaluation, not one per row");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/SqlExpressionDepthGuardIssue5851FollowupTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/SqlExpressionDepthGuardIssue5851FollowupTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.sql.antlr;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.parser.Statement;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,16 +55,15 @@ class SqlExpressionDepthGuardIssue5851FollowupTest {
     final SQLAntlrParser parser = new SQLAntlrParser(null);
     final String sql = "SELECT FROM V WHERE " + "(".repeat(6000) + "1=1" + ")".repeat(6000);
 
-    final long start = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> parser.parse(sql))
         .isInstanceOf(CommandSQLParsingException.class)
         .hasMessageContaining("nest")
         .hasMessageContaining("arcadedb.sql.maxExpressionDepth");
-    final long elapsed = System.currentTimeMillis() - start;
 
     // Rejected on the O(n) token-stream pre-scan, well before any ANTLR prediction work: previously this
     // exact input burned well over two minutes of CPU before being forcibly interrupted.
-    assertThat(elapsed).as("expected a fast rejection").isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "an O(n) token-stream rejection from the two minutes of ANTLR prediction it replaced");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryHelperLikeRegexTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryHelperLikeRegexTimeoutTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.utility.StallAwareStopwatch;
 import com.arcadedb.utility.TimeBoundRegex;
 import org.junit.jupiter.api.Test;
 
@@ -57,11 +58,10 @@ class QueryHelperLikeRegexTimeoutTest extends TestHelper {
   void likeAbortsCatastrophicBacktrackingWithinTheDeadline() {
     final String input = "a".repeat(41); // all 'a's: never matches the pattern's literal 'c' tail
 
-    final long begin = System.nanoTime();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> QueryHelper.like(input, PATHOLOGICAL_LIKE_PATTERN, 200)).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
 
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded LIKE match");
   }
 
   @Test
@@ -73,15 +73,14 @@ class QueryHelperLikeRegexTimeoutTest extends TestHelper {
       database.command("sql", "INSERT INTO LikePathological SET name = '" + "a".repeat(41) + "'");
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT FROM LikePathological WHERE name LIKE '" + PATHOLOGICAL_LIKE_PATTERN + "'");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded LIKE match");
   }
 
   @Test
@@ -93,15 +92,14 @@ class QueryHelperLikeRegexTimeoutTest extends TestHelper {
       database.command("sql", "INSERT INTO ILikePathological SET name = '" + "A".repeat(41) + "'");
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT FROM ILikePathological WHERE name ILIKE '" + PATHOLOGICAL_LIKE_PATTERN + "'");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded LIKE match");
   }
 
   @Test
@@ -124,16 +122,15 @@ class QueryHelperLikeRegexTimeoutTest extends TestHelper {
       database.command("sql", "INSERT INTO MultiLikePathological SET tags = " + list);
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT FROM MultiLikePathological WHERE tags LIKE '" + PATHOLOGICAL_LIKE_PATTERN + "'");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-item budgets would take >= 2000ms; a shared deadline keeps the whole evaluation
     // close to the single configured 200ms bound instead. 1000ms leaves generous CI-runner slack on both sides.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one 200ms budget shared by the whole evaluation, not one per item");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/SQLMethodAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/SQLMethodAdditionalCoverageTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -202,17 +203,16 @@ class SQLMethodAdditionalCoverageTest extends TestHelper {
         database.command("sql", "INSERT INTO NormalizeMultiRow SET name = '" + pathological + "'");
     });
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> {
       final ResultSet rs = database.query("sql", "SELECT name.normalize('NFC', '(.*a){20}$') AS r FROM NormalizeMultiRow");
       while (rs.hasNext())
         rs.next();
     }).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-row budgets would take >= 2000ms; a shared deadline keeps the whole query close
     // to the single configured 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one 200ms budget shared by the whole query, not one per row");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodNormalizeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodNormalizeTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.sql.method.string;
 
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.sql.executor.SQLMethod;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -70,11 +71,10 @@ class SQLMethodNormalizeTest {
     // catastrophic match takes.
     final String pathologicalInput = "a".repeat(40) + "!";
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> method.execute(pathologicalInput, null, null, new Object[] { "NFC", "(.*a){20}$" }))
         .isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded match");
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
@@ -31,6 +31,7 @@ import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
@@ -732,13 +733,12 @@ class DocumentValidationTest extends TestHelper {
     final MutableDocument d = database.newDocument(clazz.getName());
     d.set("string", "a".repeat(40) + "!");
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(d::validate).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // Generous upper bound: proves validation was aborted near the configured deadline rather than merely
     // being slow (the unbounded match takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the configured 200ms deadline from an unbounded match");
   }
 
   @Test
@@ -760,13 +760,12 @@ class DocumentValidationTest extends TestHelper {
     for (int i = 0; i < 10; i++)
       d.set("field" + i, pathological);
 
-    final long begin = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(d::validate).isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = System.currentTimeMillis() - begin;
 
     // 10 independent 200ms-per-property budgets would take >= 2000ms; a shared deadline keeps the whole
     // document validation close to the single configured 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one 200ms budget shared by the whole document, not one per property");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/utility/JvmStallMonitor.java
+++ b/engine/src/test/java/com/arcadedb/utility/JvmStallMonitor.java
@@ -38,7 +38,17 @@ import java.util.concurrent.locks.LockSupport;
  * the sampler is discounted.
  * <p>
  * The counter is started lazily, on the first {@link StallAwareStopwatch}, so suites that take no timing
- * measurement pay nothing for it.
+ * measurement pay nothing for it. The sampler then runs for the rest of the JVM's life: it is a daemon with no
+ * stop path on purpose, because a test JVM's life is the whole window anyone can measure. Anything longer-lived
+ * that wants to reuse this needs a shutdown story first.
+ * <p>
+ * The sensitivity this trades away, so that nobody rediscovers it as a surprise: the monitor cannot tell a stall
+ * from the measured thread's own work being slow on an oversubscribed box, because both look like the sampler
+ * losing the CPU. On a heavily loaded runner a genuine complexity regression can therefore be discounted along
+ * with the noise and slip under its bound. That is the deliberate trade - a bound that is silent on a loaded
+ * machine beats one that is red on a healthy one for reasons that have nothing to do with the code - but it is
+ * why {@link StallAwareStopwatch#assertStayedUnder} bounds still want an order of magnitude of headroom over the
+ * honest measured time rather than being tuned down to whatever currently passes.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  * @see StallAwareStopwatch
@@ -50,6 +60,12 @@ final class JvmStallMonitor {
   /**
    * Slack allowed on top of the tick before a gap counts as a stall. {@code parkNanos()} routinely overshoots by
    * a few milliseconds on a healthy machine; charging that as a stall would slowly eat away at every bound.
+   * <p>
+   * The floor this puts under the whole mechanism: nothing below tick + tolerance is ever discounted, so a bound
+   * tighter than about 20 ms is measuring raw scheduling jitter and gets no help here. Only one assertion in the
+   * suite is anywhere near that ({@code PaginatedSparseVectorEngineBackpressureTest}, at 50 ms); if that one ever
+   * flakes, this constant is the first place to look, and lowering it costs every other measurement a slow drip
+   * of bogus discount in exchange.
    */
   static final long TOLERANCE_NANOS = TimeUnit.MILLISECONDS.toNanos(10);
 

--- a/engine/src/test/java/com/arcadedb/utility/JvmStallMonitor.java
+++ b/engine/src/test/java/com/arcadedb/utility/JvmStallMonitor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Test-only accounting of the wall-clock time during which the whole JVM was not making progress: stop-the-world
+ * GC pauses, and CPU starvation severe enough that a runnable thread does not get scheduled for tens of
+ * milliseconds at a time. Both are routine late in a 12 000-test single-JVM suite run and both inflate every
+ * wall-clock measurement taken in that JVM, whatever the code under test is doing (see #6260).
+ * <p>
+ * A single daemon thread parks for {@link #TICK_NANOS} at a time and accumulates, into a monotonically
+ * increasing counter, however much longer than that each park actually took. The difference of two readings of
+ * that counter is therefore the stall observed inside the interval between them, and subtracting it from a
+ * wall-clock measurement taken over the same interval leaves the time the JVM was actually running.
+ * <p>
+ * Deliberately NOT subtracted: time the measured thread spends sleeping, parked or blocked on I/O. The sampler
+ * keeps ticking then, so a test that blocks for a second still measures a second. Only a stall that also stops
+ * the sampler is discounted.
+ * <p>
+ * The counter is started lazily, on the first {@link StallAwareStopwatch}, so suites that take no timing
+ * measurement pay nothing for it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ * @see StallAwareStopwatch
+ */
+final class JvmStallMonitor {
+  /** How long the sampler parks between two readings. 100 wake-ups a second is not measurable against a test suite. */
+  static final long TICK_NANOS = TimeUnit.MILLISECONDS.toNanos(10);
+
+  /**
+   * Slack allowed on top of the tick before a gap counts as a stall. {@code parkNanos()} routinely overshoots by
+   * a few milliseconds on a healthy machine; charging that as a stall would slowly eat away at every bound.
+   */
+  static final long TOLERANCE_NANOS = TimeUnit.MILLISECONDS.toNanos(10);
+
+  /** Name of the sampler thread, so a test can confirm it is running. */
+  static final String THREAD_NAME = "arcadedb-test-stall-monitor";
+
+  private static final AtomicLong ACCUMULATED_STALL_NANOS = new AtomicLong();
+
+  private JvmStallMonitor() {
+  }
+
+  /** Holder idiom: the sampler thread starts on the first read of {@link #accumulatedStallNanos()}, not on class load. */
+  private static final class Sampler {
+    static {
+      final Thread sampler = new Thread(Sampler::sample, THREAD_NAME);
+      sampler.setDaemon(true);
+      // Deliberately left at the default priority: the sampler is a proxy for the measured thread, so it has to
+      // compete for a core on the same terms. Raising it would let it keep ticking through exactly the CPU
+      // starvation the measured thread is suffering, which is the half of the problem GC pauses do not cover.
+      sampler.start();
+    }
+
+    static void ensureStarted() {
+      // Referencing this class is what runs the initializer above; there is nothing else to do here.
+    }
+
+    private static void sample() {
+      long previous = System.nanoTime();
+      while (true) {
+        LockSupport.parkNanos(TICK_NANOS);
+        final long now = System.nanoTime();
+        final long stallNanos = stallNanosForGap(now - previous);
+        previous = now;
+        if (stallNanos > 0)
+          ACCUMULATED_STALL_NANOS.addAndGet(stallNanos);
+      }
+    }
+  }
+
+  /**
+   * Total stall observed since the sampler started. Only differences between two readings are meaningful; the
+   * absolute value is not.
+   */
+  static long accumulatedStallNanos() {
+    Sampler.ensureStarted();
+    return ACCUMULATED_STALL_NANOS.get();
+  }
+
+  /** Charged as a stall only what exceeds the tick plus the tolerance. Split out so the accounting is testable. */
+  static long stallNanosForGap(final long gapNanos) {
+    final long excessNanos = gapNanos - TICK_NANOS - TOLERANCE_NANOS;
+    return excessNanos > 0 ? excessNanos : 0;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/LockManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/LockManagerTest.java
@@ -264,11 +264,10 @@ class LockManagerTest {
     lockManager.tryLock(resource, "holder", 5000);
 
     final long timeoutMs = 300L;
-    final long start = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     final LockManager.LOCK_STATUS status = lockManager.tryLock(resource, "waiter", timeoutMs);
-    final long elapsed = System.currentTimeMillis() - start;
 
     assertThat(status).isEqualTo(LockManager.LOCK_STATUS.NO);
-    assertThat(elapsed).isLessThan(timeoutMs + 250);
+    stopwatch.assertStayedUnder(timeoutMs + 250, "one 300ms wait, not the 600ms a double-wait would produce");
   }
 }

--- a/engine/src/test/java/com/arcadedb/utility/RetryBackoffTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/RetryBackoffTest.java
@@ -81,10 +81,9 @@ class RetryBackoffTest {
 
   @Test
   void sleepReturnsImmediatelyWhenTheCapIsNotPositive() {
-    final long start = System.nanoTime();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     RetryBackoff.sleep(3, 2, 0);
-    final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
-    assertThat(elapsedMs).isLessThan(50);
+    stopwatch.assertStayedUnder(50, "a non-positive cap meaning no sleep at all");
   }
 
   @Test
@@ -93,13 +92,12 @@ class RetryBackoffTest {
     final long cap = 200;
     final int attempt = 2; // window = min(200, 2*2^2) = 8ms
 
-    final long start = System.nanoTime();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     RetryBackoff.sleep(attempt, base, cap);
-    final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
     // Generous upper bound: the window is 8ms, so anything close to the cap (200ms) would indicate the
     // implementation is not actually scaling the sleep down for an early attempt.
-    assertThat(elapsedMs).isLessThan(cap);
+    stopwatch.assertStayedUnder(cap, "this attempt's 8ms window, not the 200ms cap");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatch.java
+++ b/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatch.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A stopwatch for tests that have to bound an operation in wall-clock time, reporting the elapsed time with the
+ * JVM-wide stalls inside the measurement window taken out of it (see {@link JvmStallMonitor}).
+ * <p>
+ * The problem it solves (#6260): late in a 12 000-test single-JVM run a stop-the-world pause of tens of seconds
+ * is not exotic, so any bound with less headroom than that becomes a coin flip on the JVM's mood rather than a
+ * statement about the code. Loosening the bound is not always available as a fix - several of these bounds are
+ * discriminating between a shared 200 ms deadline and ten independent ones, so they have to stay below 2 s to
+ * mean anything. Subtracting the stall keeps the bound tight AND makes it immune to the pause.
+ * <p>
+ * The two assertion methods differ only in the failure message, and that is the point: the message has to say
+ * what the number is for, so that the next person to see it go red knows whether loosening it is a repair or a
+ * cover-up.
+ * <ul>
+ * <li>{@link #assertGaveUpWithin} - the bound separates a bounded operation from an unbounded one. It is a
+ * tripwire; anywhere between the real limit and the unbounded behaviour will do, and generous is free.</li>
+ * <li>{@link #assertStayedUnder} - the bound IS the assertion, standing in for a complexity claim that has no
+ * other practical expression. Loosening it deletes the test.</li>
+ * </ul>
+ * A short wait that is expected to TIME OUT needs neither: a stall only makes it more true.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class StallAwareStopwatch {
+  private final LongSupplier stallNanos;
+  private final long         beginNanos;
+  private final long         beginStallNanos;
+
+  private StallAwareStopwatch(final LongSupplier stallNanos) {
+    this.stallNanos = stallNanos;
+    this.beginStallNanos = stallNanos.getAsLong();
+    this.beginNanos = System.nanoTime();
+  }
+
+  /** Starts measuring now. */
+  public static StallAwareStopwatch start() {
+    return new StallAwareStopwatch(JvmStallMonitor::accumulatedStallNanos);
+  }
+
+  /** Starts measuring against a caller-supplied stall source, so the accounting can be driven deterministically. */
+  static StallAwareStopwatch startWith(final LongSupplier stallNanos) {
+    return new StallAwareStopwatch(stallNanos);
+  }
+
+  /**
+   * The raw stall counter, for tests that time a sequence of instants rather than one window and so cannot use a
+   * stopwatch: sample it alongside each {@code System.nanoTime()} and difference both to get a stall-free gap.
+   * Only differences between two readings are meaningful.
+   */
+  public static long jvmStallNanos() {
+    return JvmStallMonitor.accumulatedStallNanos();
+  }
+
+  /** Raw wall-clock time since {@link #start()}, stalls included. */
+  public long elapsedMs() {
+    return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - beginNanos);
+  }
+
+  /** How much of {@link #elapsedMs()} the JVM as a whole spent not running. */
+  public long stallMs() {
+    return TimeUnit.NANOSECONDS.toMillis(Math.max(0L, stallNanos.getAsLong() - beginStallNanos));
+  }
+
+  /** {@link #elapsedMs()} without the stall: the time the operation could actually have been using. */
+  public long effectiveMs() {
+    return Math.max(0L, elapsedMs() - stallMs());
+  }
+
+  /**
+   * Asserts the operation gave up rather than running to its unbounded end. The bound is a tripwire between the
+   * two, not a latency budget, so it should sit well clear of both sides.
+   *
+   * @param boundMs         the tripwire
+   * @param whatItSeparates what the bound discriminates, e.g. "a 200ms deadline from an unbounded match"
+   */
+  public StallAwareStopwatch assertGaveUpWithin(final long boundMs, final String whatItSeparates) {
+    return check(boundMs, "gave up within %,d ms", whatItSeparates,
+        "This bound is a tripwire separating " + whatItSeparates + ", not a latency budget: widening it is safe, "
+            + "narrowing it is what would break.");
+  }
+
+  /**
+   * Asserts the operation stayed under a bound that IS the assertion - the only practical expression of a
+   * complexity claim (a regex that must not backtrack exponentially, a deadline shared across rows instead of
+   * charged per row).
+   *
+   * @param boundMs the bound the claim rests on
+   * @param claim   what the bound proves, e.g. "one shared 200ms budget, not ten independent per-row ones"
+   */
+  public StallAwareStopwatch assertStayedUnder(final long boundMs, final String claim) {
+    return check(boundMs, "stayed under %,d ms", claim,
+        "This bound IS the assertion (" + claim + "): loosening it deletes the test. If it is red on a healthy "
+            + "machine, the behaviour regressed.");
+  }
+
+  private StallAwareStopwatch check(final long boundMs, final String what, final String subject, final String advice) {
+    final long elapsedMs = elapsedMs();
+    final long stallMs = stallMs();
+    assertThat(Math.max(0L, elapsedMs - stallMs))
+        .as(what + " [%s]%n  measured %,d ms, of which %,d ms the JVM was stalled (stop-the-world pause or CPU "
+            + "starvation, discounted).%n  %s", boundMs, subject, elapsedMs, stallMs, advice)
+        .isLessThan(boundMs);
+    return this;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatch.java
+++ b/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatch.java
@@ -119,6 +119,9 @@ public final class StallAwareStopwatch {
   }
 
   private StallAwareStopwatch check(final long boundMs, final String what, final String subject, final String advice) {
+    // The two reads are separate snapshots, and the order matters: sampling the stall AFTER the elapsed time means
+    // the stall window can only be wider than the elapsed one, never narrower, so the discount can only come out
+    // too generous. Read the other way round it could come out too small and fail a run that was fine.
     final long elapsedMs = elapsedMs();
     final long stallMs = stallMs();
     assertThat(Math.max(0L, elapsedMs - stallMs))

--- a/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatchTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatchTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces #6260 and covers its fix: the wall-clock bounds in the engine suite went red on the shared JVM's
+ * stop-the-world pauses rather than on the behaviour they test. {@code AsyncShutdownDrainTest} measured 27 396 ms
+ * for a {@code close()} bounded by a 1 s timeout plus a 2 s join, and {@code Issue6199DrainWakeupTest} measured
+ * 24 143 ms for a wait bounded by 200 ms - both while the code behaved correctly.
+ * <p>
+ * The stall is injected here rather than provoked, because provoking a multi-second stop-the-world pause on
+ * demand is exactly as unreliable as the flake being fixed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class StallAwareStopwatchTest {
+
+  @Test
+  void aStalledJvmNoLongerFailsABoundTheCodeRespected() {
+    final AtomicLong stallNanos = new AtomicLong();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.startWith(stallNanos::get);
+
+    // The observed failure: 27,396ms measured for an operation whose honest cost is a few seconds, because the
+    // JVM spent ~24s of the window not running.
+    busyElapse(120);
+    stallNanos.set(TimeUnit.MILLISECONDS.toNanos(24_000));
+
+    assertThat(stopwatch.stallMs()).isEqualTo(24_000);
+    assertThat(stopwatch.effectiveMs()).isZero();
+
+    // Pre-fix this same window failed a 15s bound. It is the JVM's mood that changed, not the code's behaviour.
+    stopwatch.assertGaveUpWithin(15_000, "a 1s close timeout from a 60s wedged worker");
+    stopwatch.assertStayedUnder(1_000, "one shared budget, not ten independent ones");
+  }
+
+  @Test
+  void aGenuinelySlowOperationStillFails() {
+    // No stall to hide behind: the bound has to still be able to go red, or the fix would have deleted the tests
+    // it was meant to save.
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.startWith(() -> 0L);
+    busyElapse(120);
+
+    assertThatThrownBy(() -> stopwatch.assertStayedUnder(50, "one shared budget, not ten independent ones"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("loosening it deletes the test");
+    assertThatThrownBy(() -> stopwatch.assertGaveUpWithin(50, "a deadline from an unbounded match"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("tripwire");
+  }
+
+  @Test
+  void aStallLargerThanTheWindowDoesNotProduceNegativeTime() {
+    final AtomicLong stallNanos = new AtomicLong();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.startWith(stallNanos::get);
+
+    busyElapse(20);
+    // A stall straddling the start of the window is attributed to it in full, so the discount can legitimately
+    // exceed the window itself. It must clamp rather than run negative.
+    stallNanos.set(TimeUnit.HOURS.toNanos(1));
+
+    assertThat(stopwatch.effectiveMs()).isZero();
+    stopwatch.assertStayedUnder(1, "a stall wider than the window cannot make the measurement negative");
+  }
+
+  @Test
+  void blockingIsNotDiscountedAsAStall() throws Exception {
+    // The measured thread sleeping is not the JVM stalling: the sampler keeps ticking, so the second is charged
+    // in full. Anything else and every test that waits on a latch would become unbounded.
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    Thread.sleep(1_000);
+
+    assertThat(stopwatch.elapsedMs()).isGreaterThanOrEqualTo(1_000);
+    // Deliberately lenient: this test runs on the same shared JVM as everything else, so it must not itself
+    // depend on the machine being idle. Discounting 90% of a plain sleep would take real starvation, and that
+    // is the one case where discounting it is the right answer anyway.
+    assertThat(stopwatch.effectiveMs())
+        .as("a sleeping test thread must still be charged for the time it slept")
+        .isGreaterThan(100);
+  }
+
+  @Test
+  void routineParkJitterIsNotChargedAsAStall() {
+    assertThat(JvmStallMonitor.stallNanosForGap(JvmStallMonitor.TICK_NANOS)).isZero();
+    assertThat(JvmStallMonitor.stallNanosForGap(JvmStallMonitor.TICK_NANOS + JvmStallMonitor.TOLERANCE_NANOS)).isZero();
+    assertThat(JvmStallMonitor.stallNanosForGap(0)).isZero();
+  }
+
+  @Test
+  void aGapWiderThanTheToleranceIsChargedInFull() {
+    final long gapNanos = TimeUnit.SECONDS.toNanos(24) + JvmStallMonitor.TICK_NANOS + JvmStallMonitor.TOLERANCE_NANOS;
+
+    assertThat(JvmStallMonitor.stallNanosForGap(gapNanos)).isEqualTo(TimeUnit.SECONDS.toNanos(24));
+  }
+
+  @Test
+  void theMonitorStartsOnFirstUseAndOnlyEverAccumulates() {
+    final long before = JvmStallMonitor.accumulatedStallNanos();
+    busyElapse(50);
+    final long after = JvmStallMonitor.accumulatedStallNanos();
+
+    assertThat(before).isNotNegative();
+    assertThat(after).as("readings must be monotonic, or differencing them would be meaningless").isGreaterThanOrEqualTo(before);
+    assertThat(Thread.getAllStackTraces().keySet().stream().anyMatch(t -> JvmStallMonitor.THREAD_NAME.equals(t.getName())))
+        .as("reading the counter must have started the sampler")
+        .isTrue();
+  }
+
+  /** Burns wall-clock time without parking, so the window is real for both the stopwatch and the sampler. */
+  private static void busyElapse(final long millis) {
+    final long untilNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(millis);
+    while (System.nanoTime() < untilNanos)
+      Thread.onSpinWait();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/TimeBoundRegexTest.java
@@ -53,14 +53,13 @@ class TimeBoundRegexTest {
     final Pattern pathological = Pattern.compile("(.*a){20}$");
     final String input = "a".repeat(40) + "!";
 
-    final long begin = System.nanoTime();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> TimeBoundRegex.matches(pathological, input, 200))
         .isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
 
     // Generous upper bound: proves the match was aborted near the requested deadline rather than
     // merely being slow (the unbounded match takes tens of seconds).
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the requested 200ms deadline from an unbounded match");
   }
 
   @Test
@@ -80,12 +79,11 @@ class TimeBoundRegexTest {
     final Pattern pathological = Pattern.compile("(.*a){20}$");
     final String input = "a".repeat(40) + "!";
 
-    final long begin = System.nanoTime();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> TimeBoundRegex.replaceAll(pathological, input, "x", 200))
         .isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
 
-    assertThat(elapsedMillis).isLessThan(5000);
+    stopwatch.assertGaveUpWithin(5000, "the requested 200ms deadline from an unbounded match");
   }
 
   @Test
@@ -98,18 +96,17 @@ class TimeBoundRegexTest {
     final long deadline = TimeBoundRegex.newDeadline(200);
 
     // First call consumes the whole 200ms budget and trips the deadline.
-    final long begin = System.nanoTime();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     assertThatThrownBy(() -> TimeBoundRegex.replaceAllUntil(pathological, input, "x", deadline))
         .isInstanceOf(TimeoutException.class);
     // A second call against the same (now-expired) shared deadline must fail almost immediately, not run for
     // another full budget - proving the deadline is a shared, absolute point in time, not a per-call timeout.
     assertThatThrownBy(() -> TimeBoundRegex.replaceAllUntil(pathological, input, "x", deadline))
         .isInstanceOf(TimeoutException.class);
-    final long elapsedMillis = (System.nanoTime() - begin) / 1_000_000L;
 
     // Two independent 200ms budgets would take >= 400ms; a shared deadline keeps both calls close to the
     // single 200ms bound instead.
-    assertThat(elapsedMillis).isLessThan(1000);
+    stopwatch.assertStayedUnder(1000, "one 200ms deadline shared by both calls, not one each");
   }
 
   @Test


### PR DESCRIPTION
Fixes #6260.

## The problem

Two engine tests went red in a full-suite run **while the code behaved correctly**:

| test | bounded by | measured |
|---|---|---|
| `AsyncShutdownDrainTest.closeDoesNotHangOnAWedgedAsyncWorker` | a ~1 s `ASYNC_CLOSE_TIMEOUT` plus a 2 s join | **27,396 ms** |
| `Issue6199DrainWakeupTest.theResidualDrainKeepsItsHardDeadline` | a 200 ms deadline | **24,143 ms** |

Both pass in isolation. Late in a 12,000-test single-JVM run a stop-the-world pause of tens of seconds is not exotic, and any assertion whose headroom is smaller than that becomes a coin flip on the JVM's mood rather than a statement about the code.

## Why the issue's own proposal is not enough, and what this does instead

The issue proposes reclassifying each bound and widening the ones that are only tripwires. That is right as far as it goes, but it cannot cover the set. `grep` turns up 40 elapsed-time assertions in the engine suite, and a large family of them reads:

```java
// 10 independent 200ms-per-row budgets would take >= 2000ms; a shared deadline keeps the whole
// evaluation close to the single configured 200ms bound instead.
assertThat(elapsedMillis).isLessThan(1000);
```

That 1000 **cannot** be widened. It is discriminating one shared 200 ms deadline from ten independent per-row ones, so the moment it goes past 2000 the assertion stops asserting anything. Widening it is not a repair, it is a deletion. And the same stall that broke the two named tests breaks these too - it is simply luckier so far.

So instead of adjusting the numbers, this fixes the **measurement**. A daemon sampler parks for 10 ms at a time and accumulates, into a monotonic counter, however much longer than that each park actually took. The difference of two readings is the JVM-wide stall observed inside that interval; subtracting it from a wall-clock measurement over the same interval leaves the time the JVM was actually running. Every bound stays exactly as tight as it was, and none of them can be tripped by a pause.

```java
final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
assertThatThrownBy(...).isInstanceOf(TimeoutException.class);
stopwatch.assertStayedUnder(1000, "one 200ms budget shared by the whole evaluation, not one per row");
```

What is deliberately **not** discounted: time the measured thread spends sleeping, parked or blocked on I/O. The sampler keeps ticking then, so a test that waits a second is still charged a second - only a stall that also stops the sampler is taken out. Otherwise every latch wait in the suite would silently become unbounded. The sampler also runs at the default thread priority on purpose: it is a proxy for the measured thread, so it has to lose the same races for a core. Raising it would let it tick straight through the CPU starvation the measured thread is suffering, and starvation is the half of the problem a GC-pause-only view cannot see.

## The two assertions, and why there are two

They differ only in the failure message, and that is the point - the message is what stops the next person from "fixing" a red run by loosening the number:

- **`assertGaveUpWithin(bound, whatItSeparates)`** - the bound is a tripwire between a bounded operation and an unbounded one. Generous is free here; a wider bound cannot turn a passing run red. Failure says so explicitly.
- **`assertStayedUnder(bound, claim)`** - the bound IS the assertion, standing in for a complexity claim with no other practical expression (a regex that must not backtrack exponentially, a deadline shared across rows rather than charged per row). Failure says loosening it deletes the test.

A short wait expected to TIME OUT needs neither, and neither does a lower bound: a stall only makes those more true.

## Scope

40 assertions across 26 test classes converted. Per the taxonomy above:

- **Left alone** - the `isGreaterThanOrEqualTo` sites in `SQLScriptAdditionalCoverageTest`, `CodeUtilsTest`, `PaginatedSparseVectorEngineBackpressureTest`, `Issue5693TxRetryDelayScopeTest`.
- **Split** - the two `isBetween` sites (`FlushRobustnessTest`, `Issue6125SnapshotBarrierAndCapTest`) now read raw wall clock for the floor (which proves the wait really blocked) and the discounted time for the ceiling.
- **Sampled per gap** - `Issue5587TxRetryExponentialBackoffTest` compares the sum of early retry gaps against the sum of late ones. A pause landing in either half skews the ratio, so it now samples the stall counter alongside each timestamp and differences both.
- **`@Timeout` raised** - three annotations at 30 s on tests whose own budget is already 16 s or more. JUnit's timeout is plain wall clock and cannot be discounted, so it has to be sized as a hang detector, not as a latency bound.

`CLAUDE.md` gains the rule so new tests do not reintroduce the pattern.

## Verification

- `StallAwareStopwatchTest` reproduces the reported failure directly: with a 24 s stall injected into the window, a measurement that failed a 15 s bound pre-fix now passes, while an equally slow operation with no stall to hide behind **still fails** - the fix must not have deleted the tests it was meant to save. The stall is injected rather than provoked because provoking a multi-second stop-the-world pause on demand is exactly as unreliable as the flake being fixed.
- Full `engine` suite: **12,093 tests, 0 failures, 0 errors** (`mvn -o -pl engine -am test -DexcludedGroups=benchmark,vector,slow`), plus the `slow` and `vector` lanes for the touched classes.

## Files

New (engine test sources):
- `engine/src/test/java/com/arcadedb/utility/JvmStallMonitor.java`
- `engine/src/test/java/com/arcadedb/utility/StallAwareStopwatch.java`
- `engine/src/test/java/com/arcadedb/utility/StallAwareStopwatchTest.java`

The helper lives in the `engine` test-jar, so the `server` and protocol modules can adopt it for their own timing assertions in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yjKJXMNMQeLPKdCno7cFX