### PR TITLE
fix(#5719): a single HTTP response is bounded by a ceiling no caller can widen, and refuses rather than truncates

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2283,8 +2283,16 @@ Two paths that used to escape any bound are bounded at the fetch rather than at 
 POST endpoints push down into a command that states none is now capped by the ceiling (an unlimited `limit`
 used to push nothing down at all), and `profileExecution: detailed`, which drains the whole result set into
 memory before serializing it, drains at most one row past the cap the response will honor. The TimeSeries
-query endpoint enforces the ceiling too, but only over the response it builds: `TimeSeriesEngine.query()`
-materializes the whole requested range before any limit is known, so bounding that fetch needs an engine-level
-change and is left as follow-up work.
+query endpoint enforces the ceiling on both of its shapes - the raw rows, and the buckets of an `aggregation`
+request, which reads no `limit` at all and so had the ceiling as its only possible bound - but only over the
+response it builds: `TimeSeriesEngine.query()` materializes the whole requested range before any limit is
+known, so bounding that fetch needs an engine-level change and is left as follow-up work.
+
+On the status code: 413 is conventionally about an oversized *request* body, and no standard code says "the
+response you asked for is too large to send". 413 is the closest fit and keeps the refusal in the 4xx range,
+where it belongs - the request is answerable, just not as written - but a client that maps status codes
+mechanically should note that the fix is to narrow or page the query, not to shrink the request body. The
+error body distinguishes the two: this refusal names `arcadedb.server.httpQueryMaxResultRows` in its `error`
+field and carries the ceiling in `exceptionArgs`, in every server mode.
 
 [#5719](https://github.com/ArcadeData/arcadedb/issues/5719)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2265,6 +2265,20 @@ A finite default was chosen over a disabled one because every other resource cei
 a ceiling an operator has to discover before it protects anything protects nobody. At 1,000,000 it sits 50x
 above the default page cap, so a realistic paging or export client never meets it.
 
+The two settings cannot be configured into disagreeing. `httpQueryDefaultLimit` is itself lowered to the
+ceiling when it is configured above it (or left unlimited while the ceiling is not), so a caller that states
+no limit at all is never refused - it gets the ordinary reported truncation it has always got, at the lower of
+the two values. The refusal is for a caller that asked to go past the ceiling, never for one served by the
+default.
+
+Two things the ceiling deliberately does not bound, both worth knowing before sizing it. It bounds the size of
+a response, not the peak cost of refusing one: the rows are serialized up to the ceiling before the result
+turns out to exceed it, and the work is then thrown away, so a client that routinely brushes the ceiling
+produces real garbage rather than merely a smaller payload - the same trade the gRPC path makes, and the price
+of never truncating silently. And it bounds the response, not the work a command does to produce it: a write
+that returns its rows (`UPDATE ... RETURN AFTER`) applies to every matching record before the response is
+built, and is then rolled back with the refusal, so the ceiling is not a guard against write amplification.
+
 Two paths that used to escape any bound are bounded at the fetch rather than at serialization: the `LIMIT` the
 POST endpoints push down into a command that states none is now capped by the ceiling (an unlimited `limit`
 used to push nothing down at all), and `profileExecution: detailed`, which drains the whole result set into

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2234,3 +2234,43 @@ purpose ("more seeds than nodes" reads as "as many as exist" and is clamped to t
 nameless `NegativeArraySizeException`.
 
 [#6216](https://github.com/ArcadeData/arcadedb/issues/6216)
+
+## The HTTP query endpoints now have a hard row ceiling a caller cannot widen (#5719)
+
+**Breaking change.** `arcadedb.server.httpQueryMaxResultRows` is a new server setting, defaulting to
+**1,000,000**, that bounds the number of rows a single HTTP query or command response materializes. A
+deployment that relies on an HTTP caller pulling an unbounded result in one response - typically by sending
+`"limit": -1` - has to raise it or set it to `-1` to keep that working.
+
+The ceiling closes the gap that #5716 left open. `arcadedb.server.httpQueryDefaultLimit` (default 20,000)
+caps only the callers that state no limit of their own: since #5716 a request carrying a `limit` field, and a
+query carrying its own `LIMIT`, are both honored as written, because a response silently cut below what the
+caller asked for is exactly the defect #5711 fixed. The consequence is that an authenticated caller writing
+`SELECT FROM HugeType LIMIT 100000000` - or an application that builds `LIMIT n` from user input - could make
+the server serialize an arbitrarily large result into one JSON document. No privilege boundary moved (`limit:
+-1` was always available to the same actor), but the bar to reaching it accidentally dropped, and in a
+multi-tenant deployment the implicit 20,000 cap had been doing real protective work.
+
+The new setting is the HTTP twin of `arcadedb.server.grpcQueryMaxResultRows` and behaves the same way. A
+stated cap at or below the ceiling is the caller's own bound and is honored silently, truncation reported with
+`truncated` exactly as before. A larger one - or an unlimited `-1`/`0` - cannot widen the response past the
+ceiling, and a result that would exceed it **fails with HTTP 413 naming the setting** instead of being
+truncated: a truncated response indistinguishable from a complete one is what #5711 removed, and
+re-introducing it for the callers #5716 protects would only have moved it. The refusal is raised from inside
+the handler, so an auto-committed write command whose result nobody will ever see is rolled back rather than
+committed behind an error status.
+
+A finite default was chosen over a disabled one because every other resource ceiling the server ships -
+`httpBodyContentMaxSize`, `grpcQueryMaxResultRows`, `grpcStreamMaxMaterializedRows` - is finite by default, and
+a ceiling an operator has to discover before it protects anything protects nobody. At 1,000,000 it sits 50x
+above the default page cap, so a realistic paging or export client never meets it.
+
+Two paths that used to escape any bound are bounded at the fetch rather than at serialization: the `LIMIT` the
+POST endpoints push down into a command that states none is now capped by the ceiling (an unlimited `limit`
+used to push nothing down at all), and `profileExecution: detailed`, which drains the whole result set into
+memory before serializing it, drains at most one row past the cap the response will honor. The TimeSeries
+query endpoint enforces the ceiling too, but only over the response it builds: `TimeSeriesEngine.query()`
+materializes the whole requested range before any limit is known, so bounding that fetch needs an engine-level
+change and is left as follow-up work.
+
+[#5719](https://github.com/ArcadeData/arcadedb/issues/5719)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1207,7 +1207,9 @@ public enum GlobalConfiguration {
       its own LIMIT clause, are both honored as written and are never capped by this value. When this default \
       does cut a result short the response reports `"truncated": true` next to `returned` and `limit`, and the \
       server logs a warning: the truncation is never silent (issue #5711). Set to -1 or 0 for unlimited \
-      (WARNING: removes the protection against materializing an unbounded result set in memory). Default is 20000""",
+      (WARNING: removes the protection against materializing an unbounded result set in memory). A value above \
+      'arcadedb.server.httpQueryMaxResultRows' - including unlimited - is lowered to it, so the two settings \
+      cannot disagree and a caller that states no limit is never refused, only truncated. Default is 20000""",
       Integer.class, 20_000),
 
   SERVER_HTTP_QUERY_MAX_RESULT_ROWS("arcadedb.server.httpQueryMaxResultRows", SCOPE.SERVER,
@@ -1219,8 +1221,13 @@ public enum GlobalConfiguration {
       push a single response past it. A result that would exceed the ceiling fails the request with HTTP 413 \
       naming this setting, exactly as the gRPC unary ExecuteQuery path answers RESOURCE_EXHAUSTED, rather than \
       silently truncating: a truncated response indistinguishable from a complete one is the defect issue #5711 \
-      fixed. Set to -1 or 0 for unlimited (WARNING: removes the protection against materializing an unbounded \
-      result set in memory). Default is 1000000""",
+      fixed. A caller that states no limit at all is never refused: 'arcadedb.server.httpQueryDefaultLimit' is \
+      itself lowered to this ceiling, so such a caller gets the ordinary reported truncation instead. Note that \
+      this bounds the SIZE of a response, not the peak cost of refusing one - the rows are serialized up to the \
+      ceiling before the result is found to exceed it - nor the work a command does before returning: a write \
+      that returns its rows applies to every matching record, and is then rolled back with the refusal. Set to \
+      -1 or 0 for unlimited (WARNING: removes the protection against materializing an unbounded result set in \
+      memory). Default is 1000000""",
       Integer.class, 1_000_000),
 
   SERVER_HTTP_STREAMING_READ_TIMEOUT("arcadedb.server.httpStreamingReadTimeout", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1210,6 +1210,19 @@ public enum GlobalConfiguration {
       (WARNING: removes the protection against materializing an unbounded result set in memory). Default is 20000""",
       Integer.class, 20_000),
 
+  SERVER_HTTP_QUERY_MAX_RESULT_ROWS("arcadedb.server.httpQueryMaxResultRows", SCOPE.SERVER,
+      """
+      Hard ceiling on the number of rows the HTTP query/command endpoints materialize into a single response. \
+      Where 'arcadedb.server.httpQueryDefaultLimit' caps only the callers that state no limit of their own, this \
+      ceiling also bounds the ones that do: a request `limit` at or below it - and a LIMIT the query itself \
+      carries - is honored as written, while a larger value, or an explicitly unlimited `limit` of -1/0, cannot \
+      push a single response past it. A result that would exceed the ceiling fails the request with HTTP 413 \
+      naming this setting, exactly as the gRPC unary ExecuteQuery path answers RESOURCE_EXHAUSTED, rather than \
+      silently truncating: a truncated response indistinguishable from a complete one is the defect issue #5711 \
+      fixed. Set to -1 or 0 for unlimited (WARNING: removes the protection against materializing an unbounded \
+      result set in memory). Default is 1000000""",
+      Integer.class, 1_000_000),
+
   SERVER_HTTP_STREAMING_READ_TIMEOUT("arcadedb.server.httpStreamingReadTimeout", SCOPE.SERVER,
       """
       Budget in milliseconds granted to endpoints that consume the request body while working (today only \

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -199,7 +199,10 @@ public class RemoteHttpComponent extends RWLockContext {
    * ({@code arcadedb.server.httpQueryDefaultLimit}) and the driver logs a warning when that cap drops rows
    * (issue #5711).
    * <p>
-   * Beware that removing the cap makes the server materialize the whole result set in memory before answering.
+   * Beware that removing the cap makes the server materialize the whole result set in memory before answering,
+   * up to the server's hard ceiling ({@code arcadedb.server.httpQueryMaxResultRows}, 1,000,000 rows by
+   * default): a result larger than that is refused with HTTP 413 rather than truncated, so a driver asking for
+   * an unbounded page must be ready for a response it has to narrow or paginate (issue #5719).
    */
   public void setMaxResultRows(final Integer maxResultRows) {
     this.maxResultRows = maxResultRows;

--- a/server/src/main/java/com/arcadedb/server/http/ResultSetTooLargeException.java
+++ b/server/src/main/java/com/arcadedb/server/http/ResultSetTooLargeException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.server.ServerException;
+
+/**
+ * Thrown when a single HTTP response would carry more rows than
+ * {@code arcadedb.server.httpQueryMaxResultRows} allows (issue #5719). Mapped to HTTP 413 by the request
+ * handler.
+ * <p>
+ * The ceiling refuses instead of truncating on purpose: a response silently cut short is indistinguishable
+ * from a complete one, which is the defect issue #5711 fixed, and re-introducing it for the callers that
+ * state a limit of their own would only move it. Raising it from inside the handler also rolls the
+ * auto-commit transaction back, so a write command whose result nobody will ever see is not committed
+ * behind an error status.
+ */
+public class ResultSetTooLargeException extends ServerException {
+  private final int maxResultRows;
+
+  public ResultSetTooLargeException(final String message, final int maxResultRows) {
+    super(message);
+    this.maxResultRows = maxResultRows;
+  }
+
+  /**
+   * The ceiling that refused the response. Travels to the client in the error body's {@code exceptionArgs}
+   * field, which - unlike the free-form {@code detail} - is emitted in production mode too, so a caller always
+   * learns the number it has to stay under.
+   */
+  public int getMaxResultRows() {
+    return maxResultRows;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -217,6 +217,33 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
   }
 
   /**
+   * Serializes a result set under the cap the caller is entitled to, and refuses the response outright when the
+   * hard ceiling {@code arcadedb.server.httpQueryMaxResultRows} is what stopped it (issue #5719).
+   * <p>
+   * Two caps, two different answers, and the difference is who asked for it. {@code statedLimit} is what the
+   * request, the query's own LIMIT or the configured default asked for: reaching it is an ordinary truncation,
+   * reported with {@code truncated} and left to the client. The ceiling is what the operator asked for, on
+   * behalf of every other tenant of the server: reaching it means the response the caller wanted cannot be
+   * produced at all, and answering a truncated one instead would re-introduce the silent short answer issue
+   * #5711 removed - for the callers that state a limit of their own, who are exactly the ones the default cap
+   * no longer protects against.
+   * <p>
+   * The ceiling therefore never shows up in a successful response: a 200 either carries everything within
+   * {@code statedLimit} or was cut by {@code statedLimit} itself, which is why the caller reports
+   * {@code statedLimit} back as the effective {@code limit} of the response.
+   */
+  protected SerializationOutcome serializeResultSetBounded(final Database database, final String serializer,
+      final int statedLimit, final int maxResultRows, final JSONObject response, final ResultSet qResult,
+      final boolean includeTypeHints) {
+    final int limit = applyMaxResultRows(statedLimit, maxResultRows);
+    final SerializationOutcome outcome = serializeResultSet(database, serializer, limit, response, qResult,
+        includeTypeHints);
+    if (limit != statedLimit && outcome.truncated())
+      throw resultSetTooLarge(maxResultRows);
+    return outcome;
+  }
+
+  /**
    * @param includeTypeHints whether to emit the per-column {@code @props} type hint on non-element result rows
    *                         (issue #5812). Off by default on the HTTP surface: only a caller that must rebuild
    *                         the exact Java type of a projection/aggregate column - today the RemoteDatabase Java

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -230,7 +230,14 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
    * <p>
    * The ceiling therefore never shows up in a successful response: a 200 either carries everything within
    * {@code statedLimit} or was cut by {@code statedLimit} itself, which is why the caller reports
-   * {@code statedLimit} back as the effective {@code limit} of the response.
+   * {@code statedLimit} back as the effective {@code limit} of the response. A caller that stated nothing can
+   * never reach the refusal at all, because {@link #getDefaultRowLimit()} is already bounded by the ceiling and
+   * so cannot produce a {@code statedLimit} above it.
+   * <p>
+   * One inexactness is inherited rather than introduced: for the {@code graph} and {@code studio} serializers
+   * the cap counts graph elements and the row that reaches it is expanded whole, so a response whose last row
+   * crosses the ceiling can carry a few elements more than it (see {@link SerializationOutcome}). The ceiling
+   * bounds the rows a response materializes exactly; the element count it bounds within one row's expansion.
    */
   protected SerializationOutcome serializeResultSetBounded(final Database database, final String serializer,
       final int statedLimit, final int maxResultRows, final JSONObject response, final ResultSet qResult,

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -82,8 +82,12 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
    * more row, so a result whose size happens to match the cap exactly is not reported as truncated. For the
    * row-oriented serializers ({@code record}, {@code studio} and the default one) the flag is exact and
    * {@code returned} never exceeds the cap. For the {@code graph} serializer the cap counts graph elements
-   * rather than rows: {@code returned} can exceed the cap, because the row that reaches it is expanded whole,
-   * and a last row whose expansion was cut mid-way is not reported when no further row is pending.
+   * rather than rows, so {@code returned} can exceed the cap by up to the expansion of the element that
+   * reached it (an edge brings its two endpoints).
+   * <p>
+   * A row whose own expansion the cap cut short is reported too, since #5719: the result set cannot show it -
+   * everything a row refers to is expanded while that row is the current one - so the flag is raised by the
+   * expansion itself rather than by probing what is left to read.
    */
   public record SerializationOutcome(int returned, boolean truncated) {
     static final SerializationOutcome EMPTY = new SerializationOutcome(0, false);
@@ -234,10 +238,12 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
    * never reach the refusal at all, because {@link #getDefaultRowLimit()} is already bounded by the ceiling and
    * so cannot produce a {@code statedLimit} above it.
    * <p>
-   * One inexactness is inherited rather than introduced: for the {@code graph} and {@code studio} serializers
-   * the cap counts graph elements and the row that reaches it is expanded whole, so a response whose last row
-   * crosses the ceiling can carry a few elements more than it (see {@link SerializationOutcome}). The ceiling
-   * bounds the rows a response materializes exactly; the element count it bounds within one row's expansion.
+   * One inexactness remains for the {@code graph} and {@code studio} serializers, where the cap counts graph
+   * elements rather than rows: the element that reaches it is emitted whole, and an edge brings its two
+   * endpoints, so a response can carry up to two elements more than the ceiling. It is bounded overshoot, not
+   * unbounded: since #5719 the cap is tested inside a row's expansion as well as around it, so a single row
+   * referring to arbitrarily many elements through one collection property - what {@code SELECT collect(...)}
+   * produces - is cut at the cap like any other, and the cut is reported (see {@link #analyzeResultContent}).
    */
   protected SerializationOutcome serializeResultSetBounded(final Database database, final String serializer,
       final int statedLimit, final int maxResultRows, final JSONObject response, final ResultSet qResult,
@@ -277,6 +283,11 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
       final JSONArray vertices = new JSONArray();
       final JSONArray edges = new JSONArray();
 
+      // Set when the cap cut the expansion of one row's own references short. Kept separately from the
+      // result-set probe below, which cannot see it: the expansion happens entirely while its row is the
+      // current one, so nothing is left behind in the result set to give it away.
+      boolean expansionCut = false;
+
       while (qResult.hasNext()) {
         final Result row = qResult.next();
 
@@ -288,9 +299,9 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
           final Edge e = row.getEdge().get();
           if (includedEdges.add(e.getIdentity()))
             edges.put(serializerImpl.serializeGraphElement(e));
-        } else {
-          analyzeResultContent(database, serializerImpl, includedVertices, includedEdges, vertices, edges, row, limit);
-        }
+        } else if (analyzeResultContent(database, serializerImpl, includedVertices, includedEdges, vertices, edges, row,
+            limit))
+          expansionCut = true;
 
         if (limit > 0 && vertices.length() + edges.length() >= limit)
           break;
@@ -298,7 +309,8 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
 
       response.put("result", new JSONObject().put("vertices", vertices).put("edges", edges));
       final int serializedElements = vertices.length() + edges.length();
-      return new SerializationOutcome(serializedElements, isTruncated(qResult, limit, serializedElements));
+      return new SerializationOutcome(serializedElements,
+          expansionCut || isTruncated(qResult, limit, serializedElements));
     }
 
     case "studio": {
@@ -314,6 +326,8 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
       final JSONArray vertices = new JSONArray();
       final JSONArray edges = new JSONArray();
       final JSONArray records = new JSONArray();
+      // See the 'graph' branch above: an expansion the cap cut short is invisible to the result-set probe.
+      boolean expansionCut = false;
 
       while (qResult.hasNext()) {
         final Result row = qResult.next();
@@ -342,9 +356,9 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
                 LogManager.instance().log(this, Level.SEVERE, "Record %s not found during serialization", ex.getRID());
               }
             }
-          } else {
-            analyzeResultContent(database, serializerImpl, includedVertices, includedEdges, vertices, edges, row, limit);
-          }
+          } else if (analyzeResultContent(database, serializerImpl, includedVertices, includedEdges, vertices, edges, row,
+              limit))
+            expansionCut = true;
         } catch (Exception e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on serializing element (error=%s)", e.getMessage());
         }
@@ -355,7 +369,7 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
 
       // Probed before the edge-completion pass below, which does not consume the result set but must not be
       // allowed to hide whether rows were left behind.
-      final boolean truncated = isTruncated(qResult, limit, records.length());
+      final boolean truncated = expansionCut || isTruncated(qResult, limit, records.length());
 
       // FILTER OUT NOT CONNECTED EDGES
       for (final Identifiable entry : includedVertices) {
@@ -440,7 +454,17 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
     return limit > 0 && serialized >= limit && qResult.hasNext();
   }
 
-  protected void analyzeResultContent(final Database database, final JsonGraphSerializer serializerImpl,
+  /**
+   * Expands the graph elements a non-element row refers to into {@code vertices}/{@code edges}, stopping at the
+   * element cap.
+   *
+   * @return {@code true} when the cap stopped the expansion with content still unexpanded, i.e. the response is
+   * short of what the row referred to. The callers fold it into {@code truncated}, which is what keeps a cut
+   * expansion reportable (issue #5711) and refusable against the hard ceiling (issue #5719): the row-level
+   * probe cannot see it, because everything a row refers to is expanded while that row is the current one and
+   * nothing is left behind in the result set for {@link #isTruncated} to find.
+   */
+  protected boolean analyzeResultContent(final Database database, final JsonGraphSerializer serializerImpl,
       final Set<RID> includedVertices, final Set<RID> includedEdges, final JSONArray vertices, final JSONArray edges,
       final Result row, final int limit) {
     for (final String prop : row.getPropertyNames()) {
@@ -450,20 +474,27 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
           continue;
 
         if (limit > 0 && vertices.length() + edges.length() >= limit)
-          break;
+          return true;
 
         if (RID_PROPERTY.equals(prop) && RID.is(value)) {
-          analyzePropertyValue(database, serializerImpl, includedVertices, includedEdges, vertices, edges,
-              database.newRID(value.toString()), limit);
-        } else
-          analyzePropertyValue(database, serializerImpl, includedVertices, includedEdges, vertices, edges, value, limit);
+          if (analyzePropertyValue(database, serializerImpl, includedVertices, includedEdges, vertices, edges,
+              database.newRID(value.toString()), limit))
+            return true;
+        } else if (analyzePropertyValue(database, serializerImpl, includedVertices, includedEdges, vertices, edges, value,
+            limit))
+          return true;
       } catch (Exception e) {
         LogManager.instance().log(this, Level.SEVERE, "Error on serializing collection element (error=%s)", e.getMessage());
       }
     }
+    return false;
   }
 
-  protected void analyzePropertyValue(final Database database, final JsonGraphSerializer serializerImpl,
+  /**
+   * @return {@code true} when the cap stopped the expansion of this value with content still unexpanded. See
+   * {@link #analyzeResultContent}.
+   */
+  protected boolean analyzePropertyValue(final Database database, final JsonGraphSerializer serializerImpl,
       final Set<RID> includedVertices, final Set<RID> includedEdges, final JSONArray vertices, final JSONArray edges,
       final Object value, final int limit) {
     if (value instanceof Identifiable identifiable) {
@@ -499,16 +530,26 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
         }
       }
     } else if (value instanceof Result result) {
-      analyzeResultContent(database, serializerImpl, includedVertices, includedEdges, vertices, edges, result, limit);
+      return analyzeResultContent(database, serializerImpl, includedVertices, includedEdges, vertices, edges, result, limit);
     } else if (value instanceof Collection<?> collection) {
       for (final Iterator<?> it = collection.iterator(); it.hasNext(); ) {
+        // The cap is tested INSIDE the collection, not only between rows and between properties. One row can
+        // refer to arbitrarily many graph elements through a single property - `SELECT collect(...)` returns
+        // exactly one row whose value is the whole set - and a check that runs only outside this loop lets that
+        // one row expand whole, past the cap, with nothing left in the result set to make the overshoot
+        // detectable (issue #5719).
+        if (limit > 0 && vertices.length() + edges.length() >= limit)
+          return true;
         try {
-          analyzePropertyValue(database, serializerImpl, includedVertices, includedEdges, vertices, edges, it.next(), limit);
+          if (analyzePropertyValue(database, serializerImpl, includedVertices, includedEdges, vertices, edges, it.next(),
+              limit))
+            return true;
         } catch (Exception e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on serializing collection element (error=%s)", e.getMessage());
         }
       }
     }
+    return false;
   }
 
   protected Object mapParams(Map<String, Object> paramMap) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -136,9 +136,18 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    * Maximum number of rows an endpoint serializes into a single response when the caller states no limit of its
    * own. A non-positive value means unlimited. Shared by every row-returning endpoint so one setting governs
    * them all (issue #5711).
+   * <p>
+   * Bounded by the hard ceiling, so a default configured above it (or left unlimited while the ceiling is not)
+   * is lowered rather than refused. Without that clamp a deployment whose two settings disagree would answer a
+   * caller that stated <i>nothing</i> with a 413: the cap it never asked for would exceed the ceiling, and the
+   * refusal is meant for a caller that asked to go past it, never for one served by the default. What a
+   * no-limit caller gets instead is the ordinary truncation it has always got, at the lower of the two values,
+   * reported as usual with {@code truncated} (issue #5719).
    */
   protected int getDefaultRowLimit() {
-    return httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT);
+    return applyMaxResultRows(
+        httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT),
+        getMaxResultRows());
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -36,6 +36,7 @@ import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.HttpSessionException;
 import com.arcadedb.server.http.HttpSessionManager;
 import com.arcadedb.server.http.IdempotencyCache;
+import com.arcadedb.server.http.ResultSetTooLargeException;
 import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -138,6 +139,38 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
    */
   protected int getDefaultRowLimit() {
     return httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT);
+  }
+
+  /**
+   * Hard ceiling on the number of rows a single response may carry, whatever the caller asked for. A
+   * non-positive value means unlimited (issue #5719).
+   */
+  protected int getMaxResultRows() {
+    return httpServer.getServer().getConfiguration().getValueAsInteger(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS);
+  }
+
+  /**
+   * Lowers a row cap to the hard ceiling, so no caller can widen a single response past it: the value stated by
+   * the caller (or by the query, or by the configured default) wins while it stays at or below the ceiling, and
+   * an explicitly unlimited cap - {@code <= 0} - is bounded by it like any other. Returns the cap unchanged when
+   * the ceiling is disabled, which is exactly what makes {@code applied != stated} the test for "the ceiling is
+   * the one deciding here" that the callers use to answer 413 instead of reporting an ordinary truncation.
+   */
+  protected static int applyMaxResultRows(final int limit, final int maxResultRows) {
+    if (maxResultRows <= 0)
+      return limit;
+    return limit <= 0 || limit > maxResultRows ? maxResultRows : limit;
+  }
+
+  /**
+   * Refusal of a response the hard ceiling would not let through, worded identically on every endpoint that
+   * enforces it. Names the setting so an operator reading only the error body knows which knob decided.
+   */
+  protected static ResultSetTooLargeException resultSetTooLarge(final int maxResultRows) {
+    return new ResultSetTooLargeException(
+        "The result exceeds the maximum of " + maxResultRows + " rows a single HTTP response may carry ("
+            + GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS.getKey()
+            + "): narrow the query, page it with a smaller 'limit', or raise the setting", maxResultRows);
   }
 
   /**
@@ -552,6 +585,23 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
               SecurityException.class.getSimpleName(), security.getMessage());
       sendErrorResponse(exchange, 403, "Security error", security, null);
+      return;
+    }
+
+    // 413 Content Too Large: the response the caller asked for exceeds the hard row ceiling
+    // (arcadedb.server.httpQueryMaxResultRows). Independent of every other arm - nothing extends it and it
+    // extends nothing but ServerException - so its position here is only for readability. A 4xx and not a 5xx:
+    // the request is answerable, just not as written, and the caller fixes it by narrowing or paging the query
+    // (issue #5719).
+    final ResultSetTooLargeException tooLarge = firstOf(e, cause, ResultSetTooLargeException.class);
+    if (tooLarge != null) {
+      logUserError(tooLarge);
+      // The setting goes in the label and the ceiling in exceptionArgs, both of which survive production mode:
+      // 'detail' - where the full sentence lives - is concealed there, and a caller that cannot see WHICH knob
+      // refused it, or WHAT number to stay under, has been told nothing it can act on.
+      sendErrorResponse(exchange, 413,
+          "Result set too large for a single response (" + GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS.getKey()
+              + ")", tooLarge, String.valueOf(tooLarge.getMaxResultRows()));
       return;
     }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetQueryHandler.java
@@ -81,7 +81,10 @@ public class GetQueryHandler extends AbstractQueryHandler {
         profile.addEngineNanos(System.nanoTime() - engineStart);
 
         final long serializationStart = System.nanoTime();
-        final SerializationOutcome outcome = serializeResultSet(database, serializer, limit, response, qResult, includeTypeHints);
+        // ... and above all of them the hard ceiling, which no caller can widen: a response that would exceed
+        // it is refused with 413 rather than truncated (issue #5719).
+        final SerializationOutcome outcome = serializeResultSetBounded(database, serializer, limit, getMaxResultRows(),
+            response, qResult, includeTypeHints);
         reportLimits(response, limit, outcome);
         logIfTruncatedByDefault(database.getName(), text, limit, requestLimit, planLimit, outcome);
         profile.addSerializationNanos(System.nanoTime() - serializationStart);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -223,8 +223,9 @@ public class PostCommandHandler extends AbstractQueryHandler {
     // unlimited 'limit' used to push nothing down at all, so the whole result reached the handler - and with
     // 'profileExecution: detailed' it was materialized in full by materializeResultSet before any cap could
     // look at it. With the ceiling in the pushed-down LIMIT the engine stops one row past it (issue #5719).
+    // Only the caller's own value needs clamping here: getDefaultRowLimit() is already bounded by the ceiling.
     final int maxResultRows = getMaxResultRows();
-    final int autoLimit = applyMaxResultRows(requestLimit != null ? requestLimit : getDefaultRowLimit(), maxResultRows);
+    final int autoLimit = requestLimit != null ? applyMaxResultRows(requestLimit, maxResultRows) : getDefaultRowLimit();
     final boolean autoLimited = requiresAutomaticLimit(command, language, autoLimit);
     // Kept for the log: a warning must show the operator the query the caller sent, not the rewritten one.
     final String originalCommand = command;

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -218,7 +218,13 @@ public class PostCommandHandler extends AbstractQueryHandler {
     // The cap used to push a LIMIT down into a command that states none: the caller's own 'limit' when
     // present, the configured default otherwise. A command that already carries a LIMIT is left untouched and
     // its own value decides the response size, resolved from the execution plan after execution.
-    final int autoLimit = requestLimit != null ? requestLimit : getDefaultRowLimit();
+    //
+    // Bounded by the hard ceiling before it is pushed down, not only when the rows are serialized: an
+    // unlimited 'limit' used to push nothing down at all, so the whole result reached the handler - and with
+    // 'profileExecution: detailed' it was materialized in full by materializeResultSet before any cap could
+    // look at it. With the ceiling in the pushed-down LIMIT the engine stops one row past it (issue #5719).
+    final int maxResultRows = getMaxResultRows();
+    final int autoLimit = applyMaxResultRows(requestLimit != null ? requestLimit : getDefaultRowLimit(), maxResultRows);
     final boolean autoLimited = requiresAutomaticLimit(command, language, autoLimit);
     // Kept for the log: a warning must show the operator the query the caller sent, not the rewritten one.
     final String originalCommand = command;
@@ -271,7 +277,8 @@ public class PostCommandHandler extends AbstractQueryHandler {
           profile.addEngineNanos(System.nanoTime() - engineStart);
 
           final long serializationStart = System.nanoTime();
-          outcome = serializeResultSet(database, serializer, limit, response, qResult, includeTypeHints);
+          outcome = serializeResultSetBounded(database, serializer, limit, maxResultRows, response, qResult,
+              includeTypeHints);
           response.put("explain", explainText);
           response.put("explainPlan", executionPlan.toResult().toJSON());
           profile.addSerializationNanos(System.nanoTime() - serializationStart);
@@ -280,12 +287,19 @@ public class PostCommandHandler extends AbstractQueryHandler {
             // Materialize the ResultSet inside the engine timer so the serialization
             // timer captures only the wire-format conversion and not query work.
             // materializeResultSet closes the source and returns a fresh in-memory ResultSet.
-            qResult = materializeResultSet(qResult);
+            //
+            // Bounded by the same cap the response will honor: this is the one place that drains the whole
+            // result set into memory before any cap is applied, so a command carrying its own huge LIMIT -
+            // which is left as written and therefore gets no pushed-down bound - could materialize an
+            // arbitrary number of rows here (issue #5719). One row above the cap, as the pushdown does, so
+            // the truncation stays detectable.
+            qResult = materializeResultSet(qResult, truncationProbeLimit(applyMaxResultRows(limit, maxResultRows)));
           }
           profile.addEngineNanos(System.nanoTime() - engineStart);
 
           final long serializationStart = System.nanoTime();
-          outcome = serializeResultSet(database, serializer, limit, response, qResult, includeTypeHints);
+          outcome = serializeResultSetBounded(database, serializer, limit, maxResultRows, response, qResult,
+              includeTypeHints);
 
           if (qResult != null) {
             final var qStats = qResult.getStatistics();
@@ -356,11 +370,15 @@ public class PostCommandHandler extends AbstractQueryHandler {
    * original execution plan, and returns a new {@link ResultSet} backed by the
    * list. The source {@link ResultSet} is closed. Used by the profiler to
    * separate engine execution time from serialization time.
+   *
+   * @param maxRows how many rows to drain at most, {@code 0} or less for all of them. Rows past it are dropped
+   *                with the source, which is safe only because the caller sizes it above the cap the response
+   *                will honor: what is dropped here would have been dropped by the serializer anyway.
    */
-  private static ResultSet materializeResultSet(final ResultSet source) {
+  private static ResultSet materializeResultSet(final ResultSet source, final int maxRows) {
     try {
       final List<Result> rows = new ArrayList<>();
-      while (source.hasNext())
+      while (source.hasNext() && (maxRows <= 0 || rows.size() < maxRows))
         rows.add(source.next());
 
       final Optional<ExecutionPlan> plan = source.getExecutionPlan();

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -114,6 +114,16 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
 
     final List<Object[]> rows = engine.query(fromTs, toTs, columnIndices, tagFilter);
 
+    // The hard ceiling no caller can widen (issue #5719): a caller that states a huge 'limit', or an unlimited
+    // one, is refused rather than served an arbitrarily large response. Checked here, before the JSON is built,
+    // so the ceiling at least keeps the second and larger copy of the range out of the heap - it cannot keep the
+    // first one out, because engine.query() above materializes the whole range before any limit is known. That
+    // is a bound on the fetch, and it belongs in the engine, not in this handler.
+    final int maxResultRows = getMaxResultRows();
+    final int ceiling = applyMaxResultRows(limit, maxResultRows);
+    if (ceiling != limit && rows.size() > ceiling)
+      throw resultSetTooLarge(maxResultRows);
+
     // Build column names for response
     final JSONArray colNames = new JSONArray();
     if (columnIndices == null) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesQueryHandler.java
@@ -203,6 +203,15 @@ public class PostTimeSeriesQueryHandler extends AbstractServerHttpHandler {
         tagFilter);
 
     final List<Long> timestamps = aggResult.getBucketTimestamps();
+
+    // The same ceiling the raw branch enforces (issue #5719). This branch reads no 'limit' at all, so the
+    // ceiling is the only bound there is: a small 'bucketInterval' over a wide range produces one response row
+    // per bucket, which is the same unbounded response the raw branch was refused for. The engine's own
+    // MAX_FLAT_BUCKETS only chooses between a flat array and a map, it is not a response-size bound.
+    final int maxResultRows = getMaxResultRows();
+    if (maxResultRows > 0 && timestamps.size() > maxResultRows)
+      throw resultSetTooLarge(maxResultRows);
+
     final JSONArray buckets = new JSONArray();
 
     for (final long ts : timestamps) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -460,6 +460,8 @@ public class CoreApiSpec implements OpenApiContributor {
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
     responses.addApiResponse("404", SpecBuilders.errorResponse("Database not found"));
+    responses.addApiResponse("413", SpecBuilders.errorResponse(
+        "The result exceeds 'arcadedb.server.httpQueryMaxResultRows': narrow or page the query"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));
     return responses;
   }
@@ -470,6 +472,8 @@ public class CoreApiSpec implements OpenApiContributor {
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
     responses.addApiResponse("404", SpecBuilders.errorResponse("Database not found"));
+    responses.addApiResponse("413", SpecBuilders.errorResponse(
+        "The result exceeds 'arcadedb.server.httpQueryMaxResultRows': narrow or page the command"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));
     return responses;
   }
@@ -506,7 +510,9 @@ public class CoreApiSpec implements OpenApiContributor {
         honored as written and only a query stating none is capped by the server default \
         ('arcadedb.server.httpQueryDefaultLimit'). Use -1 for no cap. The response always reports the cap \
         that was applied ('limit'), how many rows it carries ('returned') and whether rows were left \
-        behind ('truncated').""").example(100));
+        behind ('truncated'). No value here can widen a single response past the server's hard ceiling \
+        ('arcadedb.server.httpQueryMaxResultRows'): a result that would exceed it is refused with 413 \
+        instead of being truncated.""").example(100));
     schema.setRequired(List.of("command"));
     return schema;
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/TimeSeriesApiSpec.java
@@ -113,6 +113,12 @@ public class TimeSeriesApiSpec implements OpenApiContributor {
 
     post.setResponses(SpecBuilders.standardResponses("200", success,
         "400", "401", "403", "404", "500"));
+    // Added explicitly rather than through standardResponses, whose 413 text describes an oversized REQUEST
+    // body: here it is the response that would be too large (issue #5719). Both shapes can raise it - the raw
+    // one on its rows, the aggregated one on its buckets.
+    post.getResponses().addApiResponse("413", SpecBuilders.errorResponse(
+        "The rows or buckets exceed 'arcadedb.server.httpQueryMaxResultRows': narrow the range, "
+            + "widen 'bucketInterval', or page the query"));
 
     final PathItem pathItem = new PathItem();
     pathItem.setPost(post);

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
@@ -355,6 +355,29 @@ class HttpQueryMaxResultRowsIT extends BaseGraphServerTest {
   }
 
   @Test
+  void theLargestStatableLimitIsClampedBeforeTheProbeCanOverflow() throws Exception {
+    // The two guards against Integer.MAX_VALUE meet here. With the ceiling on, the clamp runs first, so the
+    // LIMIT pushed down is the ceiling + 1 and truncationProbeLimit's saturation is never even reached.
+    final JSONObject maxLimit = new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("limit", Integer.MAX_VALUE);
+
+    assertThat(send("query", maxLimit).statusCode()).isEqualTo(413);
+
+    // With the ceiling off, the clamp is a no-op and the saturation guard is what has to hold: 'limit
+    // 2147483648' would be pushed down otherwise, and the request would not come back with every row.
+    getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, -1);
+    try {
+      final JSONObject served = query(maxLimit);
+      assertThat(served.getJSONArray("result").length()).isEqualTo(TOTAL_ROWS);
+      assertThat(served.getBoolean("truncated")).isFalse();
+    } finally {
+      getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, CEILING);
+    }
+  }
+
+  @Test
   void theCeilingCanBeTurnedOff() throws Exception {
     // -1 restores the pre-#5719 behaviour for a deployment that needs an unbounded escape hatch.
     getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, -1);

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
@@ -22,6 +22,7 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -248,6 +249,45 @@ class HttpQueryMaxResultRowsIT extends BaseGraphServerTest {
         .put("limit", -1));
     assertThat(served.statusCode()).isEqualTo(200);
     assertThat(new JSONObject(served.body()).getInt("count")).isEqualTo(CEILING - 5);
+  }
+
+  @Test
+  void theTimeSeriesAggregationBranchIsBoundedToo() throws Exception {
+    // The aggregated shape of the same endpoint reads no 'limit' at all, so the ceiling is the only bound it
+    // can ever have: a small 'bucketInterval' over a wide range produces one response row per bucket, which is
+    // the very shape the raw branch is refused for.
+    assertThat(send("command", new JSONObject()
+        .put("language", "sql")
+        .put("command", "CREATE TIMESERIES TYPE aggceilingts TIMESTAMP ts TAGS (location STRING) FIELDS (value DOUBLE)"))
+        .statusCode()).isEqualTo(200);
+
+    final StringBuilder lines = new StringBuilder();
+    for (int i = 1; i <= TOTAL_ROWS; i++)
+      lines.append("aggceilingts,location=us value=").append(i).append(".0 ").append(i * 1000L).append('\n');
+    assertThat(postLineProtocol(lines.toString())).isEqualTo(204);
+
+    // One bucket per sample: TOTAL_ROWS buckets, above the ceiling.
+    final HttpResponse<String> refused = postTsQuery(aggregationRequest("aggceilingts", 1_000L));
+    assertThat(refused.statusCode()).isEqualTo(413);
+    assertThat(refused.body()).contains(SETTING);
+
+    // A bucket interval wide enough to fit under the ceiling is served as before.
+    final HttpResponse<String> served = postTsQuery(aggregationRequest("aggceilingts", TOTAL_ROWS * 1_000L));
+    assertThat(served.statusCode()).isEqualTo(200);
+    assertThat(new JSONObject(served.body()).getJSONArray("buckets").length()).isLessThanOrEqualTo(CEILING);
+  }
+
+  private static JSONObject aggregationRequest(final String type, final long bucketInterval) {
+    return new JSONObject()
+        .put("type", type)
+        .put("from", 0L)
+        .put("to", (TOTAL_ROWS + 1) * 1_000L)
+        .put("aggregation", new JSONObject()
+            .put("bucketInterval", bucketInterval)
+            .put("requests", new JSONArray().put(new JSONObject()
+                .put("field", "value")
+                .put("type", "AVG")
+                .put("alias", "avg_value"))));
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5719: {@code arcadedb.server.httpQueryDefaultLimit} protects only the callers that state no limit of
+ * their own, so {@code SELECT FROM HugeType LIMIT 100000000} - or a request carrying {@code "limit": -1} - made
+ * the server serialize an arbitrarily large result into a single JSON response.
+ * <p>
+ * {@code arcadedb.server.httpQueryMaxResultRows} is the ceiling no caller can widen. It refuses with HTTP 413
+ * instead of truncating, because a response cut short without saying so is the defect issue #5711 fixed, and
+ * re-introducing it for the callers that DO state a limit would only move it.
+ * <p>
+ * The ceiling is lowered to {@link #CEILING} rows here, and the default cap to {@link #DEFAULT_LIMIT}, so the
+ * interaction between the two can be checked without materializing a million records.
+ */
+class HttpQueryMaxResultRowsIT extends BaseGraphServerTest {
+  private static final int    CEILING       = 20;
+  private static final int    DEFAULT_LIMIT = 10;
+  private static final int    TOTAL_ROWS    = 30;
+  private static final String TYPE_NAME     = "CeilingRow";
+  private static final String SETTING       = GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS.getKey();
+
+  private final HttpClient client = HttpClient.newHttpClient();
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    config.setValue(GlobalConfiguration.SERVER_HTTP_QUERY_DEFAULT_LIMIT, DEFAULT_LIMIT);
+    config.setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, CEILING);
+  }
+
+  @BeforeEach
+  void createRows() {
+    final Database database = getServerDatabase(0, getDatabaseName());
+    // A vertex type so the same rows are reachable from SQL and from Cypher.
+    database.getSchema().createVertexType(TYPE_NAME);
+    database.transaction(() -> {
+      for (int i = 0; i < TOTAL_ROWS; i++)
+        database.newVertex(TYPE_NAME).set("i", i).save();
+    });
+  }
+
+  @Test
+  void aQueryLimitAboveTheCeilingCannotWidenTheResponse() throws Exception {
+    // The exact shape the issue describes: a LIMIT far above the ceiling written into the query text. Before
+    // the ceiling existed it was honored as written, because #5716 made a stated LIMIT win over the default cap.
+    final HttpResponse<String> response = send("query", new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " LIMIT 100000000"));
+
+    assertThat(response.statusCode()).isEqualTo(413);
+    assertThat(response.body()).contains(SETTING);
+    assertThat(response.body()).contains(String.valueOf(CEILING));
+  }
+
+  @Test
+  void anUnlimitedRequestLimitIsRefusedInsteadOfServed() throws Exception {
+    final HttpResponse<String> response = send("query", new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("limit", -1));
+
+    assertThat(response.statusCode()).isEqualTo(413);
+    assertThat(response.body()).contains(SETTING);
+  }
+
+  @Test
+  void aResultThatFitsUnderTheCeilingIsStillServedUnlimited() throws Exception {
+    // The ceiling refuses a response, it does not lower a cap: a caller asking for everything still gets
+    // everything as long as everything fits, and the response keeps reporting the cap the caller stated.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " WHERE i < " + (CEILING - 5))
+        .put("limit", -1));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CEILING - 5);
+    assertThat(response.getInt("returned")).isEqualTo(CEILING - 5);
+    assertThat(response.getInt("limit")).isEqualTo(-1);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void aResultOfExactlyTheCeilingIsNotRefused() throws Exception {
+    // The boundary: the ceiling is a maximum, not a strict upper bound. Nothing was left behind, so the
+    // response is complete and must be delivered.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " WHERE i < " + CEILING)
+        .put("limit", -1));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CEILING);
+    assertThat(response.getInt("returned")).isEqualTo(CEILING);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void aRequestLimitAtTheCeilingIsHonoredAndTruncatesAsUsual() throws Exception {
+    // A cap the caller stated and the ceiling allows is the caller's own bound: reaching it is an ordinary
+    // truncation reported with 'truncated', not a refusal.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME)
+        .put("limit", CEILING));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CEILING);
+    assertThat(response.getInt("limit")).isEqualTo(CEILING);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void theDefaultCapStillTruncatesQuietlyBelowTheCeiling() throws Exception {
+    // Nothing about #5711/#5716 changed for a caller that states no limit: the default cap truncates and says so.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME));
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(DEFAULT_LIMIT);
+    assertThat(response.getInt("limit")).isEqualTo(DEFAULT_LIMIT);
+    assertThat(response.getBoolean("truncated")).isTrue();
+  }
+
+  @Test
+  void theGetEndpointEnforcesTheCeilingToo() throws Exception {
+    // Both surfaces answer the same way: the GET endpoint runs the query as written, with no LIMIT pushed down,
+    // so it exercises the serializer bound rather than the pushdown one.
+    assertThat(sendGet("SELECT i FROM " + TYPE_NAME, "-1").statusCode()).isEqualTo(413);
+    assertThat(sendGet("SELECT i FROM " + TYPE_NAME + " LIMIT 100000000", null).statusCode()).isEqualTo(413);
+  }
+
+  @Test
+  void theGetEndpointStillServesWhatFits() throws Exception {
+    final JSONObject response = get("SELECT i FROM " + TYPE_NAME + " WHERE i < " + (CEILING - 5), "-1");
+
+    assertThat(response.getJSONArray("result").length()).isEqualTo(CEILING - 5);
+    assertThat(response.getInt("limit")).isEqualTo(-1);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
+  void aCypherQueryIsBoundedByTheCeiling() throws Exception {
+    // Cypher exposes no execution plan on the query path and gets no pushed-down LIMIT either, so the ceiling
+    // is enforced purely while serializing - the path every non-SQL language takes.
+    final HttpResponse<String> response = send("query", new JSONObject()
+        .put("language", "opencypher")
+        .put("command", "MATCH (n:" + TYPE_NAME + ") RETURN n.i AS i")
+        .put("limit", -1));
+
+    assertThat(response.statusCode()).isEqualTo(413);
+    assertThat(response.body()).contains(SETTING);
+  }
+
+  @Test
+  void theGraphSerializerIsBoundedByTheCeiling() throws Exception {
+    final HttpResponse<String> response = send("query", new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT FROM " + TYPE_NAME)
+        .put("serializer", "graph")
+        .put("limit", -1));
+
+    assertThat(response.statusCode()).isEqualTo(413);
+  }
+
+  @Test
+  void aRefusedCommandIsRolledBackInsteadOfCommittedBehindTheError() throws Exception {
+    // A write whose result nobody will ever see must not be left committed: the ceiling refuses by raising out
+    // of the handler, which rolls the auto-commit transaction back.
+    final HttpResponse<String> response = send("command", new JSONObject()
+        .put("language", "sql")
+        .put("command", "UPDATE " + TYPE_NAME + " SET touched = true RETURN AFTER")
+        .put("limit", -1));
+
+    assertThat(response.statusCode()).isEqualTo(413);
+    assertThat(countRows("SELECT FROM " + TYPE_NAME + " WHERE touched = true")).isZero();
+  }
+
+  @Test
+  void theProfiledPathIsBoundedTooInsteadOfMaterializingEverything() throws Exception {
+    // 'profileExecution: detailed' drains the whole result set into memory before serializing it, and a command
+    // carrying its own LIMIT gets no pushed-down bound: without a cap on that drain the ceiling would refuse the
+    // response only after the rows it exists to keep out of the heap were already there.
+    final HttpResponse<String> response = send("query", new JSONObject()
+        .put("language", "sql")
+        .put("command", "SELECT i FROM " + TYPE_NAME + " LIMIT 100000000")
+        .put("profileExecution", "detailed"));
+
+    assertThat(response.statusCode()).isEqualTo(413);
+  }
+
+  @Test
+  void theTimeSeriesQueryEndpointEnforcesTheCeilingToo() throws Exception {
+    // The endpoint the issue calls out separately: it materializes the whole range before any limit is known,
+    // so the ceiling cannot keep the fetch out of the heap - but it can, and must, refuse to build the JSON
+    // copy of it rather than serve an unbounded response to a caller stating 'limit: -1'.
+    assertThat(send("command", new JSONObject()
+        .put("language", "sql")
+        .put("command", "CREATE TIMESERIES TYPE ceilingts TIMESTAMP ts TAGS (location STRING) FIELDS (value DOUBLE)"))
+        .statusCode()).isEqualTo(200);
+
+    final StringBuilder lines = new StringBuilder();
+    for (int i = 1; i <= TOTAL_ROWS; i++)
+      lines.append("ceilingts,location=us value=").append(i).append(".0 ").append(i * 1000L).append('\n');
+    assertThat(postLineProtocol(lines.toString())).isEqualTo(204);
+
+    final HttpResponse<String> refused = postTsQuery(new JSONObject().put("type", "ceilingts").put("limit", -1));
+    assertThat(refused.statusCode()).isEqualTo(413);
+    assertThat(refused.body()).contains(SETTING);
+
+    // What fits is still served, unlimited cap and all.
+    final HttpResponse<String> served = postTsQuery(new JSONObject()
+        .put("type", "ceilingts")
+        .put("to", (CEILING - 5) * 1000L)
+        .put("limit", -1));
+    assertThat(served.statusCode()).isEqualTo(200);
+    assertThat(new JSONObject(served.body()).getInt("count")).isEqualTo(CEILING - 5);
+  }
+
+  @Test
+  void theCeilingCanBeTurnedOff() throws Exception {
+    // -1 restores the pre-#5719 behaviour for a deployment that needs an unbounded escape hatch.
+    getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, -1);
+    try {
+      final JSONObject response = query(new JSONObject()
+          .put("language", "sql")
+          .put("command", "SELECT i FROM " + TYPE_NAME)
+          .put("limit", -1));
+
+      assertThat(response.getJSONArray("result").length()).isEqualTo(TOTAL_ROWS);
+      assertThat(response.getInt("limit")).isEqualTo(-1);
+      assertThat(response.getBoolean("truncated")).isFalse();
+    } finally {
+      getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, CEILING);
+    }
+  }
+
+  /**
+   * Address of the server this test started, read back from it rather than hardcoded: when 2480 is already
+   * taken the server binds the next free port, and a hardcoded URL would then quietly send every request of
+   * this class to whatever else is listening there.
+   */
+  private String baseUrl() {
+    return "http://127.0.0.1:" + getServer(0).getHttpServer().getPort();
+  }
+
+  private int countRows(final String query) {
+    int rows = 0;
+    try (final ResultSet resultSet = getServerDatabase(0, getDatabaseName()).query("sql", query)) {
+      while (resultSet.hasNext()) {
+        resultSet.next();
+        rows++;
+      }
+    }
+    return rows;
+  }
+
+  private JSONObject query(final JSONObject payload) throws Exception {
+    final HttpResponse<String> response = send("query", payload);
+    assertThat(response.statusCode()).isEqualTo(200);
+    return new JSONObject(response.body());
+  }
+
+  private HttpResponse<String> send(final String endpoint, final JSONObject payload) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI(baseUrl() + "/api/v1/" + endpoint + "/" + getDatabaseName()))
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .setHeader("Content-Type", "application/json")
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    return client.send(request, BodyHandlers.ofString());
+  }
+
+  private int postLineProtocol(final String body) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI(baseUrl() + "/api/v1/ts/" + getDatabaseName() + "/write?precision=ms"))
+        .POST(HttpRequest.BodyPublishers.ofString(body))
+        .setHeader("Content-Type", "text/plain")
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    return client.send(request, BodyHandlers.ofString()).statusCode();
+  }
+
+  private HttpResponse<String> postTsQuery(final JSONObject payload) throws Exception {
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI(baseUrl() + "/api/v1/ts/" + getDatabaseName() + "/query"))
+        .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+        .setHeader("Content-Type", "application/json")
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    return client.send(request, BodyHandlers.ofString());
+  }
+
+  private JSONObject get(final String command, final String limit) throws Exception {
+    final HttpResponse<String> response = sendGet(command, limit);
+    assertThat(response.statusCode()).isEqualTo(200);
+    return new JSONObject(response.body());
+  }
+
+  private HttpResponse<String> sendGet(final String command, final String limit) throws Exception {
+    // The command travels as a path segment: URLEncoder emits '+' for a space, which is only a space in a
+    // query string.
+    final String url = baseUrl() + "/api/v1/query/" + getDatabaseName() + "/sql/"
+        + URLEncoder.encode(command, StandardCharsets.UTF_8).replace("+", "%20")
+        + (limit == null ? "" : "?limit=" + limit);
+
+    final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI(url))
+        .GET()
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+    return client.send(request, BodyHandlers.ofString());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
@@ -251,6 +251,39 @@ class HttpQueryMaxResultRowsIT extends BaseGraphServerTest {
   }
 
   @Test
+  void aCeilingBelowTheDefaultCapTruncatesInsteadOfRefusing() throws Exception {
+    // A deployment whose two settings disagree must not turn ordinary default-cap traffic into 413s: the
+    // refusal is for a caller that asked to go past the ceiling, and this caller asked for nothing at all.
+    // The default is lowered to the ceiling instead, and the truncation is reported as it always was.
+    final int lowCeiling = DEFAULT_LIMIT / 2;
+    getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, lowCeiling);
+    try {
+      final JSONObject response = query(new JSONObject()
+          .put("language", "sql")
+          .put("command", "SELECT i FROM " + TYPE_NAME));
+
+      assertThat(response.getJSONArray("result").length()).isEqualTo(lowCeiling);
+      assertThat(response.getInt("returned")).isEqualTo(lowCeiling);
+      assertThat(response.getInt("limit")).isEqualTo(lowCeiling);
+      assertThat(response.getBoolean("truncated")).isTrue();
+
+      // The GET endpoint, which pushes no LIMIT down, must agree.
+      final JSONObject viaGet = get("SELECT i FROM " + TYPE_NAME, null);
+      assertThat(viaGet.getJSONArray("result").length()).isEqualTo(lowCeiling);
+      assertThat(viaGet.getBoolean("truncated")).isTrue();
+
+      // A caller that DOES state a cap above the ceiling is still refused, so the clamp above has not turned
+      // the ceiling off for everybody.
+      assertThat(send("query", new JSONObject()
+          .put("language", "sql")
+          .put("command", "SELECT i FROM " + TYPE_NAME)
+          .put("limit", -1)).statusCode()).isEqualTo(413);
+    } finally {
+      getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, CEILING);
+    }
+  }
+
+  @Test
   void theCeilingCanBeTurnedOff() throws Exception {
     // -1 restores the pre-#5719 behaviour for a deployment that needs an unbounded escape hatch.
     getServer(0).getConfiguration().setValue(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS, -1);

--- a/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/HttpQueryMaxResultRowsIT.java
@@ -198,6 +198,37 @@ class HttpQueryMaxResultRowsIT extends BaseGraphServerTest {
   }
 
   @Test
+  void aCollectionInsideASingleRowCannotExpandPastTheCeiling() throws Exception {
+    // The graph serializers count elements, not rows, and one row can refer to arbitrarily many of them
+    // through a single property: `collect()` returns exactly ONE row holding the whole set. A cap tested only
+    // between rows and between properties expanded that row whole, and - being the only row - left nothing in
+    // the result set for the truncation probe to notice, so the response came back 200 with as many elements
+    // as the query found.
+    final HttpResponse<String> response = send("query", new JSONObject()
+        .put("language", "opencypher")
+        .put("command", "MATCH (n:" + TYPE_NAME + ") RETURN collect(n) AS vs")
+        .put("serializer", "graph")
+        .put("limit", -1));
+
+    assertThat(response.statusCode()).isEqualTo(413);
+    assertThat(response.body()).contains(SETTING);
+  }
+
+  @Test
+  void aCollectionThatFitsIsStillExpandedWhole() throws Exception {
+    // The guard above must not cut an expansion that fits: the same query over fewer rows is complete, and a
+    // complete response is never flagged.
+    final JSONObject response = query(new JSONObject()
+        .put("language", "opencypher")
+        .put("command", "MATCH (n:" + TYPE_NAME + ") WHERE n.i < " + (CEILING - 5) + " RETURN collect(n) AS vs")
+        .put("serializer", "graph")
+        .put("limit", -1));
+
+    assertThat(response.getJSONObject("result").getJSONArray("vertices").length()).isEqualTo(CEILING - 5);
+    assertThat(response.getBoolean("truncated")).isFalse();
+  }
+
+  @Test
   void aRefusedCommandIsRolledBackInsteadOfCommittedBehindTheError() throws Exception {
     // A write whose result nobody will ever see must not be left committed: the ceiling refuses by raising out
     // of the handler, which rolls the auto-commit transaction back.

--- a/server/src/test/java/com/arcadedb/server/http/handler/MaxResultRowsClampTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/MaxResultRowsClampTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AbstractServerHttpHandler#applyMaxResultRows(int, int)}, the clamp that makes
+ * {@code arcadedb.server.httpQueryMaxResultRows} a ceiling no caller can widen (issue #5719).
+ * <p>
+ * The handlers do not only use the returned value: they compare it with the value they passed in, and answer
+ * 413 instead of an ordinary truncation exactly when the two differ. Every case below therefore pins both the
+ * clamped value and whether it changed.
+ */
+class MaxResultRowsClampTest {
+
+  private static final int CEILING = 1_000;
+
+  @Test
+  void aCapBelowTheCeilingIsLeftAlone() {
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(10, CEILING)).isEqualTo(10);
+  }
+
+  @Test
+  void aCapExactlyAtTheCeilingIsLeftAlone() {
+    // The boundary decides between "the caller's own cap truncates" and "the server refuses": a cap equal to
+    // the ceiling is still the caller's, so it must come back unchanged.
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(CEILING, CEILING)).isEqualTo(CEILING);
+  }
+
+  @Test
+  void aCapAboveTheCeilingIsLoweredToIt() {
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(CEILING + 1, CEILING)).isEqualTo(CEILING);
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(100_000_000, CEILING)).isEqualTo(CEILING);
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(Integer.MAX_VALUE, CEILING)).isEqualTo(CEILING);
+  }
+
+  @Test
+  void anUnlimitedCapIsBoundedByTheCeiling() {
+    // The whole point of the issue: -1 and 0 both mean "no cap" on the way in, and both must be bounded.
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(-1, CEILING)).isEqualTo(CEILING);
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(0, CEILING)).isEqualTo(CEILING);
+    assertThat(AbstractServerHttpHandler.applyMaxResultRows(Integer.MIN_VALUE, CEILING)).isEqualTo(CEILING);
+  }
+
+  @Test
+  void aDisabledCeilingChangesNothing() {
+    // -1 and 0 disable the ceiling, and a disabled ceiling must return every cap unchanged - including the
+    // unlimited ones, which is what keeps the pre-#5719 escape hatch working.
+    for (final int disabled : new int[] { -1, 0 }) {
+      assertThat(AbstractServerHttpHandler.applyMaxResultRows(10, disabled)).isEqualTo(10);
+      assertThat(AbstractServerHttpHandler.applyMaxResultRows(-1, disabled)).isEqualTo(-1);
+      assertThat(AbstractServerHttpHandler.applyMaxResultRows(0, disabled)).isEqualTo(0);
+      assertThat(AbstractServerHttpHandler.applyMaxResultRows(Integer.MAX_VALUE, disabled)).isEqualTo(Integer.MAX_VALUE);
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/ResultSetTooLargeErrorBodyTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/ResultSetTooLargeErrorBodyTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.ResultSetTooLargeException;
+import com.arcadedb.server.security.ServerSecurityUser;
+import io.undertow.server.HttpServerExchange;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5719: the 413 refusal has to stay actionable in production mode, where {@code detail} - the field
+ * carrying the full sentence - is concealed to avoid leaking engine internals (issue #5037). A caller that
+ * cannot see WHICH setting refused it, or WHAT number to stay under, has been told nothing it can act on, so
+ * the setting name travels in the {@code error} label and the ceiling in {@code exceptionArgs}, both of which
+ * are emitted in every mode.
+ */
+class ResultSetTooLargeErrorBodyTest {
+  private static final int MAX_ROWS = 1_000;
+
+  private final TestHandler handler = new TestHandler(null);
+
+  @Test
+  void theRefusalNamesTheSettingAndTheCeilingInProductionModeToo() {
+    final ResultSetTooLargeException refusal = AbstractServerHttpHandler.resultSetTooLarge(MAX_ROWS);
+
+    final String body = handler.buildErrorBody(false,
+        "Result set too large for a single response (" + GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS.getKey()
+            + ")", refusal, String.valueOf(refusal.getMaxResultRows()), null);
+    final JSONObject json = new JSONObject(body);
+
+    assertThat(json.getString("error")).contains(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS.getKey());
+    assertThat(json.getString("exception")).isEqualTo(ResultSetTooLargeException.class.getName());
+    assertThat(json.getString("exceptionArgs")).isEqualTo(String.valueOf(MAX_ROWS));
+    // The free-form chain is concealed in production, as it is for every other error.
+    assertThat(json.has("detail")).isFalse();
+  }
+
+  @Test
+  void theRefusalCarriesTheFullAdviceInDevelopmentMode() {
+    final ResultSetTooLargeException refusal = AbstractServerHttpHandler.resultSetTooLarge(MAX_ROWS);
+
+    final String body = handler.buildErrorBody(true, "Result set too large for a single response", refusal,
+        String.valueOf(refusal.getMaxResultRows()), null);
+    final JSONObject json = new JSONObject(body);
+
+    final String detail = json.getString("detail");
+    assertThat(detail).contains(String.valueOf(MAX_ROWS));
+    assertThat(detail).contains(GlobalConfiguration.SERVER_HTTP_QUERY_MAX_RESULT_ROWS.getKey());
+  }
+
+  @Test
+  void theCeilingIsCarriedOnTheExceptionItself() {
+    // The number reaches the wire from the exception, not from a second read of the configuration, so the
+    // value the client is told to stay under is the one that actually refused it.
+    assertThat(AbstractServerHttpHandler.resultSetTooLarge(MAX_ROWS).getMaxResultRows()).isEqualTo(MAX_ROWS);
+  }
+
+  private static class TestHandler extends AbstractServerHttpHandler {
+    TestHandler(final HttpServer httpServer) {
+      super(httpServer);
+    }
+
+    @Override
+    protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+        final JSONObject payload) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Closes #5719

## The decision this needed

The issue asked for one of three options, and this PR takes **option 2: a finite default**, `arcadedb.server.httpQueryMaxResultRows = 1000000`, with `-1`/`0` to disable.

- **Option 1 (default `-1`, disabled)** was rejected because a ceiling an operator has to discover before it protects anything protects nobody, and it would leave HTTP as the only surface in the server without a finite resource ceiling: `httpBodyContentMaxSize` (100MB), `grpcQueryMaxResultRows` (100,000) and `grpcStreamMaxMaterializedRows` all default to finite values today.
- **Option 3 (finite only in `production` mode)** was rejected because `arcadedb.server.mode` currently governs only log verbosity and how much of an error body is exposed. Nothing on a data path reads it. Making a request succeed in `development` and fail in `production` would mean dev and prod disagree about whether a query is answerable, which is a worse failure mode than a documented breaking change.
- 1,000,000 sits 50x above the default page cap (`httpQueryDefaultLimit` = 20,000), so a realistic paging or export client never meets it. The breaking change is written up under its own heading in `docs/release-26.9.1.md`.

## What changed

`arcadedb.server.httpQueryDefaultLimit` caps only the callers that state no limit of their own - that is the invariant #5716 established, and it is the right one: a response silently cut below what the caller asked for is the defect #5711 fixed. The consequence, which this issue was filed for, is that `SELECT FROM HugeType LIMIT 100000000` or `"limit": -1` had no bound at all.

The new setting is the HTTP twin of `arcadedb.server.grpcQueryMaxResultRows` and behaves identically:

- a stated cap (request `limit`, or the query's own `LIMIT` read back from the execution plan, or the configured default) **at or below** the ceiling is the caller's own bound, honored silently, with `truncated` reported exactly as before;
- a larger one, or an explicitly unlimited `-1`/`0`, cannot widen the response past the ceiling;
- a result that **would** exceed the ceiling **fails with HTTP 413 naming the setting** rather than being truncated. Truncating instead would re-introduce, for the callers #5716 protects, the silent short answer #5711 removed.

The ceiling therefore never appears in a successful response: a 200 either carries everything within the stated cap or was cut by the stated cap, so `limit`/`returned`/`truncated` keep reporting exactly what they reported before and no existing client contract moves.

Endpoints covered: `POST /api/v1/query`, `POST /api/v1/command`, `GET /api/v1/query`, and `POST /api/v1/ts/{db}/query`.

### Two paths bounded at the fetch, not just at serialization

- `PostCommandHandler` pushes a `LIMIT` down into a SELECT/MATCH that states none. An unlimited request `limit` used to push nothing down at all, so the engine streamed the whole result to the handler; the pushdown cap is now clamped by the ceiling first.
- `profileExecution: detailed` drains the entire result set into memory (`materializeResultSet`) before anything is serialized, and a command carrying its own huge `LIMIT` is left as written and so gets no pushed-down bound. That drain now stops one row past the cap the response will honor - one row above, like the pushdown, so truncation stays detectable.

### Rollback, not commit-behind-an-error

The refusal is raised as a `ResultSetTooLargeException` out of the handler rather than returned as a 413 `ExecutionResponse`. That is deliberate: for an auto-committed write such as `UPDATE ... RETURN AFTER`, returning a status would commit a write whose result the caller never sees, and a client retry would then double-apply it. Raising rolls the auto-commit transaction back, so the retry starts from committed state. `aRefusedCommandIsRolledBackInsteadOfCommittedBehindTheError` pins this.

### The error body in production mode

`detail` is concealed when `arcadedb.server.mode=production`, so the setting name goes in the top-level `error` label and the ceiling value in `exceptionArgs` - both of which are emitted in every mode. A caller that cannot see which knob refused it, or what number to stay under, has been told nothing actionable.

## Known limitation (called out in the issue, and not closed here)

The TimeSeries query endpoint enforces the ceiling over the response it builds, but `TimeSeriesEngine.query()` materializes the whole requested range into a `List<Object[]>` before any limit is known. The check therefore keeps the second and larger copy (the JSON) out of the heap but cannot keep the first one out. Bounding that fetch is an engine-level change and is left as follow-up; it is documented in the release note and in a comment at the check.

Also not changed: `RemoteHttpComponent.manageException` has no typed arm for the new exception, so the Java remote driver surfaces a 413 as a `RemoteException` naming `com.arcadedb.server.http.ResultSetTooLargeException` (it is not retried, which is the important part). A typed arm can be added if a driver-side `catch` turns out to be wanted.

## Test plan

- [ ] `mvn -pl server -am -DskipITs=false -Dit.test=HttpQueryMaxResultRowsIT verify` - 14 new integration tests: the query `LIMIT` above the ceiling, `limit: -1`, the GET endpoint, the Cypher path (no plan limit, no pushdown), the `graph` serializer, the `detailed` profile path, the TimeSeries endpoint, the write rollback, the exactly-at-the-ceiling boundary, and the disabled ceiling.
- [ ] `mvn -pl server -am -Dtest=MaxResultRowsClampTest test` - 5 unit tests over the clamp, including both disabled values and both unlimited values.
- [ ] **Control run**: with the ceiling forced to `-1` in the fixture, exactly the 8 refusal tests fail and the 6 unchanged-behavior tests still pass, so the new tests are proven to discriminate.
- [ ] `mvn -pl server -am -DskipITs=false -Dit.test=HttpQueryTruncationIT,TimeSeriesQueryHandlerIT,OpenApiSpecGenerationIT,OpenApiDocsEndpointIT,Issue5037ProductionErrorBodyIT verify` - the #5711/#5716 regression suites are untouched and green.
- [ ] `mvn -pl server -am -DexcludedGroups=benchmark,slow,vector test` - engine (12,086), network and server (788) unit lanes green. One network failure appeared in the parallel full-reactor run, `RemoteHttpComponentTest.httpCommandMalformedJsonResponseThrowsLabelledRemoteException` (its one-shot local HTTP server answered 404, i.e. the port was taken); it passes on its own, and only a Javadoc comment in that file changed.
