### PR TITLE
fix(#6259): a committer waits for flush-queue room before the page-manager lock, not inside it

### DIFF
--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -332,6 +332,7 @@ public class Profiler {
     json.put("snapshotBarrierMaxTime", new JSONObject().put("value", pStats.snapshotBarrierMaxMillis));
     json.put("snapshotBarriersInexact", new JSONObject().put("count", pStats.snapshotBarriersInexact));
     json.put("deferredRAM", new JSONObject().put("space", pStats.deferredRAMBytes));
+    json.put("pageFlushQueueWaits", new JSONObject().put("count", pStats.flushQueueWaits));
 
     final long freeSpace = new File(".").getFreeSpace();
     final long totalSpace = new File(".").getTotalSpace();
@@ -497,8 +498,8 @@ public class Profiler {
       buffer.append("%n INDEXES compactions=%d".formatted(indexCompactions));
 
       buffer.append(
-        "%n PAGE-MANAGER flushQueue=%d deferredRAM=%s cacheHits=%d cacheMiss=%d concModExceptions=%d evictionRuns=%d pagesEvicted=%d".formatted(
-          pageFlushQueueLength, FileUtils.getSizeAsString(pStats.deferredRAMBytes),
+        "%n PAGE-MANAGER flushQueue=%d flushQueueWaits=%d deferredRAM=%s cacheHits=%d cacheMiss=%d concModExceptions=%d evictionRuns=%d pagesEvicted=%d".formatted(
+          pageFlushQueueLength, pStats.flushQueueWaits, FileUtils.getSizeAsString(pStats.deferredRAMBytes),
           pageCacheHits, pageCacheMiss, concurrentModificationExceptions, evictionRuns, pagesEvicted));
 
       // #5608: read this line together with concModExceptions above. Contention absorbed by a merge never becomes a

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -245,6 +245,8 @@ public class PageManager extends LockContext {
     public long   snapshotBarriersInexact;
     /** See {@link PageManager#getDeferredRAMBytes()} (#6087): dirty pages held in RAM by a flush suspension. */
     public long   deferredRAMBytes;
+    /** See {@link PageManager#getFlushQueueWaits()} (#6259): commits held waiting for room in the flush queue. */
+    public long   flushQueueWaits;
   }
 
   private PageManager() {
@@ -919,6 +921,21 @@ public class PageManager extends LockContext {
   }
 
   /**
+   * How many times a writer had to WAIT for room in the bounded flush queue instead of being admitted straight away
+   * (issue #6259) - that is, how often the disk has not kept up with the write rate.
+   * <p>
+   * The companion of {@code pageFlushQueueLength} and the number that queue length cannot give: the length is an
+   * instant, sampled between two bursts as easily as during one, while this is cumulative evidence that commits were
+   * actually held. Rising while the length reads low means the pipeline is saturating in bursts.
+   *
+   * @return 0 when nothing has ever been throttled, or when the page manager is closed.
+   */
+  public long getFlushQueueWaits() {
+    final PageManagerFlushThread thread = flushThread;
+    return thread != null ? thread.queueSlotWaits.get() : 0L;
+  }
+
+  /**
    * The same backlog as {@link #getDeferredRAMBytes}, for a single database (issue #6200): the number that says WHICH
    * suspension is costing the heap, which the JVM-wide total cannot.
    *
@@ -1164,20 +1181,30 @@ public class PageManager extends LockContext {
    */
   public void publishPages(final List<MutablePage> pagesToWrite, final Map<PageId, MutablePage> newPages,
       final boolean asyncFlush) throws IOException, InterruptedException {
-    // OUTSIDE THE LOCK, AND THAT IS THE ENTIRE POINT (issue #6200): while a database is suspended its dirty pages
-    // pile up in RAM, and the cap that bounds that backlog is served by holding ITS committers here. Held one line
-    // lower - inside lock() - the wait would be served while holding a JVM-WIDE lock, so throttling the committers
-    // of the one suspended database would stall the committers of every other database with them.
-    if (asyncFlush)
+    // BOTH WAITS ARE OUTSIDE THE LOCK, AND THAT IS THE ENTIRE POINT (issues #6200 and #6259). Publication holds the
+    // JVM-wide page-manager lock across BOTH of its halves - the page write and the flush enqueue - because the
+    // snapshot t0 barrier (#6075/#6125) rests on exactly that, so the enqueue cannot move out; what can, and must, is
+    // everything the enqueue might WAIT for. Served one line lower, inside lock(), each of these would be charged to
+    // every committer of every database in the process:
+    //   - #6200: while a database is suspended its dirty pages pile up in RAM, and the cap that bounds that backlog
+    //     is served by holding ITS committers.
+    //   - #6259: when the bounded flush queue fills - a write burst, a slow volume, an fsync spike - the committer
+    //     waits for room HERE, and reaches its offer inside the lock with a slot already reserved for it.
+    boolean flushSlotReserved = false;
+    if (asyncFlush) {
       awaitDeferredBacklogUnderCap(pagesToWrite);
+      flushSlotReserved = reserveFlushQueueSlot(pagesToWrite);
+    }
 
+    boolean handedOver = false;
     lock();
     try {
       // Write pages (and put in readCache) BEFORE updating pageCount, otherwise concurrent
       // transactions can observe pageCount > readCache state and treat the new page as a
       // pre-existing empty page (sparse-file semantics), allowing two records' chunk chains
       // to land on the same physical slot.
-      writePagesNoBackpressure(pagesToWrite, asyncFlush);
+      handedOver = true;
+      writePagesNoBackpressure(pagesToWrite, asyncFlush, flushSlotReserved);
 
       if (newPages != null)
         for (final MutablePage p : newPages.values()) {
@@ -1190,6 +1217,11 @@ public class PageManager extends LockContext {
 
     } finally {
       unlock();
+      if (flushSlotReserved && !handedOver)
+        // Nothing between the reservation and the call below can throw today (lock() is a plain ReentrantLock), so
+        // this is insurance rather than a live path - but a reservation dropped on the floor would shrink the flush
+        // pipeline by one slot for the life of the process, which is not a failure mode worth leaving to inspection.
+        releaseFlushQueueSlot();
     }
   }
 
@@ -1334,6 +1366,7 @@ public class PageManager extends LockContext {
     stats.snapshotBarrierMaxMillis = maxSnapshotBarrierMillis.get();
     stats.snapshotBarriersInexact = totalSnapshotBarriersInexact.get();
     stats.deferredRAMBytes = getDeferredRAMBytes();
+    stats.flushQueueWaits = getFlushQueueWaits();
     collectSnapshotGauges(stats);
     return stats;
   }
@@ -1394,30 +1427,74 @@ public class PageManager extends LockContext {
 
   public void writePages(final List<MutablePage> updatedPages, final boolean asyncFlush) throws IOException, InterruptedException {
     // Entry point of the asynchronous writers that do NOT go through publishPages (LSM index compaction): they hold
-    // no page-manager lock, so the deferred-backlog cap of #4728 can be served right here (issue #6200).
-    if (asyncFlush)
+    // no page-manager lock, so the deferred-backlog cap of #4728 (issue #6200) and the flush-queue admission control
+    // (issue #6259) are both served right here, in the same order and for the same reasons as in publishPages.
+    boolean flushSlotReserved = false;
+    if (asyncFlush) {
       awaitDeferredBacklogUnderCap(updatedPages);
-    writePagesNoBackpressure(updatedPages, asyncFlush);
+      flushSlotReserved = reserveFlushQueueSlot(updatedPages);
+    }
+    writePagesNoBackpressure(updatedPages, asyncFlush, flushSlotReserved);
   }
 
   /**
-   * {@link #writePages} without the deferred-backlog wait, for the one caller that has already served it before
-   * taking the page-manager lock: {@link #publishPages} (issue #6200).
+   * {@link #writePages} without the two waits that must be served before the page-manager lock, for the caller that
+   * has already served them: {@link #publishPages} (issues #6200 and #6259).
+   *
+   * @param flushSlotReserved a flush-queue reservation taken by the caller before it took the lock. This method owns
+   *                          it from here on - handing it to the enqueue, or giving it back on any path that does not
+   *                          reach one - so the caller must not release it again.
    */
-  private void writePagesNoBackpressure(final List<MutablePage> updatedPages, final boolean asyncFlush)
-      throws IOException, InterruptedException {
-    if (asyncFlush) {
-      for (final MutablePage page : updatedPages)
-        putPageInReadCache(new CachedPage(page, true));
-      flushThread.scheduleFlushOfPages(updatedPages);
-    } else {
-      // SYNCHRONOUS FLUSH
-      for (final MutablePage page : updatedPages) {
-        flushPage(page);
-        // ADD THE PAGE IN TO READ CACHE. FROM THIS POINT THE PAGE IS NEVER MODIFIED, SO IT CAN BE CACHED
-        putPageInReadCache(new CachedPage(page, false));
+  private void writePagesNoBackpressure(final List<MutablePage> updatedPages, final boolean asyncFlush,
+      final boolean flushSlotReserved) throws IOException, InterruptedException {
+    boolean handedOver = false;
+    try {
+      if (asyncFlush) {
+        for (final MutablePage page : updatedPages)
+          putPageInReadCache(new CachedPage(page, true));
+        handedOver = true;
+        flushThread.scheduleFlushOfPages(updatedPages, flushSlotReserved);
+      } else {
+        // SYNCHRONOUS FLUSH
+        for (final MutablePage page : updatedPages) {
+          flushPage(page);
+          // ADD THE PAGE IN TO READ CACHE. FROM THIS POINT THE PAGE IS NEVER MODIFIED, SO IT CAN BE CACHED
+          putPageInReadCache(new CachedPage(page, false));
+        }
       }
+    } finally {
+      if (flushSlotReserved && !handedOver)
+        // The read-cache loop above threw: the enqueue was never reached, so the slot goes back rather than being
+        // held by a publication that is not going to happen.
+        releaseFlushQueueSlot();
     }
+  }
+
+  /**
+   * Reserves the flush-queue slot the enqueue inside the page-manager lock will need, waiting HERE - outside that
+   * lock - for as long as the queue is full (issue #6259). See
+   * {@link PageManagerFlushThread#reserveQueueSlot()} for why the wait cannot live where the enqueue does.
+   *
+   * @return {@code false} when there is nothing to enqueue, or when the flush thread is shutting down: either way no
+   *     reservation is held and none has to be released.
+   */
+  private boolean reserveFlushQueueSlot(final List<MutablePage> pages) throws InterruptedException {
+    final PageManagerFlushThread thread = flushThread;
+    if (thread == null || pages == null || pages.isEmpty())
+      return false;
+    return thread.reserveQueueSlot();
+  }
+
+  /**
+   * Gives back a reservation that never reached an enqueue. Re-reads the field rather than capturing the thread that
+   * granted it: the only way to observe a different one here is a full page-manager shutdown and restart in the
+   * window, which needs every database in the JVM to have been closed mid-publication - and would have thrown at the
+   * enqueue long before reaching this.
+   */
+  private void releaseFlushQueueSlot() {
+    final PageManagerFlushThread thread = flushThread;
+    if (thread != null)
+      thread.releaseQueueReservation(false);
   }
 
   protected void flushPage(final MutablePage page) throws IOException {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1218,9 +1218,11 @@ public class PageManager extends LockContext {
     } finally {
       unlock();
       if (flushSlotReserved && !handedOver)
-        // Nothing between the reservation and the call below can throw today (lock() is a plain ReentrantLock), so
-        // this is insurance rather than a live path - but a reservation dropped on the floor would shrink the flush
-        // pipeline by one slot for the life of the process, which is not a failure mode worth leaving to inspection.
+        // Not a live path TODAY - nothing between the reservation and the hand-off below can throw, lock() being a
+        // plain ReentrantLock - but it is not a comment about today: this covers ANY future statement inserted
+        // between them that throws, which is exactly the refactor that would otherwise strand a reservation. And a
+        // stranded one is silent and permanent: the flush pipeline is one slot smaller for the life of the process,
+        // with nothing in a running system ever pointing at it (review of #6269).
         releaseFlushQueueSlot();
     }
   }
@@ -1464,8 +1466,9 @@ public class PageManager extends LockContext {
       }
     } finally {
       if (flushSlotReserved && !handedOver)
-        // The read-cache loop above threw: the enqueue was never reached, so the slot goes back rather than being
-        // held by a publication that is not going to happen.
+        // The read-cache loop above threw, or anything a later refactor puts before the hand-off does: the enqueue
+        // was never reached, so the slot goes back rather than being held by a publication that is not going to
+        // happen. Unlike its twin in publishPages this one IS reachable today - putPageInReadCache does I/O.
         releaseFlushQueueSlot();
     }
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -81,7 +81,7 @@ public class PageManagerFlushThread extends Thread {
   /** Default of {@link #queueSlotWaitPollMillis}. */
   private final static long                                                     DEFAULT_QUEUE_SLOT_WAIT_POLL_MILLIS = 100;
   /** How long a committer may be held waiting for a flush-queue slot before saying so, once, at WARNING. */
-  private final static long                                                     QUEUE_SLOT_WARN_MILLIS            = 10_000;
+  private final static long                                                     QUEUE_SLOT_WARN_MILLIS              = 10_000;
   /**
    * Fallback wake-up interval of {@link #waitAllPagesOfDatabaseAreFlushed(Database)}, per instance so the
    * regression test of issue #6199 can stretch it far enough to prove the wait is released by the drain

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -77,6 +78,10 @@ public class PageManagerFlushThread extends Thread {
   private final static long                                                     DEFERRED_BACKLOG_WAIT_POLL_MILLIS = 100;
   /** How long a committer may be held by the deferred-backlog cap before saying so, once, at WARNING. */
   private final static long                                                     DEFERRED_BACKLOG_WARN_MILLIS      = 10_000;
+  /** Default of {@link #queueSlotWaitPollMillis}. */
+  private final static long                                                     DEFAULT_QUEUE_SLOT_WAIT_POLL_MILLIS = 100;
+  /** How long a committer may be held waiting for a flush-queue slot before saying so, once, at WARNING. */
+  private final static long                                                     QUEUE_SLOT_WARN_MILLIS            = 10_000;
   /**
    * Fallback wake-up interval of {@link #waitAllPagesOfDatabaseAreFlushed(Database)}, per instance so the
    * regression test of issue #6199 can stretch it far enough to prove the wait is released by the drain
@@ -86,6 +91,16 @@ public class PageManagerFlushThread extends Thread {
    * bounds how often the no-progress timeout below is re-evaluated, and how long a lost notification would cost.
    */
   long                                                                          flushWaitPollMillis = DEFAULT_FLUSH_WAIT_POLL_MILLIS;
+  /**
+   * Fallback wake-up interval of {@link #reserveQueueSlot}. Every slot the flush thread frees is signalled, so this
+   * only bounds how often a parked committer re-reads the one condition that is NOT signalled - the shutdown flag -
+   * and how long a lost notification would cost.
+   * <p>
+   * Per instance, not static, for the same reason {@link #flushWaitPollMillis} is: the regression test of #6259
+   * stretches it far enough to prove the wait is released by the poll's signal rather than by the interval elapsing,
+   * and a static would leak that value into every other test class sharing the JVM.
+   */
+  long                                                                          queueSlotWaitPollMillis = DEFAULT_QUEUE_SLOT_WAIT_POLL_MILLIS;
   // Package-private so the white-box regression test for issue #5068 can fabricate an in-flight batch and
   // deterministically exercise an interrupt during waitForCurrentFlushToComplete.
   final                AtomicReference<PagesToFlush>                            nextPagesToFlush    = new AtomicReference<>();
@@ -117,6 +132,48 @@ public class PageManagerFlushThread extends Thread {
    * {@link #awaitDeferredBacklogUnderCap}. {@code 0} disables the cap (unbounded, pre-#4728 behavior).
    */
   private final        long                                   maxDeferredRAM;
+
+  /** Capacity of {@link #queue}, the ceiling the admission control of {@link #reserveQueueSlot} enforces (#6259). */
+  private final        int                                    queueCapacity;
+
+  /**
+   * Slots of {@link #queue} promised to a caller that has not enqueued its batch yet (issue #6259).
+   * <p>
+   * A reservation is what lets {@code PageManager.publishPages} wait for queue room BEFORE taking the JVM-wide
+   * page-manager lock and still find the room when it enqueues one line later, inside it. Admission is granted only
+   * while {@code queue.size() + reservations < queueCapacity}, so the sum never exceeds the capacity and the holder
+   * of a reservation is guaranteed a free slot: its {@code offer} inside the lock cannot block.
+   * <p>
+   * Deliberately derived from the QUEUE'S OWN size rather than from a permit counter mirroring it (a
+   * {@link java.util.concurrent.Semaphore} sized to the capacity was the obvious alternative). A permit count has to
+   * be kept in step with the queue by hand at every enqueue and every poll, and a single missed release silently
+   * shrinks the pipeline for the life of the process; reading the queue tells the truth by construction, so a batch
+   * that reaches the queue by any other route - a white-box test, a future call site - narrows admission instead of
+   * corrupting the bound. The cost is one {@code ArrayBlockingQueue.size()} per publication, which takes the same
+   * internal lock the {@code offer} on the next line takes anyway.
+   * <p>
+   * Package-private so the regression test of #6259 can assert the one thing inspection cannot: that every path out
+   * of a publication gives its reservation back. A leaked one is invisible and permanent - it shrinks the pipeline
+   * by a slot for the life of the process.
+   */
+  final                AtomicInteger                          queueReservations = new AtomicInteger();
+
+  /**
+   * How many callers are parked in {@link #reserveQueueSlot}. Read (not taken) by the flush thread on every poll, so
+   * the common case - nobody waiting, the queue nowhere near full - costs one volatile read per batch instead of a
+   * monitor. Same shape as the drain signal of #6199.
+   */
+  private final        AtomicInteger                          queueSlotWaiters  = new AtomicInteger();
+
+  /** Monitor the callers of {@link #reserveQueueSlot} park on; notified whenever a batch leaves {@link #queue}. */
+  private final        Object                                 queueSlotLock     = new Object();
+
+  /**
+   * How many times a caller had to WAIT for a flush-queue slot rather than being admitted straight away. Exposed
+   * (package-private) because that is the difference between the two shapes of this backpressure the regression test
+   * of #6259 has to tell apart: waiting outside the page-manager lock, or blocking inside it.
+   */
+  final                AtomicLong                             queueSlotWaits    = new AtomicLong();
 
   /**
    * Per-database count of pages that LEFT the flush pipeline: the progress signal for
@@ -219,32 +276,171 @@ public class PageManagerFlushThread extends Thread {
     setDaemon(true);
     this.pageManager = pageManager;
     this.logContext = LogManager.instance().getContext();
-    this.queue = new ArrayBlockingQueue<>(configuration.getValueAsInteger(GlobalConfiguration.PAGE_FLUSH_QUEUE));
+    this.queueCapacity = configuration.getValueAsInteger(GlobalConfiguration.PAGE_FLUSH_QUEUE);
+    this.queue = new ArrayBlockingQueue<>(queueCapacity);
     final long maxDeferredMB = configuration.getValueAsLong(GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM);
     this.maxDeferredRAM = maxDeferredMB > 0 ? maxDeferredMB * 1024 * 1024 : 0;
   }
 
+  /**
+   * Enqueues a batch for the flush thread, reserving its queue slot HERE - which is why this overload exists and why
+   * the engine's own callers do not use it: they reserve before taking the page-manager lock (issue #6259).
+   */
   public void scheduleFlushOfPages(final List<MutablePage> pages) throws InterruptedException {
-    if (pages.isEmpty())
-      // AVOID INSERTING AN EMPTY LIST BECAUSE IS USED TO SHUTDOWN THE THREAD
-      return;
+    scheduleFlushOfPages(pages, false);
+  }
 
-    // Index pages BEFORE enqueueing so that getCachedPageFromMutablePageInQueue()
-    // can find them even if the queue.offer() hasn't completed yet.
-    pageIndex.putAll(pages);
-
-    // TRY TO INSERT THE PAGE IN THE QUEUE UNTIL THE THREAD IS STILL RUNNING
-    while (running) {
-      if (queue.offer(new PagesToFlush(pages), 1, TimeUnit.SECONDS))
+  /**
+   * @param slotReserved whether the caller already holds a reservation from {@link #reserveQueueSlot} - which it must
+   *                     have taken BEFORE the page-manager lock (issue #6259). This method releases it either way, so
+   *                     a reservation is handed over here exactly once and never leaks. When it is {@code false} the
+   *                     reservation is taken inline instead, and that wait is then served wherever the caller happens
+   *                     to be: <b>never call this form while holding the page-manager lock</b>.
+   */
+  void scheduleFlushOfPages(final List<MutablePage> pages, final boolean slotReserved) throws InterruptedException {
+    boolean reserved = slotReserved;
+    boolean enqueued = false;
+    try {
+      if (pages.isEmpty())
+        // AVOID INSERTING AN EMPTY LIST BECAUSE IS USED TO SHUTDOWN THE THREAD
         return;
+
+      if (!reserved) {
+        reserved = reserveQueueSlot();
+        if (!reserved) {
+          // SHUTTING DOWN: same outcome as the enqueue loop below giving up, and for the same reason.
+          logFailedEnqueue(pages);
+          return;
+        }
+      }
+
+      // Index pages BEFORE enqueueing so that getCachedPageFromMutablePageInQueue()
+      // can find them even if the queue.offer() hasn't completed yet.
+      pageIndex.putAll(pages);
+
+      // TRY TO INSERT THE PAGE IN THE QUEUE UNTIL THE THREAD IS STILL RUNNING. With a reservation in hand this
+      // succeeds on the first attempt - a reserved slot cannot be taken by another reserver - so the timed retry
+      // stays as the safety net it always was, for the one case the reservation does not cover: a batch that
+      // reached the queue without one (see queueReservations).
+      while (running) {
+        if (queue.offer(new PagesToFlush(pages), 1, TimeUnit.SECONDS)) {
+          enqueued = true;
+          return;
+        }
+      }
+
+      // Failed to enqueue (shutdown in progress) — remove from index
+      pageIndex.removeAll(pages);
+      logFailedEnqueue(pages);
+    } finally {
+      if (reserved)
+        // The batch occupies the slot from now on (or nothing does, and the slot is free for the next caller).
+        releaseQueueReservation(enqueued);
     }
+  }
 
-    // Failed to enqueue (shutdown in progress) — remove from index
-    pageIndex.removeAll(pages);
-
+  private void logFailedEnqueue(final List<MutablePage> pages) {
     LogManager.instance()
         .log(this, Level.SEVERE, "Error on flushing pages %s during shutdown of the database (running=%s queue=%d)", pages, running,
             queue.size());
+  }
+
+  /**
+   * Admission control on the bounded flush queue, and the reason a full queue no longer stalls the whole JVM
+   * (issue #6259).
+   * <p>
+   * {@code PageManager.publishPages} holds the JVM-wide page-manager lock across BOTH halves of publication - the
+   * page write and the flush enqueue - because the snapshot t0 barrier (#6075/#6125) rests on exactly that: it takes
+   * the same lock so that from there on no committer can put a page on disk OR into the flush pipeline. The enqueue
+   * therefore has to stay inside the lock, which leaves only one place for the WAIT to go: ahead of it. Before this,
+   * a committer that found the queue full parked in {@code queue.offer} <i>holding a lock every committer of every
+   * database in the process needs</i>, so one database's write burst against a slow volume serialized the commits of
+   * unrelated databases on idle ones. The queue filling is backpressure and is meant to hold the writers it belongs
+   * to; what was wrong is only that the wait was charged to everybody. Same distinction, and same fix, as #6200 drew
+   * for the deferred-RAM cap.
+   * <p>
+   * <b>This must be called BEFORE the page-manager lock is taken</b>, and it must hold nothing the flush thread
+   * needs: it holds only {@link #queueSlotLock}, which the flush thread takes solely to notify (never to write), and
+   * the slot it waits for is freed by the poll itself, before any page is written. So a wedged disk delays this wait
+   * by at most the batch already being written, never indefinitely.
+   *
+   * @return {@code true} when a slot was reserved, and the caller must hand it to
+   *     {@link #scheduleFlushOfPages(List, boolean)} or give it back with {@link #releaseQueueReservation};
+   *     {@code false} when the flush thread is shutting down and nothing more will be enqueued.
+   */
+  boolean reserveQueueSlot() throws InterruptedException {
+    if (tryReserveQueueSlot())
+      // THE COMMON CASE: THE QUEUE HAS ROOM, AND THE PUBLICATION PATH PAYS ONE CAS FOR IT
+      return true;
+
+    final long beginTime = System.currentTimeMillis();
+    boolean reported = false;
+    queueSlotWaits.incrementAndGet();
+    queueSlotWaiters.incrementAndGet();
+    try {
+      while (running) {
+        synchronized (queueSlotLock) {
+          if (tryReserveQueueSlot())
+            return true;
+          queueSlotLock.wait(queueSlotWaitPollMillis);
+        }
+
+        // Reported from OUTSIDE the monitor: a log write is a file write, and holding this monitor across it would
+        // make the flush thread's own signal queue behind it. Once per held committer, not once per round.
+        if (!reported && System.currentTimeMillis() - beginTime > QUEUE_SLOT_WARN_MILLIS) {
+          reported = true;
+          LogManager.instance().log(this, Level.WARNING,
+              "Commits have been throttled for %d ms waiting for room in the page-flush queue: the disk is not keeping up with the write rate, or flushing is suspended. The queue holds %d of the %d batches allowed by '%s'",
+              null, System.currentTimeMillis() - beginTime, queue.size(), queueCapacity,
+              GlobalConfiguration.PAGE_FLUSH_QUEUE.getKey());
+        }
+      }
+      // SHUTTING DOWN. Deliberately no last-minute retry for a slot: the enqueue this reservation is for is itself
+      // gated on `running`, so a slot handed out now would be released unused one line later - and the batch is
+      // recovered from the WAL either way, its entry never having been acked.
+      return false;
+    } finally {
+      queueSlotWaiters.decrementAndGet();
+    }
+  }
+
+  /** Non-blocking half of {@link #reserveQueueSlot}: takes a slot only while the queue provably has one to give. */
+  private boolean tryReserveQueueSlot() {
+    while (true) {
+      final int reservations = queueReservations.get();
+      // The queue's own size, so a batch enqueued without a reservation narrows admission instead of overflowing it.
+      if (queue.size() + reservations >= queueCapacity)
+        return false;
+      if (queueReservations.compareAndSet(reservations, reservations + 1))
+        return true;
+    }
+  }
+
+  /**
+   * Gives a reservation back.
+   *
+   * @param enqueued whether the batch took the slot. When it did, the slot is now OCCUPIED and there is nothing to
+   *                 wake anybody for - the sum {@code size + reservations} is unchanged - which is what keeps the
+   *                 normal publication path from touching {@link #queueSlotLock} at all.
+   */
+  void releaseQueueReservation(final boolean enqueued) {
+    final int remaining = queueReservations.decrementAndGet();
+    // A count below zero means a reservation was released twice, and unlike a leak it fails OPEN: admission would
+    // then hand out more slots than the queue has, putting the enqueue it exists to protect back inside the
+    // page-manager lock. Asserted rather than clamped - a clamp would hide it, and the test lanes run with -ea,
+    // which is where such a bug gets written (same reasoning as the single-database batch assert in PagesToFlush).
+    assert remaining >= 0 : "flush-queue reservations went negative (" + remaining + ")";
+    if (!enqueued)
+      signalQueueSlotAvailable();
+  }
+
+  /** Wakes the callers parked in {@link #reserveQueueSlot}, if there are any: on the flush path, usually none. */
+  private void signalQueueSlotAvailable() {
+    if (queueSlotWaiters.get() == 0)
+      return;
+    synchronized (queueSlotLock) {
+      queueSlotLock.notifyAll();
+    }
   }
 
   @Override
@@ -342,6 +538,12 @@ public class PageManagerFlushThread extends Thread {
     final PagesToFlush pagesToFlush = queue.poll(timeout, TimeUnit.MILLISECONDS);
 
     if (pagesToFlush != null) {
+      // A slot is free: admit a committer waiting for one (issue #6259). Signalled HERE, before the batch is
+      // written, because the slot IS free from here - the batch has left the queue - and the point of the whole
+      // mechanism is that a slow write delays the writes, not the admission of the next committer. The read is one
+      // volatile load when nobody is waiting, which is the normal state of a queue that is not full.
+      signalQueueSlotAvailable();
+
       // Publish the entry immediately after polling so that getCachedPageFromMutablePageInQueue()
       // can find pages that are no longer in the queue but not yet flushed to disk.  This
       // minimizes the window where a page is invisible to getMostRecentVersionOfPage().
@@ -742,16 +944,32 @@ public class PageManagerFlushThread extends Thread {
         for (final PagesToFlush batch : newDeferred) {
           // The batch moves back to the main queue and leaves the deferred backlog accounting (issue #4728).
           addDeferredRAM(database, -batchRAM(batch));
-          while (running) {
-            try {
-              if (queue.offer(batch, 1, TimeUnit.SECONDS))
+          // Re-entering the bounded queue goes through the same admission control as any other enqueue (#6259):
+          // the batch gave its slot back when the flush thread polled it, and a resume can carry thousands of them,
+          // so without a reservation this loop could fill the queue under a committer that is holding one - putting
+          // that committer's offer back inside the page-manager lock, which is the whole bug. Blocking here is safe
+          // for the same reason the offer below always was: this runs outside every lock (see above).
+          boolean reserved = false;
+          boolean enqueued = false;
+          try {
+            reserved = reserveQueueSlot();
+            if (!reserved)
+              // SHUTTING DOWN: the remaining batches stay unwritten and are recovered from the WAL, as before.
+              break;
+            while (running) {
+              if (queue.offer(batch, 1, TimeUnit.SECONDS)) {
+                enqueued = true;
                 break;
+              }
               LogManager.instance().log(this, Level.WARNING,
                   "Page flush queue is full while re-enqueueing deferred batch for database '%s'; retrying", database.getName());
-            } catch (final InterruptedException e) {
-              Thread.currentThread().interrupt();
-              break;
             }
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            break;
+          } finally {
+            if (reserved)
+              releaseQueueReservation(enqueued);
           }
         }
       }
@@ -801,7 +1019,16 @@ public class PageManagerFlushThread extends Thread {
     // Release any committer parked on the deferred-backlog cap: its database may still be suspended, and the
     // backlog is only relieved by a resume that shutdown is not going to wait for (issue #6200).
     signalDeferredRAM();
-    queue.offer(SHUTDOWN_THREAD);
+    // And any committer waiting for a flush-queue slot, for the same reason: what it is waiting for is this thread
+    // polling, and this thread is on its way out (issue #6259).
+    signalQueueSlotAvailable();
+    // The sentinel takes a queue slot like any other batch, so it is admitted like one - but never WAITS for one:
+    // a full queue simply means no sentinel, and the run loop already exits on its own once `running` is false and
+    // the queue is drained. The sentinel is what makes that exit immediate, never what makes it happen. Admitting it
+    // through the same accounting is what keeps a reserved slot reserved: taken from under a committer that holds
+    // one, it would put that committer's offer back inside the page-manager lock (issue #6259).
+    if (tryReserveQueueSlot())
+      releaseQueueReservation(queue.offer(SHUTDOWN_THREAD));
     join();
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/Issue6259FlushQueueAdmissionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6259FlushQueueAdmissionTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6259.
+ * <p>
+ * {@code PageManager.publishPages} holds the JVM-wide page-manager lock across BOTH halves of publication - the page
+ * write and the flush enqueue - and it has to: the snapshot t0 barrier (#6075/#6125) takes that same lock precisely so
+ * that from there on no committer can put a page on disk OR into the flush pipeline. The enqueue blocked, though:
+ * {@code while (running) queue.offer(batch, 1, SECONDS)}. So whenever the bounded flush queue filled - a write burst, a
+ * slow or contended volume, an fsync spike, no suspension or backup involved - the committing thread parked in that
+ * offer <b>holding a lock every committer in the process needs</b>, and one database's burst serialized the commits of
+ * every unrelated database in the JVM, including ones on idle volumes whose pages could have been written immediately.
+ * <p>
+ * The queue is meant to backpressure the writers it belongs to; what was wrong is only that the wait was charged to
+ * everybody. So the wait moved ahead of the lock, exactly as #6200 moved the deferred-RAM cap: a committer now reserves
+ * its queue slot before {@code lock()} and reaches the enqueue with the slot already its own.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6259FlushQueueAdmissionTest extends TestHelper {
+  /** A file that does not exist, so a fabricated page can be driven through the pipeline without touching a real one. */
+  private static final int  FILE_ID               = 4_000;
+  private static final int  PAGE_SIZE             = 64;
+  /**
+   * Bounds only the waits expected to SUCCEED - the short windows asserting "not released yet" are written inline - so
+   * a generous value cannot turn a passing run red, while a tight one can under the stop-the-world pauses the shared
+   * 12000-test JVM produces late in a run (#6260).
+   */
+  private static final long ASSERTION_TIMEOUT_SEC = 60;
+
+  /**
+   * The heart of the issue, and the invariant rather than the symptom: while a committer waits for room in the flush
+   * queue, another thread must still be able to take the page-manager lock.
+   * <p>
+   * Before the fix that committer did its waiting inside the lock, so this test's second thread - which wants the lock
+   * for something that needs no queue slot at all - waited for a disk it has nothing to do with. Every commit in the
+   * JVM was behind it.
+   * <p>
+   * The flush thread is wedged rather than slowed: it is held on the batch monitor it takes to write a batch, which is
+   * a real code path (the same monitor the dropped-file purge uses) and stops the pipeline exactly where a stalled
+   * disk would. It is always released, on a deadline of its own, because a flush thread left wedged would hang every
+   * other test sharing this JVM.
+   */
+  @Test
+  void aCommitterWaitingForFlushQueueRoomDoesNotHoldThePublicationLock() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+    final PageManagerFlushThread flush = pageManager.getFlushThread();
+
+    // The batch the flush thread will be held on: the test keeps its monitor, which is what the write loop takes.
+    final List<MutablePage> wedge = new ArrayList<>(List.of(page(db, 0)));
+    final CountDownLatch releaseWedge = new CountDownLatch(1);
+    final CountDownLatch wedgeHeld = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    final Thread holder = new Thread(() -> {
+      synchronized (wedge) {
+        wedgeHeld.countDown();
+        try {
+          // A deadline of its own: whatever happens to the assertions below, the flush thread comes back.
+          releaseWedge.await(ASSERTION_TIMEOUT_SEC * 2, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, "issue6259-wedge-holder");
+    holder.setDaemon(true);
+    holder.start();
+    assertThat(wedgeHeld.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).isTrue();
+
+    final Thread committer;
+    final CountDownLatch published = new CountDownLatch(1);
+    try {
+      // The flush thread polls this batch, then blocks on its monitor: from here nothing leaves the queue.
+      flush.scheduleFlushOfPages(wedge);
+      final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC);
+      while (!isWriting(flush, wedge)) {
+        assertThat(System.currentTimeMillis()).as("the flush thread never reached the batch it must be held on")
+            .isLessThan(deadline);
+        Thread.sleep(1);
+      }
+
+      // Fill every remaining slot. Committers are admitted one per free slot, so this is the state a burst against a
+      // slow disk reaches on its own - reached here deterministically instead.
+      for (int i = flush.queue.remainingCapacity(); i > 0; i--)
+        flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, i))));
+      assertThat(flush.queue.remainingCapacity()).as("the flush queue must be full for this test to test anything")
+          .isZero();
+
+      committer = new Thread(() -> {
+        try {
+          pageManager.publishPages(List.of(page(db, 999_999)), null, true);
+          published.countDown();
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6259-committer");
+      committer.start();
+
+      assertThat(published.await(500, TimeUnit.MILLISECONDS)).as(
+          "a committer must be held while the flush queue is full - that backpressure is the queue's job").isFalse();
+
+      // THE ASSERTION THE WHOLE ISSUE IS ABOUT. Before the fix the committer was parked in queue.offer holding this
+      // lock, and this call waited for the wedged flush thread - as would every commit of every other database.
+      final CountDownLatch lockTaken = new CountDownLatch(1);
+      final Thread locker = new Thread(() -> {
+        pageManager.executeInLock(() -> {
+          lockTaken.countDown();
+          return null;
+        });
+      }, "issue6259-lock-taker");
+      locker.start();
+
+      assertThat(lockTaken.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+          "the page-manager lock must stay available while a committer waits for flush-queue room: waiting inside it stalls every committer of every database in the JVM")
+          .isTrue();
+      locker.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+
+      assertThat(flush.queueSlotWaits.get()).as("and the committer must be waiting for a SLOT, not for the lock")
+          .isPositive();
+    } finally {
+      releaseWedge.countDown();
+      holder.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    }
+
+    // Released, the pipeline drains and the committer goes through.
+    assertThat(published.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+        "the committer must be admitted once the flush thread drains the queue").isTrue();
+    committer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    assertThat(failure.get()).isNull();
+
+    final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC);
+    while (!flush.queue.isEmpty() && System.currentTimeMillis() < deadline)
+      Thread.sleep(5);
+    assertThat(flush.queueReservations.get()).as("and no publication may leave a reservation behind").isZero();
+  }
+
+  /**
+   * The admission control itself: exactly {@code arcadedb.pageFlushQueue} callers get in, the next one waits, and what
+   * lets it in is the flush thread polling a batch.
+   * <p>
+   * The wait is proven to end on the POLL'S SIGNAL rather than on the fallback interval by stretching that interval to
+   * a minute: a wait that ends inside seconds cannot have been ended by it. Without the signal a committer would sit
+   * out its interval against a queue that had room all along - under a lock, before the fix, and for everybody.
+   */
+  @Test
+  void aFullQueueHoldsTheNextCommitterUntilTheFlushThreadPollsABatch() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = smallQueueFlushThread(2);
+    // Far longer than the assertions below tolerate, so only the signal can release the wait.
+    flush.queueSlotWaitPollMillis = TimeUnit.MINUTES.toMillis(1);
+
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 0))));
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 1))));
+    assertThat(flush.queue.remainingCapacity()).isZero();
+    assertThat(flush.queueReservations.get()).as("an enqueued batch holds a slot, not a reservation").isZero();
+
+    final CountDownLatch admitted = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread committer = new Thread(() -> {
+      try {
+        if (flush.reserveQueueSlot()) {
+          flush.releaseQueueReservation(false);
+          admitted.countDown();
+        }
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "issue6259-waiting-committer");
+    committer.start();
+
+    assertThat(admitted.await(500, TimeUnit.MILLISECONDS)).as("no slot, no admission").isFalse();
+    assertThat(flush.queueSlotWaits.get()).isEqualTo(1);
+
+    // One batch leaves the queue: one committer gets in.
+    flush.flushPagesFromQueueToDisk(null, 20L);
+
+    assertThat(admitted.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+        "the poll must SIGNAL the free slot: with a one-minute fallback interval, only the signal can end this wait")
+        .isTrue();
+    committer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    assertThat(failure.get()).isNull();
+    assertThat(flush.queueReservations.get()).isZero();
+  }
+
+  /**
+   * A reservation is a promise of room, so the enqueue that follows it - the one inside the page-manager lock - must
+   * never have to wait. Here the queue is one short of full and the reservation is the last slot: a second batch
+   * arriving in between must be refused admission rather than take it.
+   */
+  @Test
+  void aReservedSlotCannotBeTakenByAnotherCommitter() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = smallQueueFlushThread(2);
+
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 0))));
+    assertThat(flush.reserveQueueSlot()).as("one slot left, so one more caller gets in").isTrue();
+
+    final CountDownLatch admitted = new CountDownLatch(1);
+    final Thread other = new Thread(() -> {
+      try {
+        if (flush.reserveQueueSlot())
+          admitted.countDown();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }, "issue6259-late-committer");
+    other.setDaemon(true);
+    other.start();
+    assertThat(admitted.await(500, TimeUnit.MILLISECONDS)).as(
+        "the last slot is spoken for: admitting a second caller would put the reserver's enqueue back inside the lock")
+        .isFalse();
+
+    // The reservation is honoured: the enqueue finds the room it was promised, without waiting.
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 1))), true);
+    assertThat(flush.queue.remainingCapacity()).isZero();
+    assertThat(flush.queueReservations.get()).isZero();
+
+    other.interrupt();
+    other.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+  }
+
+  /**
+   * Every path out of a publication gives its reservation back - including the ones that never enqueue anything.
+   * <p>
+   * A leaked reservation is silent and permanent: the pipeline is one slot smaller for the life of the process, and
+   * enough of them stop it accepting anything at all. Nothing in a running system would ever point at it.
+   */
+  @Test
+  void noPathLeavesAReservationBehind() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = smallQueueFlushThread(4);
+
+    // An empty batch is never enqueued (the empty list is the shutdown sentinel), with or without a reservation.
+    flush.scheduleFlushOfPages(new ArrayList<>());
+    assertThat(flush.queueReservations.get()).isZero();
+    assertThat(flush.reserveQueueSlot()).isTrue();
+    flush.scheduleFlushOfPages(new ArrayList<>(), true);
+    assertThat(flush.queueReservations.get()).as("a reservation handed to an empty batch must come straight back")
+        .isZero();
+
+    // A real publication, through the whole PageManager path.
+    final PageManager pageManager = db.getPageManager();
+    pageManager.publishPages(List.of(page(db, 7)), null, true);
+    assertThat(pageManager.getFlushThread().queueReservations.get()).isZero();
+
+    // And a batch dropped because the thread is shutting down.
+    flush.closeAndJoin();
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 8))));
+    assertThat(flush.queueReservations.get()).as("a batch dropped at shutdown must not strand its slot").isZero();
+  }
+
+  /** True once the flush thread has polled this batch and is inside the write loop that takes its monitor. */
+  private static boolean isWriting(final PageManagerFlushThread flush, final List<MutablePage> pages) {
+    final PageManagerFlushThread.PagesToFlush current = flush.nextPagesToFlush.get();
+    return current != null && current.pages == pages;
+  }
+
+  /**
+   * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
+   * test moves it.
+   */
+  private static PageManagerFlushThread smallQueueFlushThread(final int capacity) {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.PAGE_FLUSH_QUEUE, capacity);
+    return new PageManagerFlushThread(PageManager.INSTANCE, cfg);
+  }
+
+  private static MutablePage page(final DatabaseInternal database, final int pageNumber) {
+    return new MutablePage(new PageId(database, FILE_ID, pageNumber), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6259FlushQueueAdmissionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6259FlushQueueAdmissionTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -276,10 +277,119 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
     pageManager.publishPages(List.of(page(db, 7)), null, true);
     assertThat(pageManager.getFlushThread().queueReservations.get()).isZero();
 
-    // And a batch dropped because the thread is shutting down.
+    // And a batch dropped because the thread is shutting down. closeAndJoin returns at once here: this flush thread
+    // was constructed but never start()ed, and Thread.join() on a thread in NEW state returns immediately. What is
+    // under test is the shutdown flag, not the join.
     flush.closeAndJoin();
     flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 8))));
     assertThat(flush.queueReservations.get()).as("a batch dropped at shutdown must not strand its slot").isZero();
