### PR TITLE
fix(#6124): a database the bootstrap guard kept is recorded, re-verified and reported, not forgotten

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2395,21 +2395,24 @@ public class ArcadeStateMachine extends BaseStateMachine {
     if (leaderHttpAddr == null || raftHA.isOwnHttpAddress(leaderHttpAddr))
       return; // no leader to compare against yet
 
-    final long now = System.currentTimeMillis();
     // Floored at the snapshot cadence so a WAN cluster that has widened its watchdog does not get probed
     // more often than it resyncs.
-    final long checkIntervalMs = Math.max(BOOTSTRAP_DIVERGENCE_CHECK_INTERVAL_MS, computeSnapshotWatchdogTimeoutMs());
-    final long previous = lastBootstrapDivergenceCheckMs.get();
-    if (previous != 0 && now - previous < checkIntervalMs)
+    if (!claimBootstrapDivergenceCheckSlot(System.currentTimeMillis(),
+        Math.max(BOOTSTRAP_DIVERGENCE_CHECK_INTERVAL_MS, computeSnapshotWatchdogTimeoutMs())))
       return;
-    if (!lastBootstrapDivergenceCheckMs.compareAndSet(previous, now))
-      return; // another tick won the throttle slot
 
     final Set<String> pending = new HashSet<>(bootstrapUnreconciledDatabases);
     final String clusterToken = raftHA.getClusterToken();
     try {
       // Off the HealthMonitor thread: the probe is a blocking HTTP call to the leader and the monitor
       // tick drives the Ratis lifecycle checks behind it.
+      //
+      // On the lifecycleExecutor like every other leader-facing task, and bounded so it cannot become the
+      // thing this module's CLAUDE.md warns about: the executor is single-threaded and already runs
+      // multi-minute full resyncs on it, so what matters is that this task's worst case is small next to
+      // those. It is - BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS (5 s) at most, at most once per check window
+      // (>= 5 minutes), against downloads measured in minutes. A queued resync therefore waits seconds in
+      // the worst case, not for the length of a download.
       lifecycleExecutor.submit(() -> {
         final Map<String, BootstrapBaseline> leaderStates = BootstrapElection.fetchBootstrapState(
             leaderHttpAddr, clusterToken, pending, BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS);
@@ -2425,6 +2428,20 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.WARNING,
           "Cannot schedule the bootstrap-divergence verification: executor is shut down", ree);
     }
+  }
+
+  /**
+   * Claims the one bootstrap-divergence probe slot per {@code intervalMs} window, returning whether the
+   * caller may probe. A lost CAS means another tick took the slot, so this one stands down rather than
+   * probing twice. Extracted (package-private) so the throttle is testable without a live leader: the
+   * rest of {@link #verifyBootstrapDivergence()} needs a reachable peer to reach it.
+   */
+  // @VisibleForTesting
+  boolean claimBootstrapDivergenceCheckSlot(final long now, final long intervalMs) {
+    final long previous = lastBootstrapDivergenceCheckMs.get();
+    if (previous != 0 && now - previous < intervalMs)
+      return false;
+    return lastBootstrapDivergenceCheckMs.compareAndSet(previous, now);
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -2417,9 +2417,14 @@ public class ArcadeStateMachine extends BaseStateMachine {
         final Map<String, BootstrapBaseline> leaderStates = BootstrapElection.fetchBootstrapState(
             leaderHttpAddr, clusterToken, pending, BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS);
         if (leaderStates == null) {
+          // The throttle slot is spent whether or not the probe answered, exactly as the stale-snapshot
+          // backstop spends its own on a failed attempt: the next try is the next check window, not the
+          // next health tick. Said plainly here so the wait is not read as seconds. The mark stays raised
+          // in the meantime, so a failed probe never retires an alert.
           LogManager.instance().log(this, Level.INFO,
-              "Could not verify bootstrap divergence of %s against leader %s; retrying on a later health tick",
-              pending, leaderHttpAddr);
+              "Could not verify bootstrap divergence of %s against leader %s; the divergence stays reported "
+                  + "and the check is retried in the next window (>= %d ms)",
+              pending, leaderHttpAddr, BOOTSTRAP_DIVERGENCE_CHECK_INTERVAL_MS);
           return;
         }
         reconcileBootstrapDivergence(leaderStates);
@@ -2822,12 +2827,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
               // putIfAbsent is defensive: recordBootstrapBaseline already loads before it puts, so a
               // session-applied baseline is written after this load runs and would win anyway; this
               // just guarantees the on-disk copy never overwrites a value already present in memory.
-              if (fingerprint != null)
-                bootstrapBaselines.putIfAbsent(name, new BootstrapBaseline(fingerprint, entry.getLong("lastTxId", -1)));
+              if (fingerprint == null)
+                continue;
+              bootstrapBaselines.putIfAbsent(name, new BootstrapBaseline(fingerprint, entry.getLong("lastTxId", -1)));
               // The overwrite-guard mark (issue #6124). Unlike the baseline it is not re-derivable from
               // the Raft log after a restart - the per-database replay-skip stops the refusal branch from
               // running again - so the persisted flag is the only thing that carries it forward. Absent
               // in files written before #6124: getBoolean's default reads those as "not diverged".
+              //
+              // Read only for an entry that also carries a baseline, which is what makes "every marked
+              // database has a baseline" an invariant of the in-memory state rather than a property of
+              // the current call graph - and therefore what lets the writer below iterate the baselines
+              // alone without dropping a mark on the floor.
               if (entry.getBoolean("unreconciled", false))
                 bootstrapUnreconciledDatabases.add(name);
             }
@@ -2943,12 +2954,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
           entry.put("unreconciled", true);
         json.put(e.getKey(), entry);
       }
-      // A mark is always set right after its baseline was recorded, so this loop normally adds nothing.
-      // It is here so the mark - which, unlike the baseline, cannot be re-derived from the Raft log after
-      // a restart - can never be dropped on the floor by a future caller that marks without a baseline.
-      for (final String dbName : bootstrapUnreconciledDatabases)
-        if (!json.has(dbName))
-          json.put(dbName, new JSONObject().put("unreconciled", true));
+      // Iterating the baselines alone is sufficient for the marks too: a mark is only ever added right
+      // after its baseline was recorded, and the loader refuses one on an entry that carries no
+      // fingerprint, so a marked database without a baseline cannot exist in memory to be missed here.
       FileUtils.atomicWriteFile(file.toFile(), json.toString());
     } catch (final Exception e) {
       // WARNING, not FINE: unlike the applied-index file (whose loss merely re-runs an idempotent

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -63,6 +63,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -211,6 +212,43 @@ public class ArcadeStateMachine extends BaseStateMachine {
       new ConcurrentHashMap<>();
   private volatile boolean bootstrapBaselinesLoaded   = false;
   private final    Object  bootstrapBaselinesFileLock = new Object();
+
+  /**
+   * Databases that took the "local is fresher, refuse to overwrite" branch of
+   * {@link #applyBootstrapFingerprintEntry} and were therefore NOT reinstalled from the cluster's
+   * chosen bootstrap source (issue #6124).
+   * <p>
+   * The refusal itself is correct - it protects a genuinely fresher operator copy from being
+   * silently discarded - but it leaves this node's file-id space assigned by an independent history,
+   * out of step with every other peer. Nothing reconciled that afterwards: issue #6118 made the one
+   * fatal consequence (a later replicated schema change reusing a file id already in use here) throw
+   * and resync, but that fires only if such an entry ever happens to arrive. A node that never
+   * receives a colliding schema change stayed diverged indefinitely and the condition was invisible
+   * outside a single SEVERE line emitted once at bootstrap.
+   * <p>
+   * The set is the durable record of that state: it is persisted alongside the baselines (the
+   * {@code unreconciled} flag of each entry in {@code .raft/bootstrap-baselines}), because the
+   * per-database replay-skip means the refusal branch never re-runs after a restart and the mark
+   * would otherwise be lost. It is re-verified periodically against the leader by
+   * {@link #verifyBootstrapDivergence()}, surfaced to operators by {@code ClusterAlerts}, and cleared
+   * exactly where this node's copy is actually replaced by the leader's.
+   */
+  private final Set<String> bootstrapUnreconciledDatabases = ConcurrentHashMap.newKeySet();
+
+  // Wall-clock of the last bootstrap-divergence verification submitted by verifyBootstrapDivergence();
+  // 0 = none yet. Throttles the HealthMonitor-driven check, which ticks far more often than a probe of
+  // the leader (which computes a SHA-256 over each database directory there) is worth paying for.
+  private final AtomicLong lastBootstrapDivergenceCheckMs = new AtomicLong();
+
+  // How often a still-unreconciled bootstrap divergence is re-verified against the leader. Deliberately
+  // far slower than the snapshot backstops: the condition is permanent until an operator chooses which
+  // copy the cluster keeps, so re-probing it at the health-tick rate would only re-hash every database
+  // on the leader to reach the same conclusion. Five minutes still clears the mark promptly once the
+  // copies do converge, and it bounds the repeated SEVERE to a rate an operator can live with.
+  private static final long BOOTSTRAP_DIVERGENCE_CHECK_INTERVAL_MS = 300_000L;
+  // Per-probe HTTP ceiling, matching BootstrapElection's own per-attempt cap: an unreachable or slow
+  // leader must cost one bounded attempt, not park the lifecycle executor until the next check window.
+  private static final long BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS  = 5_000L;
 
   /** Per-database bootstrap baseline as it appears in the committed Raft log entry. */
   public record BootstrapBaseline(String fingerprint, long lastTxId) {
@@ -1340,6 +1378,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.INFO,
           "HA resync finished (mode=snapshot, result=ok): snapshotIndex=%d", snapshotIndex);
       clearDivergedState();
+      // A leader-driven install reinstalls every database present on this node, so a copy the bootstrap
+      // overwrite guard had kept is gone and its divergence mark with it (issue #6124).
+      clearAllBootstrapUnreconciled();
       return installedTermIndex;
 
     } catch (final SnapshotRefusedException e) {
@@ -1979,6 +2020,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
         throw new RuntimeException("Failed to install snapshot for restored database '" + databaseName + "'", e);
       }
       LogManager.instance().log(this, Level.INFO, "Database '%s' reinstalled via forceSnapshot from leader", databaseName);
+      clearBootstrapUnreconciled(databaseName);
       return;
     }
 
