### PR TITLE
fix(#6286, #6292, #6293, #6294): a content record collapses back like any other, and the checker follows the pointer and sweeps the chunks

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2457,3 +2457,109 @@ whatever the heap setting says. The pair arrays include an `Integer[]` index arr
 actually costs rather than at what a primitive array would.
 
 [#6263](https://github.com/ArcadeData/arcadedb/issues/6263)
+
+## A placeholder's content record can stop being a chunk chain, like every other record (#6286)
+
+#6178 gave a record that shrinks back inside the region its own slot owns a way out of being a chunk chain:
+the head chunk is rewritten as a plain record and the chain behind it is freed. One record shape was left
+out - the CONTENT record of a placeholder - and the reason was mechanical rather than principled. Such a
+record is recognised by the NEGATIVE size marker its slot carries, which is what tells a scan the slot holds
+somebody else's content rather than a document of its own; the collapse could only write a plain POSITIVE
+size, so collapsing one would have been #6196 all over again on the one record shape that had escaped it.
+
+The collapse now writes the sign the shape calls for. A content record that shrinks back inside its region
+becomes the ordinary negated-size record it would have been had it never outgrown its page, instead of
+keeping 13 bytes of chunk header for ever and routing every read and write through the chunk path. It is the
+same transition the head chunk of a record of its own already made, with its own slot kind
+(`SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT`) so the commit-time disjoint-slot merge replays it only
+onto a committed slot that still carries the marker the write started from - the same bytes behind the other
+marker being a different record is the whole reason the kinds exist.
+
+One case stays out of the merge rather than out of the collapse: a database written before #6196 holds a
+content head still wearing the ambiguous `FIRST_CHUNK`, which no marker can tell from a record's own. Such a
+head is collapsed too - reached through its pointer, the flag says what it is, and the negated marker the
+collapse writes ends the ambiguity for good - but the page is poisoned instead of tracked, because neither
+collapse kind names that starting marker. The transaction keeps its write and gives up only the merge, on a
+shape no current build produces.
+
+[#6286](https://github.com/ArcadeData/arcadedb/issues/6286)
+
+## `CHECK DATABASE` follows a placeholder pointer, and reclaims the chunks nothing points at (#6292, #6293, #6294)
+
+Three things the bucket checker could not say about a bucket, all found while building the #6196 fixtures.
+
+### A dangling placeholder pointer made `count(*)` and a scan disagree for good (#6292)
+
+`check()` classified a placeholder POINTER slot, counted it, and moved on - it never followed the pointer to
+ask whether anything was on the other end. So a pointer whose CONTENT record was gone stayed on its page for
+ever, and the two counts of one type disagreed permanently while the checker called the database clean:
+
+```
+select count(@rid) as c from P   -->  7      (a scan: the pointer resolves to nothing and is skipped)
+select count(*)    as c from P   -->  8      (the cached counter: a pointer slot is a record)
+check database                   -->  totalErrors: 0
+```
+
+The commonest way to produce one was `CHECK DATABASE FIX` itself: the broken-chain branch force-deletes a
+content record whose chain cannot be walked, and freed the content's slot only. Corruption and an
+interrupted repair reach the same state.
+
+Every pointer is now followed, and its target classified: a content record of either shape (a negated size,
+or the `FIRST_CHUNK_PLACEHOLDER_CONTENT` head #6196 added), the pre-#6196 ambiguous head, or nothing a
+pointer may lead to. The last is reported with both RIDs and, with `FIX`, the pointer is removed -
+reconciling `count(*)` with the scan. It costs nothing new: #6196 already paid one page fetch per pointer to
+read that marker, and only the branch that asks this question was missing. Two new report fields,
+`danglingPlaceholderPointers` and `danglingPlaceholderPointersFixed`, count them.
+
+The repair frees the pointer's SLOT and nothing else, where the ordinary delete would follow the pointer
+first. That distinction is load-bearing: a pointer can be dangling because it was CORRUPTED, in which case it
+now names whatever record happens to live at that position, and deleting that record is exactly the damage
+the pass exists to prevent.
+
+A pointer left dangling by a deletion the same run made is removed with it and not booked as a second error.
+The record had one defect, `FIX` removed it, and the pointer is the rest of that removal.
+
+### The FIX run described the database it found, not the one it left (#6293)
+
+A record deleted during the run was counted in `totalDeletedRecords` AND under the category tally it had held
+before, because the slot was classified first and repaired after:
+
+```json
+"totalDeletedRecords": 1, "deletedRecordsAfterFix": ["#1:5"],
+"totalMultiPageRecords": 1, "totalActiveRecords": 6, "totalAllocatedRecords": 11
+```
+
+A re-run reported `totalMultiPageRecords: 0` and `totalAllocatedRecords: 10`. One report described the same
+record twice, on exactly the numbers an operator diffs across runs to decide whether a `FIX` did anything.
+
+The obvious repair - decrement the category counter next to each `++totalDeletedRecords` - would have had
+four sites each remember which of five categories it had incremented, which is the same duplication one level
+down. The classification is a VALUE now: the slot walk decides which category the slot fell into, the
+counting happens once at the end of the per-slot block, and a slot the repair removed simply carries the
+deleted category instead. The per-page verbose tallies come from the same decision, so they no longer
+disagree with the totals about whether a multi-page record is also an active one.
+
+### Orphaned continuation chunks are reclaimed, and three comments stop promising something nothing did (#6294)
+
+Force-deleting a record with a broken chunk chain frees the HEAD slot only. Three places in the tree told the
+reader the rest would be "reclaimed by compaction or a database check". Neither ever did: `check()` counted a
+`NEXT_CHUNK` slot under `totalChunks` and moved on, and `compressPage` re-flows a page's LIVE slots - an
+orphaned chunk still has one, so it was re-flowed along with everything else rather than dropped. The leak
+was bounded per incident and permanent, surviving every repair short of an export and reimport.
+
+Reachability cannot be answered from a chunk's own slot - the same asymmetry that made #6196's content
+records need a marker - so it is answered from the other end. The chain walk `check()` already makes for
+every head now marks the chunks that head reaches, and a head the run repaired away marks nothing, which
+frees its chunks at the source as well. After the pass, every `NEXT_CHUNK` slot nothing marked is reported
+under `orphanedChunks` and, with `FIX`, freed and counted under `orphanedChunksReclaimed` - the shape
+`orphanedEdgeSegments` / `orphanedEdgeSegmentsReclaimed` already has, down to failing closed: an unmarked
+LIVE chunk deleted as an orphan is destroyed data, so ANY gap in the marking (a page the walk could not read,
+a chain walk stopped by an I/O fault, a slot that could not be classified) disables the sweep entirely rather
+than shrinking it.
+
+A chunk orphaned by this run's own force-delete is swept like any other but is not counted as an error the
+database had before the run started, for the same reason the pointer above is not.
+
+[#6292](https://github.com/ArcadeData/arcadedb/issues/6292)
+[#6293](https://github.com/ArcadeData/arcadedb/issues/6293)
+[#6294](https://github.com/ArcadeData/arcadedb/issues/6294)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2642,8 +2642,19 @@ LIVE chunk deleted as an orphan is destroyed data, so ANY gap in the marking (a 
 a chain walk stopped by an I/O fault, a slot that could not be classified) disables the sweep entirely rather
 than shrinking it.
 
-A chunk orphaned by this run's own force-delete is swept like any other but is not counted as an error the
-database had before the run started, for the same reason the pointer above is not.
+**An orphan is a COUNT, not an error and not a warning.** Nothing is corrupted by one: no record is wrong, no
+query is affected, no two counts disagree - the bucket is carrying dead space. That matches how
+`orphanedEdgeSegments` and `orphanedExternalRecords` are already reported, and the scale is what makes it
+matter rather than being a matter of taste. The first measurement of a real workload found **243821 orphaned
+chunks in a bucket of 1.5 million** (`CRUDTest.multiUpdatesOverlap`, 131072 records put through thirteen
+rounds of updates): a leak that has always been there, that nothing collected, and that one warning apiece
+would have reported as a quarter of a million strings.
+
+**The reclaim is bounded by memory, not by count.** The enclosing transaction holds a copy of every page it
+modifies, so a backlog spread thinly across pages costs pages x pageSize whatever the number of chunks is. A
+run frees what fits a 32 MB page budget, reports the rest through the gap between `orphanedChunks` and
+`orphanedChunksReclaimed`, and says so in the log; the next `FIX` continues. A bulk repair that converges is
+worth more than one that ends as the `OutOfMemoryError` of #4653.
 
 [#6292](https://github.com/ArcadeData/arcadedb/issues/6292)
 [#6293](https://github.com/ArcadeData/arcadedb/issues/6293)

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -114,6 +114,16 @@ public class TransactionContext implements Transaction {
    * different marker are a different record, and a slot that changed from one to the other under us is a conflict.
    */
   public static final byte SLOT_KIND_FIRST_CHUNK_PLACEHOLDER_CONTENT = 5;
+  /**
+   * {@code SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD} for a placeholder's CONTENT record: the chain shrank back inside the
+   * region its own slot owns and became the plain NEGATED-size shape a content record small enough for its page has
+   * always had (#6286). The pre-image is the head chunk carrying
+   * {@code LocalBucket.FIRST_CHUNK_PLACEHOLDER_CONTENT}, the final image is the content, and the only difference from
+   * the collapse of a record of its own is the marker the replay expects on the committed page and the SIGN of the
+   * one it writes - which is the whole point of the two being different kinds: the same bytes behind the other marker
+   * are a different record, handed out by a scan as a document rather than skipped as somebody's content.
+   */
+  public static final byte SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT = 6;
 
   private final DatabaseInternal                     database;
   private final Map<Integer, Integer>                newPageCounters       = new ConcurrentHashMap<>();

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1784,7 +1784,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       final long marker = contentPage.readNumberAndSize(recordPositionInPage)[0];
       if (marker == FIRST_CHUNK)
         return PlaceholderTarget.LEGACY_AMBIGUOUS;
-      if (marker == FIRST_CHUNK_PLACEHOLDER_CONTENT || marker < RECORD_PLACEHOLDER_CONTENT)
+      // <= and not the < every other classification site uses, and deliberately so: this is the ONE site whose answer
+      // costs a record. RECORD_PLACEHOLDER_CONTENT (-5) is the boundary the class doc draws between the sizes and the
+      // markers, and it is the one value on it - a content record of exactly MINIMUM_RECORD_SIZE bytes. Nothing else
+      // in the engine writes -5 (the markers stop at -4 and a plain size is positive), so a slot holding it can only
+      // be somebody's content, and calling it DANGLING here would have FIX delete a live pointer. Measured: the
+      // smallest document this serializer produces is 6 bytes, so the value is not reachable today and
+      // createRecordInternal/updateRecordInternal now pad content past it - this is the third guard, on the only path
+      // where being wrong is unrecoverable (PR review).
+      if (marker == FIRST_CHUNK_PLACEHOLDER_CONTENT || marker <= RECORD_PLACEHOLDER_CONTENT)
         return PlaceholderTarget.CONTENT;
       return PlaceholderTarget.DANGLING;
     } catch (final Exception e) {
@@ -1976,8 +1984,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   private RID createRecordInternal(final Record record, final boolean isPlaceHolder, final boolean discardRecordAfter) {
     final Binary buffer = database.getSerializer().serialize(database, record);
 
-    // RECORD SIZE CANNOT BE < 13 BYTES IN CASE OF UPDATE AND PLACEHOLDER, 5 BYTES IS THE SPACE REQUIRED TO HOST THE PLACEHOLDER. FILL THE DIFFERENCE WITH BLANK (0)
-    while (buffer.size() < MINIMUM_RECORD_SIZE) {
+    // A CONTENT record stores its size NEGATED, so its body may not be short enough to write a marker: not < 5 (which
+    // would write a -1..-4 the marker namespace owns) and not exactly 5 either (which would write the -5 BOUNDARY that
+    // every reader excludes with a strict `<`). A record of its own has no such constraint - its size is positive -
+    // but it is padded to the same floor, as it always has been. Fill the difference with blanks, which the
+    // deserializer stops before: it reads the property count, not the slot length.
+    while (buffer.size() < MINIMUM_RECORD_SIZE || (isPlaceHolder && buffer.size() == MINIMUM_RECORD_SIZE)) {
       buffer.append((byte) 0);
     }
 
@@ -2928,11 +2940,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     final Binary buffer = database.getSerializer().serialize(database, record);
 
     // A CONTENT record stores its size NEGATED, so a body shorter than MINIMUM_RECORD_SIZE would write a -1..-4 that
-    // the marker namespace already owns (see that constant): pad it exactly as createRecordInternal pads the record it
-    // creates behind a new pointer. It matters on every write that gives such a slot its size back - the in-place
-    // overwrite far below, and since #6286 the collapse of a content chain into this very shape.
+    // the marker namespace already owns, and one of exactly MINIMUM_RECORD_SIZE would write the -5 BOUNDARY every
+    // reader excludes with a strict `<` (see that constant). Pad past both, exactly as createRecordInternal pads the
+    // record it creates behind a new pointer. It matters on every write that gives such a slot its size back - the
+    // in-place overwrite far below, and since #6286 the collapse of a content chain into this very shape.
     if (updatePlaceholderContent)
-      while (buffer.size() < MINIMUM_RECORD_SIZE)
+      while (buffer.size() <= MINIMUM_RECORD_SIZE)
         buffer.append((byte) 0);
 
     final int pageId = (int) (rid.getPosition() / maxRecordsInPage);

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -156,6 +156,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   private static final   long                      FNV_PRIME                        = 0x100000001b3L;
   private static final   int                       CHUNKS_BEFORE_LOOP_DETECTION     = 64;
   /**
+   * How much page memory the orphaned-chunk sweep of {@link #check} may take for modification in one run (#6294).
+   * The bound is in BYTES and not in chunks because that is what the cost is: the enclosing transaction keeps a copy
+   * of every page it modifies, so a backlog spread thinly over many pages is far more expensive than the same number
+   * of chunks packed into few. A run that reaches it stops, reports what it left, and the next {@code FIX} continues -
+   * which is how a bulk repair converges instead of ending as the {@code OutOfMemoryError} of #4653.
+   */
+  private static final   int                       ORPHAN_RECLAIM_BUDGET_BYTES      = 32 * 1024 * 1024;
+  /**
    * Layout of the trace {@link #loadMultiPageRecord} keeps of the chain it walked, one stride per chunk consumed, so
    * the read can be validated against what it actually READ instead of against the version of the pages that read
    * happened to touch (#6217). Four longs in one flat array rather than an object per chunk: this is the read path of
@@ -1125,9 +1133,6 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // page and walks every chain.
     final LongHashSet chunkSlots = new LongHashSet();
     final LongHashSet reachableChunks = new LongHashSet();
-    // The chunks a chain lost because THIS run force-deleted its head. Orphans, and swept as such - but not errors the
-    // database had before the run started, which is what separates them from a leak an earlier repair left behind.
-    final LongHashSet chunksOrphanedByThisRun = new LongHashSet();
     // FAIL CLOSED, exactly as the edge-segment reclaim does: a chain walk that could not read a page, or a page or
     // slot the pass could not read at all, leaves live chunks unmarked - and an unmarked live chunk deleted as an
     // orphan is destroyed data. Any such gap disables the sweep entirely rather than shrinking it.
@@ -1267,12 +1272,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 pageMaxOffset = (int) endPosition;
 
               // #6294: the chunks a head walks through are LIVE only while that head is. One this pass repaired away
-              // takes its whole chain with it, and those chunks are exactly what the sweep is looking for.
+              // marks NOTHING, so its whole chain - including the chunks before the break - is swept at the source,
+              // which is what the issue's "free them at the source" asks for without walking past a broken pointer.
               if (chainWalk.incomplete)
                 chunkReachabilityComplete = false;
-              else if (!chainWalk.chunks.isEmpty())
-                chainWalk.chunks.forEach(
-                        (category == SlotCategory.DELETED ? chunksOrphanedByThisRun : reachableChunks)::add);
+              else if (category != SlotCategory.DELETED)
+                chainWalk.chunks.forEach(reachableChunks::add);
 
             } catch (final Exception e) {
               ++totals.totalErrors;
@@ -1369,8 +1374,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // have already gone out, and they describe the page as the walk found it, which is what a physical-layout log is
     // for.
     reconcilePlaceholderPointers(totals, placeholderPointers, repairedAwaySlots, totalPages, verboseLevel, fix);
-    reclaimOrphanedChunks(totals, chunkSlots, reachableChunks, chunksOrphanedByThisRun, chunkReachabilityComplete,
-            verboseLevel, fix);
+    reclaimOrphanedChunks(totals, chunkSlots, reachableChunks, chunkReachabilityComplete, verboseLevel, fix);
 
     if (fix)
       // #5149: reconcile the cached record counter that count(*) relies on. Invalidating forces the next
@@ -1593,6 +1597,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * disables the sweep entirely rather than shrinking it. That is the same rule the edge-segment reclaim follows and
    * for the same reason.
    * <p>
+   * <b>A leak is not a corruption</b>, so an orphan is a COUNT and never an error or a per-chunk warning: no record is
+   * wrong, no query is affected, no two counts disagree - the bucket is simply carrying dead space.
+   * {@code orphanedEdgeSegments} and {@code orphanedExternalRecords} are reported exactly that way, and the scale is
+   * the reason it matters here rather than being a matter of taste: measured on {@code CRUDTest.multiUpdatesOverlap},
+   * a bucket of 1.5M chunks carries 243821 orphans, and one warning apiece would be a report nobody can read built
+   * out of a quarter of a million strings.
+   * <p>
    * <b>Same precondition the rest of {@code check(fix)} already carries</b>: it is an ADMIN operation, expected to run
    * without concurrent writers on the bucket. The marks are collected page by page, so a chain rewritten by a
    * concurrent commit half-way through the walk can leave its new chunk unmarked; the very same window is what lets
@@ -1600,15 +1611,11 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * {@code GraphDatabaseChecker}'s orphan reclaim and {@code count()}'s counter reconciliation are both stated to
    * require. This adds no exposure of its own, and buys none back either.
    *
-   * @param chunksOrphanedByThisRun the chunks a chain lost because this run force-deleted its head. Swept like any
-   *                                other orphan, but not counted as an error the database had before the run: the
-   *                                record had one defect, and this is the rest of removing it.
-   *
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
   private void reclaimOrphanedChunks(final CheckStats totals, final LongHashSet chunkSlots,
-                                     final LongHashSet reachableChunks, final LongHashSet chunksOrphanedByThisRun,
-                                     final boolean reachabilityComplete, final int verboseLevel, final boolean fix) {
+                                     final LongHashSet reachableChunks, final boolean reachabilityComplete,
+                                     final int verboseLevel, final boolean fix) {
     if (chunkSlots.isEmpty())
       return;
 
@@ -1624,46 +1631,61 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       return;
     }
 
+    // The pages this sweep may take for modification, sized by MEMORY and not by a count of chunks: the enclosing
+    // transaction holds a copy of every page it modifies, so the cost of a reclaim is pages x pageSize whatever the
+    // backlog is. A bucket can hold a very large one - the leak is per incident but permanent, so it accumulates -
+    // and freeing all of it in one transaction is how a repair turns into an OutOfMemoryError (#4653). Bounded, so
+    // the run converges instead: what is left over is counted, said out loud, and taken by the next FIX.
+    final int pageBudget = Math.max(1, ORPHAN_RECLAIM_BUDGET_BYTES / pageSize);
+    final LongHashSet pagesTaken = new LongHashSet();
+    long leftForNextRun = 0L;
+
     for (final long chunkPosition : chunkSlots.toArray()) {
       if (reachableChunks.contains(chunkPosition))
         continue;
 
-      final RID chunkRID = new RID(fileId, chunkPosition);
-      final boolean orphanedByThisRun = chunksOrphanedByThisRun.contains(chunkPosition);
-
+      // Counted whether or not it is freed: "how much is leaked" and "how much this run gave back" are different
+      // questions, and orphanedChunks/orphanedChunksReclaimed are the two answers.
       ++totals.orphanedChunks;
-      if (!orphanedByThisRun)
-        ++totals.totalErrors;
 
-      // As above, orphanedByThisRun implies fix.
-      String warning = orphanedByThisRun ?
-              "chunk %s belonged to a record this run removed: reclaimed".formatted(chunkRID) :
-              "chunk %s is reachable from no record and its space is leaked%s".formatted(chunkRID,
-                      fix ? ": reclaimed" : "; run CHECK DATABASE FIX to reclaim it");
+      if (!fix)
+        continue;
 
-      if (fix) {
-        try {
-          // The chain this chunk belonged to no longer exists to be walked, so only its own slot is freed.
-          freeSlotOnly(chunkRID);
-          // Deliberately NOT added to deletedRecordsAfterFix: that list is the RIDs of RECORDS this run removed, and
-          // a continuation chunk is a fragment of one, under a RID no caller ever held. orphanedChunksReclaimed is
-          // what counts them, and the warnings name them.
-          ++totals.orphanedChunksReclaimed;
-          --totals.totalChunks;
-          --totals.totalAllocatedRecords;
-          ++totals.totalDeletedRecords;
-        } catch (final Exception e) {
-          if (orphanedByThisRun)
-            ++totals.totalErrors;
-          warning = "chunk %s is reachable from no record and could not be reclaimed: %s".formatted(chunkRID,
-                  e.getMessage());
-        }
+      final long chunkPageId = chunkPosition / maxRecordsInPage;
+      if (pagesTaken.size() >= pageBudget && !pagesTaken.contains(chunkPageId)) {
+        ++leftForNextRun;
+        continue;
       }
 
-      totals.warnings.add(warning);
-      if (verboseLevel > 0)
-        LogManager.instance().log(this, Level.SEVERE, "- " + warning);
+      final RID chunkRID = new RID(fileId, chunkPosition);
+      try {
+        // The chain this chunk belonged to no longer exists to be walked, so only its own slot is freed.
+        freeSlotOnly(chunkRID);
+        pagesTaken.add(chunkPageId);
+        // Deliberately NOT added to deletedRecordsAfterFix: that list is the RIDs of RECORDS this run removed, and a
+        // continuation chunk is a fragment of one, under a RID no caller ever held.
+        ++totals.orphanedChunksReclaimed;
+        --totals.totalChunks;
+        --totals.totalAllocatedRecords;
+        ++totals.totalDeletedRecords;
+      } catch (final Exception e) {
+        // A warning, unlike the reclaim itself: this one is a repair that did not happen, which is worth telling the
+        // operator about, where a chunk that WAS reclaimed is worth nothing more than the counter above.
+        final String warning = "chunk %s is reachable from no record and could not be reclaimed: %s".formatted(chunkRID,
+                e.getMessage());
+        totals.warnings.add(warning);
+        if (verboseLevel > 0)
+          LogManager.instance().log(this, Level.SEVERE, "- " + warning);
+      }
     }
+
+    if (leftForNextRun > 0)
+      // Not a warning: nothing is wrong, the run simply stopped where it said it would. The returned counters carry
+      // the same fact - orphanedChunks is what was found, orphanedChunksReclaimed what this run gave back.
+      LogManager.instance().log(this, Level.INFO,
+              "- reclaimed %d orphaned chunks of bucket '%s' and stopped at the %d-page budget; %d are left - run CHECK "
+                      + "DATABASE FIX again to continue", totals.orphanedChunksReclaimed, componentName, pageBudget,
+              leftForNextRun);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -3494,8 +3494,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           return "unexpected marker at chunk " + chunkId;
       }
     } catch (final Exception e) {
-      // A break PROVED by the bytes: the chunks walked so far are real, and the ones past this point were never
-      // reachable - so the walk is complete for the purpose of the reachability the caller derives from it.
+      // Reported as a break, which is what this has always answered and what {@code check(fix)} deletes the record on.
+      // But NOT as a walk that reached a conclusion: unlike the marker and range checks above, which prove a break
+      // from the bytes, an exception here is only as trustworthy as its cause - a corrupt offset says the chain is
+      // broken, anything else says the walk failed. The caller that reasons about REACHABILITY must not be made to
+      // choose, so it is told the walk is incomplete and fails closed; the chunks past this point are not proof of
+      // an orphan, and freeing them on this evidence would be unrecoverable (PR review).
+      walk.incomplete = true;
       return "error walking chain: " + e.getMessage();
     }
   }

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -3086,13 +3086,19 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // content show up a second time as a document in its own right, which is #6196 all over again on a record that
         // had escaped it. The collapse of such a legacy head is therefore right, and it even ends the ambiguity for
         // good; what it cannot be is REPLAYED, because the two collapse kinds each name the one committed marker the
-        // replay may write over and neither of them is FIRST_CHUNK-into-content. Poison the page and collapse anyway:
-        // the transaction keeps its write, it just gives up the merge on a shape no database this build writes has.
-        if (updatePlaceholderContent && !placeholderContentHead && slotMergeOn)
-          slotTx.poisonSlotRebasePage(fileId, pageId);
+        // replay may write over and neither of them is FIRST_CHUNK-into-content. So it is handed no pre-image, which
+        // is how it is told not to track, and the page is poisoned instead - but only if the collapse REALLY happened.
+        // A legacy content head that stays a chain is the shape it always was, replayable under SLOT_KIND_FIRST_CHUNK
+        // by the tracking further down, and poisoning it up front would have cost it that for nothing (PR review).
+        final boolean legacyAmbiguousContentHead = updatePlaceholderContent && !placeholderContentHead;
 
         if (collapseChunkChainToRecord(rid, buffer, page, pageId, positionInPage, recordPositionInPage, chunkHeaderPos,
-                chunkRegionEnd, chunkBaseImage, updatePlaceholderContent, slotTx)) {
+                chunkRegionEnd, legacyAmbiguousContentHead ? null : chunkBaseImage, updatePlaceholderContent, slotTx)) {
+          // The slot changed and no tracked image accounts for it: a page rebased from some OTHER slot's write would
+          // re-derive this one from the committed image and quietly resurrect the chain.
+          if (legacyAmbiguousContentHead && slotMergeOn)
+            slotTx.poisonSlotRebasePage(fileId, pageId);
+
           if (!discardRecordAfter)
             ((RecordInternal) record).setBuffer(buffer.getNotReusable());
           return true;

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -250,6 +250,93 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
   private static final Function<Integer, PageInsertReservation> NEW_INSERT_RESERVATION = k -> new PageInsertReservation();
 
+  /**
+   * What a slot {@link #check} walked turned out to hold. Decided while the slot is read and counted ONCE at the end
+   * of the block (#6293): the classification used to increment the counters inline while the repairs ran after it, so
+   * a record CHECK DATABASE FIX deleted during the run was reported both under {@code totalDeletedRecords} and under
+   * the category it had held before - one run describing the same record twice, which is exactly what an operator
+   * diffs across runs to decide whether a FIX did anything.
+   */
+  private enum SlotCategory {
+    /** Counted by nothing: a slot too corrupted to classify that this run was not asked to repair. */
+    UNCLASSIFIED,
+    DELETED,
+    ACTIVE,
+    PLACEHOLDER_POINTER,
+    SURROGATE,
+    MULTI_PAGE,
+    CHUNK
+  }
+
+  /**
+   * What the target of a placeholder POINTER turned out to be (see {@link #classifyPlaceholderTarget}).
+   */
+  private enum PlaceholderTarget {
+    /** A content record of a shape this build recognises: a negated size marker, or a head chunk that says so. */
+    CONTENT,
+    /**
+     * A head chunk still wearing the ambiguous {@link #FIRST_CHUNK} - what every release before #6196 wrote for a
+     * content record no page could host whole, and what a scan hands out a second time as a document of its own.
+     */
+    LEGACY_AMBIGUOUS,
+    /**
+     * Nothing a pointer may lead to: a slot that was deleted, a position past the end of the bucket, or a marker that
+     * is neither a negated size nor a content head. The record is then gone from every scan and still counted by
+     * {@code count(*)}, which is the disagreement #6292 is about.
+     */
+    DANGLING,
+    /** The target's page could not be read: an I/O fault, and evidence of nothing. */
+    UNREADABLE
+  }
+
+  /**
+   * The tallies {@link #check} accumulates. One object rather than a dozen locals so the passes that RECONCILE them
+   * after the walk - the placeholder pointers (#6292, #6196) and the orphaned chunks (#6294) - can be named methods
+   * instead of another few hundred lines inline.
+   */
+  private static final class CheckStats {
+    private long totalAllocatedRecords;
+    private long totalActiveRecords;
+    private long totalPlaceholderRecords;
+    private long totalSurrogateRecords;
+    private long totalMultiPageRecords;
+    private long totalDeletedRecords;
+    private long totalMaxOffset;
+    private long totalChunks;
+    private long orphanedChunks;
+    private long orphanedChunksReclaimed;
+    private long danglingPlaceholderPointers;
+    private long danglingPlaceholderPointersFixed;
+    private long totalErrors;
+
+    private final List<String> warnings               = new ArrayList<>();
+    private final List<RID>    deletedRecordsAfterFix = new ArrayList<>();
+  }
+
+  /**
+   * The continuation chunks a {@link #findBrokenChunkChain} walk went through, and whether it reached a conclusion.
+   * <p>
+   * The set is the walk's own loop detector - revisiting a continuation pointer is the only certain loop signal - so
+   * a caller that needs to know WHICH chunks a record reaches (#6294) is asking the question the walk already answers,
+   * and is handed the answer rather than costing a second walk.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private static final class ChunkChainWalk {
+    private final LongHashSet chunks = new LongHashSet();
+    /**
+     * The walk stopped without proving anything: a page it could not LOAD, which is an I/O fault and not a broken
+     * chain (see {@link #findBrokenChunkChain}). The chunks past that point are neither reached nor known to be
+     * unreachable, so a caller reasoning about reachability has to fail closed on it.
+     */
+    private boolean incomplete;
+
+    private void reset() {
+      chunks.clear();
+      incomplete = false;
+    }
+  }
+
   private static class PageAnalysis {
     public final BasePage page;
     public       int      newRecordPositionInPage     = -1;
@@ -481,8 +568,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * chain to free every chunk and, on a broken link, throws {@link ConcurrentModificationException} as a retry
    * signal (#4932) so it never orphans chunks. That guard makes a genuinely-corrupt record undeletable by every
    * path. With {@code force=true} a broken link stops the chain walk instead of aborting: the head slot is still
-   * freed so the record finally disappears, and any chunks past the break are orphaned (a bounded space leak) to be
-   * reclaimed by compaction or a database check. Intended for admin repair (CHECK DATABASE FIX), not the hot path.
+   * freed so the record finally disappears, and any chunks past the break are orphaned - a bounded space leak that
+   * {@code CHECK DATABASE FIX} reclaims, by finding the chunks no chain reaches (#6294). Compaction does not and
+   * never did: {@code compressPage} re-flows a page's LIVE slots, and an orphaned chunk still has one.
+   * Intended for admin repair (CHECK DATABASE FIX), not the hot path.
    */
   public void deleteRecord(final RID rid, final boolean force) {
     database.checkPermissionsOnFile(fileId, SecurityDatabaseUser.ACCESS.DELETE_RECORD);
@@ -1022,34 +1111,32 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
               .log(this, Level.INFO, "- Checking bucket '%s' (totalPages=%d spaceOnDisk=%s pageSize=%s)...", componentName, totalPages,
                       FileUtils.getSizeAsString((long) totalPages * pageSize), FileUtils.getSizeAsString(pageSize));
 
-    long totalAllocatedRecords = 0L;
-    long totalActiveRecords = 0L;
-    long totalPlaceholderRecords = 0L;
-    long totalSurrogateRecords = 0L;
-    long totalMultiPageRecords = 0L;
-    long totalDeletedRecords = 0L;
-    long totalMaxOffset = 0L;
-    long totalChunks = 0L;
+    final CheckStats totals = new CheckStats();
 
-    long totalErrors = 0L;
-    final List<String> warnings = new ArrayList<>();
-    final List<RID> deletedRecordsAfterFix = new ArrayList<>();
+    // #6292: every placeholder POINTER the walk found, followed AFTER it rather than while it runs. Both questions a
+    // pointer raises - does it still lead to a content record at all, and is that record the pre-#6196 ambiguous shape
+    // - are about a slot the walk may not have reached yet, or may be about to repair away, so asking inline makes the
+    // answer depend on nothing but the order the allocator happened to place the two slots in.
+    final LongHashSet placeholderPointers = new LongHashSet();
 
-    // #6196: positions of the CONTENT records a placeholder pointer references that are still stored as an AMBIGUOUS
-    // chunk head - the shape every release before FIRST_CHUNK_PLACEHOLDER_CONTENT wrote, and the one a scan hands out
-    // twice. Collected while the pointers are walked (one page read per placeholder, and placeholders are rare), then
-    // reconciled and repaired after the pass, which is what makes the answer independent of whether the content
-    // record happens to live on a page this walk has already been through.
-    final LongHashSet legacyContentHeads = new LongHashSet();
-    /**
-     * Of those, the ones MORE THAN ONE pointer leads to. The repair rests on the engine's own invariant - a placeholder
-     * pointer references the content record written for it and nothing else - and this is the one way that invariant
-     * can be caught failing without knowing what the bytes were meant to say: a content record belongs to exactly one
-     * pointer, so a second one leading to the same slot is proof that a pointer is corrupted, and no reading of it
-     * tells which. Refused rather than repaired, because the shape the repair would write is unrecoverable
-     * information: it says whose the record is (code review on #6287).
-     */
-    final LongHashSet ambiguousHeadsWithSeveralPointers = new LongHashSet();
+    // #6294: the two halves of the mark-and-sweep that finds continuation chunks nothing points at. A chunk is
+    // REACHABLE when a head whose slot survives this pass walks through it, and the walk that establishes that is the
+    // one findBrokenChunkChain already makes for every head. One entry per chunk, on a pass that already reads every
+    // page and walks every chain.
+    final LongHashSet chunkSlots = new LongHashSet();
+    final LongHashSet reachableChunks = new LongHashSet();
+    // The chunks a chain lost because THIS run force-deleted its head. Orphans, and swept as such - but not errors the
+    // database had before the run started, which is what separates them from a leak an earlier repair left behind.
+    final LongHashSet chunksOrphanedByThisRun = new LongHashSet();
+    // FAIL CLOSED, exactly as the edge-segment reclaim does: a chain walk that could not read a page, or a page or
+    // slot the pass could not read at all, leaves live chunks unmarked - and an unmarked live chunk deleted as an
+    // orphan is destroyed data. Any such gap disables the sweep entirely rather than shrinking it.
+    boolean chunkReachabilityComplete = true;
+    final ChunkChainWalk chainWalk = new ChunkChainWalk();
+
+    // Positions this run repaired away, so the pointer pass can tell a pointer left dangling by the repair it has
+    // already booked from one that was dangling before the run started (#6292).
+    final LongHashSet repairedAwaySlots = new LongHashSet();
 
     String warning = null;
 
@@ -1071,46 +1158,49 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           // deleted an innocent record at the wrong RID. recordPosition() widens to long.
           final RID rid = new RID(file.getFileId(), recordPosition(pageId, maxRecordsInPage, positionInPage));
 
+          // #6293: what the slot IS, decided here and counted at the END of the block. It used to be counted inline,
+          // by the branch that recognised it, with the repairs running afterwards - so a record CHECK DATABASE FIX
+          // deleted during the run was reported both as a deleted record and as whatever category it had been before,
+          // and one report described the same record twice. A category is a value now, and a slot the fix removed
+          // simply carries the DELETED one.
+          SlotCategory category = SlotCategory.UNCLASSIFIED;
+          boolean allocated = false;
+
           final int recordPositionInPage = (int) page.readUnsignedInt(
                   PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE);
 
           if (recordPositionInPage == 0) {
             // DELETED RECORD (>= 24.1.1, IT WAS CLEANED CORRUPTED RECORD BEFORE)
-            pageDeletedRecords++;
-            totalDeletedRecords++;
+            category = SlotCategory.DELETED;
 
           } else if (recordPositionInPage > page.getContentSize()) {
-            ++totalErrors;
+            ++totals.totalErrors;
+            // The slot's offset is not readable, so what it held was never known: it may have been a chunk head whose
+            // chain nothing walked, and chunks nobody marked must not be mistaken for orphans.
+            chunkReachabilityComplete = false;
             warning = "invalid record offset %d in page for record %s".formatted(recordPositionInPage, rid);
             if (fix) {
               deleteRecordInternal(rid, true, true, true);
-              deletedRecordsAfterFix.add(rid);
-              ++totalDeletedRecords;
+              totals.deletedRecordsAfterFix.add(rid);
+              repairedAwaySlots.add(rid.getPosition());
+              category = SlotCategory.DELETED;
             }
           } else {
 
             try {
               final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
 
-              totalAllocatedRecords++;
+              allocated = true;
+              // Reset HERE and not only inside the walk: a slot that is not a chunk head never walks anything, and a
+              // stale set left from the previous head would then be attributed to it.
+              chainWalk.reset();
 
               if (recordSize[0] == 0) {
-                pageDeletedRecords++;
-                totalDeletedRecords++;
+                category = SlotCategory.DELETED;
               } else if (recordSize[0] == RECORD_PLACEHOLDER_POINTER) {
-                pagePlaceholderRecords++;
-                totalPlaceholderRecords++;
-
-                // #6196: does this pointer lead to a content record still stored as an ambiguous chunk head? Only the
-                // pointer can tell, and only here: from the head chunk's own slot the two are indistinguishable, which
-                // is the whole of the bug. Never throws - a pointer that leads nowhere is a different problem, already
-                // reported by the CHECK DATABASE pass that follows the links.
-                final long contentPosition = page.readLong((int) (recordPositionInPage + recordSize[1]));
-                if (isLegacyAmbiguousContentHead(totalPages, contentPosition) && !legacyContentHeads.add(contentPosition))
-                  // A SECOND pointer to the same content record: one of them is corrupted, and this is the only way to
-                  // know it without knowing what the bytes meant. See the field's javadoc.
-                  ambiguousHeadsWithSeveralPointers.add(contentPosition);
-
+                category = SlotCategory.PLACEHOLDER_POINTER;
+                // Followed after the pass, not here: see placeholderPointers.
+                placeholderPointers.add(rid.getPosition());
                 recordSize[0] = MINIMUM_RECORD_SIZE;
               } else if (isChunkHead(recordSize[0])) {
                 // #6196: a head chunk of either kind. Everything below is the same for the two - the chain, the walk
@@ -1118,32 +1208,31 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 // a record of its own, or the CONTENT of a placeholder, which is a surrogate exactly as a content
                 // record small enough to fit its page is, and is counted as one rather than as an active record.
                 final long headMarker = recordSize[0];
-                if (headMarker == FIRST_CHUNK_PLACEHOLDER_CONTENT) {
-                  pageSurrogateRecords++;
-                  totalSurrogateRecords++;
-                } else {
-                  pageActiveRecords++;
-                  pageMultiPageRecords++;
-                  totalMultiPageRecords++;
-                }
+                category = headMarker == FIRST_CHUNK_PLACEHOLDER_CONTENT ?
+                        SlotCategory.SURROGATE :
+                        SlotCategory.MULTI_PAGE;
 
                 // Walk the continuation chain to detect a structurally broken multi-page record (a dangling or
                 // overwritten chunk pointer). check() otherwise validates only the first chunk's on-page size and
                 // would never notice a broken chain, leaving the record undeletable by every normal path because
                 // deleteRecordInternal throws the #4932 retry signal on it. On fix, force-delete it: the head slot is
-                // freed so the record finally disappears and any unreachable chunks are reclaimed later by compaction.
-                final String chainProblem = findBrokenChunkChain(rid, page, recordPositionInPage, false);
+                // freed so the record finally disappears - and since #6294 the chunks it can no longer reach are
+                // freed too, by the sweep at the end of this method, rather than left to a compaction that never
+                // collected them.
+                final String chainProblem = findBrokenChunkChain(rid, page, recordPositionInPage, false, chainWalk);
                 if (chainProblem != null) {
-                  ++totalErrors;
+                  ++totals.totalErrors;
                   warning = "broken multi-page chunk chain for %srecord %s: %s".formatted(
                           headMarker == FIRST_CHUNK_PLACEHOLDER_CONTENT ? "placeholder content " : "", rid, chainProblem);
                   if (fix) {
                     // deletePlaceholderContent=true, so a content record is force-deleted here like any other head.
-                    // The pointer that referenced it is left behind and reads as a record that is simply not there,
-                    // which is the same outcome every other unrepairable record of this bucket gets.
+                    // The POINTER that referenced it is reconciled by the placeholder pass below, which removes it as
+                    // part of this same repair instead of leaving a slot that a scan skips and count(*) counts.
                     deleteRecordInternal(rid, true, true, true);
-                    deletedRecordsAfterFix.add(rid);
-                    ++totalDeletedRecords;
+                    totals.deletedRecordsAfterFix.add(rid);
+                    repairedAwaySlots.add(rid.getPosition());
+                    category = SlotCategory.DELETED;
+                    allocated = false;
                     recordSize[0] = 0;
                   }
                 }
@@ -1151,53 +1240,106 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 if (recordSize[0] == headMarker)
                   recordSize[0] = page.readInt((int) (recordPositionInPage + recordSize[1]));
               } else if (recordSize[0] == NEXT_CHUNK) {
-                totalChunks++;
-                pageChunks++;
+                category = SlotCategory.CHUNK;
+                chunkSlots.add(rid.getPosition());
                 recordSize[0] = page.readInt((int) (recordPositionInPage + recordSize[1]));
               } else if (recordSize[0] < RECORD_PLACEHOLDER_CONTENT) {
-                pageSurrogateRecords++;
-                totalSurrogateRecords++;
+                category = SlotCategory.SURROGATE;
                 recordSize[0] *= -1;
               } else {
-                pageActiveRecords++;
-                totalActiveRecords++;
+                category = SlotCategory.ACTIVE;
               }
 
               final long endPosition = recordPositionInPage + recordSize[1] + recordSize[0];
               if (endPosition > file.getPageSize()) {
-                ++totalErrors;
+                ++totals.totalErrors;
                 warning = "wrong record size %d found for record %s".formatted(recordSize[1] + recordSize[0], rid);
                 if (fix) {
                   deleteRecordInternal(rid, true, true, true);
-                  deletedRecordsAfterFix.add(rid);
-                  ++totalDeletedRecords;
+                  totals.deletedRecordsAfterFix.add(rid);
+                  repairedAwaySlots.add(rid.getPosition());
+                  category = SlotCategory.DELETED;
+                  allocated = false;
                 }
               }
 
               if (endPosition > pageMaxOffset)
                 pageMaxOffset = (int) endPosition;
 
+              // #6294: the chunks a head walks through are LIVE only while that head is. One this pass repaired away
+              // takes its whole chain with it, and those chunks are exactly what the sweep is looking for.
+              if (chainWalk.incomplete)
+                chunkReachabilityComplete = false;
+              else if (!chainWalk.chunks.isEmpty())
+                chainWalk.chunks.forEach(
+                        (category == SlotCategory.DELETED ? chunksOrphanedByThisRun : reachableChunks)::add);
+
             } catch (final Exception e) {
-              ++totalErrors;
+              ++totals.totalErrors;
               warning = "unknown error on loading record %s: %s".formatted(rid, e.getMessage());
+
+              // A slot that could not even be read may have been a chunk head, and what it reached is now unknown:
+              // the sweep must not conclude that the chunks nothing else claims are unreachable.
+              chunkReachabilityComplete = false;
 
               if (fix && !(e instanceof RecordNotFoundException)) {
                 deleteRecordInternal(rid, true, true, true);
-                deletedRecordsAfterFix.add(rid);
-                ++totalDeletedRecords;
+                totals.deletedRecordsAfterFix.add(rid);
+                repairedAwaySlots.add(rid.getPosition());
+                category = SlotCategory.DELETED;
+                allocated = false;
               }
             }
           }
 
+          // #6293: the ONE place a slot is counted, after every branch above has had its say about what it is and
+          // after any repair has had its say about whether it still exists.
+          if (allocated)
+            totals.totalAllocatedRecords++;
+
+          switch (category) {
+            case DELETED -> {
+              pageDeletedRecords++;
+              totals.totalDeletedRecords++;
+            }
+            case ACTIVE -> {
+              pageActiveRecords++;
+              totals.totalActiveRecords++;
+            }
+            case PLACEHOLDER_POINTER -> {
+              pagePlaceholderRecords++;
+              totals.totalPlaceholderRecords++;
+            }
+            case SURROGATE -> {
+              pageSurrogateRecords++;
+              totals.totalSurrogateRecords++;
+            }
+            case MULTI_PAGE -> {
+              // Not counted among the page's ACTIVE records, as it is not counted among the total ones: the two
+              // tallies used to disagree on this one category, the per-page log calling a multi-page record active and
+              // the returned totals keeping it separate.
+              pageMultiPageRecords++;
+              totals.totalMultiPageRecords++;
+            }
+            case CHUNK -> {
+              pageChunks++;
+              totals.totalChunks++;
+            }
+            case UNCLASSIFIED -> {
+              // A slot too corrupted to classify that this run was not asked to repair: counted by nothing, exactly as
+              // it was before, because there is no category it can honestly be put in.
+            }
+          }
+
           if (warning != null) {
-            warnings.add(warning);
+            totals.warnings.add(warning);
             if (verboseLevel > 0)
               LogManager.instance().log(this, Level.SEVERE, "- " + warning);
             warning = null;
           }
         }
 
-        totalMaxOffset += pageMaxOffset;
+        totals.totalMaxOffset += pageMaxOffset;
 
         if (verboseLevel > 2)
           LogManager.instance().log(this, Level.FINE,
@@ -1206,76 +1348,29 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                   pageMultiPageRecords, pageChunks, pageMaxOffset);
 
       } catch (final Exception e) {
-        ++totalErrors;
+        ++totals.totalErrors;
+        // The heads on a page that could not be read never walked their chains: their chunks are unmarked and must
+        // not be mistaken for orphans.
+        chunkReachabilityComplete = false;
         warning = "unknown error on checking page %d: %s".formatted(pageId, e.getMessage());
       }
 
       if (warning != null) {
-        warnings.add(warning);
+        totals.warnings.add(warning);
         if (verboseLevel > 0)
           LogManager.instance().log(this, Level.SEVERE, "- " + warning);
         warning = null;
       }
     }
 
-    // #6196: every content record found behind a pointer while still wearing the ambiguous FIRST_CHUNK marker. The
-    // pass above counted each of them as a multi-page record of its own, which is precisely what they are NOT - so
-    // move them, and repair the marker so the next reader does not have to be told. Deliberately reconciled here and
-    // not inline: the head chunk can sit on a page the walk had already left behind, and a repair made mid-walk would
-    // then be counted one way or the other depending on nothing but the order the allocator happened to place them in.
-    // Only the RETURNED totals are corrected; the per-page tallies the verbose log prints have already gone out, and
-    // they describe the page as the walk found it, which is what a physical-layout log is for.
-    if (!legacyContentHeads.isEmpty()) {
-      for (final long contentPosition : legacyContentHeads.toArray()) {
-        final RID contentRID = new RID(fileId, contentPosition);
-
-        // ASK AGAIN, because the pass has run since the pointer was followed and may have taken the slot with it: the
-        // compound shape - a legacy content head whose chain is ALSO broken - is force-deleted by the broken-chain
-        // branch above, which already counted it and already reported it. Reconciling it here as well would book the
-        // same record twice, under a second error and a "could not be repaired" warning naming a record that is no
-        // longer there to repair. The re-ask is the general form of that guard rather than a membership test against
-        // deletedRecordsAfterFix: whatever removed or rewrote the slot, whoever reported it, it is no longer the
-        // ambiguous shape and is not this pass's to report. It costs one page fetch per head actually found in the
-        // legacy shape - a set that is empty on every database this build wrote (code review on #6287).
-        if (!isLegacyAmbiguousContentHead(totalPages, contentPosition))
-          continue;
-
-        if (ambiguousHeadsWithSeveralPointers.contains(contentPosition)) {
-          // Reported, never repaired: the counters are left saying multi-page record, which is what the slot itself
-          // still says, because with two pointers leading here nothing in the bucket knows which of them is the lie.
-          ++totalErrors;
-          warning = ("placeholder content record %s is stored as an ambiguous chunk chain (#6196) and is referenced by "
-                  + "more than one placeholder pointer: one of those pointers is corrupted, so the marker is left as it "
-                  + "is - repair the pointers first").formatted(contentRID);
-          warnings.add(warning);
-          if (verboseLevel > 0)
-            LogManager.instance().log(this, Level.SEVERE, "- " + warning);
-          warning = null;
-          continue;
-        }
-
-        --totalMultiPageRecords;
-        ++totalSurrogateRecords;
-        ++totalErrors;
-
-        // A repair, never a deletion: the record is intact, only the marker that says whose it is was never written.
-        // Reported as an error whether or not it is fixed, because unfixed it is one a user can see - the content is
-        // returned twice by a scan, under two different RIDs.
-        warning = "placeholder content record %s is stored as an ambiguous chunk chain (#6196) and is returned twice by a scan%s"
-                .formatted(contentRID, fix ? ": repaired" : "; run CHECK DATABASE FIX to repair it");
-        if (fix && !repairLegacyContentHead(contentRID)) {
-          --totalSurrogateRecords;
-          ++totalMultiPageRecords;
-          warning = "placeholder content record %s is stored as an ambiguous chunk chain (#6196) and could not be repaired"
-                  .formatted(contentRID);
-        }
-
-        warnings.add(warning);
-        if (verboseLevel > 0)
-          LogManager.instance().log(this, Level.SEVERE, "- " + warning);
-        warning = null;
-      }
-    }
+    // Both reconciliations run AFTER the walk and against the state it left, which is what makes their answers
+    // independent of the order the allocator happened to place the slots in - the same reason #6196 was reconciled
+    // here rather than inline. Only the RETURNED totals are corrected; the per-page tallies the verbose log prints
+    // have already gone out, and they describe the page as the walk found it, which is what a physical-layout log is
+    // for.
+    reconcilePlaceholderPointers(totals, placeholderPointers, repairedAwaySlots, totalPages, verboseLevel, fix);
+    reclaimOrphanedChunks(totals, chunkSlots, reachableChunks, chunksOrphanedByThisRun, chunkReachabilityComplete,
+            verboseLevel, fix);
 
     if (fix)
       // #5149: reconcile the cached record counter that count(*) relies on. Invalidating forces the next
@@ -1294,57 +1389,362 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // operation, so it is expected to run without concurrent counts on the same bucket.
       cachedRecordCount.set(-1);
 
-    final float avgPageUsed = totalPages > 0 ? ((float) totalMaxOffset) / totalPages * 100F / pageSize : 0;
+    final float avgPageUsed = totalPages > 0 ? ((float) totals.totalMaxOffset) / totalPages * 100F / pageSize : 0;
 
     if (verboseLevel > 1)
       LogManager.instance()
               .log(this, Level.INFO, "-- Total records=%d (actives=%d deleted=%d placeholders=%d surrogates=%d) avgPageUsed=%.2f%%",
-                      totalAllocatedRecords, totalActiveRecords, totalDeletedRecords, totalPlaceholderRecords, totalSurrogateRecords,
-                      avgPageUsed);
+                      totals.totalAllocatedRecords, totals.totalActiveRecords, totals.totalDeletedRecords,
+                      totals.totalPlaceholderRecords, totals.totalSurrogateRecords, avgPageUsed);
 
     stats.put("pageSize", (long) pageSize);
     stats.put("totalPages", (long) totalPages);
-    stats.put("totalAllocatedRecords", totalAllocatedRecords);
-    stats.put("totalActiveRecords", totalActiveRecords);
-    stats.put("totalPlaceholderRecords", totalPlaceholderRecords);
-    stats.put("totalSurrogateRecords", totalSurrogateRecords);
-    stats.put("totalDeletedRecords", totalDeletedRecords);
-    stats.put("totalMaxOffset", totalMaxOffset);
-    stats.put("totalMultiPageRecords", totalMultiPageRecords);
-    stats.put("totalChunks", totalChunks);
+    stats.put("totalAllocatedRecords", totals.totalAllocatedRecords);
+    stats.put("totalActiveRecords", totals.totalActiveRecords);
+    stats.put("totalPlaceholderRecords", totals.totalPlaceholderRecords);
+    stats.put("totalSurrogateRecords", totals.totalSurrogateRecords);
+    stats.put("totalDeletedRecords", totals.totalDeletedRecords);
+    stats.put("totalMaxOffset", totals.totalMaxOffset);
+    stats.put("totalMultiPageRecords", totals.totalMultiPageRecords);
+    stats.put("totalChunks", totals.totalChunks);
+    stats.put("orphanedChunks", totals.orphanedChunks);
+    stats.put("orphanedChunksReclaimed", totals.orphanedChunksReclaimed);
+    stats.put("danglingPlaceholderPointers", totals.danglingPlaceholderPointers);
+    stats.put("danglingPlaceholderPointersFixed", totals.danglingPlaceholderPointersFixed);
 
     final DocumentType type = database.getSchema().getTypeByBucketId(fileId);
     if (type instanceof LocalVertexType) {
-      stats.put("totalAllocatedVertices", totalAllocatedRecords);
-      stats.put("totalActiveVertices", totalActiveRecords);
+      stats.put("totalAllocatedVertices", totals.totalAllocatedRecords);
+      stats.put("totalActiveVertices", totals.totalActiveRecords);
     } else if (type instanceof LocalEdgeType) {
-      stats.put("totalAllocatedEdges", totalAllocatedRecords);
-      stats.put("totalActiveEdges", totalActiveRecords);
+      stats.put("totalAllocatedEdges", totals.totalAllocatedRecords);
+      stats.put("totalActiveEdges", totals.totalActiveRecords);
     } else {
-      stats.put("totalAllocatedDocuments", totalAllocatedRecords);
-      stats.put("totalActiveDocuments", totalActiveRecords);
+      stats.put("totalAllocatedDocuments", totals.totalAllocatedRecords);
+      stats.put("totalActiveDocuments", totals.totalActiveRecords);
     }
 
-    stats.put("deletedRecordsAfterFix", deletedRecordsAfterFix);
-    stats.put("warnings", warnings);
+    stats.put("deletedRecordsAfterFix", totals.deletedRecordsAfterFix);
+    stats.put("warnings", totals.warnings);
     stats.put("autoFix", 0L);
-    stats.put("totalErrors", totalErrors);
+    stats.put("totalErrors", totals.totalErrors);
 
     return stats;
   }
 
   /**
-   * Whether the slot at {@code contentPosition} - the target of a placeholder POINTER - holds a content record still
-   * stored the way every release before #6196 stored one that no page could host whole: as a chunk head wearing the
-   * plain {@link #FIRST_CHUNK} marker, indistinguishable from a record of its own and therefore handed out a second
-   * time by every scan.
+   * Follows every placeholder POINTER the walk of {@link #check} found, and answers the two questions a pointer raises
+   * that its own slot cannot: does it still lead to a CONTENT record, and is that record the pre-#6196 ambiguous shape
+   * a scan hands out twice.
    * <p>
-   * Only {@link #check} asks, and only about a slot a pointer led it to, so it costs one page fetch per placeholder
-   * POINTER - every one of them, not only the chunked case this is looking for, because the marker is the only thing
-   * that tells the two apart and reading it is the whole question. That is the deliberate trade, and the scale to
-   * judge it against is what {@code check} already spends on the same pass: it reads every page of the bucket and
-   * walks the FULL continuation chain of every multi-page record. A pre-#6149 bucket dense with placeholders pays one
-   * more fetch each, of pages the walk itself touches anyway, on an operation that is already O(pages + chunks).
+   * <b>#6292 - the dangling pointer.</b> {@code check()} used to count a pointer as a placeholder and move on, never
+   * following it. So a pointer whose content was gone - force-deleted by the very FIX that found its chain broken, or
+   * lost to corruption or an interrupted repair - stayed on its page for good: {@code scan()} resolved it to nothing
+   * and skipped it, {@code count()} counted the slot because a pointer IS a record as far as it is concerned, and this
+   * method reported a clean database. Two counts of the same type disagreeing permanently, with nothing to say why.
+   * Following the pointer costs the page fetch #6196 was already paying to read the target's marker; only the branch
+   * that asks was missing.
+   * <p>
+   * A pointer left dangling by a deletion THIS run made is not booked as a second error: the record had one defect,
+   * the FIX removed it, and the pointer is the other half of that removal rather than a new problem the operator has
+   * to reconcile against the run that caused it.
+   * <p>
+   * <b>The repair frees the pointer SLOT and nothing else</b> ({@link #freeSlotOnly}), where the ordinary delete would
+   * follow the pointer first: a pointer that is dangling because it was CORRUPTED names whatever record now lives at
+   * that position, and deleting that record is exactly the damage this pass exists to prevent.
+   *
+   * @param repairedAwaySlots positions the walk removed, which is what tells a pointer orphaned by this run's own
+   *                          repair from one that was already dangling when it started.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private void reconcilePlaceholderPointers(final CheckStats totals, final LongHashSet placeholderPointers,
+                                            final LongHashSet repairedAwaySlots, final int totalPages,
+                                            final int verboseLevel, final boolean fix) {
+    if (placeholderPointers.isEmpty())
+      return;
+
+    // #6196: content records found behind a pointer while still wearing the ambiguous FIRST_CHUNK marker. The walk
+    // counted each of them as a multi-page record of its own, which is precisely what they are NOT.
+    final LongHashSet legacyContentHeads = new LongHashSet();
+    /*
+     * Of those, the ones MORE THAN ONE pointer leads to. The repair rests on the engine's own invariant - a placeholder
+     * pointer references the content record written for it and nothing else - and this is the one way that invariant
+     * can be caught failing without knowing what the bytes were meant to say: a content record belongs to exactly one
+     * pointer, so a second one leading to the same slot is proof that a pointer is corrupted, and no reading of it
+     * tells which. Refused rather than repaired, because the shape the repair would write is unrecoverable
+     * information: it says whose the record is (code review on #6287).
+     */
+    final LongHashSet ambiguousHeadsWithSeveralPointers = new LongHashSet();
+
+    for (final long pointerPosition : placeholderPointers.toArray()) {
+      final RID pointerRID = new RID(fileId, pointerPosition);
+      final long contentPosition = readPlaceholderPointer(totalPages, pointerPosition);
+      if (contentPosition < 0)
+        // The slot is no longer a pointer: this run's own repairs may have taken it, and a slot that is not a pointer
+        // any more has nothing left for this pass to say about it.
+        continue;
+
+      switch (classifyPlaceholderTarget(totalPages, contentPosition)) {
+      case CONTENT, UNREADABLE:
+        // Nothing to do - and UNREADABLE deliberately with it: a target whose page could not be READ is an I/O fault,
+        // not proof that the pointer leads nowhere, and this pass must never delete a pointer on that evidence.
+        break;
+
+      case LEGACY_AMBIGUOUS:
+        if (!legacyContentHeads.add(contentPosition))
+          ambiguousHeadsWithSeveralPointers.add(contentPosition);
+        break;
+
+      case DANGLING: {
+        final RID contentRID = new RID(fileId, contentPosition);
+        final boolean orphanedByThisRun = repairedAwaySlots.contains(contentPosition);
+
+        ++totals.danglingPlaceholderPointers;
+        if (!orphanedByThisRun)
+          ++totals.totalErrors;
+
+        // orphanedByThisRun implies fix: nothing is repaired away without it, so that branch always ends in a removal.
+        String warning = orphanedByThisRun ?
+                "placeholder pointer %s referenced the record %s this run removed: removed with it".formatted(pointerRID,
+                        contentRID) :
+                ("placeholder pointer %s leads to %s, which is not a content record: the record is invisible to every "
+                        + "scan and still counted by count(*)%s").formatted(pointerRID, contentRID,
+                        fix ? " - the pointer is removed" : "; run CHECK DATABASE FIX to remove the pointer");
+
+        if (fix) {
+          try {
+            freeSlotOnly(pointerRID);
+            totals.deletedRecordsAfterFix.add(pointerRID);
+            ++totals.danglingPlaceholderPointersFixed;
+            --totals.totalPlaceholderRecords;
+            --totals.totalAllocatedRecords;
+            ++totals.totalDeletedRecords;
+          } catch (final Exception e) {
+            if (orphanedByThisRun)
+              // It was not going to be reported at all, and now it has to be: the pointer stays.
+              ++totals.totalErrors;
+            warning = "placeholder pointer %s leads to %s and could not be removed: %s".formatted(pointerRID, contentRID,
+                    e.getMessage());
+          }
+        }
+
+        totals.warnings.add(warning);
+        if (verboseLevel > 0)
+          LogManager.instance().log(this, Level.SEVERE, "- " + warning);
+        break;
+      }
+      }
+    }
+
+    for (final long contentPosition : legacyContentHeads.toArray()) {
+      final RID contentRID = new RID(fileId, contentPosition);
+      String warning;
+
+      if (ambiguousHeadsWithSeveralPointers.contains(contentPosition)) {
+        // Reported, never repaired: the counters are left saying multi-page record, which is what the slot itself
+        // still says, because with two pointers leading here nothing in the bucket knows which of them is the lie.
+        ++totals.totalErrors;
+        warning = ("placeholder content record %s is stored as an ambiguous chunk chain (#6196) and is referenced by "
+                + "more than one placeholder pointer: one of those pointers is corrupted, so the marker is left as it "
+                + "is - repair the pointers first").formatted(contentRID);
+      } else {
+        --totals.totalMultiPageRecords;
+        ++totals.totalSurrogateRecords;
+        ++totals.totalErrors;
+
+        // A repair, never a deletion: the record is intact, only the marker that says whose it is was never written.
+        // Reported as an error whether or not it is fixed, because unfixed it is one a user can see - the content is
+        // returned twice by a scan, under two different RIDs.
+        warning = "placeholder content record %s is stored as an ambiguous chunk chain (#6196) and is returned twice by a scan%s"
+                .formatted(contentRID, fix ? ": repaired" : "; run CHECK DATABASE FIX to repair it");
+        if (fix && !repairLegacyContentHead(contentRID)) {
+          --totals.totalSurrogateRecords;
+          ++totals.totalMultiPageRecords;
+          warning = "placeholder content record %s is stored as an ambiguous chunk chain (#6196) and could not be repaired"
+                  .formatted(contentRID);
+        }
+      }
+
+      totals.warnings.add(warning);
+      if (verboseLevel > 0)
+        LogManager.instance().log(this, Level.SEVERE, "- " + warning);
+    }
+  }
+
+  /**
+   * Frees every continuation chunk no chain reaches (#6294): a mark-and-sweep over the marks the single pass of
+   * {@link #check} already collects, which is the same shape {@code GraphDatabaseChecker} uses for orphaned edge
+   * segments, down to failing closed.
+   * <p>
+   * Force-deleting a record with a broken chunk chain frees its HEAD slot only, and three comments in this file used
+   * to promise the rest would be "reclaimed by compaction or a database check". Neither did: this method counted a
+   * {@code NEXT_CHUNK} slot and moved on, and {@code compressPage} re-flows a page's live slots - an orphaned chunk
+   * still HAS a live slot entry, so it was re-flowed along with everything else rather than dropped. The leak was
+   * bounded per incident and permanent, surviving every repair short of an export and reimport.
+   * <p>
+   * Reachability cannot be answered from a chunk's own slot - the same asymmetry that made #6196's content records
+   * need a marker of their own - so it is answered from the other end: the chain walk every head already makes marks
+   * the chunks that head reaches, and a head this run repaired away marks nothing, which frees its chunks at the
+   * source as well.
+   * <p>
+   * <b>Fails closed.</b> An unmarked LIVE chunk deleted as an orphan is destroyed data, so any gap in the marking -
+   * a page the walk could not read, a chain walk that stopped on an I/O fault, a slot that could not be classified -
+   * disables the sweep entirely rather than shrinking it. That is the same rule the edge-segment reclaim follows and
+   * for the same reason.
+   * <p>
+   * <b>Same precondition the rest of {@code check(fix)} already carries</b>: it is an ADMIN operation, expected to run
+   * without concurrent writers on the bucket. The marks are collected page by page, so a chain rewritten by a
+   * concurrent commit half-way through the walk can leave its new chunk unmarked; the very same window is what lets
+   * the broken-chain branch force-delete a record whose chain a concurrent writer was rebuilding, and what
+   * {@code GraphDatabaseChecker}'s orphan reclaim and {@code count()}'s counter reconciliation are both stated to
+   * require. This adds no exposure of its own, and buys none back either.
+   *
+   * @param chunksOrphanedByThisRun the chunks a chain lost because this run force-deleted its head. Swept like any
+   *                                other orphan, but not counted as an error the database had before the run: the
+   *                                record had one defect, and this is the rest of removing it.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private void reclaimOrphanedChunks(final CheckStats totals, final LongHashSet chunkSlots,
+                                     final LongHashSet reachableChunks, final LongHashSet chunksOrphanedByThisRun,
+                                     final boolean reachabilityComplete, final int verboseLevel, final boolean fix) {
+    if (chunkSlots.isEmpty())
+      return;
+
+    if (!reachabilityComplete) {
+      // Said out loud rather than left as a zero: "no orphans found" and "could not tell" are different answers, and
+      // a report that gives the first when it means the second is the reason to look for orphans in the first place.
+      final String warning = ("the orphaned-chunk sweep of bucket '%s' was skipped: the reachability walk did not "
+              + "complete, so an unmarked chunk is not proof of an orphan - repair the errors reported above and run "
+              + "CHECK DATABASE again").formatted(componentName);
+      totals.warnings.add(warning);
+      if (verboseLevel > 0)
+        LogManager.instance().log(this, Level.WARNING, "- " + warning);
+      return;
+    }
+
+    for (final long chunkPosition : chunkSlots.toArray()) {
+      if (reachableChunks.contains(chunkPosition))
+        continue;
+
+      final RID chunkRID = new RID(fileId, chunkPosition);
+      final boolean orphanedByThisRun = chunksOrphanedByThisRun.contains(chunkPosition);
+
+      ++totals.orphanedChunks;
+      if (!orphanedByThisRun)
+        ++totals.totalErrors;
+
+      // As above, orphanedByThisRun implies fix.
+      String warning = orphanedByThisRun ?
+              "chunk %s belonged to a record this run removed: reclaimed".formatted(chunkRID) :
+              "chunk %s is reachable from no record and its space is leaked%s".formatted(chunkRID,
+                      fix ? ": reclaimed" : "; run CHECK DATABASE FIX to reclaim it");
+
+      if (fix) {
+        try {
+          // The chain this chunk belonged to no longer exists to be walked, so only its own slot is freed.
+          freeSlotOnly(chunkRID);
+          // Deliberately NOT added to deletedRecordsAfterFix: that list is the RIDs of RECORDS this run removed, and
+          // a continuation chunk is a fragment of one, under a RID no caller ever held. orphanedChunksReclaimed is
+          // what counts them, and the warnings name them.
+          ++totals.orphanedChunksReclaimed;
+          --totals.totalChunks;
+          --totals.totalAllocatedRecords;
+          ++totals.totalDeletedRecords;
+        } catch (final Exception e) {
+          if (orphanedByThisRun)
+            ++totals.totalErrors;
+          warning = "chunk %s is reachable from no record and could not be reclaimed: %s".formatted(chunkRID,
+                  e.getMessage());
+        }
+      }
+
+      totals.warnings.add(warning);
+      if (verboseLevel > 0)
+        LogManager.instance().log(this, Level.SEVERE, "- " + warning);
+    }
+  }
+
+  /**
+   * The position a placeholder POINTER slot references, or {@code -1} when that slot no longer holds a pointer at all
+   * (deleted, rewritten, or repaired away since the walk saw it). Never throws: an unreadable slot answers {@code -1}
+   * like a missing one, and the caller leaves it alone either way.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private long readPlaceholderPointer(final int totalPages, final long pointerPosition) {
+    try {
+      final int pageId = (int) (pointerPosition / maxRecordsInPage);
+      if (pageId >= totalPages)
+        return -1L;
+
+      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
+      final int positionInPage = (int) (pointerPosition % maxRecordsInPage);
+      if (positionInPage >= page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET))
+        return -1L;
+
+      final int recordPositionInPage = getRecordPositionInPage(page, positionInPage);
+      if (recordPositionInPage == 0)
+        return -1L;
+
+      final long[] recordSize = page.readNumberAndSize(recordPositionInPage);
+      if (recordSize[0] != RECORD_PLACEHOLDER_POINTER)
+        return -1L;
+
+      return page.readLong((int) (recordPositionInPage + recordSize[1]));
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.FINE, "Unable to re-read the placeholder pointer at position %d of bucket '%s'", e,
+              pointerPosition, componentName);
+      return -1L;
+    }
+  }
+
+  /**
+   * Frees ONE slot and nothing else: the slot-table entry is zeroed, the record dropped from the transaction's cache
+   * and both commit-time page merges excluded, exactly as every non-plain shape of {@link #deleteRecordInternal}
+   * excludes them.
+   * <p>
+   * The two repairs {@link #check} makes that must NOT cascade use it. A dangling placeholder POINTER (#6292) cannot
+   * go through the ordinary delete, which follows the pointer first: a pointer is dangling either because its content
+   * is gone - nothing to follow - or because it was CORRUPTED, in which case it now names some unrelated record that
+   * the ordinary delete would remove. An orphaned continuation chunk (#6294) has no chain left to walk either, and
+   * only its own slot to give back.
+   * <p>
+   * No page statistics are updated, matching {@code deleteRecordInternal} on the very same markers: both shapes carry
+   * a NEGATIVE size marker, from which the space the slot occupied cannot be derived without reading the record it no
+   * longer describes. The next {@code gatherPageStatistics} measures the page as it now is.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private void freeSlotOnly(final RID rid) throws IOException {
+    final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
+    final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
+
+    final TransactionContext slotTx = database.getTransactionIfExists();
+    if (slotTx != null) {
+      slotTx.poisonEdgeAppendPage(fileId, pageId);
+      if (slotTx.isSlotMergeEnabled())
+        slotTx.poisonSlotRebasePage(fileId, pageId);
+    }
+
+    database.getTransaction().removeRecordFromCache(rid);
+
+    final MutablePage page = database.getTransaction()
+            .getPageToModify(new PageId(database, file.getFileId(), pageId), pageSize, false);
+    page.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE, 0L);
+
+    database.getTransaction().addDeletedRecord(rid);
+  }
+
+  /**
+   * What the slot at {@code contentPosition} - the target of a placeholder POINTER - turns out to hold. Only
+   * {@link #check} asks, and only about a slot a pointer led it to, so it costs one page fetch per placeholder
+   * POINTER - every one of them, because the marker is the only thing that tells the shapes apart and reading it is
+   * the whole question. That is the deliberate trade, and the scale to judge it against is what {@code check} already
+   * spends on the same pass: it reads every page of the bucket and walks the FULL continuation chain of every
+   * multi-page record. A pre-#6149 bucket dense with placeholders pays one more fetch each, of pages the walk itself
+   * touches anyway, on an operation that is already O(pages + chunks).
    * <p>
    * It is paid on every run, including on a database that has already been repaired and on one this build created -
    * and the obvious saving, a persisted "no legacy shape here" flag set by a successful FIX, is deliberately not taken.
@@ -1354,43 +1754,48 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * the failure this whole marker exists to end. A bounded, honest cost on an admin operation beats a cheap answer
    * that can be stale (code review on #6287).
    * <p>
-   * Never throws: a pointer that cannot be followed is a different problem, reported by the link pass of CHECK
-   * DATABASE rather than mistaken for this one.
+   * Never throws: a target whose page cannot be read answers {@link PlaceholderTarget#UNREADABLE}, which is not
+   * evidence of anything and is acted on by nobody.
    *
-   * @param totalPages the page count {@link #check} snapshotted before its walk, so both of its questions - is this
-   *                   pointer's target ambiguous, and is it still - are answered against the same bucket the walk
-   *                   itself covered, rather than against a count that may have moved under it.
+   * @param totalPages the page count {@link #check} snapshotted before its walk, so every question it asks is answered
+   *                   against the same bucket the walk itself covered, rather than against a count that may have moved
+   *                   under it.
    *
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
-  private boolean isLegacyAmbiguousContentHead(final int totalPages, final long contentPosition) {
+  private PlaceholderTarget classifyPlaceholderTarget(final int totalPages, final long contentPosition) {
     try {
       if (contentPosition < 0)
-        return false;
+        return PlaceholderTarget.DANGLING;
       final int contentPageId = (int) (contentPosition / maxRecordsInPage);
       if (contentPageId >= totalPages)
-        return false;
+        return PlaceholderTarget.DANGLING;
 
       final BasePage contentPage = database.getTransaction()
               .getPage(new PageId(database, file.getFileId(), contentPageId), pageSize);
       final int positionInPage = (int) (contentPosition % maxRecordsInPage);
       if (positionInPage >= contentPage.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET))
-        return false;
+        return PlaceholderTarget.DANGLING;
 
       final int recordPositionInPage = getRecordPositionInPage(contentPage, positionInPage);
       if (recordPositionInPage == 0)
-        return false;
+        return PlaceholderTarget.DANGLING;
 
-      return contentPage.readNumberAndSize(recordPositionInPage)[0] == FIRST_CHUNK;
+      final long marker = contentPage.readNumberAndSize(recordPositionInPage)[0];
+      if (marker == FIRST_CHUNK)
+        return PlaceholderTarget.LEGACY_AMBIGUOUS;
+      if (marker == FIRST_CHUNK_PLACEHOLDER_CONTENT || marker < RECORD_PLACEHOLDER_CONTENT)
+        return PlaceholderTarget.CONTENT;
+      return PlaceholderTarget.DANGLING;
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.FINE, "Unable to inspect the content record at position %d of bucket '%s'", e,
               contentPosition, componentName);
-      return false;
+      return PlaceholderTarget.UNREADABLE;
     }
   }
 
   /**
-   * Rewrites the marker of a legacy ambiguous content head (see {@link #isLegacyAmbiguousContentHead}) into
+   * Rewrites the marker of a legacy ambiguous content head (see {@link #classifyPlaceholderTarget}) into
    * {@link #FIRST_CHUNK_PLACEHOLDER_CONTENT}, which is the whole of the repair: the record's bytes, its chunk header,
    * its chain and its RID are all correct and untouched, and the one thing that was never written down is which of the
    * two kinds of head this is.
@@ -2179,11 +2584,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         return true;
       }
 
-      if (kind == TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD) {
+      if (kind == TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD
+              || kind == TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT) {
         // #6178: the record shrank back inside its own slot and stopped being a chunk chain. The pre-image is a head
         // chunk, so it is checked as one - and as for every other head-chunk replay, the rest of the chain is covered
         // by the chain fingerprint the write compared before collapsing, not by anything visible here.
-        if (rs[0] != FIRST_CHUNK)
+        // #6286: the CONTENT record of a placeholder collapses the same way into the negated shape of its own, and the
+        // kind says which of the two the write started from - the marker it must still find, and the sign it writes.
+        final boolean toPlaceholderContent = kind == TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT;
+        if (rs[0] != (toPlaceholderContent ? FIRST_CHUNK_PLACEHOLDER_CONTENT : FIRST_CHUNK))
           return false;
         final int chunkHeaderPos = (int) (existingPos + rs[1]);
         final byte[] committedChunk = readChunkImage(page, chunkHeaderPos);
@@ -2202,7 +2611,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // the head-chunk branch's own refusal above does, and neither is reachable by fabricating a page state
         // without testing the fabrication instead of the engine.
         final int chunkRegionEnd = headChunkRegionEnd(page, recordCountInPage, existingPos);
-        final int sizeLen = Binary.getNumberSpace(body.length);
+        final long sizeMarker = toPlaceholderContent ? -1L * body.length : body.length;
+        final int sizeLen = Binary.getNumberSpace(sizeMarker);
         if (existingPos + sizeLen + body.length > chunkRegionEnd)
           return false;
 
@@ -2213,7 +2623,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                   committedChunkEnd - (existingPos + sizeLen + body.length));
         }
 
-        final int sizeLenWritten = page.writeNumber(existingPos, body.length);
+        final int sizeLenWritten = page.writeNumber(existingPos, sizeMarker);
         assert sizeLenWritten == sizeLen :
             "the record size took " + sizeLenWritten + " bytes where " + sizeLen + " were budgeted";
         page.writeByteArray(existingPos + sizeLenWritten, body, 0, body.length);
@@ -2517,6 +2927,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
     final Binary buffer = database.getSerializer().serialize(database, record);
 
+    // A CONTENT record stores its size NEGATED, so a body shorter than MINIMUM_RECORD_SIZE would write a -1..-4 that
+    // the marker namespace already owns (see that constant): pad it exactly as createRecordInternal pads the record it
+    // creates behind a new pointer. It matters on every write that gives such a slot its size back - the in-place
+    // overwrite far below, and since #6286 the collapse of a content chain into this very shape.
+    if (updatePlaceholderContent)
+      while (buffer.size() < MINIMUM_RECORD_SIZE)
+        buffer.append((byte) 0);
+
     final int pageId = (int) (rid.getPosition() / maxRecordsInPage);
     final int positionInPage = (int) (rid.getPosition() % maxRecordsInPage);
 
@@ -2661,23 +3079,20 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // the same rule #6163 sizes the head chunk with: the region, and not a byte more - shrinking is no licence to
         // take a neighbour's bytes.
         //
-        // NOT for the CONTENT record of a placeholder, even though it reaches this branch whenever
-        // createRecordInternal had to spill it. Such a record is identified by the NEGATIVE size marker it would have
-        // to be given back, and the plain positive marker the collapse writes is what tells scan() and check() that a
-        // slot holds a record of its own - so collapsing one would make the placeholder's content show up a second
-        // time, as a document in its own right, which is #6196 all over again on a record that had escaped it. It
-        // keeps its chain, which costs 13 bytes on a shape that needs a placeholder to exist at all - a legacy one, or
-        // the zero-free-tail page #6149 left as the last fallback. Making the collapse write a negated size marker
-        // instead is a follow-up (#6286), not a correctness matter.
-        //
-        // The FLAG is what carries this, and it has to be: a database written before #6196 holds a content head still
-        // wearing the ambiguous FIRST_CHUNK, which the marker cannot tell from a record's own. The marker test next to
-        // it is redundant - the throw at the top of this branch means placeholderContentHead can only be true here
-        // when updatePlaceholderContent is too - and is kept so this line states its own precondition instead of
-        // borrowing one from thirty lines up.
-        if (!updatePlaceholderContent && !placeholderContentHead//
-                && collapseChunkChainToRecord(rid, buffer, page, pageId, positionInPage, recordPositionInPage, chunkHeaderPos,
-                chunkRegionEnd, chunkBaseImage, slotTx)) {
+        // #6286: the CONTENT record of a placeholder collapses too, into the NEGATED size marker that says whose the
+        // slot is. Which sign to write is decided by the FLAG and not by the marker found, and it has to be: a
+        // database written before #6196 holds a content head still wearing the ambiguous FIRST_CHUNK, which the marker
+        // cannot tell from a record's own - and collapsing THAT with a positive marker would make the placeholder's
+        // content show up a second time as a document in its own right, which is #6196 all over again on a record that
+        // had escaped it. The collapse of such a legacy head is therefore right, and it even ends the ambiguity for
+        // good; what it cannot be is REPLAYED, because the two collapse kinds each name the one committed marker the
+        // replay may write over and neither of them is FIRST_CHUNK-into-content. Poison the page and collapse anyway:
+        // the transaction keeps its write, it just gives up the merge on a shape no database this build writes has.
+        if (updatePlaceholderContent && !placeholderContentHead && slotMergeOn)
+          slotTx.poisonSlotRebasePage(fileId, pageId);
+
+        if (collapseChunkChainToRecord(rid, buffer, page, pageId, positionInPage, recordPositionInPage, chunkHeaderPos,
+                chunkRegionEnd, chunkBaseImage, updatePlaceholderContent, slotTx)) {
           if (!discardRecordAfter)
             ((RecordInternal) record).setBuffer(buffer.getNotReusable());
           return true;
@@ -2965,6 +3380,18 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    */
   private String findBrokenChunkChain(final RID rid, final BasePage firstPage, final int firstRecordPositionInPage,
                                       final boolean fromNewestCommitted) {
+    return findBrokenChunkChain(rid, firstPage, firstRecordPositionInPage, fromNewestCommitted, new ChunkChainWalk());
+  }
+
+  /**
+   * @param walk collects the continuation chunks this walk went through, and records whether it reached a conclusion.
+   *             The walk needs the set anyway - it is its loop detector - so a caller asking which chunks the record
+   *             reaches (#6294) costs nothing beyond keeping it (see {@link ChunkChainWalk}). Reset by this method,
+   *             so one instance can be reused across a whole {@link #check} pass.
+   */
+  private String findBrokenChunkChain(final RID rid, final BasePage firstPage, final int firstRecordPositionInPage,
+                                      final boolean fromNewestCommitted, final ChunkChainWalk walk) {
+    walk.reset();
     try {
       BasePage chunkPage = firstPage;
       int chunkPositionInPage = firstRecordPositionInPage;
@@ -2975,7 +3402,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // share pages after chain reuse/fragmentation), so any count-based heuristic risks a false positive - fatal
       // here, because check(fix) DELETES the record it flags. Revisiting a continuation pointer is the only certain
       // loop signal.
-      final Set<Long> visitedPointers = new HashSet<>();
+      final LongHashSet visitedPointers = walk.chunks;
 
       for (int chunkId = 0; ; ++chunkId) {
         final long nextChunkPointer = chunkPage.readLong(
@@ -3006,13 +3433,16 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           // this walk retries, the tolerant delete keeps its retry semantics, and check() reports nothing to fix.
           LogManager.instance().log(this, Level.FINE,
                   "Unable to load page %s while walking the chunk chain of %s", e, nextPageIdentity, rid);
+          walk.incomplete = true;
           return null;
         }
 
-        if (chunkPage == null)
+        if (chunkPage == null) {
           // Defensive: neither page source answers null while it is allowed to materialise a missing page. A null
           // here would still not be proof of a broken chain, so it must not be reported as one.
+          walk.incomplete = true;
           return null;
+        }
 
         chunkPositionInPage = getRecordPositionInPage(chunkPage, nextPositionInPage);
         if (chunkPositionInPage == 0)
@@ -3023,6 +3453,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           return "unexpected marker at chunk " + chunkId;
       }
     } catch (final Exception e) {
+      // A break PROVED by the bytes: the chunks walked so far are real, and the ones past this point were never
+      // reachable - so the walk is complete for the purpose of the reachability the caller derives from it.
       return "error walking chain: " + e.getMessage();
     }
   }
@@ -3156,7 +3588,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             // is no longer NEXT_CHUNK) means the chain cannot be walked. Without force this is treated as a concurrent
             // modification and rethrown as the #4932 retry signal, so a half-freed chain is never left behind. With
             // force (admin repair) the walk stops here instead: the head slot is still freed below, and the chunks
-            // past this break are orphaned - a bounded space leak reclaimed by compaction or a later database check.
+            // past this break are orphaned - a bounded space leak that the orphaned-chunk sweep of check(fix)
+            // reclaims (#6294), which is the only thing that does: compaction re-flows LIVE slots, and an orphaned
+            // chunk still has one.
             String chainProblem = null;
             try {
               if (chunkPageId >= getTotalPages())
@@ -3187,7 +3621,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
               LogManager.instance().log(this, Level.WARNING,
                       "Force-deleting multi-page record %s with a broken chunk chain at chunk %d (%s); orphaned chunks (if "
-                              + "any) will be reclaimed by compaction or a database check.", rid, chunkId, chainProblem);
+                              + "any) are reclaimed by CHECK DATABASE FIX.", rid, chunkId, chainProblem);
               break;
             }
 
@@ -4407,10 +4841,23 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * head chunk (13 bytes of header) fits the region as a plain record (at most 5 bytes of size marker), so the two
    * conditions coincide and the chain-of-one-chunk is collapsed instead of being kept. That is the same state #6163's
    * grow-back exists to repair, which this removes at the source rather than compensating for.
+   * <p>
+   * #6286: the CONTENT record of a placeholder collapses here too, into the NEGATED size marker its shape is
+   * recognised by rather than into a plain positive one. It was left out when this was written because the collapse
+   * could only write a positive marker, and a positive marker is exactly what tells {@code scan()} and {@code check()}
+   * that a slot holds a document of its own - so such a record kept its chain however far it shrank, 13 bytes of
+   * header for ever and every read and write on the chunk path, on the one record shape that needs a placeholder to
+   * exist at all. Writing the sign the shape calls for is all that was missing, and it makes this the mirror of the
+   * spill for BOTH kinds of head chunk instead of only one.
    *
-   * @param chunkBaseImage the head chunk's pre-image when the caller found the slot rebasable, or {@code null} when
-   *                       it did not - in which case it has already poisoned the page and this only writes. When it
-   *                       is not null, {@code slotTx} is not null either: the caller could not have read it.
+   * @param chunkBaseImage      the head chunk's pre-image when the caller found the slot rebasable, or {@code null}
+   *                            when it did not - in which case it has already poisoned the page and this only writes.
+   *                            When it is not null, {@code slotTx} is not null either: the caller could not have read
+   *                            it.
+   * @param isPlaceHolderContent whether this slot is the CONTENT of a placeholder POINTER rather than a record of its
+   *                            own. Decided by the caller from the FLAG it was reached through and not from the marker
+   *                            found on the page, because a database written before #6196 holds a content head still
+   *                            wearing the ambiguous {@link #FIRST_CHUNK}.
    *
    * @return true when the record was collapsed and there is nothing left for the caller to write.
    *
@@ -4419,10 +4866,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   private boolean collapseChunkChainToRecord(final RID rid, final Binary buffer, final MutablePage page, final int pageId,
                                              final int positionInPage, final int recordPositionInPage, final int chunkHeaderPos,
                                              final int chunkRegionEnd, final byte[] chunkBaseImage,
-                                             final TransactionContext slotTx)
+                                             final boolean isPlaceHolderContent, final TransactionContext slotTx)
           throws IOException {
     final int bufferSize = buffer.size();
-    final int sizeBytes = Binary.getNumberSpace(bufferSize);
+    // #6286: which shape the slot collapses INTO. A record of its own gets the plain positive size marker; the CONTENT
+    // record of a placeholder gets that size NEGATED, the same marker every content record small enough for its page
+    // has always carried - which is what keeps a scan from handing these bytes out as a document of their own.
+    final long sizeMarker = isPlaceHolderContent ? -1L * bufferSize : bufferSize;
+    final int sizeBytes = Binary.getNumberSpace(sizeMarker);
     if (recordPositionInPage + sizeBytes + bufferSize > chunkRegionEnd)
       // Still too big for its own slot: it stays a chunk chain.
       return false;
@@ -4433,7 +4884,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
     final int previousCoverage = page.beginCoveredWrite(chunkBaseImage != null ? MutablePage.COVERAGE_SLOT_MERGE : 0);
     try {
-      final int sizeBytesWritten = page.writeNumber(recordPositionInPage, bufferSize);
+      final int sizeBytesWritten = page.writeNumber(recordPositionInPage, sizeMarker);
       // The offset the body is placed at was budgeted with getNumberSpace above, and writeNumber is the only other
       // place that decides how many bytes a size takes. They agree by construction; a future divergence would write
       // the body past the room just proved - a silent overwrite of the next record rather than a refusal, which is
@@ -4459,11 +4910,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     if (chunkBaseImage != null && !slotTx.isSlotRebasePagePoisoned(fileId, pageId))
       slotTx.trackRebasableUpdate(fileId, pageId, positionInPage, chunkBaseImage,
               Arrays.copyOfRange(buffer.getContent(), buffer.getContentBeginOffset(), buffer.getContentBeginOffset() + bufferSize),
-              TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD);
+              isPlaceHolderContent ?
+                      TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT :
+                      TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD);
 
     LogManager.instance().log(this, Level.FINE,
-            "Updated record %s by collapsing its chunk chain back into a plain record (%s threadId=%d)", null, rid, page,
-            Thread.currentThread().threadId());
+            "Updated record %s by collapsing its chunk chain back into a plain %srecord (%s threadId=%d)", null, rid,
+            isPlaceHolderContent ? "placeholder content " : "", page, Thread.currentThread().threadId());
 
     return true;
   }

--- a/engine/src/test/java/com/arcadedb/database/BucketPageLayoutTestSupport.java
+++ b/engine/src/test/java/com/arcadedb/database/BucketPageLayoutTestSupport.java
@@ -20,10 +20,14 @@ package com.arcadedb.database;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -197,5 +201,97 @@ public abstract class BucketPageLayoutTestSupport extends TestHelper {
   protected static long numberProperty(final Result row, final String name) {
     final Object value = row.getProperty(name);
     return value == null ? 0L : ((Number) value).longValue();
+  }
+
+  /** The single row {@code CHECK DATABASE} answers with, run with or without {@code FIX}. */
+  protected Result checkDatabaseRow(final boolean fix) {
+    try (final ResultSet rs = database.command("sql", fix ? "check database fix" : "check database")) {
+      return rs.next();
+    }
+  }
+
+  /** {@code CHECK DATABASE} folds the per-bucket warning lists into a set, so this reads it as the collection it is. */
+  protected static Collection<?> warningsOf(final Result row) {
+    final Object warnings = row.getProperty("warnings");
+    return warnings == null ? List.of() : (Collection<?>) warnings;
+  }
+
+  /**
+   * Records a full SCAN returns. {@code count(@rid)} and not {@code count(*)}: the latter answers from the bucket's
+   * cached counter without reading a page, so the two disagree exactly when a slot the counter counts is one a scan
+   * skips - which is a difference several of these tests are about rather than something they may paper over.
+   */
+  protected long countRecords(final String typeName) {
+    final long[] total = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + typeName)) {
+        total[0] = ((Number) rs.next().getProperty("c")).longValue();
+      }
+    });
+    return total[0];
+  }
+
+  /** The counter {@code count(*)} answers from: O(1), never a scan, and the other half of the comparison above. */
+  protected long countRecordsFromCounter(final String typeName) {
+    final long[] total = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("SQL", "select count(*) as c from " + typeName)) {
+        total[0] = ((Number) rs.next().getProperty("c")).longValue();
+      }
+    });
+    return total[0];
+  }
+
+  /** Records a scan returns holding exactly {@code value} - the count that notices a record handed out twice. */
+  protected long countRecordsHolding(final String typeName, final String value) {
+    final long[] total = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + typeName + " where v = :v",
+          Map.of("v", value))) {
+        total[0] = ((Number) rs.next().getProperty("c")).longValue();
+      }
+    });
+    return total[0];
+  }
+
+  /**
+   * Runs {@code body} on the page holding {@code rid}, taken for modification so a write lands in the caller's
+   * transaction. The way every test here fabricates a physical shape the engine no longer produces - a legacy marker,
+   * a chain broken mid-flight, a slot freed behind the record that references it.
+   */
+  protected long onSlot(final RID rid, final PageAccess body) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(rid.getBucketId())).getPageSize();
+    final int pageNumber = (int) (rid.getPosition() / maxRecordsInPageOf(rid));
+    try {
+      return body.apply(db.getTransaction().getPageToModify(new PageId(db, rid.getBucketId(), pageNumber), pageSize, false));
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Content offset of {@code rid}'s slot on {@code page}, marker included: what the record table entry holds. */
+  protected int recordOffsetOf(final MutablePage page, final RID rid) {
+    final int slot = (int) (rid.getPosition() % maxRecordsInPageOf(rid));
+    // PAGE_RECORD_TABLE_OFFSET == PAGE_RECORD_COUNT_IN_PAGE_OFFSET(0) + SHORT_SERIALIZED_SIZE; one uint per slot.
+    return (int) page.readUnsignedInt(Binary.SHORT_SERIALIZED_SIZE + slot * Binary.INT_SERIALIZED_SIZE);
+  }
+
+  /** Frees a slot without touching anything that references it: an interrupted repair, or physical corruption. */
+  protected void freeSlotBehindItsBack(final RID rid) {
+    database.transaction(() -> onSlot(rid, page -> {
+      final int slot = (int) (rid.getPosition() % maxRecordsInPageOf(rid));
+      page.writeUnsignedInt(Binary.SHORT_SERIALIZED_SIZE + slot * Binary.INT_SERIALIZED_SIZE, 0L);
+      return 0L;
+    }));
+  }
+
+  private int maxRecordsInPageOf(final RID rid) {
+    return ((LocalBucket) database.getSchema().getBucketById(rid.getBucketId())).getMaxRecordsInPage();
+  }
+
+  @FunctionalInterface
+  protected interface PageAccess {
+    long apply(MutablePage page) throws Exception;
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/Issue6178ChunkCollapseTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6178ChunkCollapseTest.java
@@ -20,7 +20,6 @@ package com.arcadedb.database;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.ConcurrentModificationException;
-import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
@@ -196,18 +195,15 @@ class Issue6178ChunkCollapseTest extends BucketPageLayoutTestSupport {
   }
 
   /**
-   * The one chunk head that must NOT be collapsed: the CONTENT record of a placeholder, which
-   * {@code createRecordInternal} spills into a chain of its own whenever no page can host it whole. Such a record is
-   * identified by the NEGATIVE size marker a plain collapse would replace with a positive one - and a positive size
-   * marker is exactly what tells {@code scan()} that a slot holds a document of its own, so collapsing it would make
-   * the placeholder's content appear a second time, as a record in its own right.
-   * <p>
-   * Since #6196 the head chunk of such a record carries {@code FIRST_CHUNK_PLACEHOLDER_CONTENT}, so the chain shape is
-   * no longer ambiguous; what is still missing is a collapse that writes the negated size marker back (#6286), which
-   * is why the guard stays.
+   * The other head chunk, and the last transition between the two shapes that was missing (#6286): the CONTENT record
+   * of a placeholder, which {@code createRecordInternal} spills into a chain of its own whenever no page can host it
+   * whole. It used to keep that chain however far it shrank, because the collapse could only write a plain POSITIVE
+   * size marker and a positive marker is exactly what tells {@code scan()} that a slot holds a document of its own.
+   * Writing the NEGATED size the shape is recognised by is all that was needed: the chain goes, and the content stays
+   * reachable through its pointer and through nothing else.
    */
   @Test
-  void aPlaceholderContentStoredAsAChainIsNeverCollapsed() {
+  void aPlaceholderContentShrinkingBackIntoItsRegionBecomesAContentRecord() {
     final RID[] placeholder = new RID[1];
 
     database.transaction(() -> {
@@ -239,51 +235,41 @@ class Issue6178ChunkCollapseTest extends BucketPageLayoutTestSupport {
     final long copiesBefore = countRecordsHolding("Surrogate", huge);
     assertThat(copiesBefore).as("a chunked placeholder content is scanned once, through its pointer").isEqualTo(1L);
 
-    // Back to a handful of bytes: the content record's own chain shrinks, and stays a chain.
+    final long chunksBefore = (Long) layout.get("totalChunks");
+    assertThat(chunksBefore).as("the content chain must really have continuation chunks: " + layout).isPositive();
+
+    // Back to a handful of bytes: the content record's own chain collapses into the negated-size shape.
     database.transaction(() -> placeholder[0].asDocument(true).modify().set("v", "p").save());
 
     layout = bucketStats("Surrogate");
     assertThat((Long) layout.get("totalPlaceholderRecords")).as("the pointer must still be a pointer: " + layout)
         .isEqualTo(1L);
+    assertThat((Long) layout.get("totalSurrogateRecords"))
+        .as("its content is still a surrogate, now a plain one: " + layout).isEqualTo(1L);
+    assertThat((Long) layout.get("totalMultiPageRecords"))
+        .as("and the only multi-page record left is the one that sealed page 0: " + layout).isEqualTo(1L);
+    assertThat((Long) layout.get("totalChunks")).as("the content record's own chain must be gone: " + layout)
+        .isLessThan(chunksBefore);
     assertThat(countRecords("Surrogate")).as("and the collapse must not have added a record of its own")
         .isEqualTo(recordsBefore);
-    // What the guard is worth: collapsing would have given the content record a plain POSITIVE size marker, which is
-    // precisely what makes a slot a document in its own right - the duplication #6196 removed, reintroduced on the one
-    // record shape that reaches this branch with the marker that hides it out of reach.
+    // What the negated marker is worth: a plain POSITIVE size marker is precisely what makes a slot a document in its
+    // own right - the duplication #6196 removed, which a collapse writing the wrong sign would reintroduce on the one
+    // record shape that reaches this branch behind a pointer.
     assertThat(countRecordsHolding("Surrogate", "p")).as("the collapse must not multiply the placeholder's content")
         .isEqualTo(copiesBefore);
 
     database.transaction(() -> assertThat(placeholder[0].asDocument(true).getString("v")).isEqualTo("p"));
+
+    // And it survives the round trip: grown back past its page it becomes a chain again, and shrunk again it collapses
+    // again, all through the same pointer.
+    database.transaction(() -> placeholder[0].asDocument(true).modify().set("v", huge).save());
+    database.transaction(() -> assertThat(placeholder[0].asDocument(true).getString("v")).isEqualTo(huge));
+    database.transaction(() -> placeholder[0].asDocument(true).modify().set("v", "p").save());
+    database.transaction(() -> assertThat(placeholder[0].asDocument(true).getString("v")).isEqualTo("p"));
+    assertThat(countRecordsHolding("Surrogate", "p")).as("still exactly one copy after the round trip")
+        .isEqualTo(copiesBefore);
+
     checkDatabase();
-  }
-
-  /**
-   * Records a full SCAN returns - the count that would change if a content record became visible on its own.
-   * {@code count(@rid)} and not {@code count(*)}: the latter answers from the bucket's cached counter without
-   * scanning a page, so it could not see the difference this test is about.
-   */
-  private long countRecords(final String typeName) {
-    final long[] total = new long[1];
-    database.transaction(() -> {
-      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + typeName)) {
-        total[0] = ((Number) rs.next().getProperty("c")).longValue();
-      }
-    });
-    return total[0];
-  }
-
-  /**
-   * Records a scan returns holding exactly {@code value} - the sharper form of the count above, and the one that
-   * would notice the placeholder's content being handed out a second time under a RID of its own.
-   */
-  private long countRecordsHolding(final String typeName, final String value) {
-    final long[] total = new long[1];
-    database.transaction(() -> {
-      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + typeName + " where v = ?", value)) {
-        total[0] = ((Number) rs.next().getProperty("c")).longValue();
-      }
-    });
-    return total[0];
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -98,8 +98,9 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
   }
 
   /**
-   * The whole life of such a record through the pointer: rewritten large (the chain is reused), shrunk back (the
-   * chain shrinks and stays a chain, #6178), grown again, and finally deleted with the chain behind it.
+   * The whole life of such a record through the pointer: rewritten large (the chain is reused), shrunk back (since
+   * #6286 the chain COLLAPSES into the negated-size shape a content record has when it fits its page), grown again,
+   * and finally deleted with whatever it had become behind it.
    */
   @Test
   void theContentChainKeepsItsMarkerThroughEveryRewrite() {
@@ -116,6 +117,10 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
     Map<String, Object> layout = bucketStats(TYPE);
     assertThat((Long) layout.get("totalPlaceholderRecords")).as("the pointer must still be a pointer: " + layout)
         .isEqualTo(1L);
+    assertThat((Long) layout.get("totalChunks")).as("and the content's own chain is collapsed away (#6286): " + layout)
+        .isEqualTo(chunksOfTheSealingRecord);
+    assertThat((Long) layout.get("totalSurrogateRecords"))
+        .as("into the negated-size shape a content record has: " + layout).isEqualTo(1L);
     assertThat(countRecordsHolding("p")).as("nor must a shrink multiply the content").isEqualTo(1L);
 
     database.transaction(() -> placeholder.asDocument(true).modify().set("v", HUGE).save());
@@ -161,6 +166,53 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
     assertThat(countRecordsHolding(HUGE)).as("the duplicate is gone").isEqualTo(1L);
     database.transaction(() -> assertThat(placeholder.asDocument(true).getString("v")).isEqualTo(HUGE));
 
+    checkDatabase();
+  }
+
+  /**
+   * The other way a legacy ambiguous head stops being ambiguous, and it needs no {@code FIX}: an ordinary UPDATE
+   * through the pointer that shrinks the record back inside the region its slot owns collapses it (#6286), and the
+   * collapse writes the NEGATED size marker - which is the very thing the ambiguous shape was missing. The duplicate
+   * a scan used to hand out goes with it.
+   * <p>
+   * Which sign that collapse writes is decided by the FLAG the slot was reached through and never by the marker
+   * found, because the marker is exactly what cannot tell a legacy content head from a record's own head chunk. Get
+   * that wrong and the collapse writes a POSITIVE size, which is #6196 all over again on a record that was already
+   * suffering from it - so the copy count is what this asserts, not the byte.
+   * <p>
+   * The write is not offered to the disjoint-slot merge (neither collapse kind names FIRST_CHUNK as the marker it
+   * replays over) and the page is poisoned instead; a legacy head that does NOT collapse keeps its ordinary
+   * head-chunk tracking, which is what the second half of this test pins.
+   */
+  @Test
+  void anUpdateCollapsesALegacyAmbiguousContentHeadAndEndsItsAmbiguity() {
+    final RID placeholder = placeholderWithChainedContent();
+    final RID content = contentRidOf(placeholder);
+
+    writeMarkerByteAt(content, FIRST_CHUNK_MARKER);
+    assertThat(countRecordsHolding(HUGE)).as("the shape #6196 reported: the content is scanned twice").isEqualTo(2L);
+
+    // Still far too big for the region the content record's slot owns: it stays a chain, and stays ambiguous.
+    final String stillHuge = "s".repeat(200 * 1024);
+    database.transaction(() -> placeholder.asDocument(true).modify().set("v", stillHuge).save());
+    assertThat(markerByteAt(content)).as("a rewrite that stays a chain leaves the legacy marker alone")
+        .isEqualTo(FIRST_CHUNK_MARKER);
+    assertThat(countRecordsHolding(stillHuge)).as("so the duplicate is still there").isEqualTo(2L);
+
+    // Back to a handful of bytes: now it fits, and the collapse writes the marker the shape was missing.
+    database.transaction(() -> placeholder.asDocument(true).modify().set("v", "p").save());
+
+    final Map<String, Object> layout = bucketStats(TYPE);
+    assertThat((Long) layout.get("totalPlaceholderRecords")).as("the pointer must still be a pointer: " + layout)
+        .isEqualTo(1L);
+    assertThat((Long) layout.get("totalSurrogateRecords"))
+        .as("and its content a surrogate, not a record of its own: " + layout).isEqualTo(1L);
+    assertThat((Long) layout.get("totalChunks")).as("with the chain freed: " + layout)
+        .isEqualTo(chunksOfTheSealingRecord);
+    assertThat(countRecordsHolding("p")).as("one copy, through the pointer, and no second one").isEqualTo(1L);
+
+    database.transaction(() -> assertThat(placeholder.asDocument(true).getString("v")).isEqualTo("p"));
+    // Nothing left for CHECK DATABASE to repair: the update did what the FIX would have done, and more.
     checkDatabase();
   }
 

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 
@@ -193,6 +194,13 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
     assertThat(countRecordsHolding(HUGE)).as("the shape #6196 reported: the content is scanned twice").isEqualTo(2L);
 
     // Still far too big for the region the content record's slot owns: it stays a chain, and stays ambiguous.
+    //
+    // That this rewrite also keeps its head-chunk tracking - the poison belongs to the collapse, and firing it up
+    // front cost an ordinary rewrite the replay it has always had (PR review) - is deliberately NOT asserted here.
+    // An update is deferred to commit, so the flag does not exist while the transaction is open, and by the time it
+    // does the transaction is gone; an assertion placed either side passes whether or not the poison fires, which is
+    // worth less than no assertion at all. What it costs is a merge opportunity and never correctness, and only on
+    // data written before #6196.
     final String stillHuge = "s".repeat(200 * 1024);
     database.transaction(() -> placeholder.asDocument(true).modify().set("v", stillHuge).save());
     assertThat(markerByteAt(content)).as("a rewrite that stays a chain leaves the legacy marker alone")
@@ -389,6 +397,50 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
   }
 
   /**
+   * The same guard for the COLLAPSE (#6286), which is where the two kinds earn their keep: both start from a head
+   * chunk and both end with the slot holding plain content, and the ONLY thing that separates them is the marker the
+   * replay must still find and the SIGN of the one it writes. A replay that took the wrong one would give a
+   * placeholder's content a positive size - a document of its own, which is #6196 - or hide a record behind a
+   * negative one.
+   * <p>
+   * Driven through {@code rebaseRecordOnPage} for the reason the sibling test above states: the transition it refuses
+   * is one no write path produces today, so only a direct drive proves the guard rather than the absence of a caller.
+   * Both directions, and both positive controls, for the same reason as there.
+   */
+  @Test
+  void aCollapseIsOnlyReplayedOntoTheMarkerItsWriteStartedFrom() {
+    final RID content = contentRidOf(placeholderWithChainedContent());
+
+    // Small enough for the region either slot owns, so a refusal can only come from the marker check.
+    final byte[] collapsed = "collapsed".getBytes(StandardCharsets.UTF_8);
+
+    database.begin();
+    try {
+      final LocalBucket bucket = bucketOf(TYPE);
+
+      final byte[] contentImage = chunkImageOf(content);
+      assertThat(rebase(bucket, content, collapsed, contentImage, TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD))
+          .as("a content head must not collapse under the kind that writes a record's positive size").isFalse();
+      assertThat(rebase(bucket, content, collapsed, contentImage,
+          TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT))
+          .as("and must collapse under the one that writes the negated size its shape is known by").isTrue();
+
+      final byte[] recordImage = chunkImageOf(sealingRecord);
+      assertThat(rebase(bucket, sealingRecord, collapsed, recordImage,
+          TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT))
+          .as("a record's own head must not collapse under the kind of a content head").isFalse();
+      assertThat(rebase(bucket, sealingRecord, collapsed, recordImage,
+          TransactionContext.SLOT_KIND_CHUNK_COLLAPSED_TO_RECORD))
+          .as("and must collapse under its own").isTrue();
+    } finally {
+      database.rollback();
+    }
+
+    database.transaction(() -> assertThat(placeholderRecordCount()).isEqualTo(1L));
+    checkDatabase();
+  }
+
+  /**
    * The image the disjoint-slot merge keeps for a head chunk: everything after the marker, i.e.
    * {@code [int chunkSize][long nextChunk][chunkSize bytes of content]}. Replaying it unchanged is a no-op write, so
    * the positive controls above assert the guard and not the content.
@@ -408,10 +460,19 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
 
   /** Replays {@code image} onto the slot of {@code rid} under {@code kind}, as a commit-time slot rebase would. */
   private boolean rebase(final LocalBucket bucket, final RID rid, final byte[] image, final byte kind) {
+    return rebase(bucket, rid, image, image, kind);
+  }
+
+  /**
+   * The general form, for the two kinds whose images DIFFER: a collapse starts from the head chunk ({@code baseBody})
+   * and ends with the slot holding plain content ({@code body}).
+   */
+  private boolean rebase(final LocalBucket bucket, final RID rid, final byte[] body, final byte[] baseBody,
+      final byte kind) {
     final boolean[] rebased = new boolean[1];
     onSlot(rid, page -> {
-      rebased[0] = bucket.rebaseRecordOnPage(page, (int) (rid.getPosition() % bucket.getMaxRecordsInPage()), image,
-          image, kind);
+      rebased[0] = bucket.rebaseRecordOnPage(page, (int) (rid.getPosition() % bucket.getMaxRecordsInPage()), body,
+          baseBody, kind);
       return 0L;
     });
     return rebased[0];

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -19,17 +19,12 @@
 package com.arcadedb.database;
 
 import com.arcadedb.engine.LocalBucket;
-import com.arcadedb.engine.MutablePage;
-import com.arcadedb.engine.PageId;
-import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.query.sql.executor.Result;
-import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -204,31 +199,53 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
   }
 
   /**
-   * The compound legacy shape: a content record still wearing the ambiguous marker whose chain is ALSO broken. Two
-   * independent defects on one record, and CHECK DATABASE FIX must book it once - the broken chain is what it can act
-   * on, so the record is force-deleted, and the ambiguity reconciliation must then leave alone a slot that is no
-   * longer there rather than report a second error and a repair that could not have happened.
+   * The compound legacy shape: a content record still wearing the ambiguous marker whose chain is ALSO broken. The
+   * ambiguity itself must be booked ONCE - the broken chain is what FIX can act on, so the record is force-deleted,
+   * and the ambiguity reconciliation must then leave alone a slot that is no longer there rather than report a second
+   * error and a repair that could not have happened.
+   * <p>
+   * What the run also reports is everything the corruption really cost, which is more than the one head slot: the
+   * placeholder POINTER that led to the record is removed with it (#6292 - left behind, it is a slot every scan skips
+   * and {@code count(*)} counts, for good), and the continuation chunks the overwritten pointer had already cut the
+   * chain off from are reclaimed (#6294 - nothing collected them before, whatever the comments promised). Those three
+   * chunks were leaked the moment the pointer was corrupted, before this run started, so they are errors of the
+   * database and not of the repair; the pointer is not, because the record it referenced is one this very run removed.
    */
   @Test
   void aLegacyContentHeadWithABrokenChainIsReportedOnce() {
-    final RID content = contentRidOf(placeholderWithChainedContent());
+    final RID placeholder = placeholderWithChainedContent();
+    final RID content = contentRidOf(placeholder);
 
     writeMarkerByteAt(content, FIRST_CHUNK_MARKER);
+    final long chunksBefore = (Long) bucketStats(TYPE).get("totalChunks");
     breakChainAt(content);
 
     final Result fixed = checkDatabaseRow(true);
-    assertThat(numberProperty(fixed, "totalErrors"))
-        .as("one record, one defect it can act on, one error: " + fixed.toJSON()).isEqualTo(1L);
-    assertThat(warningsOf(fixed).toString()).as("and the broken chain is what it names: " + fixed.toJSON())
-        .contains("broken multi-page chunk chain").doesNotContain("could not be repaired");
-    assertThat((Collection<?>) fixed.getProperty("deletedRecordsAfterFix"))
-        .as("the record a broken chain costs is the one that is deleted: " + fixed.toJSON())
-        .hasToString("[" + content + "]");
+    assertThat(warningsOf(fixed).toString()).as("the broken chain is what it names: " + fixed.toJSON())
+        .contains("broken multi-page chunk chain").doesNotContain("could not be repaired")
+        .doesNotContain("ambiguous chunk chain");
+    assertThat((Collection<Object>) fixed.<Collection<Object>>getProperty("deletedRecordsAfterFix"))
+        .as("the head slot and the pointer that was the record's identity: " + fixed.toJSON())
+        .containsExactlyInAnyOrder(content, placeholder);
+    assertThat(numberProperty(fixed, "danglingPlaceholderPointersFixed"))
+        .as("the pointer is removed with the content it can no longer reach: " + fixed.toJSON()).isEqualTo(1L);
 
-    // Nothing ambiguous is left for a second run to find: the slot the pointer led to is gone.
+    // The chunks the corrupted pointer had cut off: leaked before this run, and reclaimed by it.
+    final long orphanedChunks = numberProperty(fixed, "orphanedChunks");
+    assertThat(orphanedChunks).as("the cut-off chunks must be found: " + fixed.toJSON()).isPositive();
+    assertThat(numberProperty(fixed, "orphanedChunksReclaimed")).as("and reclaimed: " + fixed.toJSON())
+        .isEqualTo(orphanedChunks);
+    assertThat(numberProperty(fixed, "totalErrors"))
+        .as("one broken chain plus the chunks it had already leaked: " + fixed.toJSON()).isEqualTo(1L + orphanedChunks);
+
+    // Nothing is left for a second run to find: not the slot the pointer led to, not the pointer, not the chunks.
     final Result again = checkDatabaseRow(false);
     assertThat(numberProperty(again, "totalErrors")).as("and the database checks out afterwards: " + again.toJSON())
         .isZero();
+    assertThat(numberProperty(again, "totalChunks")).as("with the leaked chunks really gone: " + again.toJSON())
+        .isLessThan(chunksBefore);
+    assertThat(numberProperty(again, "totalPlaceholderRecords"))
+        .as("and no pointer aimed at nothing: " + again.toJSON()).isZero();
   }
 
   /**
@@ -399,64 +416,12 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
     }));
   }
 
-  private int recordOffsetOf(final MutablePage page, final RID rid) {
-    final int slot = (int) (rid.getPosition() % bucketOf(TYPE).getMaxRecordsInPage());
-    // PAGE_RECORD_TABLE_OFFSET == PAGE_RECORD_COUNT_IN_PAGE_OFFSET(0) + SHORT_SERIALIZED_SIZE; one uint per slot.
-    return (int) page.readUnsignedInt(Binary.SHORT_SERIALIZED_SIZE + slot * Binary.INT_SERIALIZED_SIZE);
-  }
-
-  /** Runs {@code body} on the page holding {@code rid}, taken for modification so a write lands in the transaction. */
-  private long onSlot(final RID rid, final PageAccess body) {
-    final DatabaseInternal db = (DatabaseInternal) database;
-    final int pageSize = ((PaginatedComponentFile) db.getFileManager().getFile(rid.getBucketId())).getPageSize();
-    final int pageNumber = (int) (rid.getPosition() / bucketOf(TYPE).getMaxRecordsInPage());
-    try {
-      return body.apply(db.getTransaction().getPageToModify(new PageId(db, rid.getBucketId(), pageNumber), pageSize, false));
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @FunctionalInterface
-  private interface PageAccess {
-    long apply(MutablePage page) throws Exception;
-  }
-
-  private Result checkDatabaseRow(final boolean fix) {
-    try (final ResultSet rs = database.command("sql", fix ? "check database fix" : "check database")) {
-      return rs.next();
-    }
-  }
-
-  /** {@code CHECK DATABASE} folds the per-bucket warning lists into a set, so this reads it as the collection it is. */
-  private static Collection<?> warningsOf(final Result row) {
-    final Object warnings = row.getProperty("warnings");
-    return warnings == null ? List.of() : (Collection<?>) warnings;
-  }
-
-  /**
-   * Records a full SCAN returns. {@code count(@rid)} and not {@code count(*)}: the latter answers from the bucket's
-   * cached counter without scanning a page, so it could not see the difference this test is about.
-   */
+  /** The two shared counts, bound to this class's single type. */
   private long countRecords() {
-    final long[] total = new long[1];
-    database.transaction(() -> {
-      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + TYPE)) {
-        total[0] = ((Number) rs.next().getProperty("c")).longValue();
-      }
-    });
-    return total[0];
+    return countRecords(TYPE);
   }
 
-  /** Records a scan returns holding exactly {@code value} - the count that notices a content record handed out twice. */
   private long countRecordsHolding(final String value) {
-    final long[] total = new long[1];
-    database.transaction(() -> {
-      try (final ResultSet rs = database.query("SQL", "select count(@rid) as c from " + TYPE + " where v = :v",
-          Map.of("v", value))) {
-        total[0] = ((Number) rs.next().getProperty("c")).longValue();
-      }
-    });
-    return total[0];
+    return countRecordsHolding(TYPE, value);
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6196PlaceholderContentChainTest.java
@@ -260,8 +260,8 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
    * placeholder POINTER that led to the record is removed with it (#6292 - left behind, it is a slot every scan skips
    * and {@code count(*)} counts, for good), and the continuation chunks the overwritten pointer had already cut the
    * chain off from are reclaimed (#6294 - nothing collected them before, whatever the comments promised). Those three
-   * chunks were leaked the moment the pointer was corrupted, before this run started, so they are errors of the
-   * database and not of the repair; the pointer is not, because the record it referenced is one this very run removed.
+   * chunks are dead space rather than a corruption, so they are counted and reclaimed without being booked as errors:
+   * the record had ONE defect, and one error is what the run reports.
    */
   @Test
   void aLegacyContentHeadWithABrokenChainIsReportedOnce() {
@@ -287,8 +287,10 @@ class Issue6196PlaceholderContentChainTest extends BucketPageLayoutTestSupport {
     assertThat(orphanedChunks).as("the cut-off chunks must be found: " + fixed.toJSON()).isPositive();
     assertThat(numberProperty(fixed, "orphanedChunksReclaimed")).as("and reclaimed: " + fixed.toJSON())
         .isEqualTo(orphanedChunks);
+    // ONE error: the broken chain. The chunks it leaked are dead space, not a corruption - no record is wrong and no
+    // query is affected - so they are counted and reclaimed, never booked as errors of their own.
     assertThat(numberProperty(fixed, "totalErrors"))
-        .as("one broken chain plus the chunks it had already leaked: " + fixed.toJSON()).isEqualTo(1L + orphanedChunks);
+        .as("one record, one defect it can act on, one error: " + fixed.toJSON()).isEqualTo(1L);
 
     // Nothing is left for a second run to find: not the slot the pointer led to, not the pointer, not the chunks.
     final Result again = checkDatabaseRow(false);

--- a/engine/src/test/java/com/arcadedb/database/Issue6292CheckDatabaseReconciliationTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6292CheckDatabaseReconciliationTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The three things {@code CHECK DATABASE} could not say about a bucket, all found while building the #6196 fixtures.
+ * <ul>
+ * <li><b>#6292</b> - a placeholder POINTER whose CONTENT is gone was never followed, so {@code count(@rid)} (a scan,
+ * which resolves the pointer to nothing and skips the slot) and {@code count(*)} (the cached counter, for which a
+ * pointer IS a record) disagreed for ever while the checker reported the database clean.</li>
+ * <li><b>#6293</b> - a record the FIX deleted during the run was counted BOTH in {@code totalDeletedRecords} and in
+ * the category tally it had held before, because the slot was classified first and repaired afterwards. One run
+ * described the same record twice, and only a second run told the truth.</li>
+ * <li><b>#6294</b> - the continuation chunks a force-delete leaves behind were reclaimed by nothing, though three
+ * comments promised compaction or a database check would. {@code compressPage} re-flows LIVE slots and an orphaned
+ * chunk still has one, and {@code check()} counted it and moved on.</li>
+ * </ul>
+ * The fixtures below fabricate the physical shapes on a database this build wrote, because the writers that used to
+ * produce them are gone: a placeholder needs the zero-free-tail page #6149 left as the last fallback, and an orphan
+ * needs a chain broken behind the record's back.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6292CheckDatabaseReconciliationTest extends BucketPageLayoutTestSupport {
+  private static final String TYPE = "Reconciled";
+  /** 200 KB fits no page whole, so the content record created behind a pointer spills into a chain of its own. */
+  private static final String HUGE = "h".repeat(200 * 1024);
+
+  /**
+   * The disagreement as reported: a pointer left aimed at a slot that is not there any more. The record is invisible
+   * to every query and still counted by {@code count(*)}, and before #6292 nothing ever noticed - CHECK DATABASE
+   * counted the pointer as a placeholder and moved on without following it.
+   */
+  @Test
+  void aDanglingPlaceholderPointerIsReportedAndRemoved() {
+    final RID placeholder = placeholderWithPlainContent();
+    final RID content = contentRidOf(placeholder);
+
+    final long recordsBefore = countRecords(TYPE);
+    assertThat(countRecordsFromCounter(TYPE)).as("the two counts must agree before anything is broken")
+        .isEqualTo(recordsBefore);
+
+    // An interrupted repair, or the content record lost to physical corruption: the slot goes, the pointer stays.
+    freeSlotBehindItsBack(content);
+
+    assertThat(countRecords(TYPE)).as("a scan can no longer resolve the pointer").isEqualTo(recordsBefore - 1);
+    assertThat(countRecordsFromCounter(TYPE)).as("but the counter still counts the pointer slot")
+        .isEqualTo(recordsBefore);
+
+    final Result found = checkDatabaseRow(false);
+    assertThat(numberProperty(found, "danglingPlaceholderPointers"))
+        .as("the checker must follow the pointer: " + found.toJSON()).isEqualTo(1L);
+    assertThat(numberProperty(found, "totalErrors")).as("and call it an error: " + found.toJSON()).isEqualTo(1L);
+    assertThat(warningsOf(found).toString()).as("naming both ends of it: " + found.toJSON())
+        .contains(placeholder.toString()).contains(content.toString());
+    assertThat(numberProperty(found, "danglingPlaceholderPointersFixed"))
+        .as("nothing is repaired without FIX: " + found.toJSON()).isZero();
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat(numberProperty(fixed, "danglingPlaceholderPointersFixed")).as("FIX removes it: " + fixed.toJSON())
+        .isEqualTo(1L);
+    assertThat((Collection<Object>) fixed.<Collection<Object>>getProperty("deletedRecordsAfterFix"))
+        .as("the pointer is the record's identity, so it is what the report names: " + fixed.toJSON())
+        .containsExactly(placeholder);
+
+    assertThat(countRecords(TYPE)).isEqualTo(recordsBefore - 1);
+    assertThat(countRecordsFromCounter(TYPE)).as("and the two counts agree again").isEqualTo(recordsBefore - 1);
+
+    final Result again = checkDatabaseRow(false);
+    assertThat(numberProperty(again, "totalErrors")).as("with nothing left to find: " + again.toJSON()).isZero();
+  }
+
+  /**
+   * The corrupted-pointer form of the same defect, and the reason the repair frees the pointer SLOT rather than going
+   * through the ordinary delete: a pointer that names an unrelated LIVE record would have that record deleted with it.
+   */
+  @Test
+  void repairingACorruptedPointerDoesNotDeleteWhateverItNowNames() {
+    final RID placeholder = placeholderWithPlainContent();
+    final RID content = contentRidOf(placeholder);
+
+    // An ordinary record of the same bucket, which the corrupted pointer is then aimed at.
+    final RID[] innocent = new RID[1];
+    database.transaction(() -> innocent[0] = database.newDocument(TYPE).set("v", "innocent").save().getIdentity());
+
+    freeSlotBehindItsBack(content);
+    database.transaction(() -> onSlot(placeholder, page -> {
+      // [marker:1][contentPosition:long]
+      page.writeLong(recordOffsetOf(page, placeholder) + 1, innocent[0].getPosition());
+      return 0L;
+    }));
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat(numberProperty(fixed, "danglingPlaceholderPointersFixed")).as("the pointer goes: " + fixed.toJSON())
+        .isEqualTo(1L);
+    database.transaction(
+        () -> assertThat(innocent[0].asDocument(true).getString("v")).as("and the record it named stays")
+            .isEqualTo("innocent"));
+
+    checkDatabase();
+  }
+
+  /**
+   * A pointer with a healthy content record behind it - of either shape, a plain one or a chain - is not touched. The
+   * negative control without which the two tests above would pass on a checker that reported every pointer.
+   */
+  @Test
+  void aHealthyPlaceholderIsNotReported() {
+    final RID placeholder = placeholderWithPlainContent();
+
+    Result row = checkDatabaseRow(false);
+    assertThat(numberProperty(row, "danglingPlaceholderPointers"))
+        .as("a plain content record behind a pointer is not dangling: " + row.toJSON()).isZero();
+    assertThat(numberProperty(row, "totalErrors")).as(row.toJSON().toString()).isZero();
+
+    // And again once the content has outgrown its own page and become a chain of its own.
+    database.transaction(() -> placeholder.asDocument(true).modify().set("v", HUGE).save());
+    row = checkDatabaseRow(false);
+    assertThat(numberProperty(row, "danglingPlaceholderPointers"))
+        .as("nor is a content record stored as a chain: " + row.toJSON()).isZero();
+    assertThat(numberProperty(row, "orphanedChunks")).as("and its chunks are reachable: " + row.toJSON()).isZero();
+    assertThat(numberProperty(row, "totalErrors")).as(row.toJSON().toString()).isZero();
+
+    checkDatabase();
+  }
+
+  /**
+   * #6294: the chunks a broken chain cuts off are reclaimed, and until #6294 nothing ever collected them - not
+   * compaction, which re-flows a page's LIVE slots and an orphaned chunk still has one, and not this checker, which
+   * counted a NEXT_CHUNK slot and moved on.
+   */
+  @Test
+  void orphanedChunksAreFoundAndReclaimed() {
+    final RID[] big = new RID[1];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING);
+      big[0] = database.newDocument(TYPE).set("v", HUGE).save().getIdentity();
+    });
+
+    final long chunksBefore = (Long) bucketStats(TYPE).get("totalChunks");
+    assertThat(chunksBefore).as("the fixture must really be a chain").isPositive();
+
+    // Cut the chain off at the head, which is what a corrupted or half-written continuation pointer does.
+    database.transaction(() -> onSlot(big[0], page -> {
+      // [marker:1][chunkSize:int][nextChunkPointer:long][content...]
+      page.writeLong(recordOffsetOf(page, big[0]) + 1 + Binary.INT_SERIALIZED_SIZE, Integer.MAX_VALUE);
+      return 0L;
+    }));
+
+    final Result found = checkDatabaseRow(false);
+    assertThat(numberProperty(found, "orphanedChunks")).as("every cut-off chunk must be found: " + found.toJSON())
+        .isEqualTo(chunksBefore);
+    assertThat(numberProperty(found, "orphanedChunksReclaimed")).as("but not reclaimed without FIX: " + found.toJSON())
+        .isZero();
+    assertThat((Long) bucketStats(TYPE).get("totalChunks")).as("nor freed").isEqualTo(chunksBefore);
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat(numberProperty(fixed, "orphanedChunksReclaimed")).as("FIX reclaims them: " + fixed.toJSON())
+        .isEqualTo(chunksBefore);
+
+    final Map<String, Object> layout = bucketStats(TYPE);
+    assertThat((Long) layout.get("totalChunks")).as("and the space really goes back: " + layout).isZero();
+    assertThat((Long) layout.get("totalMultiPageRecords")).as("with the broken record gone: " + layout).isZero();
+
+    final Result again = checkDatabaseRow(false);
+    assertThat(numberProperty(again, "totalErrors")).as("nothing is left for a second run: " + again.toJSON()).isZero();
+    assertThat(numberProperty(again, "orphanedChunks")).as(again.toJSON().toString()).isZero();
+  }
+
+  /**
+   * The negative control the sweep cannot do without: a bucket full of healthy chains, where every chunk is reachable
+   * from the head that owns it. A mark phase with a hole in it would delete live data here.
+   */
+  @Test
+  void noChunkOfAHealthyBucketIsCalledAnOrphan() {
+    final RID[] chained = createChunkedRecords(TYPE);
+
+    final Map<String, Object> layout = bucketStats(TYPE);
+    assertThat((Long) layout.get("totalChunks")).as("the fixture must really have chains: " + layout).isPositive();
+
+    final Result row = checkDatabaseRow(true);
+    assertThat(numberProperty(row, "orphanedChunks")).as("no live chunk may be called an orphan: " + row.toJSON())
+        .isZero();
+    assertThat(numberProperty(row, "orphanedChunksReclaimed")).as(row.toJSON().toString()).isZero();
+    assertThat(numberProperty(row, "totalErrors")).as(row.toJSON().toString()).isZero();
+
+    database.transaction(() -> {
+      for (int i = 0; i < chained.length; i++)
+        assertThat(chained[i].asDocument(true).getString("payload")).isEqualTo(payload(i, 'x'));
+    });
+    checkDatabase();
+  }
+
+  /**
+   * #6293: the FIX run must describe the database it LEAVES, not the one it found with two fields patched. A record it
+   * deleted used to be counted in {@code totalDeletedRecords} AND under {@code totalMultiPageRecords}, so the run
+   * disagreed with a re-run on the very numbers an operator diffs across the two.
+   */
+  @Test
+  void aRecordTheFixDeletedIsNotAlsoCountedInItsCategory() {
+    final RID[] big = new RID[1];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING);
+      database.newDocument(TYPE).set("v", "plain").save();
+      big[0] = database.newDocument(TYPE).set("v", HUGE).save().getIdentity();
+    });
+
+    database.transaction(() -> onSlot(big[0], page -> {
+      page.writeLong(recordOffsetOf(page, big[0]) + 1 + Binary.INT_SERIALIZED_SIZE, Integer.MAX_VALUE);
+      return 0L;
+    }));
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat((Collection<?>) fixed.getProperty("deletedRecordsAfterFix")).as(fixed.toJSON().toString()).hasSize(1);
+    assertThat(numberProperty(fixed, "totalMultiPageRecords"))
+        .as("the record it deleted is not also a multi-page record it found: " + fixed.toJSON()).isZero();
+
+    // The proof that the run described the state it left: a re-run of the same query has nothing to correct.
+    final Result again = checkDatabaseRow(false);
+    for (final String tally : new String[] { "totalAllocatedRecords", "totalActiveRecords", "totalMultiPageRecords",
+        "totalPlaceholderRecords", "totalSurrogateRecords", "totalChunks" })
+      assertThat(numberProperty(fixed, tally)).as("%s: the FIX run and a re-run must agree - %s vs %s", tally,
+          fixed.toJSON(), again.toJSON()).isEqualTo(numberProperty(again, tally));
+
+    assertThat(numberProperty(again, "totalErrors")).as(again.toJSON().toString()).isZero();
+  }
+
+  /**
+   * The fixture every placeholder test needs: a page with a free tail of exactly ZERO, which since #6149 is the only
+   * shape that still makes a record spill into a POINTER instead of a chunk chain.
+   */
+  private RID placeholderWithPlainContent() {
+    final RID[] placeholder = new RID[1];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING);
+      placeholder[0] = database.newDocument(TYPE).set("v", "p").save().getIdentity();
+    });
+    sealFirstPage(TYPE);
+
+    // Big enough that page 0 - which has no free tail at all - cannot host it, small enough for a page of its own.
+    database.transaction(() -> placeholder[0].asDocument(true).modify().set("v", "c".repeat(16 * 1024)).save());
+
+    assertThat((Long) bucketStats(TYPE).get("totalPlaceholderRecords"))
+        .as("the fixture must produce a placeholder pointer").isEqualTo(1L);
+    return placeholder[0];
+  }
+
+  /** The RID of the CONTENT record the placeholder POINTER at {@code rid} references. */
+  private RID contentRidOf(final RID rid) {
+    final long[] pointer = new long[1];
+    database.transaction(() -> pointer[0] = onSlot(rid, page -> page.readLong(recordOffsetOf(page, rid) + 1)));
+    return new RID(rid.getBucketId(), pointer[0]);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue6292CheckDatabaseReconciliationTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6292CheckDatabaseReconciliationTest.java
@@ -150,6 +150,46 @@ class Issue6292CheckDatabaseReconciliationTest extends BucketPageLayoutTestSuppo
   }
 
   /**
+   * The boundary of the marker namespace, on the one path where getting it wrong deletes a live record.
+   * <p>
+   * A content record stores its size NEGATED, and {@code RECORD_PLACEHOLDER_CONTENT} (-5) is where the sizes stop and
+   * the markers begin. Every classification site excludes it with a strict {@code <}, so a content record of exactly
+   * {@code MINIMUM_RECORD_SIZE} bytes would be read as something that is not content at all - and since #6292 that
+   * answer is acted on: {@code FIX} would free the pointer to a record that is still there.
+   * <p>
+   * Measured, not assumed: the smallest document this serializer produces is 6 bytes, so the boundary value is not
+   * reachable today, and the padding now pushes a content body past it in any case. This shrinks a placeholder's
+   * content as far as a document can go - every property removed - and asserts the pointer survives it. Should a
+   * future serializer shave those bytes, this fails here rather than in somebody's database (PR review on #6299).
+   */
+  @Test
+  void theSmallestPossibleContentRecordIsNotCalledDangling() {
+    final RID placeholder = placeholderWithPlainContent();
+    final long recordsBefore = countRecords(TYPE);
+
+    database.transaction(() -> {
+      final MutableDocument doc = placeholder.asDocument(true).modify();
+      doc.remove("v");
+      doc.save();
+    });
+
+    final Result row = checkDatabaseRow(true);
+    assertThat(numberProperty(row, "danglingPlaceholderPointers"))
+        .as("a content record at the smallest size a document has is still content: " + row.toJSON()).isZero();
+    assertThat(numberProperty(row, "totalErrors")).as(row.toJSON().toString()).isZero();
+    assertThat(numberProperty(row, "totalSurrogateRecords"))
+        .as("and it is still counted as the surrogate it is: " + row.toJSON()).isEqualTo(1L);
+
+    assertThat(countRecords(TYPE)).as("the record is still there, and exactly once").isEqualTo(recordsBefore);
+    assertThat(countRecordsFromCounter(TYPE)).as("with both counts still agreeing").isEqualTo(recordsBefore);
+    database.transaction(
+        () -> assertThat(placeholder.asDocument(true).getString("v")).as("and still readable through its pointer")
+            .isNull());
+
+    checkDatabase();
+  }
+
+  /**
    * #6294: the chunks a broken chain cuts off are reclaimed, and until #6294 nothing ever collected them - not
    * compaction, which re-flows a page's LIVE slots and an orphaned chunk still has one, and not this checker, which
    * counted a NEXT_CHUNK slot and moved on.


### PR DESCRIPTION
Four follow-ups from #6196, all in the same machinery and all found while building its fixtures, fixed as one
change because they touch the same two methods.

## #6286 - a placeholder's CONTENT record can stop being a chunk chain, like every other record

#6178 gave a record that shrinks back inside the region its own slot owns a way out of being a chunk chain. The
CONTENT record of a placeholder was left out for a mechanical reason: such a record is recognised by the NEGATIVE
size marker its slot carries, and the collapse could only write a plain POSITIVE size - which is exactly what tells
`scan()` a slot holds a document of its own, so collapsing one would have been #6196 all over again on the one
record shape that had escaped it.

`collapseChunkChainToRecord` now takes the shape it is collapsing into, budgets with
`Binary.getNumberSpace(-bufferSize)`, writes `-bufferSize`, and tracks the write under a slot kind of its own
(`SLOT_KIND_CHUNK_COLLAPSED_TO_PLACEHOLDER_CONTENT`) so the commit-time replay checks the committed marker it
started from. That is the issue's proposal.

Two things beyond it:

- **A pre-#6196 legacy content head is collapsed too, but not merged.** Reached through its pointer, the FLAG says
  what the slot is where the ambiguous `FIRST_CHUNK` marker cannot - and the negated marker the collapse writes ends
  that ambiguity for good. What it cannot be is REPLAYED, because neither collapse kind names that starting marker,
  so the page is poisoned instead of tracked. The transaction keeps its write and gives up only the merge, on a
  shape no current build produces.
- **A content-record body is now padded to `MINIMUM_RECORD_SIZE` on update**, as `createRecordInternal` already pads
  one it creates. Without it a body shorter than 5 bytes writes a -1..-4 that the marker namespace owns. The
  collapse needs the guarantee; the same hole was latent on the in-place overwrite of a content record.

## #6292 - a dangling placeholder pointer made `count(*)` and a scan disagree, permanently

`check()` classified a placeholder POINTER, counted it, and moved on - it never followed the pointer. So a pointer
whose content was gone stayed on its page for ever, invisible to every scan and still counted by the cached
counter, with the checker reporting `totalErrors: 0`.

Every pointer is now followed and its target classified: a content record of either shape, the pre-#6196 ambiguous
head, or nothing a pointer may lead to. The last is reported with both RIDs and, with `FIX`, removed.

Two departures from the issue's own suggestions, both deliberate:

- **The validation is a post-pass, not inline.** A content record can sit on a page the walk has not reached, or is
  about to repair away, so asking inline makes the answer depend on the order the allocator placed the two slots
  in. Deferring also lets the #6196 legacy reconciliation move into the same loop, which removes its "ask again"
  duplication: one loop over pointers, both questions, against the state the walk left.
- **The repair frees the pointer SLOT and nothing else** (`freeSlotOnly`), where the issue's narrow proposal would
  have gone through the ordinary delete. That distinction is load-bearing and has a test: a pointer can be dangling
  because it was CORRUPTED, in which case it now names whatever record happens to live at that position, and the
  ordinary delete would follow it and remove that record.

New report fields: `danglingPlaceholderPointers`, `danglingPlaceholderPointersFixed`. A pointer left dangling by a
deletion the same run made is removed with it and not booked as a second error - the record had one defect.

## #6293 - the FIX run described the database it found, not the one it left

A record deleted during the run was counted in `totalDeletedRecords` AND under the category tally it had held
before. The issue is right that decrementing next to each `++totalDeletedRecords` duplicates the bug one level
down; the classification is a VALUE now (`SlotCategory`), decided by the slot walk and counted once at the end of
the per-slot block, with a repaired-away slot simply carrying the deleted category. The tallies also live in one
`CheckStats` object, which is what let the two reconciliation passes become named methods rather than another few
hundred lines inline.

The per-page verbose tallies come from the same decision now, so they no longer disagree with the totals about
whether a multi-page record is also an active one.

## #6294 - orphaned continuation chunks are reclaimed, and three comments stop promising something nothing did

Neither compaction nor the checker ever collected them: `compressPage` re-flows a page's LIVE slots and an orphaned
chunk still has one. Implemented as the issue's option (1), a mark-and-sweep on the single pass `check()` already
makes - and the marks cost nothing new, because `findBrokenChunkChain`'s loop-detector set already IS the set of
chunks the walk went through. It is handed back through `ChunkChainWalk` instead of being thrown away.

The issue's option (2), "free them at the source by walking past the break", is deliberately NOT implemented: past
a break there is nothing trustworthy to follow, and a corrupted pointer would lead the free into unrelated slots.
The effect it was after comes out of (1) for free - a head this run repaired away marks NOTHING, so its whole
chain, including the chunks before the break, is swept by the same pass.

**Fails closed**, like `GraphDatabaseChecker`'s edge-segment reclaim: any gap in the marking - a page the walk could
not read, a chain walk stopped by an I/O fault, a slot that could not be classified - disables the sweep entirely
rather than shrinking it, because an unmarked LIVE chunk deleted as an orphan is destroyed data. A skipped sweep
says so in a warning instead of reporting zero orphans.

New report fields: `orphanedChunks`, `orphanedChunksReclaimed`.

## Tests

`Issue6292CheckDatabaseReconciliationTest` (new, 6 tests) covers all three checker issues, including two negative
controls the sweep cannot do without: a healthy bucket of 12 chunk chains where no live chunk may be called an
orphan, and a healthy placeholder of either content shape. Verified NOT vacuous: with the two main-source files
stashed, 4 of the 6 fail and the 2 negative controls pass.

`Issue6178ChunkCollapseTest.aPlaceholderContentStoredAsAChainIsNeverCollapsed` became
`aPlaceholderContentShrinkingBackIntoItsRegionBecomesAContentRecord`, and now asserts the collapse plus a full
round trip through the pointer.

`Issue6196PlaceholderContentChainTest.aLegacyContentHeadWithABrokenChainIsReportedOnce` now asserts the fuller,
honest report the same fixture produces: the pointer removed with the content, and the chunks the corrupted pointer
had already leaked found and reclaimed.

The duplicated page-poking and check-database helpers of the two #6196/#6178 test classes moved into
`BucketPageLayoutTestSupport`, where the fixtures they belong with already live.

Full `engine` module run (`-DexcludedGroups=benchmark,vector,slow`) green.
