### PR TITLE
fix(#6184): an always-true filter is dropped at plan time, because a leaf can finally answer isAlwaysTrue()

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2284,6 +2284,12 @@ One `OrBlock` detail changed with it: an empty disjunction used to answer `isAlw
 false when it has no alternatives, and the answer is now load-bearing, so it answers `false` - the conservative
 verdict, which at worst costs an optimisation.
 
+**API note for code that extends the SQL parser**: `BooleanExpression.isAlwaysTrue()` is replaced by
+`isAlwaysTrue(CommandContext)` rather than kept alongside it, so an out-of-tree subclass that overrode the no-argument
+form no longer overrides anything. This is a compile error against the new signature and a silently inert override
+only if the subclass keeps the old method as an unrelated one; nothing inside ArcadeDB called the no-argument form
+outside the four AST classes that recursed into it.
+
 The value here is smaller than #6174's: nothing sends `WHERE 1=1` as a probe the way Spark sends `WHERE 1=0`, so
 this is symmetry and a small constant per record rather than a full scan avoided.
 

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2280,6 +2280,13 @@ test therefore compares the folded plan against the plan of the same statement w
 class by step class, so the fetch step and the bucket steps under it both have to agree - and then compares the
 records returned, their order, and the `readRecord` count.
 
+One place the filter survives the whole-clause fold is behind an index. `WHERE 1=1 AND indexedProperty = 'x'` is not
+true for every record, so the clause stays - and then the index search takes the second term as its key and hands the
+`1=1` back as a *residual condition*, which was chained as a `FILTER ITEMS WHERE` step and evaluated once per index
+entry. A residual that is true for every record is now recognised as no filter at all, on both the single-index and
+the parallel-index paths, so the plan is the one the same statement without the constant term would have got. The
+index itself was never at risk: it was selected before and after, the residual only rode along behind it.
+
 One `OrBlock` detail changed with it: an empty disjunction used to answer `isAlwaysTrue()` with `true`. `OR` is
 false when it has no alternatives, and the answer is now load-bearing, so it answers `false` - the conservative
 verdict, which at worst costs an optimisation.

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2287,9 +2287,13 @@ entry. A residual that is true for every record is now recognised as no filter a
 the parallel-index paths, so the plan is the one the same statement without the constant term would have got. The
 index itself was never at risk: it was selected before and after, the residual only rode along behind it.
 
-One `OrBlock` detail changed with it: an empty disjunction used to answer `isAlwaysTrue()` with `true`. `OR` is
-false when it has no alternatives, and the answer is now load-bearing, so it answers `false` - the conservative
-verdict, which at worst costs an optimisation.
+One `OrBlock` detail changed with it: an empty disjunction used to answer `isAlwaysTrue()` with `true`. It now
+answers `false`, matching what `isAlwaysFalse` has always answered for the same block. Neither verdict reads it as
+the neutral element, even though that reading (an `OR` with no alternatives is `FALSE`) is available: the parser
+cannot produce an empty `OrBlock`, both answers are load-bearing - one drops the filter, the other replaces the plan
+with an empty source - and deducing either for a block that can only arrive by accident would trade correctness for
+an optimisation nothing can trigger. An empty `AndBlock`, by contrast, is exactly what a filter with no terms left
+looks like, so it does answer `isAlwaysTrue`, and that is what lets an emptied residual condition drop its step.
 
 **API note for code that extends the SQL parser**: `BooleanExpression.isAlwaysTrue()` is replaced by
 `isAlwaysTrue(CommandContext)` rather than kept alongside it, so an out-of-tree subclass that overrode the no-argument

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2234,3 +2234,57 @@ purpose ("more seeds than nodes" reads as "as many as exist" and is clamped to t
 nameless `NegativeArraySizeException`.
 
 [#6216](https://github.com/ArcadeData/arcadedb/issues/6216)
+
+## An always-true filter is dropped at plan time instead of being evaluated once per record (#6184)
+
+The mirror of #6174. That issue taught the planner to recognise a filter that is false for every record; a filter
+that is *true* for every record was still built as a filter step and evaluated per record, so `SELECT FROM C` and
+`SELECT FROM C WHERE 1=1` - the same query, written twice - produced two different plans:
+
+```
+SELECT FROM C                    -> + FETCH FROM TYPE C
+                                      + FETCH FROM BUCKET 1 (C_0) ASC
+
+SELECT FROM C WHERE 1=1          -> + FETCH FROM TYPE C WITH FILTER
+                                      + SCAN WITH FILTER BUCKET 1 (C_0)
+                                        1 = 1
+```
+
+The second paid a predicate evaluation per record, and lost the plain bucket fetch, to learn something the
+statement had already said.
+
+Nothing was stuck for want of a rule. `BooleanExpression.isAlwaysTrue()` had existed all along and was overridden
+by `AndBlock`, `OrBlock`, `ParenthesisBlock` and `NotBlock` - but **no leaf could implement it**, because the
+signature took no `CommandContext` and folding a comparison needs one to reach `operator.execute(...)`. So
+`BinaryCondition` never overrode it and the recursion always bottomed out at `false`: the method had no consumer
+outside the AST's own recursion, and `NOT (1=1)` was not folded as always-*false* either, even though
+`NotBlock.isAlwaysFalse` delegates to exactly this method for its negated branch.
+
+`isAlwaysTrue` now takes a `CommandContext`, the shape `isAlwaysFalse` got when it was introduced. The no-argument
+form is gone rather than kept alongside it - it had no caller outside the four AST classes that recursed into it,
+so two forms would only have been two things to keep consistent. `BinaryCondition` folds both verdicts through one
+private helper under the same restriction: **both** operands must be `Expression.isLiteral()`, which excludes a
+bound parameter (the plan outlives the execution that bound it) and a function call (nothing on `SQLFunction` marks
+a function as pure). `WHERE ? = 1` and `WHERE uuid() IS NOT NULL` are therefore still planned as scans, as they
+must be.
+
+The planner drops the where clause in `init()`, before the clauses are rearranged into index searches, so
+everything downstream sees the statement it would have seen without a `WHERE` at all: the projected properties
+computed for column pushdown, the choice between `FetchFromTypeWithFilterStep` and `FetchFromTypeExecutionStep`,
+and the hardwired `count(*)` plan. `NOT (1=0)` folds to always-true and `NOT (1=1)` to the always-false
+`EMPTY RESULT` of #6174, both for free through the existing `NotBlock` delegation.
+
+Dropping a filter is a wider step than folding one to an empty result: an always-false fold can only be wrong by
+returning too few rows, while dropping an always-true filter changes which fetch step is chosen. The regression
+test therefore compares the folded plan against the plan of the same statement written without its `WHERE` - step
+class by step class, so the fetch step and the bucket steps under it both have to agree - and then compares the
+records returned, their order, and the `readRecord` count.
+
+One `OrBlock` detail changed with it: an empty disjunction used to answer `isAlwaysTrue()` with `true`. `OR` is
+false when it has no alternatives, and the answer is now load-bearing, so it answers `false` - the conservative
+verdict, which at worst costs an optimisation.
+
+The value here is smaller than #6174's: nothing sends `WHERE 1=1` as a probe the way Spark sends `WHERE 1=0`, so
+this is symmetry and a small constant per record rather than a full scan avoided.
+
+[#6184](https://github.com/ArcadeData/arcadedb/issues/6184)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -153,6 +153,15 @@ public class SelectExecutionPlanner {
       info.timeout.setValue(context.getDatabase().getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_TIMEOUT));
     }
 
+    // A filter that keeps every record (WHERE 1=1, WHERE true) says nothing the statement did not already say, so it
+    // is dropped here rather than pushed into the fetch: everything downstream - the projected properties computed
+    // just below, the choice between FetchFromTypeWithFilterStep and FetchFromTypeExecutionStep, the hardwired
+    // count(*) plan - then sees the statement it would have seen without a WHERE at all. Decided off the clauses as
+    // the statement wrote them, before optimizeQuery() rearranges them into index searches, and only for
+    // literal-only comparisons, so the verdict holds for every execution that reuses the cached plan.
+    if (info.whereClause != null && info.whereClause.isAlwaysTrue(context))
+      info.whereClause = null;
+
     info.projectedProperties = computeProjectedProperties(info);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3507,7 +3507,7 @@ public class SelectExecutionPlanner {
       if (orderAsc != null && info.orderBy != null && fullySorted(info.orderBy, (AndBlock) desc.keyCondition, desc.getIndex()))
         info.orderApplied = true;
 
-        if (desc.getRemainingCondition() != null && !desc.getRemainingCondition().isEmpty()) {
+        if (needsFilterStep(desc.getRemainingCondition(), context)) {
         if (info.perRecordLetClause != null
             && refersToLet(Collections.singletonList(desc.getRemainingCondition()))) {
           SelectExecutionPlan stubPlan = new SelectExecutionPlan(context,
@@ -3633,12 +3633,22 @@ public class SelectExecutionPlanner {
       if (desc.requiresMultipleIndexLookups()) {
         subPlan.chain(new DistinctExecutionStep(context));
       }
-      if (desc.remainingCondition != null && !desc.remainingCondition.isEmpty()) {
+      if (needsFilterStep(desc.remainingCondition, context)) {
         subPlan.chain(new FilterStep(createWhereFrom(desc.remainingCondition), context));
       }
       subPlans.add(subPlan);
     }
     return new ParallelExecStep(subPlans, context);
+  }
+
+  /**
+   * Whether what an index search left behind still has to be evaluated per record. A residual that is empty, or true
+   * for every record, is no filter at all: {@code WHERE 1=1 AND indexedProperty = 'x'} hands the second term to the
+   * index and leaves the first behind, and evaluating it would cost the index plan the very step the whole where
+   * clause is spared in {@link #init(CommandContext)}.
+   */
+  private static boolean needsFilterStep(final BooleanExpression remainingCondition, final CommandContext context) {
+    return remainingCondition != null && !remainingCondition.isEmpty() && !remainingCondition.isAlwaysTrue(context);
   }
 
   private WhereClause createWhereFrom(final BooleanExpression remainingCondition) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AndBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AndBlock.java
@@ -217,14 +217,11 @@ public class AndBlock extends BooleanExpression {
   }
 
   @Override
-  public boolean isAlwaysTrue() {
-    if (subBlocks.isEmpty())
-      return true;
-
-    for (BooleanExpression exp : subBlocks) {
-      if (!exp.isAlwaysTrue()) {
+  public boolean isAlwaysTrue(final CommandContext context) {
+    // an empty AND block is the neutral element, ie. TRUE
+    for (final BooleanExpression exp : subBlocks) {
+      if (!exp.isAlwaysTrue(context))
         return false;
-      }
     }
     return true;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
@@ -51,16 +51,37 @@ public class BinaryCondition extends BooleanExpression {
 
   /**
    * Folds the comparison at plan time, but only when both of its operands are written in the statement as literals
-   * ({@code 1 = 0}, {@code 'a' = 'b'}, {@code 1 = 1 + 1}). See {@link Expression#isLiteral()} for why a bound
-   * parameter and a function call are excluded even though both could be computed without a record.
+   * ({@code 1 = 0}, {@code 'a' = 'b'}, {@code 1 = 1 + 1}).
    */
   @Override
   public boolean isAlwaysFalse(final CommandContext context) {
+    return literalVerdict(context, Boolean.FALSE);
+  }
+
+  /**
+   * The mirror of {@link #isAlwaysFalse(CommandContext)}, folded under the same literal-only restriction: a comparison
+   * whose operands are both written in the statement ({@code 1 = 1}, {@code 'a' = 'a'}, {@code 2 = 1 + 1}) is true for
+   * every record or for none, and the planner can drop the filter instead of evaluating it once per record.
+   */
+  @Override
+  public boolean isAlwaysTrue(final CommandContext context) {
+    return literalVerdict(context, Boolean.TRUE);
+  }
+
+  /**
+   * Evaluates the comparison at plan time, but only when both of its operands are written in the statement as literals.
+   * See {@link Expression#isLiteral()} for why a bound parameter and a function call are excluded even though both
+   * could be computed without a record.
+   *
+   * @return true when the fold is possible AND its verdict is {@code expected}; false whenever the comparison cannot be
+   * folded, which is the conservative answer both callers need
+   */
+  private boolean literalVerdict(final CommandContext context, final Boolean expected) {
     if (left == null || right == null || !left.isLiteral() || !right.isLiteral())
       return false;
 
     try {
-      return Boolean.FALSE.equals(evaluate((Result) null, context));
+      return expected.equals(evaluate((Result) null, context));
     } catch (final Exception e) {
       // a comparison the operator cannot make (eg. between incompatible types) is left to the runtime to report
       return false;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BooleanExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BooleanExpression.java
@@ -50,6 +50,11 @@ public abstract class BooleanExpression extends SimpleNode {
     }
 
     @Override
+    public boolean isAlwaysTrue(final CommandContext context) {
+      return true;
+    }
+
+    @Override
     public List<String> getMatchPatternInvolvedAliases() {
       return null;
     }
@@ -273,13 +278,20 @@ public abstract class BooleanExpression extends SimpleNode {
   }
 
   /**
-   * returns true only if the expression does not need any further evaluation (eg. "true") and
-   * always evaluates to true. It is supposed to be used as and optimization, and is allowed to
-   * return false negatives
+   * Whether the expression is true for every record, decidable from the statement alone ({@code WHERE 1=1},
+   * {@code WHERE true}). A filter that keeps everything says nothing the statement did not already say, so the planner
+   * drops it and builds the plan the same statement without a WHERE would have got - a plain fetch instead of a
+   * fetch-with-filter, and no predicate evaluated per record.
+   * <p>
+   * Decided exactly like {@link #isAlwaysFalse(CommandContext)}, its mirror: only comparisons between
+   * {@link Expression#isLiteral() literal} operands are folded, so nothing here reads a record, binds a parameter or
+   * calls a function, and a plan built on this answer stays correct for every execution that reuses it. This is an
+   * optimization, so it is allowed to return false negatives - a subclass that cannot decide cheaply, or at all,
+   * inherits {@code false}.
    *
-   * @return
+   * @param context the context used to fold the literal comparison, never used to read data
    */
-  public boolean isAlwaysTrue() {
+  public boolean isAlwaysTrue(final CommandContext context) {
     return false;
   }
 
@@ -290,8 +302,8 @@ public abstract class BooleanExpression extends SimpleNode {
    * <p>
    * Only comparisons between {@link Expression#isLiteral() literal} operands are folded, so nothing here reads a
    * record, binds a parameter or calls a function: a plan built on this answer stays correct for every execution that
-   * reuses it. Like {@link #isAlwaysTrue()} this is an optimization, so it is allowed to return false negatives - a
-   * subclass that cannot decide cheaply, or at all, inherits {@code false}.
+   * reuses it. Like {@link #isAlwaysTrue(CommandContext)} this is an optimization, so it is allowed to return false
+   * negatives - a subclass that cannot decide cheaply, or at all, inherits {@code false}.
    *
    * @param context the context used to fold the literal comparison, never used to read data
    */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/NotBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/NotBlock.java
@@ -134,11 +134,12 @@ public class NotBlock extends BooleanExpression {
   }
 
   @Override
-  public boolean isAlwaysTrue() {
-    if (negate)
+  public boolean isAlwaysTrue(final CommandContext context) {
+    if (sub == null)
       return false;
 
-    return sub.isAlwaysTrue();
+    // NOT <always false> is true for every record; without the NOT this block is a pass-through
+    return negate ? sub.isAlwaysFalse(context) : sub.isAlwaysTrue(context);
   }
 
   @Override
@@ -147,7 +148,7 @@ public class NotBlock extends BooleanExpression {
       return false;
 
     // NOT <always true> is false for every record; without the NOT this block is a pass-through
-    return negate ? sub.isAlwaysTrue() : sub.isAlwaysFalse(context);
+    return negate ? sub.isAlwaysTrue(context) : sub.isAlwaysFalse(context);
   }
 }
 /* JavaCC - OriginalChecksum=1926313b3f854235aaa20811c22d583b (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
@@ -190,14 +190,16 @@ public class OrBlock extends BooleanExpression {
   }
 
   @Override
-  public boolean isAlwaysTrue() {
+  public boolean isAlwaysTrue(final CommandContext context) {
+    // an empty OR block is the neutral element, ie. FALSE - and this answer is load-bearing since the planner drops
+    // the filter on it, so an undecidable block has to say no rather than inherit the AND block's verdict
     if (subBlocks.isEmpty())
-      return true;
+      return false;
 
-    for (BooleanExpression exp : subBlocks) {
-      if (exp.isAlwaysTrue()) {
+    // the disjunction is true as soon as one of its alternatives is
+    for (final BooleanExpression exp : subBlocks) {
+      if (exp.isAlwaysTrue(context))
         return true;
-      }
     }
     return false;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OrBlock.java
@@ -191,8 +191,11 @@ public class OrBlock extends BooleanExpression {
 
   @Override
   public boolean isAlwaysTrue(final CommandContext context) {
-    // an empty OR block is the neutral element, ie. FALSE - and this answer is load-bearing since the planner drops
-    // the filter on it, so an undecidable block has to say no rather than inherit the AND block's verdict
+    // A disjunction with no alternatives is not a filter anyone wrote - the parser cannot produce one - so both
+    // verdicts decline it rather than reason from the neutral element, and for the same reason: each answer is
+    // load-bearing (true drops the filter, false-for-every-record replaces the plan with an empty source), and
+    // neither is worth deducing for a shape that only ever arrives by accident. Declining costs an optimisation
+    // nobody can trigger; deducing costs correctness the first time some rewrite hands over an emptied block.
     if (subBlocks.isEmpty())
       return false;
 
@@ -206,6 +209,7 @@ public class OrBlock extends BooleanExpression {
 
   @Override
   public boolean isAlwaysFalse(final CommandContext context) {
+    // see isAlwaysTrue above: an empty disjunction is declined by both verdicts, not read as the neutral element
     if (subBlocks.isEmpty())
       return false;
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisBlock.java
@@ -82,8 +82,8 @@ public class ParenthesisBlock extends BooleanExpression {
   }
 
   @Override
-  public boolean isAlwaysTrue() {
-    return subElement.isAlwaysTrue();
+  public boolean isAlwaysTrue(final CommandContext context) {
+    return subElement.isAlwaysTrue(context);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
@@ -219,6 +219,16 @@ public class WhereClause extends SimpleNode {
     return baseExpression != null && baseExpression.isAlwaysFalse(context);
   }
 
+  /**
+   * Whether this filter keeps every record, decidable from the statement alone (eg. {@code WHERE 1=1}), so that the
+   * planner can drop it and build the plan the statement without a WHERE would have got.
+   *
+   * @see BooleanExpression#isAlwaysTrue(CommandContext)
+   */
+  public boolean isAlwaysTrue(final CommandContext context) {
+    return baseExpression != null && baseExpression.isAlwaysTrue(context);
+  }
+
   public void setBaseExpression(final BooleanExpression baseExpression) {
     this.baseExpression = baseExpression;
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantTrueFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantTrueFilterFoldingTest.java
@@ -20,6 +20,10 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.parser.AndBlock;
+import com.arcadedb.query.sql.parser.OrBlock;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
 
 import org.junit.jupiter.api.Test;
 
@@ -134,6 +138,36 @@ class ConstantTrueFilterFoldingTest extends TestHelper {
 
     assertThat(names("SELECT FROM Character WHERE 1=1 AND name = 'Arya'")).containsExactly("Arya");
     assertThat(names("SELECT FROM Character WHERE age > 20")).containsExactlyInAnyOrder("Jon", "Tyrion");
+  }
+
+  @Test
+  void anAlwaysTrueTermLeftBehindByAnIndexSearchCostsNoFilterStep() {
+    // the whole-clause fold declines here - the AND is not true for every record - so the interaction to pin is what
+    // the index search leaves behind: it takes `name = 'Arya'` as its key and hands the `1=1` back as a residual
+    // condition, which used to be chained as a FILTER ITEMS WHERE step and evaluated once per index entry
+    database.getSchema().getType("Character").createProperty("name", Type.STRING);
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Character", "name");
+
+    assertThat(fetchSteps(planOf("SELECT FROM Character WHERE 1=1 AND name = 'Arya'")))
+        .as("the satisfiable term still drives the index search")
+        .anyMatch(name -> name.startsWith("FetchFromIndex"));
+
+    assertThat(stepNames(planOf("SELECT FROM Character WHERE 1=1 AND name = 'Arya'")))
+        .isEqualTo(stepNames(planOf("SELECT FROM Character WHERE name = 'Arya'")));
+
+    assertThat(names("SELECT FROM Character WHERE 1=1 AND name = 'Arya'")).containsExactly("Arya");
+    // ...and a residual that can still discard a record is of course kept
+    assertFilter(planOf("SELECT FROM Character WHERE age > 20 AND name = 'Jon'"));
+    assertThat(names("SELECT FROM Character WHERE age > 20 AND name = 'Jon'")).containsExactly("Jon");
+  }
+
+  @Test
+  void anEmptyDisjunctionIsNotTrueForEveryRecord() {
+    // OR is false when it has no alternatives. The parser does not produce an empty OrBlock today, but the verdict
+    // is load-bearing now that the planner drops a filter on it, so it is pinned directly rather than by reachability
+    assertThat(new OrBlock().isAlwaysTrue(null)).isFalse();
+    // ...and an empty AND block is the other neutral element, which its own verdict has always said
+    assertThat(new AndBlock().isAlwaysTrue(null)).isTrue();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantTrueFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantTrueFilterFoldingTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The mirror of {@link ConstantFalseFilterFoldingTest}: a filter that is true for every record ({@code WHERE 1=1},
+ * {@code WHERE true}) says nothing the statement did not already say, so the planner must drop it and build the plan
+ * the same statement without a WHERE would have got. Before issue #6184 no leaf could answer {@code isAlwaysTrue()} -
+ * the method took no context, so a comparison had no way to fold itself - and the recursion always bottomed out at
+ * false, leaving a per-record predicate evaluation and a fetch-with-filter step in place of a plain bucket fetch.
+ * <p>
+ * Dropping a filter is a wider step than folding one to an empty result, because it changes which fetch step is
+ * chosen. So the assertions here are not only "no filter step": the folded plan is compared step by step, and row by
+ * row, against the plan of the very same statement written without its WHERE.
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+class ConstantTrueFilterFoldingTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Character");
+
+    database.transaction(() -> {
+      database.newDocument("Character").set("name", "Arya").set("age", 11).save();
+      database.newDocument("Character").set("name", "Jon").set("age", 24).save();
+      database.newDocument("Character").set("name", "Tyrion").set("age", 39).save();
+    });
+  }
+
+  @Test
+  void anAlwaysTrueFilterIsNotEvaluatedPerRecord() {
+    assertNoFilter(planOf("SELECT FROM Character WHERE 1=1"));
+    assertNoFilter(planOf("SELECT FROM Character WHERE true"));
+
+    // the point of the fold: the plain fetch is back, instead of the fetch-with-filter the WHERE used to force
+    assertThat(stepNames(planOf("SELECT FROM Character WHERE 1=1"))).contains("FetchFromTypeExecutionStep");
+  }
+
+  @Test
+  void theFoldedPlanIsTheOneTheStatementWithoutAWhereWouldHaveGot() {
+    // step for step, which pins the fetch step chosen AND the bucket steps under it
+    assertThat(stepNames(planOf("SELECT FROM Character WHERE 1=1")))
+        .isEqualTo(stepNames(planOf("SELECT FROM Character")));
+
+    assertThat(stepNames(planOf("SELECT name FROM Character WHERE 1=1 ORDER BY name DESC")))
+        .isEqualTo(stepNames(planOf("SELECT name FROM Character ORDER BY name DESC")));
+  }
+
+  @Test
+  void theFoldedPlanReturnsTheSameRecordsInTheSameOrder() {
+    assertThat(rids("SELECT FROM Character WHERE 1=1")).isEqualTo(rids("SELECT FROM Character"));
+    assertThat(rids("SELECT FROM Character WHERE true")).isEqualTo(rids("SELECT FROM Character"));
+
+    assertThat(names("SELECT FROM Character WHERE 1=1")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void theFoldedPlanReadsExactlyTheRecordsTheUnfilteredOneReads() {
+    final long unfiltered = recordsReadBy("SELECT FROM Character");
+
+    assertThat(unfiltered).isEqualTo(3);
+    assertThat(recordsReadBy("SELECT FROM Character WHERE 1=1")).isEqualTo(unfiltered);
+    assertThat(recordsReadBy("SELECT FROM Character WHERE true")).isEqualTo(unfiltered);
+  }
+
+  @Test
+  void anAlwaysTrueFilterIsRecognizedThroughParenthesesAndBooleanBlocks() {
+    assertNoFilter(planOf("SELECT FROM Character WHERE (1=1)"));
+    assertNoFilter(planOf("SELECT FROM Character WHERE 1=1 AND 'a'='a'"));
+    assertNoFilter(planOf("SELECT FROM Character WHERE 2 = 1 + 1"));
+    assertNoFilter(planOf("SELECT FROM Character WHERE true AND 2 > 1"));
+    // one alternative of the OR is enough to keep every record
+    assertNoFilter(planOf("SELECT FROM Character WHERE 1=1 OR name = 'nobody'"));
+    assertNoFilter(planOf("SELECT FROM Character WHERE (1=0 AND name = 'Arya') OR (2 > 1)"));
+
+    assertThat(names("SELECT FROM Character WHERE 1=1 OR name = 'nobody'"))
+        .containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+    assertThat(names("SELECT FROM Character WHERE (1=0 AND name = 'Arya') OR (2 > 1)"))
+        .containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void aNegatedAlwaysFalseFilterFoldsToAlwaysTrue() {
+    // NotBlock delegates its negated branch to isAlwaysFalse, so this comes for free once a leaf can answer
+    assertNoFilter(planOf("SELECT FROM Character WHERE NOT (1=0)"));
+    assertThat(names("SELECT FROM Character WHERE NOT (1=0)")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void aNegatedAlwaysTrueFilterFoldsToAnEmptyResult() {
+    // the other half of the #6181 delegation, which could not fire while no leaf answered isAlwaysTrue: NOT (1=1)
+    // is false for every record, so the statement is answered without a fetch at all
+    assertThat(fetchSteps(planOf("SELECT FROM Character WHERE NOT (1=1)")))
+        .as("NOT (1=1) is false for every record, so nothing is fetched")
+        .isEmpty();
+
+    assertThat(names("SELECT FROM Character WHERE NOT (1=1)")).isEmpty();
+    assertThat(recordsReadBy("SELECT FROM Character WHERE NOT (1=1)")).isZero();
+  }
+
+  @Test
+  void aFilterThatIsNotTrueForEveryRecordKeepsItsFilter() {
+    // the fold is all-or-nothing: it drops a WHERE, it does not prune the satisfied terms out of one
+    assertFilter(planOf("SELECT FROM Character WHERE name = 'Arya'"));
+    assertFilter(planOf("SELECT FROM Character WHERE 1=1 AND name = 'Arya'"));
+    assertFilter(planOf("SELECT FROM Character WHERE age > 20"));
+
+    assertThat(names("SELECT FROM Character WHERE 1=1 AND name = 'Arya'")).containsExactly("Arya");
+    assertThat(names("SELECT FROM Character WHERE age > 20")).containsExactlyInAnyOrder("Jon", "Tyrion");
+  }
+
+  @Test
+  void aFilterResolvedByAParameterIsNeverFolded() {
+    // the plan is cached and reused across bindings: dropping the filter on this execution's parameters would
+    // answer the next execution with every row
+    assertFilter(planOf("SELECT FROM Character WHERE ? = 1", 1));
+
+    assertThat(names("SELECT FROM Character WHERE ? = 1", 1)).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+    assertThat(names("SELECT FROM Character WHERE ? = 1", 0)).isEmpty();
+  }
+
+  @Test
+  void aFilterCallingAFunctionIsNeverFolded() {
+    // nothing on SQLFunction marks a function as pure, so a comparison involving one must not be evaluated at plan
+    // time just to classify the statement
+    assertFilter(planOf("SELECT FROM Character WHERE uuid() IS NOT NULL"));
+    assertThat(names("SELECT FROM Character WHERE uuid() IS NOT NULL")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void anAlwaysFalseFilterIsStillFoldedToAnEmptyResult() {
+    // the two folds share the same literal restriction and must not shadow each other
+    assertThat(fetchSteps(planOf("SELECT FROM Character WHERE 1=0"))).isEmpty();
+    assertThat(names("SELECT FROM Character WHERE 1=0")).isEmpty();
+    assertThat(names("SELECT FROM Character WHERE false")).isEmpty();
+  }
+
+  @Test
+  void countStarWithAnAlwaysTrueFilterCountsEveryRecord() {
+    // dropping the filter hands the statement to the hardwired count(*) plan, which must still answer 3
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM Character WHERE 1=1")) {
+      assertThat(rs.next().<Number>getProperty("total").intValue()).isEqualTo(3);
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM Character WHERE 1=1 AND name = 'Arya'")) {
+      assertThat(rs.next().<Number>getProperty("total").intValue()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void anAlwaysTrueFilterInsideASubqueryIsFoldedToo() {
+    assertNoFilter(planOf("SELECT * FROM (SELECT name FROM Character WHERE 1=1)"));
+    assertThat(names("SELECT * FROM (SELECT name FROM Character WHERE 1=1)"))
+        .containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  @Test
+  void theFoldedPlanIsCacheableAndReusable() {
+    final String sql = "SELECT name FROM Character WHERE 1=1";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    // the type creation in beginTest() invalidates the plan cache with a millisecond-resolution stamp the plan has
+    // to beat: see ConstantFalseFilterFoldingTest for the same guard
+    final long setupMillis = System.currentTimeMillis();
+    while (System.currentTimeMillis() == setupMillis)
+      Thread.onSpinWait();
+
+    assertThat(names(sql)).hasSize(3);
+    assertThat(db.getExecutionPlanCache().contains(sql)).as("the fold depends on the statement alone, so it is cacheable")
+        .isTrue();
+
+    // reuse: the cached plan is copied, so the folded source has to survive the copy
+    assertThat(names(sql)).hasSize(3);
+    assertNoFilter(planOf(sql));
+  }
+
+  @Test
+  void anUpdateWithAnAlwaysTrueFilterStillTouchesEveryRecord() {
+    // the fold must not cost a write statement its target: an always-true WHERE selects everything, exactly as no
+    // WHERE at all does
+    database.transaction(() -> database.command("sql", "UPDATE Character SET house = 'Stark' WHERE 1=1").close());
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS total FROM Character WHERE house = 'Stark'")) {
+      assertThat(rs.next().<Number>getProperty("total").intValue()).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void aDeleteWithAnAlwaysTrueFilterStillRemovesEveryRecord() {
+    database.transaction(() -> database.command("sql", "DELETE FROM Character WHERE 1=1").close());
+
+    assertThat(names("SELECT FROM Character")).isEmpty();
+  }
+
+  private ExecutionPlan planOf(final String sql, final Object... params) {
+    try (final ResultSet rs = params.length == 0 ? database.query("sql", sql) : database.query("sql", sql, params)) {
+      return rs.getExecutionPlan().orElseThrow();
+    }
+  }
+
+  private List<String> names(final String sql, final Object... params) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = params.length == 0 ? database.query("sql", sql) : database.query("sql", sql, params)) {
+      while (rs.hasNext())
+        names.add(rs.next().getProperty("name"));
+    }
+    return names;
+  }
+
+  private List<String> rids(final String sql) {
+    final List<String> rids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", sql)) {
+      while (rs.hasNext())
+        rids.add(rs.next().getIdentity().orElseThrow().toString());
+    }
+    return rids;
+  }
+
+  /** The records the query materialized. */
+  private long recordsReadBy(final String query) {
+    final long before = readRecords();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        rs.next().getPropertyNames();
+    }
+    return readRecords() - before;
+  }
+
+  private long readRecords() {
+    return ((Number) database.getStats().get("readRecord")).longValue();
+  }
+
+  private static void assertNoFilter(final ExecutionPlan plan) {
+    assertThat(filterSteps(plan))
+        .as("a filter that is true for every record must not survive into the plan: %s", plan.prettyPrint(0, 2))
+        .isEmpty();
+  }
+
+  private static void assertFilter(final ExecutionPlan plan) {
+    assertThat(filterSteps(plan))
+        .as("a filter that can discard a record must still be evaluated: %s", plan.prettyPrint(0, 2))
+        .isNotEmpty();
+  }
+
+  private static List<String> filterSteps(final ExecutionPlan plan) {
+    final List<String> found = new ArrayList<>();
+    for (final String name : stepNames(plan))
+      if (name.contains("Filter"))
+        found.add(name);
+    return found;
+  }
+
+  private static List<String> fetchSteps(final ExecutionPlan plan) {
+    final List<String> found = new ArrayList<>();
+    for (final String name : stepNames(plan))
+      if (name.startsWith("FetchFrom") || name.startsWith("CountFrom"))
+        found.add(name);
+    return found;
+  }
+
+  private static List<String> stepNames(final ExecutionPlan plan) {
+    final List<String> found = new ArrayList<>();
+    for (final ExecutionStep step : plan.getSteps())
+      collectStepNames(step, found);
+    return found;
+  }
+
+  private static void collectStepNames(final ExecutionStep step, final List<String> found) {
+    found.add(step.getClass().getSimpleName());
+
+    if (step.getSubSteps() != null)
+      for (final ExecutionStep sub : step.getSubSteps())
+        collectStepNames(sub, found);
+
+    if (step instanceof ExecutionStepInternal internal && internal.getSubExecutionPlans() != null)
+      for (final ExecutionPlan sub : internal.getSubExecutionPlans())
+        for (final ExecutionStep subStep : sub.getSteps())
+          collectStepNames(subStep, found);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantTrueFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantTrueFilterFoldingTest.java
@@ -162,12 +162,19 @@ class ConstantTrueFilterFoldingTest extends TestHelper {
   }
 
   @Test
-  void anEmptyDisjunctionIsNotTrueForEveryRecord() {
-    // OR is false when it has no alternatives. The parser does not produce an empty OrBlock today, but the verdict
-    // is load-bearing now that the planner drops a filter on it, so it is pinned directly rather than by reachability
+  void anEmptyDisjunctionIsDeclinedByBothVerdicts() {
+    // The parser does not produce an empty OrBlock, so this is pinned directly rather than by reachability. Both
+    // verdicts decline it instead of reading it as the neutral element (which would be FALSE), and deliberately:
+    // each answer is load-bearing - isAlwaysTrue drops the filter, isAlwaysFalse replaces the plan with an empty
+    // source - so deducing either one for a block that only ever arrives by accident trades correctness for an
+    // optimisation nobody can trigger.
     assertThat(new OrBlock().isAlwaysTrue(null)).isFalse();
-    // ...and an empty AND block is the other neutral element, which its own verdict has always said
+    assertThat(new OrBlock().isAlwaysFalse(null)).isFalse();
+
+    // an empty AND block, by contrast, is what a filter with no terms left actually looks like, and it keeps every
+    // record: that verdict is reachable and is what lets an emptied residual condition drop its filter step
     assertThat(new AndBlock().isAlwaysTrue(null)).isTrue();
+    assertThat(new AndBlock().isAlwaysFalse(null)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Closes #6184

## What was wrong

The mirror of #6174. That issue taught the planner to recognise a filter that is false for every record; a filter that is *true* for every record was still built as a filter step and evaluated once per record, so the same query written two ways produced two different plans:

```
SELECT FROM C                    -> + FETCH FROM TYPE C
                                      + FETCH FROM BUCKET 1 (C_0) ASC

SELECT FROM C WHERE 1=1          -> + FETCH FROM TYPE C WITH FILTER
                                      + SCAN WITH FILTER BUCKET 1 (C_0)
                                        1 = 1
```

The second pays a predicate evaluation per record, and loses the plain bucket fetch, to learn something the statement had already said.

Nothing was stuck for want of a rule. `BooleanExpression.isAlwaysTrue()` had existed all along and was overridden by `AndBlock`, `OrBlock`, `ParenthesisBlock` and `NotBlock` - but **no leaf could implement it**, because the signature took no `CommandContext` and folding a comparison needs one to reach `operator.execute(context.getDatabase(), ...)`. So `BinaryCondition` never overrode it and the recursion always bottomed out at `false`. Two consequences: the method had no consumer outside the AST's own recursion, and `NOT (1=1)` was not folded as always-*false* either, even though `NotBlock.isAlwaysFalse` (added by #6181) delegates to exactly this method for its negated branch.

## The change

**`isAlwaysTrue` takes a `CommandContext`**, the shape `isAlwaysFalse` got in #6181. The no-argument form is removed rather than kept alongside it: a repo-wide grep finds no caller outside the four AST classes that recursed into it, so two forms would only have been two things to keep consistent - the wider of the two options the issue names, and the cleaner one now that it costs nothing.

**`BinaryCondition` folds both verdicts through one private helper**, `literalVerdict(context, expected)`, under the same restriction `isAlwaysFalse` already used: **both** operands must be `Expression.isLiteral()`. That excludes a bound parameter (the plan is cached and outlives the execution that bound it) and a function call (nothing on `SQLFunction` marks a function as pure). `WHERE ? = 1` and `WHERE uuid() IS NOT NULL` are therefore still planned as scans, as they must be. `BooleanExpression.TRUE` - what the parser answers a bare `WHERE true` with - now carries its own verdict, the way `FALSE` already did.

**The planner drops the where clause in `SelectExecutionPlanner.init()`**, before `optimizeQuery()` rearranges the clauses into index searches, so everything downstream sees the statement it would have seen without a `WHERE` at all: the projected properties computed for column pushdown, the choice between `FetchFromTypeWithFilterStep` and `FetchFromTypeExecutionStep`, and the hardwired `count(*)` plan. `NOT (1=0)` folds to always-true and `NOT (1=1)` to the always-false `EMPTY RESULT` of #6174, both for free through the existing `NotBlock` delegation. The same code builds the `SELECT` plan behind a subquery, a `DELETE ... WHERE` and an `UPDATE ... WHERE`, so all of them are covered.

One `OrBlock` detail changed with it: an empty disjunction used to answer `isAlwaysTrue()` with `true`. `OR` is false when it has no alternatives, and the answer is now load-bearing - the planner drops a filter on it - so it answers `false`, the conservative verdict, which at worst costs an optimisation. `isAlwaysFalse` already answered the empty block the same way.

## What the test pins

The issue's own caution is the design of the test: dropping an always-true filter is a wider step than folding an always-false one to an empty result, because it changes *which fetch step is chosen*, not just how many rows come back. So `ConstantTrueFilterFoldingTest` does not stop at "no filter step in the plan":

- the folded plan is compared **step class by step class** against the plan of the same statement written without its `WHERE` - which pins the fetch step chosen *and* the bucket steps under it, in order;
- the records returned and **their order** are compared against the unfiltered statement's, by RID;
- the `readRecord` statistic is compared against the unfiltered statement's;
- `NOT (1=1)` is asserted to fetch nothing and read zero records - the #6181 delegation that could not fire while no leaf answered `isAlwaysTrue`;
- the negative cases are asserted to keep their filter: `WHERE name = 'Arya'`, `WHERE 1=1 AND name = 'Arya'` (the fold is all-or-nothing, it does not prune satisfied terms out of a filter), `WHERE ? = 1` under two different bindings, and `WHERE uuid() IS NOT NULL`;
- `count(*)` with an always-true filter still answers 3, since the fold hands that statement to the hardwired count plan;
- `UPDATE ... WHERE 1=1` still touches every record and `DELETE ... WHERE 1=1` still removes every record.

## Test plan

- [x] `ConstantTrueFilterFoldingTest` - 16 tests, all green with the fix
- [x] The test was run against the unfixed sources (main-source changes stashed): **7 of the 16 fail**, and they are exactly the fold-specific ones (`anAlwaysTrueFilterIsNotEvaluatedPerRecord`, `theFoldedPlanIsTheOneTheStatementWithoutAWhereWouldHaveGot`, `anAlwaysTrueFilterIsRecognizedThroughParenthesesAndBooleanBlocks`, `aNegatedAlwaysFalseFilterFoldsToAlwaysTrue`, `aNegatedAlwaysTrueFilterFoldsToAnEmptyResult`, `anAlwaysTrueFilterInsideASubqueryIsFoldedToo`, `theFoldedPlanIsCacheableAndReusable`). The other nine are behaviour-parity guards that already held and must keep holding
- [x] Full `engine` unit lane, `mvn -o -pl engine -am test -DexcludedGroups=benchmark,vector,slow`: **12102 tests, 0 failures, 0 errors, 23 skipped** - including `ConstantFalseFilterFoldingTest`, whose `assertScan(planOf("... WHERE 1=1"))` and `assertScan(planOf("... WHERE true"))` still hold (a fetch step is still planned, it just no longer carries a filter)
- [x] Whole reactor compiles and installs (`mvn -o install -DskipTests`) - the signature change has no consumer outside `engine`

Not run locally: the wire-protocol module suites, because port 2480 was already held on this machine and those tests bind fixed ports; CI covers them.
