### PR TITLE
fix(#6296, #6289): the biggest allocation of an algo call is the one nobody was looking at

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -274,17 +274,6 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
   protected static final long DOUBLE_BYTES = 8L;
 
   /**
-   * Heap cost of one entry of an {@code Integer[]}: the 8-byte reference the array holds plus the 16-byte boxed
-   * object it points at. Three times the cost of the {@code int} it carries, which is why an index array sorted
-   * through a {@code Comparator} - the only reason these arrays are boxed at all - is priced separately rather
-   * than folded into a primitive figure that would understate it.
-   * <p>
-   * Like {@link #MATRIX_ROW_OVERHEAD_BYTES} this is a heuristic for a budget check: below 128 the JVM hands out
-   * cached {@code Integer} instances and the true cost is the reference alone.
-   */
-  protected static final long BOXED_INTEGER_BYTES = 24L;
-
-  /**
    * Estimated heap footprint of a {@code new T[rows][columns]} of an element type {@code elementBytes} wide,
    * row headers included, in saturating {@code long} arithmetic.
    */
@@ -331,13 +320,19 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
       if (limit < 0)
         // Negative means no limit: skip the bookkeeping too, so a disabled budget costs nothing.
         return;
-      final long alreadyReserved = reserved;
-      reserved = saturatingSum(reserved, estimatedBytes);
-      if (reserved <= limit)
+      // Committed only once granted. A refused reservation was never granted, so recording it would make
+      // `reserved` describe heap nobody is holding - and every later message quoting "the N bytes this call
+      // already reserved" would quote a figure that includes an allocation the call was refused. No current
+      // caller survives a refusal to observe that, since the exception aborts the call; this keeps the
+      // invariant true for the one that eventually does.
+      final long total = saturatingSum(reserved, estimatedBytes);
+      if (total <= limit) {
+        reserved = total;
         return;
+      }
       throw new IllegalArgumentException(getName() + "(): " + component + " would need " + describe(estimatedBytes)
           + " bytes (" + detail + ")"
-          + (alreadyReserved > 0 ? ", on top of the " + alreadyReserved + " bytes this call already reserved" : "")
+          + (reserved > 0 ? ", on top of the " + reserved + " bytes this call already reserved" : "")
           + ", more than the " + limit + " bytes allowed. Set "
           + GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey() + " to raise the limit");
     }
@@ -349,6 +344,62 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     private static String describe(final long estimatedBytes) {
       return estimatedBytes == Long.MAX_VALUE ? "over " + Long.MAX_VALUE : Long.toString(estimatedBytes);
     }
