### PR TITLE
fix(#6283): a component and the file it holds agree on the id, and the TimeSeries header is read once, without inventing it

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
@@ -86,6 +86,9 @@ public abstract class PaginatedComponent extends Component {
     // A caller that legitimately has to build on an already-registered file resolves it FIRST through
     // FileManager.getFileByComponentName() and constructs on that file's real id, as
     // TimeSeriesTagDictionary.openOrCreate() does.
+    // The id newFileId() reserved for a construction that ends here is abandoned: nothing fills that slot and
+    // nothing reclaims it. Deliberate - this is a programming error on a path that no legitimate caller takes,
+    // and one leaked slot in the file table costs far less than a reclaim protocol racing concurrent creations.
     if (file.getFileId() != fileId)
       throw new IllegalStateException(
           "Component '" + name + "' was built on file id " + fileId + " but the file registered under that name has id "

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
@@ -75,6 +75,22 @@ public abstract class PaginatedComponent extends Component {
     this.pageSize = pageSize;
     this.file = (PaginatedComponentFile) database.getFileManager().getOrCreateFile(name, filePath, mode);
 
+    // The component and the file it holds MUST agree on the id (issue #6283). getOrCreateFile() is keyed by the
+    // component NAME and not by the path, so a name that is already registered hands back that file - carrying
+    // whatever id it was created with - while this component keeps the id it was built with, which on the
+    // id-allocating path above is a brand new one from FileManager.newFileId(). The component would then address
+    // pages of a file id that is not the file it holds. In #6198 that surfaced as "File with id 2 was not found"
+    // thrown from PageManager.loadPage, far from the cause; the variant where the bogus id happens to resolve to
+    // some other component's file is considerably worse than an exception, hence the loud failure right here,
+    // before a single page is addressed.
+    // A caller that legitimately has to build on an already-registered file resolves it FIRST through
+    // FileManager.getFileByComponentName() and constructs on that file's real id, as
+    // TimeSeriesTagDictionary.openOrCreate() does.
+    if (file.getFileId() != fileId)
+      throw new IllegalStateException(
+          "Component '" + name + "' was built on file id " + fileId + " but the file registered under that name has id "
+              + file.getFileId() + " ('" + file.getFilePath() + "')");
+
     final long fileSize = file.getSize();
     if (fileSize == 0)
       // NEW FILE, CREATE HEADER PAGE

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
@@ -756,39 +756,38 @@ public class TimeSeriesBucket extends PaginatedComponent {
   }
 
   /**
-   * Returns the total sample count stored in this bucket.
+   * Returns the total sample count stored in this bucket, or 0 when the file carries no header page.
    */
   public long getSampleCount() throws IOException {
-    if (getTotalPages() == 0)
-      return 0;
-    final BasePage headerPage = database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize);
-    return headerPage.readLong(HEADER_SAMPLE_COUNT_OFFSET);
+    final BasePage headerPage = readHeaderPage();
+    return headerPage == null ? 0 : headerPage.readLong(HEADER_SAMPLE_COUNT_OFFSET);
   }
 
   /**
-   * Returns the minimum timestamp across all samples.
+   * Returns the minimum timestamp across all samples, or {@link Long#MAX_VALUE} when there is none - the same
+   * empty marker {@link #initHeaderPage()} writes and {@link #clearDataPages()} restores, so a bucket with no
+   * header page yet answers exactly like an initialised empty one instead of claiming the epoch.
    */
   public long getMinTimestamp() throws IOException {
-    final BasePage headerPage = database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize);
-    return headerPage.readLong(HEADER_MIN_TS_OFFSET);
+    final BasePage headerPage = readHeaderPage();
+    return headerPage == null ? Long.MAX_VALUE : headerPage.readLong(HEADER_MIN_TS_OFFSET);
   }
 
   /**
-   * Returns the maximum timestamp across all samples.
+   * Returns the maximum timestamp across all samples, or {@link Long#MIN_VALUE} when there is none (see
+   * {@link #getMinTimestamp()} for why that, and not 0).
    */
   public long getMaxTimestamp() throws IOException {
-    final BasePage headerPage = database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize);
-    return headerPage.readLong(HEADER_MAX_TS_OFFSET);
+    final BasePage headerPage = readHeaderPage();
+    return headerPage == null ? Long.MIN_VALUE : headerPage.readLong(HEADER_MAX_TS_OFFSET);
   }
 
   /**
-   * Returns the number of data pages (excluding header page).
+   * Returns the number of data pages (excluding header page), or 0 when the file carries no header page.
    */
   public int getDataPageCount() throws IOException {
-    if (getTotalPages() == 0)
-      return 0;
-    final BasePage headerPage = database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize);
-    return headerPage.readInt(HEADER_DATA_PAGE_COUNT);
+    final BasePage headerPage = readHeaderPage();
+    return headerPage == null ? 0 : headerPage.readInt(HEADER_DATA_PAGE_COUNT);
   }
 
   /**
@@ -801,19 +800,21 @@ public class TimeSeriesBucket extends PaginatedComponent {
   }
 
   /**
-   * Returns true if a compaction was in progress (crash recovery check).
+   * Returns true if a compaction was in progress (crash recovery check). A file with no header page has
+   * nothing to recover, so it answers false.
    */
   public boolean isCompactionInProgress() throws IOException {
-    final BasePage headerPage = database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize);
-    return headerPage.readByte(HEADER_COMPACTION_FLAG) == 1;
+    final BasePage headerPage = readHeaderPage();
+    return headerPage != null && headerPage.readByte(HEADER_COMPACTION_FLAG) == 1;
   }
 
   /**
-   * Gets the compaction watermark (sealed store file offset).
+   * Gets the compaction watermark (sealed store file offset), or 0 - what {@link #initHeaderPage()} writes -
+   * when the file carries no header page.
    */
   public long getCompactionWatermark() throws IOException {
-    final BasePage headerPage = database.getTransaction().getPage(new PageId(database, fileId, 0), pageSize);
-    return headerPage.readLong(HEADER_COMPACTION_WATERMARK);
+    final BasePage headerPage = readHeaderPage();
+    return headerPage == null ? 0L : headerPage.readLong(HEADER_COMPACTION_WATERMARK);
   }
 
   /**
@@ -968,6 +969,49 @@ public class TimeSeriesBucket extends PaginatedComponent {
   }
 
   // --- Private helpers ---
+
+  /**
+   * Resolves the header page (page 0) for reading, or returns {@code null} when this file carries none.
+   * Every header reader goes through here so the answer to "is there a header?" is given once and given the
+   * same way (issue #6283); a reader that asks the transaction directly gets neither half of this right.
+   * <p>
+   * <b>It must not fabricate the page.</b> {@code tx.getPage()} resolves with {@code createIfNotExists=true}, so on
+   * a file with no page 0 it does not report absence - it invents a zero-filled page, caches it, and reads zeros
+   * out of it. That phantom is exactly what {@code TimeSeriesTagDictionary.readStoredHeader()} was built to avoid
+   * (issue #6198), and reading a real 0 out of it is worse than an exception: for min/max timestamp, 0 is a
+   * perfectly legal value.
+   * <p>
+   * <b>Nor may it gate on {@link #getTotalPages()}</b>, which two of these readers used to do. That counter is
+   * per-instance: it is seeded from the physical file size at construction and afterwards only the component
+   * registered with the schema gets it bumped at commit, so it under-reports for an instance built over a file
+   * whose committed pages are still in the flush queue - conflating "this instance has seen nothing" with "the
+   * file holds nothing" (issue #6198 again). The magic in page 0 has no such blind spot.
+   * <p>
+   * The active transaction's own page set comes first: it holds the copy this transaction must read - one it
+   * modified, or the page {@link #initHeaderPage()} added and has not committed yet - and neither is visible to
+   * the page manager. When the probe below does find the page, it is re-resolved through the transaction so the
+   * read takes part in its isolation like every other page read of this bucket; that second call is a read-cache
+   * hit, the page having just been loaded.
+   */
+  private BasePage readHeaderPage() throws IOException {
+    final PageId headerPageId = new PageId(database, fileId, 0);
+    final TransactionContext tx = database.getTransactionIfExists();
+    final boolean inTransaction = tx != null && tx.isActive();
+
+    BasePage headerPage;
+    if (inTransaction && tx.hasPageForRecord(headerPageId))
+      headerPage = tx.getPage(headerPageId, pageSize);
+    else {
+      // (isNew=true, createIfNotExists=false): the pair that answers "absent" with null instead of creating the
+      // page, as TimeSeriesTagDictionary.readStoredHeader() does. With isNew=false the page manager would throw
+      // on a page that is not there.
+      headerPage = database.getPageManager().getImmutablePage(headerPageId, pageSize, true, false);
+      if (headerPage != null && inTransaction)
+        headerPage = tx.getPage(headerPageId, pageSize);
+    }
+
+    return headerPage != null && headerPage.readInt(HEADER_MAGIC_OFFSET) == MAGIC_VALUE ? headerPage : null;
+  }
 
   void initHeaderPage() throws IOException {
     final TransactionContext tx = database.getTransaction();

--- a/engine/src/test/java/com/arcadedb/engine/Issue6283ComponentFileIdMismatchTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6283ComponentFileIdMismatchTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6283 (item 1): a {@link PaginatedComponent} must never end up holding a file whose id is not the one it
+ * was built with. {@code FileManager.getOrCreateFile()} is keyed by the component NAME, so a component that takes
+ * a fresh id from {@code newFileId()} and only then asks for its file is handed the already-registered one - and
+ * from that moment addresses pages of an id that is not the file it holds. Before the fix the construction
+ * succeeded and the damage surfaced much later, as "File with id N was not found" thrown from
+ * {@code PageManager.loadPage} (issue #6198), or worse, as reads of some other component's file.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6283ComponentFileIdMismatchTest extends TestHelper {
+
+  @Test
+  void componentBuiltOnAForeignFileIdFailsAtConstruction() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    database.getSchema().createDocumentType("Issue6283Type", 1);
+    final Bucket existing = database.getSchema().getType("Issue6283Type").getBuckets(false).getFirst();
+    final String name = existing.getName();
+    final int registeredFileId = existing.getFileId();
+
+    // Same component name, id-allocating constructor: it mints a new id, then getOrCreateFile() - keyed by the
+    // name - hands it back the file registered under that name, which carries registeredFileId.
+    assertThatThrownBy(() -> newBucketOnAllocatedId(db, name))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(name)
+        .hasMessageContaining("has id " + registeredFileId);
+
+    // The failed construction left the registered file alone, so the bucket is still fully usable.
+    assertThat(db.getFileManager().getFileByComponentName(name).getFileId()).isEqualTo(registeredFileId);
+    database.transaction(() -> database.newDocument("Issue6283Type").set("id", 1).save());
+    assertThat(database.countType("Issue6283Type", false)).isEqualTo(1);
+  }
+
+  @Test
+  void everyRegisteredComponentHoldsItsOwnFile() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    database.getSchema().createVertexType("Issue6283Vertex", 3).createProperty("name", Type.STRING)
+        .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++)
+        database.newVertex("Issue6283Vertex").set("name", "v" + i).save();
+    });
+
+    final LocalSchema schema = (LocalSchema) database.getSchema();
+    int checked = 0;
+    for (final ComponentFile file : db.getFileManager().getFiles()) {
+      if (file == null)
+        continue;
+      if (schema.getFileByIdIfExists(file.getFileId()) instanceof PaginatedComponent component) {
+        assertThat(component.getComponentFile().getFileId()).as("component '%s'", component.getName())
+            .isEqualTo(component.getFileId());
+        checked++;
+      }
+    }
+    // The dictionary, three buckets and the index files at the very least: without this the loop above would
+    // pass by walking nothing.
+    assertThat(checked).isGreaterThan(3);
+  }
+
+  /**
+   * A component whose id comes from {@code FileManager.newFileId()}, which is the constructor the invariant
+   * guards. Nothing here is bucket-specific: {@link LocalBucket} is simply the shortest real subclass to build.
+   */
+  private LocalBucket newBucketOnAllocatedId(final DatabaseInternal db, final String name) throws IOException {
+    return new LocalBucket(db, name, db.getDatabasePath() + File.separator + name, ComponentFile.MODE.READ_WRITE,
+        GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger(), LocalBucket.CURRENT_VERSION);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6283BucketHeaderAccessorsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6283BucketHeaderAccessorsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6283 (item 2): the header accessors of {@link TimeSeriesBucket} used to disagree with each other -
+ * {@code getSampleCount()} and {@code getDataPageCount()} short-circuited on {@code getTotalPages() == 0} while
+ * the timestamp and compaction readers went straight to {@code tx.getPage()}, which resolves with
+ * {@code createIfNotExists=true} and therefore FABRICATES a zero-filled page 0, caches it, and reads zeros out
+ * of it. Zero is a legal timestamp, so that answer is indistinguishable from a real one.
+ * <p>
+ * All of them now go through one non-fabricating header read that is authoritative on the magic in page 0, the
+ * way {@code TimeSeriesTagDictionary.readStoredHeader()} is (issue #6198).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6283BucketHeaderAccessorsTest extends TestHelper {
+
+  private List<ColumnDefinition> columns() {
+    return List.of(
+        new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+        new ColumnDefinition("temperature", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD));
+  }
+
+  /**
+   * A bucket whose file carries no header page yet: the constructor deliberately does not write one, the shard
+   * calls {@code initHeaderPage()} afterwards. Every reader must report emptiness rather than invent a page.
+   */
+  @Test
+  void aBucketWithoutAHeaderPageReportsEmptyAndLeavesNoPhantomPage() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    database.begin();
+    final TimeSeriesBucket bucket = new TimeSeriesBucket(db, "issue6283_noheader",
+        db.getDatabasePath() + "/issue6283_noheader", columns());
+    ((LocalSchema) db.getSchema()).registerFile(bucket);
+
+    assertThat(bucket.getSampleCount()).isZero();
+    assertThat(bucket.getDataPageCount()).isZero();
+    // The empty markers initHeaderPage() writes, NOT the 0 a fabricated page would have read back.
+    assertThat(bucket.getMinTimestamp()).isEqualTo(Long.MAX_VALUE);
+    assertThat(bucket.getMaxTimestamp()).isEqualTo(Long.MIN_VALUE);
+    assertThat(bucket.isCompactionInProgress()).isFalse();
+    assertThat(bucket.getCompactionWatermark()).isZero();
+
+    // Nothing was cached for a page that does not exist: asking the page manager without createIfNotExists
+    // still finds nothing.
+    assertThat(db.getPageManager().getImmutablePage(new PageId(db, bucket.getFileId(), 0), bucket.getPageSize(), true, false))
+        .isNull();
+    database.rollback();
+
+    dropBucket(db, bucket);
+  }
+
+  /**
+   * The counters written inside the current transaction - by {@code initHeaderPage()}, which adds page 0, and by
+   * the append that follows - must be the ones the readers see, before any commit.
+   */
+  @Test
+  void headerWrittenInTheCurrentTransactionIsVisibleToTheReaders() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    database.begin();
+    final TimeSeriesBucket bucket = new TimeSeriesBucket(db, "issue6283_txlocal",
+        db.getDatabasePath() + "/issue6283_txlocal", columns());
+    ((LocalSchema) db.getSchema()).registerFile(bucket);
+    bucket.initHeaderPage();
+
+    assertThat(bucket.getSampleCount()).isZero();
+    assertThat(bucket.getMinTimestamp()).isEqualTo(Long.MAX_VALUE);
+    assertThat(bucket.getMaxTimestamp()).isEqualTo(Long.MIN_VALUE);
+
+    bucket.appendSamples(new long[] { 1000L, 3000L }, new Object[] { 20.0, 22.0 });
+    assertThat(bucket.getSampleCount()).isEqualTo(2);
+    assertThat(bucket.getMinTimestamp()).isEqualTo(1000L);
+    assertThat(bucket.getMaxTimestamp()).isEqualTo(3000L);
+    assertThat(bucket.getDataPageCount()).isEqualTo(1);
+
+    bucket.setCompactionInProgress(true);
+    bucket.setCompactionWatermark(4096L);
+    assertThat(bucket.isCompactionInProgress()).isTrue();
+    assertThat(bucket.getCompactionWatermark()).isEqualTo(4096L);
+    database.commit();
+
+    // ...and again once committed, when the readers resolve the page through the page manager instead.
+    database.begin();
+    assertThat(bucket.getSampleCount()).isEqualTo(2);
+    assertThat(bucket.getMinTimestamp()).isEqualTo(1000L);
+    assertThat(bucket.getMaxTimestamp()).isEqualTo(3000L);
+    assertThat(bucket.isCompactionInProgress()).isTrue();
+    assertThat(bucket.getCompactionWatermark()).isEqualTo(4096L);
+    database.commit();
+
+    dropBucket(db, bucket);
+  }
+
+  /**
+   * The buckets built here are registered by hand and belong to no TimeSeries type, so they have to be removed
+   * before the integrity check that closes the test, which reports any file the schema does not claim.
+   */
+  private void dropBucket(final DatabaseInternal db, final TimeSeriesBucket bucket) throws IOException {
+    ((LocalSchema) db.getSchema()).removeFile(bucket.getFileId());
+    db.getPageManager().deleteFile(db, bucket.getFileId());
+    db.getFileManager().dropFile(bucket.getFileId());
+  }
+}


