### PR TITLE
fix(#6062): CHECK DATABASE remembers the adjacency list it walked instead of re-walking it per edge

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -468,6 +468,26 @@ public enum GlobalConfiguration {
       spanning several pages). Leave headroom when picking a value close to the replicated-entry limit.""",
       Integer.class, 256),
 
+  CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES("arcadedb.checkDatabaseAdjacencyCacheEntries", SCOPE.DATABASE,
+      """
+      Maximum number of adjacency-list entries CHECK DATABASE keeps materialised while answering its back-reference \
+      probes (issue #6062). The check asks, once per edge, whether the NEIGHBOUR's edge list names that edge \
+      (checkEdges) and whether the far vertex of every adjacency entry points back (checkVertices). Both questions \
+      are a linear walk of the neighbour's chunk chain, and nothing used to be remembered between two probes of the \
+      same list, so a hub of degree D was walked D times by each of them: O(D²) on exactly the vertex the check \
+      exists to survive, with every walk risking a page read once the graph exceeds the page cache. A 657GB database \
+      with hubs in the hundreds of thousands of edges measured 80 hours for one CHECK DATABASE FIX. With the cache, \
+      the first probe of a list materialises it into primitive hash sets and every later probe of it is a hash \
+      lookup, so a pass walks each list once instead of once per incident edge. Counted in ENTRIES rather than in \
+      lists because that is what the memory is proportional to and because one super-node can be larger than every \
+      other list in the database put together; the least-recently-probed list is evicted when the budget is \
+      exceeded, so hubs - the lists that pay for themselves - are the ones that stay. A single list larger than the \
+      whole budget is never cached and is answered by the original walk. At the default of 1 million entries the \
+      footprint is roughly 20MB. 0 disables the cache and restores the pre-#6062 probe, which is the escape hatch \
+      if the memory is unwelcome on a small heap; the check reports what the setting bought under the \
+      adjacencyProbes / adjacencyProbeListWalks / adjacencyEntriesScanned keys.""",
+      Integer.class, 1_000_000),
+
   PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE, "Size of the asynchronous page flush queue", Integer.class, 512),
 
   FLUSH_SUSPEND_MAX_DEFERRED_RAM("arcadedb.flushSuspendMaxDeferredRAM", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -170,6 +170,16 @@ public class DatabaseChecker {
     result.put("edgesMissingOutReference", 0L);
     result.put("edgesMissingInReference", 0L);
     result.put("unreachableEdgeRecordsFound", new LinkedHashSet<RID>());
+    // Issue #6062: what the back-reference probes cost, seeded so a run always answers "why was this slow" rather
+    // than answering it only when a graph pass happened to run. adjacencyProbes is how many times the check asked an
+    // endpoint whether its adjacency list references an edge - structurally two per edge, per pass;
+    // adjacencyProbeListWalks is how many of those had to walk a list, which used to be all of them and now grows
+    // with the number of DISTINCT lists; adjacencyEntriesScanned is the entries those walks visited, the number that
+    // was quadratic in a super-node's degree. A adjacencyProbeListWalks close to adjacencyProbes on a graph with
+    // hubs means the cache is not engaging - see arcadedb.checkDatabaseAdjacencyCacheEntries.
+    result.put("adjacencyProbes", 0L);
+    result.put("adjacencyProbeListWalks", 0L);
+    result.put("adjacencyEntriesScanned", 0L);
     result.put("warnings", new LinkedHashSet<>());
     // Issue #6143: files this node holds that no schema component claims. Report-only, always present so a clean
     // run says "none" rather than saying nothing, and empty under a RECORD scope, which cannot answer the question.

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -173,10 +173,11 @@ public class DatabaseChecker {
     // Issue #6062: what the back-reference probes cost, seeded so a run always answers "why was this slow" rather
     // than answering it only when a graph pass happened to run. adjacencyProbes is how many times the check asked an
     // endpoint whether its adjacency list references an edge - structurally two per edge, per pass;
-    // adjacencyProbeListWalks is how many of those had to walk a list, which used to be all of them and now grows
-    // with the number of DISTINCT lists; adjacencyEntriesScanned is the entries those walks visited, the number that
-    // was quadratic in a super-node's degree. A adjacencyProbeListWalks close to adjacencyProbes on a graph with
-    // hubs means the cache is not engaging - see arcadedb.checkDatabaseAdjacencyCacheEntries.
+    // adjacencyProbeListWalks is how many walks of a list answering them took, which used to be one per probe and
+    // now grows with the number of DISTINCT lists; adjacencyEntriesScanned is the entries those walks visited, the
+    // number that was quadratic in a super-node's degree. adjacencyProbeListWalks at or above adjacencyProbes on a
+    // graph with hubs means the cache is not engaging - the budget may be below the hub's degree, see
+    // arcadedb.checkDatabaseAdjacencyCacheEntries.
     result.put("adjacencyProbes", 0L);
     result.put("adjacencyProbeListWalks", 0L);
     result.put("adjacencyEntriesScanned", 0L);

--- a/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
+++ b/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
@@ -70,6 +70,13 @@ import java.util.Map;
  * what this class materialises through - and which the checker's own walk of a vertex's list goes through as well,
  * where the missing guard meant a check that never returned.
  * <p>
+ * SCOPED TO ONE PASS OVER ONE TYPE, not to the whole run. {@code checkVertices}/{@code checkEdges} each build their
+ * own, and {@code DatabaseChecker} calls them once per vertex/edge type, so a hub referenced from two source types
+ * has its list materialised once per type pass rather than once per {@code CHECK DATABASE}. Deliberate: the images
+ * are only valid while nothing writes to the lists, and each pass commits its own repairs, so a cache outliving a
+ * pass would have to survive exactly the writes it cannot survive. The cost is a constant factor in the number of
+ * types, not a return to the quadratic shape - each pass is still one walk per list.
+ * <p>
  * STALENESS IS THE CALLER'S JOB, and there is exactly one caller. A cached image is only valid while the list it was
  * built from does not change. The edge pass writes nothing while it scans; the vertex pass prunes dangling entries,
  * and calls {@link #clear()} at that site rather than naming the lists it touched - see that method. Both drop the
@@ -324,6 +331,12 @@ final class AdjacencyProbeCache {
   /**
    * The polymorphic bucket file-ids of an edge type, memoised. {@code isVertexConnectedTo} rebuilt this through a
    * stream per call, so a hub probed once per incident edge paid an array allocation per edge on top of the walk.
+   * <p>
+   * Held for the life of the cache, which is one pass over one type. A bucket added to an edge type WHILE that pass
+   * runs is therefore missed until the next pass, where the unmemoised form would have picked it up on the next
+   * probe. Left as is: a bucket added mid-scan holds no edges the scan has already read past either, so the filter
+   * is not the thing that would make such a run coherent - a schema change concurrent with a check is outside what
+   * either form promises.
    */
   private int[] bucketFilterOf(final VertexInternal vertex, final String edgeType) {
     return bucketFilters.computeIfAbsent(edgeType,

--- a/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
+++ b/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.utility.LongHashSet;
+import com.arcadedb.utility.Pair;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Answers the back-reference probes {@link GraphDatabaseChecker} makes, remembering the adjacency lists it had to
+ * walk (issue #6062).
+ * <p>
+ * WHAT IT REPLACES, and why it is worth a class of its own. The checker asks two questions of a NEIGHBOUR's
+ * adjacency list, both once per edge and both O(degree):
+ * <ul>
+ *   <li>{@code checkEdges} asks both endpoints of every edge record whether their list names it
+ *   ({@code EdgeLinkedList.containsEdge} - a linear walk of the chunk chain, or of every stripe chain for a promoted
+ *   super-node);</li>
+ *   <li>{@code checkVertices} asks the far vertex of every adjacency entry whether it points back
+ *   ({@code Vertex.isConnectedTo} → {@code EdgeLinkedList.containsVertex} - the same walk, rejecting on the
+ *   neighbour pointer instead of the edge one).</li>
+ * </ul>
+ * Nothing was remembered between two probes of the SAME list, so a hub of degree D was walked D times by each of
+ * them: O(D²) on the vertex the whole point of the check is to survive, with every walk risking a page read once the
+ * graph exceeds the page cache. A 657GB database with hubs in the hundreds of thousands of edges measured 80 hours
+ * for one {@code CHECK DATABASE FIX}.
+ * <p>
+ * WHAT IT DOES. The first probe of a (vertex, direction) list materialises it into primitive hash sets, and every
+ * later probe of that list is a hash lookup. The whole run therefore walks each list ONCE rather than once per
+ * incident edge, which takes the probe cost of a pass from {@code sum(degree²)} to {@code sum(degree)}.
+ * <p>
+ * EXACT, never approximate. A bloom/sketch answer would be worse than useless here: a false positive reads as "the
+ * back-reference is there" and silently drops a real finding, and under {@code FIX DELETE ORPHANS} the same answer
+ * decides whether a record is deleted. Every structure below is an exact set, and anything that cannot be
+ * represented exactly falls back to the original walk rather than being guessed at.
+ * <p>
+ * BOUNDED. The cache holds at most {@code maxEntries} adjacency entries across all cached lists, evicting the
+ * least-recently-probed list when the budget is exceeded, and never caches a single list bigger than the budget -
+ * such a list is answered by the original {@code EdgeLinkedList} probe, which is where the cycle-guarded chain walk
+ * lives. {@code maxEntries <= 0} disables the cache entirely and every probe takes that original path, which is the
+ * pre-#6062 behaviour and the escape hatch if the memory is ever unwelcome.
+ * <p>
+ * STALENESS IS THE CALLER'S JOB, and there is exactly one caller. A cached image is only valid while the list it was
+ * built from does not change. The edge pass writes nothing while it scans; the vertex pass prunes dangling entries,
+ * and calls {@link #clear()} at that site rather than naming the lists it touched - see that method. Both drop the
+ * cache before the post-scan repair loop. NOT thread-safe, and neither is the checker that owns it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class AdjacencyProbeCache {
+  private final GraphEngine                 graphEngine;
+  private final int                         maxEntries;
+  /** Access-ordered, so the eldest entry is the least recently PROBED list - a hub therefore never evicts itself. */
+  private final LinkedHashMap<Key, ListImage> images;
+  /** Edge-type name to its (polymorphic) bucket file-ids: the filter {@code isConnectedTo} rebuilt on every call. */
+  private final Map<String, int[]>          bucketFilters = new HashMap<>();
+
+  private int  cachedEntries;
+  private long probes;
+  private long listWalks;
+  private long entriesScanned;
+
+  AdjacencyProbeCache(final GraphEngine graphEngine, final int maxEntries) {
+    this.graphEngine = graphEngine;
+    this.maxEntries = Math.max(0, maxEntries);
+    this.images = new LinkedHashMap<>(16, 0.75f, true);
+  }
+
+  /**
+   * Whether {@code vertex}'s list in {@code direction} names {@code edgeRID}: the {@code checkEdges} back-reference
+   * probe. A vertex with no list at all answers false, exactly as the {@code inEdges == null} arm it replaces did.
+   *
+   * @throws RuntimeException whatever reading the list threw - an unreadable list is a finding of its own and the
+   *                          caller reports it as such, never as a fault of the edge
+   */
+  boolean containsEdge(final VertexInternal vertex, final Vertex.DIRECTION direction, final RID edgeRID) {
+    ++probes;
+
+    final VertexInternal source = graphEngine.getMostUpdatedVertex(vertex);
+    final EdgeLinkedList list = graphEngine.getEdgeHeadChunk(source, direction);
+    if (list == null)
+      return false;
+
+    final ListImage image = imageOf(source.getIdentity(), direction, list, false);
+    if (image != null)
+      return image.containsEdge(edgeRID);
+
+    ++listWalks;
+    return list.containsEdge(edgeRID);
+  }
+
+  /**
+   * Whether {@code vertex}'s list in {@code direction} reaches {@code neighbour} through an edge of {@code edgeType}:
+   * the {@code checkVertices} back-reference probe, and the exact question
+   * {@code GraphEngine.isVertexConnectedTo(vertex, neighbour, direction, edgeType)} answers - same single direction,
+   * same polymorphic bucket filter, same "the entry's own neighbour pointer decides, no edge record is loaded".
+   * <p>
+   * MEMOISED PER CHAIN, not per list, and that is not an optimisation detail - it is what keeps the answer identical
+   * on a promoted super-node. A neighbour-keyed probe of a {@link StripedEdgeList} does not read the whole list: it
+   * reads only the stripe of each generation that can hold that neighbour, and it is STRICT, turning a stripe head
+   * it cannot resolve into a retryable {@code ConcurrentModificationException} rather than skipping it (see
+   * {@code StripedEdgeList.chainsForNeighbour}). Building the image from the whole list instead would silently skip
+   * that chain and answer "not connected" where the engine promises to fail loudly. So the SELECTION stays with the
+   * list - {@link EdgeLinkedList#chainsForNeighbourProbe} is the very method the probe uses - and only the walk of
+   * each selected chain is remembered, keyed by that chain's head.
+   */
+  boolean isConnectedTo(final VertexInternal vertex, final Vertex.DIRECTION direction, final RID neighbour,
+      final String edgeType) {
+    ++probes;
+
+    final VertexInternal source = graphEngine.getMostUpdatedVertex(vertex);
+    final int[] bucketFilter = bucketFilterOf(source, edgeType);
+
+    final EdgeLinkedList list = graphEngine.getEdgeHeadChunk(source, direction);
+    if (list == null)
+      return false;
+
+    final List<EdgeLinkedList> chains = list.chainsForNeighbourProbe(neighbour);
+    for (int i = 0; i < chains.size(); i++) {
+      final EdgeLinkedList chain = chains.get(i);
+      final ListImage image = chainImageOf(chain);
+      if (image != null) {
+        if (image.containsNeighbour(neighbour, bucketFilter))
+          return true;
+      } else {
+        ++listWalks;
+        if (chain.containsVertex(neighbour, bucketFilter))
+          return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Forgets every image, because something wrote to an adjacency list. The caller's only invalidation tool on
+   * purpose: a prune in the vertex pass deletes the edge record, which takes the edge out of BOTH endpoints' lists,
+   * so "which lists did that change" cannot be answered without trusting the pointers the prune is happening
+   * because of. Also called when a pass stops probing, to release the memory.
+   */
+  void clear() {
+    images.clear();
+    cachedEntries = 0;
+  }
+
+  /** Back-reference questions asked. */
+  long getProbes() {
+    return probes;
+  }
+
+  /** Questions that had to touch an adjacency list to be answered - one per DISTINCT list, once the cache works. */
+  long getListWalks() {
+    return listWalks;
+  }
+
+  /** Adjacency entries visited while materialising lists: the linear cost that replaced the quadratic one. */
+  long getEntriesScanned() {
+    return entriesScanned;
+  }
+
+  /**
+   * The cached image of ONE CHAIN, keyed by its head segment. Used by the neighbour probe, whose selection of which
+   * chains to read belongs to the list - see {@link #isConnectedTo}.
+   *
+   * @return null when the chain has no head to key on (a stripe directory rather than a chain) or is not
+   * representable, and the caller must fall back to the original walk
+   */
+  private ListImage chainImageOf(final EdgeLinkedList chain) {
+    if (maxEntries == 0)
+      return null;
+
+    final RID head = chain.getChainHeadRID();
+    if (head == null)
+      return null;
+
+    return imageOf(new Key(head.getBucketId(), head.getPosition(), null), chain, true);
+  }
+
+  /**
+   * The cached image of one list, materialising it on first use.
+   *
+   * @return null when the list is not representable in the cache (too big for the budget, or holding an entry the
+   * primitive sets cannot store) and the caller must fall back to the original walk
+   */
+  private ListImage imageOf(final RID vertexRID, final Vertex.DIRECTION direction, final EdgeLinkedList list,
+      final boolean neighbourImage) {
+    if (maxEntries == 0)
+      return null;
+
+    return imageOf(new Key(vertexRID.getBucketId(), vertexRID.getPosition(), direction), list, neighbourImage);
+  }
+
+  private ListImage imageOf(final Key key, final EdgeLinkedList list, final boolean neighbourImage) {
+    final ListImage cached = images.get(key);
+    if (cached != null && cached.neighbourImage == neighbourImage)
+      // A remembered FAILURE is a cache hit too, and the important one: without it a list the cache cannot
+      // represent - one bigger than the whole budget above all - would be walked to the budget and abandoned once
+      // per probe, which is strictly worse than never having cached anything.
+      return cached.uncacheable ? null : cached;
+
+    ++listWalks;
+    final ListImage built = build(list, neighbourImage);
+
+    if (cached != null)
+      cachedEntries -= cached.entryCount;
+    images.put(key, built != null ? built : ListImage.uncacheable(neighbourImage));
+    if (built != null) {
+      cachedEntries += built.entryCount;
+      evictUntilWithinBudget(key);
+    }
+    return built;
+  }
+
+  /**
+   * Walks the list once, indexing whichever of the two probe questions the caller asked. Only ONE of the two
+   * structures is built: the vertex pass never asks the edge question of a list, nor the edge pass the neighbour
+   * one, so building both would double the footprint for nothing.
+   *
+   * @return null when the walk exceeded the budget (this one list is bigger than the whole cache may hold) or met an
+   * entry the primitive sets cannot represent
+   */
+  private ListImage build(final EdgeLinkedList list, final boolean neighbourImage) {
+    final Map<Integer, LongHashSet> edges = neighbourImage ? null : new HashMap<>();
+    final Map<Long, LongHashSet> neighbours = neighbourImage ? new HashMap<>() : null;
+
+    int count = 0;
+    final Iterator<Pair<RID, RID>> iterator = list.entryIterator();
+    while (iterator.hasNext()) {
+      final Pair<RID, RID> entry = iterator.next();
+      ++entriesScanned;
+
+      if (++count > maxEntries)
+        // BIGGER THAN THE WHOLE BUDGET: caching it would evict everything else and still not fit. Answered by the
+        // original walk instead, which also short-circuits on a hit rather than materialising the whole list.
+        return null;
+
+      final RID edgeRID = entry.getFirst();
+      final RID vertexRID = entry.getSecond();
+      if (edgeRID == null || vertexRID == null)
+        // A CORRUPT ENTRY, which the checker reports through its own walk of this list. Not representable here, and
+        // not worth a special case: the original probe skips it the same way whether or not it is cached.
+        return null;
+
+      final long edgePosition = edgeRID.getPosition();
+      final long vertexPosition = vertexRID.getPosition();
+      if (edgePosition == Long.MIN_VALUE || vertexPosition == Long.MIN_VALUE)
+        // LongHashSet reserves Long.MIN_VALUE as its empty-slot sentinel. No RID the engine writes reaches it - a
+        // lightweight edge uses -1 - but a set that silently could not hold a value would answer "not referenced"
+        // for an edge that is, so the impossible case falls back rather than being assumed away.
+        return null;
+
+      if (neighbourImage)
+        neighbours.computeIfAbsent(neighbourKey(edgeRID.getBucketId(), vertexRID.getBucketId()),
+            k -> new LongHashSet()).add(vertexPosition);
+      else
+        edges.computeIfAbsent(edgeRID.getBucketId(), k -> new LongHashSet()).add(edgePosition);
+    }
+
+    return new ListImage(neighbourImage, count, edges, neighbours);
+  }
+
+  /** Evicts least-recently-probed lists until the budget holds, never the one just built. */
+  private void evictUntilWithinBudget(final Key keep) {
+    while (cachedEntries > maxEntries && images.size() > 1) {
+      final Iterator<Map.Entry<Key, ListImage>> eldest = images.entrySet().iterator();
+      final Map.Entry<Key, ListImage> candidate = eldest.next();
+      if (candidate.getKey().equals(keep))
+        break;
+      cachedEntries -= candidate.getValue().entryCount;
+      eldest.remove();
+    }
+  }
+
+  /**
+   * The polymorphic bucket file-ids of an edge type, memoised. {@code isVertexConnectedTo} rebuilt this through a
+   * stream per call, so a hub probed once per incident edge paid an array allocation per edge on top of the walk.
+   */
+  private int[] bucketFilterOf(final VertexInternal vertex, final String edgeType) {
+    return bucketFilters.computeIfAbsent(edgeType,
+        t -> vertex.getDatabase().getSchema().getType(t).getBuckets(true).stream().mapToInt(b -> b.getFileId())
+            .toArray());
+  }
+
+  /** (edge bucket, neighbour bucket) packed into one key, so the type filter is applied without a nested map. */
+  private static long neighbourKey(final int edgeBucketId, final int vertexBucketId) {
+    return ((long) edgeBucketId << 32) | (vertexBucketId & 0xFFFFFFFFL);
+  }
+
+  /**
+   * What a cached image belongs to. Either a whole list - the owning VERTEX's RID plus the direction, as the edge
+   * probe reads it - or one chain of a striped list, its head SEGMENT's RID with a null direction. The two cannot
+   * collide even without the direction: a vertex record and an edge-list segment never share a bucket.
+   */
+  private record Key(int bucketId, long position, Vertex.DIRECTION direction) {
+  }
+
+  /**
+   * One materialised list. Positions are held in {@link LongHashSet} - a primitive open-addressing set - keyed by
+   * bucket, so a super-node's list costs roughly 11 bytes an entry instead of the ~80 a {@code HashSet<RID>} would.
+   */
+  private static final class ListImage {
+    /** The remembered verdict "this list cannot be represented"; see {@link #imageOf(Key, EdgeLinkedList, boolean)}. */
+    private static final ListImage UNCACHEABLE_EDGES     = new ListImage(false, 0, null, null, true);
+    private static final ListImage UNCACHEABLE_NEIGHBOURS = new ListImage(true, 0, null, null, true);
+
+    private final boolean                   neighbourImage;
+    private final boolean                   uncacheable;
+    private final int                       entryCount;
+    /** Edge bucket file-id to the positions of the edges in it. Null on a neighbour image. */
+    private final Map<Integer, LongHashSet> edges;
+    /** (edge bucket, neighbour bucket) to the neighbour positions. Null on an edge image. */
+    private final Map<Long, LongHashSet>    neighbours;
+
+    private ListImage(final boolean neighbourImage, final int entryCount, final Map<Integer, LongHashSet> edges,
+        final Map<Long, LongHashSet> neighbours) {
+      this(neighbourImage, entryCount, edges, neighbours, false);
+    }
+
+    private ListImage(final boolean neighbourImage, final int entryCount, final Map<Integer, LongHashSet> edges,
+        final Map<Long, LongHashSet> neighbours, final boolean uncacheable) {
+      this.neighbourImage = neighbourImage;
+      this.entryCount = entryCount;
+      this.edges = edges;
+      this.neighbours = neighbours;
+      this.uncacheable = uncacheable;
+    }
+
+    private static ListImage uncacheable(final boolean neighbourImage) {
+      return neighbourImage ? UNCACHEABLE_NEIGHBOURS : UNCACHEABLE_EDGES;
+    }
+
+    private boolean containsEdge(final RID edgeRID) {
+      final LongHashSet positions = edges.get(edgeRID.getBucketId());
+      return positions != null && positions.contains(edgeRID.getPosition());
+    }
+
+    /**
+     * Mirrors {@code MutableEdgeSegment.getFirstEdgeConnectedToVertex}: the entry matches when its neighbour is the
+     * one asked about AND its edge sits in one of the filtered buckets. A null filter accepts any edge bucket, which
+     * is why it has to sweep the map rather than index into it - the two-argument {@code isConnectedTo} passes null.
+     */
+    private boolean containsNeighbour(final RID neighbour, final int[] edgeBucketFilter) {
+      final int vertexBucketId = neighbour.getBucketId();
+      final long vertexPosition = neighbour.getPosition();
+
+      if (edgeBucketFilter == null) {
+        for (final Map.Entry<Long, LongHashSet> entry : neighbours.entrySet())
+          if ((int) (entry.getKey() & 0xFFFFFFFFL) == vertexBucketId && entry.getValue().contains(vertexPosition))
+            return true;
+        return false;
+      }
+
+      for (int i = 0; i < edgeBucketFilter.length; i++) {
+        final LongHashSet positions = neighbours.get(neighbourKey(edgeBucketFilter[i], vertexBucketId));
+        if (positions != null && positions.contains(vertexPosition))
+          return true;
+      }
+      return false;
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
+++ b/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
@@ -61,9 +61,14 @@ import java.util.Map;
  * such, and such an entry carries no adjacency entries for the first bound to see. Eviction is
  * least-recently-probed on both, so a hub - the list that pays for itself - is the one that stays, and a single list
  * bigger than the budget is never cached at all -
- * such a list is answered by the original {@code EdgeLinkedList} probe, which is where the cycle-guarded chain walk
- * lives. {@code maxEntries <= 0} disables the cache entirely and every probe takes that original path, which is the
- * pre-#6062 behaviour and the escape hatch if the memory is ever unwelcome.
+ * such a list is answered by the original {@code EdgeLinkedList} probe. {@code maxEntries <= 0} disables the cache
+ * entirely and every probe takes that original path, which is the pre-#6062 behaviour and the escape hatch if the
+ * memory is ever unwelcome.
+ * <p>
+ * A SELF-REFERENCING CHUNK ends the materialising walk rather than feeding it forever: the guard the direct
+ * {@code containsEdge}/{@code containsVertex} walks always had is now in {@link EdgeVertexIterator} too, which is
+ * what this class materialises through - and which the checker's own walk of a vertex's list goes through as well,
+ * where the missing guard meant a check that never returned.
  * <p>
  * STALENESS IS THE CALLER'S JOB, and there is exactly one caller. A cached image is only valid while the list it was
  * built from does not change. The edge pass writes nothing while it scans; the vertex pass prunes dangling entries,
@@ -248,7 +253,7 @@ final class AdjacencyProbeCache {
       cachedEntries += built.entryCount;
     // ALSO after storing a remembered failure: it holds no adjacency entries, so only the list-count bound can
     // ever evict one, and that bound is only tested here.
-    evictUntilWithinBudget(key);
+    evictUntilWithinBudget();
     return built;
   }
 
@@ -306,13 +311,12 @@ final class AdjacencyProbeCache {
    * check: they carry no adjacency entries, so the first bound alone would let them accumulate one per damaged list
    * for the whole pass.
    */
-  private void evictUntilWithinBudget(final Key keep) {
+  private void evictUntilWithinBudget() {
+    // size() > 1 is what protects the image just stored: the map is access-ordered and a put counts as an access,
+    // so that one is the most recent and can only be the eldest when it is the only one left.
     while ((cachedEntries > maxEntries || images.size() > MAX_CACHED_LISTS) && images.size() > 1) {
       final Iterator<Map.Entry<Key, ListImage>> eldest = images.entrySet().iterator();
-      final Map.Entry<Key, ListImage> candidate = eldest.next();
-      if (candidate.getKey().equals(keep))
-        break;
-      cachedEntries -= candidate.getValue().entryCount;
+      cachedEntries -= eldest.next().getValue().entryCount;
       eldest.remove();
     }
   }
@@ -382,19 +386,14 @@ final class AdjacencyProbeCache {
 
     /**
      * Mirrors {@code MutableEdgeSegment.getFirstEdgeConnectedToVertex}: the entry matches when its neighbour is the
-     * one asked about AND its edge sits in one of the filtered buckets. A null filter accepts any edge bucket, which
-     * is why it has to sweep the map rather than index into it - the two-argument {@code isConnectedTo} passes null.
+     * one asked about AND its edge sits in one of the filtered buckets. The filter is always concrete here - the
+     * checker's probe always names an edge type, which is what {@link #bucketFilterOf} resolves - so there is no
+     * accept-any-bucket branch to sweep the map for. An edge type with no buckets yields an empty filter and
+     * therefore false, exactly as {@code containsVertex} does with the same array.
      */
     private boolean containsNeighbour(final RID neighbour, final int[] edgeBucketFilter) {
       final int vertexBucketId = neighbour.getBucketId();
       final long vertexPosition = neighbour.getPosition();
-
-      if (edgeBucketFilter == null) {
-        for (final Map.Entry<Long, LongHashSet> entry : neighbours.entrySet())
-          if ((int) (entry.getKey() & 0xFFFFFFFFL) == vertexBucketId && entry.getValue().contains(vertexPosition))
-            return true;
-        return false;
-      }
 
       for (int i = 0; i < edgeBucketFilter.length; i++) {
         final LongHashSet positions = neighbours.get(neighbourKey(edgeBucketFilter[i], vertexBucketId));

--- a/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
+++ b/engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java
@@ -56,8 +56,11 @@ import java.util.Map;
  * decides whether a record is deleted. Every structure below is an exact set, and anything that cannot be
  * represented exactly falls back to the original walk rather than being guessed at.
  * <p>
- * BOUNDED. The cache holds at most {@code maxEntries} adjacency entries across all cached lists, evicting the
- * least-recently-probed list when the budget is exceeded, and never caches a single list bigger than the budget -
+ * BOUNDED, on two axes because neither implies the other: at most {@code maxEntries} adjacency entries across all
+ * cached lists, AND at most {@link #MAX_CACHED_LISTS} lists - a list the cache could not represent is remembered as
+ * such, and such an entry carries no adjacency entries for the first bound to see. Eviction is
+ * least-recently-probed on both, so a hub - the list that pays for itself - is the one that stays, and a single list
+ * bigger than the budget is never cached at all -
  * such a list is answered by the original {@code EdgeLinkedList} probe, which is where the cycle-guarded chain walk
  * lives. {@code maxEntries <= 0} disables the cache entirely and every probe takes that original path, which is the
  * pre-#6062 behaviour and the escape hatch if the memory is ever unwelcome.
@@ -70,6 +73,16 @@ import java.util.Map;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 final class AdjacencyProbeCache {
+  /**
+   * Ceiling on how many LISTS the map holds, alongside the adjacency-entry budget - because the two bounds do not
+   * imply each other. An entry that remembers "this list cannot be represented" carries no adjacency entries at all,
+   * so the entry budget never evicts one, and on the database shape this class exists for - a damaged
+   * multi-hundred-GB graph - there is one per damaged or oversized list. Left as a constant rather than a second
+   * knob: at 65,536 lists the map costs single-digit MB whatever the entry budget is set to, which is small beside
+   * the budget's own footprint and large enough that a run never thrashes on it.
+   */
+  private static final int MAX_CACHED_LISTS = 1 << 16;
+
   private final GraphEngine                 graphEngine;
   private final int                         maxEntries;
   /** Access-ordered, so the eldest entry is the least recently PROBED list - a hub therefore never evicts itself. */
@@ -169,7 +182,13 @@ final class AdjacencyProbeCache {
     return probes;
   }
 
-  /** Questions that had to touch an adjacency list to be answered - one per DISTINCT list, once the cache works. */
+  /**
+   * WALKS of an adjacency list performed to answer those questions - not probes that needed one, which is the same
+   * number everywhere except in one case worth stating because it is the case an operator stares at this counter
+   * for. The FIRST probe of a list the cache turns out not to be able to represent counts TWO: the materialisation
+   * attempt walks it up to the budget before abandoning, and the fallback then walks it for the answer. Both
+   * happened, so both are counted; the verdict is remembered, so every later probe of that list counts one.
+   */
   long getListWalks() {
     return listWalks;
   }
@@ -225,10 +244,11 @@ final class AdjacencyProbeCache {
     if (cached != null)
       cachedEntries -= cached.entryCount;
     images.put(key, built != null ? built : ListImage.uncacheable(neighbourImage));
-    if (built != null) {
+    if (built != null)
       cachedEntries += built.entryCount;
-      evictUntilWithinBudget(key);
-    }
+    // ALSO after storing a remembered failure: it holds no adjacency entries, so only the list-count bound can
+    // ever evict one, and that bound is only tested here.
+    evictUntilWithinBudget(key);
     return built;
   }
 
@@ -280,9 +300,14 @@ final class AdjacencyProbeCache {
     return new ListImage(neighbourImage, count, edges, neighbours);
   }
 
-  /** Evicts least-recently-probed lists until the budget holds, never the one just built. */
+  /**
+   * Evicts least-recently-probed lists until BOTH bounds hold - the adjacency-entry budget and
+   * {@link #MAX_CACHED_LISTS} - never the one just built. The second bound is what keeps the remembered failures in
+   * check: they carry no adjacency entries, so the first bound alone would let them accumulate one per damaged list
+   * for the whole pass.
+   */
   private void evictUntilWithinBudget(final Key keep) {
-    while (cachedEntries > maxEntries && images.size() > 1) {
+    while ((cachedEntries > maxEntries || images.size() > MAX_CACHED_LISTS) && images.size() > 1) {
       final Iterator<Map.Entry<Key, ListImage>> eldest = images.entrySet().iterator();
       final Map.Entry<Key, ListImage> candidate = eldest.next();
       if (candidate.getKey().equals(keep))

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -265,6 +265,27 @@ public class EdgeLinkedList {
   }
 
 
+  /**
+   * The chains a NEIGHBOUR-keyed probe has to consult to answer about {@code neighbour}, in the order
+   * {@link #containsVertex} consults them. A classic list is one chain: itself.
+   * <p>
+   * Exists so {@link AdjacencyProbeCache} can memoise the WALK of each chain (issue #6062) while leaving the
+   * SELECTION here, where the striped override keeps its own semantics - only the stripes that can hold the
+   * neighbour, and strict about a head it cannot resolve. A cache that picked the chains itself, or that indexed
+   * the whole list, would answer "not connected" where {@link StripedEdgeList} promises a retryable conflict.
+   */
+  List<EdgeLinkedList> chainsForNeighbourProbe(final RID neighbour) {
+    return List.of(this);
+  }
+
+  /**
+   * The head segment of THIS chain, or null when the object is a directory of chains rather than one chain (a
+   * {@link StripedEdgeList}). It is the identity {@link AdjacencyProbeCache} keys a chain image by.
+   */
+  RID getChainHeadRID() {
+    return lastSegment != null ? lastSegment.getIdentity() : null;
+  }
+
   public boolean containsVertex(final RID rid, final int[] edgeBucketFilter) {
     EdgeSegment current = lastSegment;
     while (current != null) {

--- a/engine/src/main/java/com/arcadedb/graph/EdgeVertexIterator.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeVertexIterator.java
@@ -56,7 +56,9 @@ public class EdgeVertexIterator extends ResettableIteratorBase<Pair<RID, RID>> {
       // had all along and this iterator did not: on such a chain - corruption, and the corruption CHECK DATABASE
       // exists to survive - the walk yielded the chunk's entries forever. The checker walks a vertex's own edge
       // list through here, so the effect was a check that never returned rather than one that reported the damage.
-      // The sibling iterators (EdgeIterator, VertexIterator, RIDIterator, IteratorFilterBase) still lack it.
+      // The sibling iterators (EdgeIterator, VertexIterator, RIDIterator, IteratorFilterBase) still lack it, so the
+      // same chain still hangs an ordinary traversal: issue #6278, which is where lifting this into the shared
+      // chunk-hop belongs. Not done here because nothing in #6062 consumes them.
       if (currentIdentity != null && currentIdentity.equals(currentContainer.getIdentity())) {
         currentContainer = null;
         return false;

--- a/engine/src/main/java/com/arcadedb/graph/EdgeVertexIterator.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeVertexIterator.java
@@ -49,8 +49,18 @@ public class EdgeVertexIterator extends ResettableIteratorBase<Pair<RID, RID>> {
     if (currentPosition.get() < currentContainer.getUsed())
       return true;
 
+    final RID currentIdentity = currentContainer.getIdentity();
     currentContainer = currentContainer.getPrevious();
     if (currentContainer != null) {
+      // A CHUNK POINTING AT ITSELF ends the walk, the same guard EdgeLinkedList.containsEdge/containsVertex have
+      // had all along and this iterator did not: on such a chain - corruption, and the corruption CHECK DATABASE
+      // exists to survive - the walk yielded the chunk's entries forever. The checker walks a vertex's own edge
+      // list through here, so the effect was a check that never returned rather than one that reported the damage.
+      // The sibling iterators (EdgeIterator, VertexIterator, RIDIterator, IteratorFilterBase) still lack it.
+      if (currentIdentity != null && currentIdentity.equals(currentContainer.getIdentity())) {
+        currentContainer = null;
+        return false;
+      }
       currentPosition.set(MutableEdgeSegment.CONTENT_START_POSITION);
       return currentPosition.get() < currentContainer.getUsed();
     }

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -57,6 +57,11 @@ public class GraphDatabaseChecker {
    * repair loops would put a configuration lookup on the per-record path for a value that cannot change under it.
    */
   private final int              repairBatchPages;
+  /**
+   * Adjacency-entry budget of {@link AdjacencyProbeCache} (issue #6062), read once per checker for the same reason
+   * as {@link #repairBatchPages}: it is a database-scoped setting and cannot change under a running check.
+   */
+  private final int              adjacencyCacheEntries;
 
   // Progress reporting (issue #5372): the step identity (name/index/totalSteps) is assigned by the caller
   // (DatabaseChecker owns the step plan); this class emits within-step done/total, throttled to integer
@@ -74,6 +79,23 @@ public class GraphDatabaseChecker {
     this.graphEngine = database.getGraphEngine();
     this.repairBatchPages = database.getConfiguration()
         .getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES);
+    this.adjacencyCacheEntries = database.getConfiguration()
+        .getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES);
+  }
+
+  /**
+   * Publishes what the back-reference probes of one pass cost (issue #6062), so the answer to "why is CHECK DATABASE
+   * still slow on this database" is in the result rather than in a profiler.
+   * <p>
+   * {@code adjacencyProbes} is how many back-reference questions the pass asked - two per edge, structurally.
+   * {@code adjacencyProbeListWalks} is how many of them had to walk an adjacency list to be answered: it used to
+   * equal the probe count, and now grows with the number of DISTINCT lists instead. {@code adjacencyEntriesScanned}
+   * is the entries those walks visited, which is the number that was quadratic in a hub's degree.
+   */
+  private static void putProbeCounters(final Map<String, Object> stats, final AdjacencyProbeCache probeCache) {
+    stats.put("adjacencyProbes", probeCache.getProbes());
+    stats.put("adjacencyProbeListWalks", probeCache.getListWalks());
+    stats.put("adjacencyEntriesScanned", probeCache.getEntriesScanned());
   }
 
   /** Installs the progress receiver and this checker's step identity in the caller's step plan. */
@@ -548,6 +570,12 @@ public class GraphDatabaseChecker {
     final Set<RID> deletedRecords = new LinkedHashSet<>();
     /** Adjacency entries this run re-linked, of either kind - see the {@code reconnectedEdges} stat (issue #6136). */
     long reconnectedEdges = 0;
+    /**
+     * Answers the "does the far vertex point back?" probe without re-walking the same list once per incident edge
+     * (issue #6062). Scoped to this pass: the images it holds are only valid while the lists are not written to, and
+     * the repairs this pass plans are applied after the scan, with the cache dropped first.
+     */
+    final AdjacencyProbeCache probeCache = new AdjacencyProbeCache(graphEngine, adjacencyCacheEntries);
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -563,9 +591,11 @@ public class GraphDatabaseChecker {
 
           // No longer re-assigned from the two checks: neither of them writes the vertex any more (#6136), so the
           // saved mutable copy they used to hand back does not exist and the immutable one stays current.
-          checkOutgoingEdges(fix, vertex, vertexIdentity, plan, missingReferences, missingReferenceErrors, report);
+          checkOutgoingEdges(fix, vertex, vertexIdentity, plan, missingReferences, missingReferenceErrors, report,
+              probeCache);
 
-          checkIncomingEdges(fix, vertex, vertexIdentity, plan, missingReferences, missingReferenceErrors, report);
+          checkIncomingEdges(fix, vertex, vertexIdentity, plan, missingReferences, missingReferenceErrors, report,
+              probeCache);
 
         } catch (final Throwable e) {
           report.warn("vertex " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
@@ -616,6 +646,10 @@ public class GraphDatabaseChecker {
 
       progressComplete();
 
+      // NOTHING PROBES AFTER THIS POINT, and everything below writes to the very lists the images describe: drop
+      // them rather than reason about which repair invalidates which image.
+      probeCache.clear();
+
       if (fix) {
         reconnectedEdges = applyRepairPlan(plan, report);
 
@@ -653,6 +687,7 @@ public class GraphDatabaseChecker {
 
     } finally {
       putRepairCounters(stats, autoFix.get(), report.prunedDanglingEntries, reconnectedEdges);
+      putProbeCounters(stats, probeCache);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("duplicateLightEdges", report.duplicateLightEdges);
@@ -892,7 +927,7 @@ public class GraphDatabaseChecker {
 
   private void checkIncomingEdges(final boolean fix, final Vertex vertex, final RID vertexIdentity,
       final RepairPlan plan, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors,
-      final CheckReport report) {
+      final CheckReport report, final AdjacencyProbeCache probeCache) {
     final Set<RID> reconnectInEdges = plan.reconnectInEdges;
     final Set<RID> reconnectOutEdges = plan.reconnectOutEdges;
 
@@ -1061,7 +1096,9 @@ public class GraphDatabaseChecker {
                 if (((EdgeType) edge.getType()).isBidirectional() && inVertex != null) {
                   Boolean connected = null;
                   try {
-                    connected = inVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.OUT, edge.getTypeName());
+                    // Same question isConnectedTo(vertexIdentity, OUT, type) answered, memoised per list (#6062).
+                    connected = probeCache.isConnectedTo(inVertex, Vertex.DIRECTION.OUT, vertexIdentity,
+                        edge.getTypeName());
                   } catch (final Exception probeError) {
                     // The FAR vertex's OUT list is unreadable: never blame this edge record for it (before this
                     // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
@@ -1102,6 +1139,16 @@ public class GraphDatabaseChecker {
 
             if (fix && removeEntry) {
               in.remove();
+              // EVERY image, not just this vertex's (#6062). The remove is not local to the list being walked:
+              // EdgeVertexIterator.remove() DELETES the edge record first, and GraphEngine.deleteEdge takes the
+              // edge out of BOTH endpoints' lists - so a prune here can change a list this cache holds an image of,
+              // for a vertex the walk has not reached and through an endpoint pair a corrupt entry may misreport.
+              // Naming the affected lists exactly would mean trusting the very pointers the prune is happening
+              // because of, so the whole cache goes instead: prunes are repairs on a damaged database, and paying
+              // one rebuild each is the price of the probe never answering from a list that no longer exists that
+              // way. The worst case - damage that is overwhelmingly dangling entries - is no slower than it was
+              // before this cache existed.
+              probeCache.clear();
               // Pruning a dangling list entry IS a repair, and counting it is what keeps autoFix meaning "repairs
               // performed" now that it no longer counts deletes that failed (issue #6128). Without this an operator
               // who ran FIX over a database whose only damage was dangling references - the commonest shape, since
@@ -1128,7 +1175,7 @@ public class GraphDatabaseChecker {
 
   private void checkOutgoingEdges(final boolean fix, final Vertex vertex, final RID vertexIdentity,
       final RepairPlan plan, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors,
-      final CheckReport report) {
+      final CheckReport report, final AdjacencyProbeCache probeCache) {
     final Set<RID> reconnectOutEdges = plan.reconnectOutEdges;
     final Set<RID> reconnectInEdges = plan.reconnectInEdges;
 
@@ -1310,7 +1357,9 @@ public class GraphDatabaseChecker {
                   // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
                   Boolean connected = null;
                   try {
-                    connected = outVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.IN, edge.getTypeName());
+                    // See the twin in checkIncomingEdges: memoised per list rather than re-walked per edge (#6062).
+                    connected = probeCache.isConnectedTo(outVertex, Vertex.DIRECTION.IN, vertexIdentity,
+                        edge.getTypeName());
                   } catch (final Exception probeError) {
                     // The FAR vertex's IN list is unreadable: never blame this edge record for it (before this
                     // guard the probe failure flagged the edge as corrupted and fix mode deleted a VALID edge).
@@ -1350,6 +1399,9 @@ public class GraphDatabaseChecker {
 
             if (fix && removeEntry) {
               out.remove();
+              // See the twin in checkIncomingEdges: the prune deletes the edge record, so it can change any list
+              // this cache holds an image of, and every image is dropped rather than guessed at (#6062).
+              probeCache.clear();
               // See the twin in checkIncomingEdges: a pruned dangling entry is a repair and is counted as one.
               ++report.prunedDanglingEntries;
             }
@@ -1482,6 +1534,12 @@ public class GraphDatabaseChecker {
     final Set<RID> unreadableListVertices = new HashSet<>();
     /** Records this run actually removed, surfaced as {@code deletedRecordsAfterFix}. */
     final Set<RID> deletedRecords = new LinkedHashSet<>();
+    /**
+     * Answers "does this endpoint's list name the edge?" without re-walking the same list once per incident edge
+     * (issue #6062). Safe for the whole scan: this pass writes nothing while it scans - the deletes happen in the
+     * repair loop below, after the cache is dropped.
+     */
+    final AdjacencyProbeCache probeCache = new AdjacencyProbeCache(graphEngine, adjacencyCacheEntries);
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -1539,9 +1597,12 @@ public class GraphDatabaseChecker {
 
             if (inVertex != null)
               try {
-                final EdgeLinkedList inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) inVertex, Vertex.DIRECTION.IN);
+                // Memoised per list (#6062). A vertex with no IN list at all answers false, exactly as the
+                // inEdges == null arm this replaces did, and an unreadable one still throws into the guard below.
+                final boolean referenced = probeCache.containsEdge((VertexInternal) inVertex, Vertex.DIRECTION.IN,
+                    edgeRID);
                 inProbed = true;
-                if (inEdges == null || !inEdges.containsEdge(edgeRID)) {
+                if (!referenced) {
                   // LEGITIMATE FOR A UNIDIRECTIONAL EDGE TYPE, a defect for a bidirectional one - which is why the
                   // raw counter below cannot be read as a defect count and #6090 added ones that can. Bumped here
                   // unconditionally, exactly as before, so its published meaning does not shift under existing
@@ -1578,9 +1639,11 @@ public class GraphDatabaseChecker {
 
             if (outVertex != null)
               try {
-                final EdgeLinkedList outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) outVertex, Vertex.DIRECTION.OUT);
+                // See the incoming side: memoised per list rather than re-walked per edge (#6062).
+                final boolean referenced = probeCache.containsEdge((VertexInternal) outVertex, Vertex.DIRECTION.OUT,
+                    edgeRID);
                 outProbed = true;
-                if (outEdges == null || !outEdges.containsEdge(edgeRID)) {
+                if (!referenced) {
                   // ALWAYS A DEFECT, for every edge type: no outgoing traversal can reach the record. Same
                   // unconditional bump of the legacy counter as the incoming side, for the same reason.
                   missingReferenceBack.incrementAndGet();
@@ -1680,6 +1743,9 @@ public class GraphDatabaseChecker {
 
       progressComplete();
 
+      // NOTHING PROBES AFTER THIS POINT and the repair loop deletes records: drop the images (#6062).
+      probeCache.clear();
+
       if (fix) {
         for (final RID rid : report.corruptedRecords) {
           if (rid == null)
@@ -1721,6 +1787,7 @@ public class GraphDatabaseChecker {
       // it as evidence that this arm prunes today. reconnectedEdges is structurally zero here for the same reason:
       // this arm plans no re-links.
       putRepairCounters(stats, autoFix.get(), report.prunedDanglingEntries, 0L);
+      putProbeCounters(stats, probeCache);
       stats.put("deletedRecordsAfterFix", deletedRecords);
       stats.put("corruptedRecords", report.corruptedRecords);
       stats.put("invalidLinks", report.invalidLinks);

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -88,9 +88,11 @@ public class GraphDatabaseChecker {
    * still slow on this database" is in the result rather than in a profiler.
    * <p>
    * {@code adjacencyProbes} is how many back-reference questions the pass asked - two per edge, structurally.
-   * {@code adjacencyProbeListWalks} is how many of them had to walk an adjacency list to be answered: it used to
-   * equal the probe count, and now grows with the number of DISTINCT lists instead. {@code adjacencyEntriesScanned}
-   * is the entries those walks visited, which is the number that was quadratic in a hub's degree.
+   * {@code adjacencyProbeListWalks} is how many walks of an adjacency list answering them took: it used to equal the
+   * probe count, and now grows with the number of DISTINCT lists instead. It can exceed the probe count on a list
+   * the cache cannot represent, which walks twice on its first probe and once thereafter - see
+   * {@link AdjacencyProbeCache#getListWalks()}. {@code adjacencyEntriesScanned} is the entries those walks visited,
+   * which is the number that was quadratic in a hub's degree.
    */
   private static void putProbeCounters(final Map<String, Object> stats, final AdjacencyProbeCache probeCache) {
     stats.put("adjacencyProbes", probeCache.getProbes());

--- a/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
+++ b/engine/src/main/java/com/arcadedb/graph/StripedEdgeList.java
@@ -426,6 +426,16 @@ public class StripedEdgeList extends EdgeLinkedList {
     return false;
   }
 
+  /**
+   * The same chains {@link #containsVertex} reads, handed out so {@link AdjacencyProbeCache} can memoise the walk of
+   * each one without taking over the selection (issue #6062). STRICT, like every neighbour-keyed read here: a stripe
+   * head that cannot be resolved becomes a retryable conflict rather than a chain silently missing from the answer.
+   */
+  @Override
+  List<EdgeLinkedList> chainsForNeighbourProbe(final RID neighbour) {
+    return chainsForNeighbour(neighbour);
+  }
+
   @Override
   public long count(final String... edgeTypes) {
     long total = 0;

--- a/engine/src/test/java/com/arcadedb/graph/Issue6062AdjacencyProbeCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6062AdjacencyProbeCacheTest.java
@@ -20,13 +20,16 @@ package com.arcadedb.graph;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.DatabaseChecker;
+import com.arcadedb.utility.Pair;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -239,6 +242,47 @@ class Issue6062AdjacencyProbeCacheTest extends TestHelper {
     assertThat((Long) partial.get("adjacencyEntriesScanned"))
         .as("the over-budget list must be walked to the budget once, not once per probe")
         .isLessThanOrEqualTo(5L * DEGREE);
+  }
+
+  /**
+   * A CHUNK POINTING AT ITSELF must end the walk, not feed it forever.
+   * <p>
+   * {@code EdgeLinkedList.containsEdge}/{@code containsVertex} have always broken out of such a chain; the iterator
+   * behind {@code entryIterator()} did not - and the checker walks a vertex's own edge list through it, so this
+   * shape of corruption meant a {@code CHECK DATABASE} that never returned. This PR gives the same iterator a second
+   * consumer (the probe cache materialises through it), which is why the guard belongs here now.
+   * <p>
+   * Asserted by walking under a HARD CAP rather than by running the check under a timeout: an unterminating walk
+   * does not fail a test, it hangs the build, and a regression has to come back as a red test. Without the guard the
+   * walk reaches the cap and the assertion fails in milliseconds.
+   */
+  @Test
+  void aSelfReferencingChunkEndsTheWalkInsteadOfFeedingItForever() {
+    final RID hub = createHubWithDistinctSpokes();
+
+    // Point the hub's IN head chunk at itself.
+    database.transaction(() -> {
+      final RID head = ((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk();
+      final MutableEdgeSegment segment = (MutableEdgeSegment) database.lookupByRID(head, true);
+      segment.setPrevious(segment);
+      ((DatabaseInternal) database).updateRecord(segment);
+    });
+
+    final int cap = 8 * DEGREE;
+    final int[] walked = new int[1];
+    database.transaction(() -> {
+      final EdgeLinkedList list = ((DatabaseInternal) database).getGraphEngine()
+          .getEdgeHeadChunk((VertexInternal) hub.asVertex(true), Vertex.DIRECTION.IN);
+      final Iterator<Pair<RID, RID>> entries = list.entryIterator();
+      while (walked[0] <= cap && entries.hasNext()) {
+        entries.next();
+        ++walked[0];
+      }
+    });
+
+    assertThat(walked[0])
+        .as("the self-loop must end the walk; without the guard it yields the chunk's entries forever")
+        .isLessThanOrEqualTo(DEGREE);
   }
 
   /** A healthy graph stays healthy: the cache must not invent a finding either. */

--- a/engine/src/test/java/com/arcadedb/graph/Issue6062AdjacencyProbeCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6062AdjacencyProbeCacheTest.java
@@ -208,6 +208,39 @@ class Issue6062AdjacencyProbeCacheTest extends TestHelper {
         .isLessThan((Long) direct.get("adjacencyProbeListWalks"));
   }
 
+  /**
+   * The FALLBACK path: a budget smaller than the hub's degree. That list cannot be represented at all, so it is
+   * walked to the budget, abandoned, and answered by the original {@code EdgeLinkedList} probe - and the verdict is
+   * remembered, so the abandoned walk happens once rather than once per probe. What must not change is a single
+   * finding, which is what this asserts against both the fully cached and the fully disabled run.
+   */
+  @Test
+  void aListLargerThanTheWholeBudgetFallsBackWithoutChangingAFinding() {
+    createHubWithDistinctSpokes();
+
+    final Map<String, Object> cached = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    // Below the hub's degree, above a spoke's: the hub falls back, the spokes still cache.
+    GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES.setValue(10);
+    final Map<String, Object> partial = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES.setValue(0);
+    final Map<String, Object> direct = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    assertThat(warnings(partial)).isEmpty();
+    assertThat(partial.get("edgesMissingInReference")).isEqualTo(cached.get("edgesMissingInReference"));
+    assertThat(partial.get("edgesMissingOutReference")).isEqualTo(cached.get("edgesMissingOutReference"));
+    assertThat(partial.get("missingReferenceBack")).isEqualTo(direct.get("missingReferenceBack"));
+    assertThat(partial.get("unreachableEdgeRecords")).isEqualTo(direct.get("unreachableEdgeRecords"));
+    assertThat(partial.get("totalCorruptedRecords")).isEqualTo(direct.get("totalCorruptedRecords"));
+
+    // The verdict on the hub is REMEMBERED: its list is abandoned once, not once per incident edge, so the run
+    // stays far below the "walk the hub per probe" volume the fully disabled run pays.
+    assertThat((Long) partial.get("adjacencyEntriesScanned"))
+        .as("the over-budget list must be walked to the budget once, not once per probe")
+        .isLessThanOrEqualTo(5L * DEGREE);
+  }
+
   /** A healthy graph stays healthy: the cache must not invent a finding either. */
   @Test
   void aHealthyGraphReportsNothing() {

--- a/engine/src/test/java/com/arcadedb/graph/Issue6062AdjacencyProbeCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6062AdjacencyProbeCacheTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.DatabaseChecker;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6062: {@code CHECK DATABASE} paid an unconditional O(degree) linear walk of a
+ * neighbour's adjacency list PER EDGE, so a super-node of degree D cost O(D²) and a real database was measured at
+ * 80 hours.
+ * <p>
+ * Two independent probes produced that shape and both are covered here: {@code checkEdges} asked both endpoints of
+ * every edge whether their list names the record ({@code EdgeLinkedList.containsEdge}), and {@code checkVertices}
+ * asked the far vertex of every adjacency entry whether it points back ({@code isConnectedTo} →
+ * {@code EdgeLinkedList.containsVertex}). Neither remembered anything between two probes of the SAME list, so a hub
+ * referenced by D edges had its list walked D times.
+ * <p>
+ * The assertions are on counters the check now publishes, never on elapsed time: {@code adjacencyProbes} is how many
+ * back-reference questions the run asked, {@code adjacencyProbeListWalks} how many of them had to touch an adjacency
+ * list to answer, and {@code adjacencyEntriesScanned} how many list entries that cost in total. The fix makes the
+ * second grow with the number of DISTINCT lists instead of with the number of edges, and the third linear in the size
+ * of the graph instead of quadratic in the degree.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6062AdjacencyProbeCacheTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Issue6062Node";
+  private static final String EDGE_TYPE   = "Issue6062Link";
+  private static final int    DEGREE      = 400;
+
+  /**
+   * One test deliberately leaves a half-linked edge behind - that is the state under measurement - and asserts the
+   * check result itself. The blanket teardown run would only re-assert the same database with the opposite
+   * expectation.
+   */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().buildEdgeType().withName(EDGE_TYPE).withBidirectional(true).create();
+    });
+  }
+
+  @AfterEach
+  void restoreDefaults() {
+    GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES.reset();
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.reset();
+  }
+
+  /**
+   * The headline case, in its purest form: TWO vertices joined by many parallel edges, so every probe in the run
+   * asks about one of exactly two adjacency lists. The number of lists the run has to walk must therefore stay in
+   * the single digits however many edges there are - before the fix it was one walk per probe, which is one per
+   * edge per endpoint.
+   */
+  @Test
+  void theSameAdjacencyListIsNotRewalkedOncePerEdge() {
+    createParallelEdgesBetweenTwoVertices();
+
+    final Map<String, Object> result = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    final long probes = (Long) result.get("adjacencyProbes");
+    final long walks = (Long) result.get("adjacencyProbeListWalks");
+
+    assertThat(probes).as("both passes probe both endpoints of every edge").isGreaterThanOrEqualTo(2L * DEGREE);
+    assertThat(walks)
+        .as("only two adjacency lists exist in this graph, so a run must not walk one per probe")
+        .isLessThanOrEqualTo(16L);
+  }
+
+  /**
+   * The control: with the cache disabled the run falls back to the pre-fix behaviour, and the counter the test
+   * above reads goes back to one walk per probe. Without this a cache that never engaged - or a counter that
+   * measured something else - would satisfy the assertion above on its own.
+   */
+  @Test
+  void disablingTheCacheRestoresOneListWalkPerProbe() {
+    createParallelEdgesBetweenTwoVertices();
+
+    GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES.setValue(0);
+
+    final Map<String, Object> result = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    final long probes = (Long) result.get("adjacencyProbes");
+    final long walks = (Long) result.get("adjacencyProbeListWalks");
+
+    assertThat(probes).isGreaterThanOrEqualTo(2L * DEGREE);
+    assertThat(walks).as("with the cache off every probe walks a list, which is the shape #6062 reports")
+        .isEqualTo(probes);
+  }
+
+  /**
+   * The super-node shape the issue actually describes: one hub with many DISTINCT neighbours. Here the number of
+   * lists is proportional to the edge count, so the walk counter cannot discriminate - the cost is in how many
+   * ENTRIES each walk visits, which is what makes a hub quadratic. Linear in the graph after the fix; before it,
+   * every one of the {@code DEGREE} probes of the hub scanned ~{@code DEGREE/2} of its entries.
+   */
+  @Test
+  void aHubIsScannedLinearlyRatherThanOncePerIncidentEdge() {
+    createHubWithDistinctSpokes();
+
+    final Map<String, Object> result = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    final long entriesScanned = (Long) result.get("adjacencyEntriesScanned");
+
+    assertThat(entriesScanned)
+        .as("the hub's list must be materialised once per pass, not re-scanned per incident edge")
+        .isGreaterThan(0L)
+        .isLessThanOrEqualTo(10L * DEGREE);
+    assertThat((Long) result.get("adjacencyProbeListWalks"))
+        .as("and the probes of the hub after the first must be answered without touching its list at all")
+        .isLessThan((Long) result.get("adjacencyProbes"));
+  }
+
+  /**
+   * The cache must not change a single finding. A HALF-LINKED edge - present in its source's OUT list, missing
+   * from its target's IN list - is the finding the back-reference probe exists to make, and it is reported
+   * identically whether the probe reads a materialised list or walks the chain.
+   */
+  @Test
+  void theCachedAndTheDirectProbeAgreeOnAHalfLinkedEdge() {
+    final RID target = createHubWithDistinctSpokes();
+
+    // Drop the hub's IN list: every spoke's edge is now missing from its target's IN list.
+    database.transaction(() -> {
+      final MutableVertex hub = target.asVertex(true).modify();
+      hub.setInEdgesHeadChunk(null);
+      hub.save();
+    });
+
+    final Map<String, Object> cached = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES.setValue(0);
+    final Map<String, Object> direct = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    assertThat(cached.get("edgesMissingInReference")).isEqualTo((long) DEGREE);
+    assertThat(cached.get("edgesMissingInReference")).isEqualTo(direct.get("edgesMissingInReference"));
+    assertThat(cached.get("edgesMissingOutReference")).isEqualTo(direct.get("edgesMissingOutReference"));
+    assertThat(cached.get("unreachableEdgeRecords")).isEqualTo(direct.get("unreachableEdgeRecords"));
+    assertThat(cached.get("missingReferenceBack")).isEqualTo(direct.get("missingReferenceBack"));
+    assertThat(cached.get("totalCorruptedRecords")).isEqualTo(direct.get("totalCorruptedRecords"));
+    assertThat(warnings(cached)).containsExactlyInAnyOrderElementsOf(warnings(direct));
+  }
+
+  /**
+   * The PROMOTED super-node, where getting the memoisation wrong is not merely slow but wrong. A neighbour-keyed
+   * probe of a {@link StripedEdgeList} reads only the stripes that can hold that neighbour and is strict about a
+   * stripe head it cannot resolve; an image built from the whole list would skip such a chain silently. The cache
+   * therefore memoises per CHAIN and leaves the selection to
+   * {@link StripedEdgeList#chainsForNeighbourProbe(RID)} - this test is what reaches that override, and it fails if
+   * the two paths ever disagree about a healthy striped hub.
+   */
+  @Test
+  void aPromotedSuperNodeIsProbedThroughItsOwnStripeSelection() {
+    GlobalConfiguration.GRAPH_SUPERNODE_THRESHOLD.setValue(64);
+    final RID hub = createHubWithDistinctSpokes();
+
+    // PRECONDITION: the hub really is striped, or the test proves nothing about the striped path.
+    database.transaction(() -> {
+      final RID head = ((VertexInternal) hub.asVertex(true)).getInEdgesHeadChunk();
+      assertThat(database.lookupByRID(head, true)).isInstanceOf(StripeDirectory.class);
+    });
+
+    final Map<String, Object> cached = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES.setValue(0);
+    final Map<String, Object> direct = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    assertThat(warnings(cached)).isEmpty();
+    assertThat(warnings(cached)).containsExactlyInAnyOrderElementsOf(warnings(direct));
+    assertThat(cached.get("edgesMissingInReference")).isEqualTo(direct.get("edgesMissingInReference"));
+    assertThat(cached.get("edgesMissingOutReference")).isEqualTo(direct.get("edgesMissingOutReference"));
+    assertThat(cached.get("missingReferenceBack")).isEqualTo(direct.get("missingReferenceBack"));
+    assertThat((Long) cached.get("adjacencyProbeListWalks"))
+        .as("the striped hub's chains must still be memoised, not re-walked per incident edge")
+        .isLessThan((Long) direct.get("adjacencyProbeListWalks"));
+  }
+
+  /** A healthy graph stays healthy: the cache must not invent a finding either. */
+  @Test
+  void aHealthyGraphReportsNothing() {
+    createHubWithDistinctSpokes();
+
+    final Map<String, Object> result = new DatabaseChecker(database).setVerboseLevel(0).check();
+
+    assertThat(warnings(result)).isEmpty();
+    assertThat((Long) result.get("totalCorruptedRecords")).isZero();
+    assertThat((Long) result.get("unreachableEdgeRecords")).isZero();
+    assertThat((Long) result.get("edgesMissingInReference")).isZero();
+    assertThat((Long) result.get("edgesMissingOutReference")).isZero();
+  }
+
+  /** Two vertices, {@code DEGREE} parallel edges between them: exactly two adjacency lists in the whole database. */
+  private void createParallelEdgesBetweenTwoVertices() {
+    database.transaction(() -> {
+      final MutableVertex source = database.newVertex(VERTEX_TYPE).set("name", "source").save();
+      final MutableVertex destination = database.newVertex(VERTEX_TYPE).set("name", "destination").save();
+      for (int i = 0; i < DEGREE; i++)
+        source.newEdge(EDGE_TYPE, destination);
+    });
+  }
+
+  /** One hub with {@code DEGREE} distinct spokes, each pointing at it: the super-node shape from the issue. */
+  private RID createHubWithDistinctSpokes() {
+    final RID[] hub = new RID[1];
+    database.transaction(() -> hub[0] = database.newVertex(VERTEX_TYPE).set("name", "hub").save().getIdentity());
+    database.transaction(() -> {
+      final MutableVertex target = hub[0].asVertex(true).modify();
+      for (int i = 0; i < DEGREE; i++)
+        database.newVertex(VERTEX_TYPE).set("i", i).save().newEdge(EDGE_TYPE, target);
+    });
+    return hub[0];
+  }
+
+  @SuppressWarnings("unchecked")
+  private Collection<String> warnings(final Map<String, Object> result) {
+    return (Collection<String>) result.get("warnings");
+  }
+}


### PR DESCRIPTION
Closes #6062

## The cost, and where it came from

`CHECK DATABASE` asks two back-reference questions of a **neighbour's** adjacency list, both once per edge and both an O(degree) linear walk of the chunk chain:

- `checkEdges` asks both endpoints of every edge record whether their list names it (`EdgeLinkedList.containsEdge`);
- `checkVertices` asks the far vertex of every adjacency entry whether it points back (`Vertex.isConnectedTo` -> `EdgeLinkedList.containsVertex`).

Nothing was remembered between two probes of the **same** list, so a hub of degree D had its list walked D times by each of them. That is O(D²) on exactly the vertex the check exists to survive, and once the working set exceeds the page cache every one of those walks risks a real disk read. The issue reports a 657GB database with hubs in the hundreds of thousands of edges measured at **80h19m** for a single `CHECK DATABASE FIX`.

## The change

A per-pass `AdjacencyProbeCache` (`engine/src/main/java/com/arcadedb/graph/AdjacencyProbeCache.java`) materialises the first probe of a list into primitive `LongHashSet`s keyed by bucket, and answers every later probe of that list with a hash lookup. The probe cost of a pass goes from `sum(degree²)` to `sum(degree)`.

Properties that are load-bearing rather than incidental:

- **Exact, never approximate.** A bloom/sketch answer would be worse than useless: a false positive reads as "the back-reference is there" and silently drops a real finding, and under `FIX DELETE ORPHANS` the same answer decides whether a record is deleted. Anything that cannot be represented exactly - an entry the primitive sets cannot hold, a list larger than the whole budget - falls back to the original `EdgeLinkedList` walk, and that verdict is remembered so such a list is never re-walked-and-abandoned once per probe.
- **Bounded**, by `arcadedb.checkDatabaseAdjacencyCacheEntries` (new, default 1,000,000 adjacency entries, roughly 20MB). Eviction is LRU by *last probe*, so a hub - the list that pays for itself - is the one that stays. `0` disables the cache and restores the pre-fix probe exactly.
- **The striped super-node keeps its own selection semantics.** A neighbour-keyed probe of a `StripedEdgeList` reads only the stripes that can hold that neighbour and is STRICT: a stripe head it cannot resolve becomes a retryable `ConcurrentModificationException` rather than a chain silently missing from the answer (`chainsForNeighbour`, #5680). An image built from the whole list would skip that chain and answer "not connected" where the engine promises to fail loudly - which is exactly what `SuperNodeStripingTest.transientlyMissingStripeChainIsRetryableForWritesBestEffortForReads` caught on the first iteration of this change. So the neighbour probe memoises **per chain**, keyed by the chain's head segment, and leaves the selection to the new `EdgeLinkedList.chainsForNeighbourProbe` / its `StripedEdgeList` override. The edge probe keeps a whole-list image because `containsEdge` and `entryIterator` already walk the identical set of chains (`allChains(false)`).
- **Staleness is handled by clearing, not by patching.** `EdgeVertexIterator.remove()` deletes the edge record, and `GraphEngine.deleteEdge` takes the edge out of BOTH endpoints' lists, so a prune in the vertex pass can change a list the cache holds an image of - for a vertex the walk has not reached, and through an endpoint pair a corrupt entry may misreport. Naming the affected lists would mean trusting the very pointers the prune is happening because of, so the whole cache is dropped at both prune sites and before the post-scan repair loops. Prunes are repairs on a damaged database; the worst case (damage that is overwhelmingly dangling entries) is no slower than it was before this cache existed.
- The polymorphic edge-type bucket filter that `isVertexConnectedTo` rebuilt through a stream **on every call** is memoised too - a hub probed once per incident edge was paying an array allocation per edge on top of the walk.

## What the check now reports

Three counters, seeded in `DatabaseChecker` so a clean run publishes them, summed across passes by the existing `updateStats` fold:

| key | meaning |
|---|---|
| `adjacencyProbes` | back-reference questions asked (structurally two per edge, per pass) |
| `adjacencyProbeListWalks` | how many of them had to touch an adjacency list; used to be all of them |
| `adjacencyEntriesScanned` | entries those walks visited - the number that was quadratic in a hub's degree |

`adjacencyProbeListWalks` close to `adjacencyProbes` on a graph with hubs now means "the cache is not engaging", which is the diagnostic the 80-hour report had no way to produce.

## Measured by the tests, not by a stopwatch

Every assertion is on those counters; nothing here times anything.

- Two vertices joined by 400 parallel edges (exactly two adjacency lists in the database): **1600 probes, 4 list walks**. With `arcadedb.checkDatabaseAdjacencyCacheEntries=0` the same run is 1600 probes / **1600** walks - that control test is what proves the counter measures the thing and the cache is what changes it.
- One hub with 400 distinct spokes: `adjacencyEntriesScanned` = **1600**, i.e. each list materialised once per pass. Per-probe walking would put it near 160,000 on the same fixture.

## Test plan

- [ ] `mvn -o -pl engine -am test -Dtest=Issue6062AdjacencyProbeCacheTest` - 6 tests: the walk counter on a two-vertex/many-parallel-edges graph, the cache-disabled control, the linear entry count on a hub with distinct spokes, a **promoted** (striped) super-node probed through its own stripe selection, cached-vs-direct agreement on a half-linked edge, and a healthy graph reporting nothing.
- [ ] `mvn -o -pl engine -am test -Dtest='CheckDatabase*,GraphDatabaseChecker*,Issue6090*,Issue687*,Issue5147*,SuperNode*Test,Issue6048*,Issue6062*,Issue5667*' -DexcludedGroups=benchmark,vector` - 139 tests, green.
- [ ] `mvn -o -pl engine -am test -Dtest='com.arcadedb.graph.**.*Test,com.arcadedb.database.**.*Test' -DexcludedGroups=benchmark,vector,slow` - 715 tests, green.
- [ ] Operationally: run `CHECK DATABASE` on a graph with a super-node and read `adjacencyProbes` against `adjacencyProbeListWalks`; set `arcadedb.checkDatabaseAdjacencyCacheEntries=0` and confirm the two converge and the findings are unchanged.

## Two things this touches beyond the cache, both deliberate

- **`EdgeVertexIterator` now ends the walk on a chunk pointing at itself** (issue #6278 tracks lifting the same guard into the sibling iterators). This is not cache plumbing: `entryIterator()` is what the checker walks a vertex's own list with, so before this a self-referencing chunk made `CHECK DATABASE` never return rather than report the damage. Measured: with the guard forced off, `aSelfReferencingChunkEndsTheWalkInsteadOfFeedingItForever` fails in 0.152s against its hard iteration cap.
- **The edge probe now resolves the endpoint through `GraphEngine.getMostUpdatedVertex` before reading its head chunk.** `checkEdges` called `getEdgeHeadChunk` on its own handle directly, which is the one read of an edge-list head in the engine that skipped the resolution that method's own Javadoc says every such read has to go through; the neighbour probe already had it via `ImmutableVertex.isConnectedTo`. No behaviour changes today - `checkEdges` writes nothing during its scan, so the transaction cache holds nothing that could differ from the caller's handle - but the two probes now read a head the same way, which is what makes "the cached and the direct answer are the same answer" true by construction rather than by coincidence.

## Deliberately NOT in this PR

The issue lists three directions; this one takes the first and leaves the other two, each of which is a separate change with its own risk:

- **Parallelising the checker phases.** `DatabaseChecker`/`GraphDatabaseChecker` are single-threaded end to end and say so on their own fields; making them parallel means picking a dedicated pool per the `QueryEngineManager` convention, making `CheckReport` and the corrupted/warning sets thread-safe, and re-deciding what a per-type transaction means. Worth doing, not worth folding into a change whose whole argument is that the answers are identical.
- **The second full vertex scan in `reclaimOrphanedEdgeSegments`**, and the full edge-type re-scan in `reconnectEdges`. Both are already named as known limitations in the existing Javadoc; neither is quadratic.
- **A completeness-for-time mode** (sampling, a `--skip-back-reference-probe` escape hatch). `arcadedb.checkDatabaseAdjacencyCacheEntries=0` is an escape hatch in the opposite direction (memory, not time); a mode that skips the probe outright changes what a clean result certifies and should be its own decision.