+  }
+
+  /**
+   * Returns {@code 0 .. count - 1} ordered by ascending {@code weights[i]}, without boxing an index.
+   * <p>
+   * Kruskal's is the reason this exists: both places that run it - {@code algo.mst} over the edge count and
+   * {@code algo.steinerTree} over the {@code t(t-1)/2} terminal pairs - need the edge indices in weight order,
+   * and the only ready-made way to sort an index array by an external key is
+   * {@code Arrays.sort(Integer[], Comparator)}. That costs 24 bytes per entry where the {@code int} it carries
+   * occupies 4, plus a comparator call and two unboxings per comparison, and {@code algo.steinerTree}'s entry
+   * count is quadratic in a terminal list the caller supplies: ~2M entries and ~48 MB of boxed
+   * {@code Integer} at 2000 terminals. Here it is 8 bytes per entry - the index array and the merge scratch -
+   * and a primitive comparison.
+   * </p>
+   * <p>
+   * A bottom-up merge sort rather than a quicksort, for two reasons that both matter on this path: the keys are
+   * user data, and a quicksort on an adversarially ordered key array degrades to O(n²) on inputs a caller
+   * chooses; and merging is stable, so equal weights keep index order exactly as the {@code TimSort} behind
+   * {@code Arrays.sort(Integer[], ...)} did. {@link Double#compare} is the comparison, so {@code NaN} and
+   * {@code -0.0} order exactly as they did through the comparator.
+   * </p>
+   *
+   * @param weights key per index; only the first {@code count} entries are read
+   * @param count   number of indices to order
+   */
+  protected static int[] sortedIndexesByWeight(final double[] weights, final int count) {
+    final int[] index = new int[count];
+    for (int i = 0; i < count; i++)
+      index[i] = i;
+    if (count < 2)
+      return index;
+
+    final int[] scratch = new int[count];
+    int[] from = index;
+    int[] to = scratch;
+    // Widths are stepped in long: at a count near Integer.MAX_VALUE the last doubling and the run bounds it
+    // produces overflow int, and a negative bound silently skips the merge instead of failing.
+    for (long width = 1; width < count; width <<= 1) {
+      for (long lo = 0; lo < count; lo += width << 1) {
+        final int left = (int) lo;
+        final int mid = (int) Math.min(lo + width, count);
+        final int end = (int) Math.min(lo + (width << 1), count);
+        int a = left, b = mid, out = left;
+        while (a < mid && b < end)
+          // Take the left run unless the right one is strictly smaller: that is what makes the sort stable.
+          to[out++] = Double.compare(weights[from[b]], weights[from[a]]) < 0 ? from[b++] : from[a++];
+        while (a < mid)
+          to[out++] = from[a++];
+        while (b < end)
+          to[out++] = from[b++];
+      }
+      final int[] swap = from;
+      from = to;
+      to = swap;
+    }
+    return from;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -179,10 +179,11 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
       final double[] distances = dist[i];
       final RID source = graph.getRID(i);  // one lookup per SOURCE rather than one per pair
       return IntStream.range(0, n)
-          // Negated rather than written as `distances[j] < INF`, so the row set is the one the eager loop
-          // produced for every double a distance can hold - NaN included - without the reader having to first
-          // prove NaN unreachable here.
-          .filter(j -> j != i && !(distances[j] >= INF))
+          // Identical to the eager loop's `if (i == j || dist[i][j] >= INF) continue`, NaN included: a NaN
+          // distance would pass both forms of this test differently, but none can reach the matrix - every
+          // write to it above, the edge fill and the Floyd-Warshall relaxation alike, is guarded by `<`,
+          // which a NaN fails.
+          .filter(j -> j != i && distances[j] < INF)
           .mapToObj(j -> {
             final ResultInternal r = new ResultInternal();
             r.setProperty("source", source);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
@@ -27,8 +28,9 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -46,6 +48,12 @@ import java.util.stream.Stream;
  * Note: this algorithm is O(V²) in memory and O(V³) in time. Only suitable for graphs
  * with up to a few thousand vertices - a bound the distance matrix's reservation through
  * {@link AbstractAlgoProcedure.MemoryBudget} now enforces rather than merely advises.
+ * </p>
+ * <p>
+ * The rows are produced lazily from the completed distance matrix, so the O(V²) figure above is the matrix and
+ * nothing else: a caller that reads one row holds one row. This is the only {@code algo.*} procedure whose row
+ * count is quadratic in the graph rather than bounded by a top-k, a component count or one neighbourhood, which
+ * is what made materialising it eagerly the largest allocation of the call (issue #6296).
  * </p>
  * <p>
  * Example:
@@ -154,20 +162,35 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
       }
     }
 
-    // Collect results: only reachable pairs with i != j
-    final List<Result> results = new ArrayList<>();
-    for (int i = 0; i < n; i++) {
-      for (int j = 0; j < n; j++) {
-        if (i == j || dist[i][j] >= INF)
-          continue;
-        final ResultInternal r = new ResultInternal();
-        r.setProperty("source", graph.getRID(i));
-        r.setProperty("target", graph.getRID(j));
-        r.setProperty("distance", dist[i][j]);
-        results.add(r);
-      }
-    }
-    return results.stream();
+    // Emit the reachable pairs (i != j) lazily, one row at a time.
+    //
+    // The rows are the largest allocation this procedure makes, and until issue #6296 they were the one thing in
+    // it that no budget saw: the matrix reserved above is n x n DOUBLES, the result is up to n² - n ROW OBJECTS,
+    // each a ResultInternal with a three-entry property map. At the 64 MB floor of
+    // arcadedb.cypher.algoMaxWorkingMemory the matrix check admits n ≈ 2890, and a connected graph of that size
+    // then produced ~8.3M rows - well over a gigabyte, held all at once, against the 64 MB the budget had just
+    // finished enforcing beside it. The call died of the allocation the budget was not looking at.
+    //
+    // Nothing required them to exist together: the matrix is complete before the first row is emitted, so the
+    // rows are a pure projection of it. Streaming them makes the row-side footprint O(1) and hands the decision
+    // of how many to hold to the consumer, which is where it belongs - CallStep keeps the iterator rather than
+    // collecting it (see CallStep#executeProcedure), so a LIMIT upstream now costs what it says it costs.
+    return IntStream.range(0, n).mapToObj(i -> {
+      final double[] distances = dist[i];
+      final RID source = graph.getRID(i);  // one lookup per SOURCE rather than one per pair
+      return IntStream.range(0, n)
+          // Negated rather than written as `distances[j] < INF`, so the row set is the one the eager loop
+          // produced for every double a distance can hold - NaN included - without the reader having to first
+          // prove NaN unreachable here.
+          .filter(j -> j != i && !(distances[j] >= INF))
+          .mapToObj(j -> {
+            final ResultInternal r = new ResultInternal();
+            r.setProperty("source", source);
+            r.setProperty("target", graph.getRID(j));
+            r.setProperty("distance", distances[j]);
+            return (Result) r;
+          });
+    }).flatMap(Function.identity());
   }
 
   private void fillDistanceMatrixFromOLTP(final GraphData graph, final int n, final double[][] dist,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -110,16 +110,14 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     if (startIdx == null || endIdx == null)
       return Stream.empty();
 
-    // Yen's algorithm is dense here: a nodeCount x nodeCount weight matrix for the whole run, plus one
-    // nodeCount x nodeCount removed-edge mask per spur node. 800 MB and 100 MB respectively at 10 000 nodes,
-    // with no knob involved. Reserved before the first is allocated so that a graph too large for the dense
-    // formulation is a client error naming the node count and the budget, rather than an OutOfMemoryError.
-    // A fresh mask is allocated for every spur node but only one is ever live, so the PEAK is one mask: it is
-    // priced once, not per spur node. (That the mask is reallocated rather than cleared and reused is a
-    // separate question, about churn rather than about the peak, and not one a budget answers.)
-    newMemoryBudget(db).reserve(saturatingSum(matrixBytes(n, n, DOUBLE_BYTES), matrixBytes(n, n, BOOLEAN_BYTES)),
-        "the weight matrix and the removed-edge mask",
-        "a double matrix and a boolean matrix, each " + n + " x " + n + " nodes");
+    // Yen's algorithm is dense here: a nodeCount x nodeCount weight matrix for the whole run - 800 MB at
+    // 10 000 nodes, with no knob involved. Reserved before it is allocated so that a graph too large for the
+    // dense formulation is a client error naming the node count and the budget, rather than an
+    // OutOfMemoryError. The two spur masks beside it are nodeCount-sized and allocated once for the whole call
+    // (see below), so they are a rounding error next to the matrix and are priced with it rather than apart.
+    newMemoryBudget(db).reserve(saturatingSum(matrixBytes(n, n, DOUBLE_BYTES), matrixBytes(2, n, BOOLEAN_BYTES)),
+        "the weight matrix and the spur masks",
+        "a double matrix of " + n + " x " + n + " nodes and two boolean masks of " + n + " nodes");
 
     // Build weighted adjacency matrix (OUT direction)
     final double[][] weightMatrix = new double[n][n];
@@ -166,11 +164,26 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     kPaths.add(firstPath);
     kWeights.add(pathWeight(firstPath, weightMatrix));
 
-    // Candidate paths: PriorityQueue of {weight, path}
-    final PriorityQueue<double[]> candidates = new PriorityQueue<>(Comparator.comparingDouble(a2 -> a2[0]));
-    // We'll encode paths as serialized int arrays stored separately
+    // Candidate paths, as parallel lists of the path and its cost.
     final List<int[]> candidatePaths = new ArrayList<>();
     final List<Double> candidateCosts = new ArrayList<>();
+
+    // The two masks Yen's spur loop needs, allocated once for the whole call and cleared entry by entry
+    // between spur nodes (issue #6289).
+    //
+    // `removedSpurTargets` used to be a nodeCount x nodeCount boolean matrix allocated fresh per spur node -
+    // ~1 MB per allocation at 1000 nodes, ~200 MB through the young generation for a single k=10 call over a
+    // 20-hop path. It never needed a row per source: every edge it removes leaves the SAME node. The removal
+    // loop below keeps an edge (p[i], p[i+1]) of a previously-found path only when that path shares the root
+    // p[0..i] with prevPath, and prevPath[i] IS the spur node - so p[i] == spurNode for every entry it ever
+    // set, and the other n-1 rows were allocated, zeroed and read only to prove they were empty. One row
+    // indexed by target says exactly as much, in O(nodeCount) rather than O(nodeCount²).
+    //
+    // Cleared rather than reallocated because the entries set are the few the two loops below can name: at
+    // most one per previously-found path, and one per root-path node. Clearing exactly those is O(paths + i),
+    // where an Arrays.fill would be O(nodeCount) and a fresh allocation O(nodeCount) plus the zeroing.
+    final boolean[] removedSpurTargets = new boolean[n];
+    final boolean[] removedNodes = new boolean[n];
 
     for (int ki = 1; ki < k; ki++) {
       final int[] prevPath = kPaths.get(ki - 1);
@@ -178,32 +191,22 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
       for (int i = 0; i < prevPath.length - 1; i++) {
         final int spurNode = prevPath[i];
         final int[] rootPath = Arrays.copyOf(prevPath, i + 1);
-        final double rootCost = pathWeight(rootPath, weightMatrix);
 
-        // Remove edges that are part of previous k-shortest paths sharing the same root
-        // We track removed edges as pairs via a HashSet-like structure (boolean matrix)
-        final boolean[][] removedEdges = new boolean[n][n];
-        for (final int[] p : kPaths) {
-          if (p.length > i + 1) {
-            boolean sameRoot = true;
-            for (int r = 0; r <= i; r++) {
-              if (p[r] != prevPath[r]) {
-                sameRoot = false;
-                break;
-              }
-            }
-            if (sameRoot)
-              removedEdges[p[i]][p[i + 1]] = true;
-          }
-        }
+        // Remove the edges leaving the spur node that are part of previously-found paths sharing this root
+        markRemovedSpurTargets(kPaths, prevPath, i, removedSpurTargets, true);
 
         // Remove root path nodes (except spurNode) from the graph
-        final boolean[] removedNodes = new boolean[n];
         for (int r = 0; r < i; r++)
           removedNodes[rootPath[r]] = true;
 
         // Find spur path from spurNode to endIdx
-        final int[] spurPath = dijkstra(weightMatrix, n, spurNode, endIdx, (u, v) -> removedEdges[u][v] || removedNodes[u] || removedNodes[v]);
+        final int[] spurPath = dijkstra(weightMatrix, n, spurNode, endIdx,
+            (u, v) -> (u == spurNode && removedSpurTargets[v]) || removedNodes[u] || removedNodes[v]);
+
+        // Both masks are shared across spur nodes, so they are handed back empty for the next one.
+        markRemovedSpurTargets(kPaths, prevPath, i, removedSpurTargets, false);
+        for (int r = 0; r < i; r++)
+          removedNodes[rootPath[r]] = false;
 
         if (spurPath != null) {
           // Build total path = rootPath + spurPath (skip duplicate spurNode)
@@ -211,10 +214,10 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
           System.arraycopy(rootPath, 0, totalPath, 0, rootPath.length - 1);
           System.arraycopy(spurPath, 0, totalPath, rootPath.length - 1, spurPath.length);
 
-          final double totalCost = rootCost - (i > 0 ? pathWeight(Arrays.copyOf(rootPath, i), weightMatrix) : 0)
-              + pathWeight(rootPath, weightMatrix) - (i > 0 ? pathWeight(Arrays.copyOf(rootPath, rootPath.length - 1), weightMatrix) : 0)
-              + pathWeight(spurPath, weightMatrix);
-          // Simpler: just compute full path weight
+          // The cost of the concatenated path, walked once. The incremental form this replaced - root cost
+          // plus spur cost, corrected for the prefixes counted twice - computed the same number four ways and
+          // then threw it away in favour of this line, at the price of two Arrays.copyOf and four pathWeight
+          // walks per spur node.
           final double fullCost = pathWeight(totalPath, weightMatrix);
 
           // Check if already in candidates or kPaths
@@ -274,6 +277,32 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
   @FunctionalInterface
   private interface EdgeFilter {
     boolean isRemoved(int u, int v);
+  }
+
+  /**
+   * Marks (or unmarks) the targets of the edges Yen's removes for the spur node {@code prevPath[spurIndex]}:
+   * the successor of that node in every already-found path whose first {@code spurIndex + 1} nodes match
+   * {@code prevPath}.
+   * <p>
+   * The same traversal both sets and clears, so the mask handed to the next spur node is empty without an
+   * {@code Arrays.fill} over the node count or a fresh allocation - it touches only the entries it can name.
+   */
+  private static void markRemovedSpurTargets(final List<int[]> kPaths, final int[] prevPath, final int spurIndex,
+      final boolean[] removedSpurTargets, final boolean marked) {
+    for (final int[] p : kPaths) {
+      if (p.length <= spurIndex + 1)
+        continue;
+      boolean sameRoot = true;
+      for (int r = 0; r <= spurIndex; r++) {
+        if (p[r] != prevPath[r]) {
+          sameRoot = false;
+          break;
+        }
+      }
+      if (sameRoot)
+        // p[spurIndex] == prevPath[spurIndex] == the spur node, which is why only the target needs indexing.
+        removedSpurTargets[p[spurIndex + 1]] = marked;
+    }
   }
 
   private static int[] dijkstra(final double[][] w, final int n, final int src, final int dst,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -29,7 +29,6 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -151,11 +150,9 @@ public class AlgoMST extends AbstractAlgoProcedure {
       }
     }
 
-    // Sort edge indices by weight (Integer[] boxing, one allocation O(E))
-    final Integer[] sortIdx = new Integer[ec];
-    for (int i = 0; i < ec; i++)
-      sortIdx[i] = i;
-    Arrays.sort(sortIdx, (a, b) -> Double.compare(ew[a], ew[b]));
+    // Sort edge indices by weight, over primitive indices: one int[] of order plus one of merge scratch,
+    // against the 24 bytes per edge an Integer[] cost (issue #6289).
+    final int[] sortIdx = sortedIndexesByWeight(ew, ec);
 
     // Union-Find with path compression + union by rank
     final int[] parent = new int[n];

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
@@ -59,7 +59,7 @@ import java.util.stream.Stream;
  * </p>
  *
  * <p>Working set: a {@code terminals x nodeCount} pair of Dijkstra tables plus one entry per terminal pair -
- * about {@code t²/2} of them - in four parallel arrays, both reserved through
+ * about {@code t²/2} of them - in five parallel primitive arrays, both reserved through
  * {@link AbstractAlgoProcedure.MemoryBudget} before anything is allocated. Quadratic in a list the caller
  * supplies and nothing bounds, which is why the pair count is also computed in {@code long}.</p>
  *
@@ -125,7 +125,11 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
     final MemoryBudget memory = newMemoryBudget(db);
     memory.reserve(saturatingSum(matrixBytes(t, n, DOUBLE_BYTES), matrixBytes(t, n, INT_BYTES)),
         "the per-terminal Dijkstra tables", t + " terminals x " + n + " nodes");
-    memory.reserve(saturatingProduct(pairCount, 2 * INT_BYTES + DOUBLE_BYTES + BOXED_INTEGER_BYTES),
+    // Per pair: the endpoints pU/pV, the weight pW, and the two int arrays the index sort works over (the
+    // order and the merge scratch). Four ints and a double, all primitive - which is what
+    // sortedIndexesByWeight() is for: through Arrays.sort(Integer[], Comparator) the sort alone used to cost
+    // 24 bytes per pair, more than everything else here put together (issue #6289).
+    memory.reserve(saturatingProduct(pairCount, 4 * INT_BYTES + DOUBLE_BYTES),
         "the terminal-pair arrays", pairCount + " pairs over " + t + " terminals");
     if (pairCount > Integer.MAX_VALUE)
       throw new IllegalArgumentException(getName() + "(): " + t + " terminalNodes make " + pairCount
@@ -168,11 +172,9 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
         pi++;
       }
 
-    // Sort by weight for Kruskal's
-    final Integer[] sortIdx = new Integer[pairs];
-    for (int i = 0; i < pairs; i++)
-      sortIdx[i] = i;
-    Arrays.sort(sortIdx, (a, b) -> Double.compare(pW[a], pW[b]));
+    // Sort by weight for Kruskal's, over primitive indices: `pairs` is quadratic in a terminal list the caller
+    // supplies, so a boxed Integer[] here is ~2M objects at 2000 terminals.
+    final int[] sortIdx = sortedIndexesByWeight(pW, pairs);
 
     // Union-Find on terminal indices
     final int[] parent = new int[t];

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6263AlgoWorkingMemoryBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6263AlgoWorkingMemoryBudgetTest.java
@@ -242,7 +242,11 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
         MATCH (a:Node {name: 'A'}), (c:Node {name: 'C'}) \
         CALL algo.kShortestPaths(a, c, 2) YIELD weight \
         RETURN weight"""))
-        .hasStackTraceContaining("the weight matrix and the removed-edge mask would need 400 bytes")
+        // 328 rather than the 400 this reservation quoted before #6289: the removed-edge mask used to be
+        // priced as a square matrix, because it was allocated as one - once per spur node. It is now two
+        // node-sized masks allocated once for the whole call.
+        .hasStackTraceContaining("the weight matrix and the spur masks would need 328 bytes "
+            + "(a double matrix of 4 x 4 nodes and two boolean masks of 4 nodes)")
         .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6289AlgoAllocationChurnTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6289AlgoAllocationChurnTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression tests for issue #6289 - allocation churn on the dense {@code algo.*} paths.
+ * <p>
+ * Three findings from the review of PR #6285 (issue #6263), none of which raise a <em>peak</em> - which is why
+ * the budget added there prices them correctly and none of them is a bug it could have caught:
+ * <ol>
+ *   <li>{@code algo.kShortestPaths} allocated a {@code nodeCount x nodeCount} removed-edge mask per spur node.
+ *   Only one was ever live, so the peak was one; the churn was {@code k x pathLength} allocations of
+ *   {@code nodeCount²} bytes - ~200 MB through the young generation for a single call at 1000 nodes. The mask
+ *   never needed a row per source: every edge Yen's removes for a given spur node leaves that same node, so a
+ *   single {@code boolean[nodeCount]} indexed by target says exactly as much, and it is cleared between spur
+ *   nodes rather than reallocated.</li>
+ *   <li>{@code algo.steinerTree} and {@code algo.mst} sorted their Kruskal edge indices through an
+ *   {@code Integer[]} - 24 bytes per entry where the {@code int} occupies 4, plus two unboxings per comparison,
+ *   over an entry count that is quadratic in a caller-supplied terminal list. Both now use a primitive stable
+ *   index sort.</li>
+ *   <li>{@code MemoryBudget.reserve()} added to the running total before checking it, so a refused reservation
+ *   was recorded as granted.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6289AlgoAllocationChurnTest {
+  /**
+   * Nodes that carry the paths: a chain {@code A0 -> A1 -> ... -> A20} doubled by a bypass node per hop, so
+   * every hop offers two routes of different weight and Yen's has plenty of distinct paths to find - which is
+   * what drives the spur-node loop the mask used to be reallocated in.
+   */
+  private static final int CHAIN_HOPS = 20;
+
+  /**
+   * Isolated vertices added on top. They take no part in any path, so they change neither the number of spur
+   * nodes nor the work Dijkstra does - they change only {@code nodeCount}, which is exactly the dimension the
+   * old per-spur-node mask was quadratic in.
+   */
+  private static final int PADDING_NODES = 460;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6289-algo-churn");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final MutableVertex[] chain = new MutableVertex[CHAIN_HOPS + 1];
+      for (int i = 0; i <= CHAIN_HOPS; i++)
+        chain[i] = database.newVertex("Node").set("name", "A" + i).save();
+
+      for (int i = 0; i < CHAIN_HOPS; i++) {
+        // Direct hop, and a two-edge detour through a bypass node with a slightly different total weight so
+        // that every combination of the two is a distinct path with a distinct cost.
+        chain[i].newEdge("LINK", chain[i + 1], true, (Object[]) null).save().set("w", 10.0).save();
+        final MutableVertex bypass = database.newVertex("Node").set("name", "B" + i).save();
+        chain[i].newEdge("LINK", bypass, true, (Object[]) null).save().set("w", 5.0 + i * 0.01).save();
+        bypass.newEdge("LINK", chain[i + 1], true, (Object[]) null).save().set("w", 5.0 + i * 0.01).save();
+      }
+
+      for (int i = 0; i < PADDING_NODES; i++)
+        database.newVertex("Node").set("name", "P" + i).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  // ── 1. The per-spur-node mask ────────────────────────────────────────────
+
+  @Test
+  void kShortestPathsStillReturnsKDistinctPathsInAscendingWeight() {
+    // The correctness counterweight to the mask change. Collapsing an n x n mask to one row is only valid
+    // because every edge it removes leaves the spur node; if that were wrong, Yen's would stop excluding
+    // previously-found paths and start returning the same path twice, or returning them out of order.
+    final List<Result> paths = drain("""
+        MATCH (a:Node {name: 'A0'}), (z:Node {name: 'A20'}) \
+        CALL algo.kShortestPaths(a, z, 8, 'LINK', 'w') YIELD path, weight, rank \
+        RETURN weight, rank""");
+
+    assertThat(paths).hasSize(8);
+
+    double previous = -1.0;
+    for (int i = 0; i < paths.size(); i++) {
+      final double weight = ((Number) paths.get(i).getProperty("weight")).doubleValue();
+      assertThat(paths.get(i).<Number>getProperty("rank").intValue()).isEqualTo(i + 1);
+      assertThat(weight).as("path " + (i + 1) + " must not be cheaper than the one before it").isGreaterThanOrEqualTo(previous);
+      previous = weight;
+    }
+  }
+
+  @Test
+  void kShortestPathsPricesTwoNodeSizedMasksRatherThanASquareOne() {
+    // The reservation follows the allocation: what is held beside the weight matrix is two boolean[nodeCount]
+    // masks for the whole call, not a nodeCount x nodeCount matrix per spur node. On this graph that is
+    // 501 x 501 doubles plus two 501-entry masks.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+
+    final int n = CHAIN_HOPS * 2 + 1 + PADDING_NODES;
+    assertThatThrownBy(() -> drain("""
+        MATCH (a:Node {name: 'A0'}), (z:Node {name: 'A20'}) \
+        CALL algo.kShortestPaths(a, z, 3) YIELD weight \
+        RETURN weight"""))
+        .hasStackTraceContaining("the weight matrix and the spur masks would need")
+        .hasStackTraceContaining("a double matrix of " + n + " x " + n + " nodes and two boolean masks of " + n + " nodes")
+        .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+  }
+
+  @Test
+  @Tag("performance")
+  void kShortestPathsAllocatesTheWeightMatrixOnceAndNoMaskPerSpurNode() {
+    // Measured on the thread's own allocation counter, which no GC and no other test can move.
+    //
+    // The call below walks ~150 spur nodes over a 501-node graph. Each used to allocate a
+    // boolean[501][501] - ~264 KB - for ~40 MB of churn, against a weight matrix of 501 x 501 doubles
+    // (~2 MB) allocated once. Measured: 4.4 MB now against 43.3 MB before, so a bound of six matrices
+    // (12 MB) leaves room for Dijkstra's per-spur-node scratch on either side of it and still refuses
+    // anything that reallocates a square mask per spur node.
+    final com.sun.management.ThreadMXBean threads = threadAllocationBean();
+    assumeTrue(threads != null, "JVM does not expose per-thread allocation counters");
+
+    database.begin();
+    try {
+      for (int i = 0; i < 2; i++)
+        assertThat(drain(kShortestPaths())).isNotEmpty();
+
+      final long weightMatrixBytes = (long) (CHAIN_HOPS * 2 + 1 + PADDING_NODES) * (CHAIN_HOPS * 2 + 1 + PADDING_NODES) * 8L;
+      final long allocated = measure(threads, () -> assertThat(drain(kShortestPaths())).isNotEmpty());
+
+      assertThat(allocated)
+          .as("a square mask per spur node is what this bound separates from one weight matrix per call "
+              + "(allocated=" + allocated + " bytes, weight matrix=" + weightMatrixBytes + " bytes)")
+          .isLessThan(6 * weightMatrixBytes);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  // ── 2. The boxed Kruskal index sort ──────────────────────────────────────
+
+  @Test
+  void theIndexSortOrdersExactlyAsTheBoxedComparatorSortDid() {
+    // The replacement has to be indistinguishable from Arrays.sort(Integer[], comparingDouble) - including
+    // where the comparator's answers are least obvious. Duplicates decide stability, NaN and the infinities
+    // decide the ordering Double.compare imposes, and -0.0 sorts BELOW 0.0 through Double.compare while
+    // comparing equal through `<`, so a hand-rolled comparison on the raw doubles would quietly differ here.
+    final double[] awkward = { 0.0, -0.0, Double.NaN, Double.POSITIVE_INFINITY, 1.0, Double.NEGATIVE_INFINITY,
+        Double.NaN, 1.0, -0.0, Double.MAX_VALUE, 0.0 };
+    assertThat(AbstractAlgoProcedure.sortedIndexesByWeight(awkward, awkward.length))
+        .containsExactly(referenceOrder(awkward, awkward.length));
+
+    final Random random = new Random(42);
+    for (int count : new int[] { 0, 1, 2, 3, 7, 8, 9, 1000 }) {
+      final double[] weights = new double[count];
+      for (int i = 0; i < count; i++)
+        // A small value range on purpose: ties are what a stable sort has to preserve the index order of.
+        weights[i] = random.nextInt(5);
+      assertThat(AbstractAlgoProcedure.sortedIndexesByWeight(weights, count))
+          .as("order for " + count + " weights")
+          .containsExactly(referenceOrder(weights, count));
+    }
+  }
+
+  @Test
+  void mstAndSteinerTreeAreUnchangedByThePrimitiveSort() {
+    // Kruskal's picks edges in the order the sort produced, so a different order is a different tree. On the
+    // chain-with-bypasses graph the minimum spanning forest is deterministic: every bypass detour (2 x ~5) is
+    // cheaper than the direct hop (10), so the MST takes both bypass edges of every hop and no direct hop.
+    final List<Result> mst = drain("CALL algo.mst('w') YIELD source, target, weight RETURN weight");
+    assertThat(mst).hasSize(CHAIN_HOPS * 2);
+    for (final Result edge : mst)
+      assertThat(edge.<Number>getProperty("weight").doubleValue())
+          .as("the MST must never take a 10.0 direct hop over the two ~5.0 bypass edges beside it")
+          .isLessThan(10.0);
+
+    // The Steiner tree over the two chain ends is their shortest path, and there the choice goes the other way:
+    // a direct hop costs 10.0 against the 10.02 the two bypass edges cost together. Kruskal's over the terminal
+    // pairs is what picks it, so a mis-ordered index sort shows up here as a different tree - and the two cases
+    // together pin the ordering from both sides.
+    final List<Result> steiner = drain("""
+        MATCH (a:Node {name: 'A0'}), (z:Node {name: 'A20'}) \
+        CALL algo.steinerTree([a, z], 'LINK', 'w') YIELD source, target, weight, totalWeight \
+        RETURN weight, totalWeight""");
+    assertThat(steiner).hasSize(CHAIN_HOPS);
+    for (final Result edge : steiner) {
+      assertThat(edge.<Number>getProperty("weight").doubleValue()).isEqualTo(10.0);
+      assertThat(edge.<Number>getProperty("totalWeight").doubleValue()).isEqualTo(CHAIN_HOPS * 10.0);
+    }
+  }
+
+  @Test
+  @Tag("performance")
+  void theIndexSortDoesNotBoxAnIndex() {
+    // The point of the replacement, measured directly rather than inferred from a procedure call whose other
+    // allocations would drown it. An Integer[] costs the 8-byte reference plus a 16-byte boxed object per
+    // entry (the JVM's Integer cache covers only -128..127, which a million-entry index sort leaves at once);
+    // two int[] cost 8. The bound below sits between them.
+    final com.sun.management.ThreadMXBean threads = threadAllocationBean();
+    assumeTrue(threads != null, "JVM does not expose per-thread allocation counters");
+
+    final int count = 1_000_000;
+    final double[] weights = new double[count];
+    final Random random = new Random(7);
+    for (int i = 0; i < count; i++)
+      weights[i] = random.nextDouble();
+
+    for (int i = 0; i < 3; i++)
+      assertThat(AbstractAlgoProcedure.sortedIndexesByWeight(weights, count)).hasSize(count);
+
+    long allocated = Long.MAX_VALUE;
+    for (int round = 0; round < 3; round++)
+      allocated = Math.min(allocated,
+          measure(threads, () -> assertThat(AbstractAlgoProcedure.sortedIndexesByWeight(weights, count)).hasSize(count)));
+
+    assertThat(allocated / (double) count)
+        .as("bytes per index: two int[] is 8, an Integer[] was 24 (measured " + allocated + " bytes for " + count + ")")
+        .isLessThan(12.0);
+  }
+
+  // ── 3. A refused reservation is not a granted one ────────────────────────
+
+  @Test
+  void arefusedReservationIsNotAddedToTheRunningTotal() {
+    // MemoryBudget.reserve() used to add to the total and then check it, so a refusal left the budget
+    // recording heap nobody was holding: the next reservation was charged against a component the call had
+    // just been refused, and the "on top of the N bytes this call already reserved" in its message quoted a
+    // figure that included it. Harmless while the exception aborts the call - which is why it was filed as an
+    // invariant rather than as a bug - and a trap for the first caller that survives a refusal.
+    final AbstractAlgoProcedure procedure = new AlgoAPSP();
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1000L);
+    final AbstractAlgoProcedure.MemoryBudget budget = procedure.newMemoryBudget(database);
+
+    assertThatThrownBy(() -> budget.reserve(2000L, "an oversized component", "detail"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("more than the 1000 bytes allowed")
+        .as("nothing was reserved yet, so the message must not claim a prior reservation")
+        .hasMessageNotContaining("already reserved");
+
+    // The refused 2000 bytes were never granted, so 500 still fits the 1000-byte budget.
+    budget.reserve(500L, "a component that fits", "detail");
+
+    assertThatThrownBy(() -> budget.reserve(600L, "one component too many", "detail"))
+        .as("only the granted 500 bytes may be quoted as already reserved")
+        .hasMessageContaining("on top of the 500 bytes this call already reserved");
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /** The reference the primitive sort has to reproduce: the boxed comparator sort it replaced. */
+  private static int[] referenceOrder(final double[] weights, final int count) {
+    final Integer[] boxed = new Integer[count];
+    for (int i = 0; i < count; i++)
+      boxed[i] = i;
+    Arrays.sort(boxed, (a, b) -> Double.compare(weights[a], weights[b]));
+    final int[] order = new int[count];
+    for (int i = 0; i < count; i++)
+      order[i] = boxed[i];
+    return order;
+  }
+
+  private Stream<Result> kShortestPaths() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    final Object start = database.query("sql", "SELECT FROM Node WHERE name = 'A0'").next().getElement().orElseThrow();
+    final Object end = database.query("sql", "SELECT FROM Node WHERE name = 'A20'").next().getElement().orElseThrow();
+    return new AlgoKShortestPaths().execute(new Object[] { start, end, 8, "LINK", "w" }, null, context);
+  }
+
+  private static List<Result> drain(final Stream<Result> rows) {
+    final List<Result> results = new ArrayList<>();
+    for (final Iterator<Result> it = rows.iterator(); it.hasNext(); )
+      results.add(it.next());
+    return results;
+  }
+
+  private List<Result> drain(final String query) {
+    final ResultSet rs = database.query("opencypher", query);
+    final List<Result> results = new ArrayList<>();
+    while (rs.hasNext())
+      results.add(rs.next());
+    return results;
+  }
+
+  private static long measure(final com.sun.management.ThreadMXBean threads, final Runnable body) {
+    final long id = Thread.currentThread().threadId();
+    final long before = threads.getThreadAllocatedBytes(id);
+    body.run();
+    return threads.getThreadAllocatedBytes(id) - before;
+  }
+
+  private static com.sun.management.ThreadMXBean threadAllocationBean() {
+    if (!(ManagementFactory.getThreadMXBean() instanceof final com.sun.management.ThreadMXBean bean))
+      return null;
+    if (!bean.isThreadAllocatedMemorySupported())
+      return null;
+    bean.setThreadAllocatedMemoryEnabled(true);
+    return bean.isThreadAllocatedMemoryEnabled() ? bean : null;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6289AlgoAllocationChurnTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6289AlgoAllocationChurnTest.java
@@ -61,6 +61,14 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *   <li>{@code MemoryBudget.reserve()} added to the running total before checking it, so a refused reservation
  *   was recorded as granted.</li>
  * </ol>
+ * <p>
+ * The allocation assertions carry {@code @Tag("performance")} rather than {@code @Tag("benchmark")}, and that is
+ * deliberate: {@code benchmark} is one of the three lanes CI <em>excludes</em> from the normal build
+ * ({@code -DexcludedGroups=slow,benchmark,vector}), and a regression guard that never runs guards nothing. These
+ * are not throughput measurements - they read {@code ThreadMXBean}'s per-thread allocation counter, which no GC
+ * and no concurrent test can move - so they belong in the default lane, where {@code performance} leaves them.
+ * The tag is a label for the reader, matching {@code RidScoreMinHeapTest}; the partition CLAUDE.md describes is
+ * untouched by it.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -272,7 +280,7 @@ class Issue6289AlgoAllocationChurnTest {
   // ── 3. A refused reservation is not a granted one ────────────────────────
 
   @Test
-  void arefusedReservationIsNotAddedToTheRunningTotal() {
+  void aRefusedReservationIsNotAddedToTheRunningTotal() {
     // MemoryBudget.reserve() used to add to the total and then check it, so a refusal left the budget
     // recording heap nobody was holding: the next reservation was charged against a component the call had
     // just been refused, and the "on top of the N bytes this call already reserved" in its message quoted a

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6296AlgoAPSPLazyRowsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6296AlgoAPSPLazyRowsTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -53,6 +56,14 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Nothing required the rows to exist together: Floyd-Warshall completes the matrix before the first row is
  * emitted, so the rows are a pure projection of it. They are now produced lazily, which makes the row-side
  * footprint O(1) and puts the decision of how many to hold where it belongs - with the consumer.
+ * <p>
+ * The allocation assertions carry {@code @Tag("performance")} rather than {@code @Tag("benchmark")}, and that is
+ * deliberate: {@code benchmark} is one of the three lanes CI <em>excludes</em> from the normal build
+ * ({@code -DexcludedGroups=slow,benchmark,vector}), and a regression guard that never runs guards nothing. These
+ * are not throughput measurements - they read {@code ThreadMXBean}'s per-thread allocation counter, which no GC
+ * and no concurrent test can move - so they belong in the default lane, where {@code performance} leaves them.
+ * The tag is a label for the reader, matching {@code RidScoreMinHeapTest}; the partition CLAUDE.md describes is
+ * untouched by it.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -159,6 +170,60 @@ class Issue6296AlgoAPSPLazyRowsTest {
   }
 
   @Test
+  void theRowsAreTheSameWhenTheGraphIsCSRBacked() {
+    // The one thing making the rows lazy actually moves: `graph.getRID(i)` used to run inside execute() and
+    // now runs as the row is read. On the OLTP-backed GraphData that is `vertices.get(i).getIdentity()`, an
+    // in-memory field read that cannot care when it happens. On the CSR-backed one it goes through the
+    // GraphAnalyticalView's node mapping, which takes a database reference - so that is the path worth
+    // pinning, and it is the path the other tests here never take.
+    //
+    // Deferring it is safe because the stream is drained inside the same query execution that produced it
+    // (CallStep keeps the iterator for a read procedure and the pipeline pulls it to completion before the
+    // transaction is torn down), which is the contract every other lazily-returning algo.* procedure already
+    // relies on - algo.mst, algo.fastrp and the rest have streamed from IntStream since before this change.
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("apsp-view")
+        .withVertexTypes("Node")
+        .withEdgeTypes("LINK")
+        .build();
+    try {
+      database.begin();
+      try {
+        final BasicCommandContext context = new BasicCommandContext();
+        context.setDatabase(database);
+        final Stream<Result> rows = new AlgoAPSP().execute(new Object[0], null, context);
+
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("the view must actually be used, or this test pins the OLTP path a second time")
+            .isEqualTo(true);
+
+        // Same shape as the OLTP runs above: every ordered pair once, at its hop distance round the cycle.
+        final Set<String> pairs = new HashSet<>();
+        int fromFirstNode = 0;
+        for (final Iterator<Result> it = rows.iterator(); it.hasNext(); ) {
+          final Result row = it.next();
+          final String source = nameOf(row.getProperty("source"));
+          final String target = nameOf(row.getProperty("target"));
+          assertThat(pairs.add(source + "->" + target)).isTrue();
+          if ("N0".equals(source)) {
+            assertThat(((Number) row.getProperty("distance")).doubleValue())
+                .as("distance from N0 to " + target)
+                .isEqualTo(Integer.parseInt(target.substring(1)));
+            fromFirstNode++;
+          }
+        }
+
+        assertThat(pairs).hasSize(CYCLE_NODES * CYCLE_NODES - CYCLE_NODES);
+        assertThat(fromFirstNode).isEqualTo(CYCLE_NODES - 1);
+      } finally {
+        database.rollback();
+      }
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
   @Tag("performance")
   void buildingTheStreamCostsTheMatrixRatherThanTheRows() {
     // The measurement the issue asks for, taken from the thread's own allocation counter so that neither a GC
@@ -201,6 +266,11 @@ class Issue6296AlgoAPSPLazyRowsTest {
     final BasicCommandContext context = new BasicCommandContext();
     context.setDatabase(database);
     return new AlgoAPSP().execute(new Object[0], null, context);
+  }
+
+  /** The name of the vertex a `source`/`target` row property points at, whichever form the RID arrives in. */
+  private String nameOf(final Object rid) {
+    return ((RID) rid).asVertex().getString("name");
   }
 
   private static int drain(final Stream<Result> rows) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6296AlgoAPSPLazyRowsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6296AlgoAPSPLazyRowsTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression tests for issue #6296 - {@code algo.apsp} used to materialise every one of its {@code n² - n} rows
+ * before the caller saw the first one.
+ * <p>
+ * #6263 bounded the <em>working set</em> of an {@code algo.*} call: {@code algo.apsp}'s {@code n x n} distance
+ * matrix is now reserved against {@code arcadedb.cypher.algoMaxWorkingMemory} before it is allocated. That left
+ * the larger allocation of the same call outside every budget. At the 64 MB floor of that setting the matrix
+ * check admits about 2890 nodes, and a connected graph of 2890 nodes produced ~8.3 million {@code ResultInternal}
+ * rows - each with a three-entry property map, all alive at once, well over a gigabyte - against the 64 MB the
+ * budget had just finished enforcing on the matrix beside it. The budget did its job and the call still died, of
+ * an allocation its error message would never have mentioned.
+ * <p>
+ * Nothing required the rows to exist together: Floyd-Warshall completes the matrix before the first row is
+ * emitted, so the rows are a pure projection of it. They are now produced lazily, which makes the row-side
+ * footprint O(1) and puts the decision of how many to hold where it belongs - with the consumer.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6296AlgoAPSPLazyRowsTest {
+  /**
+   * A directed cycle: the cheapest shape in edges that makes every ordered pair reachable, so {@code n} edges
+   * buy the full {@code n² - n} result set the issue is about.
+   */
+  private static final int CYCLE_NODES = 200;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6296-apsp-lazy-rows");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final MutableVertex[] nodes = new MutableVertex[CYCLE_NODES];
+      for (int i = 0; i < CYCLE_NODES; i++)
+        nodes[i] = database.newVertex("Node").set("name", "N" + i).save();
+      for (int i = 0; i < CYCLE_NODES; i++)
+        nodes[i].newEdge("LINK", nodes[(i + 1) % CYCLE_NODES], true, (Object[]) null).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void everyReachablePairIsStillReturnedExactlyOnce() {
+    // The counterweight to the laziness assertions: a stream that emits fewer rows, or the same row twice, is
+    // not a cheaper version of the old behaviour. On a directed cycle every ordered pair (i != j) is reachable,
+    // so the row count is exactly n² - n and each (source, target) appears once.
+    final Set<String> pairs = new HashSet<>();
+    int rows = 0;
+    final ResultSet rs = database.query("opencypher",
+        "CALL algo.apsp() YIELD source, target, distance RETURN source.name AS src, target.name AS tgt, distance");
+    while (rs.hasNext()) {
+      final Result result = rs.next();
+      rows++;
+      assertThat(pairs.add(result.getProperty("src") + "->" + result.getProperty("tgt")))
+          .as("each ordered pair must be emitted once")
+          .isTrue();
+    }
+
+    assertThat(rows).isEqualTo(CYCLE_NODES * CYCLE_NODES - CYCLE_NODES);
+  }
+
+  @Test
+  void distancesAroundTheCycleAreUnchanged() {
+    // Hop count around a directed cycle, which the eager and the lazy form must agree on: N0 -> Nk costs k.
+    final ResultSet rs = database.query("opencypher", """
+        CALL algo.apsp() YIELD source, target, distance \
+        WITH source, target, distance WHERE source.name = 'N0' \
+        RETURN target.name AS tgt, distance""");
+
+    int seen = 0;
+    while (rs.hasNext()) {
+      final Result result = rs.next();
+      final int target = Integer.parseInt(((String) result.getProperty("tgt")).substring(1));
+      assertThat(((Number) result.getProperty("distance")).doubleValue())
+          .as("distance from N0 to N" + target)
+          .isEqualTo(target);
+      seen++;
+    }
+
+    assertThat(seen).isEqualTo(CYCLE_NODES - 1);
+  }
+
+  @Test
+  void aPartiallyReadStreamStillYieldsTheRestOnDemand() {
+    // The shape of the fix without a measurement: one row is readable on its own, and the remaining
+    // n² - n - 1 are still produced for a caller that goes on reading. A lazy stream that quietly drops its
+    // tail would satisfy "cheap" and fail the procedure's contract.
+    database.begin();
+    try {
+      final Iterator<Result> iterator = apspRows().iterator();
+
+      assertThat(iterator.hasNext()).isTrue();
+      final Result first = iterator.next();
+      assertThat(first.<Object>getProperty("source")).isNotNull();
+      assertThat(first.<Object>getProperty("target")).isNotNull();
+
+      int remaining = 0;
+      while (iterator.hasNext()) {
+        iterator.next();
+        remaining++;
+      }
+      assertThat(remaining).isEqualTo(CYCLE_NODES * CYCLE_NODES - CYCLE_NODES - 1);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  @Tag("performance")
+  void buildingTheStreamCostsTheMatrixRatherThanTheRows() {
+    // The measurement the issue asks for, taken from the thread's own allocation counter so that neither a GC
+    // nor another test's work can move it.
+    //
+    // Two phases of one call: execute(), which runs Floyd-Warshall and hands back the stream, and the drain
+    // that reads the rows out of it. Eagerly, the rows were built inside execute() and the drain allocated
+    // nothing worth counting - the two numbers below were the other way round. Lazily, execute() pays for the
+    // n x n matrix (320 KB here) and the drain pays for the ~40 000 rows, so the drain must dominate.
+    final com.sun.management.ThreadMXBean threads = threadAllocationBean();
+    assumeTrue(threads != null, "JVM does not expose per-thread allocation counters");
+
+    database.begin();
+    try {
+      // Warm the whole path past the interpreter, so the first measured round is not measuring class loading.
+      for (int i = 0; i < 3; i++)
+        assertThat(drain(apspRows())).isPositive();
+
+      final Stream<Result>[] held = newStreamHolder();
+      final long buildBytes = measure(threads, () -> held[0] = apspRows());
+      final long drainBytes = measure(threads, () -> assertThat(drain(held[0])).isPositive());
+
+      assertThat(drainBytes)
+          .as("the rows are the bulk of an apsp call and must be paid for as they are read, not up front "
+              + "(build=" + buildBytes + " bytes, drain=" + drainBytes + " bytes)")
+          .isGreaterThan(4 * buildBytes);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /**
+   * Calls the procedure directly rather than through Cypher: what is under measurement is where the rows are
+   * built, and the planner and the CALL pipeline would add allocation to both phases that has nothing to do
+   * with it. Requires an active transaction, like every other direct use of the graph API.
+   */
+  private Stream<Result> apspRows() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    return new AlgoAPSP().execute(new Object[0], null, context);
+  }
+
+  private static int drain(final Stream<Result> rows) {
+    int count = 0;
+    for (final Iterator<Result> it = rows.iterator(); it.hasNext(); ) {
+      it.next();
+      count++;
+    }
+    return count;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Stream<Result>[] newStreamHolder() {
+    return new Stream[1];
+  }
+
+  private static long measure(final com.sun.management.ThreadMXBean threads, final Runnable body) {
+    final long id = Thread.currentThread().threadId();
+    final long before = threads.getThreadAllocatedBytes(id);
+    body.run();
+    return threads.getThreadAllocatedBytes(id) - before;
+  }
+
+  private static com.sun.management.ThreadMXBean threadAllocationBean() {
+    if (!(ManagementFactory.getThreadMXBean() instanceof final com.sun.management.ThreadMXBean bean))
+      return null;
+    if (!bean.isThreadAllocatedMemorySupported())
+      return null;
+    bean.setThreadAllocatedMemoryEnabled(true);
+    return bean.isThreadAllocatedMemoryEnabled() ? bean : null;
+  }
+}


### PR DESCRIPTION
Closes #6296, closes #6289.

Both were surfaced while reviewing PR #6285 (issue #6263) and deliberately left out of it: #6296 is the *result* set of the same call rather than its working set, and #6289 is churn rather than a peak. Neither is something that budget could have caught.

## #6296 - `algo.apsp` materialised n² rows before returning any of them

The distance matrix is reserved against `arcadedb.cypher.algoMaxWorkingMemory`; the rows beside it were not. At the 64 MB floor of that setting the matrix check admits n ≈ 2890, and a connected graph of 2890 nodes then built ~8.3M `ResultInternal` objects - each with a three-entry property map, all alive at once, well over a gigabyte - against the 64 MB the budget had just finished enforcing next to it. The budget did its job and the call still died, of an allocation its message never named.

Floyd-Warshall completes the matrix before the first row is emitted, so the rows are a pure projection of it and nothing required them to exist together. They now stream. The row-side footprint is O(1), and `CallStep` keeps the iterator rather than collecting it, so a `LIMIT` upstream costs what it says it costs.

Measured on the 200-node cycle in the regression test (`ThreadMXBean.getThreadAllocatedBytes`, per-thread so no GC can move it):

| | building the stream | draining the ~39 800 rows |
|---|---|---|
| before | 13 621 944 bytes | 256 bytes |
| after | ~83 000 bytes | the rows |

The issue also raises whether the *row count* should be bounded. Streaming answers it in the right place: the consumer decides how many it holds, and a `LIMIT` is now what bounds the call. A top-k form of the procedure would be a different interface, not a fix, so it is left alone.

The secondary finding in the issue - `toEmbeddingList` boxing every element - is deliberately **not** taken: a primitive-backed `List<Double>` view boxes on `get()` instead of up front, so on a consumer that reads each row once it moves the allocation rather than removing it. The issue itself says it is only worth doing if a profile says the boxing shows up, and this change is not that profile.

## #6289 - allocation churn on the dense paths

**1. The per-spur-node `n x n` mask in `algo.kShortestPaths`.** ~200 MB through the young generation for one k=10 call at 1000 nodes. The issue proposed hoisting the mask and clearing it, and asked for a measurement before choosing between that and reallocation.

Neither was needed - **the mask never had to be square**, which is the better alternative the measurement would not have found. Yen's keeps the edge `(p[i], p[i+1])` only for a path sharing the root `p[0..i]` with `prevPath`, and `prevPath[i]` **is** the spur node, so every entry it ever set had the same source. The other n-1 rows were allocated and zeroed only to prove they were empty. A single `boolean[nodeCount]` indexed by target says exactly as much, in O(nodeCount) rather than O(nodeCount²).

That also removes the `Arrays.fill`-vs-reallocate question the issue framed: the mask is allocated once for the whole call and cleared by naming the few entries it set - at most one per previously-found path - so clearing is O(paths), not O(nodeCount). The budget reservation follows the allocation and now prices two node-sized masks instead of a square one.

Measured on a 501-node graph driving ~150 spur nodes: **43 259 968 -> 4 411 528 bytes** for the call, against a weight matrix of 2 008 008 bytes allocated once.

**2. The boxed `Integer[]` Kruskal sort in `algo.steinerTree` and `algo.mst`.** Replaced by one shared primitive index sort, `AbstractAlgoProcedure.sortedIndexesByWeight`.

A bottom-up **merge** sort rather than the index quicksort the issue suggested, for two reasons that both matter here: the keys are user data, so a quicksort degrades to O(n²) on an input a caller chooses; and merging is stable, which is what keeps ties in exactly the order the TimSort behind `Arrays.sort(Integer[], Comparator)` produced. `Double.compare` is the comparison, so `NaN` and `-0.0` order identically too - the test asserts the new order against the old comparator sort on both awkward and randomised inputs.

Measured: **8.4 bytes per index against 24**. `BOXED_INTEGER_BYTES`, which existed only to price that boxing honestly, is gone with it, and `algo.steinerTree`'s reservation now prices five primitive arrays per terminal pair.

**3. `MemoryBudget.reserve()` mutating before it throws.** Committed only once granted. The invariant is now observable: a refused reservation no longer appears in the "on top of the N bytes this call already reserved" of the next message.

## Also, while in `AlgoKShortestPaths`

An unused `PriorityQueue`, and a dead incremental cost expression that computed the path weight four ways - two `Arrays.copyOf` and four `pathWeight` walks per spur node - and then threw the answer away in favour of the single `pathWeight(totalPath, ...)` on the line below it. Same file, same theme.

## Verification

Every allocation assertion was checked against the old code before being trusted: reverting each fix in turn makes the corresponding test red (13.6 MB build for #6296, 43.3 MB for the mask, a lying "already reserved" figure for the budget), so none of them is vacuous.

- `Issue6296AlgoAPSPLazyRowsTest` (4 tests) - the full n² - n row set is unchanged and each pair appears once; distances around the cycle are unchanged; a partially read stream still yields its tail; and the allocation split between building and draining.
- `Issue6289AlgoAllocationChurnTest` (7 tests) - k distinct paths in ascending weight (the correctness counterweight to collapsing the mask); the reservation message; the call's allocation against the weight matrix; the index sort against the boxed comparator sort it replaced, including NaN, ±0.0, the infinities and tie stability; MST and Steiner trees unchanged, pinned from both sides (the MST takes the two cheap bypass edges of every hop, the Steiner path takes the single direct hop instead); and the budget invariant.
- `Issue6263AlgoWorkingMemoryBudgetTest` updated for the smaller `kShortestPaths` reservation (400 -> 328 bytes on its 4-node graph).
- Full `com.arcadedb.query.opencypher` sweep: 4520 tests, 0 failures.

The two `ThreadMXBean` measurements are tagged `@Tag("performance")`, matching `RidScoreMinHeapTest`, and skip themselves on a JVM without per-thread allocation counters.

## Files changed

- `engine/.../algo/AbstractAlgoProcedure.java` - `sortedIndexesByWeight`, budget invariant, `BOXED_INTEGER_BYTES` removed
- `engine/.../algo/AlgoAPSP.java` - lazy rows
- `engine/.../algo/AlgoKShortestPaths.java` - node-sized spur masks, reservation, dead code
- `engine/.../algo/AlgoMST.java`, `engine/.../algo/AlgoSteinerTree.java` - primitive index sort
- `engine/src/test/.../algo/Issue6296AlgoAPSPLazyRowsTest.java` (new), `Issue6289AlgoAllocationChurnTest.java` (new), `Issue6263AlgoWorkingMemoryBudgetTest.java`