### PR TITLE
fix(#6151): Bolt's db.labels()/relationshipTypes()/propertyKeys() answer from the procedure registry

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -57,7 +57,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
-import com.arcadedb.schema.VertexType;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.security.ServerSecurityException;
@@ -88,7 +87,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.logging.Level;
 
 import static com.arcadedb.query.opencypher.executor.steps.FinalProjectionStep.PROJECTION_NAME_METADATA;
@@ -1174,7 +1172,7 @@ public class BoltNetworkExecutor extends Thread {
    * Returns true if the query was handled as a system query, false if it should be executed normally.
    */
   private boolean handleSystemQuery(final String query) throws IOException {
-    final String normalized = query.trim().toLowerCase().replaceAll("\\s+", " ");
+    final String normalized = BoltSystemProcedures.normalize(query);
 
     if (normalized.contains("dbms.components")) {
       // CALL dbms.components() - returns server version info
@@ -1249,70 +1247,17 @@ public class BoltNetworkExecutor extends Thread {
       syntheticResults = new ArrayList<>();
       return true;
 
-    } else if (normalized.contains("db.labels") && normalized.contains("db.relationshiptypes")
-        && normalized.contains("db.propertykeys")) {
-      // Combined UNION query from Neo4j Desktop: collects labels, relationship types, property keys as lists
-      currentFields = List.of("result");
-      syntheticResults = new ArrayList<>();
-      if (database != null) {
-        // Labels (vertex types, excluding composite ~ types)
-        final List<Object> labels = new ArrayList<>();
-        for (final DocumentType type : database.getSchema().getTypes())
-          if (type instanceof VertexType && !type.getName().contains("~"))
-            labels.add(type.getName());
-        syntheticResults.add(List.of((Object) labels));
-
-        // Relationship types (edge types)
-        final List<Object> relTypes = new ArrayList<>();
-        for (final DocumentType type : database.getSchema().getTypes())
-          if (type instanceof EdgeType)
-            relTypes.add(type.getName());
-        syntheticResults.add(List.of((Object) relTypes));
-
-        // Property keys (from all non-composite types)
-        final Set<String> allKeys = new TreeSet<>();
-        for (final DocumentType type : database.getSchema().getTypes())
-          if (!type.getName().contains("~"))
-            allKeys.addAll(type.getPropertyNames());
-        syntheticResults.add(List.of((Object) new ArrayList<>(allKeys)));
-      }
-      return true;
-
-    } else if (normalized.contains("db.labels")) {
-      // CALL db.labels() - return vertex type names (excluding composite types with ~)
-      currentFields = List.of("label");
-      syntheticResults = new ArrayList<>();
-      if (database != null) {
-        for (final DocumentType type : database.getSchema().getTypes())
-          if (type instanceof VertexType && !type.getName().contains("~"))
-            syntheticResults.add(List.of(type.getName()));
-      }
-      return true;
-
-    } else if (normalized.contains("db.relationshiptypes")) {
-      // CALL db.relationshipTypes() - return edge type names
-      currentFields = List.of("relationshipType");
-      syntheticResults = new ArrayList<>();
-      if (database != null) {
-        for (final DocumentType type : database.getSchema().getTypes())
-          if (type instanceof EdgeType)
-            syntheticResults.add(List.of(type.getName()));
-      }
-      return true;
-
-    } else if (normalized.contains("db.propertykeys")) {
-      // CALL db.propertyKeys() - return all property key names
-      currentFields = List.of("propertyKey");
-      syntheticResults = new ArrayList<>();
-      if (database != null) {
-        final Set<String> allKeys = new TreeSet<>();
-        for (final DocumentType type : database.getSchema().getTypes()) {
-          if (!type.getName().contains("~"))
-            allKeys.addAll(type.getPropertyNames());
-        }
-        for (final String key : allKeys)
-          syntheticResults.add(List.of(key));
-      }
+    } else if (BoltSystemProcedures.isSchemaProcedureQuery(normalized)) {
+      // CALL db.labels() / db.relationshipTypes() / db.propertyKeys(), plus the combined UNION form Neo4j
+      // Desktop sends. Answered from CypherProcedureRegistry, so the Bolt wire and the native Cypher CALL
+      // path run the very same procedure and cannot drift apart (issue #6151). A null answer means the call
+      // is not ours to serve - it carries arguments the registry entries do not accept - so it falls through
+      // to the engine, which reports the same arity error it reports for any other client.
+      final BoltSystemProcedures.Served served = BoltSystemProcedures.serveSchemaProcedure(database, normalized);
+      if (served == null)
+        return false;
+      currentFields = served.fields();
+      syntheticResults = served.rows();
       return true;
 
     } else if (normalized.startsWith("show index")

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+import com.arcadedb.query.opencypher.procedures.db.DbLabels;
+import com.arcadedb.query.opencypher.procedures.db.DbPropertyKeys;
+import com.arcadedb.query.opencypher.procedures.db.DbRelationshipTypes;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.Result;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * Serves the three schema-introspection procedures Neo4j clients call over Bolt -
+ * {@code db.labels()}, {@code db.relationshipTypes()} and {@code db.propertyKeys()} - out of
+ * {@link CypherProcedureRegistry}, the same registry entries the native Cypher {@code CALL} path executes.
+ * <p>
+ * The Bolt executor intercepts these calls instead of running them through the query engine, because the
+ * Neo4j tooling that sends them also sends a combined {@code UNION} form the engine does not parse. The
+ * interception used to carry its own copy of what each procedure returns, which drifted from the registry
+ * versions (issue #6151): relationship types were not filtered for Cypher's composite {@code A~B} label
+ * types, and property keys came back sorted rather than in schema order. Everything here now asks the
+ * registry, so there is one implementation of each procedure and one place to fix it.
+ * </p>
+ *
+ * @author Roberto Franchini (r.franchini@arcadedata.com)
+ */
+final class BoltSystemProcedures {
+  private static final Object[] NO_ARGS       = new Object[0];
+  private static final String   LABELS        = DbLabels.NAME.toLowerCase(Locale.ROOT);
+  private static final String   RELATIONSHIPS = DbRelationshipTypes.NAME.toLowerCase(Locale.ROOT);
+  private static final String   PROPERTY_KEYS = DbPropertyKeys.NAME.toLowerCase(Locale.ROOT);
+
+  /**
+   * The field names and the rows a served query answers with, in the shape the Bolt executor streams them.
+   *
+   * @param fields the record field names, i.e. the procedure's yield fields
+   * @param rows   one entry per record, each holding one value per field
+   */
+  record Served(List<String> fields, List<List<Object>> rows) {
+  }
+
+  private BoltSystemProcedures() {
+    // Utility class - prevent instantiation
+  }
+
+  /**
+   * Normalizes a query for the Bolt executor's system-query matching: trimmed, lowercased and with every
+   * whitespace run collapsed to a single space.
+   * <p>
+   * The lowercasing is {@link Locale#ROOT}-bound on purpose: under a Turkish default locale {@code toLowerCase()}
+   * maps {@code I} to {@code ı}, so an upper-case {@code CALL DB.RELATIONSHIPTYPES()} would stop matching.
+   * </p>
+   *
+   * @param query the raw query text
+   *
+   * @return the normalized form used by every {@code contains}/{@code startsWith} check
+   */
+  static String normalize(final String query) {
+    return query.trim().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
+  }
+
+  /**
+   * Answers whether the normalized query mentions any of the three schema procedures.
+   *
+   * @param normalized a query normalized by {@link #normalize(String)}
+   *
+   * @return true if the Bolt executor should try to serve it here
+   */
+  static boolean isSchemaProcedureQuery(final String normalized) {
+    return normalized.contains(LABELS) || normalized.contains(RELATIONSHIPS) || normalized.contains(PROPERTY_KEYS);
+  }
+
+  /**
+   * Serves a schema-procedure query out of the registry.
+   * <p>
+   * Recognizes the single-procedure calls and the combined form Neo4j Desktop sends, which unions the three
+   * procedures and collects each into a list under a single {@code result} field.
+   * </p>
+   *
+   * @param database   the database the connection is bound to, may be null when none is selected yet
+   * @param normalized a query normalized by {@link #normalize(String)}
+   *
+   * @return the records to stream, or null when the query must be left to the Cypher engine - which happens
+   * when the call carries arguments (the registry rejects those with the same error the native {@code CALL}
+   * path reports) or when the procedure is not registered
+   */
+  static Served serveSchemaProcedure(final Database database, final String normalized) {
+    final boolean labels = normalized.contains(LABELS);
+    final boolean relationships = normalized.contains(RELATIONSHIPS);
+    final boolean propertyKeys = normalized.contains(PROPERTY_KEYS);
+
+    if (labels && relationships && propertyKeys)
+      return serveCombined(database, normalized);
+
+    if (labels)
+      return serveOne(database, normalized, LABELS);
+    if (relationships)
+      return serveOne(database, normalized, RELATIONSHIPS);
+    if (propertyKeys)
+      return serveOne(database, normalized, PROPERTY_KEYS);
+
+    return null;
+  }
+
+  /**
+   * Serves the combined query Neo4j Desktop sends, one row per procedure, each row holding the list of that
+   * procedure's values.
+   */
+  private static Served serveCombined(final Database database, final String normalized) {
+    final CypherProcedure labels = procedureFor(normalized, LABELS);
+    final CypherProcedure relationships = procedureFor(normalized, RELATIONSHIPS);
+    final CypherProcedure propertyKeys = procedureFor(normalized, PROPERTY_KEYS);
+    if (labels == null || relationships == null || propertyKeys == null)
+      return null;
+
+    final List<List<Object>> rows = new ArrayList<>(3);
+    if (database != null) {
+      rows.add(List.of(column(database, labels)));
+      rows.add(List.of(column(database, relationships)));
+      rows.add(List.of(column(database, propertyKeys)));
+    }
+    return new Served(List.of("result"), rows);
+  }
+
+  /**
+   * Serves a single procedure call, one record per row the procedure yields.
+   */
+  private static Served serveOne(final Database database, final String normalized, final String procedureName) {
+    final CypherProcedure procedure = procedureFor(normalized, procedureName);
+    if (procedure == null)
+      return null;
+
+    final List<String> fields = procedure.getYieldFields();
+    final List<List<Object>> rows = new ArrayList<>();
+    if (database != null) {
+      try (final Stream<Result> results = execute(database, procedure)) {
+        results.forEach(result -> {
+          final List<Object> row = new ArrayList<>(fields.size());
+          for (final String field : fields)
+            row.add(result.getProperty(field));
+          rows.add(row);
+        });
+      }
+    }
+    return new Served(fields, rows);
+  }
+
+  /**
+   * Looks the procedure up, refusing the call when it carries arguments so that the query engine gets it and
+   * reports the arity error the registry entry declares. All three procedures take none.
+   */
+  private static CypherProcedure procedureFor(final String normalized, final String procedureName) {
+    if (callHasArguments(normalized, procedureName))
+      return null;
+    return CypherProcedureRegistry.get(procedureName);
+  }
+
+  /**
+   * Reads every value of a single-field procedure into one list, for the combined query's collected form.
+   */
+  private static List<Object> column(final Database database, final CypherProcedure procedure) {
+    final String field = procedure.getYieldFields().getFirst();
+    final List<Object> values = new ArrayList<>();
+    try (final Stream<Result> results = execute(database, procedure)) {
+      results.forEach(result -> values.add(result.getProperty(field)));
+    }
+    return values;
+  }
+
+  private static Stream<Result> execute(final Database database, final CypherProcedure procedure) {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    return procedure.execute(NO_ARGS, null, context);
+  }
+
+  /**
+   * Detects a call to the named procedure that passes at least one argument, e.g. {@code CALL db.labels('x')}.
+   * <p>
+   * The Bolt interception matches procedure names by substring and cannot evaluate arguments, so a call that
+   * carries any is handed to the Cypher engine rather than answered here.
+   * </p>
+   *
+   * @param normalized    a query normalized by {@link #normalize(String)}
+   * @param procedureName the lower-case procedure name to look for
+   *
+   * @return true if the name is followed by a non-empty argument list
+   */
+  static boolean callHasArguments(final String normalized, final String procedureName) {
+    final int length = normalized.length();
+    for (int found = normalized.indexOf(procedureName); found >= 0;
+        found = normalized.indexOf(procedureName, found + 1)) {
+      int pos = found + procedureName.length();
+      while (pos < length && normalized.charAt(pos) == ' ')
+        ++pos;
+      if (pos >= length || normalized.charAt(pos) != '(')
+        continue;
+      final int close = normalized.indexOf(')', pos);
+      final String args = close < 0 ? normalized.substring(pos + 1) : normalized.substring(pos + 1, close);
+      if (!args.isBlank())
+        return true;
+    }
+    return false;
+  }
+}

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
@@ -122,6 +122,9 @@ final class BoltSystemProcedures {
     if (propertyKeys)
       return serveOne(database, normalized, PROPERTY_KEYS);
 
+    // Defensive: the caller reaches here only through isSchemaProcedureQuery(), which tests the same three
+    // substrings, so no name can be missing. Kept so the two ever diverging declines the query rather than
+    // answering it with nothing.
     return null;
   }
 

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
@@ -225,6 +225,12 @@ final class BoltSystemProcedures {
    * The Bolt interception matches procedure names by substring and cannot evaluate arguments, so a call that
    * carries any is handed to the Cypher engine rather than answered here.
    * </p>
+   * <p>
+   * This is not a Cypher tokenizer and must not be mistaken for one: it walks to the first {@code )} after the
+   * name, so a nested paren or a stray {@code )} later in the query reads as an argument list. Every error it
+   * can make is in the same direction - it declines a call it could have served, and the engine answers it -
+   * which is why the crude scan is enough for the fixed procedure names this interception covers.
+   * </p>
    *
    * @param normalized    a query normalized by {@link #normalize(String)}
    * @param procedureName the lower-case procedure name to look for

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltSystemProcedures.java
@@ -19,6 +19,7 @@
 package com.arcadedb.bolt;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
 import com.arcadedb.query.opencypher.procedures.db.DbLabels;
@@ -30,6 +31,7 @@ import com.arcadedb.query.sql.executor.Result;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
 import java.util.stream.Stream;
 
 /**
@@ -105,22 +107,34 @@ final class BoltSystemProcedures {
    *
    * @return the records to stream, or null when the query must be left to the Cypher engine - which happens
    * when the call carries arguments (the registry rejects those with the same error the native {@code CALL}
-   * path reports) or when the procedure is not registered
+   * path reports), when the procedure is not registered, and when running it raises anything at all
    */
   static Served serveSchemaProcedure(final Database database, final String normalized) {
     final boolean labels = normalized.contains(LABELS);
     final boolean relationships = normalized.contains(RELATIONSHIPS);
     final boolean propertyKeys = normalized.contains(PROPERTY_KEYS);
 
-    if (labels && relationships && propertyKeys)
-      return serveCombined(database, normalized);
+    try {
+      if (labels && relationships && propertyKeys)
+        return serveCombined(database, normalized);
 
-    if (labels)
-      return serveOne(database, normalized, LABELS);
-    if (relationships)
-      return serveOne(database, normalized, RELATIONSHIPS);
-    if (propertyKeys)
-      return serveOne(database, normalized, PROPERTY_KEYS);
+      if (labels)
+        return serveOne(database, normalized, LABELS);
+      if (relationships)
+        return serveOne(database, normalized, RELATIONSHIPS);
+      if (propertyKeys)
+        return serveOne(database, normalized, PROPERTY_KEYS);
+    } catch (final Exception e) {
+      // The Bolt executor calls its system-query interception before the try/catch that classifies query
+      // errors (CommandParsingException vs. retryable conflict vs. plain failure), so an exception escaping
+      // here would reach the connection loop's catch-all unclassified. Running a registry procedure is a
+      // wider surface than the direct schema iteration this branch used to do, so it declines instead: all
+      // three procedures are read-only, which makes re-running the query through the engine free of side
+      // effects and gets the client the engine's own, properly classified error.
+      LogManager.instance().log(BoltSystemProcedures.class, Level.FINE,
+          "Error serving schema procedure from the registry, leaving the query to the engine", e);
+      return null;
+    }
 
     // Defensive: the caller reaches here only through isSchemaProcedureQuery(), which tests the same three
     // substrings, so no name can be missing. Kept so the two ever diverging declines the query rather than
@@ -172,8 +186,14 @@ final class BoltSystemProcedures {
   }
 
   /**
-   * Looks the procedure up, refusing the call when it carries arguments so that the query engine gets it and
-   * reports the arity error the registry entry declares. All three procedures take none.
+   * Looks the procedure up, refusing any call that carries arguments so that the query engine gets it.
+   * <p>
+   * The refusal is not a statement about these procedures' arity - it is that this path only has the query
+   * TEXT and cannot evaluate an argument, so whatever a call passes has to be interpreted where arguments
+   * are evaluated. Today all three declare zero arguments and the engine answers with the registry's arity
+   * error; a procedure that later grew an optional argument would be executed there with it, which is the
+   * same outcome, reached the same way.
+   * </p>
    */
   private static CypherProcedure procedureFor(final String normalized, final String procedureName) {
     if (callHasArguments(normalized, procedureName))

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue6151BoltSchemaProcedureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue6151BoltSchemaProcedureTest.java
@@ -20,6 +20,10 @@ package com.arcadedb.bolt;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.procedures.CypherProcedure;
+import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
+import com.arcadedb.query.opencypher.procedures.db.DbLabels;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
@@ -31,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,6 +55,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class Issue6151BoltSchemaProcedureTest {
   private static final String DB_PATH = "./target/databases/Issue6151BoltSchemaProcedureTest";
+
+  /** The introspection query Neo4j Desktop sends: the three procedures unioned, each collected into a list. */
+  private static final String COMBINED_QUERY =
+      "CALL db.labels() YIELD label RETURN collect(label) AS result "
+          + "UNION CALL db.relationshipTypes() YIELD relationshipType RETURN collect(relationshipType) AS result "
+          + "UNION CALL db.propertyKeys() YIELD propertyKey RETURN collect(propertyKey) AS result";
 
   private Database db;
 
@@ -103,11 +114,7 @@ class Issue6151BoltSchemaProcedureTest {
   @Test
   @DisplayName("the combined UNION query Neo4j Desktop sends collects the engine's values")
   void theCombinedDesktopQueryCollectsTheEngineValues() {
-    final String query = "CALL db.labels() YIELD label RETURN collect(label) AS result "
-        + "UNION CALL db.relationshipTypes() YIELD relationshipType RETURN collect(relationshipType) AS result "
-        + "UNION CALL db.propertyKeys() YIELD propertyKey RETURN collect(propertyKey) AS result";
-
-    final BoltSystemProcedures.Served served = serve(query);
+    final BoltSystemProcedures.Served served = serve(COMBINED_QUERY);
     assertThat(served).isNotNull();
     assertThat(served.fields()).containsExactly("result");
     assertThat(served.rows()).hasSize(3);
@@ -158,6 +165,33 @@ class Issue6151BoltSchemaProcedureTest {
   }
 
   @Test
+  @DisplayName("the combined query with no database selected yields no rows rather than failing")
+  void theCombinedQueryWithoutADatabaseIsEmpty() {
+    final BoltSystemProcedures.Served served = BoltSystemProcedures.serveSchemaProcedure(null,
+        BoltSystemProcedures.normalize(COMBINED_QUERY));
+    assertThat(served).isNotNull();
+    assertThat(served.fields()).containsExactly("result");
+    assertThat(served.rows()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a procedure that blows up declines the query instead of escaping the interception")
+  void aFailingProcedureLeavesTheQueryToTheEngine() {
+    // The Bolt executor runs the interception before the try/catch that classifies query errors, so anything
+    // escaping here would reach the connection loop unclassified. Declining sends the query to the engine.
+    CypherProcedureRegistry.registerOrReplace(new ExplodingLabels());
+    try {
+      assertThat(serve("CALL db.labels()")).isNull();
+      assertThat(serve(COMBINED_QUERY)).isNull();
+    } finally {
+      CypherProcedureRegistry.registerOrReplace(new DbLabels());
+    }
+
+    // Restored: the same call is served again.
+    assertThat(serve("CALL db.labels()")).isNotNull();
+  }
+
+  @Test
   @DisplayName("procedure-name matching survives a locale whose lowercasing rewrites I")
   void matchingIsLocaleIndependent() {
     final Locale original = Locale.getDefault();
@@ -203,5 +237,41 @@ class Issue6151BoltSchemaProcedureTest {
       }
     }
     return values;
+  }
+
+  /**
+   * Stands in for {@code db.labels} in the registry and fails on execution, standing for any future registry
+   * entry whose work is less trivial than iterating the schema.
+   */
+  private static class ExplodingLabels implements CypherProcedure {
+    @Override
+    public String getName() {
+      return DbLabels.NAME;
+    }
+
+    @Override
+    public int getMinArgs() {
+      return 0;
+    }
+
+    @Override
+    public int getMaxArgs() {
+      return 0;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Test double that fails on execution";
+    }
+
+    @Override
+    public List<String> getYieldFields() {
+      return List.of("label");
+    }
+
+    @Override
+    public Stream<Result> execute(final Object[] args, final Result inputRow, final CommandContext context) {
+      throw new IllegalStateException("procedure blew up");
+    }
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue6151BoltSchemaProcedureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue6151BoltSchemaProcedureTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6151: the schema procedures the Bolt executor answers by itself
+ * ({@code db.labels()}, {@code db.relationshipTypes()}, {@code db.propertyKeys()}) must return exactly what
+ * the native Cypher {@code CALL} path returns, because both now run the same
+ * {@link com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry} entries.
+ * <p>
+ * Every assertion here compares the Bolt answer against the engine's answer for the same call rather than
+ * against a hardcoded expectation, so it stays true when a procedure's own semantics change. The fixture is
+ * built so the two implementations that used to exist disagree: an edge type carrying Cypher's composite
+ * {@code ~} label separator (the Bolt copy listed it, the registry filters it out) and property names
+ * declared out of alphabetical order (the Bolt copy sorted them, the registry keeps schema order).
+ * </p>
+ */
+class Issue6151BoltSchemaProcedureTest {
+  private static final String DB_PATH = "./target/databases/Issue6151BoltSchemaProcedureTest";
+
+  private Database db;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    db = factory.create();
+
+    // Property names are declared in a deliberately non-alphabetical order: the old Bolt copy sorted them.
+    db.getSchema().createVertexType("Zebra").createProperty("zeta", Type.STRING);
+    db.getSchema().getType("Zebra").createProperty("alpha", Type.STRING);
+    db.getSchema().createVertexType("Apple").createProperty("mango", Type.STRING);
+    db.getSchema().createEdgeType("KNOWS").createProperty("since", Type.INTEGER);
+    // A composite type, as the Cypher engine names one for a multi-labelled element: the registry filters
+    // these out of both db.relationshipTypes() and db.propertyKeys(), the old Bolt copy only did for labels.
+    db.getSchema().createEdgeType("KNOWS~WORKS_WITH").createProperty("ignored", Type.STRING);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null && db.isOpen())
+      db.drop();
+  }
+
+  @Test
+  @DisplayName("db.labels() over Bolt returns the engine's rows, field name included")
+  void labelsMatchTheEngine() {
+    assertServedQueryMatchesEngine("CALL db.labels()", "label");
+  }
+
+  @Test
+  @DisplayName("db.relationshipTypes() over Bolt filters composite ~ types exactly like the engine")
+  void relationshipTypesMatchTheEngine() {
+    final List<Object> served = assertServedQueryMatchesEngine("CALL db.relationshipTypes() YIELD relationshipType",
+        "relationshipType");
+    // Guards the fixture: the composite edge type exists, so a run where nothing filtered it would differ.
+    assertThat(db.getSchema().getTypes().stream().anyMatch(t -> t.getName().equals("KNOWS~WORKS_WITH"))).isTrue();
+    assertThat(served).contains("KNOWS").doesNotContain("KNOWS~WORKS_WITH");
+  }
+
+  @Test
+  @DisplayName("db.propertyKeys() over Bolt keeps the engine's order, not its own sorted one")
+  void propertyKeysMatchTheEngine() {
+    final List<Object> served = assertServedQueryMatchesEngine("CALL db.propertyKeys()", "propertyKey");
+    // Guards the fixture: alphabetical order and schema order genuinely differ here.
+    assertThat(served).containsSubsequence("zeta", "alpha");
+  }
+
+  @Test
+  @DisplayName("the combined UNION query Neo4j Desktop sends collects the engine's values")
+  void theCombinedDesktopQueryCollectsTheEngineValues() {
+    final String query = "CALL db.labels() YIELD label RETURN collect(label) AS result "
+        + "UNION CALL db.relationshipTypes() YIELD relationshipType RETURN collect(relationshipType) AS result "
+        + "UNION CALL db.propertyKeys() YIELD propertyKey RETURN collect(propertyKey) AS result";
+
+    final BoltSystemProcedures.Served served = serve(query);
+    assertThat(served).isNotNull();
+    assertThat(served.fields()).containsExactly("result");
+    assertThat(served.rows()).hasSize(3);
+
+    assertThat(served.rows().get(0).getFirst()).isEqualTo(engineValues("CALL db.labels()", "label"));
+    assertThat(served.rows().get(1).getFirst())
+        .isEqualTo(engineValues("CALL db.relationshipTypes()", "relationshipType"));
+    assertThat(served.rows().get(2).getFirst()).isEqualTo(engineValues("CALL db.propertyKeys()", "propertyKey"));
+  }
+
+  @Test
+  @DisplayName("a call carrying arguments is left to the engine, which rejects it on arity")
+  void aCallWithArgumentsIsLeftToTheEngine() {
+    assertThat(serve("CALL db.labels('unexpected')")).isNull();
+    assertThat(serve("CALL db.relationshipTypes(1)")).isNull();
+    assertThat(serve("CALL db.propertyKeys( 'x' )")).isNull();
+
+    // Whitespace between the name and its empty argument list is still a no-argument call.
+    assertThat(serve("CALL db.labels ( )")).isNotNull();
+
+    // What the Bolt connection then gets is the engine's own answer: the registry's arity error, the very
+    // error every other client sees, instead of the full label list the interception used to hand back.
+    assertThatThrownBy(() -> db.query("opencypher", "CALL db.labels('unexpected')"))
+        .hasMessageContaining("db.labels");
+  }
+
+  @Test
+  @DisplayName("no database selected yields no rows rather than failing")
+  void withoutADatabaseTheAnswerIsEmpty() {
+    final BoltSystemProcedures.Served served = BoltSystemProcedures.serveSchemaProcedure(null,
+        BoltSystemProcedures.normalize("CALL db.labels()"));
+    assertThat(served).isNotNull();
+    assertThat(served.fields()).containsExactly("label");
+    assertThat(served.rows()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("procedure-name matching survives a locale whose lowercasing rewrites I")
+  void matchingIsLocaleIndependent() {
+    final Locale original = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      final String normalized = BoltSystemProcedures.normalize("CALL DB.RELATIONSHIPTYPES()");
+      assertThat(normalized).isEqualTo("call db.relationshiptypes()");
+      assertThat(BoltSystemProcedures.isSchemaProcedureQuery(normalized)).isTrue();
+    } finally {
+      Locale.setDefault(original);
+    }
+  }
+
+  /**
+   * Serves the query through the Bolt path and asserts it carries the engine's field name and values.
+   *
+   * @return the served values, flattened, for further fixture assertions
+   */
+  private List<Object> assertServedQueryMatchesEngine(final String query, final String field) {
+    final BoltSystemProcedures.Served served = serve(query);
+    assertThat(served).isNotNull();
+    assertThat(served.fields()).containsExactly(field);
+
+    final List<Object> values = new ArrayList<>(served.rows().size());
+    for (final List<Object> row : served.rows()) {
+      assertThat(row).hasSize(1);
+      values.add(row.getFirst());
+    }
+    assertThat(values).containsExactlyElementsOf(engineValues(query, field));
+    return values;
+  }
+
+  private BoltSystemProcedures.Served serve(final String query) {
+    return BoltSystemProcedures.serveSchemaProcedure(db, BoltSystemProcedures.normalize(query));
+  }
+
+  private List<Object> engineValues(final String query, final String field) {
+    final List<Object> values = new ArrayList<>();
+    try (final ResultSet resultSet = db.query("opencypher", query)) {
+      while (resultSet.hasNext()) {
+        final Result result = resultSet.next();
+        values.add(result.getProperty(field));
+      }
+    }
+    return values;
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/Issue6151BoltSchemaProcedureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Issue6151BoltSchemaProcedureTest.java
@@ -119,6 +119,19 @@ class Issue6151BoltSchemaProcedureTest {
   }
 
   @Test
+  @DisplayName("the combined query declines as a whole when any of its three calls carries an argument")
+  void theCombinedQueryDeclinesWhenOneCallCarriesAnArgument() {
+    final String query = "CALL db.labels() YIELD label RETURN collect(label) AS result "
+        + "UNION CALL db.relationshipTypes('unexpected') YIELD relationshipType "
+        + "RETURN collect(relationshipType) AS result "
+        + "UNION CALL db.propertyKeys() YIELD propertyKey RETURN collect(propertyKey) AS result";
+
+    // One bad call sends the whole batch to the engine: answering the other two here would hand back a
+    // result set for a query the engine would have rejected.
+    assertThat(serve(query)).isNull();
+  }
+
+  @Test
   @DisplayName("a call carrying arguments is left to the engine, which rejects it on arity")
   void aCallWithArgumentsIsLeftToTheEngine() {
     assertThat(serve("CALL db.labels('unexpected')")).isNull();


### PR DESCRIPTION
Closes #6151

`BoltNetworkExecutor.handleSystemQuery()` intercepts `db.labels()`, `db.relationshipTypes()` and `db.propertyKeys()` instead of running them through the query engine, and carried its own hand-written copy of each - a second implementation of the three procedures that #6150 had just converged into `CypherProcedureRegistry`. The two copies had already drifted: Bolt listed relationship types whose name carries Cypher's composite `A~B` label separator (the registry filters them out), returned property keys sorted alphabetically (the registry keeps schema order), and answered a call with arguments as if it had none, where the native `CALL` path rejects it on arity. This replaces the three branches with a delegation to the registry entries, so both paths now run the very same `CypherProcedure` objects.

## What changed

- **New `BoltSystemProcedures`** (bolt, package-private): resolves each name in `CypherProcedureRegistry`, executes it against the connection's database through a `BasicCommandContext`, and returns the procedure's own `getYieldFields()` as the Bolt record fields plus one row per yielded result. The combined `UNION` form Neo4j Desktop sends (three `collect(...)` rows under a single `result` field) is built from the same three procedures rather than from a third copy of the logic.
- **`BoltNetworkExecutor`**: the four branches collapse to one delegation (`+12 / -67`). When the helper answers `null` - the call carries arguments, which none of these procedures accept - the interception declines and the query falls through to the engine, so the client gets the registry's arity error instead of a silently-wrong full result.
- **Normalization moved into the helper** and is now `Locale.ROOT`-bound. Under a Turkish default locale `toLowerCase()` maps `I` to `ı`, which would have stopped `CALL DB.RELATIONSHIPTYPES()` matching at all.

The interception itself is kept: the combined Neo4j Desktop query is not something the Cypher engine parses, so removing it is not on the table here.

## Behavior changes visible to a Bolt client

| Call | before | after (= native Cypher) |
|---|---|---|
| `db.relationshipTypes()` | included composite `A~B` edge types | filtered out |
| `db.propertyKeys()` | alphabetically sorted | schema order |
| `db.labels(<arg>)` etc. | argument ignored, full result returned | engine's arity error, as for every other client |

`db.labels()` itself is unchanged - that one copy already matched the registry.

## Test plan

- [x] New `bolt/src/test/java/com/arcadedb/bolt/Issue6151BoltSchemaProcedureTest.java` (10 tests). Every assertion compares the Bolt answer against what `db.query("opencypher", …)` returns for the same call, so it pins convergence rather than a hardcoded expectation. The fixture is built to make the old and new answers differ: an edge type named `KNOWS~WORKS_WITH`, and property names declared out of alphabetical order.
- [x] Proven able to fail: with the pre-fix Bolt copy temporarily reinstated in the helper, `relationshipTypesMatchTheEngine` and `propertyKeysMatchTheEngine` fail (`expected "mango" but was "alpha"`, and `KNOWS~WORKS_WITH` "not expected"); with the fix in place all of them pass.
- [x] Whole `bolt` module unit suite green: `Tests run: 319, Failures: 0, Errors: 0`.
- [x] Covered: the combined Desktop `UNION` query, a call with arguments declining interception (standalone and inside the combined form), a connection with no database selected (single and combined form), a registry procedure that throws (declines to the engine rather than escaping the interception, which runs ahead of the executor's error classification), and locale-independent matching.
- [x] Engine side unaffected: `Cypher*Test` 1231 green, `Issue61*Test`/`OpenCypher*Test` 1982 green.