### PR DESCRIPTION
Closes #6283.

The issue carries four items: two actionable, two recorded as investigated negative results.

## Item 1 - a component and the file it holds must agree on the id

`FileManager.getOrCreateFile()` is keyed by the **component name**, not by the path. The id-allocating
`PaginatedComponent` constructor takes a fresh id from `newFileId()`, bakes it into the path, and only then asks
for the file - so when that name is already registered it is handed a file carrying a *different* id while
`Component.fileId` keeps the freshly minted one. From that point the component addresses pages of a file id that
is not the file it holds. In #6198 that surfaced as `File with id 2 was not found` thrown from
`PageManager.loadPage`, far from the cause; the variant where the bogus id happens to resolve to some other
component's file is worse than an exception.

The invariant is now asserted where it is established - in the constructor, right after `getOrCreateFile()` and
before a single page is addressed:

```java
if (file.getFileId() != fileId)
  throw new IllegalStateException("Component '" + name + "' was built on file id " + fileId
      + " but the file registered under that name has id " + file.getFileId() + " ('" + file.getFilePath() + "')");
```

One comparison per component construction, and the whole bug class becomes an immediate local error. The message
names both ids and the registered file's path, so the fix is obvious from the failure alone: a caller that
legitimately has to build on an already-registered file resolves it first through
`FileManager.getFileByComponentName()` and constructs on that file's real id, the way
`TimeSeriesTagDictionary.openOrCreate()` does since #6198.