@@ -2067,21 +2109,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
     }
 
     // Compute local state.
-    final String localFingerprint;
-    final long localLastTxId;
-    final String localPath;
+    final BootstrapBaseline local;
     try {
-      final ServerDatabase serverDb = server.getDatabase(dbName);
-      final DatabaseInternal embedded = serverDb.getWrappedDatabaseInstance().getEmbedded();
-      if (!(embedded instanceof LocalDatabase localDb)) {
-        LogManager.instance().log(this, Level.WARNING,
-            "BOOTSTRAP_FINGERPRINT_ENTRY for '%s': embedded database is not a LocalDatabase, skipping",
-            dbName);
-        return;
-      }
-      localPath = localDb.getDatabasePath();
-      localFingerprint = BootstrapFingerprint.compute(new File(localPath));
-      localLastTxId = localDb.getLastTransactionId();
+      local = readLocalBootstrapState(dbName);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING,
           "Could not read local bootstrap state for '%s': %s; falling back to leader-shipped full snapshot",
@@ -2089,6 +2119,14 @@ public class ArcadeStateMachine extends BaseStateMachine {
       installFromLeaderForBootstrap(dbName);
       return;
     }
+    if (local == null) {
+      LogManager.instance().log(this, Level.WARNING,
+          "BOOTSTRAP_FINGERPRINT_ENTRY for '%s': embedded database is not a LocalDatabase, skipping",
+          dbName);
+      return;
+    }
+    final String localFingerprint = local.fingerprint();
+    final long localLastTxId = local.lastTxId();
 
     // Match: bootstrap locally, no bytes move.
     if (localLastTxId == chosenLastTxId && chosenFingerprint.equals(localFingerprint)) {
@@ -2104,14 +2142,22 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // others, and restart. Without this guard, a misconfigured rolling deploy could erase newer
     // transactions on a single pod by re-bootstrapping from older peers.
     if (localLastTxId > chosenLastTxId) {
+      // The refusal keeps this node's file-id space assigned by an independent history, and nothing
+      // used to reconcile it afterwards (issue #6124). Record it durably so the condition survives the
+      // restart that the per-database replay-skip stops this branch from re-evaluating, gets re-verified
+      // against the leader by verifyBootstrapDivergence(), and is visible in the cluster status instead
+      // of only in this one log line.
+      markBootstrapUnreconciled(dbName);
       LogManager.instance().log(this, Level.SEVERE,
           """
           Database '%s': local lastTxId=%d is GREATER than cluster bootstrap lastTxId=%d. \
           This peer's data is fresher than the cluster's chosen baseline (committed \
           BOOTSTRAP_FINGERPRINT_ENTRY). Refusing to overwrite local data. To preserve it, \
           stop the cluster, copy this peer's database directory to every other peer, then \
-          restart all peers.""",
-          dbName, localLastTxId, chosenLastTxId);
+          restart all peers. Until this node's copy is reconciled its file ids are out of step \
+          with the rest of the cluster: to discard it and adopt the leader's copy instead, run \
+          POST /api/v1/cluster/resync/%s on this node.""",
+          dbName, localLastTxId, chosenLastTxId, dbName);
       return;
     }
 
@@ -2201,6 +2247,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
           this::guardedLeaderHttpAddress, this::guardedLeaderHttpsAddress, clusterToken, server);
       LogManager.instance().log(this, Level.INFO,
           "Database '%s' reinstalled after bootstrap mismatch", dbName);
+      clearBootstrapUnreconciled(dbName);
     } catch (final IOException e) {
       throw new RuntimeException("Failed to install snapshot for bootstrap-mismatched database '" + dbName + "'", e);
     }
@@ -2257,6 +2304,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
       SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
           this::guardedLeaderHttpAddress, this::guardedLeaderHttpsAddress, clusterToken, server);
       LogManager.instance().log(this, Level.INFO, "Database '%s' resynced from leader on operator request", dbName);
+      // This is the action the bootstrap-divergence alert asks the operator for: the local copy the
+      // overwrite guard kept has just been replaced, so the mark goes with it (issue #6124).
+      clearBootstrapUnreconciled(dbName);
     } catch (final IOException e) {
       throw new ReplicationException("Failed to resync database '" + dbName + "' from leader", e);
     }
@@ -2270,6 +2320,170 @@ public class ArcadeStateMachine extends BaseStateMachine {
   public BootstrapBaseline getBootstrapBaseline(final String dbName) {
     ensureBootstrapBaselinesLoaded();
     return bootstrapBaselines.get(dbName);
+  }
+
+  /**
+   * Reads this node's own {@code (fingerprint, lastTxId)} for {@code dbName} - the same pair the
+   * bootstrap protocol compares peers on - or {@code null} when the database is not backed by a
+   * {@link LocalDatabase} (nothing to fingerprint). Shared by the bootstrap verification in
+   * {@link #applyBootstrapFingerprintEntry} and the periodic re-verification in
+   * {@link #reconcileBootstrapDivergence}, so the two can never drift on what "local state" means.
+   *
+   * @throws Exception when the database cannot be opened or its directory cannot be read; callers
+   *                   decide what an unreadable local copy means for them.
+   */
+  private BootstrapBaseline readLocalBootstrapState(final String dbName) throws Exception {
+    final ServerDatabase serverDb = server.getDatabase(dbName);
+    final DatabaseInternal embedded = serverDb.getWrappedDatabaseInstance().getEmbedded();
+    if (!(embedded instanceof LocalDatabase localDb))
+      return null;
+    return new BootstrapBaseline(BootstrapFingerprint.compute(new File(localDb.getDatabasePath())),
+        localDb.getLastTransactionId());
+  }
+
+  /**
+   * Databases that took the bootstrap "local is fresher, refuse to overwrite" branch and have not been
+   * reconciled with the cluster since (issue #6124), sorted for deterministic output. Read by
+   * {@code ClusterAlerts} so the condition is visible in {@code GET /api/v1/cluster} rather than only in
+   * a SEVERE line emitted once, at bootstrap, possibly several restarts ago.
+   */
+  public List<String> getBootstrapUnreconciledDatabases() {
+    ensureBootstrapBaselinesLoaded();
+    // The overwhelmingly common answer, and this is read on every Studio status poll: allocate nothing
+    // for it.
+    if (bootstrapUnreconciledDatabases.isEmpty())
+      return Collections.emptyList();
+    final List<String> names = new ArrayList<>(bootstrapUnreconciledDatabases);
+    Collections.sort(names);
+    return names;
+  }
+
+  /**
+   * Periodic re-verification of every database left diverged by the bootstrap overwrite guard
+   * (issue #6124), driven by the {@link HealthMonitor} tick.
+   * <p>
+   * The guard is deliberately passive - it protects an operator's fresher copy by leaving it alone -
+   * but it used to leave nothing behind that would ever look at that copy again. This asks the leader
+   * for its current {@code (fingerprint, lastTxId)} for exactly those databases and either
+   * <ul>
+   *   <li><b>confirms convergence</b> (the leader's fingerprint now equals this node's, i.e. the two
+   *       copies are byte-identical over the persisted content) and drops the mark, or</li>
+   *   <li><b>escalates</b>: re-raises the divergence as an operator-visible SEVERE naming both states
+   *       and the resync endpoint, and keeps the mark (and therefore the cluster alert) raised.</li>
+   * </ul>
+   * It deliberately does NOT resync by itself. Reinstalling from the leader is exactly what the guard
+   * refused to do, and doing it later behind the operator's back would discard the fresher data the
+   * guard exists to protect (the philosophy issue #6118 kept). The reconciliation is one explicit
+   * {@code POST /api/v1/cluster/resync/{database}} away, and this makes sure someone knows to run it.
+   * <p>
+   * Zero cost in the normal case: the marked set is empty and the method returns after one volatile
+   * read. When it is non-empty, the probe is throttled to one attempt per
+   * {@link #BOOTSTRAP_DIVERGENCE_CHECK_INTERVAL_MS} - it makes the leader hash every database directory
+   * it holds - and skipped on the leader, which has nothing to compare itself against.
+   */
+  public void verifyBootstrapDivergence() {
+    final RaftHAServer raftHA = this.raftHAServer;
+    if (raftHA == null || server == null || raftHA.isLeader())
+      return;
+    ensureBootstrapBaselinesLoaded();
+    if (bootstrapUnreconciledDatabases.isEmpty())
+      return;
+
+    // Same two questions the other HealthMonitor-driven backstop asks before burning a throttle slot
+    // (issue #6202): the address must identify a single peer and must not be our own.
+    final String leaderHttpAddr = raftHA.getUnambiguousPeerHttpAddress(raftHA.getLeaderId());
+    if (leaderHttpAddr == null || raftHA.isOwnHttpAddress(leaderHttpAddr))
+      return; // no leader to compare against yet
+
+    final long now = System.currentTimeMillis();
+    // Floored at the snapshot cadence so a WAN cluster that has widened its watchdog does not get probed
+    // more often than it resyncs.
+    final long checkIntervalMs = Math.max(BOOTSTRAP_DIVERGENCE_CHECK_INTERVAL_MS, computeSnapshotWatchdogTimeoutMs());
+    final long previous = lastBootstrapDivergenceCheckMs.get();
+    if (previous != 0 && now - previous < checkIntervalMs)
+      return;
+    if (!lastBootstrapDivergenceCheckMs.compareAndSet(previous, now))
+      return; // another tick won the throttle slot
+
+    final Set<String> pending = new HashSet<>(bootstrapUnreconciledDatabases);
+    final String clusterToken = raftHA.getClusterToken();
+    try {
+      // Off the HealthMonitor thread: the probe is a blocking HTTP call to the leader and the monitor
+      // tick drives the Ratis lifecycle checks behind it.
+      lifecycleExecutor.submit(() -> {
+        final Map<String, BootstrapBaseline> leaderStates = BootstrapElection.fetchBootstrapState(
+            leaderHttpAddr, clusterToken, pending, BOOTSTRAP_DIVERGENCE_PROBE_TIMEOUT_MS);
+        if (leaderStates == null) {
+          LogManager.instance().log(this, Level.INFO,
+              "Could not verify bootstrap divergence of %s against leader %s; retrying on a later health tick",
+              pending, leaderHttpAddr);
+          return;
+        }
+        reconcileBootstrapDivergence(leaderStates);
+      });
+    } catch (final RejectedExecutionException ree) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot schedule the bootstrap-divergence verification: executor is shut down", ree);
+    }
+  }
+
+  /**
+   * Compares this node's copy of every still-unreconciled database against the leader's reported state
+   * and either clears the mark or re-raises the alert. Package-private and free of network I/O so the
+   * verdict is unit-testable without a live cluster; {@link #verifyBootstrapDivergence()} supplies the
+   * leader's states over the existing {@code /api/v1/cluster/bootstrap-state} RPC.
+   * <p>
+   * A database the leader does not report (dropped there, or not open) is left marked: absence is not
+   * evidence of convergence.
+   */
+  // @VisibleForTesting
+  void reconcileBootstrapDivergence(final Map<String, BootstrapBaseline> leaderStates) {
+    for (final String dbName : getBootstrapUnreconciledDatabases()) {
+      final BootstrapBaseline leaderState = leaderStates.get(dbName);
+      if (leaderState == null) {
+        LogManager.instance().log(this, Level.INFO,
+            "Bootstrap divergence of '%s' could not be verified: the leader reported no state for it", dbName);
+        continue;
+      }
+      if (server == null || !server.existsDatabase(dbName)) {
+        // Not currently loaded on this node. Deliberately neither cleared nor opened: existsDatabase
+        // answers "is it in the registry", not "is it on disk", so retiring the alert here would drop a
+        // real divergence for a database that is merely closed - and opening one just to fingerprint it
+        // would undo an operator's decision to leave it closed. A database actually dropped loses its
+        // mark with its baseline, on the DROP entry.
+        continue;
+      }
+      final BootstrapBaseline local;
+      try {
+        local = readLocalBootstrapState(dbName);
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Could not read local state of '%s' to verify bootstrap divergence: %s", dbName, e.getMessage());
+        continue;
+      }
+      if (local == null)
+        continue; // not a LocalDatabase: nothing to fingerprint, leave the mark alone
+
+      if (leaderState.fingerprint() != null && leaderState.fingerprint().equals(local.fingerprint())) {
+        clearBootstrapUnreconciled(dbName);
+        LogManager.instance().log(this, Level.INFO,
+            "Database '%s' is no longer diverged from the cluster: its content now matches the leader "
+                + "(fingerprint=%s, lastTxId=%d). Clearing the bootstrap-divergence alert.",
+            dbName, BootstrapElection.abbreviate(local.fingerprint()), local.lastTxId());
+        continue;
+      }
+
+      LogManager.instance().log(this, Level.SEVERE,
+          """
+          Database '%s' is STILL diverged from the cluster after the bootstrap overwrite guard kept the \
+          local copy: local (lastTxId=%d, fingerprint=%s) vs leader (lastTxId=%d, fingerprint=%s). This \
+          node's file ids were assigned by an independent history, so a later replicated schema change \
+          can collide with them. Either preserve this copy (stop the cluster and copy this node's \
+          database directory to every peer) or discard it and adopt the leader's copy by running \
+          POST /api/v1/cluster/resync/%s on this node.""",
+          dbName, local.lastTxId(), BootstrapElection.abbreviate(local.fingerprint()),
+          leaderState.lastTxId(), BootstrapElection.abbreviate(leaderState.fingerprint()), dbName);
+    }
   }
 
   /**
@@ -2593,6 +2807,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
               // just guarantees the on-disk copy never overwrites a value already present in memory.
               if (fingerprint != null)
                 bootstrapBaselines.putIfAbsent(name, new BootstrapBaseline(fingerprint, entry.getLong("lastTxId", -1)));
+              // The overwrite-guard mark (issue #6124). Unlike the baseline it is not re-derivable from
+              // the Raft log after a restart - the per-database replay-skip stops the refusal branch from
+              // running again - so the persisted flag is the only thing that carries it forward. Absent
+              // in files written before #6124: getBoolean's default reads those as "not diverged".
+              if (entry.getBoolean("unreconciled", false))
+                bootstrapUnreconciledDatabases.add(name);
             }
           }
         }
@@ -2629,8 +2849,57 @@ public class ArcadeStateMachine extends BaseStateMachine {
   private void evictBootstrapBaseline(final String dbName) {
     synchronized (bootstrapBaselinesFileLock) {
       ensureBootstrapBaselinesLoaded();
-      if (bootstrapBaselines.remove(dbName) != null)
+      // The overwrite-guard mark lives in the same file entry, so a dropped database must lose both or
+      // the alert would outlive the database it names (issue #6124).
+      final boolean wasUnreconciled = bootstrapUnreconciledDatabases.remove(dbName);
+      if (bootstrapBaselines.remove(dbName) != null || wasUnreconciled)
         persistBootstrapBaselinesFile();
+    }
+  }
+
+  /**
+   * Durably records that {@code dbName} took the bootstrap "local is fresher, refuse to overwrite"
+   * branch and is therefore diverged from the rest of the cluster (issue #6124). Written under the same
+   * lock as the baselines because it is persisted in the same file entry; the caller has already
+   * recorded the baseline, so the entry exists.
+   */
+  private void markBootstrapUnreconciled(final String dbName) {
+    synchronized (bootstrapBaselinesFileLock) {
+      ensureBootstrapBaselinesLoaded();
+      if (bootstrapUnreconciledDatabases.add(dbName))
+        persistBootstrapBaselinesFile();
+    }
+  }
+
+  /**
+   * Clears the bootstrap-divergence mark of {@code dbName} (issue #6124). Called from every path that
+   * actually replaces this node's copy with the leader's - the bootstrap install, the targeted and
+   * operator-triggered resyncs, the forced reinstall - and from
+   * {@link #reconcileBootstrapDivergence} when the two copies are confirmed identical. Idempotent, and
+   * it does not rewrite the file when nothing was marked.
+   */
+  // @VisibleForTesting
+  void clearBootstrapUnreconciled(final String dbName) {
+    synchronized (bootstrapBaselinesFileLock) {
+      ensureBootstrapBaselinesLoaded();
+      if (bootstrapUnreconciledDatabases.remove(dbName))
+        persistBootstrapBaselinesFile();
+    }
+  }
+
+  /**
+   * Clears every bootstrap-divergence mark (issue #6124). Used by the two full-resync paths, which
+   * reinstall EVERY database present on this node from the leader - the same reasoning
+   * {@link #clearDivergedState()} makes for the diverged set.
+   */
+  // @VisibleForTesting
+  void clearAllBootstrapUnreconciled() {
+    synchronized (bootstrapBaselinesFileLock) {
+      ensureBootstrapBaselinesLoaded();
+      if (!bootstrapUnreconciledDatabases.isEmpty()) {
+        bootstrapUnreconciledDatabases.clear();
+        persistBootstrapBaselinesFile();
+      }
     }
   }
 
