### PR TITLE
fix(#6185): a schema probe is described whether it is spelled WHERE 1=0 or LIMIT 0

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2234,3 +2234,28 @@ purpose ("more seeds than nodes" reads as "as many as exist" and is clamped to t
 nameless `NegativeArraySizeException`.
 
 [#6216](https://github.com/ArcadeData/arcadedb/issues/6216)
+
+## A schema probe spelled `LIMIT 0` gets a RowDescription over a row source the schema cannot describe (#6185)
+
+`SELECT expand(shortestPath(#1:0, #1:5)) LIMIT 0` is a schema probe, and #6172 had already made a probe
+describable no matter how its rows are computed: when the statement returns nothing, the Postgres wire protocol
+replays it without the clause that empties it and reads the columns off the first row, which is the only way to
+name the columns of a row source that is not a schema type - a graph function, a `TRAVERSE`, a `MATCH`, a constant
+table. The trigger for that replay looked only at the `WHERE` clause, so a client that spells the probe `LIMIT 0` -
+Tableau and several JDBC/BI tools do - was answered with an empty RowDescription again, exactly as before the fix.
+
+The trigger is now "the statement is empty by construction", the same question the SQL planner asks in #6174 when
+it folds the fetch away, and it is read at every level of the query, so `LIMIT 0` on the probed subquery counts as
+well as `LIMIT 0` on the statement the client sent. Only a literal `LIMIT 0` qualifies (`Limit.isAlwaysEmpty()`): a
+bound `LIMIT ?` belongs to one execution, and the replay must not be triggered by a value the next execution can
+change.
+
+The two spellings are deliberately not answered in the same order, because they do not carry the same intent. The
+replay evaluates the query's projection for real, once, on one row - the caveat that has been documented on
+`sampleProbeColumns` since #6172 - so a projected function with a side effect runs once per probe that takes that
+path. `WHERE 1=0` has no purpose other than probing, so it is replayed first, as it always was. `LIMIT 0` is also
+how a client asks an expensive query for nothing at all, so it is replayed only after the static resolution of the
+row source has come back with nothing: a `LIMIT 0` over a shape the schema can describe is answered from the
+schema, without evaluating anything, and only the shapes that cannot be answered any other way are replayed.
+
+[#6185](https://github.com/ArcadeData/arcadedb/issues/6185)

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -48,6 +48,7 @@ import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.query.sql.parser.FromClause;
 import com.arcadedb.query.sql.parser.FromItem;
 import com.arcadedb.query.sql.parser.Identifier;
+import com.arcadedb.query.sql.parser.Limit;
 import com.arcadedb.query.sql.parser.MatchStatement;
 import com.arcadedb.query.sql.parser.Projection;
 import com.arcadedb.query.sql.parser.ProjectionItem;
@@ -1157,8 +1158,13 @@ public class PostgresNetworkExecutor extends Thread {
 
   /**
    * Schema-discovery fallback for queries that returned 0 rows. RowDescription must still carry column metadata
-   * so JDBC clients (Spark/PySpark probe schema with WHERE 1=0) can build a typed result set. Returns null when
-   * no schema match is found, letting the caller fall through to the empty-RowDescription default.
+   * so JDBC clients - Spark and PySpark probe a schema with {@code WHERE 1=0}, Tableau and several JDBC/BI tools
+   * with {@code LIMIT 0} - can build a typed result set. Returns null when no schema match is found, letting the
+   * caller fall through to the empty-RowDescription default.
+   * <p>
+   * Two answers are available, and which one is asked first is decided by how the probe is spelled: a replay of
+   * the query without the clause that empties it ({@link #sampleProbeColumns}) or a static resolution of the row
+   * source ({@link #getColumnsFromQuerySchema}). See {@link ProbeSpelling}.
    */
   private Map<String, PostgresType> resolveEmptyResultSchemaColumns(final String query, final String language,
       final Object[] parameters, final Statement alreadyParsed) {
@@ -1172,49 +1178,99 @@ public class PostgresNetworkExecutor extends Thread {
     // the extended protocol parsed this very text when it prepared the portal: reuse it instead of parsing twice
     final Statement parsed = alreadyParsed != null ? alreadyParsed : parseStatement(query);
 
-    // A schema probe returns no rows by construction, so replaying it without its constant-false filter is the
-    // only way to learn the columns of a row source that is not a schema type - a graph function, a TRAVERSE, a
-    // constant table (issue #6156). It is also the most faithful answer for the shapes the schema can describe,
-    // because the columns and their types come from the very rows the un-probed query would return.
-    final Map<String, PostgresType> sampled = sampleProbeColumns(parsed, parameters);
-    if (sampled != null && !sampled.isEmpty())
-      return sampled;
+    final ProbeSpelling probe = probeSpelling(parsed);
 
-    if (!query.toUpperCase(Locale.ENGLISH).trim().startsWith("SELECT") && !(parsed instanceof MatchStatement))
-      return null;
+    // A constant-false filter has no purpose other than probing, so it is answered by the replay first: replaying
+    // the statement without it is the only way to learn the columns of a row source that is not a schema type - a
+    // graph function, a TRAVERSE, a constant table (issue #6156) - and it is the most faithful answer for the
+    // shapes the schema can describe too, because the columns and their types come from the very rows the
+    // un-probed query would return.
+    if (probe == ProbeSpelling.CONSTANT_FALSE_FILTER) {
+      final Map<String, PostgresType> sampled = sampleProbeColumns(parsed, parameters);
+      if (sampled != null && !sampled.isEmpty())
+        return sampled;
+    }
 
-    final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(query, parsed);
-    return schemaColumns != null && !schemaColumns.isEmpty() ? schemaColumns : null;
+    if (query.toUpperCase(Locale.ENGLISH).trim().startsWith("SELECT") || parsed instanceof MatchStatement) {
+      final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(query, parsed);
+      if (schemaColumns != null && !schemaColumns.isEmpty())
+        return schemaColumns;
+    }
+
+    // LIMIT 0 is the other spelling of a probe (issue #6185), but unlike a constant-false filter it is also how a
+    // client asks an expensive query for nothing at all. So it earns the replay - which evaluates the projection
+    // for real, once - only where nothing else can answer: after the static resolution above has come back empty.
+    if (probe == ProbeSpelling.LIMIT_ZERO) {
+      final Map<String, PostgresType> sampled = sampleProbeColumns(parsed, parameters);
+      if (sampled != null && !sampled.isEmpty())
+        return sampled;
+    }
+
+    return null;
   }
 
   /**
-   * Runs the probe again with its constant-false filters removed and reports the columns of the first row it
+   * How a statement says, in its own text, that it cannot return a row. Both spellings mark a schema probe, and
+   * the caller replays either of them, but they do not deserve the replay equally - see
+   * {@link #resolveEmptyResultSchemaColumns}, which orders them against the static resolution.
+   */
+  private enum ProbeSpelling {
+    NOT_A_PROBE, CONSTANT_FALSE_FILTER, LIMIT_ZERO
+  }
+
+  /**
+   * Reads off the statement, or a subquery it selects from, whether it is empty by construction and how it says
+   * so - the same question {@code SelectExecutionPlanner.emptyByConstructionReason} asks when it folds the fetch
+   * away. A constant-false filter wins over a {@code LIMIT 0} found at another level, because it is the spelling
+   * that can have no other purpose.
+   * <p>
+   * Nothing here evaluates a function or reads a bound parameter: {@code WhereClause.isAlwaysFalse} folds only
+   * comparisons between literals, and {@link Limit#isAlwaysEmpty()} only a literal {@code LIMIT 0}. This is asked
+   * of every query that comes back empty, the vast majority of which are not probes at all.
+   */
+  private ProbeSpelling probeSpelling(final Statement parsed) {
+    if (!(parsed instanceof SelectStatement select))
+      return ProbeSpelling.NOT_A_PROBE;
+
+    // the database has to be on the context: the constant-folding below needs it
+    final CommandContext context = createProbeContext();
+
+    ProbeSpelling spelling = ProbeSpelling.NOT_A_PROBE;
+    for (SelectStatement level = select; level != null; level = selectedSubQuery(level)) {
+      if (isAlwaysFalseFilter(level.getWhereClause(), context))
+        return ProbeSpelling.CONSTANT_FALSE_FILTER;
+
+      final Limit limit = level.getLimit();
+      if (limit != null && limit.isAlwaysEmpty())
+        spelling = ProbeSpelling.LIMIT_ZERO;
+    }
+
+    return spelling;
+  }
+
+  /**
+   * Runs the probe again with the clauses that empty it removed, and reports the columns of the first row it
    * returns. This is what makes a probe describable no matter how its rows are computed: whatever the un-probed
-   * query would send on the wire is exactly what gets announced. Returns null when the statement carries no
-   * constant-false filter - then the empty result is the query's own answer and there is nothing to replay - or
-   * when the replay itself finds no row.
+   * query would send on the wire is exactly what gets announced. Returns null when the replay finds no row.
+   * <p>
+   * Only a statement the caller has already classified as a probe ({@link #probeSpelling}) reaches this, so the
+   * AST deep copy below is never paid for by a query that legitimately returns no rows - the common case on this
+   * path by a wide margin.
    * <p>
    * Note that the replay evaluates the query's projection for real, once, on one row. The original probe never
-   * did: its filter discards every row before the projection runs. So a projected function that has a side
-   * effect - a sequence's {@code next()}, a user-defined function that writes - is invoked once per probe that
-   * takes this path. The alternative is to describe a computed projection by guessing, which is what left this
-   * whole family of queries undescribable in the first place; the statically-resolvable shapes are answered
-   * without a replay by {@link #getColumnsFromQuerySchema} whenever they return rows of their own.
+   * did: its filter, or its LIMIT 0, discards every row before the projection runs. So a projected function that
+   * has a side effect - a sequence's {@code next()}, a user-defined function that writes - is invoked once per
+   * probe that takes this path. The alternative is to describe a computed projection by guessing, which is what
+   * left this whole family of queries undescribable in the first place; the statically-resolvable shapes are
+   * answered without a replay by {@link #getColumnsFromQuerySchema} whenever it can name their columns.
    */
   private Map<String, PostgresType> sampleProbeColumns(final Statement parsed, final Object[] parameters) {
     if (!(parsed instanceof SelectStatement select))
       return null;
 
     try {
-      // the database has to be on the context: both the constant-folding below and the replay itself need it
-      final BasicCommandContext context = new BasicCommandContext();
-      context.setConfiguration(server.getConfiguration());
-      context.setDatabase(database);
-
-      // Read the parsed statement before copying it: a query that legitimately returns no rows is the common
-      // case on this path and must not pay for an AST deep copy it turns out it cannot use.
-      if (!hasAlwaysFalseFilter(select, context))
-        return null;
+      // the database has to be on the context: the replay runs against it
+      final CommandContext context = createProbeContext();
 
       final SelectStatement sample = select.copy();
       stripProbe(sample, context);
@@ -1229,23 +1285,19 @@ public class PostgresNetworkExecutor extends Thread {
     }
   }
 
-  /**
-   * Whether the statement, or a subquery it selects from, filters on a condition that is false for every row.
-   * That is what marks the statement as a schema probe and makes it worth replaying.
-   */
-  private boolean hasAlwaysFalseFilter(final SelectStatement select, final CommandContext context) {
-    if (isAlwaysFalseFilter(select.getWhereClause(), context))
-      return true;
-
-    final SelectStatement subQuery = selectedSubQuery(select);
-    return subQuery != null && hasAlwaysFalseFilter(subQuery, context);
+  private CommandContext createProbeContext() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setConfiguration(server.getConfiguration());
+    context.setDatabase(database);
+    return context;
   }
 
   /**
-   * Turns a copy of the probe into the query it is a probe of, in place: the constant-false filters go, and so
-   * do the clauses that only choose which rows come back. Dropping ORDER BY, SKIP and LIMIT costs nothing - the
-   * columns of a row do not depend on where it sits in the result - and it keeps the replay from materializing
-   * and sorting a whole result set just to hand over its first row.
+   * Turns a copy of the probe into the query it is a probe of, in place: the constant-false filters go, and so do
+   * the clauses that only choose which rows come back - the {@code LIMIT 0} of a probe spelled that way among them.
+   * Dropping ORDER BY, SKIP and LIMIT costs nothing - the columns of a row do not depend on where it sits in the
+   * result - and it keeps the replay from materializing and sorting a whole result set just to hand over its first
+   * row.
    * <p>
    * A whole WHERE clause goes, not just the constant-false term inside it, so {@code WHERE 1=0 AND name = :n}
    * samples the unfiltered target. That rests on the caller reading nothing but column names and types off the

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -19,6 +19,8 @@
 package com.arcadedb.postgres;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.function.java.JavaClassFunctionLibraryDefinition;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
@@ -46,6 +48,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static com.arcadedb.schema.Property.CAT_PROPERTY;
@@ -1208,6 +1211,106 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
             DROP TYPE Hero6156 UNSAFE;
             """);
       }
+    }
+  }
+
+  /**
+   * Issue #6185: {@code LIMIT 0} is the other spelling of a schema probe - Tableau and several JDBC/BI tools send
+   * it instead of {@code WHERE 1=0} - but only the constant-false filter triggered the replay, so a probe over a
+   * row source the schema cannot describe (a graph function, a TRAVERSE, an expand()) came back with an empty
+   * RowDescription again. The two spellings are not answered the same way: {@code WHERE 1=0} has no purpose other
+   * than probing and is replayed first, while {@code LIMIT 0} is also how a client asks an expensive query for
+   * nothing at all, so it earns the replay - which evaluates the projection for real, once - only after the static
+   * resolution has failed.
+   */
+  @Test
+  void schemaProbeSpelledLimitZeroReturnsTheDescription() throws Exception {
+    final Database serverDatabase = getServerDatabase(0, getDatabaseName());
+    serverDatabase.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("probe6185", ProbeCounter6185.class));
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("""
+            {sqlscript}
+            CREATE VERTEX TYPE Hero6185 IF NOT EXISTS;
+            CREATE PROPERTY Hero6185.name IF NOT EXISTS STRING;
+            CREATE EDGE TYPE Appearance6185 IF NOT EXISTS;
+            CREATE PROPERTY Appearance6185.weight IF NOT EXISTS INTEGER;
+            INSERT INTO Hero6185 SET name = 'Napoleon';
+            INSERT INTO Hero6185 SET name = 'Myriel';
+            CREATE EDGE Appearance6185 FROM (SELECT FROM Hero6185 WHERE name = 'Napoleon')
+              TO (SELECT FROM Hero6185 WHERE name = 'Myriel') SET weight = 1;
+            """);
+      }
+
+      // The shape from the issue: a graph function as the row source, which nothing static can describe.
+      final String shortestPath = "shortestPath((SELECT FROM Hero6185 WHERE name = 'Napoleon'), "
+          + "(SELECT FROM Hero6185 WHERE name = 'Myriel'), 'BOTH', 'Appearance6185')";
+      assertProbedColumns(conn, "SELECT * FROM (SELECT expand(" + shortestPath + ")) SPARK_GEN_SUBQ_0 LIMIT 0", "name",
+          RID_PROPERTY, TYPE_PROPERTY, CAT_PROPERTY);
+      assertProbedColumns(conn, "SELECT * FROM (SELECT name, @rid AS rid FROM (SELECT expand(" + shortestPath
+          + "))) SPARK_GEN_SUBQ_0 LIMIT 0", "name", "rid");
+
+      // expand() throws the row away, so only the replay can tell what the query produces.
+      assertProbedColumns(conn, "SELECT * FROM (SELECT expand([1,2,3]) AS n) t LIMIT 0", "n");
+      // ... and the LIMIT 0 may sit on the subquery rather than on the statement the client sent.
+      assertProbedColumns(conn, "SELECT * FROM (SELECT expand([1,2,3]) AS n LIMIT 0) t", "n");
+
+      // A TRAVERSE row source, and the shapes the schema can describe, answer with LIMIT 0 as well.
+      assertProbedColumns(conn, "SELECT * FROM (SELECT FROM (TRAVERSE out('Appearance6185') FROM "
+              + "(SELECT FROM Hero6185 WHERE name = 'Napoleon') MAXDEPTH 2)) t LIMIT 0", "name", RID_PROPERTY, TYPE_PROPERTY,
+          CAT_PROPERTY);
+      assertProbedColumns(conn, "SELECT name FROM Hero6185 LIMIT 0", "name");
+      assertProbedColumns(conn, "SELECT * FROM (SELECT name FROM Hero6185) SPARK_GEN_SUBQ_0 LIMIT 0", "name");
+
+      // Only a literal LIMIT 0 marks a probe: a bound parameter belongs to one execution, so it is left alone and
+      // the query stays as undescribable as it was.
+      try (var st = conn.prepareStatement("SELECT * FROM (SELECT expand([1,2,3]) AS n) t LIMIT ?")) {
+        st.setInt(1, 0);
+        try (var rs = st.executeQuery()) {
+          assertThat(rs.getMetaData().getColumnCount()).isZero();
+        }
+      }
+
+      // The two spellings are ordered differently against the static resolution, and the projected function call
+      // counts how many times each of them evaluated the projection for real. LIMIT 0 over a row source the schema
+      // describes is answered without a replay ...
+      ProbeCounter6185.CALLS.set(0);
+      assertProbedColumns(conn, "SELECT `probe6185.tick`() AS n FROM Hero6185 LIMIT 0", "n");
+      assertThat(ProbeCounter6185.CALLS.get()).isZero();
+
+      // ... while the same query spelled WHERE 1=0 is replayed, which is the caveat documented on sampleProbeColumns.
+      assertProbedColumns(conn, "SELECT `probe6185.tick`() AS n FROM Hero6185 WHERE 1=0", "n");
+      assertThat(ProbeCounter6185.CALLS.get()).isEqualTo(1);
+
+      // Sanity check: the same queries without the probe still return their rows.
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery("SELECT * FROM (SELECT expand([1,2,3]) AS n) t")) {
+          assertThat(rs.next()).isTrue();
+          assertThat(rs.getInt("n")).isEqualTo(1);
+        }
+      }
+
+      try (var st = conn.createStatement()) {
+        st.execute("""
+            {sqlscript}
+            DROP TYPE Appearance6185 UNSAFE;
+            DROP TYPE Hero6185 UNSAFE;
+            """);
+      }
+    } finally {
+      serverDatabase.getSchema().unregisterFunctionLibrary("probe6185");
+    }
+  }
+
+  /**
+   * Counts how many times a projected function was actually evaluated, which is how the LIMIT 0 test tells a
+   * schema probe answered statically from one answered by replaying the query.
+   */
+  public static class ProbeCounter6185 {
+    public static final AtomicInteger CALLS = new AtomicInteger();
+
+    public static int tick() {
+      return CALLS.incrementAndGet();
     }
   }
 


### PR DESCRIPTION
Closes #6185

`SELECT expand(shortestPath(#1:0, #1:5)) LIMIT 0` came back with an empty RowDescription. #6172 had already made
a schema probe describable no matter how its rows are computed - when the statement returns nothing, the Postgres
wire protocol replays it without the clause that empties it and reads the columns off the first row - but the
trigger for that replay looked only at the `WHERE` clause. A client that spells the probe `LIMIT 0`, which Tableau
and several JDBC/BI tools do, never reached it, so the row sources that cannot be described statically - a graph
function, a `TRAVERSE`, an `expand()`, a constant table - were undescribable again, which is exactly the family of
queries #6156 existed to fix.

## What changed

- the trigger is now "the statement is empty by construction", the same question
  `SelectExecutionPlanner.emptyByConstructionReason` asks when it folds the fetch away, and the method is named for
  what it detects rather than for one of its two spellings: `probeSpelling()` answers `NOT_A_PROBE` /
  `CONSTANT_FALSE_FILTER` / `LIMIT_ZERO`.
- it is read at every level of the query, so a `LIMIT 0` on the probed subquery counts as well as one on the
  statement the client sent, and a constant-false filter found at any level still wins over a `LIMIT 0` found at
  another.
- only a literal `LIMIT 0` qualifies (`Limit.isAlwaysEmpty()`, added in #6181): a bound `LIMIT ?` belongs to one
  execution, so it is left alone and the query stays as undescribable as it was.
- `stripProbe` already dropped `ORDER BY`/`SKIP`/`LIMIT` from the replayed copy, so the replay of a `LIMIT 0`
  statement needed no new stripping.

## The decision the issue asked to weigh

The issue asked whether the widened trigger should require the row source to be undescribable statically first,
for the `LIMIT 0` spelling only. It does.

The replay evaluates the query's projection for real, once, on one row - the caveat documented on
`sampleProbeColumns` since #6172 - so a projected function with a side effect is invoked once per probe that takes
that path. `WHERE 1=0` has no purpose other than probing, so it is still replayed first, and the most faithful
answer for the shapes the schema can describe is still the one taken from the very rows the un-probed query would
return. `LIMIT 0` is less unambiguous: it is also how a client asks an expensive query for nothing at all. So it is
replayed only after `getColumnsFromQuerySchema` has come back with nothing, which keeps the replay to the cases
that cannot be answered any other way.

That ordering is pinned by a test rather than only by prose. A projected Java function counts its own invocations:
`SELECT probe6185.tick() AS n FROM Hero6185 LIMIT 0` is answered with column `n` while the counter stays at 0,
while the same query spelled `WHERE 1=0` is answered with `n` and the counter reads 1.

## Test plan

- [x] new regression test `PostgresWJdbcIT#schemaProbeSpelledLimitZeroReturnsTheDescription`: red on `main` (the
      `shortestPath` probe announces no columns at all), green with the fix
- [x] it covers the graph-function row source from the issue, an `expand()` projection, a `TRAVERSE`, a `LIMIT 0`
      sitting on the subquery, the shapes the schema can describe, the bound `LIMIT ?` that must not be folded, and
      the invocation counts that pin the static-first ordering
- [x] whole `postgresw` module, unit tests and integration tests:
      `mvn -pl postgresw verify -DskipITs=false` (the `PostgresWJdbcIT`, `PostgresProtocolIT` and `PostgresTypeTest`
      suites cover the RowDescription paths this touches)
- [x] release note added to `docs/release-26.9.1.md`
