### PR TITLE
fix(#6281): an index build waits for the async BATCH, not just its tasks, and a flush backlog stays inside its own database

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2515,4 +2515,12 @@ The bound that *is* expressed in bytes remains `arcadedb.flushSuspendMaxDeferred
 or less, which used to fail at startup on `ArrayBlockingQueue`'s constructor, is now raised to 1: with
 admission as the only bound, a budget of 0 would refuse every publication for ever.
 
+**One published metric changed scale with it.** `pageFlushQueueLength` used to top out at `pageFlushQueue`,
+because the queue's capacity was that setting - so `pageFlushQueueLength >= pageFlushQueue` was a natural
+"the pipeline is full" alert. It is now a sum across every open database and can run to
+`pageFlushQueue x open databases`, which makes that comparison meaningless. The signal it used to carry is
+published alongside it as `pageFlushQueueMaxPerDatabase` (and as `flushQueueMaxPerDb` in the profiler dump):
+the busiest single database's share, which is exactly what `pageFlushQueue` bounds, so that is the one to
+alert on.
+
 [#6281](https://github.com/ArcadeData/arcadedb/issues/6281)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2234,3 +2234,60 @@ purpose ("more seeds than nodes" reads as "as many as exist" and is clamped to t
 nameless `NegativeArraySizeException`.
 
 [#6216](https://github.com/ArcadeData/arcadedb/issues/6216)
+
+## An index build waits for the async batch, not just for its tasks (#6281)
+
+`CREATE INDEX` builds by scanning the buckets, so everything the asynchronous executor was asked to write has
+to be committed before the scan starts. The guard that was supposed to ensure that read the wrong predicate:
+
+```java
+while (database.isAsyncProcessing())
+  database.async().waitCompletion();
+```
+
+`isAsyncProcessing()` answers about *tasks* - queued or executing. An async worker opens a transaction when it
+starts and keeps it open across up to `arcadedb.asyncTxBatchSize` (10240) tasks, so a worker whose queue has
+drained is still holding every record of the current batch **uncommitted**. On the runs where that predicate
+happened to answer `false` - which is a matter of thread scheduling, not of load - the guard was skipped
+entirely: the index was built by scanning a bucket that did not contain those records, and they committed
+afterwards with no entry ever added for them. The result was an index that is empty, readable, and reported
+healthy by `CHECK DATABASE`, while `SELECT ... WHERE id = ?` silently answered nothing for records that were
+there. Reproduced with 200 asynchronously inserted records: 0 index entries, 0 rows returned.
+
+The barrier is now unconditional. `waitCompletion()` is the only operation that closes the open batch - it
+enqueues a marker *behind* everything already submitted on every worker, and that marker commits - so there is
+no cheap predicate to test first, and testing one is what let the barrier be skipped. `isAsyncProcessing()` is
+deliberately left answering about tasks: broadening it to "a transaction is open" would make it permanently
+true for as long as the workers live. The same barrier now precedes `REBUILD INDEX`, whose scan sees the same
+partial view - there it does not lose index entries, since those records apply their own staged entries when
+they commit, but it does make the BM25 counters, the misplaced-record detection of #832 and the reported
+totals be about all of the data rather than about whatever happened to be committed.
+
+`ACIDTransactionTest.indexCreationWhileAsyncMustFail`, which existed to cover exactly this, had been vacuous
+for years: it expected a `NeedRetryException` from a creation that has drained the executor rather than
+refusing since long before this release, so its `catch` never fired and its only assertion was the record
+count - which an empty index satisfies just as well as a complete one. It now asserts the index.
+
+### The page-flush queue is bounded per database, not per JVM
+
+**Behaviour change worth checking if you run many databases in one JVM with a non-default
+`arcadedb.pageFlushQueue`.** That setting was a single JVM-wide queue capacity. #6259 moved the wait for room
+in it out of the page-manager lock, so a full queue stopped freezing every committer in the process - but the
+coupling itself survived: one database's write burst against a slow volume still consumed the admission budget
+of every other database, so a committer on an idle database on an idle volume waited for a disk it has nothing
+to do with.
+
+The budget is now per database, held as one count per database that covers a slot from the moment a committer
+reserves it to the moment the flush thread polls the batch it became. The shared queue keeps global FIFO order
+and carries no capacity of its own - one queue rather than one per database is what avoids having to invent a
+fairness policy for a flush thread choosing between queues on every poll.
+
+The trade-off, stated because it changes the shape of a memory ceiling: worst-case flush-pipeline occupancy is
+now `pageFlushQueue x open databases` batches rather than a flat `pageFlushQueue`. That is inherent to bounding
+per database, and the number being multiplied was never a byte bound to begin with - one batch is one
+transaction's dirty pages - but a deployment that sized `pageFlushQueue` against total heap should re-check it.
+The bound that *is* expressed in bytes remains `arcadedb.flushSuspendMaxDeferredRAM`. A `pageFlushQueue` of 0
+or less, which used to fail at startup on `ArrayBlockingQueue`'s constructor, is now raised to 1: with
+admission as the only bound, a budget of 0 would refuse every publication for ever.
+
+[#6281](https://github.com/ArcadeData/arcadedb/issues/6281)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2484,9 +2484,13 @@ enqueues a marker *behind* everything already submitted on every worker, and tha
 no cheap predicate to test first, and testing one is what let the barrier be skipped. `isAsyncProcessing()` is
 deliberately left answering about tasks: broadening it to "a transaction is open" would make it permanently
 true for as long as the workers live. The same barrier now precedes `REBUILD INDEX`, whose scan sees the same
-partial view - there it does not lose index entries, since those records apply their own staged entries when
-they commit, but it does make the BM25 counters, the misplaced-record detection of #832 and the reported
-totals be about all of the data rather than about whatever happened to be committed.
+partial view. The rebuild proper does not lose index entries there - those records apply their own staged
+entries when they commit - so what it gains is the misplaced-record detection of #832 and the reported totals
+being about all of the data. `REBUILD INDEX ... WITH statsOnly = true` was worse off and is the reason the
+barrier sits ahead of that branch rather than after it: it recomputes the BM25 corpus counters by scanning the
+type and then *overwrites* the counters with what the scan found, so run against an open batch it wrote "0
+documents" over counters the records had already bumped. A type holding 200 documents was left scoring every
+BM25 query against a corpus of zero, and unlike the index-entry case that did not heal itself.
 
 `ACIDTransactionTest.indexCreationWhileAsyncMustFail`, which existed to cover exactly this, had been vacuous
 for years: it expected a `NeedRetryException` from a creation that has drained the executor rather than

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2235,7 +2235,6 @@ nameless `NegativeArraySizeException`.
 
 [#6216](https://github.com/ArcadeData/arcadedb/issues/6216)
 
-
 ## A peer address that identifies nobody says so, instead of waiting for an operation to refuse (#6267)
 
 Five follow-ups from #6221 / #6226. Four are visible to an operator; the rest are test hygiene.
@@ -2379,7 +2378,6 @@ the page as the walk found it. Both agree again once the FIX has run.
 
 [#6196](https://github.com/ArcadeData/arcadedb/issues/6196)
 
-
 ## The whole working set of a graph-algorithm call is budgeted, not just its walk buffers (#6263)
 
 Follow-up to #6216, which introduced a heap budget for the random-walk buffers of `algo.node2vec` and
@@ -2492,6 +2490,14 @@ type and then *overwrites* the counters with what the scan found, so run against
 documents" over counters the records had already bumped. A type holding 200 documents was left scoring every
 BM25 query against a corpus of zero, and unlike the index-entry case that did not heal itself.
 
+**One refusal is new.** `CREATE INDEX`, a manual index create and `REBUILD INDEX` now raise a
+`NeedRetryException` when they run on one of the async executor's own worker threads - a command dispatched
+over HTTP with `awaitResponse=false`, for instance. The barrier cannot be satisfied from inside the thing it
+waits for: it enqueues a marker on every worker including the caller's own, and the only consumer of a
+worker's queue is that worker, so it would park for ever. `REBUILD INDEX` has refused this since #2097 and
+keeps its own message; what is new is that `CREATE INDEX` and the manual index builder refuse it too, where
+before they hung. Run the command synchronously instead.
+
 `ACIDTransactionTest.indexCreationWhileAsyncMustFail`, which existed to cover exactly this, had been vacuous
 for years: it expected a `NeedRetryException` from a creation that has drained the executor rather than
 refusing since long before this release, so its `catch` never fired and its only assertion was the record
@@ -2518,6 +2524,14 @@ transaction's dirty pages - but a deployment that sized `pageFlushQueue` against
 The bound that *is* expressed in bytes remains `arcadedb.flushSuspendMaxDeferredRAM`. A `pageFlushQueue` of 0
 or less, which used to fail at startup on `ArrayBlockingQueue`'s constructor, is now raised to 1: with
 admission as the only bound, a budget of 0 would refuse every publication for ever.
+
+One consequence worth knowing about if you run many databases that saturate their budgets at the same time:
+the committers waiting for room all park on a single shared monitor, so every batch the flush thread polls
+wakes all of them and each re-checks its own database's count before parking again. That is a deliberate
+trade - a monitor per database would move a map lookup onto the poll path, which runs per batch, to save work
+on the wait path, which only runs for a database already at its bound - and it is the same shape as the
+existing deferred-RAM cap. It is a different failure mode from the old single-queue design, though, so it is
+named here rather than left to be discovered.
 
 **One published metric changed scale with it.** `pageFlushQueueLength` used to top out at `pageFlushQueue`,
 because the queue's capacity was that setting - so `pageFlushQueueLength >= pageFlushQueue` was a natural

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -472,10 +472,10 @@ public enum GlobalConfiguration {
       """
       Maximum number of page batches EACH database may have waiting in the asynchronous flush pipeline. A committer of \
       a database that has reached it waits - before taking the page-manager lock, never inside it - until one of that \
-      database's own batches is written; the committers of every other database are admitted straight through. Was a \
-      single JVM-wide bound until issue #6281, which made one database's write burst against a slow volume throttle \
-      the commits of unrelated databases on idle ones. Values below 1 are raised to 1: since #6281 this is the only \
-      bound on the pipeline, so a budget of 0 would refuse every publication for ever.\
+      database's own batches is written; the committers of every other database are admitted straight through. This \
+      was a single JVM-wide bound before issue #6281, which is what let one database's write burst against a slow \
+      volume throttle the commits of unrelated databases on idle ones. Values below 1 are raised to 1: this is now \
+      the only bound on the pipeline, so a budget of 0 would refuse every publication for ever.\
       """, Integer.class, 512),
 
   FLUSH_SUSPEND_MAX_DEFERRED_RAM("arcadedb.flushSuspendMaxDeferredRAM", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -468,7 +468,14 @@ public enum GlobalConfiguration {
       spanning several pages). Leave headroom when picking a value close to the replicated-entry limit.""",
       Integer.class, 256),
 
-  PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE, "Size of the asynchronous page flush queue", Integer.class, 512),
+  PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE,
+      """
+      Maximum number of page batches EACH database may have waiting in the asynchronous flush pipeline. A committer of \
+      a database that has reached it waits - before taking the page-manager lock, never inside it - until one of that \
+      database's own batches is written; the committers of every other database are admitted straight through. Was a \
+      single JVM-wide bound until issue #6281, which made one database's write burst against a slow volume throttle \
+      the commits of unrelated databases on idle ones.\
+      """, Integer.class, 512),
 
   FLUSH_SUSPEND_MAX_DEFERRED_RAM("arcadedb.flushSuspendMaxDeferredRAM", SCOPE.DATABASE,
       """

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -474,7 +474,8 @@ public enum GlobalConfiguration {
       a database that has reached it waits - before taking the page-manager lock, never inside it - until one of that \
       database's own batches is written; the committers of every other database are admitted straight through. Was a \
       single JVM-wide bound until issue #6281, which made one database's write burst against a slow volume throttle \
-      the commits of unrelated databases on idle ones.\
+      the commits of unrelated databases on idle ones. Values below 1 are raised to 1: since #6281 this is the only \
+      bound on the pipeline, so a budget of 0 would refuse every publication for ever.\
       """, Integer.class, 512),
 
   FLUSH_SUSPEND_MAX_DEFERRED_RAM("arcadedb.flushSuspendMaxDeferredRAM", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -268,6 +268,9 @@ public class Profiler {
     json.put("pagesReadSize", new JSONObject().put("space", pagesReadSize));
     json.put("pagesWrittenSize", new JSONObject().put("space", pagesWrittenSize));
     json.put("pageFlushQueueLength", new JSONObject().put("value", pageFlushQueueLength));
+    // The per-database companion (#6281): pageFlushQueueLength is a sum across databases and no longer comparable
+    // with arcadedb.pageFlushQueue, while this one is exactly what that setting bounds.
+    json.put("pageFlushQueueMaxPerDatabase", new JSONObject().put("value", pStats.pageFlushQueueMaxPerDatabase));
     json.put("asyncQueueLength", new JSONObject().put("value", asyncQueueLength));
     json.put("asyncParallelLevel", new JSONObject().put("count", asyncParallelLevel));
     json.put("pageCacheHits", new JSONObject().put("count", pageCacheHits));
@@ -498,8 +501,8 @@ public class Profiler {
       buffer.append("%n INDEXES compactions=%d".formatted(indexCompactions));
 
       buffer.append(
-        "%n PAGE-MANAGER flushQueue=%d flushQueueWaits=%d deferredRAM=%s cacheHits=%d cacheMiss=%d concModExceptions=%d evictionRuns=%d pagesEvicted=%d".formatted(
-          pageFlushQueueLength, pStats.flushQueueWaits, FileUtils.getSizeAsString(pStats.deferredRAMBytes),
+        "%n PAGE-MANAGER flushQueue=%d flushQueueMaxPerDb=%d flushQueueWaits=%d deferredRAM=%s cacheHits=%d cacheMiss=%d concModExceptions=%d evictionRuns=%d pagesEvicted=%d".formatted(
+          pageFlushQueueLength, pStats.pageFlushQueueMaxPerDatabase, pStats.flushQueueWaits, FileUtils.getSizeAsString(pStats.deferredRAMBytes),
           pageCacheHits, pageCacheMiss, concurrentModificationExceptions, evictionRuns, pagesEvicted));
 
       // #5608: read this line together with concModExceptions above. Contention absorbed by a merge never becomes a

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -123,6 +123,10 @@ public interface DatabaseInternal extends Database {
    * {@link #isAsyncProcessing()} instead is not equivalent, and that was the bug of issue #6281: the predicate answers
    * about TASKS, and the tasks of a batch are all long finished while their records are still uncommitted, so an index
    * built on the strength of a {@code false} there was built over a bucket that did not contain them yet.
+   *
+   * @throws com.arcadedb.exception.NeedRetryException when called from one of the executor's OWN worker threads - a
+   *     command dispatched with {@code awaitResponse=false}, for instance. The wait cannot be satisfied from inside
+   *     the thing it waits for, so it is refused rather than deadlocked on; run the command synchronously instead.
    */
   void waitForAsyncCompletion();
 

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -113,6 +113,19 @@ public interface DatabaseInternal extends Database {
 
   boolean isAsyncProcessing();
 
+  /**
+   * Barrier against the asynchronous executor: returns only once every task already submitted has run <b>and</b> the
+   * batch transaction each worker keeps open across {@link com.arcadedb.GlobalConfiguration#ASYNC_TX_BATCH_SIZE} tasks
+   * has been committed. Does nothing - and in particular does not start the executor - on a database that never used
+   * it.
+   * <p>
+   * This is what a caller that needs to <i>read</i> what the async side wrote has to use. Polling
+   * {@link #isAsyncProcessing()} instead is not equivalent, and that was the bug of issue #6281: the predicate answers
+   * about TASKS, and the tasks of a batch are all long finished while their records are still uncommitted, so an index
+   * built on the strength of a {@code false} there was built over a bucket that did not contain them yet.
+   */
+  void waitForAsyncCompletion();
+
   long getResultSetLimit();
 
   long getReadTimeout();

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -455,6 +455,21 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     if (executor == null)
       return;
 
+    // REFUSED, not attempted, when the caller is one of the executor's own workers. waitCompletion() enqueues a
+    // marker on every worker - this thread's own included - and blocks until each has run, and the only consumer of
+    // a worker's queue is that worker: it would park on a marker nobody can dequeue and be lost for the life of the
+    // process. There is no honest alternative to refusing, either. Silently skipping the wait would put back exactly
+    // the bug this barrier exists to close, over the caller's OWN uncommitted batch; committing that batch here would
+    // commit the enclosing task's writes mid-task, which is the per-task atomicity AsyncThread.executeTask guards.
+    //
+    // NeedRetryException, and worded like it, because that is what RebuildIndexStatement.buildIndex already threw for
+    // this exact situation (issue #2097) - the guard now lives once, on the operation that cannot be satisfied,
+    // instead of once per call site that happens to remember it.
+    if (executor.isCurrentThreadOneOfMyWorkers())
+      throw new NeedRetryException(
+          "Cannot wait for the asynchronous executor of database '" + name + "' from one of its own worker threads: "
+              + "the wait would never end. Run this command synchronously (awaitResponse=true) instead");
+
     // Unconditional, and that is the whole point (issue #6281). isProcessing() is not a precondition that can be
     // tested first: a worker keeps ONE transaction open across up to ASYNC_TX_BATCH_SIZE tasks, so an executor whose
     // queues are drained and whose workers are parked can still be holding thousands of uncommitted records.
@@ -463,6 +478,11 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // The loop then covers what a single pass cannot: tasks submitted by OTHER threads while this one was waiting.
     do {
       executor.waitCompletion();
+      // waitCompletion() answers an interrupt by restoring the flag and returning, so without this the loop would
+      // spin: every further pass would be interrupted at its first queue offer and come straight back. The caller's
+      // cancellation is left on the thread for it to observe.
+      if (Thread.currentThread().isInterrupted())
+        return;
     } while (isAsyncProcessing());
   }
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -446,6 +446,11 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   public void waitForAsyncCompletion() {
     // Read the field, never async(): that accessor CREATES the executor - worker threads included - and a database
     // that never used async must not grow a thread pool just because somebody asked whether it was idle.
+    //
+    // And read it WITHOUT asyncLock, unlike isAsyncProcessing() one method up. That lock exists to serialize the
+    // lazy creation in async(); the field is volatile and, once assigned, is never assigned again - not even on
+    // close - so the only two values this read can see are "no executor yet" and "the one and only executor". A
+    // lock here would buy nothing and would be held across a blocking wait.
     final DatabaseAsyncExecutorImpl executor = async;
     if (executor == null)
       return;

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -442,6 +442,25 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     return false;
   }
 
+  @Override
+  public void waitForAsyncCompletion() {
+    // Read the field, never async(): that accessor CREATES the executor - worker threads included - and a database
+    // that never used async must not grow a thread pool just because somebody asked whether it was idle.
+    final DatabaseAsyncExecutorImpl executor = async;
+    if (executor == null)
+      return;
+
+    // Unconditional, and that is the whole point (issue #6281). isProcessing() is not a precondition that can be
+    // tested first: a worker keeps ONE transaction open across up to ASYNC_TX_BATCH_SIZE tasks, so an executor whose
+    // queues are drained and whose workers are parked can still be holding thousands of uncommitted records.
+    // waitCompletion() is the only operation that closes that batch - it enqueues a marker BEHIND everything already
+    // submitted on every worker and that marker commits - so it has to run even when the executor looks idle.
+    // The loop then covers what a single pass cannot: tasks submitted by OTHER threads while this one was waiting.
+    do {
+      executor.waitCompletion();
+    } while (isAsyncProcessing());
+  }
+
   public DatabaseAsyncExecutor async() {
     if (async == null) {
       asyncLock.lock();

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1341,6 +1341,19 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   }
 
   /**
+   * Whether the calling thread is one of THIS executor's own workers.
+   * <p>
+   * The question {@link #waitCompletion()} cannot survive being asked from inside the executor: it enqueues a marker
+   * on every worker - the caller's own included - and then blocks until each one has run, and the only consumer of a
+   * worker's queue is that worker. A worker that calls it parks on a marker nobody can ever dequeue, and is lost for
+   * the life of the process (issue #6281 review). Same test as {@code offerWaiting}'s: the owner check matters
+   * because a second database's workers are threads of the same class but not of this executor.
+   */
+  public boolean isCurrentThreadOneOfMyWorkers() {
+    return Thread.currentThread() instanceof AsyncThread worker && worker.getOwner() == this;
+  }
+
+  /**
    * Whether any worker still has a TASK queued or in execution.
    * <p>
    * <b>Not a durability predicate, and never usable as one</b> (issue #6281): a worker opens a transaction when it

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1340,6 +1340,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     return (value & 0x7fffffff) % threads.length;
   }
 
+  /**
+   * Whether any worker still has a TASK queued or in execution.
+   * <p>
+   * <b>Not a durability predicate, and never usable as one</b> (issue #6281): a worker opens a transaction when it
+   * starts and keeps it open across up to {@link GlobalConfiguration#ASYNC_TX_BATCH_SIZE} tasks, so {@code false} here
+   * means only that the tasks have RUN - their records can still be sitting uncommitted in that batch, invisible to
+   * every reader. A caller that needs to read what the async side wrote must use
+   * {@link com.arcadedb.database.DatabaseInternal#waitForAsyncCompletion()}, which enqueues a marker behind everything
+   * already submitted and commits the batch. Deliberately left answering about tasks only: broadening it to "a
+   * transaction is open" would make it permanently true for as long as the workers are alive, which is no answer at
+   * all.
+   */
   @Override
   public boolean isProcessing() {
     final AsyncThread[] threads = executorThreads;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -186,7 +186,21 @@ public class PageManager extends LockContext {
     public long pagesReadSize;
     public long pagesWritten;
     public long pagesWrittenSize;
+    /**
+     * Batches waiting in the flush pipeline across EVERY open database. Its scale changed with issue #6281: until
+     * then the queue was capacity-bound to {@code arcadedb.pageFlushQueue}, so this reaching that value meant "the
+     * pipeline is full". The bound is now per database, so this is a sum and can reach
+     * {@code pageFlushQueue x open databases}. An alert comparing it against {@code pageFlushQueue} therefore no
+     * longer says what it used to - {@link #pageFlushQueueMaxPerDatabase} is the number that still does.
+     */
     public int  pageFlushQueueLength;
+    /**
+     * The busiest single database's share of that pipeline - reserved by a committer or occupied by its batch - which
+     * is what {@code arcadedb.pageFlushQueue} actually bounds since issue #6281. This reaching the configured value
+     * is the "a database is at its bound, and its committers are being held" signal that
+     * {@link #pageFlushQueueLength} used to carry, and it is the one to alert on.
+     */
+    public int  pageFlushQueueMaxPerDatabase;
     public long cacheHits;
     public long cacheMiss;
     public long concurrentModificationExceptions;
@@ -1354,6 +1368,7 @@ public class PageManager extends LockContext {
     stats.pagesWritten = totalPagesWritten.get();
     stats.pagesWrittenSize = totalPagesWrittenSize.get();
     stats.pageFlushQueueLength = flushThread != null ? flushThread.queue.size() : 0;
+    stats.pageFlushQueueMaxPerDatabase = flushThread != null ? flushThread.maxSlotsUsedByAnyDatabase() : 0;
     stats.cacheHits = cacheHits.get();
     stats.cacheMiss = cacheMiss.get();
     stats.concurrentModificationExceptions = totalConcurrentModificationExceptions.get();

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1229,7 +1229,7 @@ public class PageManager extends LockContext {
         // between them that throws, which is exactly the refactor that would otherwise strand a reservation. And a
         // stranded one is silent and permanent: the flush pipeline is one slot smaller for the life of the process,
         // with nothing in a running system ever pointing at it (review of #6269).
-        releaseFlushQueueSlot();
+        releaseFlushQueueSlot(pagesToWrite);
     }
   }
 
@@ -1449,9 +1449,9 @@ public class PageManager extends LockContext {
    * {@link #writePages} without the two waits that must be served before the page-manager lock, for the caller that
    * has already served them: {@link #publishPages} (issues #6200 and #6259).
    *
-   * @param flushSlotReserved a flush-queue reservation taken by the caller before it took the lock. This method owns
-   *                          it from here on - handing it to the enqueue, or giving it back on any path that does not
-   *                          reach one - so the caller must not release it again.
+   * @param flushSlotReserved a flush-pipeline slot taken by the caller, on the pages' own database's budget, before it
+   *                          took the lock. This method owns it from here on - handing it to the enqueue, or giving it
+   *                          back on any path that does not reach one - so the caller must not release it again.
    */
   private void writePagesNoBackpressure(final List<MutablePage> updatedPages, final boolean asyncFlush,
       final boolean flushSlotReserved) throws IOException, InterruptedException {
@@ -1461,7 +1461,8 @@ public class PageManager extends LockContext {
         for (final MutablePage page : updatedPages)
           putPageInReadCache(new CachedPage(page, true));
         handedOver = true;
-        flushThread.scheduleFlushOfPages(updatedPages, flushSlotReserved);
+        flushThread.scheduleFlushOfPages(updatedPages,
+            flushSlotReserved ? updatedPages.getFirst().getPageId().getDatabase() : null);
       } else {
         // SYNCHRONOUS FLUSH
         for (final MutablePage page : updatedPages) {
@@ -1475,14 +1476,15 @@ public class PageManager extends LockContext {
         // The read-cache loop above threw, or anything a later refactor puts before the hand-off does: the enqueue
         // was never reached, so the slot goes back rather than being held by a publication that is not going to
         // happen. Unlike its twin in publishPages this one IS reachable today - putPageInReadCache does I/O.
-        releaseFlushQueueSlot();
+        releaseFlushQueueSlot(updatedPages);
     }
   }
 
   /**
    * Reserves the flush-queue slot the enqueue inside the page-manager lock will need, waiting HERE - outside that
    * lock - for as long as the queue is full (issue #6259). See
-   * {@link PageManagerFlushThread#reserveQueueSlot()} for why the wait cannot live where the enqueue does.
+   * {@link PageManagerFlushThread#reserveQueueSlot(com.arcadedb.database.BasicDatabase)} for why the wait cannot live
+   * where the enqueue does, and why the budget it draws on is the batch's own database's (issue #6281).
    *
    * @return {@code false} when there is nothing to enqueue, or when the flush thread is shutting down: either way no
    *     reservation is held and none has to be released.
@@ -1491,7 +1493,7 @@ public class PageManager extends LockContext {
     final PageManagerFlushThread thread = flushThread;
     if (thread == null || pages == null || pages.isEmpty())
       return false;
-    return thread.reserveQueueSlot();
+    return thread.reserveQueueSlot(pages.getFirst().getPageId().getDatabase());
   }
 
   /**
@@ -1500,10 +1502,10 @@ public class PageManager extends LockContext {
    * window, which needs every database in the JVM to have been closed mid-publication - and would have thrown at the
    * enqueue long before reaching this.
    */
-  private void releaseFlushQueueSlot() {
+  private void releaseFlushQueueSlot(final List<MutablePage> pages) {
     final PageManagerFlushThread thread = flushThread;
-    if (thread != null)
-      thread.releaseQueueReservation(false);
+    if (thread != null && pages != null && !pages.isEmpty())
+      thread.releaseQueueReservation(pages.getFirst().getPageId().getDatabase());
   }
 
   protected void flushPage(final MutablePage page) throws IOException {

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -72,8 +72,15 @@ public class PageManagerFlushThread extends Thread {
    * writes hard on all of them at once should lower {@code arcadedb.pageFlushQueue} accordingly; the bound that IS
    * expressed in bytes, and the one to reach for when heap is the concern, is
    * {@code arcadedb.flushSuspendMaxDeferredRAM}.
+   * <p>
+   * <b>Package-private, where it used to be public.</b> While the queue carried the capacity a direct
+   * {@code queue.offer} was merely impolite; now that admission is the only bound and {@link #offerBatch} is the one
+   * place a slot is charged, a direct offer silently bypasses the accounting - which is exactly what several
+   * white-box tests were doing before this issue swept them. Narrowing the field makes that a compile error outside
+   * this package instead of a discipline to remember. Nothing outside needed it: {@code PageManager} is in this
+   * package too, and the depth reaches operators through {@code PPageManagerStats}.
    */
-  public final         LinkedBlockingQueue<PagesToFlush>                        queue               = new LinkedBlockingQueue<>();
+  final                LinkedBlockingQueue<PagesToFlush>                        queue               = new LinkedBlockingQueue<>();
   private final        String                                                   logContext;
   private volatile     boolean                                                  running             = true;
   // Per-database suspension REFCOUNT (issue #5068): flushing is suspended while the count is > 0. Backup,
@@ -274,6 +281,22 @@ public class PageManagerFlushThread extends Thread {
   public static class PagesToFlush {
     public final BasicDatabase     database;
     public final List<MutablePage> pages;
+    /**
+     * The very counter of {@link #slotsInUse} this batch's slot was taken from, captured when the batch entered the
+     * queue and used to give that slot back when it leaves (issue #6281 review, round 9).
+     * <p>
+     * A reference and not a second map lookup, because the lookup would not be asking the same question by then.
+     * {@code LocalDatabase} defines equality by DATABASE PATH, not by instance, so a batch of a database that has
+     * since been closed resolves - through its stale {@code database} field - to whatever entry is keyed at that
+     * path NOW. A database dropped and recreated at the same path (a restore, a re-provision, any number of tests)
+     * would therefore have the NEW instance's budget decremented for a batch that was never charged against it:
+     * assertion failure in the test lanes, and silent admission drift with assertions off. Holding the counter
+     * removes the question - the release goes to the number the charge came from, whatever the map says later.
+     * <p>
+     * Plain field, no volatile: it is written before {@code queue.offer} and read after {@code queue.poll}, and a
+     * {@link BlockingQueue} establishes happens-before between the two.
+     */
+    private AtomicInteger slotCharged;
 
     public PagesToFlush(final List<MutablePage> pages) {
       // removeAllPagesOfDatabase()/removePagesOfFileFromBatch() mutate this list (clear()/it.remove()) when a
@@ -411,8 +434,15 @@ public class PageManagerFlushThread extends Thread {
    *                 {@code false} charges one here instead, for a caller that never reserved.
    */
   void offerBatch(final PagesToFlush batch, final boolean slotHeld) {
-    if (!slotHeld && batch.database != null)
-      slotsInUse.computeIfAbsent(batch.database, k -> new AtomicInteger()).incrementAndGet();
+    if (batch.database != null) {
+      // Resolved ONCE, here, and carried by the batch from now on - see PagesToFlush.slotCharged for why the release
+      // side must not ask the map again. Safe to resolve here and not at reservation time: the two happen within one
+      // publication of a database that is by definition still open, so this is the same counter the reservation
+      // incremented; what is not safe is resolving it after the batch has sat in the queue across a close.
+      batch.slotCharged = slotsInUse.computeIfAbsent(batch.database, k -> new AtomicInteger());
+      if (!slotHeld)
+        batch.slotCharged.incrementAndGet();
+    }
     // The queue is unbounded (the bound is admission), so this never blocks and never returns false.
     queue.offer(batch);
   }
@@ -537,16 +567,20 @@ public class PageManagerFlushThread extends Thread {
     signalQueueSlotAvailable();
   }
 
-  /** Releases the slot a batch occupied from the moment it was reserved to the moment it left {@link #queue}. */
+  /**
+   * Releases the slot a batch occupied from the moment it was reserved to the moment it left {@link #queue}, giving
+   * it back to the exact counter it was taken from rather than to whatever {@link #slotsInUse} holds for that path
+   * now (see {@link PagesToFlush#slotCharged}).
+   */
   private void releaseSlotOfPolledBatch(final PagesToFlush batch) {
-    if (batch.database == null)
-      return;
-    final AtomicInteger slots = slotsInUse.get(batch.database);
+    final AtomicInteger slots = batch.slotCharged;
     if (slots == null)
+      // The shutdown sentinel, or a batch that reached the queue without going through offerBatch: neither was
+      // charged, so neither has anything to give back.
       return;
     final int remaining = slots.decrementAndGet();
-    assert remaining >= 0 :
-        "flush-queue slots of database '" + batch.database.getName() + "' went negative (" + remaining + ")";
+    assert remaining >= 0 : "flush-queue slots of database '" + (batch.database != null ? batch.database.getName() : "?")
+        + "' went negative (" + remaining + ")";
   }
 
   /**
@@ -1401,12 +1435,19 @@ public class PageManagerFlushThread extends Thread {
 
   public void removeAllPagesOfDatabase(final Database database) {
     for (final PagesToFlush pagesToFlush : queue.stream().toList())
-      if (database.equals(pagesToFlush.database))
+      if (database.equals(pagesToFlush.database)) {
         synchronized (pagesToFlush.pages) {
           for (final MutablePage page : pagesToFlush.pages)
             pageIndex.remove(page.getPageId());
           pagesToFlush.pages.clear();
         }
+        // And take the emptied wrapper OUT of the queue rather than leaving it to be polled and skipped. It carries
+        // no pages any more, so the poll would do nothing but release its slot - and by then this database's budget
+        // is gone and, since databases compare by PATH, a database reopened at the same path in the meantime would
+        // be the one that resolved. Removing it here is what makes that window not exist rather than merely
+        // survivable (issue #6281 review, round 9; the slot it held goes with the budget dropped below).
+        queue.remove(pagesToFlush);
+      }
 
     // Also clean index entries for pages currently being flushed, and forget the database's pending count with them
     pageIndex.removeAllOfDatabase(database);

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -318,6 +318,11 @@ public class PageManagerFlushThread extends Thread {
     setDaemon(true);
     this.pageManager = pageManager;
     this.logContext = LogManager.instance().getContext();
+    // Clamped, where `new ArrayBlockingQueue(queueCapacity)` used to throw IllegalArgumentException on a
+    // non-positive setting. Deliberate rather than an oversight: with admission as the only bound, a capacity of 0
+    // would refuse EVERY publication for ever - an unrecoverable hang instead of a startup failure - and the queue no
+    // longer takes a capacity argument that would reject it on the way in. One is the smallest budget that still
+    // makes progress. See the PAGE_FLUSH_QUEUE javadoc.
     this.queueCapacity = Math.max(1, configuration.getValueAsInteger(GlobalConfiguration.PAGE_FLUSH_QUEUE));
     final long maxDeferredMB = configuration.getValueAsLong(GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM);
     this.maxDeferredRAM = maxDeferredMB > 0 ? maxDeferredMB * 1024 * 1024 : 0;

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -549,6 +549,18 @@ public class PageManagerFlushThread extends Thread {
         "flush-queue slots of database '" + batch.database.getName() + "' went negative (" + remaining + ")";
   }
 
+  /**
+   * The busiest database's slot count: what {@code arcadedb.pageFlushQueue} bounds, and therefore the number an
+   * operator can still compare against that setting now that {@code pageFlushQueueLength} is a sum across databases
+   * (issue #6281). O(open databases), read once per stats scrape and never on a write path.
+   */
+  int maxSlotsUsedByAnyDatabase() {
+    int max = 0;
+    for (final AtomicInteger slots : slotsInUse.values())
+      max = Math.max(max, slots.get());
+    return max;
+  }
+
   /** How many pipeline slots a database is currently using (reserved or queued). Package-private for the tests. */
   int slotsUsedBy(final BasicDatabase database) {
     if (database == null)

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -1503,10 +1503,11 @@ public class PageManagerFlushThread extends Thread {
       final MutablePage indexed = pageIndex.remove(pageId);
       final List<MutablePage> detached = new ArrayList<>(1);
 
-      // Iterated directly rather than through a snapshot: ArrayBlockingQueue's iterator is weakly consistent and
+      // Iterated directly rather than through a snapshot: LinkedBlockingQueue's iterator is weakly consistent and
       // never throws ConcurrentModificationException, and this runs per replayed page, so the copy would be pure
-      // overhead. The walk is bounded by the flush queue depth (arcadedb.pageFlushQueue) plus the deferred backlog,
-      // which is itself capped by arcadedb.flushSuspendMaxDeferredRAM.
+      // overhead. The walk is bounded by the pipeline depth - since #6281 that is arcadedb.pageFlushQueue times the
+      // number of OPEN DATABASES, the queue itself no longer carrying a capacity - plus the deferred backlog, which
+      // is itself capped by arcadedb.flushSuspendMaxDeferredRAM.
       for (final PagesToFlush batch : queue)
         removePagesOfPageIdFromBatch(batch, pageId, detached);
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -49,7 +49,31 @@ import java.util.logging.Level;
  */
 public class PageManagerFlushThread extends Thread {
   private final        PageManager                                              pageManager;
-  public final         ArrayBlockingQueue<PagesToFlush>                         queue;
+  /**
+   * The single ordering queue of the flush pipeline, and deliberately NOT the thing that bounds it (issue #6281).
+   * <p>
+   * It used to be an {@code ArrayBlockingQueue} sized to {@code arcadedb.pageFlushQueue}, which made that setting a
+   * JVM-WIDE ceiling: one database's write burst filled it and the committers of every other database in the process
+   * then queued behind a disk they have nothing to do with. #6259 took that wait out of the page-manager lock, so the
+   * stall stopped being global-with-a-lock-held, but the coupling itself survived - an idle database still had to wait
+   * for a busy one's backlog to drain before it could publish a page.
+   * <p>
+   * The bound now lives entirely in {@link #slotsInUse}, per database, so the physical occupancy here is the SUM of
+   * the per-database bounds and the queue itself needs no capacity of its own. Keeping one queue rather than one per
+   * database is what preserves global FIFO order across databases for free: a per-database queue would need the flush
+   * thread to choose between them on every poll, which is a fairness policy - and a starvation risk - that this
+   * design simply does not have.
+   * <p>
+   * <b>The stated cost:</b> the worst-case occupancy is now {@code pageFlushQueue x open databases} batches rather
+   * than {@code pageFlushQueue}, and a batch holds deep copies of its pages (see {@link CachedPage}), so they are real
+   * heap. That is inherent to bounding per database - a per-database queue multiplies by exactly the same factor - and
+   * the number being multiplied was never a byte bound to begin with: one batch is one transaction's dirty pages, so
+   * 512 of them was already anywhere between 512 pages and half a million. A process running many databases that
+   * writes hard on all of them at once should lower {@code arcadedb.pageFlushQueue} accordingly; the bound that IS
+   * expressed in bytes, and the one to reach for when heap is the concern, is
+   * {@code arcadedb.flushSuspendMaxDeferredRAM}.
+   */
+  public final         LinkedBlockingQueue<PagesToFlush>                        queue               = new LinkedBlockingQueue<>();
   private final        String                                                   logContext;
   private volatile     boolean                                                  running             = true;
   // Per-database suspension REFCOUNT (issue #5068): flushing is suspended while the count is > 0. Backup,
@@ -133,39 +157,57 @@ public class PageManagerFlushThread extends Thread {
    */
   private final        long                                   maxDeferredRAM;
 
-  /** Capacity of {@link #queue}, the ceiling the admission control of {@link #reserveQueueSlot} enforces (#6259). */
+  /**
+   * How many batches ONE database may have in the flush pipeline at once - the ceiling
+   * {@link #reserveQueueSlot(BasicDatabase)} enforces, per database since #6281 and JVM-wide before it.
+   */
   private final        int                                    queueCapacity;
 
   /**
-   * Slots of {@link #queue} promised to a caller that has not enqueued its batch yet (issue #6259).
+   * Pipeline slots each database is using: reserved by a committer that has not enqueued yet, or occupied by a batch
+   * of that database sitting in {@link #queue}. One number for both halves, and the ONLY bound on the pipeline
+   * (issues #6259 and #6281).
    * <p>
-   * A reservation is what lets {@code PageManager.publishPages} wait for queue room BEFORE taking the JVM-wide
-   * page-manager lock and still find the room when it enqueues one line later, inside it. Admission is granted only
-   * while {@code queue.size() + reservations < queueCapacity}, so the sum never exceeds the capacity and the holder
-   * of a reservation is guaranteed a free slot: its {@code offer} inside the lock cannot block.
+   * <b>Reserving is what lets {@code PageManager.publishPages} wait for room BEFORE taking the JVM-wide page-manager
+   * lock</b> and still find that room when it enqueues one line later, inside it (#6259). Admission is granted only
+   * while a database's count is below {@link #queueCapacity}, so the holder of a reservation is guaranteed a slot and
+   * its {@code offer} inside the lock cannot block.
    * <p>
-   * Deliberately derived from the QUEUE'S OWN size rather than from a permit counter mirroring it (a
-   * {@link java.util.concurrent.Semaphore} sized to the capacity was the obvious alternative). A permit count has to
-   * be kept in step with the queue by hand at every enqueue and every poll, and a single missed release silently
-   * shrinks the pipeline for the life of the process; reading the queue tells the truth by construction, so a batch
-   * that reaches the queue by any other route - a white-box test, a future call site - narrows admission instead of
-   * corrupting the bound. The cost is one {@code ArrayBlockingQueue.size()} per publication, which takes the same
-   * internal lock the {@code offer} on the next line takes anyway.
+   * <b>And keying it by database is what stops one database's backlog from being another's problem</b> (#6281). The
+   * count is bumped at reservation and dropped only when the batch LEAVES the queue, so a reservation and the batch it
+   * becomes are one continuous occupancy rather than two counters that have to agree.
    * <p>
-   * Package-private so the regression test of #6259 can assert the one thing inspection cannot: that every path out
-   * of a publication gives its reservation back. A leaked one is invisible and permanent - it shrinks the pipeline
-   * by a slot for the life of the process.
+   * This replaces {@code queue.size() + reservations} against a physically bounded queue. That form read the truth off
+   * the queue by construction, which is a property worth naming since it is the one given up here: an
+   * {@code ArrayBlockingQueue} cannot say how many of its elements belong to database D, so per-database admission has
+   * to be counted by hand. It is kept honest by routing EVERY enqueue through {@link #offerBatch} and every poll
+   * through the single decrement in {@link #flushPagesFromQueueToDisk}, and by asserting the count never goes
+   * negative - a drift the other way (a leaked slot) is what {@code noPathLeavesAReservationBehind} exists to catch.
+   * <p>
+   * Package-private so the regression tests of #6259 and #6281 can assert the one thing inspection cannot: that every
+   * path out of a publication gives its slot back. A leaked one is invisible and permanent - it shrinks that
+   * database's pipeline for as long as it stays open.
    */
-  final                AtomicInteger                          queueReservations = new AtomicInteger();
+  final ConcurrentHashMap<BasicDatabase, AtomicInteger> slotsInUse = new ConcurrentHashMap<>();
 
   /**
-   * How many callers are parked in {@link #reserveQueueSlot}. Read (not taken) by the flush thread on every poll, so
-   * the common case - nobody waiting, the queue nowhere near full - costs one volatile read per batch instead of a
-   * monitor. Same shape as the drain signal of #6199.
+   * How many callers are parked in {@link #reserveQueueSlot(BasicDatabase)}. Read (not taken) by the flush thread on
+   * every poll, so the common case - nobody waiting, no database anywhere near its bound - costs one volatile read per
+   * batch instead of a monitor. Same shape as the drain signal of #6199.
    */
   private final        AtomicInteger                          queueSlotWaiters  = new AtomicInteger();
 
-  /** Monitor the callers of {@link #reserveQueueSlot} park on; notified whenever a batch leaves {@link #queue}. */
+  /**
+   * Monitor the callers of {@link #reserveQueueSlot(BasicDatabase)} park on; notified whenever a batch leaves
+   * {@link #queue}.
+   * <p>
+   * ONE monitor for every database, not one per database, even though admission is per-database since #6281: a woken
+   * committer re-reads its OWN database's count and parks again if the freed slot was not for it. The alternative - a
+   * monitor per database - would spare those spurious wake-ups at the cost of a map lookup on the poll path, which
+   * runs per batch, to save work on the wait path, which by construction only runs when a database is already at its
+   * bound and therefore already slower than everything else. Same trade, and the same "the herd is bounded by
+   * construction" argument, as {@link #deferredRAMLock}.
+   */
   private final        Object                                 queueSlotLock     = new Object();
 
   /**
@@ -276,8 +318,7 @@ public class PageManagerFlushThread extends Thread {
     setDaemon(true);
     this.pageManager = pageManager;
     this.logContext = LogManager.instance().getContext();
-    this.queueCapacity = configuration.getValueAsInteger(GlobalConfiguration.PAGE_FLUSH_QUEUE);
-    this.queue = new ArrayBlockingQueue<>(queueCapacity);
+    this.queueCapacity = Math.max(1, configuration.getValueAsInteger(GlobalConfiguration.PAGE_FLUSH_QUEUE));
     final long maxDeferredMB = configuration.getValueAsLong(GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM);
     this.maxDeferredRAM = maxDeferredMB > 0 ? maxDeferredMB * 1024 * 1024 : 0;
   }
@@ -287,56 +328,88 @@ public class PageManagerFlushThread extends Thread {
    * the engine's own callers do not use it: they reserve before taking the page-manager lock (issue #6259).
    */
   public void scheduleFlushOfPages(final List<MutablePage> pages) throws InterruptedException {
-    scheduleFlushOfPages(pages, false);
+    scheduleFlushOfPages(pages, null);
   }
 
   /**
-   * @param slotReserved whether the caller already holds a reservation from {@link #reserveQueueSlot} - which it must
-   *                     have taken BEFORE the page-manager lock (issue #6259). This method releases it either way, so
-   *                     a reservation is handed over here exactly once and never leaks. When it is {@code false} the
-   *                     reservation is taken inline instead, and that wait is then served wherever the caller happens
-   *                     to be: <b>never call this form while holding the page-manager lock</b>.
+   * @param slotReservedFor the database whose pipeline slot the caller already holds from
+   *                        {@link #reserveQueueSlot(BasicDatabase)} - which it must have taken BEFORE the page-manager
+   *                        lock (issue #6259). This method disposes of it either way, so a slot is handed over here
+   *                        exactly once and never leaks. Naming the database rather than passing a bare {@code true}
+   *                        is what lets an empty batch - which has no pages and therefore no database of its own -
+   *                        still give the slot back to the right budget (issue #6281). {@code null} means the caller
+   *                        holds nothing and the reservation is taken inline instead, in which case the wait is served
+   *                        wherever the caller happens to be: <b>never call this form while holding the page-manager
+   *                        lock</b>.
    */
-  void scheduleFlushOfPages(final List<MutablePage> pages, final boolean slotReserved) throws InterruptedException {
-    boolean reserved = slotReserved;
+  void scheduleFlushOfPages(final List<MutablePage> pages, final BasicDatabase slotReservedFor) throws InterruptedException {
+    BasicDatabase slotHeldFor = slotReservedFor;
     boolean enqueued = false;
     try {
       if (pages.isEmpty())
         // AVOID INSERTING AN EMPTY LIST BECAUSE IS USED TO SHUTDOWN THE THREAD
         return;
 
-      if (!reserved) {
-        reserved = reserveQueueSlot();
-        if (!reserved) {
-          // SHUTTING DOWN: same outcome as the enqueue loop below giving up, and for the same reason.
+      final BasicDatabase database = pages.getFirst().pageId.getDatabase();
+      assert slotReservedFor == null || slotReservedFor.equals(database) :
+          "a slot reserved for database '" + slotReservedFor.getName() + "' cannot pay for a batch of '"
+              + database.getName() + "'";
+
+      if (slotHeldFor == null) {
+        if (!reserveQueueSlot(database)) {
+          // SHUTTING DOWN: same outcome as the enqueue below giving up, and for the same reason.
           logFailedEnqueue(pages);
           return;
         }
+        slotHeldFor = database;
       }
 
       // Index pages BEFORE enqueueing so that getCachedPageFromMutablePageInQueue()
       // can find them even if the queue.offer() hasn't completed yet.
       pageIndex.putAll(pages);
 
-      // TRY TO INSERT THE PAGE IN THE QUEUE UNTIL THE THREAD IS STILL RUNNING. With a reservation in hand this
-      // succeeds on the first attempt - a reserved slot cannot be taken by another reserver - so the timed retry
-      // stays as the safety net it always was, for the one case the reservation does not cover: a batch that
-      // reached the queue without one (see queueReservations).
-      while (running) {
-        if (queue.offer(new PagesToFlush(pages), 1, TimeUnit.SECONDS)) {
-          enqueued = true;
-          return;
-        }
+      if (running) {
+        // The queue carries no capacity of its own since #6281 - admission is the bound - so this cannot block and
+        // cannot fail. The `running` check is all that is left of the old retry loop, and it is the only thing it ever
+        // really did: refuse to enqueue into a pipeline that is shutting down.
+        offerBatch(new PagesToFlush(pages), true);
+        enqueued = true;
+        return;
       }
 
       // Failed to enqueue (shutdown in progress) — remove from index
       pageIndex.removeAll(pages);
       logFailedEnqueue(pages);
     } finally {
-      if (reserved)
-        // The batch occupies the slot from now on (or nothing does, and the slot is free for the next caller).
-        releaseQueueReservation(enqueued);
+      if (slotHeldFor != null && !enqueued)
+        // Nothing took the slot, so it goes straight back. When the batch DID take it the slot stays occupied until
+        // the flush thread polls it: since #6281 a reservation and the batch it becomes are one occupancy, not two.
+        releaseQueueReservation(slotHeldFor);
     }
+  }
+
+  /** The per-database bound admission enforces: {@code arcadedb.pageFlushQueue}. Package-private for the tests. */
+  int getQueueCapacity() {
+    return queueCapacity;
+  }
+
+  /**
+   * The one door into {@link #queue}, and therefore the one place the per-database occupancy of {@link #slotsInUse}
+   * is charged (issue #6281). A batch that reached the queue by any other route would be polled - and its slot
+   * released - without ever having been charged for one, which is the one way the count can go negative.
+   * <p>
+   * Package-private rather than private because the white-box tests of the suspend/interrupt paths fabricate batches
+   * and put them in the pipeline directly: they must go through here for the same reason.
+   *
+   * @param slotHeld {@code true} when the caller already holds the slot this batch is about to occupy - every engine
+   *                 path does, having reserved it before the page-manager lock - so ownership simply carries over.
+   *                 {@code false} charges one here instead, for a caller that never reserved.
+   */
+  void offerBatch(final PagesToFlush batch, final boolean slotHeld) {
+    if (!slotHeld && batch.database != null)
+      slotsInUse.computeIfAbsent(batch.database, k -> new AtomicInteger()).incrementAndGet();
+    // The queue is unbounded (the bound is admission), so this never blocks and never returns false.
+    queue.offer(batch);
   }
 
   private void logFailedEnqueue(final List<MutablePage> pages) {
@@ -346,31 +419,40 @@ public class PageManagerFlushThread extends Thread {
   }
 
   /**
-   * Admission control on the bounded flush queue, and the reason a full queue no longer stalls the whole JVM
-   * (issue #6259).
+   * Admission control on the flush pipeline: the reason a backlog no longer stalls the whole JVM (issue #6259), and
+   * since #6281 the reason it no longer reaches past the database it belongs to.
    * <p>
    * {@code PageManager.publishPages} holds the JVM-wide page-manager lock across BOTH halves of publication - the
    * page write and the flush enqueue - because the snapshot t0 barrier (#6075/#6125) rests on exactly that: it takes
    * the same lock so that from there on no committer can put a page on disk OR into the flush pipeline. The enqueue
-   * therefore has to stay inside the lock, which leaves only one place for the WAIT to go: ahead of it. Before this,
+   * therefore has to stay inside the lock, which leaves only one place for the WAIT to go: ahead of it. Before #6259,
    * a committer that found the queue full parked in {@code queue.offer} <i>holding a lock every committer of every
    * database in the process needs</i>, so one database's write burst against a slow volume serialized the commits of
-   * unrelated databases on idle ones. The queue filling is backpressure and is meant to hold the writers it belongs
-   * to; what was wrong is only that the wait was charged to everybody. Same distinction, and same fix, as #6200 drew
-   * for the deferred-RAM cap.
+   * unrelated databases on idle ones.
+   * <p>
+   * That fix moved the wait, and this one removes it for everybody it was never meant for. The queue filling is
+   * backpressure and is meant to hold the writers it belongs to - but {@code arcadedb.pageFlushQueue} was one JVM-wide
+   * number, so the writers it held were every database's. The budget is now per database: a burst on A consumes A's
+   * slots and B is admitted straight through, whatever A's disk is doing. Same distinction, and the third instance of
+   * the same fix, as #6200 drew for the deferred-RAM cap and #6259 for the position of this wait.
    * <p>
    * <b>This must be called BEFORE the page-manager lock is taken</b>, and it must hold nothing the flush thread
    * needs: it holds only {@link #queueSlotLock}, which the flush thread takes solely to notify (never to write), and
    * the slot it waits for is freed by the poll itself, before any page is written. So a wedged disk delays this wait
    * by at most the batch already being written, never indefinitely.
    *
+   * @param database the database the batch belongs to, whose budget the slot comes out of. {@code null} - which only
+   *                 the shutdown sentinel is - is admitted unconditionally: it carries no pages and belongs to no
+   *                 budget.
+   *
    * @return {@code true} when a slot was reserved, and the caller must hand it to
-   *     {@link #scheduleFlushOfPages(List, boolean)} or give it back with {@link #releaseQueueReservation};
-   *     {@code false} when the flush thread is shutting down and nothing more will be enqueued.
+   *     {@link #scheduleFlushOfPages(List, BasicDatabase)} or give it back with
+   *     {@link #releaseQueueReservation(BasicDatabase)}; {@code false} when the flush thread is shutting down and
+   *     nothing more will be enqueued.
    */
-  boolean reserveQueueSlot() throws InterruptedException {
-    if (tryReserveQueueSlot())
-      // THE COMMON CASE: THE QUEUE HAS ROOM, AND THE PUBLICATION PATH PAYS ONE CAS FOR IT
+  boolean reserveQueueSlot(final BasicDatabase database) throws InterruptedException {
+    if (tryReserveQueueSlot(database))
+      // THE COMMON CASE: THE DATABASE IS UNDER ITS BOUND, AND THE PUBLICATION PATH PAYS ONE CAS FOR IT
       return true;
 
     final long beginTime = System.currentTimeMillis();
@@ -380,7 +462,7 @@ public class PageManagerFlushThread extends Thread {
     try {
       while (running) {
         synchronized (queueSlotLock) {
-          if (tryReserveQueueSlot())
+          if (tryReserveQueueSlot(database))
             return true;
           queueSlotLock.wait(queueSlotWaitPollMillis);
         }
@@ -390,9 +472,9 @@ public class PageManagerFlushThread extends Thread {
         if (!reported && System.currentTimeMillis() - beginTime > QUEUE_SLOT_WARN_MILLIS) {
           reported = true;
           LogManager.instance().log(this, Level.WARNING,
-              "Commits have been throttled for %d ms waiting for room in the page-flush queue: the disk is not keeping up with the write rate, or flushing is suspended. The queue holds %d of the %d batches allowed by '%s'",
-              null, System.currentTimeMillis() - beginTime, queue.size(), queueCapacity,
-              GlobalConfiguration.PAGE_FLUSH_QUEUE.getKey());
+              "Commits on database '%s' have been throttled for %d ms waiting for room in its page-flush queue: the disk is not keeping up with the write rate, or flushing is suspended. The database holds %d of the %d batches allowed by '%s' (%d in the shared pipeline across all databases)",
+              null, database != null ? database.getName() : "?", System.currentTimeMillis() - beginTime,
+              slotsUsedBy(database), queueCapacity, GlobalConfiguration.PAGE_FLUSH_QUEUE.getKey(), queue.size());
         }
       }
       // SHUTTING DOWN. Deliberately no last-minute retry for a slot: the enqueue this reservation is for is itself
@@ -404,37 +486,73 @@ public class PageManagerFlushThread extends Thread {
     }
   }
 
-  /** Non-blocking half of {@link #reserveQueueSlot}: takes a slot only while the queue provably has one to give. */
-  private boolean tryReserveQueueSlot() {
+  /**
+   * Non-blocking half of {@link #reserveQueueSlot(BasicDatabase)}: takes a slot only while THIS database is provably
+   * under its bound.
+   */
+  boolean tryReserveQueueSlot(final BasicDatabase database) {
+    if (database == null)
+      // The shutdown sentinel. It occupies no budget, so there is nothing to take and nothing to give back.
+      return true;
+
+    final AtomicInteger slots = slotsInUse.computeIfAbsent(database, k -> new AtomicInteger());
     while (true) {
-      final int reservations = queueReservations.get();
-      // The queue's own size, so a batch enqueued without a reservation narrows admission instead of overflowing it.
-      if (queue.size() + reservations >= queueCapacity)
+      final int used = slots.get();
+      if (used >= queueCapacity)
         return false;
-      if (queueReservations.compareAndSet(reservations, reservations + 1))
+      if (slots.compareAndSet(used, used + 1))
         return true;
     }
   }
 
   /**
-   * Gives a reservation back.
-   *
-   * @param enqueued whether the batch took the slot. When it did, the slot is now OCCUPIED and there is nothing to
-   *                 wake anybody for - the sum {@code size + reservations} is unchanged - which is what keeps the
-   *                 normal publication path from touching {@link #queueSlotLock} at all.
+   * Gives a reserved slot back to a database's budget, for a publication that never reached an enqueue.
+   * <p>
+   * There is deliberately no "the batch took it" form: when the batch IS enqueued the slot stays occupied - ownership
+   * passes to the batch until the flush thread polls it (see {@link #releaseSlotOfPolledBatch}) - so there is nothing
+   * to give back and nobody to wake, which is what keeps the normal publication path from touching
+   * {@link #queueSlotLock} at all.
    */
-  void releaseQueueReservation(final boolean enqueued) {
-    final int remaining = queueReservations.decrementAndGet();
-    // A count below zero means a reservation was released twice, and unlike a leak it fails OPEN: admission would
-    // then hand out more slots than the queue has, putting the enqueue it exists to protect back inside the
-    // page-manager lock. Asserted rather than clamped - a clamp would hide it, and the test lanes run with -ea,
-    // which is where such a bug gets written (same reasoning as the single-database batch assert in PagesToFlush).
-    assert remaining >= 0 : "flush-queue reservations went negative (" + remaining + ")";
-    if (!enqueued)
-      signalQueueSlotAvailable();
+  void releaseQueueReservation(final BasicDatabase database) {
+    if (database == null)
+      return;
+
+    final AtomicInteger slots = slotsInUse.get(database);
+    if (slots == null)
+      // The database was closed or dropped under us: removeAllPagesOfDatabase forgot its budget, and a budget that
+      // no longer exists cannot be over-drawn.
+      return;
+
+    final int remaining = slots.decrementAndGet();
+    // A count below zero means a slot was released twice, and unlike a leak it fails OPEN: admission would then hand
+    // out more slots than the budget has, putting the enqueue it exists to protect back inside the page-manager lock.
+    // Asserted rather than clamped - a clamp would hide it, and the test lanes run with -ea, which is where such a bug
+    // gets written (same reasoning as the single-database batch assert in PagesToFlush).
+    assert remaining >= 0 : "flush-queue slots of database '" + database.getName() + "' went negative (" + remaining + ")";
+    signalQueueSlotAvailable();
   }
 
-  /** Wakes the callers parked in {@link #reserveQueueSlot}, if there are any: on the flush path, usually none. */
+  /** Releases the slot a batch occupied from the moment it was reserved to the moment it left {@link #queue}. */
+  private void releaseSlotOfPolledBatch(final PagesToFlush batch) {
+    if (batch.database == null)
+      return;
+    final AtomicInteger slots = slotsInUse.get(batch.database);
+    if (slots == null)
+      return;
+    final int remaining = slots.decrementAndGet();
+    assert remaining >= 0 :
+        "flush-queue slots of database '" + batch.database.getName() + "' went negative (" + remaining + ")";
+  }
+
+  /** How many pipeline slots a database is currently using (reserved or queued). Package-private for the tests. */
+  int slotsUsedBy(final BasicDatabase database) {
+    if (database == null)
+      return 0;
+    final AtomicInteger slots = slotsInUse.get(database);
+    return slots != null ? slots.get() : 0;
+  }
+
+  /** Wakes the callers parked in {@link #reserveQueueSlot(BasicDatabase)}, if any: on the flush path, usually none. */
   private void signalQueueSlotAvailable() {
     if (queueSlotWaiters.get() == 0)
       return;
@@ -538,10 +656,12 @@ public class PageManagerFlushThread extends Thread {
     final PagesToFlush pagesToFlush = queue.poll(timeout, TimeUnit.MILLISECONDS);
 
     if (pagesToFlush != null) {
-      // A slot is free: admit a committer waiting for one (issue #6259). Signalled HERE, before the batch is
-      // written, because the slot IS free from here - the batch has left the queue - and the point of the whole
-      // mechanism is that a slow write delays the writes, not the admission of the next committer. The read is one
-      // volatile load when nobody is waiting, which is the normal state of a queue that is not full.
+      // A slot of THIS batch's database is free again (issue #6281): give it back and admit a committer waiting for
+      // one (issue #6259). Both happen HERE, before the batch is written, because the slot IS free from here - the
+      // batch has left the queue - and the point of the whole mechanism is that a slow write delays the writes, not
+      // the admission of the next committer. The signal reads one volatile when nobody is waiting, which is the
+      // normal state of a pipeline no database has filled.
+      releaseSlotOfPolledBatch(pagesToFlush);
       signalQueueSlotAvailable();
 
       // Publish the entry immediately after polling so that getCachedPageFromMutablePageInQueue()
@@ -937,39 +1057,32 @@ public class PageManagerFlushThread extends Thread {
       // Phase 3b: re-enqueue the detached batches into the main queue so the background thread picks them up.
       // They are appended to the tail of the queue, so if any post-unsuspend commits have already been
       // enqueued they will be flushed first. WAL-based recovery guarantees correctness even if the flush order
-      // differs from commit order. This blocking re-enqueue is deliberately done OUTSIDE the lock: queue.offer
-      // can block when the queue is full, and the only consumer that drains the queue (the flush thread) needs
-      // the same per-database lock to make progress, so holding it across the offer would deadlock.
+      // differs from commit order. The reservation below can WAIT (this database is at its bound), and that wait is
+      // deliberately done OUTSIDE the lock: the only consumer that frees a slot is the flush thread, which needs the
+      // same per-database lock to make progress, so holding it across the wait would deadlock.
       if (newDeferred != null) {
         for (final PagesToFlush batch : newDeferred) {
           // The batch moves back to the main queue and leaves the deferred backlog accounting (issue #4728).
           addDeferredRAM(database, -batchRAM(batch));
-          // Re-entering the bounded queue goes through the same admission control as any other enqueue (#6259):
-          // the batch gave its slot back when the flush thread polled it, and a resume can carry thousands of them,
-          // so without a reservation this loop could fill the queue under a committer that is holding one - putting
-          // that committer's offer back inside the page-manager lock, which is the whole bug. Blocking here is safe
-          // for the same reason the offer below always was: this runs outside every lock (see above).
+          // Re-entering the pipeline goes through the same admission control as any other enqueue (#6259): the batch
+          // gave its slot back when the flush thread polled it, and a resume can carry thousands of them, so without
+          // a reservation this loop could exhaust the database's budget under a committer that is holding one -
+          // putting that committer's offer back inside the page-manager lock, which is the whole bug.
           boolean reserved = false;
           boolean enqueued = false;
           try {
-            reserved = reserveQueueSlot();
-            if (!reserved)
+            reserved = reserveQueueSlot(database);
+            if (!reserved || !running)
               // SHUTTING DOWN: the remaining batches stay unwritten and are recovered from the WAL, as before.
               break;
-            while (running) {
-              if (queue.offer(batch, 1, TimeUnit.SECONDS)) {
-                enqueued = true;
-                break;
-              }
-              LogManager.instance().log(this, Level.WARNING,
-                  "Page flush queue is full while re-enqueueing deferred batch for database '%s'; retrying", database.getName());
-            }
+            offerBatch(batch, true);
+            enqueued = true;
           } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             break;
           } finally {
-            if (reserved)
-              releaseQueueReservation(enqueued);
+            if (reserved && !enqueued)
+              releaseQueueReservation(database);
           }
         }
       }
@@ -1022,13 +1135,11 @@ public class PageManagerFlushThread extends Thread {
     // And any committer waiting for a flush-queue slot, for the same reason: what it is waiting for is this thread
     // polling, and this thread is on its way out (issue #6259).
     signalQueueSlotAvailable();
-    // The sentinel takes a queue slot like any other batch, so it is admitted like one - but never WAITS for one:
-    // a full queue simply means no sentinel, and the run loop already exits on its own once `running` is false and
-    // the queue is drained. The sentinel is what makes that exit immediate, never what makes it happen. Admitting it
-    // through the same accounting is what keeps a reserved slot reserved: taken from under a committer that holds
-    // one, it would put that committer's offer back inside the page-manager lock (issue #6259).
-    if (tryReserveQueueSlot())
-      releaseQueueReservation(queue.offer(SHUTDOWN_THREAD));
+    // The sentinel belongs to no database, so it draws on no database's budget and can never be refused (issue
+    // #6281): before that, a queue filled by one database could swallow it, and the exit then had to wait for the
+    // run loop to notice `running` on its own. It carries no pages, so admitting it costs nothing it could starve
+    // anyone of.
+    offerBatch(SHUTDOWN_THREAD, true);
     join();
   }
 
@@ -1304,6 +1415,11 @@ public class PageManagerFlushThread extends Thread {
     suspendLocks.remove(database);
     replayDrainLocks.remove(database);
     flushedPagesPerDatabase.remove(database);
+    // Its pipeline budget goes with the rest of its bookkeeping (#6281). Batches of this database may still be in the
+    // queue - emptied above, but still there - and will be polled after this: releaseSlotOfPolledBatch finds no entry
+    // and does nothing, which is the right answer for a budget that no longer exists. Dropping it here is what keeps
+    // the closed Database instance from being pinned as a map key for the flush thread's lifetime.
+    slotsInUse.remove(database);
 
     // Deliberately outside that monitor: batchRAM takes each batch's own monitor, and the one nesting this class
     // allows is suspendLock BEFORE batch.pages (what the defer path does). These batches are already detached, so

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -102,22 +102,29 @@ public class RebuildIndexStatement extends DDLStatement {
       }
     }
 
+    final Database database = context.getDatabase();
+
+    // Both branches below SCAN the live data, and a worker of the async executor keeps ONE transaction open across up
+    // to ASYNC_TX_BATCH_SIZE tasks - so records it has already written can still be uncommitted, and invisible to any
+    // scan, even with every queue drained (issue #6281). Wait for that batch first.
+    //
+    // Deliberately weaker than the claim the same barrier carries in TypeIndexBuilder, and measured rather than
+    // assumed: a rebuild that runs inside that window does NOT lose entries. Those records staged their index
+    // operations in their own transaction when they were saved, and applying them at commit repopulates what the
+    // rebuild's scan could not see - a regression test written to catch a loss here passes with this call removed,
+    // which is why there is no such test. What the window does cost is a rebuild computed over a partial view: the
+    // BM25 counters of the statsOnly branch (which is why this sits AHEAD of it rather than after), the misplaced-
+    // record detection of issue #832, and the reported totals. An operator who rebuilds right after a bulk async
+    // load expects those numbers to be about all of the data. Costs nothing on a database that never used async.
+    ((DatabaseInternal) database).waitForAsyncCompletion();
+
     if (statsOnly)
-      return recomputeStatistics(context.getDatabase(), result);
+      return recomputeStatistics(database, result);
 
     final AtomicLong total = new AtomicLong();
     final AtomicLong misplaced = new AtomicLong();
     // Types found to contain records sitting outside their partition hash-target bucket (issue #832).
     final Set<DocumentType> typesToRepartition = ConcurrentHashMap.newKeySet();
-
-    final Database database = context.getDatabase();
-
-    // A rebuild SCANS the buckets, so it needs the same barrier a CREATE INDEX does (issue #6281): a worker of the
-    // async executor keeps one transaction open across up to ASYNC_TX_BATCH_SIZE tasks, so records it has already
-    // written can still be uncommitted - and invisible to this scan - even with every queue drained. Rebuilding
-    // around them produces exactly what the issue was about: an index missing entries, and lookups that silently
-    // answer nothing for records that are there. Costs nothing on a database that never used the async API.
-    ((DatabaseInternal) database).waitForAsyncCompletion();
 
     final Index.BuildIndexCallback callback = (document, totalIndexed) -> {
       total.incrementAndGet();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -104,6 +104,19 @@ public class RebuildIndexStatement extends DDLStatement {
 
     final Database database = context.getDatabase();
 
+    // The refusal of issue #2097 comes FIRST, ahead of the barrier below. buildIndex() has raised it for years when
+    // this runs on one of the async executor's own worker threads (an HTTP command with awaitResponse=false), for the
+    // very reason the barrier cannot run there either - and buildIndex() is reached only much further down, and never
+    // at all on the statsOnly branch. Leaving it where it was would have let the barrier answer first, with a message
+    // about waiting rather than about rebuilding, and would have left #2097's own regression test asserting a
+    // refusal that no longer came from the place it was written for.
+    final DatabaseContext.DatabaseContextTL asyncContext = DatabaseContext.INSTANCE.getContextIfExists(
+        database.getDatabasePath());
+    if (asyncContext != null && asyncContext.asyncMode)
+      throw new NeedRetryException(
+          "Cannot rebuild index while running in asynchronous context. "
+              + "Use synchronous execution (awaitResponse=true) or run the command directly.");
+
     // Both branches below SCAN the live data, and a worker of the async executor keeps ONE transaction open across up
     // to ASYNC_TX_BATCH_SIZE tasks - so records it has already written can still be uncommitted, and invisible to any
     // scan, even with every queue drained (issue #6281). Wait for that batch first.

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -112,6 +112,13 @@ public class RebuildIndexStatement extends DDLStatement {
 
     final Database database = context.getDatabase();
 
+    // A rebuild SCANS the buckets, so it needs the same barrier a CREATE INDEX does (issue #6281): a worker of the
+    // async executor keeps one transaction open across up to ASYNC_TX_BATCH_SIZE tasks, so records it has already
+    // written can still be uncommitted - and invisible to this scan - even with every queue drained. Rebuilding
+    // around them produces exactly what the issue was about: an index missing entries, and lookups that silently
+    // answer nothing for records that are there. Costs nothing on a database that never used the async API.
+    ((DatabaseInternal) database).waitForAsyncCompletion();
+
     final Index.BuildIndexCallback callback = (document, totalIndexed) -> {
       total.incrementAndGet();
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -125,14 +125,23 @@ public class RebuildIndexStatement extends DDLStatement {
     // to ASYNC_TX_BATCH_SIZE tasks - so records it has already written can still be uncommitted, and invisible to any
     // scan, even with every queue drained (issue #6281). Wait for that batch first.
     //
-    // Deliberately weaker than the claim the same barrier carries in TypeIndexBuilder, and measured rather than
-    // assumed: a rebuild that runs inside that window does NOT lose entries. Those records staged their index
-    // operations in their own transaction when they were saved, and applying them at commit repopulates what the
-    // rebuild's scan could not see - a regression test written to catch a loss here passes with this call removed,
-    // which is why there is no such test. What the window does cost is a rebuild computed over a partial view: the
-    // BM25 counters of the statsOnly branch (which is why this sits AHEAD of it rather than after), the misplaced-
-    // record detection of issue #832, and the reported totals. An operator who rebuilds right after a bulk async
-    // load expects those numbers to be about all of the data. Costs nothing on a database that never used async.
+    // The two branches are hurt differently by that window, and both claims below are measured rather than assumed.
+    //
+    // The REBUILD proper does NOT lose index entries: those records staged their index operations in their own
+    // transaction when they were saved, and applying them at commit repopulates what the rebuild's scan could not
+    // see. A regression test written to catch a loss there passes with this call removed, which is why there is no
+    // such test. What it costs is a rebuild computed over a partial view - the misplaced-record detection of issue
+    // #832, and the reported totals.
+    //
+    // The statsOnly branch is worse, which is why this sits AHEAD of it rather than after: it recomputes the BM25
+    // corpus counters by scanning the type and then OVERWRITES the counters with what the scan found. Run inside the
+    // window it finds nothing committed and writes "0 documents" over counters the records had already bumped when
+    // they were saved, so the corpus size stays 0 for a type full of documents and every BM25 score is computed
+    // against it until somebody recomputes again. That one does not heal itself, and it has a test
+    // (Issue6281AsyncBatchIndexBuildTest#aStatsRecomputeOverAnIdleAsyncExecutorStillCountsItsUncommittedBatch:
+    // 0 of 200 documents counted with this call removed).
+    //
+    // Costs nothing on a database that never used the async API.
     ((DatabaseInternal) database).waitForAsyncCompletion();
 
     if (statsOnly)

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -72,15 +72,26 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
   public Index create() {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
 
+    // The FOURTH way into a bucket scan, and the one issue #6281's first pass missed. TypeIndexBuilder pays the
+    // barrier before delegating here, and so does REBUILD INDEX - but this builder is reachable on its own through
+    // the public Schema.buildBucketIndex(...), which is how CHECK DATABASE ... FIX rebuilds an index it found
+    // damaged (DatabaseChecker). Reached that way it would scan a bucket that does not yet contain whatever an async
+    // worker is still holding in its open batch, and produce the same silently incomplete index #6281 is about.
+    // Paying it twice on the paths that already did costs one marker round-trip per worker on an executor that is by
+    // then drained; missing it once costs an index.
+    database.waitForAsyncCompletion();
+
     final int totalThreads = database.async().getThreadCount();
-    final CountDownLatch semaphoreToStart = new CountDownLatch(totalThreads);
     final CountDownLatch semaphoreAfterFinish = new CountDownLatch(1);
 
     try {
+      // These tasks park every worker for the duration of the build, so nothing writes underneath it. They used to
+      // count down a second latch, semaphoreToStart, that nothing ever awaited - the build began whether or not the
+      // workers had actually reached the pause. What that latch was reaching for is what the barrier above now
+      // provides properly, so it is gone rather than left looking like a guard.
       for (int i = 0; i < totalThreads; i++) {
         ((DatabaseAsyncExecutorImpl) database.async()).scheduleTask(i, new DatabaseAsyncExecuteAlone(semaphoreAfterFinish, () -> {
           try {
-            semaphoreToStart.countDown();
             semaphoreAfterFinish.await(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
           } catch (InterruptedException e) {
             // SHUTDOWN IN PROGRESS

--- a/engine/src/main/java/com/arcadedb/schema/ManualIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/ManualIndexBuilder.java
@@ -96,10 +96,10 @@ public class ManualIndexBuilder extends IndexBuilder<Index> {
           "Cannot create the manual index '" + indexName + "' as " + indexType + ": a manual index is not bound to a "
               + "type, and only " + SUPPORTED_INDEX_TYPES + " can be built without one");
 
-    // Wait for any running async tasks (e.g., compaction) to complete before creating new index
-    // This prevents NeedRetryException when creating multiple indexes sequentially on large datasets
-    while (database.isAsyncProcessing())
-      database.async().waitCompletion();
+    // Same barrier as TypeIndexBuilder.create(), and for the same reason (issue #6281): isAsyncProcessing() reports
+    // TASKS, and a worker keeps one transaction open across up to ASYNC_TX_BATCH_SIZE of them, so an executor with
+    // drained queues can still be holding thousands of uncommitted records. Only waitCompletion() closes that batch.
+    database.waitForAsyncCompletion();
 
     final LocalSchema schema = database.getSchema().getEmbedded();
 

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -193,10 +193,17 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
       throw new DatabaseMetadataException(
           "Cannot create index on type '" + metadata.typeName + "' because indexType was not specified");
 
-    // Wait for any running async tasks (e.g., compaction) to complete before creating new index
-    // This prevents NeedRetryException when creating multiple indexes sequentially on large datasets
-    while (database.isAsyncProcessing())
-      database.async().waitCompletion();
+    // The index is built by SCANNING the buckets, so everything the async executor has been asked to write has to be
+    // committed first, or the build simply does not see it and the records end up with no entry at all - a silent
+    // wrong answer on every lookup, not a slow one (issue #6281).
+    //
+    // This used to be `while (database.isAsyncProcessing()) waitCompletion()`, which is not the same barrier: that
+    // predicate reports queued and executing TASKS, while a worker holds ONE transaction open across up to
+    // ASYNC_TX_BATCH_SIZE (10240 by default) of them. An executor whose queues happen to be drained at the instant of
+    // the check therefore answers "idle" while still sitting on thousands of uncommitted records, and the guard was
+    // then skipped entirely. It also prevents the NeedRetryException a running compaction used to raise when several
+    // indexes are created in a row on a large dataset, which is what the guard was originally added for.
+    database.waitForAsyncCompletion();
 
     // Carry the user-supplied TypeIndex name (set via {@link #withIndexName}) onto the
     // IndexMetadata so it propagates to each per-bucket index and ultimately to

--- a/engine/src/test/java/com/arcadedb/ACIDTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/ACIDTransactionTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.engine.WALFile;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.index.Index;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -88,8 +89,18 @@ class ACIDTransactionTest extends TestHelper {
     database.transaction(() -> assertThat(database.countType("V", true)).isEqualTo(TOT));
   }
 
+  /**
+   * Creates an index while asynchronous inserts of the very records it has to cover are in flight, then crashes.
+   * <p>
+   * This used to be {@code indexCreationWhileAsyncMustFail} and expected a {@link NeedRetryException} from the
+   * creation. That expectation has been dead for a long time - {@code TypeIndexBuilder.create()} drains the async
+   * executor before building instead of refusing - so the {@code catch} was never entered and the test asserted
+   * nothing about the index at all: only the record count, which an EMPTY index satisfies just as well as a complete
+   * one. That is exactly what issue #6281 found it hiding, so what it checks now is the index (see
+   * {@link com.arcadedb.index.Issue6281AsyncBatchIndexBuildTest} for the barrier itself).
+   */
   @Test
-  void indexCreationWhileAsyncMustFail() {
+  void indexCreatedWhileAsyncInsertsAreInFlightSurvivesACrash() {
     final Database db = database;
 
     final int TOT = 100;
@@ -107,12 +118,8 @@ class ACIDTransactionTest extends TestHelper {
         db.async().createRecord(v, null);
       }
 
-      // creating the index should throw exception because there's an aync creation ongoing: sometimes it doesn't happen, the async is finished
-      try {
-        database.getSchema().getType("V").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
-      } catch (NeedRetryException e) {
-        //no action
-      }
+      // The records are still being written asynchronously here: the creation must WAIT for them, not race them.
+      database.getSchema().getType("V").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
 
       db.async().waitCompletion();
 
@@ -126,7 +133,20 @@ class ACIDTransactionTest extends TestHelper {
 
     verifyDatabaseWasNotClosedProperly();
 
-    database.transaction(() -> assertThat(database.countType("V", true)).isEqualTo(TOT));
+    database.transaction(() -> {
+      assertThat(database.countType("V", true)).isEqualTo(TOT);
+
+      // The index has to have survived the crash covering EVERY record: a build that ran ahead of the async commits
+      // leaves an index that is readable, healthy and empty, and every lookup below then silently answers nothing.
+      final Index index = database.getSchema().getIndexByName("V[id]");
+      assertThat(index.countEntries()).as("the index must cover every asynchronously inserted record").isEqualTo(TOT);
+
+      for (int i = 0; i < TOT; i++)
+        try (final ResultSet rs = database.query("sql", "select from V where id = ?", i)) {
+          assertThat(rs.hasNext()).as("record id " + i + " must be reachable through the index").isTrue();
+          assertThat(rs.next().<Integer>getProperty("id")).isEqualTo(i);
+        }
+    });
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/database/Issue5279ConcurrentInsertTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5279ConcurrentInsertTest.java
@@ -189,8 +189,12 @@ class Issue5279ConcurrentInsertTest extends TestHelper {
     // that happens to be re-placing its record exactly when a page fills up can still lose the race and retry.
     assertThat(conflicts.get()).as("pure inserts must not raise concurrent modifications").isLessThanOrEqualTo(2);
 
-    database.transaction(
-        () -> assertThat(database.countType("Case", false)).isEqualTo(1L + (long) threadCount * insertsPerThread));
+    // ...and the count has to be told about that tolerance, because the insert runs at attempts=1: a conflict
+    // tolerated above means that record was NOT written. Expecting the full total while allowing a conflict asserts
+    // both that a conflict may happen and that it may not, so the run where one DOES happen fails here (2000 against
+    // 2001) instead of at the tolerance meant to absorb it (issue #6281, same trap as the sibling Update test).
+    database.transaction(() -> assertThat(database.countType("Case", false))//
+        .isEqualTo(1L + (long) threadCount * insertsPerThread - conflicts.get()));
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/FlushRobustnessTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FlushRobustnessTest.java
@@ -85,7 +85,7 @@ class FlushRobustnessTest extends TestHelper {
     final MutablePage healthyPage = new MutablePage(healthyPageId, pageSize, new byte[pageSize], 0, 0);
     flush.pageIndex.put(brokenPage);
     flush.pageIndex.put(healthyPage);
-    flush.queue.offer(new PagesToFlush(List.of(brokenPage, healthyPage)));
+    flush.offerBatch(new PagesToFlush(List.of(brokenPage, healthyPage)), false);
 
     // #4928: the broken page's IOException must be contained: the batch continues, the healthy page reaches
     // the disk, and no entry leaks in pageIndex (a leak would hang the database close).

--- a/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6200PerDatabaseDeferredBacklogTest.java
@@ -469,7 +469,7 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
         pages.add(new MutablePage(new PageId(db, FILE_ID, i), pageSize, new byte[pageSize], 0, 0));
       final PagesToFlush trapped = new PagesToFlush(pages);
       flush.pageIndex.putAll(pages);
-      flush.queue.offer(trapped);
+      flush.offerBatch(trapped, false);
       flush.flushPagesFromQueueToDisk(null, 20L);
       assertThat(flush.getDeferredRAMBytesOf(db)).isEqualTo((long) 600 * pageSize);
 
@@ -554,7 +554,7 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
       final int pageNumber) {
     final MutablePage page = new MutablePage(new PageId(database, FILE_ID, pageNumber), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
     flush.pageIndex.put(page);
-    flush.queue.offer(new PagesToFlush(List.of(page)));
+    flush.offerBatch(new PagesToFlush(List.of(page)), false);
     return page;
   }
 
@@ -566,6 +566,6 @@ class Issue6200PerDatabaseDeferredBacklogTest extends TestHelper {
     for (int i = 0; i < pages; i++)
       batch.add(new MutablePage(new PageId(database, FILE_ID, round * pages + i), pageSize, new byte[pageSize], 0, 0));
     flush.pageIndex.putAll(batch);
-    flush.queue.offer(new PagesToFlush(batch));
+    flush.offerBatch(new PagesToFlush(batch), false);
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6259FlushQueueAdmissionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6259FlushQueueAdmissionTest.java
@@ -113,12 +113,13 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
         Thread.sleep(1);
       }
 
-      // Fill every remaining slot. Committers are admitted one per free slot, so this is the state a burst against a
-      // slow disk reaches on its own - reached here deterministically instead.
-      for (int i = flush.queue.remainingCapacity(); i > 0; i--)
+      // Fill every remaining slot OF THIS DATABASE's budget (per-database since #6281). Committers are admitted one
+      // per free slot, so this is the state a burst against a slow disk reaches on its own - reached here
+      // deterministically instead.
+      for (int i = flush.slotsUsedBy(db) + 1; i <= flush.getQueueCapacity(); i++)
         flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, i))));
-      assertThat(flush.queue.remainingCapacity()).as("the flush queue must be full for this test to test anything")
-          .isZero();
+      assertThat(flush.slotsUsedBy(db)).as("the database's flush budget must be exhausted for this test to test anything")
+          .isEqualTo(flush.getQueueCapacity());
 
       committer = new Thread(() -> {
         try {
@@ -165,7 +166,7 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
     final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC);
     while (!flush.queue.isEmpty() && System.currentTimeMillis() < deadline)
       Thread.sleep(5);
-    assertThat(flush.queueReservations.get()).as("and no publication may leave a reservation behind").isZero();
+    assertThat(flush.slotsUsedBy(db)).as("and no publication may leave a reservation behind").isZero();
   }
 
   /**
@@ -185,15 +186,15 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
 
     flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 0))));
     flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 1))));
-    assertThat(flush.queue.remainingCapacity()).isZero();
-    assertThat(flush.queueReservations.get()).as("an enqueued batch holds a slot, not a reservation").isZero();
+    assertThat(flush.slotsUsedBy(db)).as("an enqueued batch KEEPS the slot it was reserved on until it is polled")
+        .isEqualTo(2);
 
     final CountDownLatch admitted = new CountDownLatch(1);
     final AtomicReference<Throwable> failure = new AtomicReference<>();
     final Thread committer = new Thread(() -> {
       try {
-        if (flush.reserveQueueSlot()) {
-          flush.releaseQueueReservation(false);
+        if (flush.reserveQueueSlot(db)) {
+          flush.releaseQueueReservation(db);
           admitted.countDown();
         }
       } catch (final Throwable e) {
@@ -213,7 +214,9 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
         .isTrue();
     committer.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
     assertThat(failure.get()).isNull();
-    assertThat(flush.queueReservations.get()).isZero();
+    // One batch left the queue and the admitted committer gave its slot straight back: the other batch still holds
+    // the one it was enqueued on.
+    assertThat(flush.slotsUsedBy(db)).isEqualTo(1);
   }
 
   /**
@@ -227,12 +230,12 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
     final PageManagerFlushThread flush = smallQueueFlushThread(2);
 
     flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 0))));
-    assertThat(flush.reserveQueueSlot()).as("one slot left, so one more caller gets in").isTrue();
+    assertThat(flush.reserveQueueSlot(db)).as("one slot left, so one more caller gets in").isTrue();
 
     final CountDownLatch admitted = new CountDownLatch(1);
     final Thread other = new Thread(() -> {
       try {
-        if (flush.reserveQueueSlot())
+        if (flush.reserveQueueSlot(db))
           admitted.countDown();
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -245,9 +248,8 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
         .isFalse();
 
     // The reservation is honoured: the enqueue finds the room it was promised, without waiting.
-    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 1))), true);
-    assertThat(flush.queue.remainingCapacity()).isZero();
-    assertThat(flush.queueReservations.get()).isZero();
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 1))), db);
+    assertThat(flush.slotsUsedBy(db)).as("both slots are now held by enqueued batches").isEqualTo(2);
 
     other.interrupt();
     other.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
@@ -266,23 +268,27 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
 
     // An empty batch is never enqueued (the empty list is the shutdown sentinel), with or without a reservation.
     flush.scheduleFlushOfPages(new ArrayList<>());
-    assertThat(flush.queueReservations.get()).isZero();
-    assertThat(flush.reserveQueueSlot()).isTrue();
-    flush.scheduleFlushOfPages(new ArrayList<>(), true);
-    assertThat(flush.queueReservations.get()).as("a reservation handed to an empty batch must come straight back")
+    assertThat(flush.slotsUsedBy(db)).isZero();
+    assertThat(flush.reserveQueueSlot(db)).isTrue();
+    flush.scheduleFlushOfPages(new ArrayList<>(), db);
+    assertThat(flush.slotsUsedBy(db)).as("a reservation handed to an empty batch must come straight back")
         .isZero();
 
-    // A real publication, through the whole PageManager path.
+    // A real publication, through the whole PageManager path. The slot stays with the batch until the (real, running)
+    // flush thread polls it, so the assertion is about what is left AFTER the pipeline drains.
     final PageManager pageManager = db.getPageManager();
     pageManager.publishPages(List.of(page(db, 7)), null, true);
-    assertThat(pageManager.getFlushThread().queueReservations.get()).isZero();
+    final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC);
+    while (pageManager.getFlushThread().slotsUsedBy(db) > 0 && System.currentTimeMillis() < deadline)
+      Thread.sleep(5);
+    assertThat(pageManager.getFlushThread().slotsUsedBy(db)).isZero();
 
     // And a batch dropped because the thread is shutting down. closeAndJoin returns at once here: this flush thread
     // was constructed but never start()ed, and Thread.join() on a thread in NEW state returns immediately. What is
     // under test is the shutdown flag, not the join.
     flush.closeAndJoin();
     flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 8))));
-    assertThat(flush.queueReservations.get()).as("a batch dropped at shutdown must not strand its slot").isZero();
+    assertThat(flush.slotsUsedBy(db)).as("a batch dropped at shutdown must not strand its slot").isZero();
   }
 
   /**
@@ -315,11 +321,11 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
         try {
           start.await();
           for (int i = 0; i < 2_000; i++) {
-            if (!flush.reserveQueueSlot())
+            if (!flush.reserveQueueSlot(db))
               return;
             maxHeld.accumulateAndGet(held.incrementAndGet(), Math::max);
             held.decrementAndGet();
-            flush.releaseQueueReservation(false);
+            flush.releaseQueueReservation(db);
           }
         } catch (final Throwable e) {
           failure.compareAndSet(null, e);
@@ -338,7 +344,7 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
         "the CAS loop must never hand out more reservations than the queue has slots: each one is a promise that the enqueue inside the page-manager lock will not block")
         .isLessThanOrEqualTo(capacity);
     assertThat(maxHeld.get()).as("and the race must actually have contended, or this test proves nothing").isGreaterThan(1);
-    assertThat(flush.queueReservations.get()).isZero();
+    assertThat(flush.slotsUsedBy(db)).isZero();
 
     // PHASE 2: the whole path at once - producers reserving and enqueueing, a drainer polling - so the two halves of
     // the sum (queue size and reservations) move against each other under contention rather than one at a time.
@@ -351,9 +357,9 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
       final Thread producer = new Thread(() -> {
         try {
           for (int i = 0; i < batchesPerProducer; i++) {
-            final boolean reserved = flush.reserveQueueSlot();
+            final boolean reserved = flush.reserveQueueSlot(db);
             assertThat(reserved).isTrue();
-            flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, id * batchesPerProducer + i))), true);
+            flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, id * batchesPerProducer + i))), db);
           }
         } catch (final Throwable e) {
           failure.compareAndSet(null, e);
@@ -386,7 +392,7 @@ class Issue6259FlushQueueAdmissionTest extends TestHelper {
 
     assertThat(failure.get()).isNull();
     assertThat(flush.queue).isEmpty();
-    assertThat(flush.queueReservations.get()).as(
+    assertThat(flush.slotsUsedBy(db)).as(
         "the accounting must come back to zero: a slot leaked per round shrinks the pipeline until it stops admitting anything")
         .isZero();
     assertThat(flush.pageIndex.pendingOf(db)).as("and every page must have left the pipeline").isZero();

--- a/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
@@ -200,6 +200,32 @@ class Issue6281PerDatabaseFlushQueueTest extends TestHelper {
   }
 
   /**
+   * A non-positive {@code arcadedb.pageFlushQueue} is raised to 1 rather than rejected.
+   * <p>
+   * It used to be rejected, by {@code ArrayBlockingQueue}'s constructor, and that was fine while the queue carried
+   * the capacity. Now that admission is the only bound, a budget of 0 would refuse every publication for ever - an
+   * unrecoverable hang in place of a startup failure - and there is no constructor left to reject it on the way in.
+   */
+  @Test
+  void aNonPositiveBudgetIsRaisedToOneRatherThanRefusingEveryPublication() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    for (final int configured : new int[] { 0, -1 }) {
+      final PageManagerFlushThread flush = smallQueueFlushThread(configured);
+      assertThat(flush.getQueueCapacity()).as("a budget of %d must not stay one that admits nothing", configured)
+          .isEqualTo(1);
+
+      // And it genuinely admits: one batch in, the next caller held until that one is polled.
+      flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 0))));
+      assertThat(flush.slotsUsedBy(db)).isEqualTo(1);
+      assertThat(flush.tryReserveQueueSlot(db)).as("...and exactly one, so the second is refused").isFalse();
+
+      flush.flushPagesFromQueueToDisk(null, 20L);
+      assertThat(flush.slotsUsedBy(db)).isZero();
+    }
+  }
+
+  /**
    * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
    * test moves it.
    */

--- a/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6281, item 3.
+ * <p>
+ * {@code arcadedb.pageFlushQueue} was one JVM-wide bound: the flush queue was an {@code ArrayBlockingQueue} of that
+ * size shared by every database in the process. #6259 took the wait for room out of the page-manager lock, so a full
+ * queue stopped freezing the whole JVM - but the coupling itself survived. One database's write burst against a slow
+ * volume still consumed the admission budget of every other database, so a committer of an idle database on an idle
+ * volume waited for a disk it has nothing to do with. It waited outside the lock rather than inside it, which is
+ * strictly better and still not right.
+ * <p>
+ * The budget is now per database, and the shared queue carries no capacity of its own: it is an ordering structure,
+ * and admission is the bound. A per-database QUEUE would have bounded the same thing while forcing the single flush
+ * thread to choose between queues on every poll - a fairness policy, and a starvation risk, that a per-database
+ * BUDGET over one FIFO queue simply does not have.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6281PerDatabaseFlushQueueTest extends TestHelper {
+  /** A file that does not exist, so a fabricated page can be driven through the pipeline without touching a real one. */
+  private static final int  FILE_ID               = 4_100;
+  private static final int  PAGE_SIZE             = 64;
+  /**
+   * Bounds only the waits expected to SUCCEED - the short windows asserting "not released yet" are written inline - so
+   * a generous value cannot turn a passing run red, while a tight one can under the stop-the-world pauses the shared
+   * 12000-test JVM produces late in a run (#6260).
+   */
+  private static final long ASSERTION_TIMEOUT_SEC = 60;
+
+  /**
+   * The issue itself: one database sitting at its bound must not cost another database's committer anything at all.
+   * <p>
+   * Before this, both committers were competing for the same {@code arcadedb.pageFlushQueue} slots, so B's admission
+   * was gated on A's disk. The flush thread here is detached and never started, which is what a wedged disk looks
+   * like from admission's point of view: nothing is ever polled, so nothing is ever given back.
+   */
+  @Test
+  void aDatabaseAtItsBoundDoesNotHoldTheCommittersOfAnother() throws Exception {
+    final DatabaseInternal busy = (DatabaseInternal) database;
+    final Database idle = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-idle");
+    try {
+      final PageManagerFlushThread flush = smallQueueFlushThread(2);
+
+      // Database A exhausts its budget: two batches, nothing polling.
+      flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(busy, 0))));
+      flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(busy, 1))));
+      assertThat(flush.slotsUsedBy(busy)).isEqualTo(2);
+
+      // ...so A's next committer waits, which is what the budget is FOR.
+      final CountDownLatch busyAdmitted = new CountDownLatch(1);
+      final Thread busyCommitter = new Thread(() -> {
+        try {
+          if (flush.reserveQueueSlot(busy))
+            busyAdmitted.countDown();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }, "issue6281-busy-committer");
+      busyCommitter.setDaemon(true);
+      busyCommitter.start();
+      assertThat(busyAdmitted.await(500, TimeUnit.MILLISECONDS)).as(
+          "the database at its bound must be held: that backpressure is the budget's job").isFalse();
+
+      // THE ASSERTION THE WHOLE ITEM IS ABOUT: database B has published nothing, so it owes nothing and waits for
+      // nothing - however full A's share of the pipeline is, and whatever A's disk is doing.
+      final CountDownLatch idleAdmitted = new CountDownLatch(1);
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final Thread idleCommitter = new Thread(() -> {
+        try {
+          if (flush.reserveQueueSlot((DatabaseInternal) idle)) {
+            idleAdmitted.countDown();
+            flush.releaseQueueReservation((DatabaseInternal) idle);
+          }
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      }, "issue6281-idle-committer");
+      idleCommitter.setDaemon(true);
+      idleCommitter.start();
+
+      assertThat(idleAdmitted.await(ASSERTION_TIMEOUT_SEC, TimeUnit.SECONDS)).as(
+          "a committer of an idle database must not queue behind another database's backlog: one database's slow disk is not everybody's")
+          .isTrue();
+      idleCommitter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+      assertThat(failure.get()).isNull();
+      assertThat(flush.slotsUsedBy(idle)).isZero();
+
+      // And A is still exactly where it was: admitting B took nothing from it.
+      assertThat(busyAdmitted.getCount()).isEqualTo(1);
+      assertThat(flush.slotsUsedBy(busy)).isEqualTo(2);
+
+      busyCommitter.interrupt();
+      busyCommitter.join(TimeUnit.SECONDS.toMillis(ASSERTION_TIMEOUT_SEC));
+    } finally {
+      idle.drop();
+    }
+  }
+
+  /**
+   * The queue is no longer what bounds the pipeline, so N databases at their bound hold N times the budget between
+   * them - which is the whole point, and the property a shared {@code ArrayBlockingQueue} could not express.
+   */
+  @Test
+  void theBoundIsPerDatabaseAndTheSharedQueueHasNoneOfItsOwn() throws Exception {
+    final DatabaseInternal first = (DatabaseInternal) database;
+    final Database second = TestHelper.createDatabase("target/databases/" + getClass().getSimpleName() + "-second");
+    try {
+      final int capacity = 3;
+      final PageManagerFlushThread flush = smallQueueFlushThread(capacity);
+
+      for (int i = 0; i < capacity; i++) {
+        flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(first, i))));
+        flush.scheduleFlushOfPages(new ArrayList<>(List.of(page((DatabaseInternal) second, i))));
+      }
+
+      assertThat(flush.slotsUsedBy(first)).isEqualTo(capacity);
+      assertThat(flush.slotsUsedBy(second)).isEqualTo(capacity);
+      assertThat(flush.queue).as("the shared queue holds the SUM of the per-database budgets").hasSize(2 * capacity);
+
+      // Neither database can take one more, and neither is holding the other back.
+      assertThat(flush.tryReserveQueueSlot(first)).isFalse();
+      assertThat(flush.tryReserveQueueSlot(second)).isFalse();
+
+      // A poll frees a slot of exactly ONE database: the one whose batch it was.
+      flush.flushPagesFromQueueToDisk(null, 20L);
+      assertThat(flush.slotsUsedBy(first)).as("the polled batch was the first database's").isEqualTo(capacity - 1);
+      assertThat(flush.slotsUsedBy(second)).as("and its poll gave nothing back to the other").isEqualTo(capacity);
+    } finally {
+      second.drop();
+    }
+  }
+
+  /**
+   * A database that is closed or dropped takes its budget with it: the entry keying the dead instance must not be left
+   * behind, and the batches of that database still in the queue must not drive its count negative when they are polled.
+   */
+  @Test
+  void aDroppedDatabaseLeavesNoBudgetBehind() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManagerFlushThread flush = smallQueueFlushThread(4);
+
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 0))));
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 1))));
+    assertThat(flush.slotsUsedBy(db)).isEqualTo(2);
+
+    flush.removeAllPagesOfDatabase(db);
+    assertThat(flush.slotsInUse).doesNotContainKey(db);
+
+    // The emptied batches are still in the queue and are polled normally: with the budget gone there is nothing to
+    // give back, and nothing that could go negative (the assertion inside would fail this test under -ea).
+    flush.flushPagesFromQueueToDisk(null, 20L);
+    flush.flushPagesFromQueueToDisk(null, 20L);
+    assertThat(flush.queue).isEmpty();
+    assertThat(flush.slotsUsedBy(db)).isZero();
+
+    // And the database can be used again from scratch, its budget rebuilt on demand.
+    flush.scheduleFlushOfPages(new ArrayList<>(List.of(page(db, 2))));
+    assertThat(flush.slotsUsedBy(db)).isEqualTo(1);
+  }
+
+  /**
+   * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when the
+   * test moves it.
+   */
+  private static PageManagerFlushThread smallQueueFlushThread(final int capacity) {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.PAGE_FLUSH_QUEUE, capacity);
+    return new PageManagerFlushThread(PageManager.INSTANCE, cfg);
+  }
+
+  private static MutablePage page(final DatabaseInternal database, final int pageNumber) {
+    return new MutablePage(new PageId(database, FILE_ID, pageNumber), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
@@ -155,10 +155,17 @@ class Issue6281PerDatabaseFlushQueueTest extends TestHelper {
       assertThat(flush.tryReserveQueueSlot(first)).isFalse();
       assertThat(flush.tryReserveQueueSlot(second)).isFalse();
 
+      // The gauge an operator can still compare against arcadedb.pageFlushQueue. pageFlushQueueLength is the SUM
+      // across databases now - 2 x capacity right here - which is why it needed a companion and not just a doc note.
+      assertThat(flush.maxSlotsUsedByAnyDatabase()).as(
+          "the busiest database's share is what the setting bounds, whatever the shared queue holds").isEqualTo(capacity);
+
       // A poll frees a slot of exactly ONE database: the one whose batch it was.
       flush.flushPagesFromQueueToDisk(null, 20L);
       assertThat(flush.slotsUsedBy(first)).as("the polled batch was the first database's").isEqualTo(capacity - 1);
       assertThat(flush.slotsUsedBy(second)).as("and its poll gave nothing back to the other").isEqualTo(capacity);
+      assertThat(flush.maxSlotsUsedByAnyDatabase()).as("the busiest is now the database that lost nothing")
+          .isEqualTo(capacity);
     } finally {
       second.drop();
     }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6281PerDatabaseFlushQueueTest.java
@@ -200,6 +200,61 @@ class Issue6281PerDatabaseFlushQueueTest extends TestHelper {
   }
 
   /**
+   * A batch left over from a database that has since been closed must not be able to spend a DIFFERENT database's
+   * budget - specifically not the budget of a database reopened at the same path.
+   * <p>
+   * {@code LocalDatabase} defines equality by database PATH, not by instance, so a stale batch's {@code database}
+   * field resolves to whatever entry is keyed at that path now. Releasing through a map lookup would therefore
+   * decrement the new instance's count for a slot it never took: an assertion failure here, and silent admission
+   * drift with assertions off.
+   * <p>
+   * Two things close that, and this test pins the first: the emptied wrapper is taken OUT of the queue when its
+   * database goes, so there is nothing left to poll. The second - the batch carrying the counter it was charged on
+   * rather than looking one up - is defence in depth, and measured as such: with the queue removal in place this
+   * test passes even with that capture reverted, because it can no longer reach the release. It is kept because the
+   * removal has to be remembered at every future path that could leave a batch queued across a close, and the
+   * capture does not.
+   */
+  @Test
+  void aBatchOfAClosedDatabaseCannotSpendTheBudgetOfOneReopenedAtTheSamePath() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-recycled";
+    final PageManagerFlushThread flush = smallQueueFlushThread(4);
+
+    final Database first = TestHelper.createDatabase(path);
+    try {
+      flush.scheduleFlushOfPages(new ArrayList<>(List.of(page((DatabaseInternal) first, 0))));
+      flush.scheduleFlushOfPages(new ArrayList<>(List.of(page((DatabaseInternal) first, 1))));
+      assertThat(flush.slotsUsedBy(first)).isEqualTo(2);
+
+      // The database goes away with its batches still in the pipeline.
+      flush.removeAllPagesOfDatabase(first);
+      assertThat(flush.queue).as("an emptied batch of a closed database has no business staying queued").isEmpty();
+    } finally {
+      first.drop();
+    }
+
+    // A new database at the SAME path: a different instance, an equal map key.
+    final Database second = TestHelper.createDatabase(path);
+    try {
+      assertThat(second).isEqualTo(first);
+      assertThat(second).isNotSameAs(first);
+
+      flush.scheduleFlushOfPages(new ArrayList<>(List.of(page((DatabaseInternal) second, 0))));
+      assertThat(flush.slotsUsedBy(second)).isEqualTo(1);
+
+      // Drain everything the pipeline still holds. The new database must be charged for its own batch and nothing
+      // else - a stale release landing here would take its count to -1 and trip the assert inside.
+      while (!flush.queue.isEmpty())
+        flush.flushPagesFromQueueToDisk(null, 20L);
+
+      assertThat(flush.slotsUsedBy(second)).as("the reopened database pays for its own batches and no one else's")
+          .isZero();
+    } finally {
+      second.drop();
+    }
+  }
+
+  /**
    * A non-positive {@code arcadedb.pageFlushQueue} is raised to 1 rather than rejected.
    * <p>
    * It used to be rejected, by {@code ArrayBlockingQueue}'s constructor, and that was fine while the queue carried

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
@@ -70,7 +70,7 @@ class PageManagerFlushSuspendBackpressureTest extends TestHelper {
         final PageId pageId = new PageId(database, 9, i);
         final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
         flush.pageIndex.put(page);
-        flush.queue.offer(new PagesToFlush(List.of(page)));
+        flush.offerBatch(new PagesToFlush(List.of(page)), false);
       }
 
       // Drive the flush thread by hand: with the database suspended every batch is deferred, never written.
@@ -119,7 +119,7 @@ class PageManagerFlushSuspendBackpressureTest extends TestHelper {
       final PageId pageId = new PageId(database, 9, i);
       final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
       flush.pageIndex.put(page);
-      flush.queue.offer(new PagesToFlush(List.of(page)));
+      flush.offerBatch(new PagesToFlush(List.of(page)), false);
     }
 
     for (int i = 0; i < batches; i++)

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendDeferRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendDeferRaceTest.java
@@ -92,7 +92,7 @@ class PageManagerFlushSuspendDeferRaceTest extends TestHelper {
     final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 0, 0);
     final PagesToFlush batch = new PagesToFlush(List.of(page));
     flush.pageIndex.put(page);
-    flush.queue.offer(batch);
+    flush.offerBatch(batch, false);
 
     final Thread flusher = new Thread(() -> {
       try {

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
@@ -180,7 +180,7 @@ class PageManagerFlushSuspendRefCountTest extends TestHelper {
       final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 0, 0);
       final PagesToFlush batch = new PagesToFlush(List.of(page));
       flush.pageIndex.put(page);
-      flush.queue.offer(batch);
+      flush.offerBatch(batch, false);
       flush.flushPagesFromQueueToDisk(null, 1_000L);
       assertThat(flush.queue).isEmpty(); // THE BATCH WAS DEFERRED, NOT LEFT IN THE QUEUE
 

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushThreadInterruptTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushThreadInterruptTest.java
@@ -61,7 +61,7 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
     final PageId pageId = new PageId(db, fileId, pageNum);
     final MutablePage page = new MutablePage(pageId, pageSize, new byte[pageSize], 0, 0);
     flush.pageIndex.put(page);
-    flush.queue.offer(new PagesToFlush(List.of(page)));
+    flush.offerBatch(new PagesToFlush(List.of(page)), false);
 
     // Occupy the page's I/O slot so the flush thread spins inside concurrentPageAccess (where the interrupt
     // check lives) until the slot is released, making the interrupt timing deterministic. NOTE: pendingFlushPages
@@ -123,7 +123,7 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
     final MutablePage freePage = new MutablePage(freePageId, pageSize, new byte[pageSize], 0, 0);
     flush.pageIndex.put(blockedPage);
     flush.pageIndex.put(freePage);
-    flush.queue.offer(new PagesToFlush(List.of(blockedPage, freePage)));
+    flush.offerBatch(new PagesToFlush(List.of(blockedPage, freePage)), false);
 
     final Field pendingField = PageManager.class.getDeclaredField("pendingFlushPages");
     pendingField.setAccessible(true);
@@ -185,7 +185,7 @@ class PageManagerFlushThreadInterruptTest extends TestHelper {
     final PageId pageId = new PageId(db, fileId, pageNum);
     final MutablePage page = new MutablePage(pageId, pageSize, new byte[pageSize], 0, 0);
     flush.pageIndex.put(page);
-    flush.queue.offer(new PagesToFlush(List.of(page)));
+    flush.offerBatch(new PagesToFlush(List.of(page)), false);
 
     // Drive the (unstarted) flush thread by hand: with the database suspended, the batch is deferred.
     flush.flushPagesFromQueueToDisk(null, 100L);

--- a/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
@@ -199,6 +199,42 @@ class Issue6281AsyncBatchIndexBuildTest extends TestHelper {
     assertThat(metadata.getSumDocLength()).as("and so must the length total it averages").isPositive();
   }
 
+  /**
+   * The fourth way into a bucket scan: {@code Schema.buildBucketIndex(...)} on its own.
+   * <p>
+   * {@code TypeIndexBuilder} pays the barrier before delegating down to this builder, and so does
+   * {@code REBUILD INDEX} - but it is public API in its own right, and {@code CHECK DATABASE ... FIX} rebuilds a
+   * damaged index through it. Reached that way it has to pay the barrier itself, or it produces exactly the
+   * silently incomplete index this issue is about.
+   */
+  @Test
+  void aBucketIndexBuiltDirectlyOverAnIdleAsyncExecutorStillCoversItsUncommittedBatch() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+    final String bucketName = database.getSchema().getType("V").getBuckets(false).getFirst().getName();
+
+    database.async().setParallelLevel(2);
+
+    final CountDownLatch executed = new CountDownLatch(TOT);
+    for (int i = 0; i < TOT; i++) {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", i);
+      database.async().createRecord(v, record -> executed.countDown());
+    }
+
+    assertThat(executed.await(30, TimeUnit.SECONDS)).isTrue();
+    waitForIdleAsyncExecutor();
+    assertThat(database.countType("V", false)).as("the async batch must still be open").isZero();
+
+    final Index bucketIndex = database.getSchema().buildBucketIndex("V", bucketName, new String[] { "id" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+
+    database.async().waitCompletion();
+
+    assertThat(database.countType("V", false)).isEqualTo(TOT);
+    assertThat(bucketIndex.countEntries()).as("a directly built bucket index must cover every record of its bucket")
+        .isEqualTo(TOT);
+  }
+
   private void assertIndexCoversEveryRecord() {
     assertThat(database.countType("V", false)).isEqualTo(TOT);
 

--- a/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Issue #6281: an index is built by SCANNING the buckets, so everything the asynchronous executor was asked to write
  * has to be committed before the build starts. The guard that was supposed to ensure that polled
- * {@code database.isAsyncProcessing()} and only drained the executor when it answered {@code true}.
+ * {@code database.isAsyncProcessing()} and drained the executor only when it answered {@code true}.
  * <p>
  * That predicate answers about TASKS, while a worker opens one transaction when it starts and keeps it open across up
  * to {@link com.arcadedb.GlobalConfiguration#ASYNC_TX_BATCH_SIZE} tasks (10240 by default). An executor whose queues

--- a/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
@@ -21,13 +21,16 @@ package com.arcadedb.index;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -105,6 +108,48 @@ class Issue6281AsyncBatchIndexBuildTest extends TestHelper {
     database.async().waitCompletion();
 
     assertIndexCoversEveryRecord();
+  }
+
+  /**
+   * The barrier cannot be satisfied from inside the thing it waits for, so it must REFUSE rather than park there.
+   * <p>
+   * {@code waitCompletion()} enqueues a marker on every worker - the caller's own included - and blocks until each has
+   * run, and the only consumer of a worker's queue is that worker. A worker that reaches the barrier would park on a
+   * marker nobody can dequeue and be lost for the life of the process, which is a worse failure than the one the
+   * barrier fixes. {@code RebuildIndexStatement.buildIndex} has refused this since issue #2097; the refusal now lives
+   * on the barrier itself, so no call site can reach the hang by forgetting to reimplement it.
+   * <p>
+   * Both bounds here are HANG DETECTORS, not latency bounds - the assertion is the exception, which arrives in
+   * milliseconds. Measured with the guard removed: the surefire fork does not merely fail, it never finishes at all
+   * (killed after 400 s), because the lost worker takes the database's close with it. That is what the guard turns
+   * into a one-line refusal.
+   */
+  @Test
+  @Timeout(60)
+  void theBarrierRefusesToBeCalledFromOneOfTheExecutorsOwnWorkers() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.async().setParallelLevel(2);
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<Throwable> raised = new AtomicReference<>();
+    database.async().transaction(() -> {
+      try {
+        // Exactly what an async CREATE INDEX does, minus the SQL layer: this runs ON a worker thread.
+        database.getSchema().getType("V").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+      } catch (final Throwable e) {
+        raised.compareAndSet(null, e);
+      } finally {
+        done.countDown();
+      }
+    });
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).as("the worker must come back rather than park on its own marker")
+        .isTrue();
+    assertThat(raised.get()).as("the barrier must refuse, not hang").isInstanceOf(NeedRetryException.class);
+    assertThat(raised.get()).hasMessageContaining("worker threads");
+
+    database.async().waitCompletion();
   }
 
   private void assertIndexCoversEveryRecord() {

--- a/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
@@ -22,7 +22,9 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.FullTextIndexMetadata;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
@@ -150,6 +152,51 @@ class Issue6281AsyncBatchIndexBuildTest extends TestHelper {
     assertThat(raised.get()).hasMessageContaining("worker threads");
 
     database.async().waitCompletion();
+  }
+
+  /**
+   * The same barrier on {@code REBUILD INDEX ... WITH statsOnly = true}, which returns before the rebuild proper and
+   * so needs the wait ahead of it rather than after.
+   * <p>
+   * That branch recomputes the BM25 corpus counters by SCANNING the type and then OVERWRITING the counters with what
+   * the scan found. Run against an open async batch it finds nothing committed and writes "0 documents" over counters
+   * the records had already bumped when they were saved - so the corpus size stays 0 for a type holding 200
+   * documents, and every BM25 score is computed against it, until somebody recomputes again. Unlike the index-entry
+   * case this does NOT heal itself, which is why it gets a test and the rebuild path's weaker claim does not.
+   */
+  @Test
+  void aStatsRecomputeOverAnIdleAsyncExecutorStillCountsItsUncommittedBatch() throws Exception {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc").close();
+      database.command("sql", "CREATE PROPERTY Doc.content STRING").close();
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT").close();
+    });
+
+    database.async().setParallelLevel(2);
+
+    final CountDownLatch executed = new CountDownLatch(TOT);
+    for (int i = 0; i < TOT; i++) {
+      final MutableDocument doc = database.newDocument("Doc");
+      doc.set("content", "java tutorial alpha");
+      database.async().createRecord(doc, record -> executed.countDown());
+    }
+
+    assertThat(executed.await(30, TimeUnit.SECONDS)).isTrue();
+    waitForIdleAsyncExecutor();
+    assertThat(database.countType("Doc", false)).as("the async batch must still be open").isZero();
+
+    try (final ResultSet rs = database.command("sql", "REBUILD INDEX `Doc[content]` WITH statsOnly = true")) {
+      assertThat(rs.next().<Number>getProperty("statsRecomputed").intValue()).isEqualTo(1);
+    }
+
+    database.async().waitCompletion();
+
+    assertThat(database.countType("Doc", false)).isEqualTo(TOT);
+    final FullTextIndexMetadata metadata = ((LSMTreeFullTextIndex) ((TypeIndex) database.getSchema()
+        .getIndexByName("Doc[content]")).getIndexesOnBuckets()[0]).getFullTextMetadata();
+    assertThat(metadata.getTotalDocs()).as(
+        "the corpus size BM25 scores against must be the whole corpus, not what happened to be committed").isEqualTo(TOT);
+    assertThat(metadata.getSumDocLength()).as("and so must the length total it averages").isPositive();
   }
 
   private void assertIndexCoversEveryRecord() {

--- a/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6281AsyncBatchIndexBuildTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6281: an index is built by SCANNING the buckets, so everything the asynchronous executor was asked to write
+ * has to be committed before the build starts. The guard that was supposed to ensure that polled
+ * {@code database.isAsyncProcessing()} and only drained the executor when it answered {@code true}.
+ * <p>
+ * That predicate answers about TASKS, while a worker opens one transaction when it starts and keeps it open across up
+ * to {@link com.arcadedb.GlobalConfiguration#ASYNC_TX_BATCH_SIZE} tasks (10240 by default). An executor whose queues
+ * happen to be drained therefore reports itself idle while still holding every record of the current batch
+ * uncommitted, the guard was skipped entirely, and the index was built over a bucket that did not contain them. The
+ * records then commit afterwards, with no entry ever added for them: the index ends up EMPTY and every lookup answers
+ * nothing, silently, on a database that {@code CHECK DATABASE} calls healthy.
+ * <p>
+ * The barrier is now unconditional ({@link DatabaseInternal#waitForAsyncCompletion()}), because there is no cheap
+ * predicate to test first: only {@code waitCompletion()} closes the open batch.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6281AsyncBatchIndexBuildTest extends TestHelper {
+  private static final int TOT = 200;
+
+  /**
+   * The exact shape of the bug: every async task has already RUN - nothing is queued and no worker is executing - and
+   * the records are all still uncommitted in the workers' open batch transaction when the index is created.
+   */
+  @Test
+  void anIndexCreatedOverAnIdleAsyncExecutorStillCoversItsUncommittedBatch() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.async().setParallelLevel(2);
+
+    final CountDownLatch executed = new CountDownLatch(TOT);
+    for (int i = 0; i < TOT; i++) {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", i);
+      database.async().createRecord(v, record -> executed.countDown());
+    }
+
+    // Every task has run...
+    assertThat(executed.await(30, TimeUnit.SECONDS)).isTrue();
+    // ...and the workers are back to parking on their empty queues, which is the state the old guard read as "idle".
+    waitForIdleAsyncExecutor();
+
+    // The precondition the whole issue rests on, and the reason "idle" was never the same as "done": not one of
+    // those records is committed yet. This is a property of the batching (TOT < ASYNC_TX_BATCH_SIZE), not a race.
+    assertThat(database.countType("V", false)).as("the async batch must still be open").isZero();
+
+    database.getSchema().getType("V").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+
+    database.async().waitCompletion();
+
+    assertIndexCoversEveryRecord();
+  }
+
+  /**
+   * The same creation with the executor genuinely busy. This path always worked - the old predicate answered
+   * {@code true} and the drain ran - and it must keep working now that the drain is unconditional.
+   */
+  @Test
+  void anIndexCreatedWhileTheAsyncExecutorIsBusyCoversEveryRecord() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.async().setParallelLevel(2);
+
+    for (int i = 0; i < TOT; i++) {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", i);
+      database.async().createRecord(v, null);
+    }
+
+    database.getSchema().getType("V").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+
+    database.async().waitCompletion();
+
+    assertIndexCoversEveryRecord();
+  }
+
+  private void assertIndexCoversEveryRecord() {
+    assertThat(database.countType("V", false)).isEqualTo(TOT);
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index.countEntries()).as("every record must have an entry in the index").isEqualTo(TOT);
+
+    for (int i = 0; i < TOT; i++)
+      try (final ResultSet rs = database.query("sql", "select from V where id = ?", i)) {
+        assertThat(rs.hasNext()).as("record id " + i + " must be reachable through the index").isTrue();
+        assertThat(rs.next().<Integer>getProperty("id")).isEqualTo(i);
+      }
+  }
+
+  /**
+   * Settles on the state the old guard mistook for "everything is written": queues empty, no task executing. Bounded
+   * because it is a set-up step and not what is under test - if the executor never settles the assertions below still
+   * hold, they just stop reproducing the bug.
+   */
+  private void waitForIdleAsyncExecutor() throws InterruptedException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    for (int i = 0; i < 500 && db.isAsyncProcessing(); i++)
+      Thread.sleep(10);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodTransformTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodTransformTest.java
@@ -235,6 +235,10 @@ class SQLMethodTransformTest {
       }
 
       @Override
+      public void waitForAsyncCompletion() {
+      }
+
+      @Override
       public long getResultSetLimit() {
         return 0;
       }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1192,6 +1192,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   @Override
+  public void waitForAsyncCompletion() {
+    proxied.waitForAsyncCompletion();
+  }
+
+  @Override
   public LocalTransactionExplicitLock acquireLock() {
     return proxied.acquireLock();
   }

--- a/server/src/main/java/com/arcadedb/server/ServerDatabase.java
+++ b/server/src/main/java/com/arcadedb/server/ServerDatabase.java
@@ -489,6 +489,11 @@ public class ServerDatabase implements DatabaseInternal {
     return wrapped.isAsyncProcessing();
   }
 
+  @Override
+  public void waitForAsyncCompletion() {
+    wrapped.waitForAsyncCompletion();
+  }
+
   public DocumentIndexer getIndexer() {
     return wrapped.getIndexer();
   }


### PR DESCRIPTION
Closes #6281.

Three independent items, plus an answer to the issue's open question.

## Item 1 - two assertions that cannot both hold

`Issue5279ConcurrentInsertTest.sustainedConcurrentInsertsOnASingleBucketNeverConflict` tolerates up to two conflicts at `attempts=1` and then demands the exact full count. A conflict tolerated there means that record was **not** written, so the run that actually uses the tolerance fails at the count (2000 against 2001) instead of passing at the tolerance meant to absorb it.

Same trap PR #6223 fixed in the sibling `Issue5279ConcurrentUpdateTest`; the count now subtracts `conflicts.get()`. Both classes were swept for the shape - nothing else matched.

## Item 2 - the real find: a silent, empty index

`DatabaseAsyncExecutorImpl.isProcessing()` answers about **tasks** (queued or executing). An async worker `begin()`s a transaction when it *starts* and keeps it open across up to `ASYNC_TX_BATCH_SIZE` (10240 by default) tasks. So an executor whose queues happen to be drained reports itself idle while still holding **every record of the current batch uncommitted**.

`TypeIndexBuilder.create()` guarded with:

```java
while (database.isAsyncProcessing())
  database.async().waitCompletion();
```

On the runs where that predicate answered `false`, the guard was skipped **entirely**: the index was built by scanning a bucket that did not contain those records, and they committed afterwards with no entry ever added for them. The result is an index that is empty, readable, and reported healthy by `CHECK DATABASE`, while every lookup silently answers nothing.

Reproduced deterministically before the fix - 200 records inserted, `index.countEntries()` = 0, `select from V where id = 42` returns nothing:

```
SCRATCH: isAsyncProcessing=false committedBefore=0
SCRATCH: index V[id] entries=0
SCRATCH: lookupById42=false
```

**The fix** is a barrier that cannot be skipped: `DatabaseInternal.waitForAsyncCompletion()`, a `do { waitCompletion() } while (isAsyncProcessing())`. `waitCompletion()` is the only operation that closes the open batch - it enqueues a marker *behind* everything already submitted on every worker, and that marker commits - so it has to run even when the executor looks idle. It reads the `async` field rather than `async()`, which would *create* the executor, so a database that never used the async API neither waits nor grows a thread pool.

Applied to `TypeIndexBuilder`, `ManualIndexBuilder` and `RebuildIndexStatement` - `REBUILD INDEX` scans the buckets the same way and had the same exposure.

`isProcessing()` is deliberately left answering about tasks, with a Javadoc saying so: broadening it to "a transaction is open" would make it permanently true for as long as the workers are alive, which is no answer at all.

### The test the issue pointed at was vacuous

`ACIDTransactionTest.indexCreationWhileAsyncMustFail` expected a `NeedRetryException` from the creation. That expectation has been dead for years - `create()` drains the async executor rather than refusing - so the `catch` was never entered (verified: 0 of 100 runs) and the only assertion left was the record count, which an **empty** index satisfies just as well as a complete one. That is what it was hiding.

Renamed to `indexCreatedWhileAsyncInsertsAreInFlightSurvivesACrash` and made to assert the index itself: `countEntries()` and a lookup for every record, after the crash and recovery.

## Item 3 - per-database flush budget

`arcadedb.pageFlushQueue` was one JVM-wide `ArrayBlockingQueue`. #6259 took the wait for room out of the page-manager lock, so a full queue stopped freezing the whole JVM - but the coupling itself survived: one database's burst still consumed the admission budget of every other database in the process.

**A better alternative than the per-database queue the issue proposes:** a per-database *budget* over ONE unbounded queue. A per-database queue bounds the same thing while forcing the single flush thread to choose between queues on every poll - a fairness policy, and a starvation risk, that a budget over one FIFO queue simply does not have. One queue keeps global FIFO order across databases for free.

`slotsInUse: ConcurrentHashMap<BasicDatabase, AtomicInteger>` merges the old `queue.size() + reservations` into ONE count per database, charged at reservation and released only when the batch **leaves** the queue - so a reservation and the batch it becomes are one continuous occupancy rather than two counters that have to agree. Every enqueue goes through `offerBatch`, every poll through one release, and the count is asserted never to go negative.

The property given up is named in the code: `queue.size()` read the truth by construction, and an `ArrayBlockingQueue` cannot say how many of its elements belong to database D. So is the cost: worst-case occupancy is now `pageFlushQueue x open databases` batches, the same factor a per-database queue multiplies by, on a number that was never a byte bound to begin with (one batch is one transaction's dirty pages). The bound that *is* expressed in bytes remains `arcadedb.flushSuspendMaxDeferredRAM`.

## The issue's open question

Item 2's root cause is a property of the index-build guard alone and has nothing to do with #6269: it fires whenever the async queues happen to be drained at the instant of the check, which thread scheduling on a loaded CI box makes more likely on some runs than others. The specific `page 0: keys cannot be read (Invalid position ...)` warning was **not** reproduced locally, so I am not claiming it as explained - but the test that produced it now asserts the index rather than a bare warnings count, so a recurrence will say what is wrong instead of only that something is.

## Verification

- New: `Issue6281AsyncBatchIndexBuildTest` (fails on the previous code: `[every record must have an entry in the index] expected 200 but was 0`), `Issue6281PerDatabaseFlushQueueTest`.
- `engine`: 12111 tests, 0 failures.
- `server`: 783 tests, 0 failures.
- Full reactor compiles.