@@ -2651,8 +2920,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
         final JSONObject entry = new JSONObject();
         entry.put("fingerprint", e.getValue().fingerprint());
         entry.put("lastTxId", e.getValue().lastTxId());
+        // Written only when set, so a healthy cluster's file keeps exactly the shape it had before
+        // issue #6124 and an older build reading it simply ignores the extra key.
+        if (bootstrapUnreconciledDatabases.contains(e.getKey()))
+          entry.put("unreconciled", true);
         json.put(e.getKey(), entry);
       }
+      // A mark is always set right after its baseline was recorded, so this loop normally adds nothing.
+      // It is here so the mark - which, unlike the baseline, cannot be re-derived from the Raft log after
+      // a restart - can never be dropped on the floor by a future caller that marks without a baseline.
+      for (final String dbName : bootstrapUnreconciledDatabases)
+        if (!json.has(dbName))
+          json.put(dbName, new JSONObject().put("unreconciled", true));
       FileUtils.atomicWriteFile(file.toFile(), json.toString());
     } catch (final Exception e) {
       // WARNING, not FINE: unlike the applied-index file (whose loss merely re-runs an idempotent
@@ -2831,6 +3110,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
     LogManager.instance().log(this, Level.INFO,
         "Snapshot resync completed: reinstalled %d database(s) from the leader; diverged state cleared", resynced);
     clearDivergedState();
+    // Every present database now carries the leader's copy, including any the bootstrap overwrite guard
+    // had kept (issue #6124).
+    clearAllBootstrapUnreconciled();
     // The databases now carry the leader's state, so a read floor published by a stale marker in
     // reinitialize() is satisfied. Record the marker index as the persisted applied position too:
     // without it the very same gap is re-detected on the next restart and the node re-downloads
@@ -2996,6 +3278,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
               LogManager.instance().log(this, Level.INFO,
                   "Targeted snapshot resync of quarantined database '%s' completed", dbName);
               clearDivergedDatabase(dbName);
+              clearBootstrapUnreconciled(dbName);
             }
           } finally {
             snapshotDownloadLock.unlock();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -443,20 +443,75 @@ class BootstrapElection {
         || statusCode == 429 || statusCode >= 500;
   }
 
-  private CompletableFuture<ProbeOutcome> queryPeer(final RaftPeerId peerId,
-      final String httpAddr, final Set<String> dbFilter, final long attemptTimeoutMs) {
-    final String url = "http://" + httpAddr + "/api/v1/cluster/bootstrap-state";
+  /**
+   * Builds the authenticated {@code POST /api/v1/cluster/bootstrap-state} request for {@code httpAddr}.
+   * Shared by the election's async fan-out and the synchronous single-peer probe
+   * {@link #fetchBootstrapState}, so both reach the endpoint with the same credentials (issue #6124).
+   */
+  static HttpRequest bootstrapStateRequest(final String httpAddr, final String clusterToken, final long timeoutMs) {
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
-        .uri(URI.create(url))
-        .timeout(Duration.ofMillis(attemptTimeoutMs))
+        .uri(URI.create("http://" + httpAddr + "/api/v1/cluster/bootstrap-state"))
+        .timeout(Duration.ofMillis(timeoutMs))
         .header("Content-Type", "application/json")
         .POST(HttpRequest.BodyPublishers.ofString("{}"));
-    final String token = haServer.getClusterToken();
-    if (token != null && !token.isBlank())
-      builder.header("X-ArcadeDB-Cluster-Token", token);
+    if (clusterToken != null && !clusterToken.isBlank())
+      builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
     builder.header("X-ArcadeDB-Forwarded-User", "root");
+    return builder.build();
+  }
 
-    return HTTP.sendAsync(builder.build(), HttpResponse.BodyHandlers.ofString())
+  /**
+   * Parses a {@code /bootstrap-state} response body into the reported {@code (fingerprint, lastTxId)}
+   * per database, restricted to {@code dbFilter}. Throws on a malformed body; callers decide whether
+   * that is retryable.
+   */
+  static Map<String, ArcadeStateMachine.BootstrapBaseline> parseBootstrapState(final String body,
+      final Set<String> dbFilter) {
+    final JSONObject json = new JSONObject(body);
+    final JSONArray dbs = json.getJSONArray("databases");
+    final Map<String, ArcadeStateMachine.BootstrapBaseline> result = new HashMap<>();
+    for (int i = 0; i < dbs.length(); i++) {
+      final JSONObject db = dbs.getJSONObject(i);
+      final String name = db.getString("name");
+      if (dbFilter != null && !dbFilter.contains(name))
+        continue;
+      result.put(name, new ArcadeStateMachine.BootstrapBaseline(db.getString("fingerprint"), db.getLong("lastTxId")));
+    }
+    return result;
+  }
+
+  /**
+   * Synchronous single-peer {@code /bootstrap-state} probe (issue #6124), used to re-verify a database
+   * that the bootstrap overwrite guard left diverged against the current leader. Returns {@code null}
+   * on any failure (unreachable peer, non-200, malformed body) - the caller retries on a later health
+   * tick rather than drawing a conclusion from a failed probe.
+   */
+  static Map<String, ArcadeStateMachine.BootstrapBaseline> fetchBootstrapState(final String httpAddr,
+      final String clusterToken, final Set<String> dbFilter, final long timeoutMs) {
+    try {
+      final HttpResponse<String> response = HTTP.send(bootstrapStateRequest(httpAddr, clusterToken, timeoutMs),
+          HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        LogManager.instance().log(BootstrapElection.class, Level.INFO,
+            "bootstrap-state probe of %s answered HTTP %d", httpAddr, response.statusCode());
+        return null;
+      }
+      return parseBootstrapState(response.body(), dbFilter);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    } catch (final Exception e) {
+      LogManager.instance().log(BootstrapElection.class, Level.INFO,
+          "bootstrap-state probe of %s failed: %s", httpAddr, e.getMessage());
+      return null;
+    }
+  }
+
+  private CompletableFuture<ProbeOutcome> queryPeer(final RaftPeerId peerId,
+      final String httpAddr, final Set<String> dbFilter, final long attemptTimeoutMs) {
+    final HttpRequest request = bootstrapStateRequest(httpAddr, haServer.getClusterToken(), attemptTimeoutMs);
+
+    return HTTP.sendAsync(request, HttpResponse.BodyHandlers.ofString())
         .thenApply(resp -> {
           final int status = resp.statusCode();
           if (status != 200) {
@@ -469,17 +524,11 @@ class BootstrapElection {
             return retryable ? ProbeOutcome.retryable("HTTP " + status) : ProbeOutcome.fatal("HTTP " + status);
           }
           try {
-            final JSONObject json = new JSONObject(resp.body());
-            final JSONArray dbs = json.getJSONArray("databases");
             final Map<String, PeerState> result = new HashMap<>();
-            for (int i = 0; i < dbs.length(); i++) {
-              final JSONObject db = dbs.getJSONObject(i);
-              final String name = db.getString("name");
-              if (!dbFilter.contains(name))
-                continue;
-              result.put(name, new PeerState(peerId, name, db.getString("fingerprint"),
-                  db.getLong("lastTxId")));
-            }
+            for (final Map.Entry<String, ArcadeStateMachine.BootstrapBaseline> e :
+                parseBootstrapState(resp.body(), dbFilter).entrySet())
+              result.put(e.getKey(), new PeerState(peerId, e.getKey(), e.getValue().fingerprint(),
+                  e.getValue().lastTxId()));
             return ProbeOutcome.ok(result);
           } catch (final Exception e) {
             LogManager.instance().log(this, Level.WARNING,
@@ -668,7 +717,12 @@ class BootstrapElection {
     return null;
   }
 
-  private static String abbreviate(final String fingerprint) {
+  /**
+   * Shortens a 64-char fingerprint for logging. Package-private so the post-bootstrap divergence
+   * verification in {@link ArcadeStateMachine} reports fingerprints in the same shape the bootstrap
+   * election does (issue #6124).
+   */
+  static String abbreviate(final String fingerprint) {
     if (fingerprint == null || fingerprint.length() <= 16)
       return String.valueOf(fingerprint);
     return fingerprint.substring(0, 8) + "..." + fingerprint.substring(fingerprint.length() - 8);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
@@ -110,6 +110,7 @@ public class ClusterAlerts {
     if (stateMachine != null) {
       checkLeaderMissingDatabases(stateMachine, alerts, visibleDatabases);
       checkFailedAcquireDatabases(stateMachine, alerts, visibleDatabases);
+      checkBootstrapDivergedDatabases(stateMachine, alerts, visibleDatabases);
     }
     addLaggingFollowerAlert(followerSamples, alerts);
     return alerts;
@@ -222,6 +223,43 @@ public class ClusterAlerts {
             + "they may stay absent even after the leader's copy is healthy.")
         .put("recommendation", "Once the leader's copy is healthy, force a fresh download on this node "
             + "(POST /api/v1/cluster/resync/{database}). Check the logs for the underlying acquisition error.")
+        .put("details", new JSONObject().put("databases", names)));
+  }
+
+  /**
+   * Flags databases this node kept through the bootstrap "local is fresher, refuse to overwrite" guard
+   * (issue #6124). The refusal protects a genuinely fresher operator copy, but it leaves this node's
+   * file ids assigned by a history no other peer shares, and nothing reconciles that by itself - the
+   * only automatic consequence is a hard failure if a later replicated schema change happens to collide
+   * with one of those ids (issue #6118). Surfaced as an alert so the divergence is discoverable before
+   * that collision, rather than only in a SEVERE line emitted once at bootstrap.
+   */
+  static void checkBootstrapDivergedDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts,
+      final Set<String> visibleDatabases) {
+    addBootstrapDivergedAlert(visible(stateMachine.getBootstrapUnreconciledDatabases(), visibleDatabases), alerts);
+  }
+
+  /** Pure alert builder (package-private for unit testing): appends the bootstrap-divergence alert iff {@code diverged} is non-empty. */
+  static void addBootstrapDivergedAlert(final List<String> diverged, final JSONArray alerts) {
+    if (diverged == null || diverged.isEmpty())
+      return;
+
+    final JSONArray names = new JSONArray();
+    for (final String name : diverged)
+      names.put(name);
+
+    alerts.put(new JSONObject()
+        .put("id", "bootstrap-diverged-databases")
+        .put("severity", SEVERITY_CRITICAL)
+        .put("title", "Database(s) kept a local copy the cluster never adopted")
+        .put("message", "At first cluster formation this node held " + diverged.size() + " database(s) fresher than "
+            + "the cluster's chosen bootstrap baseline, so they were kept instead of being reinstalled from the "
+            + "leader. Their file ids were assigned by an independent history and are out of step with every other "
+            + "peer: a later replicated schema change that reuses one of them fails and forces a full resync of the "
+            + "database. The copies are otherwise intact - nothing has been lost.")
+        .put("recommendation", "Decide which copy the cluster should keep. To preserve this node's data, stop the "
+            + "cluster, copy its database directory to every peer and restart. To discard it and adopt the leader's "
+            + "copy, run POST /api/v1/cluster/resync/{database} on this node.")
         .put("details", new JSONObject().put("databases", names)));
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -111,6 +111,19 @@ public final class HealthMonitor {
      */
     default void retryUnfilledSnapshotGap() {
     }
+
+    /**
+     * Re-verifies, against the leader, every database this node kept through the bootstrap
+     * "local is fresher, refuse to overwrite" guard (issue #6124), clearing the mark once the two
+     * copies match and otherwise re-raising an operator-visible alert. No-op when no database took that
+     * branch, on the leader, and between throttled attempts.
+     * <p>
+     * It needs its own hook for the same structural reason {@link #retryUnfilledSnapshotGap()} does: the
+     * node is not lagging and not diverged in the Raft sense - it applies every entry it is sent - so
+     * none of the lag- or divergence-driven checks can ever see it.
+     */
+    default void verifyBootstrapDivergence() {
+    }
   }
 
   // How long (as a multiple of the recovery duration) the follower must look healthy before a prior
@@ -219,6 +232,10 @@ public final class HealthMonitor {
     // Independent of the lag checks below, which are structurally blind to an unfilled snapshot gap
     // (issue #6111). Self-throttled by the target.
     target.retryUnfilledSnapshotGap();
+    // Likewise invisible to the lag and divergence checks below: a node the bootstrap overwrite guard
+    // left with its own copy applies every entry it is sent and reports perfect health (issue #6124).
+    // Self-throttled by the target, and free when no database took that branch.
+    target.verifyBootstrapDivergence();
     final LifeCycle.State state = target.getRaftLifeCycleState();
     if (state == LifeCycle.State.CLOSED || state == LifeCycle.State.EXCEPTION) {
       handleUnhealthyState(state);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1158,6 +1158,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   @Override
+  public void verifyBootstrapDivergence() {
+    if (raftServer == null || shutdownRequested)
+      return;
+    final ArcadeStateMachine sm = stateMachine;
+    if (sm != null)
+      sm.verifyBootstrapDivergence();
+  }
+
+  @Override
   public void reportResyncProgress() {
     final FollowerResyncProgressTracker tracker = resyncProgressTracker;
     if (tracker == null || raftServer == null || shutdownRequested || isLeader())

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapDivergenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapDivergenceTest.java
@@ -299,6 +299,24 @@ class ArcadeStateMachineBootstrapDivergenceTest {
         .containsExactly(DB_OTHER);
   }
 
+  /**
+   * A mark is only ever loaded for an entry that also carries a baseline. That is what makes "every
+   * marked database has a baseline" an invariant of the in-memory state rather than a property of the
+   * current call graph, and therefore what lets the writer iterate the baselines alone without dropping
+   * a mark on the floor.
+   */
+  @Test
+  void aMarkWithoutABaselineIsNotLoaded() throws Exception {
+    final Path raftDir = serverDir.resolve(".raft");
+    Files.createDirectories(raftDir);
+    Files.writeString(raftDir.resolve("bootstrap-baselines"), "{\"" + DB_OTHER + "\":{\"unreconciled\":true}}");
+
+    final ArcadeStateMachine sm = newStateMachine();
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+    assertThat(sm.getBootstrapBaseline(DB_OTHER)).isNull();
+  }
+
   /** With nothing diverged the verification is a no-op that cannot invent an alert. */
   @Test
   void reconcilingWithNoDivergenceDoesNothing() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapDivergenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapDivergenceTest.java
@@ -308,4 +308,40 @@ class ArcadeStateMachineBootstrapDivergenceTest {
 
     assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
   }
+
+  /**
+   * The probe throttle: one attempt per window, and a second attempt inside it stands down. Without this
+   * the health tick (seconds apart) would make the leader hash every database directory it holds on every
+   * tick, forever, to reach a conclusion that only changes when an operator acts.
+   */
+  @Test
+  void theProbeIsThrottledToOneAttemptPerWindow() {
+    final ArcadeStateMachine sm = newStateMachine();
+
+    assertThat(sm.claimBootstrapDivergenceCheckSlot(1_000_000L, 300_000L))
+        .as("the first attempt claims the slot").isTrue();
+    assertThat(sm.claimBootstrapDivergenceCheckSlot(1_000_001L, 300_000L))
+        .as("an attempt inside the window stands down").isFalse();
+    assertThat(sm.claimBootstrapDivergenceCheckSlot(1_299_999L, 300_000L))
+        .as("still inside the window").isFalse();
+    assertThat(sm.claimBootstrapDivergenceCheckSlot(1_300_000L, 300_000L))
+        .as("the next window re-arms").isTrue();
+  }
+
+  /**
+   * The whole verification stands down when there is no Raft server to name a leader, and does so
+   * WITHOUT burning the throttle slot: a node that spends its first ticks without a leader must still get
+   * a full-rate first probe once one appears.
+   */
+  @Test
+  void verificationWithoutARaftServerIsANoOpThatKeepsTheThrottleSlot() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+
+    sm.verifyBootstrapDivergence();
+
+    assertThat(sm.getBootstrapUnreconciledDatabases())
+        .as("the mark is untouched when the check cannot run").containsExactly(DB_A);
+    assertThat(sm.claimBootstrapDivergenceCheckSlot(1_000_000L, 300_000L))
+        .as("no throttle slot was consumed").isTrue();
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapDivergenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapDivergenceTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.BootstrapFingerprint;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ha.raft.ArcadeStateMachine.BootstrapBaseline;
+import com.arcadedb.utility.FileUtils;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6124.
+ * <p>
+ * When a peer's local copy of a database is fresher than the cluster's committed bootstrap baseline,
+ * {@link ArcadeStateMachine#applyBootstrapFingerprintEntry} refuses to overwrite it. That refusal is
+ * correct, but it used to leave nothing behind: the node's file-id space stayed assigned by an
+ * independent history, no code path ever looked at it again, and the only trace was a single SEVERE
+ * line at bootstrap. These tests pin the durable mark the refusal now records, the periodic
+ * verification that clears it once the copies converge, and the paths that clear it because this
+ * node's copy was actually replaced by the leader's.
+ * <p>
+ * Driven against a real (unstarted) {@link ArcadeDBServer} and a real {@link LocalDatabase}, no
+ * mocking framework - the same harness as {@code ArcadeStateMachineBootstrapBaselinePersistenceTest}.
+ */
+class ArcadeStateMachineBootstrapDivergenceTest {
+
+  private static final String DB_A     = "db-a";
+  private static final String DB_OTHER = "db-other";
+
+  @TempDir
+  private Path           serverDir;
+  private ArcadeDBServer server;
+  private LocalDatabase  localDbA;
+  private String         dbAPath;
+
+  @BeforeEach
+  void setUp() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    server = new ArcadeDBServer(config);
+
+    dbAPath = serverDir.resolve(DB_A).toString();
+    localDbA = (LocalDatabase) new DatabaseFactory(dbAPath).create();
+    server.registerDatabase(DB_A, localDbA);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (localDbA != null && localDbA.isOpen())
+      localDbA.close();
+    if (dbAPath != null)
+      FileUtils.deleteRecursively(new File(dbAPath));
+  }
+
+  private ArcadeStateMachine newStateMachine() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    return sm;
+  }
+
+  private ByteString encodeBaseline(final String dbName, final String fingerprint, final long lastTxId) {
+    return RaftLogEntryCodec.encodeBootstrapFingerprintEntry(dbName, fingerprint, lastTxId);
+  }
+
+  /** Applies a baseline strictly older than the local copy, which is the "refuse to overwrite" branch. */
+  private ArcadeStateMachine applyStaleBaseline(final ArcadeStateMachine sm) {
+    final long localLastTxId = localDbA.getLastTransactionId();
+    sm.applyBootstrapFingerprintEntry(
+        RaftLogEntryCodec.decode(encodeBaseline(DB_A, "f".repeat(64), localLastTxId - 1)), 50L);
+    return sm;
+  }
+
+  private String localFingerprint() {
+    return BootstrapFingerprint.compute(new File(dbAPath));
+  }
+
+  /**
+   * The refusal is recorded, not merely logged: the database is reported as diverged from the cluster
+   * so the condition can be surfaced and re-checked instead of being forgotten the moment the log line
+   * scrolls away.
+   */
+  @Test
+  void refusingToOverwriteALocallyFresherCopyRecordsTheDivergence() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+
+    assertThat(sm.getBootstrapUnreconciledDatabases())
+        .as("the database kept by the overwrite guard is reported as diverged")
+        .containsExactly(DB_A);
+  }
+
+  /**
+   * A local copy that matches the committed baseline is NOT diverged: the mark must be specific to the
+   * refusal branch, or every healthy node would raise the alert.
+   */
+  @Test
+  void aLocalCopyThatMatchesTheBaselineIsNotRecordedAsDiverged() {
+    final ArcadeStateMachine sm = newStateMachine();
+    sm.applyBootstrapFingerprintEntry(
+        RaftLogEntryCodec.decode(encodeBaseline(DB_A, localFingerprint(), localDbA.getLastTransactionId())), 50L);
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+  }
+
+  /**
+   * The mark survives a restart. This is the whole reason it is persisted rather than kept in memory:
+   * the per-database replay-skip stops {@code applyBootstrapFingerprintEntry} from re-evaluating the
+   * refusal after a restart, so an in-memory mark would silently disappear on the first bounce and the
+   * node would go back to being diverged with nobody tracking it.
+   */
+  @Test
+  void theDivergenceMarkSurvivesARestart() {
+    applyStaleBaseline(newStateMachine());
+
+    final ArcadeStateMachine reopened = newStateMachine();
+    assertThat(reopened.getBootstrapUnreconciledDatabases())
+        .as("a fresh state machine recovers the mark from disk")
+        .containsExactly(DB_A);
+  }
+
+  /** The persisted shape is pinned independently of the reader: an extra flag on the existing entry. */
+  @Test
+  void theDivergenceMarkIsPersistedAsAFlagOnTheBaselineEntry() throws Exception {
+    applyStaleBaseline(newStateMachine());
+
+    final JSONObject json = new JSONObject(
+        Files.readString(serverDir.resolve(".raft").resolve("bootstrap-baselines")).trim());
+    assertThat(json.getJSONObject(DB_A).getBoolean("unreconciled", false)).isTrue();
+  }
+
+  /**
+   * A healthy database's persisted entry keeps exactly the shape it had before this change - the flag is
+   * written only when set, so an older build reading the file sees nothing new.
+   */
+  @Test
+  void aReconciledDatabaseCarriesNoFlagInThePersistedFile() throws Exception {
+    final ArcadeStateMachine sm = newStateMachine();
+    sm.applyBootstrapFingerprintEntry(
+        RaftLogEntryCodec.decode(encodeBaseline(DB_A, localFingerprint(), localDbA.getLastTransactionId())), 50L);
+
+    final JSONObject json = new JSONObject(
+        Files.readString(serverDir.resolve(".raft").resolve("bootstrap-baselines")).trim());
+    assertThat(json.getJSONObject(DB_A).has("unreconciled")).isFalse();
+  }
+
+  /**
+   * The verification's confirming outcome: once the leader reports the same fingerprint, the two copies
+   * are byte-identical over the persisted content and the divergence is over. The mark is dropped, and
+   * durably - a restart must not resurrect an alert that has been answered.
+   */
+  @Test
+  void aLeaderFingerprintThatMatchesClearsTheDivergence() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+
+    sm.reconcileBootstrapDivergence(Map.of(DB_A, new BootstrapBaseline(localFingerprint(), 99L)));
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+    assertThat(newStateMachine().getBootstrapUnreconciledDatabases())
+        .as("clearing the mark is durable")
+        .isEmpty();
+  }
+
+  /**
+   * The verification's escalating outcome: a leader whose copy still differs leaves the mark raised, so
+   * the alert keeps being reported until an operator decides which copy the cluster keeps.
+   */
+  @Test
+  void aLeaderFingerprintThatDiffersKeepsTheDivergenceRaised() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+
+    sm.reconcileBootstrapDivergence(Map.of(DB_A, new BootstrapBaseline("a".repeat(64), 12345L)));
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).containsExactly(DB_A);
+  }
+
+  /**
+   * A leader that reports no state for the database proves nothing: absence is not convergence, so the
+   * mark stays. Without this the first probe answered by a leader that had not opened the database yet
+   * would silently retire the alert.
+   */
+  @Test
+  void aLeaderThatDoesNotReportTheDatabaseKeepsTheDivergenceRaised() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+
+    sm.reconcileBootstrapDivergence(Map.of(DB_OTHER, new BootstrapBaseline("b".repeat(64), 1L)));
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).containsExactly(DB_A);
+  }
+
+  /** Replacing this node's copy with the leader's ends the divergence, durably. */
+  @Test
+  void resyncingTheDatabaseFromTheLeaderClearsTheDivergence() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+
+    sm.clearBootstrapUnreconciled(DB_A);
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+    assertThat(newStateMachine().getBootstrapUnreconciledDatabases()).isEmpty();
+  }
+
+  /** A full resync reinstalls every present database, so it ends every divergence at once. */
+  @Test
+  void aFullResyncClearsEveryDivergence() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+
+    sm.clearAllBootstrapUnreconciled();
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+    assertThat(newStateMachine().getBootstrapUnreconciledDatabases()).isEmpty();
+  }
+
+  /**
+   * Dropping the database takes its mark with it: the alert must not outlive the database it names, and
+   * the flag lives in the same persisted entry the drop evicts.
+   */
+  @Test
+  void droppingTheDatabaseClearsItsDivergence() {
+    final ArcadeStateMachine sm = applyStaleBaseline(newStateMachine());
+    assertThat(sm.getBootstrapUnreconciledDatabases()).containsExactly(DB_A);
+
+    sm.applyDropDatabaseEntry(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeDropDatabaseEntry(DB_A)));
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+    assertThat(newStateMachine().getBootstrapUnreconciledDatabases())
+        .as("the dropped database's mark does not linger in the persisted file")
+        .isEmpty();
+  }
+
+  /**
+   * One database's divergence does not disturb another database's baseline: the mark is written into the
+   * shared baselines file, which is rewritten whole on every change.
+   */
+  @Test
+  void markingOneDatabasePreservesAnotherDatabasesBaseline() {
+    final ArcadeStateMachine sm = newStateMachine();
+    sm.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_OTHER, "c".repeat(64), 7L)), 49L);
+    applyStaleBaseline(sm);
+
+    final ArcadeStateMachine reopened = newStateMachine();
+    assertThat(reopened.getBootstrapUnreconciledDatabases()).containsExactly(DB_A);
+    assertThat(reopened.getBootstrapBaseline(DB_OTHER)).isNotNull();
+    assertThat(reopened.getBootstrapBaseline(DB_OTHER).fingerprint()).isEqualTo("c".repeat(64));
+    assertThat(reopened.getBootstrapBaseline(DB_A))
+        .as("the refused database still records the committed baseline it refused")
+        .isNotNull();
+  }
+
+  /**
+   * A marked database that is not loaded on this node keeps its mark. {@code existsDatabase} answers
+   * "is it in the registry", not "is it on disk", so treating absence as convergence would silently
+   * retire a real divergence for a database an operator merely left closed. The mark is also read back
+   * from a hand-written file here, which pins the persisted flag's reader independently of its writer.
+   */
+  @Test
+  void aDatabaseThatIsNotLoadedKeepsItsDivergence() throws Exception {
+    final Path raftDir = serverDir.resolve(".raft");
+    Files.createDirectories(raftDir);
+    Files.writeString(raftDir.resolve("bootstrap-baselines"),
+        "{\"" + DB_OTHER + "\":{\"fingerprint\":\"" + "e".repeat(64) + "\",\"lastTxId\":4,\"unreconciled\":true}}");
+
+    final ArcadeStateMachine sm = newStateMachine();
+    assertThat(sm.getBootstrapUnreconciledDatabases()).containsExactly(DB_OTHER);
+
+    sm.reconcileBootstrapDivergence(Map.of(DB_OTHER, new BootstrapBaseline("e".repeat(64), 4L)));
+
+    assertThat(sm.getBootstrapUnreconciledDatabases())
+        .as("a database that is not loaded here is neither cleared nor opened to be fingerprinted")
+        .containsExactly(DB_OTHER);
+  }
+
+  /** With nothing diverged the verification is a no-op that cannot invent an alert. */
+  @Test
+  void reconcilingWithNoDivergenceDoesNothing() {
+    final ArcadeStateMachine sm = newStateMachine();
+
+    sm.reconcileBootstrapDivergence(Map.of(DB_A, new BootstrapBaseline("d".repeat(64), 3L)));
+
+    assertThat(sm.getBootstrapUnreconciledDatabases()).isEmpty();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapStateProbeParsingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapStateProbeParsingTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.server.ha.raft.ArcadeStateMachine.BootstrapBaseline;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpRequest;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the shared {@code /api/v1/cluster/bootstrap-state} probe helpers (issue #6124).
+ * <p>
+ * The bootstrap election's async fan-out and the post-bootstrap divergence verification now reach the
+ * endpoint through the same request builder and the same response parser, so a change to either cannot
+ * leave the two paths disagreeing about credentials or about what the response means.
+ */
+class BootstrapStateProbeParsingTest {
+
+  private static final String BODY = """
+      {"peerId":"n1","databases":[
+        {"name":"alpha","fingerprint":"aaaa","lastTxId":12},
+        {"name":"beta","fingerprint":"bbbb","lastTxId":7}
+      ]}""";
+
+  @Test
+  void theRequestCarriesTheClusterCredentialsEveryPeerRpcUses() {
+    final HttpRequest request = BootstrapElection.bootstrapStateRequest("host:2480", "the-token", 1234L);
+
+    assertThat(request.uri().toString()).isEqualTo("http://host:2480/api/v1/cluster/bootstrap-state");
+    assertThat(request.method()).isEqualTo("POST");
+    assertThat(request.headers().firstValue("X-ArcadeDB-Cluster-Token")).hasValue("the-token");
+    assertThat(request.headers().firstValue("X-ArcadeDB-Forwarded-User")).hasValue("root");
+  }
+
+  @Test
+  void aBlankTokenIsOmittedRatherThanSentEmpty() {
+    final HttpRequest request = BootstrapElection.bootstrapStateRequest("host:2480", "  ", 1234L);
+    assertThat(request.headers().firstValue("X-ArcadeDB-Cluster-Token")).isEmpty();
+  }
+
+  @Test
+  void theResponseIsParsedIntoTheReportedStatePerDatabase() {
+    final Map<String, BootstrapBaseline> states = BootstrapElection.parseBootstrapState(BODY, Set.of("alpha", "beta"));
+
+    assertThat(states).hasSize(2);
+    assertThat(states.get("alpha").fingerprint()).isEqualTo("aaaa");
+    assertThat(states.get("alpha").lastTxId()).isEqualTo(12L);
+    assertThat(states.get("beta").lastTxId()).isEqualTo(7L);
+  }
+
+  @Test
+  void databasesOutsideTheFilterAreDropped() {
+    final Map<String, BootstrapBaseline> states = BootstrapElection.parseBootstrapState(BODY, Set.of("beta"));
+
+    assertThat(states).containsOnlyKeys("beta");
+  }
+
+  @Test
+  void aNullFilterKeepsEveryReportedDatabase() {
+    assertThat(BootstrapElection.parseBootstrapState(BODY, null)).containsOnlyKeys("alpha", "beta");
+  }
+
+  @Test
+  void aMalformedBodyThrowsSoTheCallerCanTreatItAsAFailedProbe() {
+    assertThatThrownBy(() -> BootstrapElection.parseBootstrapState("{\"peerId\":\"n1\"}", null))
+        .isInstanceOf(RuntimeException.class);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAlertsBootstrapDivergenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAlertsBootstrapDivergenceTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the bootstrap-divergence cluster alert (issue #6124).
+ * <p>
+ * A node that kept its own copy of a database through the bootstrap "local is fresher, refuse to
+ * overwrite" guard is diverged from the rest of the cluster for that database, and the only prior
+ * evidence was one SEVERE log line emitted at bootstrap - possibly several restarts ago. The alert
+ * makes the condition readable from {@code GET /api/v1/cluster} for as long as it lasts.
+ */
+class ClusterAlertsBootstrapDivergenceTest {
+
+  @Test
+  void noAlertWhenNothingIsDiverged() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addBootstrapDivergedAlert(List.of(), alerts);
+    assertThat(alerts.isEmpty()).isTrue();
+  }
+
+  @Test
+  void nullListRaisesNoAlert() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addBootstrapDivergedAlert(null, alerts);
+    assertThat(alerts.isEmpty()).isTrue();
+  }
+
+  @Test
+  void divergedDatabasesRaiseACriticalAlertNamingThemAndTheResyncEndpoint() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addBootstrapDivergedAlert(List.of("beta", "alpha"), alerts);
+
+    assertThat(alerts.length()).isEqualTo(1);
+    final JSONObject alert = alerts.getJSONObject(0);
+    assertThat(alert.getString("id")).isEqualTo("bootstrap-diverged-databases");
+    assertThat(alert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_CRITICAL);
+    // The operator has to choose which copy the cluster keeps, so the alert must name both options and
+    // the endpoint that performs the destructive one.
+    assertThat(alert.getString("recommendation")).contains("POST /api/v1/cluster/resync/{database}");
+    assertThat(alert.getString("message")).contains("2 database(s)");
+
+    final JSONArray names = alert.getJSONObject("details").getJSONArray("databases");
+    assertThat(names.length()).isEqualTo(2);
+    // The list is reported in the order given: getBootstrapUnreconciledDatabases() already sorts it.
+    assertThat(names.getString(0)).isEqualTo("beta");
+    assertThat(names.getString(1)).isEqualTo("alpha");
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HealthMonitorBootstrapDivergenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HealthMonitorBootstrapDivergenceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.util.LifeCycle;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@link HealthMonitor} tick must drive the bootstrap-divergence verification (issue #6124).
+ * <p>
+ * A node the bootstrap overwrite guard left with its own copy of a database is not lagging and not
+ * diverged in the Raft sense - it applies every entry it is sent and reports zero lag - so none of the
+ * monitor's other checks can ever see it. Without its own hook on the tick, nothing would re-examine
+ * that copy for the life of the process.
+ */
+class HealthMonitorBootstrapDivergenceTest {
+
+  private static final class CountingTarget implements HealthMonitor.HealthTarget {
+    final AtomicReference<LifeCycle.State> state             = new AtomicReference<>(LifeCycle.State.RUNNING);
+    final AtomicInteger                    verifications     = new AtomicInteger();
+    volatile boolean                       shutdownRequested = false;
+
+    @Override
+    public LifeCycle.State getRaftLifeCycleState() {
+      return state.get();
+    }
+
+    @Override
+    public boolean isShutdownRequested() {
+      return shutdownRequested;
+    }
+
+    @Override
+    public void restartRatisIfNeeded() {
+    }
+
+    @Override
+    public void verifyBootstrapDivergence() {
+      verifications.incrementAndGet();
+    }
+  }
+
+  @Test
+  void everyTickVerifiesBootstrapDivergence() {
+    final CountingTarget target = new CountingTarget();
+    final HealthMonitor monitor = new HealthMonitor(target, 0);
+
+    monitor.tick();
+    monitor.tick();
+
+    assertThat(target.verifications.get()).isEqualTo(2);
+  }
+
+  @Test
+  void anUnhealthyRatisLifecycleStillVerifiesBootstrapDivergence() {
+    // The check runs before the lifecycle branch returns early: a node whose Ratis server is CLOSED is
+    // exactly the kind that has been sitting on a diverged copy unnoticed.
+    final CountingTarget target = new CountingTarget();
+    target.state.set(LifeCycle.State.CLOSED);
+    final HealthMonitor monitor = new HealthMonitor(target, 0);
+
+    monitor.tick();
+
+    assertThat(target.verifications.get()).isEqualTo(1);
+  }
+
+  @Test
+  void aShutdownRequestSkipsTheVerification() {
+    final CountingTarget target = new CountingTarget();
+    target.shutdownRequested = true;
+    final HealthMonitor monitor = new HealthMonitor(target, 0);
+
+    monitor.tick();
+
+    assertThat(target.verifications.get()).isZero();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Makes the bootstrap "local is fresher, refuse to overwrite" refusal a **recorded, re-verified, operator-visible** state instead of a single log line that scrolls away.

1. **Durable mark.** Taking the refusal branch of `ArcadeStateMachine.applyBootstrapFingerprintEntry` records the database in a new `bootstrapUnreconciledDatabases` set, persisted as an `unreconciled` flag on that database's entry in the existing `.raft/bootstrap-baselines` file. It has to be persisted rather than kept in memory precisely because the per-database replay-skip stops the branch from re-evaluating after a restart: an in-memory mark would vanish on the first bounce. The flag is written only when set, so a healthy cluster's file keeps exactly the shape it had before and an older build ignores the extra key.

2. **Active verification.** A new `verifyBootstrapDivergence()` hook on the `HealthMonitor` tick probes the leader over the *existing* `POST /api/v1/cluster/bootstrap-state` RPC for exactly those databases and either
   - **confirms convergence** (the leader now reports the same fingerprint, i.e. the two copies are byte-identical over the persisted content) and drops the mark, or
   - **escalates**: a SEVERE naming both `(lastTxId, fingerprint)` pairs and the resync endpoint, with the mark left raised.

   It needs its own hook for the same structural reason `retryUnfilledSnapshotGap()` does: such a node is not lagging and not diverged in the Raft sense - it applies every entry it is sent and reports zero lag - so no lag- or divergence-driven check can ever see it. Free in the normal case (empty set, one volatile read), skipped on the leader, throttled to one probe per 5 minutes (floored at the snapshot watchdog cadence) with a 5 s per-probe HTTP ceiling, because the probe makes the leader hash every database directory it holds.

3. **Operator-visible alert.** A `bootstrap-diverged-databases` critical alert in `ClusterAlerts`, so the condition is readable from `GET /api/v1/cluster` (and Studio's HA panel) for as long as it lasts.

4. **Clearing.** The mark is dropped exactly where this node's copy is actually replaced by the leader's: the bootstrap install, the forced `forceSnapshot` reinstall, the targeted quarantine resync, the operator-triggered `POST /api/v1/cluster/resync/{database}`, the full resync, and the leader-driven snapshot install. A dropped database loses its mark with its baseline.

### Why it deliberately does not resync by itself

Reinstalling from the leader is exactly what the guard refused to do. Doing it later, in the background, would discard the fresher operator data the guard exists to protect - and the leader's `lastTxId` passes this node's within seconds of the cluster taking any write, so an "is the leader ahead now?" trigger would fire almost immediately and quietly reverse the guard. The automatic action is therefore to *verify and surface*; the destructive reconciliation stays one explicit operator request away, and both the alert and the log line name it. This keeps the philosophy #6118 preserved.

### Reuse

The election's async fan-out and the new synchronous probe now share one request builder (`BootstrapElection.bootstrapStateRequest`) and one response parser (`parseBootstrapState`), so the two paths cannot drift on credentials or on what the response means. `applyBootstrapFingerprintEntry` and the verification share `readLocalBootstrapState`, so they cannot drift on what "local state" means either. Fingerprints are abbreviated for logging through the election's existing helper.

## Motivation

`BootstrapElection` elects one cluster-wide bootstrap source from *aggregate* freshness across all databases, so it is normal - not operator error - for a different, non-elected node to independently hold a higher `lastTxId` for one *specific* database after a concurrent cold boot. The overwrite guard then correctly leaves that node's copy alone.

What the refusal left behind was nothing. The node's file ids stay assigned by a history no other peer shares, and the only trace was one SEVERE emitted once, at bootstrap. #6118 closed the one consequence that silently ate data (a later replicated schema change reusing a file id already in use there), but reactively: it fires only if such an entry ever happens to collide. A node that never receives a colliding schema change stayed diverged indefinitely, discoverable only by an explicit `CHECK DATABASE`, a manual comparison, or bad luck.

## Related issues

Closes #6124. Follow-up to #6063 / #6118 (the reactive half of the same divergence), and reuses the #4147 bootstrap-state machinery.

## Additional Notes

- No new configuration knob and no new HTTP endpoint: the probe reuses the authenticated cluster RPC that already exists, and the check interval / probe timeout are internal constants (5 min / 5 s).
- `getBootstrapUnreconciledDatabases()` is read on every Studio status poll and returns `Collections.emptyList()` without allocating in the (overwhelmingly common) healthy case.
- A marked database that is not currently *loaded* on the node is neither cleared nor opened to be fingerprinted: `existsDatabase` answers "is it in the registry", not "is it on disk", so retiring the alert there would drop a real divergence for a database an operator merely left closed.

## Checklist

- [x] I have run the build using `mvn clean package` command (ran `mvn -pl ha-raft -am install -DskipTests` plus the full `ha-raft` unit suite)
- [x] My unit tests cover both failure and success scenarios

### Test plan

New unit tests, all in `ha-raft`, no mocking framework (real unstarted `ArcadeDBServer` + real `LocalDatabase`, the `ArcadeStateMachineBootstrapBaselinePersistenceTest` harness):

- `ArcadeStateMachineBootstrapDivergenceTest` (14 tests): the refusal records the divergence; a matching baseline does not; the mark survives a restart; the persisted shape (flag present when diverged, absent when not); a matching leader fingerprint clears it, durably; a differing one, and a leader that does not report the database, both keep it raised; a database not loaded here is neither cleared nor opened; per-database and full resync clear it; a drop clears it; marking one database preserves another's baseline.
- `HealthMonitorBootstrapDivergenceTest`: every tick drives the verification, including on a CLOSED Ratis lifecycle; a shutdown request skips it.
- `ClusterAlertsBootstrapDivergenceTest`: the alert's id/severity/details and the resync endpoint in the recommendation; empty and null lists raise nothing.
- `BootstrapStateProbeParsingTest`: the shared request carries the cluster token and forwarded-user headers (and omits a blank token); the shared parser honours the database filter and throws on a malformed body.

**The tests can fail:** with `markBootstrapUnreconciled(dbName)` removed from the refusal branch, 7 of the 14 divergence tests fail.

**No regressions:** full `ha-raft` unit lane (`-DexcludedGroups=benchmark,vector,slow`) green.
