### PR TITLE
fix(#6295, #6300, #6301, #6302): a weight belongs to its own edge, and the phase a call spends its time in is the one that has to be abortable

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2574,7 +2574,7 @@ Two more procedures were reading weights through the same broken helper and are 
   when a view existed. It also now builds its edge list in parallel primitive arrays rather than a
   `List<int[]>` and a `List<Double>`, which the O(V x E) relaxation loop reads up to `V - 1` times.
 
-**One provider-contract change comes with it.** `GraphTraversalProvider.hasEdgeProperties()` now means "edge
+**Two provider-contract changes come with it.** `GraphTraversalProvider.hasEdgeProperties()` now means "edge
 property columns are materialised **and** the positional mapping `getEdgeProperty` relies on is exact", and
 `GraphAnalyticalView` answers `false` while a delta overlay is active. The columns are aligned with the base
 CSR's forward edge slots, while `getNeighborIds` serves the overlay's view of the node - deletions dropped,
@@ -2583,6 +2583,17 @@ column store. Callers (`algo.apsp`, `algo.bellmanford`, `algo.steinerTree`, `SQL
 `SQLFunctionBellmanFord`, `algo.dijkstra.singleSource`) now read the edge records in that state, which is
 slower and exact, instead of a weight belonging to another edge. This is the same "say unknown rather than
 guess" convention `countEdgesBetween` and `getMeanEdgesPerConnectedPair` already use.
+
+The second is `servesEdgeProperty(propertyName, edgeTypes...)`, which is the question a weighted algorithm
+actually has to ask. `hasEdgeProperties()` answers only "are there edge property columns at all", so a view built
+with `.withEdgeProperties("distance")` answered yes to a call asking for `cost` - and since a missing column and
+an edge with no value both come back as `null`, the caller could not tell them apart and treated the entire graph
+as unweighted. That is the same wrong answer as a misaligned weight, reached from the other direction, and it
+silently inverted results: on a graph where `X-Y-Z` costs 2.0 and the direct `X-Z` hop costs 50.0, unit weights
+make the 50.0 hop win. `algo.apsp`, `algo.bellmanford`, `algo.steinerTree`, `algo.dijkstra.singleSource`,
+`SQLFunctionAstar` and `SQLFunctionBellmanFord` now all gate on it and fall back to the edge records otherwise.
+`SQLFunctionBellmanFord` additionally passed `null` as the edge type to `getEdgeProperty`, which can never
+resolve a column store, so its CSR path had been using a unit weight for every edge unconditionally.
 
 [#6301](https://github.com/ArcadeData/arcadedb/issues/6301)
 

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2542,3 +2542,113 @@ the busiest single database's share, which is exactly what `pageFlushQueue` boun
 alert on.
 
 [#6281](https://github.com/ArcadeData/arcadedb/issues/6281)
+
+## An edge weight belongs to the edge it was read from, whichever backing answered (#6301)
+
+`algo.steinerTree` paired weights with neighbours **by iteration position**. The adjacency list was built with
+the `relTypes` filter applied and in the backing store's order; the weight array beside it was filled
+positionally from an *unfiltered* `getEdges(BOTH)` walk in OLTP order. Nothing reconciled the two, so
+`adjW[i][j]` was "the weight of the j-th edge I happened to see", not "the weight of the edge to `adj[i][j]`".
+That array is what Dijkstra runs on in step 1, so the **tree itself** moved, not only the `weight` column.
+
+Two shapes made it visible. An edge type the caller excluded still lent its weight to an included edge: three
+vertices on a `ROAD` path of weight 1 per hop plus one `NOISE` edge of weight 999 hanging off the first
+returned `weight: 999.0` and `totalWeight: 1000.0` for a tree that costs 2.0. And the same query answered
+differently depending on whether a Graph Analytical View happened to exist, because the CSR neighbour order
+need not match the OLTP one - a view is meant to be a transparent accelerator, and here its mere presence made
+the procedure prefer a 51.0 tree over the 2.0 one.
+
+The fix removes the second traversal rather than repairing it. `GraphData.weightedAdjacency(direction,
+weightProperty, relTypes)` produces the neighbour list and its weights from **one** walk of the same edges -
+from the view's columnar edge properties when it has them, from the edge records otherwise - so the pairing is
+correct by construction and the two backings return the same multiset of `(neighbour, weight)` pairs.
+
+Two more procedures were reading weights through the same broken helper and are fixed with it:
+
+- **`algo.apsp`** with no `relTypes` filter on a view that materialises edge properties produced an *empty*
+  weight row against a non-empty neighbour row, i.e. an `ArrayIndexOutOfBoundsException` for a query that
+  worked perfectly without the view. With several edge types it mismatched instead of failing, because the
+  adjacency is sorted across types and the weights were concatenated per type.
+- **`algo.bellmanford`** fell back to a **unit weight for every edge** whenever the graph was CSR-backed and
+  the view had no column for the requested property - silently ignoring `weightProperty` altogether, and only
+  when a view existed. It also now builds its edge list in parallel primitive arrays rather than a
+  `List<int[]>` and a `List<Double>`, which the O(V x E) relaxation loop reads up to `V - 1` times.
+
+**One provider-contract change comes with it.** `GraphTraversalProvider.hasEdgeProperties()` now means "edge
+property columns are materialised **and** the positional mapping `getEdgeProperty` relies on is exact", and
+`GraphAnalyticalView` answers `false` while a delta overlay is active. The columns are aligned with the base
+CSR's forward edge slots, while `getNeighborIds` serves the overlay's view of the node - deletions dropped,
+additions merged in, the whole list re-sorted - so the n-th neighbour of that list is not the n-th edge of the
+column store. Callers (`algo.apsp`, `algo.bellmanford`, `algo.steinerTree`, `SQLFunctionAstar`,
+`SQLFunctionBellmanFord`, `algo.dijkstra.singleSource`) now read the edge records in that state, which is
+slower and exact, instead of a weight belonging to another edge. This is the same "say unknown rather than
+guess" convention `countEdgesBetween` and `getMeanEdgesPerConnectedPair` already use.
+
+[#6301](https://github.com/ArcadeData/arcadedb/issues/6301)
+
+## The phase a graph-algorithm call spends its time in is now abortable too (#6295, #6302)
+
+#6216 and #6264 gave every iteration-shaped `algo.*` knob a checkpoint inside the loop it drives, on the
+principle that for time there is no honest ceiling to pick, so a long run should be **abortable** rather than
+forbidden. Both picked their procedures by asking "does it have an iteration knob?". Two blind spots follow
+from that question, and this release closes both.
+
+### The dominant phase is not always the loop the knob drives (#6295)
+
+`arcadedb.command.timeout` set to 1000 ms, on a 2000-node graph:
+`CALL algo.hashgnn({embeddingDimension: 4096, iterations: 1})` **ran for 112,988 ms and returned a result** -
+the deadline overshot by 113x and never observed. `algo.hashgnn`'s MinHash reduction runs *after* the
+`iterations` loop and costs `4 x embeddingDimension²` operations per node, and that bounded per-node figure is
+then multiplied by an unbounded node count. The lens missed it because `embeddingDimension` *has* a ceiling
+(#6065 capped it at 4096), which made it look handled.
+
+The question that finds this shape is **"which loop over the node count has no checkpoint"**, not "which knob
+has no cap". Asking it across the package also found the pre-loop initialisation of `algo.hashgnn`,
+`algo.fastrp` and `algo.graphsage`, and `algo.slpa`'s post-processing and its O(degree²) `mostFrequent`. All
+now carry a checkpoint.
+
+### A guard belongs wherever the work is unbounded, not only where a knob multiplies it (#6302)
+
+The four densest procedures in the package had no guard at all, and `algo.apsp` makes the case on its own: the
+#6263 working-memory budget caps its distance matrix at `arcadedb.cypher.algoMaxWorkingMemory`, whose 64 MB
+floor **admits n ≈ 2890**, and 2890³ is ~2.4e10 iterations of the Floyd-Warshall triple loop. That is minutes
+of CPU on one query thread during which `Thread.interrupt()`, `arcadedb.command.timeout` and the client
+cancelling all did nothing. The budget and the timeout are meant to be complementary halves of one guarantee,
+and the memory half was waving through a run the time half could not stop.
+
+A sweep over all 68 procedures asking "can one call of this run for minutes on an accepted input?" settled the
+rest in one pass. Every procedure whose dominant loop is superlinear in the graph is now abortable:
+`algo.apsp`, `algo.kShortestPaths`, `algo.steinerTree`, `algo.mst`, `algo.bellmanford`, `algo.betweenness`,
+`algo.closeness`, `algo.harmonic`, `algo.eccentricity`, `algo.maxFlow`, `algo.msa`, `algo.knn`,
+`algo.hierarchicalClustering`, `algo.clique`, `algo.allSimplePaths`, `algo.kTruss`, `algo.triangleCount`,
+`algo.localClusteringCoefficient`, `algo.densestSubgraph`, `algo.bipartiteMatching`, `algo.voteRank` and
+`algo.richClub`.
+
+Procedures that make a single O(V + E) pass are deliberately left alone: one pass costs what loading the graph
+and emitting the rows already cost, so a checkpoint inside it would bound nothing the surrounding pipeline does
+not. One gap is named rather than hidden: `algo.localClusteringCoefficient`'s CSR path hands the whole
+computation to a `GraphAlgorithms` kernel that counts triangles across a thread pool, and the `WorkCheckpoint`
+hook is specified to be called between iterations on the calling thread - covering that kernel is a change to
+how it partitions its work, not a checkpoint that can be dropped in.
+
+[#6295](https://github.com/ArcadeData/arcadedb/issues/6295)
+[#6302](https://github.com/ArcadeData/arcadedb/issues/6302)
+
+## `algo.mst`'s edge arrays are priced against the working-memory budget (#6300)
+
+#6263 reserved the dense working set of every `algo.*` procedure that builds one, choosing them by two
+criteria: sized by a knob, or quadratic in the node count. `algo.mst` is neither - it is linear in the **edge**
+count, three parallel arrays plus the index sort, 24 bytes per edge - which reads like the graph paying for
+itself. But linear in the edge count is not small: the edge count is the largest linear dimension a graph has,
+usually an order of magnitude above the node count, and at 100M edges that is ~2.4 GB requested with no check
+and no error naming what asked for it, i.e. exactly the `OutOfMemoryError` shape #6065, #6216 and #6263 exist
+to replace with a client error. "Linear" was never the criterion; the criterion is whether the caller can
+predict a ceiling.
+
+The reservation is made **as the counting pass runs** rather than once it has finished. Both refuse the same
+calls, but a check afterwards first pays in full for a traversal it will then throw away - the same argument
+that puts `algo.steinerTree`'s reservation ahead of its adjacency build. The new
+`MemoryBudget.capacityFor(bytesPerItem)` is what hands the walk its own stopping rule; the refusal itself still
+goes through `MemoryBudget.reserve`, so the message names the same component and the same setting either way.
+
+[#6300](https://github.com/ArcadeData/arcadedb/issues/6300)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -2584,8 +2584,15 @@ column store. Callers (`algo.apsp`, `algo.bellmanford`, `algo.steinerTree`, `SQL
 slower and exact, instead of a weight belonging to another edge. This is the same "say unknown rather than
 guess" convention `countEdgesBetween` and `getMeanEdgesPerConnectedPair` already use.
 
-The second is `servesEdgeProperty(propertyName, edgeTypes...)`, which is the question a weighted algorithm
-actually has to ask. `hasEdgeProperties()` answers only "are there edge property columns at all", so a view built
+The second is `edgeWeightsOf(nodeId, direction, propertyName, defaultWeight, edgeTypes...)`, which returns one
+node's neighbours and their weights together and is now **the only supported way to read an edge property
+positionally**. Pairing `getNeighborIds` with `getEdgeProperty` by hand is wrong in two ways that produce a wrong
+answer rather than an error: a multi-type neighbour list is merged and sorted across types while the property
+columns are per type, and `DIRECTION.BOTH` has no column at all - a provider resolves `OUT` and `IN` only, so a
+`BOTH` lookup returns `null` for every edge. `bellmanFord()`'s direction argument *defaults* to `BOTH`, so the
+plain three-argument `bellmanFord(src, dst, 'weight')` had been unit-weighting the entire graph the moment a
+view existed; `astar()` with `direction: 'BOTH'` priced every edge at 0.0, making all paths tie. Its companion
+`servesEdgeProperty(propertyName, edgeTypes...)` answers the gating question. `hasEdgeProperties()` answers only "are there edge property columns at all", so a view built
 with `.withEdgeProperties("distance")` answered yes to a call asking for `cost` - and since a missing column and
 an edge with no value both come back as `null`, the caller could not tell them apart and treated the entire graph
 as unweighted. That is the same wrong answer as a misaligned weight, reached from the other direction, and it

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -28,6 +28,7 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.NodeEdgeWeights;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -255,28 +256,26 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
 
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(
         ctx.getDatabase(), paramEdgeTypeNames);
-    final String edgeType = paramEdgeTypeNames != null && paramEdgeTypeNames.length > 0 ? paramEdgeTypeNames[0] : null;
-    // The provider may only serve the weight when it holds a column for THIS property: asking the coarser
-    // hasEdgeProperties() lets a view built over another property through, and every getEdgeProperty then
-    // returns null so the whole neighbourhood comes back at the default weight (issue #6301).
-    if (provider != null && edgeType != null && provider.servesEdgeProperty(paramWeightFieldName, edgeType)) {
+    if (provider != null) {
       final int nodeId = provider.getNodeId(node.getIdentity());
-      if (nodeId >= 0) {
-        final int[] neighborIds = provider.getNeighborIds(nodeId, paramDirection, paramEdgeTypeNames);
+      // edgeWeightsOf() answers null unless the provider can serve THIS property for EVERY type in play, and it
+      // is the only thing that pairs a CSR edge with its own weight correctly. Reading getNeighborIds and
+      // getEdgeProperty side by side here got it wrong twice over (issue #6301): the neighbour list is merged and
+      // sorted across types while the property column is per type, and a BOTH lookup has no column at all, so it
+      // answered null for every edge and quietly priced the whole neighbourhood at MIN - free.
+      final NodeEdgeWeights edges = nodeId >= 0 ?
+          provider.edgeWeightsOf(nodeId, paramDirection, paramWeightFieldName, MIN, paramEdgeTypeNames) : null;
+      if (edges != null) {
+        final int[] neighborIds = edges.neighbors();
+        final double[] weights = edges.weights();
         for (int i = 0; i < neighborIds.length; i++) {
           final RID neighborRid = provider.getRID(neighborIds[i]);
-          if (neighborRid != null) {
-            double weight = MIN;
-            if (edgeType != null) {
-              final Object wObj = provider.getEdgeProperty(nodeId, i, paramDirection, edgeType, paramWeightFieldName);
-              if (wObj instanceof Number num)
-                weight = num.doubleValue();
-            }
-            try {
-              result.put(neighborRid.asVertex(), weight);
-            } catch (final Exception e) {
-              // deleted vertex — skip
-            }
+          if (neighborRid == null)
+            continue;
+          try {
+            result.put(neighborRid.asVertex(), weights[i]);
+          } catch (final Exception e) {
+            // deleted vertex — skip
           }
         }
         return result;

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -255,13 +255,14 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
 
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(
         ctx.getDatabase(), paramEdgeTypeNames);
-    if (provider != null && provider.hasEdgeProperties()) {
+    final String edgeType = paramEdgeTypeNames != null && paramEdgeTypeNames.length > 0 ? paramEdgeTypeNames[0] : null;
+    // The provider may only serve the weight when it holds a column for THIS property: asking the coarser
+    // hasEdgeProperties() lets a view built over another property through, and every getEdgeProperty then
+    // returns null so the whole neighbourhood comes back at the default weight (issue #6301).
+    if (provider != null && edgeType != null && provider.servesEdgeProperty(paramWeightFieldName, edgeType)) {
       final int nodeId = provider.getNodeId(node.getIdentity());
       if (nodeId >= 0) {
-        final int[] neighborIds = paramEdgeTypeNames != null && paramEdgeTypeNames.length > 0
-            ? provider.getNeighborIds(nodeId, paramDirection, paramEdgeTypeNames)
-            : provider.getNeighborIds(nodeId, paramDirection);
-        final String edgeType = paramEdgeTypeNames != null && paramEdgeTypeNames.length > 0 ? paramEdgeTypeNames[0] : null;
+        final int[] neighborIds = provider.getNeighborIds(nodeId, paramDirection, paramEdgeTypeNames);
         for (int i = 0; i < neighborIds.length; i++) {
           final RID neighborRid = provider.getRID(neighborIds[i]);
           if (neighborRid != null) {

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -109,7 +109,16 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
     final Vertex.DIRECTION dir = parseDirection(direction);
 
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db);
-    final boolean useCSR = provider != null && provider.hasEdgeProperties();
+    // getEdgeProperty() is addressed per edge type and this function takes no type filter, so the columnar path
+    // can only resolve a graph whose provider holds exactly one type - and only when that type carries the
+    // property actually asked for. Anything else read a null property value for every edge and treated the whole
+    // graph as unit-weighted, silently ignoring weightProperty (issue #6301); those cases now take the edge
+    // records below, which are exact.
+    final String[] materializedTypes = provider != null ? provider.getMaterializedEdgeTypes() : null;
+    final String csrEdgeType = materializedTypes != null && materializedTypes.length == 1 ? materializedTypes[0] : null;
+    final boolean unweighted = weightProperty == null || weightProperty.isEmpty();
+    final boolean useCSR = provider != null && provider.hasEdgeProperties()
+        && (unweighted || (csrEdgeType != null && provider.servesEdgeProperty(weightProperty, csrEdgeType)));
 
     for (int i = 0; i < n; i++) {
       final Vertex v = vertices.get(i);
@@ -134,7 +143,7 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
               continue;
             double w = 1.0;
             if (weightProperty != null && !weightProperty.isEmpty()) {
-              final Object wObj = provider.getEdgeProperty(nodeId, ni, dir, null, weightProperty);
+              final Object wObj = provider.getEdgeProperty(nodeId, ni, dir, csrEdgeType, weightProperty);
               if (wObj instanceof Number num)
                 w = num.doubleValue();
             }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -28,6 +28,7 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.NodeEdgeWeights;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.schema.DocumentType;
@@ -109,24 +110,24 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
     final Vertex.DIRECTION dir = parseDirection(direction);
 
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db);
-    // getEdgeProperty() is addressed per edge type and this function takes no type filter, so the columnar path
-    // can only resolve a graph whose provider holds exactly one type - and only when that type carries the
-    // property actually asked for. Anything else read a null property value for every edge and treated the whole
-    // graph as unit-weighted, silently ignoring weightProperty (issue #6301); those cases now take the edge
-    // records below, which are exact.
-    final String[] materializedTypes = provider != null ? provider.getMaterializedEdgeTypes() : null;
-    final String csrEdgeType = materializedTypes != null && materializedTypes.length == 1 ? materializedTypes[0] : null;
-    final boolean unweighted = weightProperty == null || weightProperty.isEmpty();
-    final boolean useCSR = provider != null && provider.hasEdgeProperties()
-        && (unweighted || (csrEdgeType != null && provider.servesEdgeProperty(weightProperty, csrEdgeType)));
+    // The columnar path is taken per node and only when edgeWeightsOf() can answer - i.e. when the provider can
+    // serve THIS property for every type it holds. Pairing getNeighborIds with getEdgeProperty by hand was wrong
+    // in two ways (issue #6301): the neighbour list is merged and sorted across types while the columns are per
+    // type, and `direction` defaults to BOTH here, which has no column at all - so the plain three-argument call
+    // read a null property value for every edge and silently unit-weighted the whole graph. Anything the
+    // provider cannot answer exactly falls to the edge records below, which are.
+    final String weightColumn = weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null;
 
     for (int i = 0; i < n; i++) {
       final Vertex v = vertices.get(i);
 
-      if (useCSR) {
+      if (provider != null && weightColumn != null) {
         final int nodeId = provider.getNodeId(v.getIdentity());
-        if (nodeId >= 0) {
-          final int[] neighborIds = provider.getNeighborIds(nodeId, dir);
+        final NodeEdgeWeights edges = nodeId >= 0 ?
+            provider.edgeWeightsOf(nodeId, dir, weightColumn, 1.0) : null;
+        if (edges != null) {
+          final int[] neighborIds = edges.neighbors();
+          final double[] weights = edges.weights();
           for (int ni = 0; ni < neighborIds.length; ni++) {
             final var neighborRid = provider.getRID(neighborIds[ni]);
             if (neighborRid == null)
@@ -141,14 +142,8 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
             final Integer j = vertexIndex.get(neighborVertex);
             if (j == null)
               continue;
-            double w = 1.0;
-            if (weightProperty != null && !weightProperty.isEmpty()) {
-              final Object wObj = provider.getEdgeProperty(nodeId, ni, dir, csrEdgeType, weightProperty);
-              if (wObj instanceof Number num)
-                w = num.doubleValue();
-            }
             edgeList.add(new int[] { i, j });
-            edgeWeights.add(w);
+            edgeWeights.add(weights[ni]);
           }
           continue;
         }

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -157,8 +157,28 @@ public interface GraphTraversalProvider {
   }
 
   /**
-   * Returns true if this provider has edge property columns materialized.
-   * When true, {@link #getEdgeProperty} can be used to retrieve edge properties from CSR storage.
+   * Returns the edge types this provider actually holds, or {@code null} when it cannot enumerate them.
+   * <p>
+   * {@link #getEdgeProperty} is addressed per edge type, so a caller that was given no type filter but needs
+   * edge properties has to ask which types exist rather than pass "all types" down. A provider that answers
+   * {@code null} simply cannot serve such a caller, which then falls back to reading the edge records.
+   */
+  default String[] getMaterializedEdgeTypes() {
+    return null;
+  }
+
+  /**
+   * Returns true if this provider has edge property columns materialized <em>and</em> the positional mapping
+   * {@link #getEdgeProperty} relies on is exact.
+   * <p>
+   * The second half is what makes the answer usable. {@code getEdgeProperty} addresses an edge by its position
+   * in the node's neighbour list for a direction, so it means something only while that position identifies the
+   * same edge {@link #getNeighborIds} reports there. A provider whose neighbour lists no longer line up with its
+   * property columns - because pending changes are served from a side structure, say - must answer {@code false}
+   * rather than hand back a weight belonging to another edge. The caller holds the edge records and can always
+   * read the property itself; a plausible wrong number is the one outcome it cannot recover from. Same
+   * "say unknown rather than guess" convention as {@link #countEdgesBetween} and
+   * {@link #getMeanEdgesPerConnectedPair}.
    */
   default boolean hasEdgeProperties() {
     return false;

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -185,6 +185,48 @@ public interface GraphTraversalProvider {
   }
 
   /**
+   * Returns true if this provider can serve {@code propertyName} for {@code edgeType} through
+   * {@link #getEdgeProperty}.
+   * <p>
+   * {@link #hasEdgeProperties()} answers the coarser question - are there edge property columns at all - and a
+   * caller that asks only that one gets {@code null} back from every {@link #getEdgeProperty} call when the view
+   * happens to materialise a <em>different</em> property than the one requested. Since a {@code null} property
+   * value is also the ordinary way of saying "this edge has no value", the caller cannot tell the two apart and
+   * silently treats the whole graph as unweighted. That is the same failure as reading a weight that belongs to
+   * another edge, arrived at from the other direction, so the question a weighted algorithm has to ask is this
+   * one: can you serve <em>this</em> property?
+   *
+   * @param edgeType     the edge type name
+   * @param propertyName the property the caller intends to read
+   */
+  default boolean hasEdgeProperty(final String edgeType, final String propertyName) {
+    return false;
+  }
+
+  /**
+   * Returns true if this provider can serve {@code propertyName} for every one of {@code edgeTypes} - or, when
+   * none are given, for every type it materialises.
+   * <p>
+   * The question a weighted algorithm actually has to ask, and the reason it is answered here rather than
+   * open-coded per caller: "all types" has to be resolved against what the provider holds before the per-type
+   * check means anything, and a caller that resolves it differently gets a different answer to the same
+   * question. Answers {@code false} for a provider that cannot enumerate its types, since it then cannot
+   * promise anything about the ones it was not told about.
+   *
+   * @param propertyName the property the caller intends to read
+   * @param edgeTypes    the types in play, empty or null for every materialised one
+   */
+  default boolean servesEdgeProperty(final String propertyName, final String... edgeTypes) {
+    final String[] types = edgeTypes != null && edgeTypes.length > 0 ? edgeTypes : getMaterializedEdgeTypes();
+    if (types == null || types.length == 0)
+      return false;
+    for (final String type : types)
+      if (!hasEdgeProperty(type, propertyName))
+        return false;
+    return true;
+  }
+
+  /**
    * Returns an edge property value from columnar storage, or null if not materialized.
    * <p>
    * The {@code neighborIndex} is the position within the node's adjacency list for the given direction

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -246,6 +246,66 @@ public interface GraphTraversalProvider {
   }
 
   /**
+   * Returns one node's neighbours together with the edge-property value of each edge reaching them, or
+   * {@code null} when this provider cannot serve {@code propertyName} for every type in play.
+   * <p>
+   * <b>This is the only correct way to read an edge property positionally, and the reason it lives here rather
+   * than in each caller.</b> {@link #getEdgeProperty} is addressed by (type, direction, position), and two things
+   * break a caller that pairs it with {@link #getNeighborIds} by hand:
+   * <ul>
+   *   <li>a multi-type neighbour list is <em>merged and sorted</em> across types, so position {@code j} in it is
+   *       not position {@code j} in any one type's column - the weight lands on another edge, or on none;</li>
+   *   <li>{@link Vertex.DIRECTION#BOTH} has no column of its own at all. A provider resolves {@code OUT} and
+   *       {@code IN}, so a {@code BOTH} lookup answers {@code null} for every edge and the caller silently reads
+   *       the whole neighbourhood at its default weight.</li>
+   * </ul>
+   * Both are handled here once: the walk takes one slice per (type, direction) pair, each of which <em>is</em>
+   * positional, and concatenates them.
+   *
+   * @param nodeId        the node whose edges to read
+   * @param direction     traversal direction; {@code BOTH} walks the outgoing and incoming slices in turn
+   * @param propertyName  the edge property to read
+   * @param defaultWeight value for an edge carrying no numeric value for that property
+   * @param edgeTypes     the types in play, empty or null for every materialised one
+   */
+  default NodeEdgeWeights edgeWeightsOf(final int nodeId, final Vertex.DIRECTION direction,
+      final String propertyName, final double defaultWeight, final String... edgeTypes) {
+    if (!servesEdgeProperty(propertyName, edgeTypes))
+      return null;
+
+    final String[] types = edgeTypes != null && edgeTypes.length > 0 ? edgeTypes : getMaterializedEdgeTypes();
+    final Vertex.DIRECTION[] directions = direction == Vertex.DIRECTION.BOTH ?
+        new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN } :
+        new Vertex.DIRECTION[] { direction };
+
+    final int[][] slices = new int[types.length * directions.length][];
+    int degree = 0;
+    int s = 0;
+    for (final String type : types)
+      for (final Vertex.DIRECTION d : directions) {
+        final int[] slice = getNeighborIds(nodeId, d, type);
+        slices[s++] = slice;
+        degree += slice.length;
+      }
+
+    final int[] neighbors = new int[degree];
+    final double[] weights = new double[degree];
+    int pos = 0;
+    s = 0;
+    for (final String type : types)
+      for (final Vertex.DIRECTION d : directions) {
+        final int[] slice = slices[s++];
+        for (int j = 0; j < slice.length; j++) {
+          neighbors[pos] = slice[j];
+          final Object value = getEdgeProperty(nodeId, j, d, type, propertyName);
+          weights[pos] = value instanceof Number num ? num.doubleValue() : defaultWeight;
+          pos++;
+        }
+      }
+    return new NodeEdgeWeights(neighbors, weights);
+  }
+
+  /**
    * Returns true if this provider's data is stale (not reflecting latest committed changes).
    * A provider may still be ready ({@link #isReady()}) while stale, if configured to serve stale data.
    */

--- a/engine/src/main/java/com/arcadedb/graph/NodeEdgeWeights.java
+++ b/engine/src/main/java/com/arcadedb/graph/NodeEdgeWeights.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+/**
+ * One node's neighbours and the edge-property value of each edge reaching them, produced together.
+ * <p>
+ * {@code weights[j]} belongs to the edge to {@code neighbors[j]} <em>by construction</em>: both arrays are filled
+ * from one walk of the same per-type, per-direction adjacency slices, each of which is positional against
+ * {@link GraphTraversalProvider#getEdgeProperty}. Handing the two back together is what removes the reconciliation
+ * step - and every place that reconciled them afterwards got it wrong, which is issue #6301.
+ *
+ * @param neighbors dense neighbour ids
+ * @param weights   the property value of the edge to the neighbour at the same index
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public record NodeEdgeWeights(int[] neighbors, double[] weights) {
+}

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1207,6 +1207,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   @Override
+  public boolean hasEdgeProperty(final String edgeType, final String propertyName) {
+    final Snapshot snap = this.snapshot;
+    if (snap == null || snap.edgeColumnStores == null || snap.overlay != null)
+      return false;
+    final ColumnStore edgeColStore = snap.edgeColumnStores.get(edgeType);
+    return edgeColStore != null && edgeColStore.getColumn(propertyName) != null;
+  }
+
+  @Override
   public Object getEdgeProperty(final int nodeId, final int neighborIndex,
       final Vertex.DIRECTION direction, final String edgeType, final String propertyName) {
     final Snapshot snap = checkBuilt();

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1184,9 +1184,26 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   @Override
+  public String[] getMaterializedEdgeTypes() {
+    final Snapshot snap = this.snapshot;
+    return snap == null ? null : snap.csrPerType.keySet().toArray(new String[0]);
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * An active delta overlay makes the answer no rather than yes. The edge property columns are aligned with the
+   * base CSR's forward edge slots, while {@link #getNeighborIds} serves the overlay's view of the node: deleted
+   * edges dropped, added ones merged in, the whole list re-sorted. The n-th neighbour of that list is then not
+   * the n-th edge of the column store, and {@link #getEdgeProperty}'s positional contract - the reason a caller
+   * may ask by index at all - no longer holds. Reporting "no edge properties" sends the caller to the edge
+   * records, which are exact; reporting "yes" would hand it a weight belonging to some other edge. Same reading
+   * as {@link #getMeanEdgesPerConnectedPair}, which answers unknown for the same overlay.
+   */
+  @Override
   public boolean hasEdgeProperties() {
     final Snapshot snap = this.snapshot;
-    return snap != null && snap.edgeColumnStores != null && !snap.edgeColumnStores.isEmpty();
+    return snap != null && snap.edgeColumnStores != null && !snap.edgeColumnStores.isEmpty() && snap.overlay == null;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -29,6 +29,7 @@ import com.arcadedb.graph.GraphEngine;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NeighborView;
+import com.arcadedb.graph.NodeEdgeWeights;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -731,53 +732,20 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     }
 
     /**
-     * Columnar build: one slice per (edge type, direction), each already positional against
-     * {@link GraphTraversalProvider#getEdgeProperty}. Concatenating the slices keeps that alignment, where
-     * merging them into the sorted list {@link #adjacency} returns would lose it.
+     * Columnar build: one call per node into {@link GraphTraversalProvider#edgeWeightsOf}, which is where the
+     * per-type, per-direction slicing that keeps a weight with its own edge lives. Nothing about that pairing is
+     * re-derived here, so the CSR path of an {@code algo.*} procedure, of {@code astar} and of
+     * {@code bellmanFord} cannot drift apart from one another.
      */
     private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
         final String weightProperty, final String[] types) {
-      final Vertex.DIRECTION[] directions = dir == Vertex.DIRECTION.BOTH ?
-          new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN } :
-          new Vertex.DIRECTION[] { dir };
-
-      // The (type, direction) pairs are the same for every node, so they are flattened once here rather than
-      // re-derived by a second nested walk inside the loop.
-      final int sliceCount = types.length * directions.length;
-      final String[] sliceType = new String[sliceCount];
-      final Vertex.DIRECTION[] sliceDirection = new Vertex.DIRECTION[sliceCount];
-      for (int s = 0, t = 0; t < types.length; t++)
-        for (final Vertex.DIRECTION d : directions) {
-          sliceType[s] = types[t];
-          sliceDirection[s] = d;
-          s++;
-        }
-
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
-      final int[][] slices = new int[sliceCount][];
       for (int i = 0; i < nodeCount; i++) {
         guard.checkPeriodically(i);
-        int degree = 0;
-        for (int s = 0; s < sliceCount; s++) {
-          slices[s] = provider.getNeighborIds(i, sliceDirection[s], sliceType[s]);
-          degree += slices[s].length;
-        }
-
-        final int[] nodeNeighbors = new int[degree];
-        final double[] nodeWeights = new double[degree];
-        int pos = 0;
-        for (int s = 0; s < sliceCount; s++) {
-          final int[] slice = slices[s];
-          for (int j = 0; j < slice.length; j++) {
-            nodeNeighbors[pos] = slice[j];
-            final Object weight = provider.getEdgeProperty(i, j, sliceDirection[s], sliceType[s], weightProperty);
-            nodeWeights[pos] = weight instanceof Number num ? num.doubleValue() : 1.0;
-            pos++;
-          }
-        }
-        neighbors[i] = nodeNeighbors;
-        weights[i] = nodeWeights;
+        final NodeEdgeWeights edges = provider.edgeWeightsOf(i, dir, weightProperty, 1.0, types);
+        neighbors[i] = edges.neighbors();
+        weights[i] = edges.weights();
       }
       return new WeightedAdjacency(neighbors, weights);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphEngine;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
@@ -337,6 +338,25 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     }
 
     /**
+     * How many items of {@code bytesPerItem} this call may still reserve, or {@link Long#MAX_VALUE} when the
+     * budget is disabled.
+     * <p>
+     * For a working set whose size is only known by walking the graph - {@code algo.mst}'s edge arrays are sized
+     * by a count that takes a full traversal to obtain - this hands the walk its own stopping rule. The
+     * alternative is to reserve once the count is known, which refuses exactly the same calls but only after
+     * paying in full for a traversal it then throws away. The refusal itself still goes through
+     * {@link #reserve}, so there is one place that decides and one shape of message, whichever end of the walk
+     * it fires at.
+     *
+     * @param bytesPerItem estimated footprint of one item; a non-positive value means "no per-item cost"
+     */
+    public long capacityFor(final long bytesPerItem) {
+      if (limit < 0 || bytesPerItem <= 0)
+        return Long.MAX_VALUE;
+      return (limit - reserved) / bytesPerItem;
+    }
+
+    /**
      * A saturated estimate is reported as "over Long.MAX_VALUE" rather than as the ceiling itself: the figure
      * is no longer representable, and quoting it as if it were exact would misstate by an unknown amount.
      */
@@ -555,7 +575,8 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
    * Provides uniform access to adjacency, vertex lookup, and RID resolution regardless of backing.
    */
   protected static class GraphData {
-    private static final int[] EMPTY_NEIGHBORS = new int[0];
+    private static final int[]    EMPTY_NEIGHBORS = new int[0];
+    private static final double[] EMPTY_WEIGHTS   = new double[0];
 
     public final int                     nodeCount;
     private final GraphTraversalProvider provider;
@@ -649,57 +670,153 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     }
 
     /**
-     * Builds weighted adjacency from CSR edge properties when available. Returns edge weights
-     * aligned with the adjacency array returned by {@link #adjacency(Vertex.DIRECTION, String...)}.
+     * A neighbour list and the weight of each of its edges, produced together.
      * <p>
-     * Returns {@code null} if edge properties are not available in CSR (caller should extract
-     * weights from OLTP edges in that case).
-     * <p>
-     * For each node {@code i}, {@code result[i][j]} is the weight of the edge to {@code adj[i][j]}.
+     * {@code weights[i][j]} is the weight of the edge to {@code neighbors[i][j]} <em>by construction</em>: both
+     * arrays are filled from one walk of the same edges, so there is no later reconciliation step that can get
+     * the pairing wrong. That is the whole point of returning the two together rather than offering weights
+     * "aligned with" an adjacency the caller obtained separately - issue #6301 is what the second shape costs.
      *
-     * @param dir            traversal direction
-     * @param weightProperty edge property name for weights
-     * @param relTypes       edge types to filter
-     * @return double[][] of weights aligned with adjacency, or null if not available
+     * @param neighbors dense neighbour ids per node
+     * @param weights   weight of the edge to the neighbour at the same index
      */
-    public double[][] edgeWeights(final Vertex.DIRECTION dir, final String weightProperty,
-        final String... relTypes) {
-      if (provider == null || !provider.hasEdgeProperties())
-        return null;
-
-      final double[][] weights = new double[nodeCount][];
-      for (int i = 0; i < nodeCount; i++) {
-        final String[] types = relTypes != null && relTypes.length > 0 ? relTypes : null;
-        if (types != null && types.length == 1) {
-          // Single edge type: direct per-neighbor weight extraction
-          final int[] neighbors = provider.getNeighborIds(i, dir, types[0]);
-          weights[i] = new double[neighbors.length];
-          for (int j = 0; j < neighbors.length; j++) {
-            final Object w = provider.getEdgeProperty(i, j, dir, types[0], weightProperty);
-            weights[i][j] = w instanceof Number num ? num.doubleValue() : 1.0;
-          }
-        } else {
-          // Multiple edge types: concatenate per-type weights to match adjacency order
-          final List<Double> wts = new ArrayList<>();
-          final String[] allTypes = types != null ? types : getProviderEdgeTypes();
-          for (final String edgeType : allTypes) {
-            final int[] neighbors = provider.getNeighborIds(i, dir, edgeType);
-            for (int j = 0; j < neighbors.length; j++) {
-              final Object w = provider.getEdgeProperty(i, j, dir, edgeType, weightProperty);
-              wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
-            }
-          }
-          weights[i] = new double[wts.size()];
-          for (int j = 0; j < wts.size(); j++)
-            weights[i][j] = wts.get(j);
-        }
-      }
-      return weights;
+    public record WeightedAdjacency(int[][] neighbors, double[][] weights) {
     }
 
-    private String[] getProviderEdgeTypes() {
-      // Fallback: return empty array to indicate all types
-      return new String[0];
+    /**
+     * Builds the neighbour lists and their edge weights in a single pass, from columnar edge properties when the
+     * view has them and from the edge records otherwise.
+     * <p>
+     * The two sources produce the same multiset of {@code (neighbour, weight)} pairs per node - the same edges,
+     * differing only in the order they are listed - which is the property that matters: a Graph Analytical View
+     * is an accelerator, and an algorithm reading weights through it must reach the answer it would have reached
+     * without it.
+     * <p>
+     * A {@code null} {@code weightProperty} means unit weights, and then this is {@link #adjacency} with a
+     * {@code 1.0} beside every entry.
+     *
+     * @param dir            traversal direction; {@code BOTH} lists a node's outgoing and incoming edges alike
+     * @param weightProperty edge property holding the weight, or {@code null} for unit weights
+     * @param relTypes       edge types to filter by, empty/null for all of them
+     */
+    public WeightedAdjacency weightedAdjacency(final Vertex.DIRECTION dir, final String weightProperty,
+        final String... relTypes) {
+      if (weightProperty == null) {
+        final int[][] neighbors = adjacency(dir, relTypes);
+        final double[][] weights = new double[nodeCount][];
+        for (int i = 0; i < nodeCount; i++) {
+          weights[i] = new double[neighbors[i].length];
+          Arrays.fill(weights[i], 1.0);
+        }
+        return new WeightedAdjacency(neighbors, weights);
+      }
+
+      // getEdgeProperty() addresses an edge by (type, direction, position), so "all types" has to be resolved
+      // to the actual list before the columnar path can be used at all. A provider that cannot enumerate its
+      // types, or has not materialised the property columns, sends us to the edge records - which are exact.
+      final String[] types = relTypes != null && relTypes.length > 0 ? relTypes
+          : provider != null ? provider.getMaterializedEdgeTypes() : null;
+      if (provider != null && provider.hasEdgeProperties() && types != null && types.length > 0)
+        return weightedAdjacencyFromColumns(dir, weightProperty, types);
+
+      return weightedAdjacencyFromRecords(dir, weightProperty, relTypes);
+    }
+
+    /**
+     * Columnar build: one slice per (edge type, direction), each already positional against
+     * {@link GraphTraversalProvider#getEdgeProperty}. Concatenating the slices keeps that alignment, where
+     * merging them into the sorted list {@link #adjacency} returns would lose it.
+     */
+    private WeightedAdjacency weightedAdjacencyFromColumns(final Vertex.DIRECTION dir, final String weightProperty,
+        final String[] types) {
+      final Vertex.DIRECTION[] directions = dir == Vertex.DIRECTION.BOTH ?
+          new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN } :
+          new Vertex.DIRECTION[] { dir };
+
+      final int[][] neighbors = new int[nodeCount][];
+      final double[][] weights = new double[nodeCount][];
+      final int[][] slices = new int[types.length * directions.length][];
+      for (int i = 0; i < nodeCount; i++) {
+        int degree = 0;
+        int s = 0;
+        for (final String type : types)
+          for (final Vertex.DIRECTION d : directions) {
+            final int[] slice = provider.getNeighborIds(i, d, type);
+            slices[s++] = slice;
+            degree += slice.length;
+          }
+
+        final int[] nodeNeighbors = new int[degree];
+        final double[] nodeWeights = new double[degree];
+        int pos = 0;
+        s = 0;
+        for (final String type : types)
+          for (final Vertex.DIRECTION d : directions) {
+            final int[] slice = slices[s++];
+            for (int j = 0; j < slice.length; j++) {
+              nodeNeighbors[pos] = slice[j];
+              final Object weight = provider.getEdgeProperty(i, j, d, type, weightProperty);
+              nodeWeights[pos] = weight instanceof Number num ? num.doubleValue() : 1.0;
+              pos++;
+            }
+          }
+        neighbors[i] = nodeNeighbors;
+        weights[i] = nodeWeights;
+      }
+      return new WeightedAdjacency(neighbors, weights);
+    }
+
+    /**
+     * Record build: the neighbour and the weight come off the same {@link Edge}, so they cannot be mismatched.
+     * Works for a CSR-backed graph too - {@link #getVertex} and {@link #indexOf} bridge back to the records -
+     * which is what makes it the fallback whenever the columnar path cannot answer exactly.
+     */
+    private WeightedAdjacency weightedAdjacencyFromRecords(final Vertex.DIRECTION dir, final String weightProperty,
+        final String[] relTypes) {
+      final int[][] neighbors = new int[nodeCount][];
+      final double[][] weights = new double[nodeCount][];
+      // One growable pair of scratch buffers for the whole graph rather than a list per node: the degree is
+      // unknown before the walk, and a per-node ArrayList<Double> would box every weight.
+      int[] scratchNeighbors = new int[16];
+      double[] scratchWeights = new double[16];
+
+      for (int i = 0; i < nodeCount; i++) {
+        final Vertex vertex = getVertex(i);
+        if (vertex == null) {
+          // Deleted since the CSR was built: no edges to read, and every other caller in this package skips it.
+          neighbors[i] = EMPTY_NEIGHBORS;
+          weights[i] = EMPTY_WEIGHTS;
+          continue;
+        }
+
+        final RID vertexRid = vertex.getIdentity();
+        final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
+            vertex.getEdges(dir, relTypes) :
+            vertex.getEdges(dir);
+        int degree = 0;
+        for (final Edge edge : edges) {
+          try {
+            final RID neighborRid = GraphEngine.neighborRid(edge, vertexRid, dir);
+            final int neighbor = neighborRid != null ? indexOf(neighborRid) : -1;
+            if (neighbor < 0)
+              continue;
+            if (degree == scratchNeighbors.length) {
+              scratchNeighbors = Arrays.copyOf(scratchNeighbors, degree * 2);
+              scratchWeights = Arrays.copyOf(scratchWeights, degree * 2);
+            }
+            final Object weight = edge.get(weightProperty);
+            scratchNeighbors[degree] = neighbor;
+            scratchWeights[degree] = weight instanceof Number num ? num.doubleValue() : 1.0;
+            degree++;
+          } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e': 'edge' is the loop variable in this scope
+            // Ghost edge: a dangling pointer to a record that is gone. Skipped, as everywhere else in the package.
+            GhostEdgeReporter.reportSkipped(rnf);
+          }
+        }
+        neighbors[i] = Arrays.copyOf(scratchNeighbors, degree);
+        weights[i] = Arrays.copyOf(scratchWeights, degree);
+      }
+      return new WeightedAdjacency(neighbors, weights);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -695,16 +695,19 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * A {@code null} {@code weightProperty} means unit weights, and then this is {@link #adjacency} with a
      * {@code 1.0} beside every entry.
      *
+     * @param guard          checkpoint for the walk; it visits every edge of the graph, so it is itself one of the
+     *                       graph-driven loops that has to be abortable
      * @param dir            traversal direction; {@code BOTH} lists a node's outgoing and incoming edges alike
      * @param weightProperty edge property holding the weight, or {@code null} for unit weights
      * @param relTypes       edge types to filter by, empty/null for all of them
      */
-    public WeightedAdjacency weightedAdjacency(final Vertex.DIRECTION dir, final String weightProperty,
-        final String... relTypes) {
+    public WeightedAdjacency weightedAdjacency(final WorkGuard guard, final Vertex.DIRECTION dir,
+        final String weightProperty, final String... relTypes) {
       if (weightProperty == null) {
         final int[][] neighbors = adjacency(dir, relTypes);
         final double[][] weights = new double[nodeCount][];
         for (int i = 0; i < nodeCount; i++) {
+          guard.checkPeriodically(i);
           weights[i] = new double[neighbors[i].length];
           Arrays.fill(weights[i], 1.0);
         }
@@ -713,13 +716,18 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
 
       // getEdgeProperty() addresses an edge by (type, direction, position), so "all types" has to be resolved
       // to the actual list before the columnar path can be used at all. A provider that cannot enumerate its
-      // types, or has not materialised the property columns, sends us to the edge records - which are exact.
-      final String[] types = relTypes != null && relTypes.length > 0 ? relTypes
-          : provider != null ? provider.getMaterializedEdgeTypes() : null;
-      if (provider != null && provider.hasEdgeProperties() && types != null && types.length > 0)
-        return weightedAdjacencyFromColumns(dir, weightProperty, types);
+      // types, or cannot serve THIS property for every one of them, sends us to the edge records - which are
+      // exact. Asking only whether the provider has edge properties at all is not enough: a view built over
+      // `distance` answers yes to a call asking for `cost`, and then every getEdgeProperty returns null and the
+      // whole graph is silently unweighted - the same wrong answer as a misaligned weight, reached from the
+      // other direction.
+      if (provider != null && provider.servesEdgeProperty(weightProperty, relTypes)) {
+        final String[] types = relTypes != null && relTypes.length > 0 ? relTypes
+            : provider.getMaterializedEdgeTypes();
+        return weightedAdjacencyFromColumns(guard, dir, weightProperty, types);
+      }
 
-      return weightedAdjacencyFromRecords(dir, weightProperty, relTypes);
+      return weightedAdjacencyFromRecords(guard, dir, weightProperty, relTypes);
     }
 
     /**
@@ -727,39 +735,47 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * {@link GraphTraversalProvider#getEdgeProperty}. Concatenating the slices keeps that alignment, where
      * merging them into the sorted list {@link #adjacency} returns would lose it.
      */
-    private WeightedAdjacency weightedAdjacencyFromColumns(final Vertex.DIRECTION dir, final String weightProperty,
-        final String[] types) {
+    private WeightedAdjacency weightedAdjacencyFromColumns(final WorkGuard guard, final Vertex.DIRECTION dir,
+        final String weightProperty, final String[] types) {
       final Vertex.DIRECTION[] directions = dir == Vertex.DIRECTION.BOTH ?
           new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT, Vertex.DIRECTION.IN } :
           new Vertex.DIRECTION[] { dir };
 
+      // The (type, direction) pairs are the same for every node, so they are flattened once here rather than
+      // re-derived by a second nested walk inside the loop.
+      final int sliceCount = types.length * directions.length;
+      final String[] sliceType = new String[sliceCount];
+      final Vertex.DIRECTION[] sliceDirection = new Vertex.DIRECTION[sliceCount];
+      for (int s = 0, t = 0; t < types.length; t++)
+        for (final Vertex.DIRECTION d : directions) {
+          sliceType[s] = types[t];
+          sliceDirection[s] = d;
+          s++;
+        }
+
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
-      final int[][] slices = new int[types.length * directions.length][];
+      final int[][] slices = new int[sliceCount][];
       for (int i = 0; i < nodeCount; i++) {
+        guard.checkPeriodically(i);
         int degree = 0;
-        int s = 0;
-        for (final String type : types)
-          for (final Vertex.DIRECTION d : directions) {
-            final int[] slice = provider.getNeighborIds(i, d, type);
-            slices[s++] = slice;
-            degree += slice.length;
-          }
+        for (int s = 0; s < sliceCount; s++) {
+          slices[s] = provider.getNeighborIds(i, sliceDirection[s], sliceType[s]);
+          degree += slices[s].length;
+        }
 
         final int[] nodeNeighbors = new int[degree];
         final double[] nodeWeights = new double[degree];
         int pos = 0;
-        s = 0;
-        for (final String type : types)
-          for (final Vertex.DIRECTION d : directions) {
-            final int[] slice = slices[s++];
-            for (int j = 0; j < slice.length; j++) {
-              nodeNeighbors[pos] = slice[j];
-              final Object weight = provider.getEdgeProperty(i, j, d, type, weightProperty);
-              nodeWeights[pos] = weight instanceof Number num ? num.doubleValue() : 1.0;
-              pos++;
-            }
+        for (int s = 0; s < sliceCount; s++) {
+          final int[] slice = slices[s];
+          for (int j = 0; j < slice.length; j++) {
+            nodeNeighbors[pos] = slice[j];
+            final Object weight = provider.getEdgeProperty(i, j, sliceDirection[s], sliceType[s], weightProperty);
+            nodeWeights[pos] = weight instanceof Number num ? num.doubleValue() : 1.0;
+            pos++;
           }
+        }
         neighbors[i] = nodeNeighbors;
         weights[i] = nodeWeights;
       }
@@ -771,14 +787,15 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
      * Works for a CSR-backed graph too - {@link #getVertex} and {@link #indexOf} bridge back to the records -
      * which is what makes it the fallback whenever the columnar path cannot answer exactly.
      */
-    private WeightedAdjacency weightedAdjacencyFromRecords(final Vertex.DIRECTION dir, final String weightProperty,
-        final String[] relTypes) {
+    private WeightedAdjacency weightedAdjacencyFromRecords(final WorkGuard guard, final Vertex.DIRECTION dir,
+        final String weightProperty, final String[] relTypes) {
       final int[][] neighbors = new int[nodeCount][];
       final double[][] weights = new double[nodeCount][];
       // One growable pair of scratch buffers for the whole graph rather than a list per node: the degree is
       // unknown before the walk, and a per-node ArrayList<Double> would box every weight.
       int[] scratchNeighbors = new int[16];
       double[] scratchWeights = new double[16];
+      int edgeStep = 0;
 
       for (int i = 0; i < nodeCount; i++) {
         final Vertex vertex = getVertex(i);
@@ -795,6 +812,9 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
             vertex.getEdges(dir);
         int degree = 0;
         for (final Edge edge : edges) {
+          // Throttled by EDGE rather than by vertex: one supernode can hold millions of them, and the walk
+          // deserialises each, so a per-vertex checkpoint would leave that whole node unabortable.
+          guard.checkPeriodically(edgeStep++);
           try {
             final RID neighborRid = GraphEngine.neighborRid(edge, vertexRid, dir);
             final int neighbor = neighborRid != null ? indexOf(neighborRid) : -1;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -20,13 +20,11 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
-import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.List;
 import java.util.function.Function;
@@ -47,7 +45,9 @@ import java.util.stream.Stream;
  * <p>
  * Note: this algorithm is O(V²) in memory and O(V³) in time. Only suitable for graphs
  * with up to a few thousand vertices - a bound the distance matrix's reservation through
- * {@link AbstractAlgoProcedure.MemoryBudget} now enforces rather than merely advises.
+ * {@link AbstractAlgoProcedure.MemoryBudget} now enforces rather than merely advises. The time half of that
+ * guarantee is a {@link WorkGuard} checkpoint inside the Floyd-Warshall loop: the budget's own floor admits about
+ * 2890 nodes, which is ~2.4e10 iterations, so a graph it accepts must at least be abortable (issue #6302).
  * </p>
  * <p>
  * The rows are produced lazily from the completed distance matrix, so the O(V²) figure above is the matrix and
@@ -104,6 +104,7 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
     final String[] relTypes     = args.length > 1 ? extractRelTypes(args[1]) : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
     final int n = graph.nodeCount;
@@ -119,39 +120,43 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
     // Allocate distance matrix: one large contiguous allocation is GC-friendly
     final double[][] dist = new double[n][n];
     for (int i = 0; i < n; i++) {
+      // One row is already O(n) writes, so the check costs nothing beside it and needs no throttle.
+      guard.check();
       for (int j = 0; j < n; j++)
         dist[i][j] = i == j ? 0.0 : INF;
     }
 
-    // Fill direct edges: try CSR edge properties first, fall back to OLTP
-    final int[][] adj = graph.adjacency(Vertex.DIRECTION.OUT, relTypes);
-    final double[][] edgeWts = weightProperty != null ? graph.edgeWeights(Vertex.DIRECTION.OUT, weightProperty, relTypes) : null;
-
-    if (edgeWts != null) {
-      // CSR path: edge weights from columnar storage
-      for (int i = 0; i < n; i++) {
-        for (int j = 0; j < adj[i].length; j++) {
-          final double w = edgeWts[i][j];
-          if (w < dist[i][adj[i][j]])
-            dist[i][adj[i][j]] = w;
-        }
+    // Fill direct edges. Neighbours and weights are built together - from the columnar edge properties when
+    // the view has them, from the edge records otherwise - so a weight always belongs to the neighbour it is
+    // written against, whatever the edge-type filter and whichever backing answered (issue #6301).
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(Vertex.DIRECTION.OUT, weightProperty,
+        relTypes);
+    final int[][] adj = weighted.neighbors();
+    final double[][] edgeWts = weighted.weights();
+    for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
+      for (int j = 0; j < adj[i].length; j++) {
+        final double w = edgeWts[i][j];
+        if (w < dist[i][adj[i][j]])
+          dist[i][adj[i][j]] = w;
       }
-    } else if (graph.isCSRBacked() && weightProperty == null) {
-      // CSR path: unweighted (unit weight)
-      for (int i = 0; i < n; i++) {
-        for (final int neighbor : adj[i]) {
-          if (1.0 < dist[i][neighbor])
-            dist[i][neighbor] = 1.0;
-        }
-      }
-    } else {
-      // OLTP path: extract weights from edges
-      fillDistanceMatrixFromOLTP(graph, n, dist, relTypes, weightProperty);
     }
 
-    // Floyd-Warshall
+    // Floyd-Warshall.
+    //
+    // The triple loop is O(V³) with no knob anywhere in it - the graph alone sizes it - and until issue #6302
+    // nothing inside it could end a run: not a thread interrupt, not arcadedb.command.timeout, not a client
+    // cancelling the query. The memory budget above caps the matrix at arcadedb.cypher.algoMaxWorkingMemory,
+    // whose 64 MB floor admits n ≈ 2890, and 2890³ is ~2.4e10 iterations - minutes of CPU on one query thread,
+    // on an input the budget explicitly accepts. The two halves of the guarantee have to agree: a call the
+    // budget refuses fails immediately, so a call it admits must at least be abortable.
+    //
+    // The checkpoint sits on the `i` loop rather than the `k` loop: `k` runs only V times while its body is
+    // O(V²), so a check per `k` leaves abort latency quadratic. One `i` iteration is O(V) writes, which is
+    // already more than a flag test, so it needs no throttle either.
     for (int k = 0; k < n; k++) {
       for (int i = 0; i < n; i++) {
+        guard.check();
         if (dist[i][k] >= INF)
           continue;  // Skip unreachable intermediate
         for (int j = 0; j < n; j++) {
@@ -194,32 +199,4 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
     }).flatMap(Function.identity());
   }
 
-  private void fillDistanceMatrixFromOLTP(final GraphData graph, final int n, final double[][] dist,
-      final String[] relTypes, final String weightProperty) {
-    for (int i = 0; i < n; i++) {
-      final Vertex v = graph.getVertex(i);
-      if (v == null)
-        continue;
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          v.getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          v.getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges) {
-        try {
-          final int j = graph.indexOf(e.getIn());
-          if (j < 0)
-            continue;
-          final double w;
-          if (weightProperty != null) {
-            final Object wObj = e.get(weightProperty);
-            w = wObj instanceof Number num ? num.doubleValue() : 1.0;
-          } else
-            w = 1.0;
-          if (w < dist[i][j])
-            dist[i][j] = w;
-        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
-          GhostEdgeReporter.reportSkipped(rnf);
-        }
-      }
-    }
-  }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -129,7 +129,7 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
     // Fill direct edges. Neighbours and weights are built together - from the columnar edge properties when
     // the view has them, from the edge records otherwise - so a weight always belongs to the neighbour it is
     // written against, whatever the edge-type filter and whichever backing answered (issue #6301).
-    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(Vertex.DIRECTION.OUT, weightProperty,
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT, weightProperty,
         relTypes);
     final int[][] adj = weighted.neighbors();
     final double[][] edgeWts = weighted.weights();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
@@ -26,6 +26,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
@@ -115,7 +116,8 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
     currentPath.add(startNode);
     visited.add(startNode.getIdentity());
 
-    findPaths(startNode, endNode, relTypes, skipRelTypes, skipVertexTypes, maxDepth, currentPath, visited, allPaths, context);
+    findPaths(startNode, endNode, relTypes, skipRelTypes, skipVertexTypes, maxDepth, currentPath, visited, allPaths,
+        context, newWorkGuard(context));
 
     return allPaths.stream().map(pathElements -> {
       final List<Object> nodes = new ArrayList<>();
@@ -161,7 +163,12 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
   private void findPaths(final Vertex current, final Vertex target, final String[] relTypes,
                          final Set<String> skipRelTypes, final Set<String> skipVertexTypes, final int remainingDepth,
                          final List<Object> currentPath, final Set<RID> visited,
-                         final List<List<Object>> allPaths, final CommandContext context) {
+                         final List<List<Object>> allPaths, final CommandContext context, final WorkGuard guard) {
+
+    // Enumerating simple paths is exponential in the graph: `maxDepth` bounds the LENGTH of a path, not how many
+    // of them there are, and a dense graph of even modest depth has more than can be counted. One call expands a
+    // vertex, which is more than a flag test costs (issue #6302).
+    guard.check();
 
     if (current.getIdentity().equals(target.getIdentity())) {
       allPaths.add(new ArrayList<>(currentPath));
@@ -196,7 +203,8 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           // try-finally so the path/visited bookkeeping is unwound even if the recursion throws,
           // leaving no dirty state for the rest of this branch.
           try {
-            findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
+            findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths,
+                context, guard);
           } finally {
             currentPath.removeLast();
             currentPath.removeLast();
@@ -234,7 +242,8 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           // try-finally so the path/visited bookkeeping is unwound even if the recursion throws,
           // leaving no dirty state for the rest of this branch.
           try {
-            findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
+            findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths,
+                context, guard);
           } finally {
             currentPath.removeLast();
             currentPath.removeLast();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
@@ -20,13 +20,11 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
-import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -106,6 +104,7 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final String[] relTypes = relType != null && !relType.isEmpty() ? new String[] { relType } : null;
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
     final int n = graph.nodeCount;
@@ -117,36 +116,34 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
     if (startIdx < 0 || endIdx < 0)
       return Stream.empty();
 
-    // Build edge list: try CSR edge properties first, fall back to OLTP
-    final int[][] adj = graph.adjacency(Vertex.DIRECTION.OUT, relTypes);
-    final double[][] edgeWts = graph.edgeWeights(Vertex.DIRECTION.OUT, weightProperty, relTypes);
+    // Build the edge list. Neighbours and weights come out of one walk of the same edges - columnar when the
+    // view materialises the property, the edge records otherwise - so a weight always belongs to the edge it is
+    // written against. The form this replaced read the weights through a second, independently ordered
+    // traversal (issue #6301) and, worse, fell back to a unit weight for EVERY edge whenever the graph was
+    // CSR-backed without the property column: the same query answered `weightProperty` on OLTP and ignored it
+    // entirely once a Graph Analytical View existed.
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(Vertex.DIRECTION.OUT,
+        weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null, relTypes);
+    final int[][] adj = weighted.neighbors();
+    final double[][] adjW = weighted.weights();
 
-    final List<int[]> edgeList = new ArrayList<>();
-    final List<Double> weightList = new ArrayList<>();
+    int edgeCount = 0;
+    for (int i = 0; i < n; i++)
+      edgeCount += adj[i].length;
 
-    if (edgeWts != null) {
-      // CSR path: edge weights from columnar storage
-      for (int i = 0; i < n; i++) {
-        for (int j = 0; j < adj[i].length; j++) {
-          edgeList.add(new int[] { i, adj[i][j] });
-          weightList.add(edgeWts[i][j]);
-        }
-      }
-    } else {
-      // OLTP path: extract weights from edges
-      for (int i = 0; i < n; i++) {
-        for (int j = 0; j < adj[i].length; j++) {
-          edgeList.add(new int[] { i, adj[i][j] });
-          // Need to get weight from OLTP edge — use default 1.0 when adj is CSR-backed
-          // and edge properties are not in CSR (the adjacency structure is still CSR-accelerated)
-          weightList.add(1.0);
-        }
-      }
-      // If graph is OLTP-backed, rebuild with actual weights from edges
-      if (!graph.isCSRBacked()) {
-        edgeList.clear();
-        weightList.clear();
-        buildEdgeListFromOLTP(graph, n, relTypes, weightProperty, edgeList, weightList);
+    // Parallel primitive arrays rather than a List<int[]> and a List<Double>: the relaxation below reads every
+    // edge up to n - 1 times, so this is the hottest loop in the procedure and the one place boxing is paid for
+    // over and over.
+    final int[] edgeFrom = new int[edgeCount];
+    final int[] edgeTo = new int[edgeCount];
+    final double[] edgeWeight = new double[edgeCount];
+    int e = 0;
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < adj[i].length; j++) {
+        edgeFrom[e] = i;
+        edgeTo[e] = adj[i][j];
+        edgeWeight[e] = adjW[i][j];
+        e++;
       }
     }
 
@@ -159,13 +156,15 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
     dist[startIdx] = 0.0;
 
     // Bellman-Ford relaxation: V-1 iterations
-    final int edgeCount = edgeList.size();
     for (int iter = 0; iter < n - 1; iter++) {
+      // n - 1 passes over every edge is O(V x E), and nothing about the call bounds either factor - the graph
+      // alone sizes both. The early exit below ends a converged run, not a long one.
+      guard.check();
       boolean anyRelaxed = false;
-      for (int e = 0; e < edgeCount; e++) {
-        final int u = edgeList.get(e)[0];
-        final int v = edgeList.get(e)[1];
-        final double w = weightList.get(e);
+      for (int k = 0; k < edgeCount; k++) {
+        final int u = edgeFrom[k];
+        final int v = edgeTo[k];
+        final double w = edgeWeight[k];
         if (dist[u] != Double.MAX_VALUE && dist[u] + w < dist[v]) {
           dist[v] = dist[u] + w;
           prev[v] = u;
@@ -178,10 +177,10 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
 
     // Check for negative cycles reachable from start
     boolean negativeCycle = false;
-    for (int e = 0; e < edgeCount; e++) {
-      final int u = edgeList.get(e)[0];
-      final int v = edgeList.get(e)[1];
-      final double w = weightList.get(e);
+    for (int k = 0; k < edgeCount; k++) {
+      final int u = edgeFrom[k];
+      final int v = edgeTo[k];
+      final double w = edgeWeight[k];
       if (dist[u] != Double.MAX_VALUE && dist[u] + w < dist[v]) {
         negativeCycle = true;
         break;
@@ -229,32 +228,4 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
     return Stream.of(result);
   }
 
-  private void buildEdgeListFromOLTP(final GraphData graph, final int n, final String[] relTypes,
-      final String weightProperty, final List<int[]> edgeList, final List<Double> weightList) {
-    for (int i = 0; i < n; i++) {
-      final Vertex v = graph.getVertex(i);
-      if (v == null)
-        continue;
-      final Iterable<Edge> edges = relTypes != null ?
-          v.getEdges(Vertex.DIRECTION.OUT, relTypes) :
-          v.getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge edge : edges) {
-        try {
-          final int j = graph.indexOf(edge.getIn());
-          if (j < 0)
-            continue;
-          double w = 1.0;
-          if (weightProperty != null && !weightProperty.isEmpty()) {
-            final Object wObj = edge.get(weightProperty);
-            if (wObj instanceof Number num)
-              w = num.doubleValue();
-          }
-          edgeList.add(new int[] { i, j });
-          weightList.add(w);
-        } catch (final RecordNotFoundException e) {
-          GhostEdgeReporter.reportSkipped(e);
-        }
-      }
-    }
-  }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
@@ -122,7 +122,7 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
     // traversal (issue #6301) and, worse, fell back to a unit weight for EVERY edge whenever the graph was
     // CSR-backed without the property column: the same query answered `weightProperty` on OLTP and ignored it
     // entirely once a Graph Analytical View existed.
-    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(Vertex.DIRECTION.OUT,
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.OUT,
         weightProperty != null && !weightProperty.isEmpty() ? weightProperty : null, relTypes);
     final int[][] adj = weighted.neighbors();
     final double[][] adjW = weighted.weights();
@@ -175,8 +175,10 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
         break;
     }
 
-    // Check for negative cycles reachable from start
+    // Check for negative cycles reachable from start: one more pass over every edge, guarded like the
+    // relaxation passes above rather than left as the one unabortable loop in the method.
     boolean negativeCycle = false;
+    guard.check();
     for (int k = 0; k < edgeCount; k++) {
       final int u = edgeFrom[k];
       final int v = edgeTo[k];

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -26,6 +26,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -99,6 +100,7 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
     final boolean normalized = config == null || !Boolean.FALSE.equals(config.get("normalized"));
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
     final List<Vertex> vertices = new ArrayList<>();
     final Iterator<Vertex> vertIter = getAllVertices(db, null);
     while (vertIter.hasNext())
@@ -113,8 +115,12 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
 
     final double[] betweenness = new double[n];
 
-    // Brandes algorithm
+    // Brandes algorithm.
+    //
+    // A forward BFS and a backward accumulation per source node, so O(V x E) sized by nothing but the graph
+    // (issue #6302). The inner checkpoints keep the abort latency below one whole source's pass.
     for (int s = 0; s < n; s++) {
+      guard.check();
       final Vertex source = vertices.get(s);
 
       final Deque<Integer> stack = new ArrayDeque<>();
@@ -132,7 +138,9 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
       final Queue<Integer> queue = new LinkedList<>();
       queue.add(s);
 
+      int visited = 0;
       while (!queue.isEmpty()) {
+        guard.checkPeriodically(visited++);
         final int v = queue.poll();
         stack.push(v);
 
@@ -162,7 +170,9 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
 
       // Back-propagation
       final double[] delta = new double[n];
+      int accumulated = 0;
       while (!stack.isEmpty()) {
+        guard.checkPeriodically(accumulated++);
         final int w = stack.pop();
         for (final int v : predecessors.get(w)) {
           delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBipartiteMatching.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBipartiteMatching.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,6 +90,7 @@ public class AlgoBipartiteMatching extends AbstractAlgoProcedure {
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -105,6 +107,7 @@ public class AlgoBipartiteMatching extends AbstractAlgoProcedure {
     final int[] bfsQ = new int[n];
 
     for (int root = 0; root < n && bipartite; root++) {
+      guard.checkPeriodically(root);
       if (color[root] != -1)
         continue;
       color[root] = 0;
@@ -152,6 +155,9 @@ public class AlgoBipartiteMatching extends AbstractAlgoProcedure {
 
     int matching = 0;
     while (hopcroftBFS(pairU, pairV, dist, L, leftGlobal, rightOf, adj)) {
+      // One phase per round, each a BFS plus a DFS over every edge: O(E x sqrt(V)) sized by the graph alone
+      // (issue #6302). A phase is already a whole traversal, so the check needs no throttle.
+      guard.check();
       for (int u = 1; u <= L; u++) {
         if (pairU[u] == NIL && hopcroftDFS(u, pairU, pairV, dist, leftGlobal, rightOf, adj))
           matching++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
@@ -24,6 +24,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -90,6 +91,7 @@ public class AlgoClique extends AbstractAlgoProcedure {
     final int minSize       = args.length > 1 ? extractInt((Number) args[1], "minSize") : 3;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -128,6 +130,10 @@ public class AlgoClique extends AbstractAlgoProcedure {
     stack.push(new StackFrame(initialR, initialP, initialX));
 
     while (!stack.isEmpty()) {
+      // Maximal-clique enumeration is exponential in the graph in the worst case, and neither `minSize` nor
+      // anything else bounds the search - minSize only filters what is reported (issue #6302). One frame costs
+      // at least a bit-set scan, so the check needs no throttle.
+      guard.check();
       final StackFrame frame = stack.peek();
 
       if (frame.P.isEmpty() && frame.X.isEmpty()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClosenessCentrality.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClosenessCentrality.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.Arrays;
 import java.util.List;
@@ -84,6 +85,7 @@ public class AlgoClosenessCentrality extends AbstractAlgoProcedure {
     final boolean normalized = args.length > 2 ? Boolean.parseBoolean(args[2].toString()) : true;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -99,6 +101,10 @@ public class AlgoClosenessCentrality extends AbstractAlgoProcedure {
     final double[] scores = new double[n];
 
     for (int src = 0; src < n; src++) {
+      // One BFS per source is O(V + E), and it runs once per node: O(V x (V + E)) sized by nothing but the
+      // graph (issue #6302). The inner checkpoint is what keeps the abort latency below a whole traversal on a
+      // graph where one BFS is itself long.
+      guard.check();
       Arrays.fill(dist, -1);
       dist[src] = 0;
       int head = 0, tail = 0;
@@ -107,6 +113,7 @@ public class AlgoClosenessCentrality extends AbstractAlgoProcedure {
       int reachable = 0;
 
       while (head < tail) {
+        guard.checkPeriodically(head);
         final int u = queue[head++];
         final int[] neighbors = adj[u];
         for (int k = 0; k < neighbors.length; k++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDensestSubgraph.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDensestSubgraph.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.Arrays;
 import java.util.List;
@@ -83,6 +84,7 @@ public class AlgoDensestSubgraph extends AbstractAlgoProcedure {
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -109,6 +111,9 @@ public class AlgoDensestSubgraph extends AbstractAlgoProcedure {
     int remaining = n;
 
     while (remaining > 1) {
+      // One vertex peeled per round, chosen by a linear scan and snapshotted by another: O(V²) before the edge
+      // work, with the graph alone sizing it (issue #6302).
+      guard.check();
       final double density = (double) totalEdges / remaining;
       if (density > bestDensity) {
         bestDensity = density;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
@@ -113,7 +113,10 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
 
     // Try CSR-accelerated path: requires a provider with edge properties
     final GraphTraversalProvider provider = findProvider(db, relTypes);
-    if (provider instanceof GraphAnalyticalView gav && gav.hasEdgeProperties()) {
+    // Not the coarser hasEdgeProperties(): the CSR kernel below reads the weight column directly and falls back
+    // to a unit weight when it is missing, so a view materialising some OTHER property would silently answer an
+    // unweighted shortest path to a weighted question (issue #6301).
+    if (provider instanceof GraphAnalyticalView gav && gav.servesEdgeProperty(weightProperty, relTypes)) {
       context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
       return executeWithCSR(context, gav, startNode.getIdentity(), relTypes, weightProperty, dir);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoEccentricity.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoEccentricity.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.Arrays;
 import java.util.List;
@@ -83,6 +84,7 @@ public class AlgoEccentricity extends AbstractAlgoProcedure {
     final Vertex.DIRECTION dir = args.length > 1 ? parseDirection(extractString(args[1], "direction")) : Vertex.DIRECTION.BOTH;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -97,6 +99,10 @@ public class AlgoEccentricity extends AbstractAlgoProcedure {
     final int[] dist = new int[n];
 
     for (int src = 0; src < n; src++) {
+      // One BFS per source is O(V + E), and it runs once per node: O(V x (V + E)) sized by nothing but the
+      // graph (issue #6302). The inner checkpoint is what keeps the abort latency below a whole traversal on a
+      // graph where one BFS is itself long.
+      guard.check();
       Arrays.fill(dist, -1);
       dist[src] = 0;
       int head = 0, tail = 0;
@@ -104,6 +110,7 @@ public class AlgoEccentricity extends AbstractAlgoProcedure {
       int maxDist = 0;
 
       while (head < tail) {
+        guard.checkPeriodically(head);
         final int u = queue[head++];
         for (final int v : adj[u]) {
           if (dist[v] == -1) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
@@ -138,6 +138,10 @@ public class AlgoFastRP extends AbstractAlgoProcedure {
     final double val = Math.sqrt(3.0);
     final double[][] embed = new double[n][dimensions];
     for (int i = 0; i < n; i++) {
+      // nodeCount x dimensions draws, before the first propagation round - so the checkpoint inside that round
+      // never sees this phase (issue #6295). `dimensions` has a ceiling, the node count has none, and a bounded
+      // per-node cost times an unbounded node count is still unbounded.
+      guard.checkPeriodically(i);
       for (int d = 0; d < dimensions; d++) {
         final int r = rng.nextInt(6);
         if (r == 0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
@@ -145,6 +145,9 @@ public class AlgoGraphSAGE extends AbstractAlgoProcedure {
     final Random rng = seed >= 0 ? new Random(seed) : new Random();
     double[][] embed = new double[n][initDim];
     for (int i = 0; i < n; i++) {
+      // nodeCount x initDim Gaussian draws plus a normalisation each, and all of it before the first layer - so
+      // the checkpoint inside the layer loop never sees this phase (issue #6295).
+      guard.checkPeriodically(i);
       embed[i][0] = Math.log1p(degree[i]) / logMaxDeg; // structural feature
       for (int d = 1; d < initDim; d++)
         embed[i][d] = rng.nextGaussian() * 0.1;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHarmonicCentrality.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHarmonicCentrality.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.Arrays;
 import java.util.List;
@@ -84,6 +85,7 @@ public class AlgoHarmonicCentrality extends AbstractAlgoProcedure {
     final boolean normalized   = args.length > 2 ? Boolean.parseBoolean(args[2].toString()) : true;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -98,6 +100,10 @@ public class AlgoHarmonicCentrality extends AbstractAlgoProcedure {
     final double[] scores = new double[n];
 
     for (int src = 0; src < n; src++) {
+      // One BFS per source is O(V + E), and it runs once per node: O(V x (V + E)) sized by nothing but the
+      // graph (issue #6302). The inner checkpoint is what keeps the abort latency below a whole traversal on a
+      // graph where one BFS is itself long.
+      guard.check();
       Arrays.fill(dist, -1);
       dist[src] = 0;
       int head = 0, tail = 0;
@@ -105,6 +111,7 @@ public class AlgoHarmonicCentrality extends AbstractAlgoProcedure {
       double harmonicSum = 0.0;
 
       while (head < tail) {
+        guard.checkPeriodically(head);
         final int u = queue[head++];
         for (final int v : adj[u]) {
           if (dist[v] == -1) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
@@ -133,6 +133,9 @@ public class AlgoHashGNN extends AbstractAlgoProcedure {
     // Initialise: each node gets ~12.5% sparse random binary feature vector
     final boolean[][] features = new boolean[n][numFeatures];
     for (int i = 0; i < n; i++) {
+      // Rejection sampling over numFeatures bits, once per node. Bounded per node, unbounded over the graph -
+      // and it runs BEFORE the message-passing loop, so the checkpoint inside that loop never sees it.
+      guard.checkPeriodically(i);
       // Use per-node deterministic seed for reproducible initialisation
       final Random nodeRng = seed >= 0 ? new Random(seed + i * 1_000_003L) :
           new Random(graph.getRID(i).hashCode() * 1_000_003L + i);
@@ -179,10 +182,27 @@ public class AlgoHashGNN extends AbstractAlgoProcedure {
       }
     }
 
-    // Compute MinHash signature → float embedding
+    // Compute MinHash signature → float embedding.
+    //
+    // This phase, not the loop `iterations` drives, is where an algo.hashgnn call actually spends its time, and
+    // until issue #6295 it was the one phase no checkpoint reached. Per node it costs embeddingDimension x
+    // numFeatures = 4 x embeddingDimension² operations - 6.7e7 at the 4096 cap - and that bounded per-node figure
+    // is then multiplied by an unbounded node count. Measured: 113 seconds against a 1000 ms
+    // arcadedb.command.timeout on 2000 nodes, and the call RETURNED rather than aborting.
+    //
+    // The lens that missed it looked for knobs with no ceiling; embeddingDimension has one (#6065), which is
+    // exactly why it looked handled. The question that finds it is "which loop over the node count has no
+    // checkpoint", and the phases after the knob-driven loop are where to ask it.
+    //
+    // The counter spans both loops rather than sitting on either: on a wide embedding one node is already 6.7e7
+    // operations, so a per-node checkpoint would be too coarse, and on a narrow one (embeddingDimension 1, 64
+    // features) a per-dimension clock read would cost more than the work it guards. One check per 1024
+    // (node, dimension) pairs is bounded by numFeatures x 1024 operations either way.
     final double[][] embeddings = new double[n][embDim];
+    int reductionStep = 0;
     for (int i = 0; i < n; i++) {
       for (int d = 0; d < embDim; d++) {
+        guard.checkPeriodically(reductionStep++);
         int minHash = Integer.MAX_VALUE;
         final int a = hashA[d], b = hashB[d];
         for (int f = 0; f < numFeatures; f++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHierarchicalClustering.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHierarchicalClustering.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -86,6 +87,7 @@ public class AlgoHierarchicalClustering extends AbstractAlgoProcedure {
     final int numClusters = args.length > 1 && args[1] instanceof Number n ? extractInt(n, "numClusters") : 2;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -115,6 +117,9 @@ public class AlgoHierarchicalClustering extends AbstractAlgoProcedure {
 
     // Agglomerative: repeatedly merge until we have targetClusters
     while (currentClusters > targetClusters) {
+      // One merge per round and a full scan of the graph to choose it: O(V x (V + E)) bit-set intersections,
+      // sized by the graph and by a cluster target that defaults to 2 (issue #6302).
+      guard.check();
       // Find the two nodes (representing different clusters) with highest similarity
       // Similarity = common neighbors (Jaccard numerator) — use BitSet AND cardinality
       int bestU = -1;
@@ -122,6 +127,7 @@ public class AlgoHierarchicalClustering extends AbstractAlgoProcedure {
       int bestSim = -1;
 
       for (int u = 0; u < n; u++) {
+        guard.checkPeriodically(u);
         final int rootU = find(parent, u);
         for (final int v : adj[u]) {
           if (v <= u)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -95,6 +96,7 @@ public class AlgoKNN extends AbstractAlgoProcedure {
     final Vertex.DIRECTION dir = args.length > 2 ? parseDirection(extractString(args[2], "direction")) : Vertex.DIRECTION.BOTH;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -119,6 +121,10 @@ public class AlgoKNN extends AbstractAlgoProcedure {
     final List<Result> results = new ArrayList<>();
 
     for (int u = 0; u < n; u++) {
+      // Every node is compared against every other, so this is O(V²) bit-set intersections with nothing but the
+      // graph to size it (issue #6302). One u is already a full pass over the other n - 1 nodes, which is more
+      // than enough to swallow an unthrottled check.
+      guard.check();
       if (adj[u].length == 0)
         continue;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,6 +95,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     final String weightProperty   = args.length > 4 ? extractString(args[4], "weightProperty") : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
     final List<Vertex> vertices = new ArrayList<>();
     final Iterator<Vertex> iter = getAllVertices(db, null);
     while (iter.hasNext())
@@ -125,6 +127,8 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
       Arrays.fill(row, Double.MAX_VALUE);
 
     for (int i = 0; i < n; i++) {
+      // One row of the matrix is O(n) and one vertex's edges are O(degree); either is more than a flag test.
+      guard.check();
       weightMatrix[i][i] = 0.0;
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
@@ -157,7 +161,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     final List<Double> kWeights  = new ArrayList<>(Math.min(k, n));
 
     // Find first shortest path with Dijkstra
-    final int[] firstPath = dijkstra(weightMatrix, n, startIdx, endIdx, null);
+    final int[] firstPath = dijkstra(weightMatrix, n, startIdx, endIdx, null, guard);
     if (firstPath == null)
       return Stream.empty();
 
@@ -186,9 +190,17 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     final boolean[] removedNodes = new boolean[n];
 
     for (int ki = 1; ki < k; ki++) {
+      // Yen's is O(k x pathLength x V²) over a dense matrix, and `k` is deliberately left unbounded above
+      // because the loop stops as soon as no candidate remains. "Unbounded but self-terminating" still needs a
+      // way out: nothing here could observe a thread interrupt or arcadedb.command.timeout before issue #6302,
+      // so a k that ran for minutes ran for minutes. The two checkpoints below cost one flag test per spur node
+      // and per matrix row respectively, both already O(V) bodies.
+      guard.check();
       final int[] prevPath = kPaths.get(ki - 1);
 
       for (int i = 0; i < prevPath.length - 1; i++) {
+        // One spur node is a whole Dijkstra over the dense matrix, i.e. O(V²).
+        guard.check();
         final int spurNode = prevPath[i];
         final int[] rootPath = Arrays.copyOf(prevPath, i + 1);
 
@@ -201,7 +213,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
 
         // Find spur path from spurNode to endIdx
         final int[] spurPath = dijkstra(weightMatrix, n, spurNode, endIdx,
-            (u, v) -> (u == spurNode && removedSpurTargets[v]) || removedNodes[u] || removedNodes[v]);
+            (u, v) -> (u == spurNode && removedSpurTargets[v]) || removedNodes[u] || removedNodes[v], guard);
 
         // Both masks are shared across spur nodes, so they are handed back empty for the next one.
         markRemovedSpurTargets(kPaths, prevPath, i, removedSpurTargets, false);
@@ -306,7 +318,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
   }
 
   private static int[] dijkstra(final double[][] w, final int n, final int src, final int dst,
-      final EdgeFilter removed) {
+      final EdgeFilter removed, final WorkGuard guard) {
     final double[] dist = new double[n];
     final int[] prev    = new int[n];
     Arrays.fill(dist, Double.MAX_VALUE);
@@ -318,6 +330,9 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     pq.offer(new double[] { 0.0, src });
 
     while (!pq.isEmpty()) {
+      // Relaxing one settled node scans the whole matrix row, so a single Dijkstra here is O(V²) and has to be
+      // abortable from inside rather than only between spur nodes.
+      guard.check();
       final double[] top  = pq.poll();
       final double cost   = top[0];
       final int u         = (int) top[1];

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
@@ -96,9 +96,11 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
       return Stream.empty();
     final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH, relTypes);
 
-    // Build neighbor BitSets for O(1) membership test
+    // Build neighbor BitSets for O(1) membership test: a nodeCount x nodeCount bit matrix, built before the
+    // peeling loop that carries the checkpoint.
     final BitSet[] neighborSets = new BitSet[n];
     for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
       neighborSets[i] = new BitSet(n);
       for (final int j : adj[i])
         neighborSets[i].set(j);
@@ -125,8 +127,10 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     final int[] support = new int[edgeCount];
     final boolean[] removed = new boolean[edgeCount];
 
-    // Compute initial support for each edge
+    // Compute initial support for each edge: a bit-set clone and intersection per edge, each O(nodeCount / 64),
+    // and all of it before the peeling loop that carries the checkpoint.
     for (int e = 0; e < edgeCount; e++) {
+      guard.checkPeriodically(e);
       final int u = edges.get(e)[0];
       final int v = edges.get(e)[1];
       // |N(u) ∩ N(v)| — use BitSet AND
@@ -209,9 +213,11 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
       final BitSet[] neighborSetsOrig, final Map<Long, Integer> edgeMap,
       final List<int[]> edges, final int edgeCount) {
 
-    // Rebuild neighbor sets (fresh copy)
+    // Rebuild neighbor sets (fresh copy). A nodeCount x nodeCount bit matrix and an O(E) fill, both before the
+    // peeling loop below, so its checkpoint never reaches them.
     final BitSet[] neighborSets = new BitSet[n];
     for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
       neighborSets[i] = new BitSet(n);
       for (final int j : adj[i])
         neighborSets[i].set(j);
@@ -222,8 +228,10 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     // edgeTruss[e] = the truss number assigned to edge e
     final int[] edgeTruss = new int[edgeCount];
 
-    // Compute initial support
+    // Compute initial support: a bit-set clone and intersection per edge, each O(nodeCount / 64) - the most
+    // expensive single phase here on a large graph, and the last one that had no checkpoint.
     for (int e = 0; e < edgeCount; e++) {
+      guard.checkPeriodically(e);
       final int u = edges.get(e)[0];
       final int v = edges.get(e)[1];
       final BitSet inter = (BitSet) neighborSets[u].clone();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -85,6 +86,7 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     final int kParam = args.length > 1 && args[1] instanceof Number n ? extractInt(n, "k") : 3;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -142,8 +144,13 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     int currentK = 2;
     boolean anyRemoved = true;
     while (anyRemoved) {
+      // A full sweep of every edge per round, repeated until a round removes nothing, and each removal walks the
+      // common neighbourhood of the edge's endpoints. Sized by the graph and by k, with nothing to stop it from
+      // inside before issue #6302.
+      guard.check();
       anyRemoved = false;
       for (int e = 0; e < edgeCount; e++) {
+        guard.checkPeriodically(e);
         if (!removed[e] && support[e] < currentK - 2) {
           removed[e] = true;
           anyRemoved = true;
@@ -180,7 +187,7 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     // Assign truss numbers: nodes in remaining edges get at least kParam truss number
     // For full decomposition, track max k where each node is still connected
     // Re-run the full decomposition
-    final int[] nodeTruss = computeFullTrussDecomposition(n, adj, neighborSets, edgeMap, edges, edgeCount);
+    final int[] nodeTruss = computeFullTrussDecomposition(guard, n, adj, neighborSets, edgeMap, edges, edgeCount);
 
     final List<Result> results = new ArrayList<>(n);
     for (int i = 0; i < n; i++) {
@@ -198,7 +205,7 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     return idx == null ? -1 : idx;
   }
 
-  private int[] computeFullTrussDecomposition(final int n, final int[][] adj,
+  private int[] computeFullTrussDecomposition(final WorkGuard guard, final int n, final int[][] adj,
       final BitSet[] neighborSetsOrig, final Map<Long, Integer> edgeMap,
       final List<int[]> edges, final int edgeCount) {
 
@@ -229,8 +236,10 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     while (removedCount < edgeCount) {
       boolean anyRemoved = true;
       while (anyRemoved) {
+        guard.check();
         anyRemoved = false;
         for (int e = 0; e < edgeCount; e++) {
+          guard.checkPeriodically(e);
           if (!removed[e] && support[e] < k - 2) {
             removed[e] = true;
             edgeTruss[e] = k - 1;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLocalClusteringCoefficient.java
@@ -26,6 +26,7 @@ import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.Arrays;
 import java.util.List;
@@ -124,6 +125,7 @@ public class AlgoLocalClusteringCoefficient extends AbstractAlgoProcedure {
   }
 
   private Stream<Result> executeWithOLTP(final Database db, final String[] relTypes, final CommandContext context) {
+    final WorkGuard guard = newWorkGuard(context);
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
     final int n = graph.nodeCount;
@@ -138,6 +140,15 @@ public class AlgoLocalClusteringCoefficient extends AbstractAlgoProcedure {
     // Count triangles using sorted-merge intersection — O(m * sqrt(m)) time, O(m) memory
     final long[] triangles = new long[n];
     for (int u = 0; u < n; u++) {
+      // One node intersects its neighbour list against each of its neighbours', which is O(degree²) on a
+      // supernode and O(m x sqrt(m)) over the graph - nothing but the graph sizes it (issue #6302).
+      //
+      // Only the OLTP path is covered here. The CSR path hands the whole computation to
+      // GraphAlgorithms#localClusteringCoefficient, which counts triangles across a thread pool, and the
+      // WorkCheckpoint hook #6264 introduced is specified to be called between iterations on the calling
+      // thread rather than from inside a parallel chunk - so covering that kernel is a change to how it
+      // partitions its work, not a checkpoint that can be dropped in here.
+      guard.check();
       final int[] neighborsU = adj[u];
       for (final int v : neighborsU) {
         // Count common neighbors of u and v via sorted merge

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -137,14 +137,17 @@ public class AlgoMST extends AbstractAlgoProcedure {
     // pass 2.
     // Pass 1: count
     int edgeCount = 0;
+    int edgeStep = 0;
     for (int i = 0; i < n; i++) {
-      // Both passes deserialise every edge record of the graph, so each is O(V + E) of real work with nothing
-      // but the graph to bound it (issue #6302).
-      guard.checkPeriodically(i);
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
+        // Both passes deserialise every edge record of the graph, so each is O(V + E) of real work with nothing
+        // but the graph to bound it (issue #6302). Throttled by EDGE rather than by vertex: a near-star graph
+        // puts millions of edges inside a single vertex iteration, and a per-vertex checkpoint would leave that
+        // whole node unabortable - which is exactly the case the budget cannot catch when it is disabled.
+        guard.checkPeriodically(edgeStep++);
         try {
           if (ridToIdx.containsKey(e.getIn())) {
             edgeCount++;
@@ -170,12 +173,13 @@ public class AlgoMST extends AbstractAlgoProcedure {
     final int[]    ev = new int[edgeCount];
     final double[] ew = new double[edgeCount];
     int ec = 0;
+    edgeStep = 0;
     for (int i = 0; i < n; i++) {
-      guard.checkPeriodically(i);
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
+        guard.checkPeriodically(edgeStep++);
         try {
           final Integer j = ridToIdx.get(e.getIn());
           if (j == null)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -50,11 +51,23 @@ import java.util.stream.Stream;
  * RETURN source.name, target.name, weight
  * </pre>
  * </p>
+ * <p>
+ * Working set: three edge-sized arrays plus the index sort's two, 24 bytes per edge, reserved through
+ * {@link AbstractAlgoProcedure.MemoryBudget} as the counting pass runs so that a graph too large to serve is
+ * refused mid-walk rather than after one (issue #6300). The passes themselves and Kruskal's loop carry a
+ * {@link WorkGuard} checkpoint, since O(E log E) over a graph nothing bounds has to be abortable (issue #6302).
+ * </p>
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class AlgoMST extends AbstractAlgoProcedure {
   public static final String NAME = "algo.mst";
+
+  /**
+   * Heap this procedure spends per edge: the two endpoint arrays and the weight array it fills, plus the index
+   * array and merge scratch {@link #sortedIndexesByWeight(double[], int)} allocates over them.
+   */
+  private static final long EDGE_BYTES = 2 * INT_BYTES + DOUBLE_BYTES + 2 * INT_BYTES;
 
   @Override
   public String getName() {
@@ -89,6 +102,7 @@ public class AlgoMST extends AbstractAlgoProcedure {
     final String[] relTypes     = args.length > 1 ? extractRelTypes(args[1]) : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
     final List<Vertex> vertices = new ArrayList<>();
     final Iterator<Vertex> iter = getAllVertices(db, null);
     while (iter.hasNext())
@@ -100,6 +114,22 @@ public class AlgoMST extends AbstractAlgoProcedure {
 
     final Map<RID, Integer> ridToIdx = buildRidIndex(vertices);
 
+    // The working set here is sized by the EDGE count, which is the one dense shape #6263 did not price: its
+    // criterion was "knob-sized or quadratic in the node count", and edge-linear reads like the graph paying for
+    // itself. It is not small - the edge count is the largest linear dimension a graph has, usually an order of
+    // magnitude above the node count - and linear was never the criterion. What matters is whether the caller can
+    // predict a ceiling, and here there is none: 100M edges ask for ~2.4 GB with nothing between them and the
+    // allocator (issue #6300).
+    //
+    // 24 bytes per edge: the endpoints eu/ev and the weight ew, plus the two int arrays sortedIndexesByWeight
+    // works over (the order and the merge scratch).
+    //
+    // The budget is consulted as pass 1 counts rather than once it is done. Both refuse the same calls, but a
+    // check afterwards first pays in full for a traversal it will throw away - the same argument that puts
+    // algo.steinerTree's reservation ahead of its adjacency build.
+    final MemoryBudget memory = newMemoryBudget(db);
+    final long maxEdges = memory.capacityFor(EDGE_BYTES);
+
     // Collect edges — two passes to allocate primitive arrays without reallocation. Ghost edges are
     // skipped identically in both passes (same getEdges() order), so the pass-2 fill never exceeds the
     // pass-1 count and the arrays are always sized correctly. This is safe because an edge record is
@@ -108,18 +138,32 @@ public class AlgoMST extends AbstractAlgoProcedure {
     // Pass 1: count
     int edgeCount = 0;
     for (int i = 0; i < n; i++) {
+      // Both passes deserialise every edge record of the graph, so each is O(V + E) of real work with nothing
+      // but the graph to bound it (issue #6302).
+      guard.checkPeriodically(i);
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
         try {
-          if (ridToIdx.containsKey(e.getIn()))
+          if (ridToIdx.containsKey(e.getIn())) {
             edgeCount++;
+            if (edgeCount > maxEdges)
+              // Over budget: reserve() is what refuses, so the message names the same component, figure and
+              // setting it would have named had the count finished first.
+              memory.reserve(saturatingProduct(edgeCount, EDGE_BYTES), "the edge arrays",
+                  "more than " + maxEdges + " edges");
+          }
         } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }
+    // Succeeds by construction - the loop above stopped the walk the moment the count passed what the budget
+    // allows - and is made anyway so the reservation is recorded against the call rather than only tested. What
+    // it costs is one comparison; what it buys is that `reserved` describes the heap this call actually holds,
+    // which is the invariant every other component priced here relies on.
+    memory.reserve(saturatingProduct(edgeCount, EDGE_BYTES), "the edge arrays", edgeCount + " edges");
 
     // Pass 2: fill primitive arrays
     final int[]    eu = new int[edgeCount];
@@ -127,6 +171,7 @@ public class AlgoMST extends AbstractAlgoProcedure {
     final double[] ew = new double[edgeCount];
     int ec = 0;
     for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
@@ -168,6 +213,8 @@ public class AlgoMST extends AbstractAlgoProcedure {
     double totalWeight = 0.0;
 
     for (int k = 0; k < ec && mstSize < n - 1; k++) {
+      // O(E) iterations of two union-find finds each - small enough per iteration to throttle the check.
+      guard.checkPeriodically(k);
       final int idx = sortIdx[k];
       final int ru  = find(parent, eu[idx]);
       final int rv  = find(parent, ev[idx]);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,6 +93,7 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
     final String capacityProperty = args.length > 3 ? extractString(args[3], "capacityProperty") : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
     final List<Vertex> vertices = new ArrayList<>();
     final Iterator<Vertex> iter = getAllVertices(db, null);
     while (iter.hasNext())
@@ -152,6 +154,10 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
     double maxFlow = 0.0;
 
     while (true) {
+      // Edmonds-Karp augments once per iteration and each augmentation is a BFS over the dense residual
+      // matrix, so the loop is O(V x E²) with the graph alone sizing it - no knob, and until issue #6302 no
+      // way for a thread interrupt or arcadedb.command.timeout to end it.
+      guard.check();
       // BFS to find augmenting path from src to snk
       Arrays.fill(parent, -1);
       parent[srcIdx] = srcIdx;
@@ -160,6 +166,9 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
 
       bfs:
       while (head < tail) {
+        // Scanning one settled node's residual row is O(V), so a single BFS is O(V²) and needs a checkpoint of
+        // its own rather than one per augmentation.
+        guard.check();
         final int u = queue[head++];
         for (int v = 0; v < n; v++) {
           if (parent[v] == -1 && residual[u][v] > 0) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -95,6 +96,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     final String weightProperty = args.length > 2 ? extractString(args[2], "weightProperty") : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
     final List<Vertex> vertices = new ArrayList<>();
     final Iterator<Vertex> it = getAllVertices(db, null);
     while (it.hasNext())
@@ -160,7 +162,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     }
 
     // Run Chu-Liu/Edmonds on node IDs 0..n-1, root = rootIdx
-    final int[] msaEdges = edmonds(n, rootIdx, eFrom, eTo, eW, ec);
+    final int[] msaEdges = edmonds(guard, n, rootIdx, eFrom, eTo, eW, ec);
     if (msaEdges == null)
       return Stream.empty();
 
@@ -194,8 +196,13 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
    * @param eW         edge weight array
    * @param m          number of edges
    */
-  private static int[] edmonds(final int n, final int root,
+  private static int[] edmonds(final WorkGuard guard, final int n, final int root,
       final int[] eFrom, final int[] eTo, final double[] eW, final int m) {
+    // Contracting one cycle per level and re-running over every edge is O(V x E), with the graph alone sizing
+    // both factors: the same Kruskal/Borůvka-shaped family as algo.mst, and equally unabortable before issue
+    // #6302. One level is already a full pass over the edges, so the check is placed per level and per traced
+    // path rather than per edge.
+    guard.check();
     if (n == 1)
       return new int[0];
 
@@ -230,6 +237,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     final int[][] cycleNodes = new int[n][]; // cycleNodes[c] = nodes in cycle c
 
     for (int start = 0; start < n; start++) {
+      guard.checkPeriodically(start);
       if (start == root || color[start] == 2)
         continue;
 
@@ -323,7 +331,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     }
 
     // ── Step 5: recurse on contracted graph ─────────────────────────────────
-    final int[] subResult = edmonds(newN, newRoot, nFrom, nTo, nW, newM);
+    final int[] subResult = edmonds(guard, newN, newRoot, nFrom, nTo, nW, newM);
     if (subResult == null)
       return null;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRichClub.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRichClub.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,6 +83,7 @@ public class AlgoRichClub extends AbstractAlgoProcedure {
     final int minDegree = args.length > 1 && args[1] instanceof Number n ? extractInt(n, "minDegree") : 2;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -108,6 +110,9 @@ public class AlgoRichClub extends AbstractAlgoProcedure {
     final List<Result> results = new ArrayList<>(maxDegree - minDegree + 1);
 
     for (int k = minDegree; k <= maxDegree; k++) {
+      // One pass over every node and every edge per degree threshold, and the number of thresholds is the
+      // graph's maximum degree: O(maxDegree x (V + E)), sized entirely by the graph (issue #6302).
+      guard.check();
       // Build mask: nodes with degree > k
       final boolean[] inRichClub = new boolean[n];
       int nodeCount = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSLPA.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSLPA.java
@@ -137,6 +137,9 @@ public class AlgoSLPA extends AbstractAlgoProcedure {
 
     // Each node starts with a unique label equal to its index
     for (int i = 0; i < n; i++) {
+      // Allocating and zeroing nodeCount x (iterations + 1) ints is the same product the budget prices, and it
+      // happens before the first propagation round - so it needs its own checkpoint (issue #6295).
+      guard.checkPeriodically(i);
       memory[i] = new int[(int) rowCapacity];
       memory[i][0] = i;
       memorySize[i] = 1;
@@ -175,18 +178,26 @@ public class AlgoSLPA extends AbstractAlgoProcedure {
         }
 
         // Listener adds the most-frequent heard label to its memory
-        final int mostFreq = mostFrequent(heard, heardCount, rng);
+        final int mostFreq = mostFrequent(heard, heardCount, rng, guard);
         memory[listener][memorySize[listener]++] = mostFreq;
       }
     }
 
     // Post-processing: keep only labels with relative frequency >= threshold
     // Pre-compute communities for all nodes (pure int/map work, no vertex loading)
+    //
+    // Outside the propagation rounds, so the checkpoint inside them never sees this: nodeCount x (iterations + 1)
+    // boxed map merges, which is the same product the label memory is priced on. The budget bounds the heap that
+    // product costs and says nothing about the time, so at a raised arcadedb.cypher.algoMaxWorkingMemory this
+    // grows without any checkpoint behind it (issue #6295). The counter spans both loops for the same reason it
+    // does in algo.hashgnn: a per-node check is too coarse when one node remembers a million labels.
     @SuppressWarnings("unchecked")
     final List<Long>[] allCommunities = new List[n];
+    int postStep = 0;
     for (int i = 0; i < n; i++) {
       final Map<Integer, Integer> freq = new HashMap<>();
       for (int j = 0; j < memorySize[i]; j++) {
+        guard.checkPeriodically(postStep++);
         final int label = memory[i][j];
         freq.merge(label, 1, Integer::sum);
       }
@@ -209,12 +220,20 @@ public class AlgoSLPA extends AbstractAlgoProcedure {
     });
   }
 
-  /** Returns the most-frequent element in arr[0..len), breaking ties randomly. */
-  private int mostFrequent(final int[] arr, final int len, final Random rng) {
+  /**
+   * Returns the most-frequent element in arr[0..len), breaking ties randomly.
+   * <p>
+   * The scan is O(len²) in the listener's degree, so one supernode's turn is a whole quadratic pass between two
+   * of the caller's per-node checkpoints - 4e8 comparisons at degree 20 000. The guard comes in with the array
+   * for that reason (issue #6295): the checkpoint on the outer scan bounds the abort latency by 1024 x len
+   * rather than by len², and costs one flag test per candidate where each candidate already costs a full pass.
+   */
+  private int mostFrequent(final int[] arr, final int len, final Random rng, final WorkGuard guard) {
     // Frequency map using arrays (avoid HashMap allocation for small len)
     int bestLabel = arr[0], bestCount = 0;
     // Simple O(len^2) scan — len = number of neighbours, typically small
     for (int i = 0; i < len; i++) {
+      guard.checkPeriodically(i);
       int count = 0;
       for (int j = 0; j < len; j++)
         if (arr[j] == arr[i]) count++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
@@ -19,12 +19,11 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.RID;
-import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,7 +60,14 @@ import java.util.stream.Stream;
  * <p>Working set: a {@code terminals x nodeCount} pair of Dijkstra tables plus one entry per terminal pair -
  * about {@code t²/2} of them - in five parallel primitive arrays, both reserved through
  * {@link AbstractAlgoProcedure.MemoryBudget} before anything is allocated. Quadratic in a list the caller
- * supplies and nothing bounds, which is why the pair count is also computed in {@code long}.</p>
+ * supplies and nothing bounds, which is why the pair count is also computed in {@code long}. The time it buys is
+ * bounded the other way, by a {@link WorkGuard} checkpoint in each of the Dijkstra, Kruskal and pruning loops
+ * (issue #6302).</p>
+ *
+ * <p>Edge weights are read through {@code GraphData.weightedAdjacency}, which produces the neighbour list and its
+ * weights from one walk of the same edges. Deriving them from a second, independently ordered traversal is what
+ * made a {@code relTypes} filter and the mere presence of a Graph Analytical View each change the tree this
+ * procedure returned (issue #6301).</p>
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -104,6 +110,7 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
       return Stream.empty();
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
     final int n = graph.nodeCount;
@@ -135,9 +142,15 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
       throw new IllegalArgumentException(getName() + "(): " + t + " terminalNodes make " + pairCount
           + " terminal pairs, more than the " + Integer.MAX_VALUE + " entries a Java array can hold");
 
-    // Build weighted adjacency lists (undirected for shortest paths)
-    final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH, relTypes);
-    final double[][] adjW = buildWeightedAdj(graph, adj, weightProperty);
+    // Build weighted adjacency lists (undirected for shortest paths). Neighbours and weights come out of one
+    // walk of the same edges, which is what keeps `adjW[i][j]` the weight of the edge to `adj[i][j]`: the
+    // hand-rolled second traversal this replaced filled the weights positionally from an unfiltered
+    // getEdges(BOTH) walk and attached them to whatever neighbour happened to sit at that index, so a relTypes
+    // filter or a Graph Analytical View each silently changed the tree Dijkstra went on to find (issue #6301).
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(Vertex.DIRECTION.BOTH, weightProperty,
+        relTypes);
+    final int[][] adj = weighted.neighbors();
+    final double[][] adjW = weighted.weights();
 
     // Map terminals to their indices
     final int[] termIdx = new int[t];
@@ -152,9 +165,12 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
     final double[][] dist = new double[t][n]; // dist[ti][v] = shortest path from terminal ti to v
     final int[][] prev = new int[t][n];       // prev[ti][v] = predecessor of v in Dijkstra from ti
     for (int ti = 0; ti < t; ti++) {
+      // One Dijkstra per terminal over the whole graph: O(t x (V + E) log V), sized by a terminal list the
+      // caller supplies and by the graph, with no knob to cap either (issue #6302).
+      guard.check();
       Arrays.fill(dist[ti], Double.MAX_VALUE);
       Arrays.fill(prev[ti], -1);
-      dijkstra(termIdx[ti], adj, adjW, dist[ti], prev[ti]);
+      dijkstra(termIdx[ti], adj, adjW, dist[ti], prev[ti], guard);
     }
 
     // ── Step 2: Build complete graph on terminals, run MST (Kruskal's) ────
@@ -187,6 +203,9 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
     final int[] mstV = new int[t - 1];
     int mstSize = 0;
     for (int k = 0; k < pairs && mstSize < t - 1; k++) {
+      // `pairs` is quadratic in the terminal list, and one iteration is two union-find finds - small enough
+      // that the check is throttled rather than paid per pair.
+      guard.checkPeriodically(k);
       final int idx = sortIdx[k];
       if (pW[idx] == Double.MAX_VALUE)
         continue; // unreachable pair
@@ -237,8 +256,12 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
     // Iteratively remove non-terminal leaves
     boolean changed = true;
     while (changed) {
+      // Leaf pruning repeats until a whole pass changes nothing, so it is O(V x (V + E)) in the worst case -
+      // one more graph-driven loop with nothing to bound it.
+      guard.check();
       changed = false;
       for (int i = 0; i < n; i++) {
+        guard.checkPeriodically(i);
         if (!steinerNodes[i] || isTerminal(i, termIdx))
           continue;
         if (steinerDeg[i] == 1) {
@@ -294,12 +317,14 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
   // ── Dijkstra ─────────────────────────────────────────────────────────────
 
   private static void dijkstra(final int src, final int[][] adj, final double[][] adjW,
-      final double[] dist, final int[] prev) {
+      final double[] dist, final int[] prev, final WorkGuard guard) {
     dist[src] = 0.0;
     // PriorityQueue entry: [cost, node]
     final PriorityQueue<double[]> pq = new PriorityQueue<>(Comparator.comparingDouble(e -> e[0]));
     pq.offer(new double[]{ 0.0, src });
     while (!pq.isEmpty()) {
+      // Settling one node costs its degree, which on a supernode is the whole edge list.
+      guard.check();
       final double[] top = pq.poll();
       final double d = top[0];
       final int u = (int) top[1];
@@ -353,39 +378,5 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
         return;
       }
     }
-  }
-
-  private double[][] buildWeightedAdj(final GraphData graph, final int[][] adj,
-      final String weightProp) {
-    final int n = graph.nodeCount;
-    final double[][] adjW = new double[n][];
-    for (int i = 0; i < n; i++) {
-      adjW[i] = new double[adj[i].length];
-      Arrays.fill(adjW[i], 1.0);
-    }
-    if (weightProp == null)
-      return adjW;
-    for (int i = 0; i < n; i++) {
-      final Iterable<Edge> edges = graph.getVertex(i).getEdges(Vertex.DIRECTION.BOTH);
-      // Build a temporary map: neighbour index → weight
-      final double[] tmpW = new double[adj[i].length];
-      Arrays.fill(tmpW, 1.0);
-      int pos = 0;
-      for (final Edge e : edges) {
-        final RID nbRid = neighborRid(e, graph.getRID(i), Vertex.DIRECTION.BOTH);
-        if (nbRid == null)
-          continue;
-        final int nbIdx = graph.indexOf(nbRid);
-        if (nbIdx < 0)
-          continue;
-        if (pos < adj[i].length) {
-          final Object w = e.get(weightProp);
-          tmpW[pos] = w instanceof Number num ? num.doubleValue() : 1.0;
-          pos++;
-        }
-      }
-      adjW[i] = tmpW;
-    }
-    return adjW;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
@@ -147,7 +147,7 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
     // hand-rolled second traversal this replaced filled the weights positionally from an unfiltered
     // getEdges(BOTH) walk and attached them to whatever neighbour happened to sit at that index, so a relTypes
     // filter or a Graph Analytical View each silently changed the tree Dijkstra went on to find (issue #6301).
-    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(Vertex.DIRECTION.BOTH, weightProperty,
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, Vertex.DIRECTION.BOTH, weightProperty,
         relTypes);
     final int[][] adj = weighted.neighbors();
     final double[][] adjW = weighted.weights();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoTriangleCount.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoTriangleCount.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.BitSet;
 import java.util.List;
@@ -82,6 +83,7 @@ public class AlgoTriangleCount extends AbstractAlgoProcedure {
     final String[] relTypes = args.length > 0 ? extractRelTypes(args[0]) : null;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -105,6 +107,10 @@ public class AlgoTriangleCount extends AbstractAlgoProcedure {
     // For each node u, for each neighbor v of u, count common neighbors
     // Each triangle (u,v,w) is counted at u via (v,w) AND via (w,v) → divide by 2
     for (int u = 0; u < n; u++) {
+      // One node costs the sum of its neighbours' degrees, so the whole loop is O(sum of degree²) - quadratic
+      // in the degree distribution, and a single supernode's turn is long enough to want the check unthrottled
+      // (issue #6302).
+      guard.check();
       long count = 0;
       final int[] nu = adj[u];
       for (int ki = 0; ki < nu.length; ki++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoVoteRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoVoteRank.java
@@ -23,6 +23,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.utility.NumberUtils;
 
 import java.util.ArrayList;
@@ -83,6 +84,7 @@ public class AlgoVoteRank extends AbstractAlgoProcedure {
     final int topK          = args.length > 1 ? NumberUtils.saturateToInt((Number) args[1]) : Integer.MAX_VALUE;
 
     final Database db = context.getDatabase();
+    final WorkGuard guard = newWorkGuard(context);
 
     final GraphData graph = loadGraph(db, null, relTypes, context);
 
@@ -112,6 +114,9 @@ public class AlgoVoteRank extends AbstractAlgoProcedure {
     int electedCount = 0;
 
     while (electedCount < limit) {
+      // One election per round, each a full scan of the nodes plus a two-hop walk from the winner: O(topK x
+      // (V + E)), and topK defaults to "every node" (issue #6302).
+      guard.check();
       // Find node with highest vote score among non-elected
       int best = -1;
       double bestScore = -1.0;

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6301CsrEdgeWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6301CsrEdgeWeightAlignmentTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.graph;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6301 in the two SQL graph functions that read edge weights out of a Graph
+ * Analytical View: {@code astar()} and {@code bellmanFord()}.
+ * <p>
+ * Both paired {@link com.arcadedb.graph.GraphTraversalProvider#getNeighborIds} with
+ * {@link com.arcadedb.graph.GraphTraversalProvider#getEdgeProperty} by hand, which is wrong in two independent
+ * ways and silently so - a wrong weight produces a wrong path, never an exception:
+ * <ul>
+ *   <li><b>a multi-type neighbour list is merged and sorted across types</b>, while the property columns are per
+ *       type, so position {@code j} in the list is not position {@code j} in any one column;</li>
+ *   <li><b>{@code BOTH} has no column at all.</b> A provider resolves {@code OUT} and {@code IN} only, so a
+ *       {@code BOTH} lookup answers {@code null} for every edge - and {@code bellmanFord}'s direction argument
+ *       <em>defaults</em> to {@code BOTH}, which made the plain three-argument call unit-weight the whole graph
+ *       the moment a view existed.</li>
+ * </ul>
+ * Both now go through {@code GraphTraversalProvider.edgeWeightsOf}, which walks one slice per (type, direction)
+ * and is the same helper the {@code algo.*} procedures use, so the three cannot drift apart again.
+ * <p>
+ * The fixture is the discriminator: {@code A-B-C-D} at 1.0 per hop against a direct {@code A-C} at 100.0. By
+ * weight the shortest path from A to D is the four-vertex {@code A-B-C-D}; by hop count - which is what unit
+ * weights collapse to - it is the three-vertex {@code A-C-D}. So a test that gets the weights wrong does not
+ * merely report a wrong number, it returns a different path.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6301CsrEdgeWeightAlignmentTest {
+  private Database        database;
+  private MutableVertex[] nodes;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6301-csr-edge-weights");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("node");
+    // Declared, so a view built over it actually materialises the edge property column - without the declaration
+    // the columnar path is never taken and this test would silently pin the OLTP one twice.
+    database.getSchema().createEdgeType("road").createProperty("weight", Type.DOUBLE);
+
+    database.transaction(() -> {
+      nodes = new MutableVertex[4];
+      for (int i = 0; i < 4; i++)
+        nodes[i] = database.newVertex("node").set("name", String.valueOf((char) ('A' + i))).save();
+      nodes[0].newEdge("road", nodes[1], true, new Object[] { "weight", 1.0 }).save();
+      nodes[1].newEdge("road", nodes[2], true, new Object[] { "weight", 1.0 }).save();
+      nodes[2].newEdge("road", nodes[3], true, new Object[] { "weight", 1.0 }).save();
+      nodes[0].newEdge("road", nodes[2], true, new Object[] { "weight", 100.0 }).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void bellmanFordKeepsItsWeightsOnACsrBackedGraph() {
+    assertThat(bellmanFordPath()).as("OLTP: A-B-C-D costs 3.0, the direct A-C hop alone costs 100.0")
+        .containsExactly(rid(0), rid(1), rid(2), rid(3));
+
+    final GraphAnalyticalView view = weightedView("bellman-csr-view");
+    try {
+      assertThat(bellmanFordPath())
+          .as("the same call with a view present: BOTH has no property column, so this used to unit-weight "
+              + "every edge and return the two-hop A-C-D instead")
+          .containsExactly(rid(0), rid(1), rid(2), rid(3));
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void astarKeepsItsWeightsOnACsrBackedGraph() {
+    // Directions are exercised both ways round: OUT is the direction whose column exists, BOTH is the one that
+    // has none and used to price every edge at MIN - which for astar is 0.0, i.e. free, so every path tied and
+    // the first one found won.
+    for (final String direction : new String[] { "OUT", "BOTH" }) {
+      assertThat(astarPath(direction)).as("OLTP, direction=%s", direction)
+          .containsExactly(rid(0), rid(1), rid(2), rid(3));
+    }
+
+    final GraphAnalyticalView view = weightedView("astar-csr-view");
+    try {
+      for (final String direction : new String[] { "OUT", "BOTH" }) {
+        assertThat(astarPath(direction)).as("view present, direction=%s", direction)
+            .containsExactly(rid(0), rid(1), rid(2), rid(3));
+      }
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void aViewMaterialisingAnotherPropertyDoesNotUnweightTheGraph() {
+    // The other half of the same question: the view holds `other`, the call asks for `weight`. Every
+    // getEdgeProperty then answers null, which is indistinguishable from "this edge has no value", so the only
+    // safe reading is that the provider cannot serve the request at all.
+    database.getSchema().getType("road").createProperty("other", Type.DOUBLE);
+    database.transaction(() -> {
+      for (final var edge : nodes[0].getEdges(Vertex.DIRECTION.OUT))
+        edge.asEdge().modify().set("other", 1.0).save();
+    });
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("other-property-view")
+        .withVertexTypes("node")
+        .withEdgeTypes("road")
+        .withEdgeProperties("other")
+        .build();
+    try {
+      assertThat(bellmanFordPath()).as("`other` is materialised, `weight` is not, so the records answer")
+          .containsExactly(rid(0), rid(1), rid(2), rid(3));
+    } finally {
+      view.drop();
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private GraphAnalyticalView weightedView(final String name) {
+    return GraphAnalyticalView.builder(database)
+        .withName(name)
+        .withVertexTypes("node")
+        .withEdgeTypes("road")
+        .withEdgeProperties("weight")
+        .build();
+  }
+
+  /** {@code bellmanFord(A, D, 'weight')} - three arguments, so the direction defaults to BOTH. */
+  @SuppressWarnings("unchecked")
+  private List<RID> bellmanFordPath() {
+    database.begin();
+    try {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      return (List<RID>) new SQLFunctionBellmanFord().execute(null, null, null,
+          new Object[] { nodes[0], nodes[3], "'weight'" }, context);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  private List<RID> astarPath(final String direction) {
+    database.begin();
+    try {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final Map<String, Object> options = new HashMap<>();
+      options.put("direction", direction);
+      options.put("edgeTypeNames", new String[] { "road" });
+      return new SQLFunctionAstar().execute(null, null, null,
+          new Object[] { nodes[0], nodes[3], "'weight'", options }, context);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  private RID rid(final int index) {
+    return nodes[index].getIdentity();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6295AlgoUnguardedPhaseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6295AlgoUnguardedPhaseTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6295 - the phase an {@code algo.*} call actually spends its time in is not always
+ * the loop its knob drives, and the phases <em>after</em> that loop are where #6216 and #6264 stopped looking.
+ * <p>
+ * Both of those issues hunted knobs whose value is unbounded. {@code algo.hashgnn}'s {@code embeddingDimension}
+ * is not one - #6065 capped it at 4096 - which is exactly why the lens walked past it. The MinHash reduction runs
+ * after the {@code iterations} loop and costs {@code embeddingDimension x numFeatures} = 4 x
+ * {@code embeddingDimension²} operations <em>per node</em>, and that bounded per-node figure is then multiplied
+ * by an unbounded node count. Measured on {@code main}: 112,988 ms against a 1000 ms
+ * {@code arcadedb.command.timeout}, and the call returned a result rather than aborting.
+ * <p>
+ * The question that finds this shape is not "which knob has no ceiling" but <b>"which loop over the node count
+ * has no checkpoint"</b>. Asking it across the package turned up {@code algo.slpa}'s post-processing (one boxed
+ * map merge per remembered label, {@code nodeCount x (iterations + 1)} of them, after the propagation rounds),
+ * {@code algo.slpa}'s {@code mostFrequent} (O(degree²) for one listener, between two per-node checkpoints), and
+ * the pre-loop initialisation of {@code algo.hashgnn}, {@code algo.fastrp} and {@code algo.graphsage}.
+ * <p>
+ * <b>Only {@code algo.hashgnn}'s reduction is pinned as a binary outcome here</b>, and the reason the others are
+ * not is worth recording rather than papering over. A test of that kind needs a fixture where the unguarded phase
+ * outlasts a deadline that the guarded phase before it comfortably survives, and only the reduction gives that: it
+ * is three orders of magnitude larger than the message-passing round beside it. The rest are the same defect at a
+ * far smaller scale, and their cost sits within a small factor of the guarded phase that precedes them - SLPA's
+ * propagation and its post-processing are both O(nodeCount x iterations) and were measured at the same order, and
+ * the initialisation phases of {@code algo.fastrp} and {@code algo.graphsage} are O(nodeCount x dimension) beside a
+ * first layer that costs the same. Any threshold picked between two phases that close together would be measuring
+ * the fixture and the runner, not the checkpoint. The issue's own numbers say as much: 113x over the deadline for
+ * the reduction against 1086 ms over a 1000 ms deadline for SLPA. They are still fixed - a checkpoint that cannot
+ * be isolated by a test is not a checkpoint that does nothing - and {@link #theGuardedPhasesStillProduceTheirResult}
+ * pins that adding them changed no answer.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6295AlgoUnguardedPhaseTest {
+  private Database database;
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * {@code algo.hashgnn}'s MinHash reduction, with the {@code iterations} loop deliberately reduced to a single
+   * round so that the checkpoint #6264 put inside it runs once, before any real work, and cannot be what fires.
+   * <p>
+   * 300 nodes at {@code embeddingDimension: 2048} is 300 x 2048 x 8192 ≈ 5e9 inner iterations in the reduction
+   * against 300 x 2 x 8192 ≈ 5e6 in the single message-passing round - three orders of magnitude apart, so a 1 s
+   * deadline can only land in the reduction. Without a checkpoint there the call grinds through all of it and
+   * returns embeddings; with one it gives up about a second in.
+   */
+  @Test
+  @Tag("slow")
+  @Timeout(300)
+  void hashGnnObservesTheDeadlineInsideTheMinHashReduction() {
+    cycle("test-issue-6295-hashgnn-minhash", 300);
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 1_000L);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drain(
+        "CALL algo.hashgnn({embeddingDimension: 2048, iterations: 1, seed: 1}) YIELD node RETURN node"))
+        .as("the reduction is where an algo.hashgnn call spends its time, so it is where the deadline has to be seen")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+
+    stopwatch.assertGaveUpWithin(120_000L, "a reduction aborted from inside, not one run to completion");
+  }
+
+  /**
+   * The counterweight: with no deadline configured, every procedure the sweep touched still produces its result at
+   * an ordinary size. A checkpoint that aborted a healthy run, or one placed where it changes the answer, would
+   * satisfy the test above and fail here - which is what covers the phases that cannot be isolated by a deadline.
+   */
+  @Test
+  @Timeout(120)
+  void theGuardedPhasesStillProduceTheirResult() {
+    cycle("test-issue-6295-unguarded-phases-happy-path", 40);
+
+    assertThat(drain("CALL algo.hashgnn({embeddingDimension: 16, iterations: 2, seed: 1}) YIELD node, embedding "
+        + "RETURN node, embedding")).hasSize(40);
+    assertThat(drain("CALL algo.slpa({iterations: 5, seed: 1}) YIELD node, communities RETURN node, communities"))
+        .hasSize(40);
+    assertThat(drain("CALL algo.fastrp({dimensions: 16, iterations: 2, seed: 1}) YIELD node RETURN node"))
+        .hasSize(40);
+    assertThat(drain("CALL algo.graphsage({embeddingDimension: 16, layers: 2, seed: 1}) YIELD node RETURN node"))
+        .hasSize(40);
+  }
+
+  // ── Fixtures ─────────────────────────────────────────────────────────────
+
+  /** A directed cycle of {@code nodeCount} nodes: every node has one out-edge and one in-edge. */
+  private void cycle(final String name, final int nodeCount) {
+    create(name);
+    database.transaction(() -> {
+      final List<MutableVertex> nodes = new ArrayList<>(nodeCount);
+      for (int i = 0; i < nodeCount; i++)
+        nodes.add(database.newVertex("Node").set("idx", i).save());
+      for (int i = 0; i < nodeCount; i++)
+        nodes.get(i).newEdge("LINK", nodes.get((i + 1) % nodeCount), true, (Object[]) null).save();
+    });
+  }
+
+  private void create(final String name) {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/" + name);
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+  }
+
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
+    final ResultSet rs = database.query("opencypher", query);
+    while (rs.hasNext())
+      rows.add(rs.next());
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6300 - {@code algo.mst} was the one dense {@code algo.*} path the #6263
+ * working-memory budget did not price.
+ * <p>
+ * #6263 reserved the dense working set of every procedure that builds one, choosing them by two criteria: sized by
+ * a knob, or quadratic in the node count. {@code algo.mst} is neither. It is linear in the <em>edge</em> count -
+ * three parallel arrays plus the index sort, 24 bytes per edge - which reads like the graph paying for itself.
+ * But linear in the edge count is not small: the edge count is the largest linear dimension a graph has, usually
+ * an order of magnitude above the node count, and 100M edges is ~2.4 GB requested with no check and no error
+ * naming what asked for it. "Linear" was never the criterion; the criterion is whether the caller can predict a
+ * ceiling, and here there is none.
+ * <p>
+ * The reservation is made as the counting pass runs rather than once it has finished. Both refuse the same calls,
+ * but a check afterwards first pays in full for a traversal it will then throw away - the same argument that puts
+ * {@code algo.steinerTree}'s reservation ahead of its adjacency build. The refusal itself still goes through
+ * {@code MemoryBudget.reserve}, so the message names the same component and the same setting either way.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6300AlgoMSTEdgeBudgetTest {
+  /** Ten edges, so a budget sized for four of them is refused while a default budget is not. */
+  private static final int EDGE_COUNT = 10;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6300-mst-edge-budget");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // A path of EDGE_COUNT + 1 nodes: connected, so the MST spans every node and no edge is redundant.
+    database.transaction(() -> {
+      final List<MutableVertex> nodes = new ArrayList<>(EDGE_COUNT + 1);
+      for (int i = 0; i <= EDGE_COUNT; i++)
+        nodes.add(database.newVertex("Node").set("idx", i).save());
+      for (int i = 0; i < EDGE_COUNT; i++)
+        nodes.get(i).newEdge("LINK", nodes.get(i + 1), true, new Object[] { "w", (double) (i + 1) }).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void theEdgeArraysAreRefusedWhenTheyDoNotFitTheBudget() {
+    // 24 bytes per edge, so 100 bytes buys four of them and the fifth is over.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+
+    assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source, target RETURN source, target"))
+        .as("the edge arrays are the dense working set of an algo.mst call and must be priced like any other")
+        .hasStackTraceContaining("algo.mst(): the edge arrays would need")
+        .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+  }
+
+  @Test
+  void theRefusalNamesTheEdgeCountItStoppedAt() {
+    // The message quotes the count reached, not the graph's total: the walk stops when the budget runs out, so
+    // there is no total to quote yet. That is the observable difference between reserving during the counting
+    // pass and reserving after it - and it is the whole point of the placement.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+
+    assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source RETURN source"))
+        .hasStackTraceContaining("more than 4 edges");
+  }
+
+  @Test
+  void aBudgetThatFitsLetsTheCallThrough() {
+    // The counterweight: the reservation must not refuse a graph it can serve. 10 edges at 24 bytes is 240, so
+    // 1 KB is comfortable, and the MST of a path is the path itself - every edge, at its own weight.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1024L);
+
+    final List<Object> rows = drain("CALL algo.mst('w') YIELD source, weight, totalWeight RETURN source, weight, totalWeight");
+    assertThat(rows).hasSize(EDGE_COUNT);
+  }
+
+  @Test
+  void aDisabledBudgetPricesNothing() {
+    // A negative limit means "no limit" throughout the budget, and it must reach the per-edge capacity too -
+    // a capacity computed by dividing a negative limit would refuse every graph instead of accepting them all.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, -1L);
+
+    assertThat(drain("CALL algo.mst('w') YIELD source RETURN source")).hasSize(EDGE_COUNT);
+  }
+
+  @Test
+  void theMinimumSpanningTreeIsUnchanged() {
+    // The reservation and the checkpoints must not move the answer. On a path every edge is a bridge, so the MST
+    // is the whole path and its total weight is 1 + 2 + ... + EDGE_COUNT.
+    final ResultSet rs = database.query("opencypher",
+        "CALL algo.mst('w') YIELD weight, totalWeight RETURN weight, totalWeight");
+    double sum = 0.0;
+    int rows = 0;
+    double reportedTotal = -1.0;
+    while (rs.hasNext()) {
+      final var row = rs.next();
+      sum += ((Number) row.getProperty("weight")).doubleValue();
+      reportedTotal = ((Number) row.getProperty("totalWeight")).doubleValue();
+      rows++;
+    }
+
+    assertThat(rows).isEqualTo(EDGE_COUNT);
+    assertThat(sum).isEqualTo(EDGE_COUNT * (EDGE_COUNT + 1) / 2.0);
+    assertThat(reportedTotal).isEqualTo(sum);
+  }
+
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
+    final ResultSet rs = database.query("opencypher", query);
+    while (rs.hasNext())
+      rows.add(rs.next());
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
@@ -274,6 +274,81 @@ class Issue6301AlgoSteinerTreeWeightAlignmentTest {
     }
   }
 
+  @Test
+  void aViewThatMaterialisedADifferentPropertyDoesNotMakeTheGraphUnweighted() {
+    // The narrower half of the same defect, and the one a coarse "does this view have edge properties?" gate
+    // walks straight into: the view materialises `other`, the query asks for `w`, so every getEdgeProperty
+    // returns null and every edge silently weighs 1.0 - which inverts the answer here, since X-Y-Z costs 2.0
+    // and the direct X-Z hop costs 50.0. A null property value is also how "this edge has no value" is
+    // reported, so the caller cannot tell the two apart and has to ask the sharper question up front.
+    database.getSchema().getType("ROAD").createProperty("other", Type.DOUBLE);
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      final MutableVertex z = database.newVertex("N").set("name", "Z").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 1.0, "other", 1.0 }).save();
+      y.newEdge("ROAD", z, true, new Object[] { "w", 1.0, "other", 1.0 }).save();
+      x.newEdge("ROAD", z, true, new Object[] { "w", 50.0, "other", 1.0 }).save();
+    });
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("steiner-view-other-property")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("other")
+        .build();
+    try {
+      final List<Result> rows = steinerTree("X", "Z", "ROAD", "w");
+      assertThat(totalWeightOf(rows))
+          .as("the view holds `other`, not `w`, so the weights must come from the edge records")
+          .isEqualTo(2.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void anActiveOverlayDoesNotLendItsWeightsToTheWrongEdges() {
+    // The overlay case, exercised through algo.bellmanford so the narrowing is pinned for a caller outside the
+    // procedures rewritten here. Edge property columns are aligned with the base CSR's forward slots, while
+    // getNeighborIds serves the overlay's view of the node - deletions dropped, additions merged, the list
+    // re-sorted - so the n-th neighbour is no longer the n-th edge of the column store. The provider now says
+    // it cannot serve edge properties in that state, and the weights come from the records instead.
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      final MutableVertex z = database.newVertex("N").set("name", "Z").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 1.0 }).save();
+      y.newEdge("ROAD", z, true, new Object[] { "w", 1.0 }).save();
+      x.newEdge("ROAD", z, true, new Object[] { "w", 50.0 }).save();
+    });
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("overlay-view")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.SYNCHRONOUS)
+        .build();
+    try {
+      assertThat(view.hasEdgeProperties()).as("no overlay yet, so the columns are addressable").isTrue();
+
+      // A committed change the synchronous view absorbs into its delta overlay rather than by rebuilding.
+      database.transaction(() -> {
+        final MutableVertex extra = database.newVertex("N").set("name", "W").save();
+        vertexOf("X").newEdge("ROAD", extra, true, new Object[] { "w", 7.0 }).save();
+      });
+
+      assertThat(view.hasEdgeProperties())
+          .as("with an overlay active the positional mapping no longer holds, so the honest answer is no")
+          .isFalse();
+      assertThat(view.hasEdgeProperty("ROAD", "w")).isFalse();
+      assertThat(bellmanFordWeight()).as("X-Y-Z at 2.0, read from the edge records").isEqualTo(2.0);
+    } finally {
+      view.drop();
+    }
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   /** The weight of the {@code algo.bellmanford} path from X to Z over the {@code w} property. */
@@ -326,6 +401,10 @@ class Issue6301AlgoSteinerTreeWeightAlignmentTest {
     } finally {
       database.rollback();
     }
+  }
+
+  private com.arcadedb.graph.Vertex vertexOf(final String name) {
+    return (com.arcadedb.graph.Vertex) vertexNamed(name);
   }
 
   private Object vertexNamed(final String name) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -372,8 +373,8 @@ class Issue6301AlgoSteinerTreeWeightAlignmentTest {
     try {
       final BasicCommandContext context = new BasicCommandContext();
       context.setDatabase(database);
-      final RID fromRid = ((com.arcadedb.graph.Vertex) vertexNamed(from)).getIdentity();
-      final RID toRid = ((com.arcadedb.graph.Vertex) vertexNamed(to)).getIdentity();
+      final RID fromRid = ((Vertex) vertexNamed(from)).getIdentity();
+      final RID toRid = ((Vertex) vertexNamed(to)).getIdentity();
       final List<Result> rows = collect(new AlgoAPSP().execute(new Object[] { "w" }, null, context));
       csrAccelerated = Boolean.TRUE.equals(context.getVariable(CommandContext.CSR_ACCELERATED_VAR));
       for (final Result row : rows)
@@ -403,8 +404,8 @@ class Issue6301AlgoSteinerTreeWeightAlignmentTest {
     }
   }
 
-  private com.arcadedb.graph.Vertex vertexOf(final String name) {
-    return (com.arcadedb.graph.Vertex) vertexNamed(name);
+  private Vertex vertexOf(final String name) {
+    return (Vertex) vertexNamed(name);
   }
 
   private Object vertexNamed(final String name) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6301AlgoSteinerTreeWeightAlignmentTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6301 - {@code algo.steinerTree} paired an edge weight with the neighbour it was
+ * <em>iterated at</em> rather than with the neighbour it belongs to.
+ * <p>
+ * The adjacency list was built with the {@code relTypes} filter applied and in the backing store's order; the
+ * weight array beside it was filled positionally from an <em>unfiltered</em> {@code getEdges(BOTH)} walk in OLTP
+ * order. Nothing reconciled the two, so {@code adjW[i][j]} was "the weight of the j-th edge I happened to see",
+ * not "the weight of the edge to {@code adj[i][j]}". That array is what Dijkstra runs on in step 1, so the tree
+ * itself moved, not merely the {@code weight} column of the result.
+ * <p>
+ * Two shapes make it visible, and both are pinned here:
+ * <ul>
+ *   <li>an edge type the caller excluded still lands its weight on an included edge;</li>
+ *   <li>the same query answers differently depending on whether a {@link GraphAnalyticalView} happens to exist,
+ *       because the CSR neighbour order need not match the OLTP one. A view is meant to be a transparent
+ *       accelerator, so this is the worst failure mode it has.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6301AlgoSteinerTreeWeightAlignmentTest {
+  private Database database;
+  /** Whether the last {@link #apspDistance} call actually went through a provider rather than the OLTP records. */
+  private boolean  csrAccelerated;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6301-steiner-weights");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    // The weight is a DECLARED property on both edge types: a Graph Analytical View only materialises an edge
+    // property column for a property the schema knows about, and without the column the view falls back to the
+    // edge records - which would leave the columnar half of the fix untested.
+    database.getSchema().createEdgeType("ROAD").createProperty("w", Type.DOUBLE);
+    database.getSchema().createEdgeType("NOISE").createProperty("w", Type.DOUBLE);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void anExcludedEdgeTypeDoesNotLendItsWeightToAnIncludedEdge() {
+    // X -ROAD(1)- Y -ROAD(1)- Z, plus one NOISE(999) edge hanging off X. `relTypes='ROAD'` excludes NOISE
+    // entirely, so the tree connecting X and Z is X-Y-Z and costs 2.0.
+    //
+    // Positionally, the NOISE edge was the first edge X's unfiltered walk produced, so its 999.0 landed on
+    // slot 0 of X's ROAD-only adjacency - the X-Y edge - and the answer came back 500x too expensive.
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      final MutableVertex z = database.newVertex("N").set("name", "Z").save();
+      final MutableVertex noise = database.newVertex("N").set("name", "NOISE_TARGET").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 1.0 }).save();
+      y.newEdge("ROAD", z, true, new Object[] { "w", 1.0 }).save();
+      x.newEdge("NOISE", noise, true, new Object[] { "w", 999.0 }).save();
+    });
+
+    final List<Result> rows = steinerTree("X", "Z", "ROAD", "w");
+
+    assertThat(rows).as("the tree connecting X and Z is X-Y-Z, two edges").hasSize(2);
+    for (final Result row : rows) {
+      assertThat(((Number) row.getProperty("weight")).doubleValue())
+          .as("every ROAD edge of the tree weighs 1.0; 999.0 belongs to the excluded NOISE edge")
+          .isEqualTo(1.0);
+      assertThat(((Number) row.getProperty("totalWeight")).doubleValue()).isEqualTo(2.0);
+    }
+  }
+
+  @Test
+  void theAnalyticalViewDoesNotChangeTheTree() {
+    // One edge type, no filter subtlety at all: X has two ROAD neighbours (Y at 1.0 and Z at 50.0) and Y-Z
+    // costs 1.0, so the cheapest tree joining X and Z is X-Y-Z at 2.0.
+    //
+    // The OLTP walk produced X's edges in creation order and the CSR produces them in dense-id order, so the
+    // positional pairing swapped 1.0 and 50.0 exactly when a view existed - and Dijkstra then preferred the
+    // direct 50.0 hop, returning a 51.0 tree for a query that had returned 2.0 a moment earlier.
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      final MutableVertex z = database.newVertex("N").set("name", "Z").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 1.0 }).save();
+      x.newEdge("ROAD", z, true, new Object[] { "w", 50.0 }).save();
+      y.newEdge("ROAD", z, true, new Object[] { "w", 1.0 }).save();
+    });
+
+    final List<Result> oltp = steinerTree("X", "Z", "ROAD", "w");
+    assertThat(totalWeightOf(oltp)).as("OLTP: the cheapest tree is X-Y-Z").isEqualTo(2.0);
+    assertThat(oltp).hasSize(2);
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("steiner-view")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      final List<Result> csr = steinerTree("X", "Z", "ROAD", "w");
+      assertThat(totalWeightOf(csr))
+          .as("a Graph Analytical View is a transparent accelerator: same query, same tree")
+          .isEqualTo(2.0);
+      assertThat(csr).hasSize(2);
+      for (final Result row : csr)
+        assertThat(((Number) row.getProperty("weight")).doubleValue()).isEqualTo(1.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void theViewIsActuallyExercised() {
+    // The counterweight to the test above: if the view were silently ignored, both halves of it would be the
+    // OLTP run and it would pin nothing. CSR_ACCELERATED_VAR is what the procedure sets when loadGraph()
+    // resolves a provider, so asserting on it is what makes the comparison meaningful.
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 3.0 }).save();
+    });
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("steiner-view-probe")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      database.begin();
+      try {
+        final BasicCommandContext context = new BasicCommandContext();
+        context.setDatabase(database);
+        final List<Result> rows = collect(new AlgoSteinerTree().execute(
+            new Object[] { List.of(vertexNamed("X"), vertexNamed("Y")), "ROAD", "w" }, null, context));
+
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("the view must actually back the call")
+            .isEqualTo(true);
+        assertThat(rows).hasSize(1);
+        assertThat(((Number) rows.getFirst().getProperty("weight")).doubleValue()).isEqualTo(3.0);
+      } finally {
+        database.rollback();
+      }
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void parallelEdgesOfTheSamePairKeepTheirOwnWeights() {
+    // Two ROAD edges join X and Y, at 7.0 and at 2.0. Whichever adjacency slot each lands in, the pair of
+    // weights present must be {2.0, 7.0} - so the shortest path from X to Y costs 2.0 and not 7.0. Pairing by
+    // neighbour rather than by position has to survive a neighbour appearing more than once.
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 7.0 }).save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 2.0 }).save();
+    });
+
+    final List<Result> rows = steinerTree("X", "Y", "ROAD", "w");
+    assertThat(rows).hasSize(1);
+    assertThat(totalWeightOf(rows)).isEqualTo(2.0);
+  }
+
+  @Test
+  void weightsSurviveAViewThatDidNotMaterialiseThem() {
+    // algo.bellmanford took the CSR path on the strength of the adjacency alone and then, finding no property
+    // column for `w`, used a unit weight for EVERY edge - silently, and only when a view existed. X-Y-Z costs
+    // 2.0 and the direct X-Z hop costs 50.0, so unit weights invert the answer: the direct hop wins at 1.0.
+    //
+    // The view here deliberately materialises no edge properties, which is the configuration that triggered it.
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      final MutableVertex z = database.newVertex("N").set("name", "Z").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 1.0 }).save();
+      y.newEdge("ROAD", z, true, new Object[] { "w", 1.0 }).save();
+      x.newEdge("ROAD", z, true, new Object[] { "w", 50.0 }).save();
+    });
+
+    assertThat(bellmanFordWeight()).as("OLTP: X-Y-Z at 2.0 beats the direct 50.0 hop").isEqualTo(2.0);
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("bellman-view-no-edge-properties")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .build();
+    try {
+      assertThat(bellmanFordWeight())
+          .as("a view without the property column must send the weights back to the edge records, not to 1.0")
+          .isEqualTo(2.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void everyEdgeTypeIsWeightedWhenNoFilterIsGiven() {
+    // With no relTypes the CSR weight lookup had no type to address its property columns by, and produced an
+    // empty weight row against a non-empty neighbour row - an ArrayIndexOutOfBoundsException out of algo.apsp
+    // for a query that worked perfectly without the view. Two edge types make the "all types" path the one
+    // under test rather than the single-type shortcut.
+    database.transaction(() -> {
+      final MutableVertex x = database.newVertex("N").set("name", "X").save();
+      final MutableVertex y = database.newVertex("N").set("name", "Y").save();
+      final MutableVertex z = database.newVertex("N").set("name", "Z").save();
+      x.newEdge("ROAD", y, true, new Object[] { "w", 2.0 }).save();
+      y.newEdge("NOISE", z, true, new Object[] { "w", 3.0 }).save();
+    });
+
+    assertThat(apspDistance("X", "Z")).as("OLTP: 2.0 + 3.0 across the two edge types").isEqualTo(5.0);
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("apsp-view-all-types")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD", "NOISE")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      final double distance = apspDistance("X", "Z");
+      assertThat(csrAccelerated).as("the view must actually back the call, or this pins the OLTP path twice")
+          .isTrue();
+      assertThat(distance)
+          .as("the same distance, whichever backing answered and however many edge types are in play")
+          .isEqualTo(5.0);
+    } finally {
+      view.drop();
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /** The weight of the {@code algo.bellmanford} path from X to Z over the {@code w} property. */
+  private double bellmanFordWeight() {
+    database.begin();
+    try {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final List<Result> rows = collect(new AlgoBellmanFord().execute(
+          new Object[] { vertexNamed("X"), vertexNamed("Z"), "ROAD", "w" }, null, context));
+      assertThat(rows).hasSize(1);
+      return ((Number) rows.getFirst().getProperty("weight")).doubleValue();
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /** The {@code algo.apsp} distance between two named vertices over the {@code w} property, all edge types. */
+  private double apspDistance(final String from, final String to) {
+    database.begin();
+    try {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final RID fromRid = ((com.arcadedb.graph.Vertex) vertexNamed(from)).getIdentity();
+      final RID toRid = ((com.arcadedb.graph.Vertex) vertexNamed(to)).getIdentity();
+      final List<Result> rows = collect(new AlgoAPSP().execute(new Object[] { "w" }, null, context));
+      csrAccelerated = Boolean.TRUE.equals(context.getVariable(CommandContext.CSR_ACCELERATED_VAR));
+      for (final Result row : rows)
+        if (fromRid.equals(row.getProperty("source")) && toRid.equals(row.getProperty("target")))
+          return ((Number) row.getProperty("distance")).doubleValue();
+      throw new AssertionError(from + " -> " + to + " is not in the apsp result");
+    } finally {
+      database.rollback();
+    }
+  }
+
+  /**
+   * Calls the procedure directly rather than through Cypher: the two terminals are looked up by name and handed
+   * over as vertices, which is what the CALL form does anyway, and it keeps the assertions about the procedure
+   * rather than about the planner. Requires an active transaction, like every direct use of the graph API.
+   */
+  private List<Result> steinerTree(final String from, final String to, final String relTypes,
+      final String weightProperty) {
+    database.begin();
+    try {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      return collect(new AlgoSteinerTree().execute(
+          new Object[] { List.of(vertexNamed(from), vertexNamed(to)), relTypes, weightProperty }, null, context));
+    } finally {
+      database.rollback();
+    }
+  }
+
+  private Object vertexNamed(final String name) {
+    return database.query("sql", "SELECT FROM N WHERE name = ?", name).next().getElement().orElseThrow().asVertex();
+  }
+
+  private static List<Result> collect(final Stream<Result> rows) {
+    final List<Result> collected = new ArrayList<>();
+    rows.forEach(collected::add);
+    return collected;
+  }
+
+  private static double totalWeightOf(final List<Result> rows) {
+    assertThat(rows).isNotEmpty();
+    double sum = 0.0;
+    for (final Result row : rows)
+      sum += ((Number) row.getProperty("weight")).doubleValue();
+    // totalWeight repeats on every row and must agree with the edges actually returned.
+    for (final Result row : rows)
+      assertThat(((Number) row.getProperty("totalWeight")).doubleValue()).isEqualTo(sum);
+    return sum;
+  }
+
+  @SuppressWarnings("unused")
+  private static String nameOf(final Object rid) {
+    return ((RID) rid).asVertex().getString("name");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6302AlgoGraphDrivenWorkGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6302AlgoGraphDrivenWorkGuardTest.java
@@ -170,6 +170,63 @@ class Issue6302AlgoGraphDrivenWorkGuardTest {
   }
 
   /**
+   * {@code algo.msa} is the only procedure here whose guard is threaded through a <em>recursion</em>: Chu-Liu/
+   * Edmonds contracts a cycle and re-runs itself on the smaller graph, so both the checkpoint's placement across
+   * levels and the new leading parameter on the recursive self-call have to hold. The cycle fixture in
+   * {@link #setup} never contracts anything - each non-root vertex's cheapest incoming edge already forms a path
+   * from the root - so it exercises level 1 only.
+   * <p>
+   * Here R reaches A and B at cost 10 while A and B reach each other at cost 1, so the cheapest-incoming
+   * selection is the 2-cycle A-B and the algorithm must contract it and recurse. The arborescence that comes back
+   * is one 10 edge into the cycle plus one 1 edge inside it.
+   */
+  @Test
+  @Timeout(120)
+  void msaStaysAbortableThroughItsCycleContractionRecursion() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6302-msa-contraction");
+    if (factory.exists())
+      factory.open().drop();
+    final Database contracted = factory.create();
+    try {
+      contracted.getSchema().createVertexType("Node");
+      contracted.getSchema().createEdgeType("LINK");
+      contracted.transaction(() -> {
+        final MutableVertex r = contracted.newVertex("Node").set("name", "R").save();
+        final MutableVertex a = contracted.newVertex("Node").set("name", "A").save();
+        final MutableVertex b = contracted.newVertex("Node").set("name", "B").save();
+        r.newEdge("LINK", a, true, new Object[] { "w", 10.0 }).save();
+        r.newEdge("LINK", b, true, new Object[] { "w", 10.0 }).save();
+        a.newEdge("LINK", b, true, new Object[] { "w", 1.0 }).save();
+        b.newEdge("LINK", a, true, new Object[] { "w", 1.0 }).save();
+      });
+
+      final String query = "MATCH (r:Node {name:'R'}) CALL algo.msa(r, 'LINK', 'w') "
+          + "YIELD source, target, weight RETURN source, target, weight";
+
+      double total = 0.0;
+      int rows = 0;
+      final ResultSet rs = contracted.query("opencypher", query);
+      while (rs.hasNext()) {
+        total += ((Number) rs.next().getProperty("weight")).doubleValue();
+        rows++;
+      }
+      assertThat(rows).as("an arborescence spans every non-root vertex").isEqualTo(2);
+      assertThat(total).as("one 10 edge into the contracted cycle plus one 1 edge inside it").isEqualTo(11.0);
+
+      Thread.currentThread().interrupt();
+      assertThatThrownBy(() -> {
+        final ResultSet aborted = contracted.query("opencypher", query);
+        while (aborted.hasNext())
+          aborted.next();
+      }).as("the checkpoint has to survive being threaded through the contraction recursion")
+          .hasStackTraceContaining("algo.msa() has been interrupted");
+    } finally {
+      Thread.interrupted();
+      contracted.drop();
+    }
+  }
+
+  /**
    * {@code algo.apsp} is the sharp case, and the one worth pinning against the clock rather than the interrupt
    * flag: Floyd-Warshall's triple loop is O(V³) on an input the memory budget explicitly admits, and the
    * deadline has to be observed <em>inside</em> it. 1500 nodes is 3.4e9 relaxations, several seconds of CPU, so

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6302AlgoGraphDrivenWorkGuardTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6302AlgoGraphDrivenWorkGuardTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6302 - the {@code algo.*} procedures whose work is multiplied by the <em>graph</em>
+ * rather than by a knob had no {@link com.arcadedb.query.sql.executor.WorkGuard} at all.
+ * <p>
+ * #6216 and #6264 established the rule that a long run should be abortable rather than forbidden, because time,
+ * unlike memory, has no honest ceiling to pick. Both selected their procedures by asking "does it have an
+ * iteration knob?", which is a proxy that misses every graph-driven loop - and the graph-driven ones are the
+ * slowest in the package. {@code algo.apsp} makes the case on its own: the #6263 working-memory budget caps its
+ * distance matrix at {@code arcadedb.cypher.algoMaxWorkingMemory}, whose 64 MB floor admits about 2890 nodes, and
+ * 2890³ is ~2.4e10 iterations of the Floyd-Warshall triple loop. The budget's own answer to "is this graph
+ * acceptable?" was yes, and nothing could then stop the run it had just accepted - not a thread interrupt, not
+ * {@code arcadedb.command.timeout}, not the client hanging up.
+ * <p>
+ * The criterion applied here is the one the issue argues for: a guard belongs wherever the work is unbounded by
+ * anything the caller controls, not only where a knob multiplies it. That covers the four procedures the issue
+ * names and every other whose dominant loop is superlinear in the graph - all-pairs and per-source traversals,
+ * peeling and contraction rounds, clique and simple-path enumeration. Procedures that make a single O(V + E)
+ * pass are deliberately left alone: one pass costs what loading the graph and emitting the rows already cost, so
+ * a checkpoint inside it would bound nothing the surrounding pipeline does not.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6302AlgoGraphDrivenWorkGuardTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6302-algo-work-guard");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // Directed cycle A→B→C→D→A with a weight on every edge: every node has in- and out-edges, every ordered
+    // pair is reachable, and the graph is bipartite - enough for every procedure below to reach its main loop.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      final MutableVertex d = database.newVertex("Node").set("name", "D").save();
+      a.newEdge("LINK", b, true, new Object[] { "w", 1.0 }).save();
+      b.newEdge("LINK", c, true, new Object[] { "w", 1.0 }).save();
+      c.newEdge("LINK", d, true, new Object[] { "w", 1.0 }).save();
+      d.newEdge("LINK", a, true, new Object[] { "w", 1.0 }).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    // A test that arms the interrupt flag must not leave it set for whatever runs next on this thread.
+    Thread.interrupted();
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  /**
+   * The interrupt is the deterministic half of the guarantee: it is already pending when the call starts, so the
+   * first checkpoint the procedure reaches must observe it, whatever the machine's speed. Nothing upstream of the
+   * procedure consumes the flag, and the guard names the procedure in its message, so the assertion cannot pass
+   * because something else aborted the query.
+   * <p>
+   * Each of these ran to completion before this change and returned a result.
+   */
+  @ParameterizedTest(name = "{0}")
+  @CsvSource(delimiter = '|', value = {
+      "algo.apsp                        | CALL algo.apsp() YIELD source RETURN source",
+      "algo.mst                         | CALL algo.mst('w') YIELD source RETURN source",
+      "algo.kShortestPaths              | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.kShortestPaths(a, c, 3) YIELD rank RETURN rank",
+      "algo.steinerTree                 | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.steinerTree([a, c], 'LINK', 'w') YIELD weight RETURN weight",
+      "algo.bellmanford                 | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.bellmanford(a, c, 'LINK', 'w') YIELD weight RETURN weight",
+      "algo.betweenness                 | CALL algo.betweenness() YIELD node RETURN node",
+      "algo.closeness                   | CALL algo.closeness() YIELD node RETURN node",
+      "algo.harmonic                    | CALL algo.harmonic() YIELD node RETURN node",
+      "algo.eccentricity                | CALL algo.eccentricity() YIELD node RETURN node",
+      "algo.maxFlow                     | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.maxFlow(a, c, 'LINK', 'w') YIELD maxFlow RETURN maxFlow",
+      "algo.msa                         | MATCH (a:Node {name:'A'}) CALL algo.msa(a, 'LINK', 'w') YIELD source RETURN source",
+      "algo.knn                         | CALL algo.knn(2) YIELD node1 RETURN node1",
+      "algo.hierarchicalClustering      | CALL algo.hierarchicalClustering('LINK', 2) YIELD node RETURN node",
+      "algo.clique                      | CALL algo.clique('LINK', 2) YIELD nodes RETURN nodes",
+      "algo.allsimplepaths              | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.allSimplePaths(a, c, 'LINK', 5) YIELD path RETURN path",
+      "algo.kTruss                      | CALL algo.kTruss('LINK', 3) YIELD node RETURN node",
+      "algo.triangleCount               | CALL algo.triangleCount() YIELD node RETURN node",
+      "algo.localClusteringCoefficient  | CALL algo.localClusteringCoefficient() YIELD node RETURN node",
+      "algo.densestSubgraph             | CALL algo.densestSubgraph() YIELD node RETURN node",
+      "algo.bipartiteMatching           | CALL algo.bipartiteMatching() YIELD node1 RETURN node1",
+      "algo.voteRank                    | CALL algo.voteRank() YIELD node RETURN node",
+      "algo.richClub                    | CALL algo.richClub() YIELD degree RETURN degree" })
+  @Timeout(120)
+  void aGraphDrivenProcedureStopsOnAThreadInterrupt(final String procedure, final String query) {
+    Thread.currentThread().interrupt();
+
+    assertThatThrownBy(() -> drain(query))
+        .as("%s has no knob to cap its work, so it must at least be abortable", procedure)
+        .hasStackTraceContaining(procedure + "() has been interrupted");
+  }
+
+  /**
+   * The counterweight: with nothing armed, every one of them still returns its result. A guard that aborted a
+   * healthy call, or one placed where it changes the answer, would pass the test above and fail here.
+   */
+  @ParameterizedTest(name = "{0}")
+  @CsvSource(delimiter = '|', value = {
+      "algo.apsp                        | CALL algo.apsp() YIELD source RETURN source",
+      "algo.mst                         | CALL algo.mst('w') YIELD source RETURN source",
+      "algo.kShortestPaths              | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.kShortestPaths(a, c, 3) YIELD rank RETURN rank",
+      "algo.steinerTree                 | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.steinerTree([a, c], 'LINK', 'w') YIELD weight RETURN weight",
+      "algo.bellmanford                 | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.bellmanford(a, c, 'LINK', 'w') YIELD weight RETURN weight",
+      "algo.betweenness                 | CALL algo.betweenness() YIELD node RETURN node",
+      "algo.closeness                   | CALL algo.closeness() YIELD node RETURN node",
+      "algo.harmonic                    | CALL algo.harmonic() YIELD node RETURN node",
+      "algo.eccentricity                | CALL algo.eccentricity() YIELD node RETURN node",
+      "algo.maxFlow                     | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.maxFlow(a, c, 'LINK', 'w') YIELD maxFlow RETURN maxFlow",
+      "algo.msa                         | MATCH (a:Node {name:'A'}) CALL algo.msa(a, 'LINK', 'w') YIELD source RETURN source",
+      "algo.knn                         | CALL algo.knn(2) YIELD node1 RETURN node1",
+      "algo.hierarchicalClustering      | CALL algo.hierarchicalClustering('LINK', 2) YIELD node RETURN node",
+      "algo.allsimplepaths              | MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) CALL algo.allSimplePaths(a, c, 'LINK', 5) YIELD path RETURN path",
+      "algo.triangleCount               | CALL algo.triangleCount() YIELD node RETURN node",
+      "algo.localClusteringCoefficient  | CALL algo.localClusteringCoefficient() YIELD node RETURN node",
+      "algo.densestSubgraph             | CALL algo.densestSubgraph() YIELD node RETURN node",
+      "algo.bipartiteMatching           | CALL algo.bipartiteMatching() YIELD node1 RETURN node1",
+      "algo.voteRank                    | CALL algo.voteRank() YIELD node RETURN node",
+      "algo.richClub                    | CALL algo.richClub() YIELD degree RETURN degree" })
+  @Timeout(120)
+  void anUninterruptedCallStillReturnsItsResult(final String procedure, final String query) {
+    assertThat(drain(query)).as("%s must still answer when nothing asked it to stop", procedure).isNotEmpty();
+  }
+
+  /**
+   * {@code algo.apsp} is the sharp case, and the one worth pinning against the clock rather than the interrupt
+   * flag: Floyd-Warshall's triple loop is O(V³) on an input the memory budget explicitly admits, and the
+   * deadline has to be observed <em>inside</em> it. 1500 nodes is 3.4e9 relaxations, several seconds of CPU, so
+   * a 1 s deadline lands well inside the {@code k} loop - and the whole graph is only an 18 MB matrix, which the
+   * 64 MB budget floor accepts without complaint. That is the issue's point in one fixture: the budget says yes,
+   * and before this change nothing could then say stop.
+   * <p>
+   * The elapsed bound is measured with {@link StallAwareStopwatch} so a JVM-wide pause inside the window is
+   * discounted rather than charged to the procedure. It is a tripwire between "aborted from inside the loop"
+   * and "ran the loop to the end", not a latency budget: widen it rather than delete it if it ever flakes.
+   */
+  @Test
+  @Tag("slow")
+  @Timeout(300)
+  void apspObservesTheDeadlineInsideTheTripleLoop() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6302-apsp-deadline");
+    if (factory.exists())
+      factory.open().drop();
+    final Database dense = factory.create();
+    try {
+      dense.getSchema().createVertexType("Node");
+      dense.getSchema().createEdgeType("LINK");
+
+      final int nodeCount = 1500;
+      dense.transaction(() -> {
+        final List<MutableVertex> nodes = new ArrayList<>(nodeCount);
+        for (int i = 0; i < nodeCount; i++)
+          nodes.add(dense.newVertex("Node").set("idx", i).save());
+        for (int i = 0; i < nodeCount; i++)
+          nodes.get(i).newEdge("LINK", nodes.get((i + 1) % nodeCount), true, (Object[]) null).save();
+      });
+
+      dense.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 1_000L);
+
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+      assertThatThrownBy(() -> {
+        final ResultSet rs = dense.query("opencypher", "CALL algo.apsp() YIELD source RETURN source");
+        while (rs.hasNext())
+          rs.next();
+      }).as("O(V³) with no knob is exactly the shape that has to be abortable")
+          .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+
+      stopwatch.assertGaveUpWithin(60_000L, "a Floyd-Warshall pass aborted from inside, not run to the end");
+    } finally {
+      dense.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT,
+          GlobalConfiguration.COMMAND_TIMEOUT.getDefValue());
+      dense.drop();
+    }
+  }
+
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
+    final ResultSet rs = database.query("opencypher", query);
+    while (rs.hasNext())
+      rows.add(rs.next());
+    return rows;
+  }
+}


### PR DESCRIPTION
Fixes #6295, #6300, #6301, #6302.

## #6301 - an edge weight was attached to whatever neighbour sat at that index

`AlgoSteinerTree.buildWeightedAdj` paired weights with neighbours **by iteration position**. `adj[i]` was built
with the `relTypes` filter applied and in the backing store's order; `tmpW` was filled positionally from an
*unfiltered* `getEdges(BOTH)` walk in OLTP order. `nbIdx` was computed and then used only as a skip test, never as
the index to write at. That array is what Dijkstra runs on in step 1, so the **tree itself** changed, not only the
`weight` column.

Both reproductions from the issue are pinned as tests and both were verified red before the fix:

- an excluded `NOISE` edge of weight 999 landed on an included `ROAD` edge → `weight: 999.0`, `totalWeight: 1000.0`
  for a tree that costs 2.0;
- with a Graph Analytical View present the same query returned a 51.0 tree where OLTP returned 2.0. A view is meant
  to be a transparent accelerator, so this is the worst failure mode it has.

**The fix removes the second traversal rather than repairing it.** `GraphData.weightedAdjacency(direction,
weightProperty, relTypes)` produces the neighbour list and its weights from **one** walk of the same edges - from
the view's columnar edge properties when it has them, from the edge records otherwise - so the pairing is correct
by construction and the two backings return the same multiset of `(neighbour, weight)` pairs. `buildWeightedAdj` is
deleted, and so is the old `GraphData.edgeWeights`.

The issue suggested reusing `edgeWeights(...)`. That could not be taken as-is, and the reason is the interesting
part: **`getEdgeProperty` returns null for `DIRECTION.BOTH`**, which is the direction `algo.steinerTree` needs, and
`getNeighborIds(i, BOTH, type)` is a sorted *merge* of the OUT and IN slices, so no positional mapping to the
column store exists for it at all. `weightedAdjacencyFromColumns` walks one slice per (type, direction) instead,
each of which *is* positional, and concatenates them.

The same helper was broken for its two existing callers, and both are fixed with it:

- **`algo.apsp`** with no `relTypes` filter on a view with edge properties produced an *empty* weight row against a
  non-empty neighbour row: an `ArrayIndexOutOfBoundsException` for a query that worked without the view. With
  several edge types it mismatched silently, because the adjacency is sorted across types while the weights were
  concatenated per type.
- **`algo.bellmanford`** fell back to a **unit weight for every edge** whenever the graph was CSR-backed and the
  view had no column for the property - ignoring `weightProperty` entirely, and only when a view existed. Its edge
  list is now parallel primitive arrays rather than `List<int[]>` + `List<Double>`, which the O(V x E) relaxation
  reads up to `V - 1` times.

**One provider-contract change.** `GraphTraversalProvider.hasEdgeProperties()` now means "the columns are
materialised **and** the positional mapping `getEdgeProperty` relies on is exact", and `GraphAnalyticalView` answers
`false` while a delta overlay is active: the columns are aligned with the base CSR's forward slots while
`getNeighborIds` serves the overlay's view of the node (deletions dropped, additions merged, list re-sorted), so
the n-th neighbour is not the n-th edge of the column store. `SQLFunctionAstar`, `SQLFunctionBellmanFord` and
`algo.dijkstra.singleSource` pair positionally too and gain the same protection: in that state they read the edge
records, which is slower and exact. Same "say unknown rather than guess" convention as `countEdgesBetween` and
`getMeanEdgesPerConnectedPair`.

## #6295 - the phase a call spends its time in was outside every checkpoint

`algo.hashgnn`'s MinHash reduction runs **after** the loop `iterations` drives, and costs
`4 x embeddingDimension²` operations per node - a bounded per-node figure multiplied by an unbounded node count.
Reproduced as the issue measured it: the deadline overshot by two orders of magnitude and the call *returned*.

The generalisable lesson, and the one applied here: **#6216 and #6264 hunted knobs with no ceiling;
`embeddingDimension` HAS one (#6065), which is exactly why the lens walked past it. Ask "which loop over the node
count has no checkpoint", not "which knob has no cap".** That sweep also found the pre-loop initialisation of
`algo.hashgnn`, `algo.fastrp` and `algo.graphsage`, and `algo.slpa`'s post-processing and its O(degree²)
`mostFrequent`. All now carry a checkpoint; the two-phase ones use a counter spanning both loops, because a
per-node check is too coarse on a wide embedding and a per-dimension clock read is too expensive on a narrow one.

## #6302 - a guard belongs wherever the work is unbounded, not only where a knob multiplies it

`algo.apsp` makes the case alone: the #6263 budget's 64 MB floor **admits n ≈ 2890**, and 2890³ is ~2.4e10
Floyd-Warshall iterations during which `Thread.interrupt()`, `arcadedb.command.timeout` and client cancellation all
did nothing. The memory half of the guarantee was waving through a run the time half could not stop.

Taking the issue's "better framing" rather than its four-procedure list, all 68 procedures were swept with the
question "can one call of this run for minutes on an accepted input?". **22 are now abortable**: `apsp`,
`kShortestPaths`, `steinerTree`, `mst`, `bellmanford`, `betweenness`, `closeness`, `harmonic`, `eccentricity`,
`maxFlow`, `msa`, `knn`, `hierarchicalClustering`, `clique`, `allSimplePaths`, `kTruss`, `triangleCount`,
`localClusteringCoefficient`, `densestSubgraph`, `bipartiteMatching`, `voteRank`, `richClub`.

Procedures making a single O(V + E) pass are deliberately left alone: one pass costs what loading the graph and
emitting the rows already cost, so a checkpoint there bounds nothing the surrounding pipeline does not. One gap is
named rather than hidden: `algo.localClusteringCoefficient`'s CSR path delegates to a `GraphAlgorithms` kernel that
counts triangles across a thread pool, and `WorkCheckpoint` is specified to be called between iterations on the
calling thread - covering it is a change to how that kernel partitions its work.

## #6300 - `algo.mst`'s edge arrays are the one dense path #6263 did not price

24 bytes per edge across `eu`/`ev`/`ew` and the index sort, unreserved. #6263's criterion was "knob-sized or
quadratic in the node count", and edge-linear reads like the graph paying for itself - but the edge count is the
largest linear dimension a graph has, and 100M edges is ~2.4 GB with nothing between it and the allocator.

**The issue asked for the reservation to be made before the pass-1 count loop, which cannot be done as stated:**
nothing knows the edge count before the walk, and every cheap upper bound (`countType` over the edge types) is
itself a scan. What it wants is achievable another way, and that is what is implemented: the new
`MemoryBudget.capacityFor(bytesPerItem)` turns the budget into a bound the walk carries, so the count stops the
moment it passes what the budget allows. The refusal still goes through `reserve()`, so the message names the same
component and the same setting either way. The issue's Borůvka-over-CSR alternative is not taken here - it would
remove the allocation rather than bound it, but it changes tie-breaking and result ordering, which is a different
change from closing a hole in the budget.

`algo.mst`'s `List<Vertex>` + `Map<RID, Integer>` are noted in the issue and left alone on purpose: that is the
shared OLTP loading path every procedure uses, so pricing it in one procedure would be inconsistent. It belongs in
`loadGraph`, as one change, if it is wanted.

## Verification

- `Issue6301AlgoSteinerTreeWeightAlignmentTest` (6) - both reproductions, the analytical-view comparison with an
  explicit `CSR_ACCELERATED_VAR` assertion so it cannot silently pin the OLTP path twice, parallel edges, the
  bellmanford unit-weight fallback, the apsp all-types crash. **4 of 6 verified red on the pre-fix code.**
- `Issue6302AlgoGraphDrivenWorkGuardTest` (42) - every one of the 22 procedures aborts on a pending thread
  interrupt and still returns its result without one, plus a `@Tag("slow")` deadline test on `algo.apsp` at 1500
  nodes. **Verified: with the Floyd-Warshall checkpoint removed the same test runs the loop to completion and
  returns.**
- `Issue6295AlgoUnguardedPhaseTest` (2) - the MinHash reduction aborts on a deadline that the single message-passing
  round comfortably survives. **Verified red (no exception, ran to completion) with the checkpoint removed.**
- `Issue6300AlgoMSTEdgeBudgetTest` (5) - refusal, the message naming the count the walk stopped at, a budget that
  fits, a disabled budget, and the MST itself unchanged. **2 of 5 verified red on the pre-fix code.**

Only `algo.hashgnn`'s reduction is pinned as a binary abort, and the test javadoc records why the others are not:
SLPA's propagation and its post-processing are both O(nodeCount x iterations) and measured at the same order, so
any threshold between them would be measuring the fixture rather than the checkpoint. They are covered by the
no-regression test instead.

Full runs: 2541 tests across `Algo*`/`Issue62*`/`Issue63*`/`Cypher*`/`GraphAnalyticalView*`/`SQLFunction*`, 1639
across `com.arcadedb.graph.**` and `com.arcadedb.function.**`, plus the `slow` lane for the touched classes. All
green.

## Follow-up worth filing

`GraphAnalyticalView.getEdgeProperty`'s positional contract is broken by an active overlay for *any* caller, not
only these. This PR makes the four known callers fall back safely via `hasEdgeProperties()`, but the SPI method
itself still returns a value addressed against the base CSR while `getNeighborIds` returns the overlay's list. A
provider-side fix (an overlay-aware property lookup, or an explicit "unknown" return) would close the shape rather
than the instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yjKJXMNMQeLPKdCno7cFX