+  }
+
+  /**
+   * The admission bound under real contention, which the deterministic tests above cannot reach: many threads racing
+   * the CAS loop of {@code tryReserveQueueSlot} against a queue of 4.
+   * <p>
+   * The bound is what the enqueue inside the page-manager lock rests on - a reservation is only worth holding if it
+   * guarantees a free slot - and a time-of-check/time-of-use regression in that loop would break it while leaving
+   * every single-threaded test green. Phase 1 races reservations alone, so the assertion is exact: the number held at
+   * once can never exceed the capacity. Phase 2 then runs the whole path (reserve, enqueue, drain) concurrently to
+   * prove the accounting comes back to zero rather than drifting a slot per round.
+   */
+  @Test
+  void theAdmissionBoundHoldsUnderContention() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int capacity = 4;
+    final int threads = 12;
+    final PageManagerFlushThread flush = smallQueueFlushThread(capacity);
+
+    final AtomicInteger held = new AtomicInteger();
+    final AtomicInteger maxHeld = new AtomicInteger();
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final CountDownLatch start = new CountDownLatch(1);
+
+    // PHASE 1: reservations only. Nothing is ever enqueued, so the queue stays empty and the bound is exactly the
+    // number of reservations handed out at once - anything above the capacity is an over-admission.
+    final List<Thread> racers = new ArrayList<>();
+    for (int t = 0; t < threads; t++) {
+      final Thread racer = new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < 2_000; i++) {
+            if (!flush.reserveQueueSlot())
+              return;
+            maxHeld.accumulateAndGet(held.incrementAndGet(), Math::max);
+            held.decrementAndGet();
+            flush.releaseQueueReservation(false);
+          }
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6259-racer-" + t);
+      racer.setDaemon(true);
+      racers.add(racer);
+      racer.start();
+    }
+    start.countDown();
+    for (final Thread racer : racers)
+      racer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+
+    assertThat(failure.get()).isNull();
+    assertThat(maxHeld.get()).as(
+        "the CAS loop must never hand out more reservations than the queue has slots: each one is a promise that the enqueue inside the page-manager lock will not block")
+        .isLessThanOrEqualTo(capacity);
+    assertThat(maxHeld.get()).as("and the race must actually have contended, or this test proves nothing").isGreaterThan(1);
+    assertThat(flush.queueReservations.get()).isZero();
+
+    // PHASE 2: the whole path at once - producers reserving and enqueueing, a drainer polling - so the two halves of
+    // the sum (queue size and reservations) move against each other under contention rather than one at a time.
+    final int batchesPerProducer = 200;
+    final int producerCount = 6;
+    final CountDownLatch producersDone = new CountDownLatch(producerCount);
+    final List<Thread> producers = new ArrayList<>();
+    for (int t = 0; t < producerCount; t++) {
+      final int id = t;
+      final Thread producer = new Thread(() -> {
+        try {
+          for (int i = 0; i < batchesPerProducer; i++) {
+            final boolean reserved = flush.reserveQueueSlot();
+            assertThat(reserved).isTrue();
+            flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, id * batchesPerProducer + i))), true);
+          }
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        } finally {
+          producersDone.countDown();
+        }
+      }, "issue6259-producer-" + t);
+      producer.setDaemon(true);
+      producers.add(producer);
+      producer.start();
+    }
+
+    final Thread drainer = new Thread(() -> {
+      try {
+        while (producersDone.getCount() > 0 || !flush.queue.isEmpty())
+          flush.flushPagesFromQueueToDisk(null, 5L);
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "issue6259-drainer");
+    drainer.setDaemon(true);
+    drainer.start();
+
+    assertThat(producersDone.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+        "every producer must get through: a reservation that is never granted, or an enqueue that blocks behind one, hangs here")
+        .isTrue();
+    drainer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    for (final Thread producer : producers)
+      producer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+
+    assertThat(failure.get()).isNull();
+    assertThat(flush.queue).isEmpty();
+    assertThat(flush.queueReservations.get()).as(
+        "the accounting must come back to zero: a slot leaked per round shrinks the pipeline until it stops admitting anything")
+        .isZero();
+    assertThat(flush.pageIndex.pendingOf(db)).as("and every page must have left the pipeline").isZero();
   }
 
   /** True once the flush thread has polled this batch and is inside the write loop that takes its monitor. */


### PR DESCRIPTION
Fixes #6259.

## The bug

`PageManager.publishPages` holds the JVM-wide page-manager lock across **both** halves of publication - the synchronous page write and the `scheduleFlushOfPages` enqueue - and it has to: the snapshot t0 barrier (#6075/#6125) takes that same lock precisely so that from there on no committer can put a page on disk **or** into the flush pipeline, which is what makes its residual drain converge by construction.

The enqueue blocked, though:

```java
// TRY TO INSERT THE PAGE IN THE QUEUE UNTIL THE THREAD IS STILL RUNNING
while (running) {
  if (queue.offer(new PagesToFlush(pages), 1, TimeUnit.SECONDS))
    return;
}
```

So whenever the bounded flush queue (`arcadedb.pageFlushQueue`, default 512, **8 under the `low-ram` profile**) filled, the committing thread parked in that offer **holding a lock every committer in the process needs**. The queue fills whenever commits outrun the disk for a moment: a write burst, a slow or contended volume, an fsync spike, a compaction landing at the wrong time. No suspension, no backup, no HA involved - this is the non-suspension twin of #6200, which removed one trigger for this stall and left the other in place.

The result was that one database's write burst serialized the commits of every unrelated database in the JVM, including databases on a different, idle volume whose pages could have been written immediately.

## The fix

The bounded queue is *meant* to backpressure the writers it belongs to; that part is right. What was wrong is only that the wait was served while holding a JVM-wide lock, so it was charged to everybody. The enqueue cannot move out of the lock without reintroducing the gap #6125 removed - so the **wait** moves ahead of it, exactly the shape #6200 established for the deferred-RAM cap ("the ceiling is global because heap is; the response must not be").

A committer now reserves its flush-queue slot **before** `lock()` and reaches the enqueue one line later with the slot already its own, so the `offer` inside the lock cannot block. The blocking offer stays as the safety net it always was.

```java
if (asyncFlush) {
  awaitDeferredBacklogUnderCap(pagesToWrite);   // #6200
  flushSlotReserved = reserveFlushQueueSlot(pagesToWrite);   // #6259
}
lock();
```

### Deliberately not a semaphore

The issue's own proposal suggested expressing the wait as "a permit/semaphore sized to the queue". This does not do that, and the difference is the point.

A permit count has to be kept in step with the queue **by hand** at every enqueue and every poll, and a single missed release silently shrinks the pipeline for the life of the process - an invisible, permanent bug with no symptom anyone would trace back. Admission here is derived from the queue's **own size** plus a counter of slots promised but not yet used:

```java
if (queue.size() + reservations >= queueCapacity)
  return false;
```

so `size + reservations <= capacity` holds by construction, the holder of a reservation is guaranteed a free slot, and a batch that reaches the queue by any other route - a white-box test, a future call site - narrows admission instead of corrupting the bound. The cost is one `ArrayBlockingQueue.size()` per publication, which takes the same internal lock the `offer` on the next line takes anyway (and `poll(timeout)` releases that lock while it waits, so it is never held against a publication).

### Signalled, not polled

The flush thread wakes a waiting committer the moment it **polls** a batch - before writing it, because the slot is free from that point, and a slow write should delay the writes rather than the admission of the next committer. When nobody is waiting (the normal state of a queue that is not full) the signal costs one volatile read per batch, the same shape as the drain signal of #6199.

### Two paths the issue did not mention

Both would have reintroduced the bug in a narrower window, so both go through the same admission:

- **The resume's Phase 3b re-enqueue.** A resume can carry thousands of deferred batches back into the queue. Without a reservation it could fill the queue *under* a committer that is holding one, putting that committer's offer back inside the page-manager lock.
- **The shutdown sentinel**, which occupies a queue slot like any other batch - but is never allowed to *wait* for one, since the run loop already exits on its own once `running` is false and the queue is drained.

### Observability

Adds `flushQueueWaits` to the page-manager stats and to both Profiler outputs. `pageFlushQueueLength` is an instant, sampled between two bursts as easily as during one; this is cumulative evidence that commits were actually held. A committer held for more than 10 s also says so once, at WARNING, naming the queue and the configuration key.

## Verification

`Issue6259FlushQueueAdmissionTest`, 4 tests. The central one pins **the invariant rather than the symptom**, as the issue asked: while a committer is waiting for queue room, another thread must be able to take the page-manager lock. The flush thread is wedged on the batch monitor its write loop takes - a real code path, stopping the pipeline exactly where a stalled disk would - and always released on a deadline of its own, since a flush thread left wedged would hang every other test sharing the JVM.

That test was **verified red against the previous shape**: with the reservation removed it fails at exactly that assertion, having waited out the full 60 s for a lock the committer was holding while parked in `offer`.

The other three cover the mechanism: exactly `arcadedb.pageFlushQueue` callers are admitted and the next one waits; a reserved slot cannot be taken by another committer; and no path out of a publication leaves a reservation behind (a leak is silent and permanent, so it is asserted rather than inspected, with an `assert` guarding the fail-open direction).

- Full `engine` suite green: **12090 tests, 0 failures, 0 errors**.
- `Issue6125SnapshotBarrierAndCapTest` green - it is what proves the publication lock still covers the enqueue.
- `Issue6200PerDatabaseDeferredBacklogTest` and the whole flush-suspend suite green.
- **No measurable cost:** 40000 commits took 629/639/637 ms and 645/656/629 ms with the admission step, against 638/633/640 ms and 652/642/641 ms without.

## Follow-up left open

Making the flush queue **per-database** remains worth measuring: it would bound each database's backlog independently and remove the cross-database coupling at its source. It does not fix this bug on its own - a committer that blocks on its OWN full queue while holding the JVM-wide lock still stalls everyone - so it would have to be combined with the admission control in this PR regardless, which is why it is not bundled here.