`PaginatedComponent` is the only caller of the by-name `getOrCreateFile` overload, so the constructor covers every
path into it. The full engine suite (12,000+ tests, all lanes but `benchmark`/`vector`/`slow`) confirms no
legitimate path builds a component on a name that is already registered.

One case the guard turns from silent breakage into a handled one: `LSMVectorIndex.getOrCreateGraphFile()` builds
`indexName + "_vecgraph"` on a fresh id whenever `graphFile == null`, so if discovery missed an already-registered
graph file it used to mis-bind and fail later; it now logs and returns null inside its own `catch`, which is the
"graph will be built on first search" path it already has.

## Item 2 - one non-fabricating header read for `TimeSeriesBucket`

The issue proposes making the four header accessors consistent by giving all of them the
`if (getTotalPages() == 0) return 0;` guard the other two had. **A better fix is available**, because both halves
of that guard are wrong:

- `getTotalPages()` is per-instance - seeded from the physical file size at construction, and afterwards bumped at
  commit only for the component registered with the schema. It under-reports for an instance built over a file
  whose committed pages are still in the flush queue. That is exactly the blind spot #6198 removed from the tag
  dictionary; copying it into two more methods would spread it rather than settle it.
- returning `0` is not the empty answer for a timestamp. `initHeaderPage()` writes `Long.MAX_VALUE` /
  `Long.MIN_VALUE` as the empty markers, and 0 is a perfectly legal timestamp, so a fabricated page is
  indistinguishable from a real one.

