### PR TITLE
fix(#6196): a placeholder's content record says whose it is, even when it had to spill

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2234,3 +2234,37 @@ purpose ("more seeds than nodes" reads as "as many as exist" and is clamped to t
 nameless `NegativeArraySizeException`.
 
 [#6216](https://github.com/ArcadeData/arcadedb/issues/6216)
+## A placeholder whose content had to spill into chunks is no longer returned twice by a scan (#6196)
+
+`SELECT FROM Doc` could return the same record twice, under two different RIDs, and `count(@rid)` counted it
+twice with it. One record shape reached it: a **placeholder** whose CONTENT record was too large for any page to
+hold whole.
+
+A record that outgrows its own page normally becomes a chunk chain in place. When its slot is too small even for
+the 14 bytes a chunk header needs - since #6149 the only remaining case, and it takes a page with a free tail of
+exactly zero - the slot becomes a 9-byte POINTER instead and the content moves to a record of its own on another
+page. Such a content record is not a document; it is reachable only through the pointer, and every reader that
+walks a page knows to skip it because its slot carries its size **negated**. That is the entire mechanism, and it
+is the one thing a content record bigger than a page cannot have: it has no size in its slot at all, because it is
+a chain. `writeMultiPageRecord` stamped the plain `FIRST_CHUNK` marker of an ordinary multi-page record on its
+head, and at that moment the information that the slot belonged to somebody else was gone - there was nowhere
+else it was written down.
+
+So the bytes were handed out twice: once through the pointer, under the RID the application knows, and once as a
+document in their own right under the head chunk's RID. `check()` had the mirror of the same confusion, counting
+the record under `totalMultiPageRecords` and never under `totalSurrogateRecords`.
+
+The head chunk of a content record now carries a marker of its own, `FIRST_CHUNK_PLACEHOLDER_CONTENT` (-4), in the
+one value the marker namespace still had free between `NEXT_CHUNK` (-3) and the negated sizes (< -5). It costs
+nothing in the stored format - one zigzag byte, exactly like the markers either side of it - and it restores the
+rule the negated size marker always expressed: a scan, a `count()` and an existence check hand out records, and
+this is not one, while everything that walks or rewrites the CHAIN treats the two heads identically.
+
+**Databases written before this** still hold the ambiguous shape, and no reader can tell it from an ordinary
+multi-page record - only the pointer that leads to it can. Rather than have every reader tolerate the ambiguity
+for ever, `CHECK DATABASE` now follows each placeholder pointer (one page read per placeholder, on a shape that is
+rare to begin with), reports a content record still stored the old way as an error naming its RID, and
+`CHECK DATABASE FIX` repairs it by rewriting that one marker. It is a repair and never a deletion: not a byte of
+the record, its chunk header or its chain is touched.
+
+[#6196](https://github.com/ArcadeData/arcadedb/issues/6196)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2267,4 +2267,12 @@ rare to begin with), reports a content record still stored the old way as an err
 `CHECK DATABASE FIX` repairs it by rewriting that one marker. It is a repair and never a deletion: not a byte of
 the record, its chunk header or its chain is touched.
 
+**Run that FIX before writing through a full scan of such a database.** Until it has run, the content record is
+still handed out under a RID of its own, and that RID looks like any other: an application that scans a type and
+updates or deletes what comes back can reach the content record directly, where nothing can tell it apart from a
+record and the write lands on content the placeholder pointer still references. This is the behaviour every
+release before this one already had - the marker is what closes it, and `CHECK DATABASE FIX` is what applies the
+marker to data written earlier. A read-only scan of an unrepaired database merely returns the record twice; a
+read-modify-write over one is worth the FIX first.
+
 [#6196](https://github.com/ArcadeData/arcadedb/issues/6196)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2262,8 +2262,7 @@ this is not one, while everything that walks or rewrites the CHAIN treats the tw
 
 **Databases written before this** still hold the ambiguous shape, and no reader can tell it from an ordinary
 multi-page record - only the pointer that leads to it can. Rather than have every reader tolerate the ambiguity
-for ever, `CHECK DATABASE` now follows each placeholder pointer (one page read per placeholder, on a shape that is
-rare to begin with), reports a content record still stored the old way as an error naming its RID, and
+for ever, `CHECK DATABASE` now follows each placeholder pointer, reports a content record still stored the old way as an error naming its RID, and
 `CHECK DATABASE FIX` repairs it by rewriting that one marker. It is a repair and never a deletion: not a byte of
 the record, its chunk header or its chain is touched.
 
@@ -2274,5 +2273,11 @@ record and the write lands on content the placeholder pointer still references. 
 release before this one already had - the marker is what closes it, and `CHECK DATABASE FIX` is what applies the
 marker to data written earlier. A read-only scan of an unrepaired database merely returns the record twice; a
 read-modify-write over one is worth the FIX first.
+
+Following the pointers costs `CHECK DATABASE` one page fetch per placeholder POINTER - every one of them, not only
+the chunked case it is looking for, because the marker on the other end is the only thing that tells the two apart.
+A pre-#6149 bucket dense with placeholders therefore pays one extra fetch each, of pages the same pass reads
+anyway, on an operation that already reads every page of the bucket and walks the full chunk chain of every
+multi-page record.
 
 [#6196](https://github.com/ArcadeData/arcadedb/issues/6196)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2280,4 +2280,11 @@ A pre-#6149 bucket dense with placeholders therefore pays one extra fetch each, 
 anyway, on an operation that already reads every page of the bucket and walks the full chunk chain of every
 multi-page record.
 
+One reporting detail to expect on an unrepaired database: only the TOTALS `CHECK DATABASE` returns are
+reconciled, because a content record can sit on a page the walk has already left behind and reconciling as it
+went would make the answer depend on the order the allocator happened to place the pages in. The per-page
+tallies printed by a verbose run are not, so for such a record a page's own `multiPageRecords` count disagrees
+with the top-level `totalSurrogateRecords` it was moved to. That is deliberate: a physical-layout log describes
+the page as the walk found it. Both agree again once the FIX has run.
+
 [#6196](https://github.com/ArcadeData/arcadedb/issues/6196)

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -105,6 +105,15 @@ public class TransactionContext implements Transaction {
    * which its writer poisons.
    */
   public static final byte SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD = 4;
+  /**
+   * {@code SLOT_KIND_FIRST_CHUNK} for the CONTENT record of a placeholder that no page could host whole, whose head
+   * chunk carries {@code LocalBucket.FIRST_CHUNK_PLACEHOLDER_CONTENT} rather than {@code FIRST_CHUNK} (#6196).
+   * Everything the replay does is the same - the images are the chunk header plus its content, the footprint is fixed
+   * for the life of the record, the rest of the chain is poisoned by its writer - and only the marker it expects to
+   * still find on the committed page differs. That is exactly what a kind of its own is for: the same bytes behind a
+   * different marker are a different record, and a slot that changed from one to the other under us is a conflict.
+   */
+  public static final byte SLOT_KIND_FIRST_CHUNK_PLACEHOLDER_CONTENT = 5;
 
   private final DatabaseInternal                     database;
   private final Map<Integer, Integer>                newPageCounters       = new ConcurrentHashMap<>();

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -66,6 +66,7 @@ import static com.arcadedb.database.Binary.LONG_SERIALIZED_SIZE;
  * <li>-1 = placeholder pointer that points to another record in another page</li>
  * <li>-2 = first chunk of a multi page record</li>
  * <li>-3 = after first chunk of a multi page record</li>
+ * <li>-4 = first chunk of a placeholder content record that no page could host whole</li>
  * <li><-5 = placeholder content pointed from another record in another page</li>
  * </ul>
  * The record size is stored as a varint (variable integer size) + the length of the size itself.
@@ -88,6 +89,25 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   public static final    long                      RECORD_PLACEHOLDER_POINTER       = -1L;    // USE -1 AS SIZE TO STORE A PLACEHOLDER (THAT POINTS TO A RECORD ON ANOTHER PAGE)
   public static final    long                      FIRST_CHUNK                      = -2L;    // USE -2 TO MARK THE FIRST CHUNK OF A BIG RECORD. FOLLOWS THE CHUNK SIZE AND THE POINTER TO THE NEXT CHUNK
   public static final    long                      NEXT_CHUNK                       = -3L;    // USE -3 TO MARK THE SECOND AND FURTHER CHUNK THAT IS PART OF A BIG RECORD THAT DOES NOT FIT A PAGE. FOLLOWS THE CHUNK SIZE AND THE POINTER TO THE NEXT CHUNK OR 0 IF THE CURRENT CHUNK IS THE LAST (NO FURTHER CHUNKS)
+  /**
+   * The head chunk of a placeholder CONTENT record - same on-page layout as {@link #FIRST_CHUNK}, and reached through a
+   * {@link #RECORD_PLACEHOLDER_POINTER} on another page instead of standing for a record of its own (#6196).
+   * <p>
+   * A content record is otherwise recognised by the NEGATIVE size marker its slot carries, and every reader that walks
+   * a page skips it on that basis. A content record no page can host whole has no size in its slot at all - it is a
+   * chunk chain - so before this marker existed its head was written as a plain {@link #FIRST_CHUNK} and the "this slot
+   * is somebody's content" information was lost at that moment: {@code scan()} handed the bytes out a second time as a
+   * document of their own, {@code count()} counted them, and {@code check()} reported a multi-page record where there
+   * was a surrogate.
+   * <p>
+   * It costs nothing in the stored format: -4 was the one value the marker namespace still had free between
+   * {@link #NEXT_CHUNK} and {@link #RECORD_PLACEHOLDER_CONTENT}, and it is one zigzag byte exactly like the markers
+   * either side of it. Databases written before it still hold the ambiguous shape; {@link #check} reports one and
+   * repairs it in place with {@code fix}, so no reader has to tolerate the ambiguity for ever.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  public static final    long                      FIRST_CHUNK_PLACEHOLDER_CONTENT  = -4L;
   protected static final int                       PAGE_RECORD_COUNT_IN_PAGE_OFFSET = 0;
   protected static final int                       PAGE_RECORD_TABLE_OFFSET         =
           PAGE_RECORD_COUNT_IN_PAGE_OFFSET + Binary.SHORT_SERIALIZED_SIZE;
@@ -362,6 +382,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.READ_RECORD);
 
     try {
+      // #6196: FIRST_CHUNK and not isChunkHead(), deliberately. A record EXISTS at this RID when the slot holds one of
+      // its own; the head chunk of a placeholder's CONTENT holds somebody else's bytes and answers false here exactly
+      // as the negated size marker of a content record that fitted its page always has.
       final long[] recordSize = readRecordSizeMarker(rid);
       return recordSize != null && (recordSize[0] > 0 || recordSize[0] == RECORD_PLACEHOLDER_POINTER
           || recordSize[0] == FIRST_CHUNK);
@@ -421,6 +444,30 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       return null;
 
     return page.readNumberAndSize(recordPositionInPage);
+  }
+
+  /**
+   * Whether the size marker of a slot says it holds the HEAD chunk of a multi-page record - a record of its own
+   * ({@link #FIRST_CHUNK}) or the CONTENT of a placeholder ({@link #FIRST_CHUNK_PLACEHOLDER_CONTENT}, #6196). The two
+   * carry the same header and the same chain behind it, so every reader that walks or rewrites the CHAIN asks this,
+   * and only the readers that decide whether the slot is a RECORD tell them apart.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private static boolean isChunkHead(final long recordSizeMarker) {
+    return recordSizeMarker == FIRST_CHUNK || recordSizeMarker == FIRST_CHUNK_PLACEHOLDER_CONTENT;
+  }
+
+  /**
+   * Whether the size marker of a slot says it holds the CONTENT of a placeholder, whichever of the two shapes it is
+   * stored in: a negated size when a page could host it whole, or the head of a chunk chain when none could (#6196).
+   * Such a slot is not a record - it is reachable only through the {@link #RECORD_PLACEHOLDER_POINTER} that references
+   * it - which is what every scan, count and existence check has to know about it.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private static boolean isPlaceholderContent(final long recordSizeMarker) {
+    return recordSizeMarker < RECORD_PLACEHOLDER_CONTENT || recordSizeMarker == FIRST_CHUNK_PLACEHOLDER_CONTENT;
   }
 
   @Override
@@ -514,7 +561,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 if (view != null && !callback.onRecord(rid, view))
                   return;
               } else if (recordSize[0] == FIRST_CHUNK) {
-                // LOAD THE ENTIRE RECORD IN CHUNKS
+                // LOAD THE ENTIRE RECORD IN CHUNKS. #6196: FIRST_CHUNK and not isChunkHead() - a scan hands out
+                // records, and the head chunk of a placeholder's CONTENT is not one. Its bytes reach the caller
+                // through the pointer branch above, under the RID the user knows, and exactly once.
                 final Binary view = loadMultiPageRecord(rid, page, recordPositionInPage, recordSize);
                 if (!callback.onRecord(rid, view))
                   return;
@@ -610,7 +659,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         return placeholderContentFingerprint(
                 new RID(fileId, recordPage.readLong((int) (recordPositionInPage + recordSize[1]))));
 
-      if (recordSize[0] != FIRST_CHUNK || !withChunkChainTail)
+      if (!isChunkHead(recordSize[0]) || !withChunkChainTail)
         // An ordinary record: the whole of it is in its own slot, nothing left to cover.
         return NO_OFF_PAGE_FINGERPRINT;
 
@@ -662,8 +711,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       final int contentOffset;
       final int contentSize;
-      if (recordSize[0] == FIRST_CHUNK) {
+      if (isChunkHead(recordSize[0])) {
         // The content record outgrew its own page in turn: its head chunk here, the rest through the chain below.
+        // #6196 gave that head a marker of its own, and a database written before it holds the ambiguous FIRST_CHUNK:
+        // both are accepted, so a fingerprint taken before a CHECK DATABASE FIX still describes the same record after.
         final int chunkHeaderPos = (int) (recordPositionInPage + recordSize[1]);
         contentSize = contentPage.readInt(chunkHeaderPos);
         contentOffset = chunkHeaderPos + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE;
@@ -928,6 +979,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
             final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
 
+            // #6196: the same three shapes a scan hands out, and for the same reason - FIRST_CHUNK and not
+            // isChunkHead(), because the head chunk of a placeholder's CONTENT is counted through its pointer.
             if (recordSize[0] > 0 || recordSize[0] == RECORD_PLACEHOLDER_POINTER || recordSize[0] == FIRST_CHUNK)
               total++;
           }
@@ -982,6 +1035,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     final List<String> warnings = new ArrayList<>();
     final List<RID> deletedRecordsAfterFix = new ArrayList<>();
 
+    // #6196: positions of the CONTENT records a placeholder pointer references that are still stored as an AMBIGUOUS
+    // chunk head - the shape every release before FIRST_CHUNK_PLACEHOLDER_CONTENT wrote, and the one a scan hands out
+    // twice. Collected while the pointers are walked (one page read per placeholder, and placeholders are rare), then
+    // reconciled and repaired after the pass, which is what makes the answer independent of whether the content
+    // record happens to live on a page this walk has already been through.
+    final LongHashSet legacyContentHeads = new LongHashSet();
+
     String warning = null;
 
     for (int pageId = 0; pageId < totalPages; ++pageId) {
@@ -1031,11 +1091,30 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
               } else if (recordSize[0] == RECORD_PLACEHOLDER_POINTER) {
                 pagePlaceholderRecords++;
                 totalPlaceholderRecords++;
+
+                // #6196: does this pointer lead to a content record still stored as an ambiguous chunk head? Only the
+                // pointer can tell, and only here: from the head chunk's own slot the two are indistinguishable, which
+                // is the whole of the bug. Never throws - a pointer that leads nowhere is a different problem, already
+                // reported by the CHECK DATABASE pass that follows the links.
+                final long contentPosition = page.readLong((int) (recordPositionInPage + recordSize[1]));
+                if (isLegacyAmbiguousContentHead(contentPosition))
+                  legacyContentHeads.add(contentPosition);
+
                 recordSize[0] = MINIMUM_RECORD_SIZE;
-              } else if (recordSize[0] == FIRST_CHUNK) {
-                pageActiveRecords++;
-                pageMultiPageRecords++;
-                totalMultiPageRecords++;
+              } else if (isChunkHead(recordSize[0])) {
+                // #6196: a head chunk of either kind. Everything below is the same for the two - the chain, the walk
+                // that checks it, the size the header declares - and the ONE thing that is not is what the slot is:
+                // a record of its own, or the CONTENT of a placeholder, which is a surrogate exactly as a content
+                // record small enough to fit its page is, and is counted as one rather than as an active record.
+                final long headMarker = recordSize[0];
+                if (headMarker == FIRST_CHUNK_PLACEHOLDER_CONTENT) {
+                  pageSurrogateRecords++;
+                  totalSurrogateRecords++;
+                } else {
+                  pageActiveRecords++;
+                  pageMultiPageRecords++;
+                  totalMultiPageRecords++;
+                }
 
                 // Walk the continuation chain to detect a structurally broken multi-page record (a dangling or
                 // overwritten chunk pointer). check() otherwise validates only the first chunk's on-page size and
@@ -1045,8 +1124,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 final String chainProblem = findBrokenChunkChain(rid, page, recordPositionInPage, false);
                 if (chainProblem != null) {
                   ++totalErrors;
-                  warning = "broken multi-page chunk chain for record %s: %s".formatted(rid, chainProblem);
+                  warning = "broken multi-page chunk chain for %srecord %s: %s".formatted(
+                          headMarker == FIRST_CHUNK_PLACEHOLDER_CONTENT ? "placeholder content " : "", rid, chainProblem);
                   if (fix) {
+                    // deletePlaceholderContent=true, so a content record is force-deleted here like any other head.
+                    // The pointer that referenced it is left behind and reads as a record that is simply not there,
+                    // which is the same outcome every other unrepairable record of this bucket gets.
                     deleteRecordInternal(rid, true, true, true);
                     deletedRecordsAfterFix.add(rid);
                     ++totalDeletedRecords;
@@ -1054,7 +1137,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                   }
                 }
 
-                if (recordSize[0] == FIRST_CHUNK)
+                if (recordSize[0] == headMarker)
                   recordSize[0] = page.readInt((int) (recordPositionInPage + recordSize[1]));
               } else if (recordSize[0] == NEXT_CHUNK) {
                 totalChunks++;
@@ -1124,6 +1207,37 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       }
     }
 
+    // #6196: every content record found behind a pointer while still wearing the ambiguous FIRST_CHUNK marker. The
+    // pass above counted each of them as a multi-page record of its own, which is precisely what they are NOT - so
+    // move them, and repair the marker so the next reader does not have to be told. Deliberately reconciled here and
+    // not inline: the head chunk can sit on a page the walk had already left behind, and a repair made mid-walk would
+    // then be counted one way or the other depending on nothing but the order the allocator happened to place them in.
+    if (!legacyContentHeads.isEmpty()) {
+      for (final long contentPosition : legacyContentHeads.toArray()) {
+        final RID contentRID = new RID(fileId, contentPosition);
+        --totalMultiPageRecords;
+        ++totalSurrogateRecords;
+        ++totalErrors;
+
+        // A repair, never a deletion: the record is intact, only the marker that says whose it is was never written.
+        // Reported as an error whether or not it is fixed, because unfixed it is one a user can see - the content is
+        // returned twice by a scan, under two different RIDs.
+        warning = "placeholder content record %s is stored as an ambiguous chunk chain (#6196) and is returned twice by a scan%s"
+                .formatted(contentRID, fix ? ": repaired" : "; run CHECK DATABASE FIX to repair it");
+        if (fix && !repairLegacyContentHead(contentRID)) {
+          --totalSurrogateRecords;
+          ++totalMultiPageRecords;
+          warning = "placeholder content record %s is stored as an ambiguous chunk chain (#6196) and could not be repaired"
+                  .formatted(contentRID);
+        }
+
+        warnings.add(warning);
+        if (verboseLevel > 0)
+          LogManager.instance().log(this, Level.SEVERE, "- " + warning);
+        warning = null;
+      }
+    }
+
     if (fix)
       // #5149: reconcile the cached record counter that count(*) relies on. Invalidating forces the next
       // count() to rescan authoritatively, and reusing the existing -1 sentinel means the value is
@@ -1178,6 +1292,92 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     stats.put("totalErrors", totalErrors);
 
     return stats;
+  }
+
+  /**
+   * Whether the slot at {@code contentPosition} - the target of a placeholder POINTER - holds a content record still
+   * stored the way every release before #6196 stored one that no page could host whole: as a chunk head wearing the
+   * plain {@link #FIRST_CHUNK} marker, indistinguishable from a record of its own and therefore handed out a second
+   * time by every scan.
+   * <p>
+   * Only {@link #check} asks, and only about a slot a pointer led it to, so the cost is one page read per placeholder
+   * on a shape that is rare to begin with. Never throws: a pointer that cannot be followed is a different problem,
+   * reported by the link pass of CHECK DATABASE rather than mistaken for this one.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private boolean isLegacyAmbiguousContentHead(final long contentPosition) {
+    try {
+      if (contentPosition < 0)
+        return false;
+      final int contentPageId = (int) (contentPosition / maxRecordsInPage);
+      if (contentPageId >= getTotalPages())
+        return false;
+
+      final BasePage contentPage = database.getTransaction()
+              .getPage(new PageId(database, file.getFileId(), contentPageId), pageSize);
+      final int positionInPage = (int) (contentPosition % maxRecordsInPage);
+      if (positionInPage >= contentPage.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET))
+        return false;
+
+      final int recordPositionInPage = getRecordPositionInPage(contentPage, positionInPage);
+      if (recordPositionInPage == 0)
+        return false;
+
+      return contentPage.readNumberAndSize(recordPositionInPage)[0] == FIRST_CHUNK;
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.FINE, "Unable to inspect the content record at position %d of bucket '%s'", e,
+              contentPosition, componentName);
+      return false;
+    }
+  }
+
+  /**
+   * Rewrites the marker of a legacy ambiguous content head (see {@link #isLegacyAmbiguousContentHead}) into
+   * {@link #FIRST_CHUNK_PLACEHOLDER_CONTENT}, which is the whole of the repair: the record's bytes, its chunk header,
+   * its chain and its RID are all correct and untouched, and the one thing that was never written down is which of the
+   * two kinds of head this is.
+   * <p>
+   * The rewrite is refused unless the new marker occupies EXACTLY the bytes the old one does. Both are one zigzag byte
+   * as {@code writeNumber} produces them, so the refusal is unreachable through a marker this engine wrote; it exists
+   * for the denormalised encoding a corrupted or hand-patched page can hold, where a shorter marker would leave the
+   * chunk header a byte adrift and cost the record its chain.
+   * <p>
+   * What it takes on trust is the engine's own invariant: a placeholder POINTER references the CONTENT record written
+   * for it and nothing else. A pointer corrupted into referencing an unrelated multi-page record would have this hide
+   * that record from scans - but such a database is already handing that record's bytes out through the placeholder,
+   * and unlike the force-delete {@code check(fix)} performs on a broken chain, this is reversible: not one byte of the
+   * record, its chunk header or its chain is touched, so rewriting the marker back restores it exactly.
+   *
+   * @return true when the marker was rewritten.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private boolean repairLegacyContentHead(final RID contentRID) {
+    try {
+      final int contentPageId = (int) (contentRID.getPosition() / maxRecordsInPage);
+      final int positionInPage = (int) (contentRID.getPosition() % maxRecordsInPage);
+      final MutablePage contentPage = database.getTransaction()
+              .getPageToModify(new PageId(database, file.getFileId(), contentPageId), pageSize, false);
+
+      final int recordPositionInPage = getRecordPositionInPage(contentPage, positionInPage);
+      final long[] recordSize = contentPage.readNumberAndSize(recordPositionInPage);
+      if (recordSize[0] != FIRST_CHUNK
+              || recordSize[1] != Binary.getNumberSpace(FIRST_CHUNK_PLACEHOLDER_CONTENT))
+        return false;
+
+      // Not a single-slot change any merge could replay: the marker decides what the slot IS.
+      final TransactionContext slotTx = database.getTransactionIfExists();
+      if (slotTx != null && slotTx.isSlotMergeEnabled())
+        slotTx.poisonSlotRebasePage(fileId, contentPageId);
+
+      contentPage.writeNumber(recordPositionInPage, FIRST_CHUNK_PLACEHOLDER_CONTENT);
+      return true;
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.SEVERE, "Unable to repair the placeholder content record %s of bucket '%s'", e,
+              contentRID, componentName);
+      return false;
+    }
   }
 
   /**
@@ -1267,20 +1467,23 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // DELETED
         return null;
 
-      if (recordSize[0] < RECORD_PLACEHOLDER_CONTENT) {
-        if (!readPlaceHolderContent)
-          // PLACEHOLDER
-          return null;
+      // #6196: a placeholder CONTENT record is refused to a caller that did not ask for one, in BOTH the shapes it can
+      // be stored in - a negated size when a page could host it whole, and a chunk head when none could. The two are
+      // separated below only because the negated one has to be turned back into a size, while the chunk head is read
+      // by the chain walk exactly as a record's own head chunk is.
+      if (isPlaceholderContent(recordSize[0]) && !readPlaceHolderContent)
+        // PLACEHOLDER CONTENT: NOT A RECORD OF ITS OWN
+        return null;
 
+      if (recordSize[0] < RECORD_PLACEHOLDER_CONTENT)
         recordSize[0] *= -1;
-      }
 
       if (recordSize[0] == RECORD_PLACEHOLDER_POINTER) {
         // FOUND PLACEHOLDER, LOAD THE REAL RECORD
         final RID placeHolderPointer = new RID(rid.getBucketId(),
                 page.readLong((int) (recordPositionInPage + recordSize[1])));
         return getRecordInternal(placeHolderPointer, true);
-      } else if (recordSize[0] == FIRST_CHUNK) {
+      } else if (isChunkHead(recordSize[0])) {
         // FOUND 1ST CHUNK, LOAD THE ENTIRE MULTI-PAGE RECORD
         return loadMultiPageRecord(rid, page, recordPositionInPage, recordSize);
       } else if (recordSize[0] == NEXT_CHUNK)
@@ -1392,7 +1595,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           //
           // The record is being created at the page's content end, so it owns nothing yet: the head chunk takes the
           // whole free tail and seals the page (#6154).
-          writeMultiPageRecord(rid, buffer, selectedPage, newRecordPositionInPage, spaceAvailableInCurrentPage, 0, 0);
+          //
+          // #6196: this is the ONE place a placeholder's CONTENT record becomes a chunk chain (an update of one that
+          // no longer fits refuses to spill and has the caller recreate it here), so it is the one place the head
+          // chunk has to be told it is content rather than a record. Everything the negated size marker would have
+          // said about the slot is said by the marker this stamps, and by nothing else.
+          writeMultiPageRecord(rid, buffer, selectedPage, newRecordPositionInPage, spaceAvailableInCurrentPage, 0, 0,
+                  isPlaceHolder);
 
         } else {
           final int byteWritten = selectedPage.writeNumber(newRecordPositionInPage,
@@ -1503,7 +1712,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         if (spaceNeeded > spaceAvailableInCurrentPage) {
           // MULTI-PAGE RECORD: only the first chunk is pinned to this slot; writeMultiPageRecord places the rest.
           // Like a normal create, the restored record starts at the page's content end and owns nothing yet (#6154).
-          writeMultiPageRecord(rid, buffer, selectedPage, newRecordPositionInPage, spaceAvailableInCurrentPage, 0, 0);
+          // A record restored at an explicit RID is a record of its own, never a placeholder's content: the content of
+          // a placeholder has no RID anyone outside the bucket knows to ask for.
+          writeMultiPageRecord(rid, buffer, selectedPage, newRecordPositionInPage, spaceAvailableInCurrentPage, 0, 0,
+                  false);
         } else {
           final int byteWritten = selectedPage.writeNumber(newRecordPositionInPage, bufferSize);
           selectedPage.writeByteArray(newRecordPositionInPage + byteWritten, buffer.getContent(), buffer.getContentBeginOffset(), bufferSize);
@@ -1628,8 +1840,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     else if (lastRecordSize[0] == RECORD_PLACEHOLDER_POINTER)
       // PLACEHOLDER, CONSIDER NEXT 9 BYTES
       return lastRecordPositionInPage + LONG_SERIALIZED_SIZE + (int) lastRecordSize[1];
-    else if (lastRecordSize[0] == FIRST_CHUNK || lastRecordSize[0] == NEXT_CHUNK) {
-      // CHUNK
+    else if (isChunkHead(lastRecordSize[0]) || lastRecordSize[0] == NEXT_CHUNK) {
+      // CHUNK (of a record, or of a placeholder's content - the footprint is the same either way)
       final int chunkSize = page.readInt((int) (lastRecordPositionInPage + lastRecordSize[1]));
       return lastRecordPositionInPage + (int) lastRecordSize[1] + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE + chunkSize;
     } else
@@ -1870,13 +2082,16 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         return false;
       final long[] rs = page.readNumberAndSize(existingPos);
 
-      if (kind == TransactionContext.SLOT_KIND_FIRST_CHUNK) {
+      if (kind == TransactionContext.SLOT_KIND_FIRST_CHUNK
+              || kind == TransactionContext.SLOT_KIND_FIRST_CHUNK_PLACEHOLDER_CONTENT) {
         // #6129: the head chunk of a multi-page record. It keeps its slot and updateMultiPageRecord only rewrites
         // INSIDE the region that slot owns (the chunk size, the pointer to the next chunk and the chunk content), so
         // re-applying our final image at the same offset reproduces the page byte for byte - exactly as for a
         // same-or-smaller overwrite. What this check cannot see is the rest of the record, which lives on other
         // pages: that is covered before the write, by the chunk-chain fingerprint (see updateRecordInternal).
-        if (rs[0] != FIRST_CHUNK)
+        // #6196: the head of a placeholder's CONTENT is the same shape behind a different marker, and the kind says
+        // which one the write started from - a slot that changed from one to the other meanwhile is a conflict.
+        if (rs[0] != (kind == TransactionContext.SLOT_KIND_FIRST_CHUNK ? FIRST_CHUNK : FIRST_CHUNK_PLACEHOLDER_CONTENT))
           return false;
         final int chunkHeaderPos = (int) (existingPos + rs[1]);
         final byte[] committedChunk = readChunkImage(page, chunkHeaderPos);
@@ -2340,7 +2555,16 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
         recordSize[0] = LONG_SERIALIZED_SIZE;
         recordSize[1] = 1L;
-      } else if (recordSize[0] == FIRST_CHUNK) {
+      } else if (isChunkHead(recordSize[0])) {
+        // #6196: a head chunk of either kind - a record of its own, or the CONTENT of a placeholder that no page could
+        // host whole. Everything below treats the two identically (the chain, its region and its footprint are the
+        // same) except the two places the difference is the whole point: the un-spill further down, which would have
+        // to write back a marker this branch is not equipped to write, and the slot kind the merge is told.
+        final boolean placeholderContentHead = recordSize[0] == FIRST_CHUNK_PLACEHOLDER_CONTENT;
+        if (placeholderContentHead && !updatePlaceholderContent)
+          // A CONTENT RECORD IS NOT UPDATABLE ON ITS OWN, exactly as the negated-size shape below is not.
+          throw new RecordNotFoundException("Record " + rid + " not found", rid);
+
         // DISJOINT-SLOT MERGE (#6129): the head chunk of a multi-page record. It keeps its slot and its region on
         // THIS page - updateMultiPageRecord rewrites the chunk size, the pointer to the next chunk and the chunk
         // content, all inside the bytes the region covers - so the change this page sees is a single-slot write that
@@ -2376,13 +2600,18 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // the same rule #6163 sizes the head chunk with: the region, and not a byte more - shrinking is no licence to
         // take a neighbour's bytes.
         //
-        // NOT for the CONTENT record of a placeholder (updatePlaceholderContent), even though it reaches this branch
-        // whenever createRecordInternal had to spill it: such a record is identified by the NEGATIVE size marker it
-        // would have to be given back, and the plain positive marker this writes is what tells scan() and check()
-        // that a slot holds a record of its own. Collapsing one would make the placeholder's content show up a second
-        // time, as a document in its own right. It keeps its chain, which costs 13 bytes on a shape that needs a
-        // placeholder to exist at all - a legacy one, or the zero-free-tail page #6149 left as the last fallback.
-        if (!updatePlaceholderContent//
+        // NOT for the CONTENT record of a placeholder, even though it reaches this branch whenever
+        // createRecordInternal had to spill it. Such a record is identified by the NEGATIVE size marker it would have
+        // to be given back, and the plain positive marker the collapse writes is what tells scan() and check() that a
+        // slot holds a record of its own - so collapsing one would make the placeholder's content show up a second
+        // time, as a document in its own right, which is #6196 all over again on a record that had escaped it. It
+        // keeps its chain, which costs 13 bytes on a shape that needs a placeholder to exist at all - a legacy one, or
+        // the zero-free-tail page #6149 left as the last fallback. Making the collapse write a negated size marker
+        // instead is a follow-up (#6286), not a correctness matter.
+        //
+        // Asked of BOTH the flag and the marker on purpose: the flag answers for a database written before #6196,
+        // whose content head still carries the ambiguous FIRST_CHUNK and must not be collapsed either.
+        if (!updatePlaceholderContent && !placeholderContentHead//
                 && collapseChunkChainToRecord(rid, buffer, page, pageId, positionInPage, recordPositionInPage, chunkHeaderPos,
                 chunkRegionEnd, chunkBaseImage, slotTx)) {
           if (!discardRecordAfter)
@@ -2402,7 +2631,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           final byte[] chunkFinalImage = readChunkImage(page, chunkHeaderPos);
           if (chunkFinalImage != null)
             slotTx.trackRebasableUpdate(fileId, pageId, positionInPage, chunkBaseImage, chunkFinalImage,
-                    TransactionContext.SLOT_KIND_FIRST_CHUNK);
+                    placeholderContentHead ?
+                            TransactionContext.SLOT_KIND_FIRST_CHUNK_PLACEHOLDER_CONTENT :
+                            TransactionContext.SLOT_KIND_FIRST_CHUNK);
           else
             // The header no longer describes a chunk that fits the page: nothing here can be replayed safely.
             slotTx.poisonSlotRebasePage(fileId, pageId);
@@ -2563,9 +2794,11 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
             // #6154: the slot's own footprint and the bytes the shift just claimed are already accounted for; the
             // rest of what the head chunk is given - the free tail, when this is the page's last record - is not.
+            // A placeholder CONTENT record never reaches here: the "CANNOT CREATE A PLACEHOLDER OF PLACEHOLDER" branch
+            // above returns first and has the caller delete and recreate it, which is where its chain is written.
             writeMultiPageRecord(rid, buffer, page, recordPositionInPage, availableSpaceInCurrentPage,
                     spillRebasable ? MutablePage.COVERAGE_SLOT_MERGE : 0,
-                    slotFootprint + Math.max(slotEnlargement, 0));
+                    slotFootprint + Math.max(slotEnlargement, 0), false);
 
             if (!spillRebasable) {
               if (slotMergeOn)
@@ -2753,7 +2986,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         return false;
 
       final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
-      if (recordSize[0] != FIRST_CHUNK)
+      if (!isChunkHead(recordSize[0]))
         // NOT A MULTI-PAGE RECORD: A CME ON IT CANNOT COME FROM A BROKEN CHAIN
         return false;
 
@@ -2829,10 +3062,16 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             // PARTIAL RECORD NOT FOUND
           }
 
-        } else if (recordSize[0] == FIRST_CHUNK) {
+        } else if (isChunkHead(recordSize[0])) {
           // The record continues on other pages through a chunk chain: freeing it touches more than this slot.
           if (slotMergeOn)
             slotTx.poisonSlotRebasePage(fileId, pageId);
+
+          // #6196: the head of a placeholder's CONTENT is freed by the same chain walk, but only on behalf of the
+          // pointer that references it - a direct delete of it is refused exactly as it is for the negated-size shape
+          // further down, which is what keeps a caller from leaving a pointer dangling.
+          if (recordSize[0] == FIRST_CHUNK_PLACEHOLDER_CONTENT && !deletePlaceholderContent)
+            throw new RecordNotFoundException("Record " + rid + " not found", rid);
 
           // 1ST CHUNK: DELETE ALL THE CHUNKS
           MutablePage chunkPage = page;
@@ -3182,7 +3421,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
         if (recordSize[0] == RECORD_PLACEHOLDER_POINTER)
           size = LONG_SERIALIZED_SIZE + (int) recordSize[1];
-        else if (recordSize[0] == FIRST_CHUNK || recordSize[0] == NEXT_CHUNK) {
+        else if (isChunkHead(recordSize[0]) || recordSize[0] == NEXT_CHUNK) {
           final int chunkSize = page.readInt(recordPositionInPage + (int) recordSize[1]);
           size = chunkSize + (int) recordSize[1] + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE; // LONG = nextChunkPointer
         } else if (recordSize[0] < RECORD_PLACEHOLDER_CONTENT)
@@ -3269,6 +3508,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // have opposite answers and used to share one flag (#6258).
       String brokenChainReason = null;
       Exception brokenChainCause = null;
+
+      // Which kind of head this attempt started from - a record's own, or a placeholder's CONTENT (#6196). Read here
+      // rather than assumed, because a retry re-reads the slot and could find the other one.
+      final long headMarker = recordSize[0];
 
       // Exact cycle detection, on the same terms as offPageContentFingerprint's walk: revisiting a continuation
       // pointer is the only certain loop signal, and a chain that never revisits one is finite by construction. The
@@ -3364,7 +3607,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // first against the newest committed image and then against this read's own chunks. When both agree, the
         // record is corrupted and every further attempt would walk into the same dead end and report a concurrency
         // problem that does not exist.
-        final String confirmed = confirmBrokenChunkChain(originalRID, chainTrace, chunks, record, lastNextChunkPointer);
+        final String confirmed = confirmBrokenChunkChain(originalRID, chainTrace, chunks, record, lastNextChunkPointer,
+                headMarker);
         if (confirmed != null)
           // Both reasons when they differ, and they can: this walk carries a loop detector the confirmation walk
           // answers as the wrong marker it finds where the chain doubles back. The first is what the READ hit, the
@@ -3383,7 +3627,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // chunk it cannot make sense of as a chunk that changed. What is left to come out of here is the failure to
         // LOAD a page at all, which is an I/O error and not a conflict - absorbing it would spend the retry budget
         // on a broken disk and then report it as "the record was modified during read".
-        final int verdict = validateChainRead(chainTrace, chunks, record, lastNextChunkPointer);
+        final int verdict = validateChainRead(chainTrace, chunks, record, lastNextChunkPointer, headMarker);
         if (verdict == CHAIN_READ_REVALIDATED)
           database.getPageManager().incrementChunkChainReadRevalidations();
         chainInconsistent = verdict == CHAIN_READ_CHANGED;
@@ -3438,13 +3682,17 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * @param lastNextChunkPointer the continuation pointer the last traced chunk carried: 0 for a chain walked to its
    *                             end, and the pointer that could not be followed for a walk the chain broke (#6258) -
    *                             which is what lets a broken chain be validated by the same comparison as a whole one.
+   * @param headMarker           the marker the head chunk carried when the walk started, {@link #FIRST_CHUNK} or
+   *                             {@link #FIRST_CHUNK_PLACEHOLDER_CONTENT} (#6196). Carried rather than assumed because
+   *                             it is part of what the comparison checks: a head whose marker changed under the read
+   *                             is a slot that stopped being what it was, exactly like one whose size or pointer did.
    *
    * @return {@link #CHAIN_READ_UNCHANGED}, {@link #CHAIN_READ_REVALIDATED} or {@link #CHAIN_READ_CHANGED}.
    *
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
   private int validateChainRead(final long[] chainTrace, final int chunks, final Binary record,
-                                final long lastNextChunkPointer) throws IOException {
+                                final long lastNextChunkPointer, final long headMarker) throws IOException {
     int verdict = CHAIN_READ_UNCHANGED;
     int contentOffset = 0;
 
@@ -3467,7 +3715,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 lastNextChunkPointer;
 
         if (!isChunkStillTheOneRead(currentPage, (int) chainTrace[trace + CHAIN_TRACE_SLOT],
-                chunk == 0 ? FIRST_CHUNK : NEXT_CHUNK, chunkSize, nextChunkPointer, record, contentOffset))
+                chunk == 0 ? headMarker : NEXT_CHUNK, chunkSize, nextChunkPointer, record, contentOffset))
           return CHAIN_READ_CHANGED;
 
         verdict = CHAIN_READ_REVALIDATED;
@@ -3546,14 +3794,16 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
   private String confirmBrokenChunkChain(final RID rid, final long[] chainTrace, final int chunks, final Binary record,
-                                         final long lastNextChunkPointer) {
+                                         final long lastNextChunkPointer, final long headMarker) {
     try {
       final String reason = findBrokenChunkChainInNewestCommitted(rid);
       if (reason == null)
         // THE COMMITTED CHAIN WALKS CLEANLY: what this read met was a chain in motion, which is what the retry is for.
         return null;
 
-      return validateChainRead(chainTrace, chunks, record, lastNextChunkPointer) == CHAIN_READ_CHANGED ? null : reason;
+      return validateChainRead(chainTrace, chunks, record, lastNextChunkPointer, headMarker) == CHAIN_READ_CHANGED ?
+              null :
+              reason;
     } catch (final Exception e) {
       // Could not prove corruption (an I/O fault, most likely): fall back to the retry rather than condemn a record.
       LogManager.instance()
@@ -3588,7 +3838,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // DELETED UNDER THE READ
       return null;
 
-    if (head.readNumberAndSize(recordPositionInPage)[0] != FIRST_CHUNK)
+    if (!isChunkHead(head.readNumberAndSize(recordPositionInPage)[0]))
       // NO LONGER A MULTI-PAGE RECORD: the record was rewritten under the read.
       return null;
 
@@ -3660,10 +3910,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    *                           a record spilling out of its page its own footprint plus whatever the in-page shift
    *                           just claimed for it (#6149). The rest is free tail this write takes, which is what
    *                           {@link #updatePageStatistics} has to be told (#6154).
+   * @param isPlaceHolderContent whether the record being written is the CONTENT of a placeholder rather than a record
+   *                           of its own, which decides the marker its head chunk is stamped with (#6196). The
+   *                           chain behind it is identical either way - only the head says which it is, and it is the
+   *                           only place that information exists once the negated size marker is out of reach.
    */
   private void writeMultiPageRecord(final RID originalRID, final Binary buffer, MutablePage currentPage, int newPosition,
                                     final int availableSpaceForFirstChunk, final int firstChunkCoverage,
-                                    final int slotBytesAlreadyOwned) throws IOException {
+                                    final int slotBytesAlreadyOwned, final boolean isPlaceHolderContent) throws IOException {
     // DISJOINT-SLOT MERGE (#5381): a multi-page write places chunk records onto pages via inline record-table
     // writes that bypass create/update/deleteRecordInternal, so it is NOT tracked. A chunk landing on a REUSED
     // page that also holds a tracked single-slot write would let the rebase re-derive that page from the tracked
@@ -3682,7 +3936,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     int chunkSize;
     try {
       // WRITE THE 1ST CHUNK
-      byteWritten = currentPage.writeNumber(newPosition, FIRST_CHUNK);
+      byteWritten = currentPage.writeNumber(newPosition,
+              isPlaceHolderContent ? FIRST_CHUNK_PLACEHOLDER_CONTENT : FIRST_CHUNK);
 
       newPosition += byteWritten;
 
@@ -4254,7 +4509,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       if (lastRecordSize[0] == RECORD_PLACEHOLDER_POINTER) {
         lastRecordSize[0] = LONG_SERIALIZED_SIZE;
         lastRecordSize[1] = 1L;
-      } else if (lastRecordSize[0] == FIRST_CHUNK || lastRecordSize[0] == NEXT_CHUNK) {
+      } else if (isChunkHead(lastRecordSize[0]) || lastRecordSize[0] == NEXT_CHUNK) {
         // CONSIDER THE CHUNK SIZE
         lastRecordSize[0] = page.readInt((int) (lastRecordPositionInPage + lastRecordSize[1]));
         lastRecordSize[1] = 1L + INT_SERIALIZED_SIZE + LONG_SERIALIZED_SIZE;

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1041,6 +1041,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // reconciled and repaired after the pass, which is what makes the answer independent of whether the content
     // record happens to live on a page this walk has already been through.
     final LongHashSet legacyContentHeads = new LongHashSet();
+    /**
+     * Of those, the ones MORE THAN ONE pointer leads to. The repair rests on the engine's own invariant - a placeholder
+     * pointer references the content record written for it and nothing else - and this is the one way that invariant
+     * can be caught failing without knowing what the bytes were meant to say: a content record belongs to exactly one
+     * pointer, so a second one leading to the same slot is proof that a pointer is corrupted, and no reading of it
+     * tells which. Refused rather than repaired, because the shape the repair would write is unrecoverable
+     * information: it says whose the record is (code review on #6287).
+     */
+    final LongHashSet ambiguousHeadsWithSeveralPointers = new LongHashSet();
 
     String warning = null;
 
@@ -1097,8 +1106,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 // is the whole of the bug. Never throws - a pointer that leads nowhere is a different problem, already
                 // reported by the CHECK DATABASE pass that follows the links.
                 final long contentPosition = page.readLong((int) (recordPositionInPage + recordSize[1]));
-                if (isLegacyAmbiguousContentHead(totalPages, contentPosition))
-                  legacyContentHeads.add(contentPosition);
+                if (isLegacyAmbiguousContentHead(totalPages, contentPosition) && !legacyContentHeads.add(contentPosition))
+                  // A SECOND pointer to the same content record: one of them is corrupted, and this is the only way to
+                  // know it without knowing what the bytes meant. See the field's javadoc.
+                  ambiguousHeadsWithSeveralPointers.add(contentPosition);
 
                 recordSize[0] = MINIMUM_RECORD_SIZE;
               } else if (isChunkHead(recordSize[0])) {
@@ -1228,6 +1239,20 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // legacy shape - a set that is empty on every database this build wrote (code review on #6287).
         if (!isLegacyAmbiguousContentHead(totalPages, contentPosition))
           continue;
+
+        if (ambiguousHeadsWithSeveralPointers.contains(contentPosition)) {
+          // Reported, never repaired: the counters are left saying multi-page record, which is what the slot itself
+          // still says, because with two pointers leading here nothing in the bucket knows which of them is the lie.
+          ++totalErrors;
+          warning = ("placeholder content record %s is stored as an ambiguous chunk chain (#6196) and is referenced by "
+                  + "more than one placeholder pointer: one of those pointers is corrupted, so the marker is left as it "
+                  + "is - repair the pointers first").formatted(contentRID);
+          warnings.add(warning);
+          if (verboseLevel > 0)
+            LogManager.instance().log(this, Level.SEVERE, "- " + warning);
+          warning = null;
+          continue;
+        }
 
         --totalMultiPageRecords;
         ++totalSurrogateRecords;
@@ -1380,6 +1405,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * that record from scans - but such a database is already handing that record's bytes out through the placeholder,
    * and unlike the force-delete {@code check(fix)} performs on a broken chain, this is reversible: not one byte of the
    * record, its chunk header or its chain is touched, so rewriting the marker back restores it exactly.
+   * <p>
+   * The one form of that corruption which can be RECOGNISED rather than merely tolerated - two pointers leading to the
+   * same slot, which a healthy bucket cannot produce - is refused by the caller before it gets here, and reported
+   * instead. See {@code ambiguousHeadsWithSeveralPointers} in {@link #check}.
    *
    * @return true when the marker was rewritten.
    *

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1309,6 +1309,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * walks the FULL continuation chain of every multi-page record. A pre-#6149 bucket dense with placeholders pays one
    * more fetch each, of pages the walk itself touches anyway, on an operation that is already O(pages + chunks).
    * <p>
+   * It is paid on every run, including on a database that has already been repaired and on one this build created -
+   * and the obvious saving, a persisted "no legacy shape here" flag set by a successful FIX, is deliberately not taken.
+   * Such a flag would have to stay true through every way old bytes can arrive in a repaired database - a restore from
+   * an older backup, an HA follower resynced from an older leader's snapshot, a file opened by an older binary and
+   * handed back - and a flag that is wrong makes {@code check} skip the one question that finds the shape, which is
+   * the failure this whole marker exists to end. A bounded, honest cost on an admin operation beats a cheap answer
+   * that can be stale (code review on #6287).
+   * <p>
    * Never throws: a pointer that cannot be followed is a different problem, reported by the link pass of CHECK
    * DATABASE rather than mistaken for this one.
    *

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1097,7 +1097,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 // is the whole of the bug. Never throws - a pointer that leads nowhere is a different problem, already
                 // reported by the CHECK DATABASE pass that follows the links.
                 final long contentPosition = page.readLong((int) (recordPositionInPage + recordSize[1]));
-                if (isLegacyAmbiguousContentHead(contentPosition))
+                if (isLegacyAmbiguousContentHead(totalPages, contentPosition))
                   legacyContentHeads.add(contentPosition);
 
                 recordSize[0] = MINIMUM_RECORD_SIZE;
@@ -1217,6 +1217,18 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     if (!legacyContentHeads.isEmpty()) {
       for (final long contentPosition : legacyContentHeads.toArray()) {
         final RID contentRID = new RID(fileId, contentPosition);
+
+        // ASK AGAIN, because the pass has run since the pointer was followed and may have taken the slot with it: the
+        // compound shape - a legacy content head whose chain is ALSO broken - is force-deleted by the broken-chain
+        // branch above, which already counted it and already reported it. Reconciling it here as well would book the
+        // same record twice, under a second error and a "could not be repaired" warning naming a record that is no
+        // longer there to repair. The re-ask is the general form of that guard rather than a membership test against
+        // deletedRecordsAfterFix: whatever removed or rewrote the slot, whoever reported it, it is no longer the
+        // ambiguous shape and is not this pass's to report. It costs one page fetch per head actually found in the
+        // legacy shape - a set that is empty on every database this build wrote (code review on #6287).
+        if (!isLegacyAmbiguousContentHead(totalPages, contentPosition))
+          continue;
+
         --totalMultiPageRecords;
         ++totalSurrogateRecords;
         ++totalErrors;
@@ -1320,14 +1332,18 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * Never throws: a pointer that cannot be followed is a different problem, reported by the link pass of CHECK
    * DATABASE rather than mistaken for this one.
    *
+   * @param totalPages the page count {@link #check} snapshotted before its walk, so both of its questions - is this
+   *                   pointer's target ambiguous, and is it still - are answered against the same bucket the walk
+   *                   itself covered, rather than against a count that may have moved under it.
+   *
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
-  private boolean isLegacyAmbiguousContentHead(final long contentPosition) {
+  private boolean isLegacyAmbiguousContentHead(final int totalPages, final long contentPosition) {
     try {
       if (contentPosition < 0)
         return false;
       final int contentPageId = (int) (contentPosition / maxRecordsInPage);
-      if (contentPageId >= getTotalPages())
+      if (contentPageId >= totalPages)
         return false;
 
       final BasePage contentPage = database.getTransaction()

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1212,6 +1212,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // move them, and repair the marker so the next reader does not have to be told. Deliberately reconciled here and
     // not inline: the head chunk can sit on a page the walk had already left behind, and a repair made mid-walk would
     // then be counted one way or the other depending on nothing but the order the allocator happened to place them in.
+    // Only the RETURNED totals are corrected; the per-page tallies the verbose log prints have already gone out, and
+    // they describe the page as the walk found it, which is what a physical-layout log is for.
     if (!legacyContentHeads.isEmpty()) {
       for (final long contentPosition : legacyContentHeads.toArray()) {
         final RID contentRID = new RID(fileId, contentPosition);

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1302,9 +1302,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * plain {@link #FIRST_CHUNK} marker, indistinguishable from a record of its own and therefore handed out a second
    * time by every scan.
    * <p>
-   * Only {@link #check} asks, and only about a slot a pointer led it to, so the cost is one page read per placeholder
-   * on a shape that is rare to begin with. Never throws: a pointer that cannot be followed is a different problem,
-   * reported by the link pass of CHECK DATABASE rather than mistaken for this one.
+   * Only {@link #check} asks, and only about a slot a pointer led it to, so it costs one page fetch per placeholder
+   * POINTER - every one of them, not only the chunked case this is looking for, because the marker is the only thing
+   * that tells the two apart and reading it is the whole question. That is the deliberate trade, and the scale to
+   * judge it against is what {@code check} already spends on the same pass: it reads every page of the bucket and
+   * walks the FULL continuation chain of every multi-page record. A pre-#6149 bucket dense with placeholders pays one
+   * more fetch each, of pages the walk itself touches anyway, on an operation that is already O(pages + chunks).
+   * <p>
+   * Never throws: a pointer that cannot be followed is a different problem, reported by the link pass of CHECK
+   * DATABASE rather than mistaken for this one.
    *
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -2670,8 +2670,11 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // the zero-free-tail page #6149 left as the last fallback. Making the collapse write a negated size marker
         // instead is a follow-up (#6286), not a correctness matter.
         //
-        // Asked of BOTH the flag and the marker on purpose: the flag answers for a database written before #6196,
-        // whose content head still carries the ambiguous FIRST_CHUNK and must not be collapsed either.
+        // The FLAG is what carries this, and it has to be: a database written before #6196 holds a content head still
+        // wearing the ambiguous FIRST_CHUNK, which the marker cannot tell from a record's own. The marker test next to
+        // it is redundant - the throw at the top of this branch means placeholderContentHead can only be true here
+        // when updatePlaceholderContent is too - and is kept so this line states its own precondition instead of
+        // borrowing one from thirty lines up.
         if (!updatePlaceholderContent && !placeholderContentHead//
                 && collapseChunkChainToRecord(rid, buffer, page, pageId, positionInPage, recordPositionInPage, chunkHeaderPos,
                 chunkRegionEnd, chunkBaseImage, slotTx)) {

--- a/engine/src/test/java/com/arcadedb/database/Issue5279ConcurrentUpdateTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5279ConcurrentUpdateTest.java
@@ -559,8 +559,14 @@ class Issue5279ConcurrentUpdateTest extends BucketPageLayoutTestSupport {
     // the update went through the placeholder-pointer fall-through and not through an in-place content update.
     final Map<String, Object> rebuilt = bucketStats("Holder");
     assertThat((Long) rebuilt.get("totalPlaceholderRecords")).isEqualTo(1L);
-    // The new content record is chunked, next to the one that sealed page 0.
-    assertThat((Long) rebuilt.get("totalMultiPageRecords")).isEqualTo(2L);
+    // Still one content record, and still only one multi-page record - the one that sealed page 0. Since #6196 a
+    // content record spilled into a chain of its own is counted as the SURROGATE it is, not as a record.
+    assertThat((Long) rebuilt.get("totalSurrogateRecords")).isEqualTo(1L);
+    assertThat((Long) rebuilt.get("totalMultiPageRecords")).isEqualTo(1L);
+    // What proves the rebuild: the new content record fits no page, so it brought continuation chunks the plain
+    // 30 KB one it replaced did not have.
+    assertThat((Long) rebuilt.get("totalChunks")).as("the rebuilt content record must be a chain: " + rebuilt)
+        .isGreaterThan((Long) layout.get("totalChunks"));
 
     checkDatabase();
   }

--- a/engine/src/test/java/com/arcadedb/database/Issue6178ChunkCollapseTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6178ChunkCollapseTest.java
@@ -201,6 +201,10 @@ class Issue6178ChunkCollapseTest extends BucketPageLayoutTestSupport {
    * identified by the NEGATIVE size marker a plain collapse would replace with a positive one - and a positive size
    * marker is exactly what tells {@code scan()} that a slot holds a document of its own, so collapsing it would make
    * the placeholder's content appear a second time, as a record in its own right.
+   * <p>
+   * Since #6196 the head chunk of such a record carries {@code FIRST_CHUNK_PLACEHOLDER_CONTENT}, so the chain shape is
+   * no longer ambiguous; what is still missing is a collapse that writes the negated size marker back (#6286), which
+   * is why the guard stays.
    */
   @Test
   void aPlaceholderContentStoredAsAChainIsNeverCollapsed() {
@@ -220,20 +224,20 @@ class Issue6178ChunkCollapseTest extends BucketPageLayoutTestSupport {
     Map<String, Object> layout = bucketStats("Surrogate");
     assertThat((Long) layout.get("totalPlaceholderRecords")).as("the fixture must really be a placeholder: " + layout)
         .isEqualTo(1L);
-    // Two chains: the record that sealed page 0 when it spilled, and the placeholder's content record - which is what
-    // makes this fixture the one this test needs, and not merely a placeholder with a plain content record.
+    // The placeholder's content is a chain of its own - which is what makes this fixture the one this test needs, and
+    // not merely a placeholder with a plain content record. Since #6196 that chain is counted as the SURROGATE it is,
+    // next to the one multi-page record the bucket really has: the record that sealed page 0 when it spilled.
+    assertThat((Long) layout.get("totalSurrogateRecords"))
+        .as("the placeholder's content must itself have spilled into a chain: " + layout).isEqualTo(1L);
     assertThat((Long) layout.get("totalMultiPageRecords"))
-        .as("the placeholder's content must itself have spilled into a chain: " + layout).isEqualTo(2L);
+        .as("and it is not a multi-page record of its own: " + layout).isEqualTo(1L);
 
     final long recordsBefore = countRecords("Surrogate");
-    // NOT one: a scan already hands this content out TWICE on unmodified main - once through the pointer, once as
-    // the chunk head in its own right, because createRecordInternal writes FIRST_CHUNK where it would have written
-    // the negative size marker that hides a content record. Filed separately as #6196 and deliberately not fixed
-    // here; asserted as it IS so that this test says what it measures, and so that fixing it turns this line red
-    // rather than leaving it quietly wrong.
+    // Exactly one since #6196 gave the head chunk of a content record a marker of its own: before that,
+    // createRecordInternal wrote FIRST_CHUNK where the negative size marker that hides a content record belonged, and
+    // a scan handed these bytes out twice - once through the pointer, once as a document in their own right.
     final long copiesBefore = countRecordsHolding("Surrogate", huge);
-    assertThat(copiesBefore).as("pre-existing #6196: a chunked placeholder content is scanned as a record of its own")
-        .isEqualTo(2L);
+    assertThat(copiesBefore).as("a chunked placeholder content is scanned once, through its pointer").isEqualTo(1L);
 
     // Back to a handful of bytes: the content record's own chain shrinks, and stays a chain.
     database.transaction(() -> placeholder[0].asDocument(true).modify().set("v", "p").save());
@@ -243,9 +247,9 @@ class Issue6178ChunkCollapseTest extends BucketPageLayoutTestSupport {
         .isEqualTo(1L);
     assertThat(countRecords("Surrogate")).as("and the collapse must not have added a record of its own")
         .isEqualTo(recordsBefore);
-    // What the guard is worth, stated against the shape above: the content is no MORE visible than it already was.
-    // Collapsing it would have given the content record a plain positive size marker, which is precisely what makes
-    // a slot a document in its own right - the same duplication as #6196, on a record that had escaped it.
+    // What the guard is worth: collapsing would have given the content record a plain POSITIVE size marker, which is
+    // precisely what makes a slot a document in its own right - the duplication #6196 removed, reintroduced on the one
+    // record shape that reaches this branch with the marker that hides it out of reach.
     assertThat(countRecordsHolding("Surrogate", "p")).as("the collapse must not multiply the placeholder's content")
         .isEqualTo(copiesBefore);
 

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -168,6 +168,43 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
   }
 
   /**
+   * The compound legacy shape: a content record still wearing the ambiguous marker whose chain is ALSO broken. Two
+   * independent defects on one record, and CHECK DATABASE FIX must book it once - the broken chain is what it can act
+   * on, so the record is force-deleted, and the ambiguity reconciliation must then leave alone a slot that is no
+   * longer there rather than report a second error and a repair that could not have happened.
+   */
+  @Test
+  void aLegacyContentHeadWithABrokenChainIsReportedOnce() {
+    final RID content = contentRidOf(placeholderWithChainedContent());
+
+    writeMarkerByteAt(content, FIRST_CHUNK_MARKER);
+    breakChainAt(content);
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat(numberProperty(fixed, "totalErrors"))
+        .as("one record, one defect it can act on, one error: " + fixed.toJSON()).isEqualTo(1L);
+    assertThat(warningsOf(fixed).toString()).as("and the broken chain is what it names: " + fixed.toJSON())
+        .contains("broken multi-page chunk chain").doesNotContain("could not be repaired");
+    assertThat((Collection<?>) fixed.getProperty("deletedRecordsAfterFix"))
+        .as("the record a broken chain costs is the one that is deleted: " + fixed.toJSON())
+        .hasToString("[" + content + "]");
+
+    // Nothing ambiguous is left for a second run to find: the slot the pointer led to is gone.
+    final Result again = checkDatabaseRow(false);
+    assertThat(numberProperty(again, "totalErrors")).as("and the database checks out afterwards: " + again.toJSON())
+        .isZero();
+  }
+
+  /** Points the head chunk of {@code rid} at a page far past the end of the bucket, which breaks its chain. */
+  private void breakChainAt(final RID rid) {
+    database.transaction(() -> onSlot(rid, page -> {
+      // [marker:1][chunkSize:int][nextChunkPointer:long][content...]
+      page.writeLong(recordOffsetOf(page, rid) + 1 + Binary.INT_SERIALIZED_SIZE, Integer.MAX_VALUE);
+      return 0L;
+    }));
+  }
+
+  /**
    * The commit-time half of the marker: the disjoint-slot merge replays a head chunk only onto a committed slot that
    * still carries the marker the write started from, and the two kinds are what tell it which one that is.
    * <p>

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6196: a placeholder whose CONTENT record had to spill into chunks was returned TWICE by a scan.
+ * <p>
+ * A content record is normally recognised by the NEGATIVE size marker its slot carries, and every reader that walks a
+ * page skips it on that basis. But a content record that no page can host whole is written by
+ * {@code writeMultiPageRecord}, which used to stamp the plain {@code FIRST_CHUNK} marker of an ordinary multi-page
+ * record on its head chunk - and with it went the only record of "this slot is somebody's content, not a record".
+ * The bytes were then handed out twice: once through the placeholder POINTER that references them, and once as a
+ * document of their own under the head chunk's RID. {@code check()} had the mirror of the same confusion, counting
+ * such a record under {@code totalMultiPageRecords} and never under {@code totalSurrogateRecords}, and {@code count()}
+ * counted it as a record.
+ * <p>
+ * The fix gives the head chunk of a content record a marker of its own, {@code FIRST_CHUNK_PLACEHOLDER_CONTENT} (-4),
+ * in the free slot the marker namespace already had between {@code NEXT_CHUNK} (-3) and the negated sizes (&lt; -5).
+ * Databases written before it still hold the ambiguous shape, so {@code CHECK DATABASE} reports one and
+ * {@code CHECK DATABASE FIX} converts it - the ambiguity is repaired, not tolerated for ever.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
+  private static final String TYPE                       = "Surrogate";
+  /** {@code LocalBucket.FIRST_CHUNK} (-2) and {@code FIRST_CHUNK_PLACEHOLDER_CONTENT} (-4), zigzag-encoded. */
+  private static final byte   FIRST_CHUNK_MARKER         = 3;
+  private static final byte   CONTENT_CHUNK_MARKER       = 7;
+  /** {@code LocalBucket.RECORD_PLACEHOLDER_POINTER} (-1), zigzag-encoded. */
+  private static final byte   PLACEHOLDER_POINTER_MARKER = 1;
+  /** 200 KB fits no page whole, so the content record created behind the pointer spills into a chain of its own. */
+  private static final String HUGE                       = "h".repeat(200 * 1024);
+
+  /** Continuation chunks the record that SEALS page 0 owns - every chunk in the bucket that is not the content's. */
+  private long chunksOfTheSealingRecord;
+
+  /**
+   * The issue as reported: the placeholder's content must be a document exactly once, under the RID the user knows,
+   * and the head chunk that holds it must be invisible to a scan, to {@code count()} and to a direct load.
+   */
+  @Test
+  void aPlaceholderWhoseContentSpilledIsScannedOnce() {
+    final RID placeholder = placeholderWithChainedContent();
+
+    final Map<String, Object> layout = bucketStats(TYPE);
+    assertThat((Long) layout.get("totalPlaceholderRecords")).as("the fixture must really be a placeholder: " + layout)
+        .isEqualTo(1L);
+    assertThat((Long) layout.get("totalSurrogateRecords"))
+        .as("the content record is a surrogate even though it is stored as a chain: " + layout).isEqualTo(1L);
+    // Only the record that sealed page 0 when it spilled: the content record's chain is no longer counted as one.
+    assertThat((Long) layout.get("totalMultiPageRecords"))
+        .as("a placeholder's content is not a multi-page record of its own: " + layout).isEqualTo(1L);
+
+    assertThat(countRecordsHolding(HUGE)).as("the content must be handed out exactly once, through the pointer")
+        .isEqualTo(1L);
+
+    final RID content = contentRidOf(placeholder);
+    assertThat(markerByteAt(content)).as("the head chunk of a content record carries its own marker")
+        .isEqualTo(CONTENT_CHUNK_MARKER);
+    database.transaction(() -> {
+      assertThat(bucketOf(TYPE).existsRecord(content)).as("a content record does not exist on its own").isFalse();
+      assertThat(bucketOf(TYPE).getRecordInternal(content, false))
+          .as("and cannot be loaded as a record on its own").isNull();
+      assertThat(placeholder.asDocument(true).getString("v")).isEqualTo(HUGE);
+    });
+
+    checkDatabase();
+  }
+
+  /**
+   * The whole life of such a record through the pointer: rewritten large (the chain is reused), shrunk back (the
+   * chain shrinks and stays a chain, #6178), grown again, and finally deleted with the chain behind it.
+   */
+  @Test
+  void theContentChainKeepsItsMarkerThroughEveryRewrite() {
+    final RID placeholder = placeholderWithChainedContent();
+    final RID content = contentRidOf(placeholder);
+
+    final String otherHuge = "o".repeat(200 * 1024);
+    database.transaction(() -> placeholder.asDocument(true).modify().set("v", otherHuge).save());
+    assertThat(markerByteAt(content)).as("a rewrite in place must not turn the content into a record")
+        .isEqualTo(CONTENT_CHUNK_MARKER);
+    assertThat(countRecordsHolding(otherHuge)).isEqualTo(1L);
+
+    database.transaction(() -> placeholder.asDocument(true).modify().set("v", "p").save());
+    Map<String, Object> layout = bucketStats(TYPE);
+    assertThat((Long) layout.get("totalPlaceholderRecords")).as("the pointer must still be a pointer: " + layout)
+        .isEqualTo(1L);
+    assertThat(countRecordsHolding("p")).as("nor must a shrink multiply the content").isEqualTo(1L);
+
+    database.transaction(() -> placeholder.asDocument(true).modify().set("v", HUGE).save());
+    assertThat(countRecordsHolding(HUGE)).isEqualTo(1L);
+
+    final long recordsBefore = countRecords();
+    database.transaction(() -> placeholder.asDocument(true).delete());
+    assertThat(countRecords()).as("deleting the pointer frees the content chain with it").isEqualTo(recordsBefore - 1);
+    layout = bucketStats(TYPE);
+    assertThat((Long) layout.get("totalPlaceholderRecords")).as("the pointer is gone: " + layout).isZero();
+    assertThat((Long) layout.get("totalSurrogateRecords")).as("no content record is left behind: " + layout).isZero();
+    // Back to the chunks the record that SEALED page 0 owns, and not one more: the content record's own chain, which
+    // was every chunk on top of those, was freed with the pointer that led to it.
+    assertThat((Long) layout.get("totalChunks")).as("nor any of its chunks: " + layout).isEqualTo(chunksOfTheSealingRecord);
+
+    checkDatabase();
+  }
+
+  /**
+   * A database written BEFORE this fix holds the ambiguous shape, and no reader can tell it from an ordinary
+   * multi-page record - so the duplicate is still there. {@code CHECK DATABASE} names it and {@code FIX} converts the
+   * marker in place, which is what keeps the tolerance out of the readers.
+   */
+  @Test
+  void checkDatabaseFixRepairsALegacyAmbiguousContentRecord() {
+    final RID placeholder = placeholderWithChainedContent();
+    final RID content = contentRidOf(placeholder);
+
+    // Downgrade the marker to what every release before this fix wrote there.
+    writeMarkerByteAt(content, FIRST_CHUNK_MARKER);
+    assertThat(countRecordsHolding(HUGE)).as("the shape #6196 reported: the content is scanned twice").isEqualTo(2L);
+
+    final Result unfixed = checkDatabaseRow(false);
+    assertThat(numberProperty(unfixed, "totalErrors")).as("check must report it: " + unfixed.toJSON()).isEqualTo(1L);
+    assertThat(warningsOf(unfixed).toString()).contains(content.toString()).contains("placeholder");
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat(numberProperty(fixed, "totalErrors")).as("fix must repair it: " + fixed.toJSON()).isEqualTo(1L);
+    assertThat((Collection<?>) fixed.getProperty("deletedRecordsAfterFix"))
+        .as("and repair it by rewriting the marker, never by deleting the record: " + fixed.toJSON()).isEmpty();
+
+    assertThat(markerByteAt(content)).isEqualTo(CONTENT_CHUNK_MARKER);
+    assertThat(countRecordsHolding(HUGE)).as("the duplicate is gone").isEqualTo(1L);
+    database.transaction(() -> assertThat(placeholder.asDocument(true).getString("v")).isEqualTo(HUGE));
+
+    checkDatabase();
+  }
+
+  /**
+   * The fixture #6196 needs: a placeholder POINTER whose CONTENT record is itself a chunk chain. Both halves are
+   * required - a page with a free tail of exactly zero (since #6149 the only shape that still produces a pointer) and
+   * a value no page can host whole.
+   */
+  private RID placeholderWithChainedContent() {
+    final RID[] placeholder = new RID[1];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING);
+      placeholder[0] = database.newDocument(TYPE).set("v", "p").save().getIdentity();
+    });
+    sealFirstPage(TYPE);
+    chunksOfTheSealingRecord = (Long) bucketStats(TYPE).get("totalChunks");
+
+    database.transaction(() -> placeholder[0].asDocument(true).modify().set("v", HUGE).save());
+
+    assertThat((Long) bucketStats(TYPE).get("totalPlaceholderRecords"))
+        .as("the fixture must produce a placeholder pointer").isEqualTo(1L);
+    return placeholder[0];
+  }
+
+  /** The RID of the CONTENT record the placeholder POINTER at {@code rid} references. */
+  private RID contentRidOf(final RID rid) {
+    final long[] pointer = new long[1];
+    database.transaction(() -> pointer[0] = onSlot(rid, page -> {
+      final int recordOffset = recordOffsetOf(page, rid);
+      assertThat(page.readByte(recordOffset)).as("%s must be a placeholder pointer", rid)
+          .isEqualTo(PLACEHOLDER_POINTER_MARKER);
+      return page.readLong(recordOffset + 1);
+    }));
+    return new RID(rid.getBucketId(), pointer[0]);
+  }
+
+  /** The single byte the record's size marker is stored as - the whole of it for every marker used here. */
+  private byte markerByteAt(final RID rid) {
+    final long[] marker = new long[1];
+    database.transaction(() -> marker[0] = onSlot(rid, page -> (long) page.readByte(recordOffsetOf(page, rid))));
+    return (byte) marker[0];
+  }
+
+  /** Rewrites that byte, which is how the pre-fix shape is fabricated on a database this build wrote. */
+  private void writeMarkerByteAt(final RID rid, final byte marker) {
+    database.transaction(() -> onSlot(rid, page -> {
+      page.writeByte(recordOffsetOf(page, rid), marker);
+      return 0L;
+    }));
+  }
+
+  private int recordOffsetOf(final MutablePage page, final RID rid) {
+    final int slot = (int) (rid.getPosition() % bucketOf(TYPE).getMaxRecordsInPage());
+    // PAGE_RECORD_TABLE_OFFSET == PAGE_RECORD_COUNT_IN_PAGE_OFFSET(0) + SHORT_SERIALIZED_SIZE; one uint per slot.
+    return (int) page.readUnsignedInt(Binary.SHORT_SERIALIZED_SIZE + slot * Binary.INT_SERIALIZED_SIZE);
+  }
+
+  /** Runs {@code body} on the page holding {@code rid}, taken for modification so a write lands in the transaction. */
+  private long onSlot(final RID rid, final PageAccess body) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(rid.getBucketId())).getPageSize();
+    final int pageNumber = (int) (rid.getPosition() / bucketOf(TYPE).getMaxRecordsInPage());
+    try {
+      return body.apply(db.getTransaction().getPageToModify(new PageId(db, rid.getBucketId(), pageNumber), pageSize, false));
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @FunctionalInterface
+  private interface PageAccess {
+    long apply(MutablePage page) throws Exception;
+  }
+
+  private Result checkDatabaseRow(final boolean fix) {
+    try (final ResultSet rs = database.command("sql", fix ? "check database fix" : "check database")) {
+      return rs.next();
+    }
+  }
+
+  /** {@code CHECK DATABASE} folds the per-bucket warning lists into a set, so this reads it as the collection it is. */
+  private static Collection<?> warningsOf(final Result row) {
+    final Object warnings = row.getProperty("warnings");
+    return warnings == null ? List.of() : (Collection<?>) warnings;
+  }
+
+  /**
+   * Records a full SCAN returns. {@code count(@rid)} and not {@code count(*)}: the latter answers from the bucket's
+   * cached counter without scanning a page, so it could not see the difference this test is about.
+   */
+  private long countRecords() {
+    final long[] total = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + TYPE)) {
+        total[0] = ((Number) rs.next().getProperty("c")).longValue();
+      }
+    });
+    return total[0];
+  }
+
+  /** Records a scan returns holding exactly {@code value} - the count that notices a content record handed out twice. */
+  private long countRecordsHolding(final String value) {
+    final long[] total = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + TYPE + " where v = :v",
+          Map.of("v", value))) {
+        total[0] = ((Number) rs.next().getProperty("c")).longValue();
+      }
+    });
+    return total[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -231,6 +231,41 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
         .isZero();
   }
 
+  /**
+   * The repair rests on the engine's own invariant - a placeholder pointer leads to the content record written for it
+   * and nothing else - and a corrupted pointer breaks it. The one form of that which can be RECOGNISED is two pointers
+   * leading to the same slot, which a healthy bucket cannot produce: FIX must then report and leave the marker alone,
+   * because the marker is unrecoverable information (it says whose the record is) and nothing here knows which of the
+   * two pointers is the lie.
+   */
+  @Test
+  void aContentHeadTwoPointersLeadToIsReportedAndLeftAlone() {
+    final RID placeholder = placeholderWithChainedContent();
+    final RID content = contentRidOf(placeholder);
+
+    writeMarkerByteAt(content, FIRST_CHUNK_MARKER);
+    // A second pointer to the same content, over a record that has room for one: a corrupted pointer, in the one shape
+    // that can be told apart from a healthy one.
+    final RID hijacked = new RID(placeholder.getBucketId(), placeholder.getPosition() + 1);
+    database.transaction(() -> onSlot(hijacked, page -> {
+      final int recordOffset = recordOffsetOf(page, hijacked);
+      page.writeByte(recordOffset, PLACEHOLDER_POINTER_MARKER);
+      page.writeLong(recordOffset + 1, content.getPosition());
+      return 0L;
+    }));
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat(warningsOf(fixed).toString()).as("the refusal must name the record and the reason: " + fixed.toJSON())
+        .contains(content.toString()).contains("more than one placeholder pointer");
+    assertThat(markerByteAt(content)).as("and the marker must be exactly as it was found").isEqualTo(FIRST_CHUNK_MARKER);
+    assertThat((Collection<?>) fixed.getProperty("deletedRecordsAfterFix"))
+        .as("nothing is deleted either: " + fixed.toJSON()).isEmpty();
+
+    // The corruption this test fabricated is deliberately NOT repairable - that is the whole point - so the type goes
+    // with the test rather than being left for the integrity check every test ends with.
+    database.transaction(() -> database.getSchema().dropType(TYPE));
+  }
+
   /** Points the head chunk of {@code rid} at a page far past the end of the bucket, which breaks its chain. */
   private void breakChainAt(final RID rid) {
     database.transaction(() -> onSlot(rid, page -> {

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.engine.PaginatedComponentFile;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6196: a placeholder whose CONTENT record had to spill into chunks was returned TWICE by a scan.
@@ -164,6 +166,40 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
     assertThat(countRecordsHolding(HUGE)).as("the duplicate is gone").isEqualTo(1L);
     database.transaction(() -> assertThat(placeholder.asDocument(true).getString("v")).isEqualTo(HUGE));
 
+    checkDatabase();
+  }
+
+  /**
+   * A content record is not a record, on the WRITE paths as much as on the read ones: reached at its own RID, an
+   * update and a delete both refuse it, exactly as they already do for a content record small enough to have kept the
+   * negated size marker. Anything else would let a caller rewrite or free content a placeholder pointer still
+   * references, leaving that pointer aimed at somebody else's bytes or at nothing.
+   * <p>
+   * Driven through {@code LocalBucket} rather than through a document, deliberately: {@code content.asDocument()} is
+   * refused one layer earlier, by the read that will not hand out a content record, so it would never reach the two
+   * guards this is about.
+   */
+  @Test
+  void aChunkedContentRecordIsNotUpdatableOrDeletableAtItsOwnRid() {
+    final RID content = contentRidOf(placeholderWithChainedContent());
+
+    database.transaction(() -> {
+      final LocalBucket bucket = bucketOf(TYPE);
+
+      final MutableDocument surrogate = database.newDocument(TYPE).set("v", "whatever the caller meant");
+      ((RecordInternal) surrogate).setIdentity(content);
+      assertThatThrownBy(() -> bucket.updateRecord(surrogate, false))
+          .as("a content record cannot be rewritten behind its placeholder's back")
+          .isInstanceOf(RecordNotFoundException.class);
+
+      assertThatThrownBy(() -> bucket.deleteRecord(content))
+          .as("nor freed, which would leave the pointer aimed at nothing")
+          .isInstanceOf(RecordNotFoundException.class);
+    });
+
+    // Both refusals left the record exactly as it was: still one copy, still reachable through the pointer.
+    assertThat(countRecordsHolding(HUGE)).isEqualTo(1L);
+    assertThat(markerByteAt(content)).isEqualTo(CONTENT_CHUNK_MARKER);
     checkDatabase();
   }
 

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.database;
 
+import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.engine.PaginatedComponentFile;
@@ -63,6 +64,8 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
 
   /** Continuation chunks the record that SEALS page 0 owns - every chunk in the bucket that is not the content's. */
   private long chunksOfTheSealingRecord;
+  /** The record that seals page 0 by spilling: an ordinary multi-page record, and the only other chunk head around. */
+  private RID  sealingRecord;
 
   /**
    * The issue as reported: the placeholder's content must be a document exactly once, under the RID the user knows,
@@ -165,6 +168,82 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
   }
 
   /**
+   * The commit-time half of the marker: the disjoint-slot merge replays a head chunk only onto a committed slot that
+   * still carries the marker the write started from, and the two kinds are what tell it which one that is.
+   * <p>
+   * Driven through {@code rebaseRecordOnPage} directly, in the manner {@code Issue6129ChunkedSlotMergeTest} already
+   * uses for the tracking guards and for the same reason: the shape transition this refuses - a slot that turns from
+   * a record's head chunk into a placeholder's content, or back, under a concurrent commit - is one no write path
+   * produces today, so a test that went through the engine would prove nothing about the guard. What must not happen
+   * is that a future one reaches it and is silently mis-merged, which is what the two refusals below assert.
+   * <p>
+   * The two positive controls are not decoration: without them a guard that refused EVERYTHING would pass this test.
+   */
+  @Test
+  void aHeadChunkIsOnlyReplayedOntoTheMarkerItsWriteStartedFrom() {
+    final RID content = contentRidOf(placeholderWithChainedContent());
+
+    database.begin();
+    try {
+      final LocalBucket bucket = bucketOf(TYPE);
+
+      // The CONTENT record's head chunk: replayable as placeholder content, refused as a record.
+      final byte[] contentImage = chunkImageOf(content);
+      assertThat(rebase(bucket, content, contentImage, TransactionContext.SLOT_KIND_FIRST_CHUNK))
+          .as("a content head must not be replayed under the kind of a record's own head").isFalse();
+      assertThat(rebase(bucket, content, contentImage, TransactionContext.SLOT_KIND_FIRST_CHUNK_PLACEHOLDER_CONTENT))
+          .as("and must be replayable under its own").isTrue();
+
+      // The record that SEALED page 0: an ordinary multi-page record, and the mirror of the above.
+      final byte[] recordImage = chunkImageOf(sealingRecord);
+      assertThat(rebase(bucket, sealingRecord, recordImage,
+          TransactionContext.SLOT_KIND_FIRST_CHUNK_PLACEHOLDER_CONTENT))
+          .as("a record's head must not be replayed under the kind of a content head").isFalse();
+      assertThat(rebase(bucket, sealingRecord, recordImage, TransactionContext.SLOT_KIND_FIRST_CHUNK))
+          .as("and must be replayable under its own").isTrue();
+    } finally {
+      database.rollback();
+    }
+
+    database.transaction(() -> assertThat(placeholderRecordCount()).isEqualTo(1L));
+    checkDatabase();
+  }
+
+  /**
+   * The image the disjoint-slot merge keeps for a head chunk: everything after the marker, i.e.
+   * {@code [int chunkSize][long nextChunk][chunkSize bytes of content]}. Replaying it unchanged is a no-op write, so
+   * the positive controls above assert the guard and not the content.
+   */
+  private byte[] chunkImageOf(final RID rid) {
+    final byte[][] image = new byte[1][];
+    onSlot(rid, page -> {
+      // Both markers this test meets are one zigzag byte, so the chunk header starts right after it.
+      final int chunkHeaderPos = recordOffsetOf(page, rid) + 1;
+      final int size = Binary.INT_SERIALIZED_SIZE + Binary.LONG_SERIALIZED_SIZE + page.readInt(chunkHeaderPos);
+      image[0] = new byte[size];
+      page.readByteArray(chunkHeaderPos, image[0], 0, size);
+      return 0L;
+    });
+    return image[0];
+  }
+
+  /** Replays {@code image} onto the slot of {@code rid} under {@code kind}, as a commit-time slot rebase would. */
+  private boolean rebase(final LocalBucket bucket, final RID rid, final byte[] image, final byte kind) {
+    final boolean[] rebased = new boolean[1];
+    onSlot(rid, page -> {
+      rebased[0] = bucket.rebaseRecordOnPage(page, (int) (rid.getPosition() % bucket.getMaxRecordsInPage()), image,
+          image, kind);
+      return 0L;
+    });
+    return rebased[0];
+  }
+
+  /** Placeholder pointers the bucket holds, so the rolled-back replays above are shown to have changed nothing. */
+  private long placeholderRecordCount() {
+    return (Long) bucketStats(TYPE).get("totalPlaceholderRecords");
+  }
+
+  /**
    * The fixture #6196 needs: a placeholder POINTER whose CONTENT record is itself a chunk chain. Both halves are
    * required - a page with a free tail of exactly zero (since #6149 the only shape that still produces a pointer) and
    * a value no page can host whole.
@@ -175,7 +254,7 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
       database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING);
       placeholder[0] = database.newDocument(TYPE).set("v", "p").save().getIdentity();
     });
-    sealFirstPage(TYPE);
+    sealingRecord = sealFirstPage(TYPE);
     chunksOfTheSealingRecord = (Long) bucketStats(TYPE).get("totalChunks");
 
     database.transaction(() -> placeholder[0].asDocument(true).modify().set("v", HUGE).save());


### PR DESCRIPTION
Fixes #6196.

## What was wrong

`SELECT FROM Doc` could return the same record twice, under two different RIDs, and `count(@rid)` counted it
twice with it. One record shape reached it: a **placeholder** whose CONTENT record was too large for any page to
hold whole.

A content record is recognised by the NEGATIVE size marker its slot carries, and every reader that walks a page
skips it on that basis. A content record no page can host whole has no size in its slot at all - it is a chunk
chain - so `writeMultiPageRecord` stamped the plain `FIRST_CHUNK` marker of an ordinary multi-page record on its
head, and the one thing that said the slot belonged to somebody else was gone at that moment. There was nowhere
else it was written down: the head chunk of a placeholder's content was indistinguishable from the head chunk of
a real record.

So `scan()` handed the bytes out as a document of their own, in addition to handing the same bytes out through
the pointer that references them. `count()` counted them. `check()` had the mirror of the same confusion,
counting the record under `totalMultiPageRecords` and never under `totalSurrogateRecords`.

## The fix, and why not the issue's own alternative

The issue offered two. The cheaper one - "stop creating the shape: refuse to place a content record that cannot
fit a page, i.e. make the spill branch of `updateRecordInternal` fall through to chunks for the RECORD ITSELF" -
turns out not to be available. That branch is reached exactly when `availableSpaceInCurrentPage <
MINIMUM_SPACE_FOR_FIRST_CHUNK`, after `slotEnlargementForChunkHead` has already tried to claim the missing bytes
through the in-page shift: the slot genuinely cannot host a 14-byte chunk header, so the record itself cannot
spill in place, and relocating its content is the only thing left. The premise that the fallback "says nothing
about whether the content will fit a page" is right, but it is not what makes the fallback necessary.

So the marker, `FIRST_CHUNK_PLACEHOLDER_CONTENT` = **-4**: the one value the namespace still had free between
`NEXT_CHUNK` (-3) and the negated sizes (< -5), one zigzag byte exactly like the markers either side of it. The
stored format grows by nothing.

Three refinements over the issue's sketch:

1. **Two predicates instead of a dozen open-coded pairs.** `isChunkHead(marker)` for every reader that walks or
   rewrites the CHAIN (the header, the region and the chain are identical for the two heads), and
   `isPlaceholderContent(marker)` for the readers that decide whether a slot is a RECORD, which is the one place
   the two differ. `scan`, `count`, `existsRecord` and `getRecordInternal` without `readPlaceHolderContent`
   deliberately test `== FIRST_CHUNK` and not `isChunkHead`, each with a comment saying so.

2. **The disjoint-slot merge keeps working on this shape.** A head-chunk update of a content record was
   rebasable before #6196 and stays rebasable, under a `SLOT_KIND_FIRST_CHUNK_PLACEHOLDER_CONTENT` of its own -
   the same replay, differing only in the marker it expects to still find on the committed page, which is
   exactly what a kind is for ("the same bytes behind a different marker are a different record"). Poisoning the
   page instead would have been simpler and would have cost this shape the concurrency #6129 gave it.

3. **Old databases are repaired, not tolerated for ever.** The issue accepted that "existing databases keep
   producing the ambiguous shape and the readers have to tolerate both for ever". They do not have to: only the
   pointer can tell the two apart, and `check()` already walks every pointer. It now follows each one (one page
   read per placeholder, on a shape that is rare to begin with), reports a content record still stored the old
   way as an error naming its RID, and `CHECK DATABASE FIX` rewrites that one marker. It is a repair and never a
   deletion - not a byte of the record, its chunk header or its chain is touched, so it is reversible even in
   the corrupted-pointer case the javadoc spells out. The identification is collected during the pass and
   reconciled after it, so the answer does not depend on whether the content record happens to sit on a page the
   walk had already left behind.

## Verification

New `Issue6196PlaceholderContentChainTest` (3 tests), all three red on `main` before the fix:

- `aPlaceholderWhoseContentSpilledIsScannedOnce` - the issue as reported: one copy in a scan, `surrogate=1` and
  `multiPage=1` in `check()`, and the head chunk invisible to `existsRecord` and to a direct load.
- `theContentChainKeepsItsMarkerThroughEveryRewrite` - large -> larger -> small -> large -> delete, with the
  marker and the copy count asserted at each step and the chain freed with the pointer at the end.
- `checkDatabaseFixRepairsALegacyAmbiguousContentRecord` - the marker byte is written back to `FIRST_CHUNK` to
  fabricate a pre-fix database, the duplicate is asserted to be there, `CHECK DATABASE` reports it,
  `CHECK DATABASE FIX` repairs it without deleting anything, and the duplicate is gone.

`Issue6178ChunkCollapseTest.aPlaceholderContentStoredAsAChainIsNeverCollapsed` asserted the bug deliberately
(with a pointer to #6196 saying so); that line now asserts one copy. `Issue5279ConcurrentUpdateTest`'s rebuilt
placeholder now proves the rebuild by the chunks it gained rather than by a `totalMultiPageRecords` that
correctly no longer counts it.

The whole `engine` module suite is green (`-DexcludedGroups=benchmark,vector,slow`).

## Follow-up

#6286: with the shape no longer ambiguous, the one transition still missing is the COLLAPSE of a content
record's chain back into a negated-size record when it shrinks inside its slot. The #6178 guard stays until
`collapseChunkChainToRecord` can write that marker.