So all **six** header readers (the four in the issue plus `isCompactionInProgress()` and
`getCompactionWatermark()`, which have the same shape) now go through a single private `readHeaderPage()`, built
like `TimeSeriesTagDictionary.readStoredHeader()`:

- resolves page 0 with `createIfNotExists=false`, so probing a file that has no header leaves no zero-filled
  phantom in the read cache;
- treats the magic in page 0 as the authority on "is there a header", which the read cache and the flush queue
  make visible whether or not the page has reached the disk;
- asks the active transaction's own page set first, so a header modified - or added by `initHeaderPage()` - in the
  current transaction is still what the readers see, and re-resolves a found page through the transaction so these
  reads keep taking part in its isolation.

Each reader then answers with the value `initHeaderPage()` would have written for an empty bucket. That also makes
a fifth (or seventh) accessor safe by construction, which was the point of the item.

## Items 3 and 4

No code, as the issue concluded: `suspendFlushAndExecute` swallowing its callback is already carried out by hand
by every production caller, and `openOrCreate` registering before initialising is forced by the commit path and
unreachable. Both are recorded in the issue so they are not re-derived.

## Tests

- `engine/.../Issue6283ComponentFileIdMismatchTest` - a second component on a registered name fails at
  construction with both ids in the message and leaves the registered file untouched; every registered component
  in a live database holds the file whose id it carries.
- `engine/.../timeseries/Issue6283BucketHeaderAccessorsTest` - a bucket whose file has no header page answers
  empty from all six readers and leaves no page 0 in the cache; a header written in the current transaction is
  visible to the readers before and after commit.

Both fail on `main` without the fix (`getMinTimestamp()` returns 0 from the fabricated page; the colliding
component constructs happily).

Full engine suite green.
