### PR TITLE
fix(#6297, #6280, #6279, #6270): a teardown that deletes what the test wrote, a warning that speaks again, and bounds that say what they are for

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -909,6 +909,16 @@ public class MatchNodeStep extends AbstractExecutionStep {
       builder.append(":").append(String.join("|", pattern.getLabels()));
     }
     builder.append(")");
+    // The ID push-down is the single most consequential thing this step can do - it turns a full type scan (and,
+    // when another MATCH NODE follows, the Cartesian product over it) into one lookupByRID - and until issue #6279
+    // it was the one optimisation the plan did not name, so nothing but a stopwatch could tell whether it fired.
+    // That is exactly what the resolution of issue #3216 asks a user to verify. Printed from the plan-time field
+    // rather than recorded during execution, so EXPLAIN answers it without running the query; the dynamic form
+    // (issue #3864) resolves per row and can only be named, not valued.
+    if (idFilter != null && !idFilter.isEmpty())
+      builder.append(" [id: ").append(idFilter).append("]");
+    else if (dynamicIdExpression != null)
+      builder.append(" [id: per-row]");
     if (usedIndexName != null)
       builder.append(" [index: ").append(usedIndexName).append("]");
     if (usedPartitionBucket != null)

--- a/engine/src/test/java/com/arcadedb/function/coll/RangeFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/coll/RangeFunctionTest.java
@@ -30,6 +30,17 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/**
+ * Advisory GHSA-xmjm-8q85-g778 and the overflow guards around it.
+ * <p>
+ * Every {@code @Timeout} here is a HANG DETECTOR, not a latency bound (issue #6270): what each of these methods
+ * regresses to is an unbounded loop or a materialised billion-element list, and what the method actually CLAIMS is
+ * carried by a structural assertion - {@code containsExactly} on the returned elements, {@code isInstanceOf}
+ * {@code LongRangeList} on the lazy one, {@code assertThatThrownBy} on the rejected one. None of those can pass
+ * while the range is being materialised, so the annotation only has to be wide enough that a stop-the-world pause
+ * cannot masquerade as the regression. The honest budget of each method is microseconds; at 5 s and 10 s these
+ * were inside the range of the 24 s stalls issue #6260 was filed on.
+ */
 @SuppressWarnings("unchecked")
 class RangeFunctionTest {
 
@@ -37,7 +48,7 @@ class RangeFunctionTest {
 
   /** Reported case: step skips past Long.MAX_VALUE - must return only the start element. */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void positiveStepOverflowReturnsOnlyFittingElements() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -47,7 +58,7 @@ class RangeFunctionTest {
 
   /** Step of 1 right up to Long.MAX_VALUE must return all 4 values. */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void positiveStepUpToMaxValue() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -61,7 +72,7 @@ class RangeFunctionTest {
 
   /** Single-element range exactly at Long.MAX_VALUE. */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void singleElementAtMaxValue() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -71,7 +82,7 @@ class RangeFunctionTest {
 
   /** Negative step that skips past Long.MIN_VALUE - must return only the start element. */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void negativeStepUnderflowReturnsOnlyFittingElements() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -81,7 +92,7 @@ class RangeFunctionTest {
 
   /** Step of -1 right down to Long.MIN_VALUE must return all 4 values. */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void negativeStepDownToMinValue() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -95,7 +106,7 @@ class RangeFunctionTest {
 
   /** Single-element range exactly at Long.MIN_VALUE. */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void singleElementAtMinValue() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -105,7 +116,7 @@ class RangeFunctionTest {
 
   /** Extreme: step = Long.MIN_VALUE; guard evaluates to 0 (MIN - MIN = 0 in two's-complement). */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void negativeStepLongMinValue() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -115,7 +126,7 @@ class RangeFunctionTest {
 
   /** Symmetric to negativeStepLongMinValue: step = Long.MAX_VALUE on the positive branch. */
   @Test
-  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void positiveStepLongMaxValue() {
     @SuppressWarnings("unchecked")
     final List<Long> result = (List<Long>) fn.execute(
@@ -134,7 +145,7 @@ class RangeFunctionTest {
 
   /** Advisory GHSA-xmjm-8q85-g778: the range is lazy, so a huge one costs a constant amount of heap. */
   @Test
-  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void largeRangeIsLazy() {
     final long previous = GlobalConfiguration.QUERY_MAX_RANGE_SIZE.getValueAsLong();
     try {
@@ -150,7 +161,7 @@ class RangeFunctionTest {
 
   /** Advisory GHSA-xmjm-8q85-g778: the reported PoC must be rejected as a client error, not attempted. */
   @Test
-  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void oversizedRangeIsRejected() {
     assertThatThrownBy(() -> fn.execute(new Object[]{ 0L, 9_999_999_999L }, null))
         .isInstanceOf(CommandSemanticException.class)
@@ -160,7 +171,7 @@ class RangeFunctionTest {
 
   /** Even with the configured limit disabled, a range cannot exceed the maximum size of a Java list. */
   @Test
-  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void rangeBiggerThanAListIsRejectedEvenWithoutLimit() {
     final long previous = GlobalConfiguration.QUERY_MAX_RANGE_SIZE.getValueAsLong();
     try {

--- a/engine/src/test/java/com/arcadedb/index/hash/HashIndexOverflowCycleTest.java
+++ b/engine/src/test/java/com/arcadedb/index/hash/HashIndexOverflowCycleTest.java
@@ -88,7 +88,7 @@ class HashIndexOverflowCycleTest extends TestHelper {
   }
 
   @Test
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void cyclicOverflowChainFailsLoudlyOnLookupInsteadOfSpinning() {
     injectSelfReferentialOverflowChain();
     reopenDatabase();
@@ -106,7 +106,7 @@ class HashIndexOverflowCycleTest extends TestHelper {
   }
 
   @Test
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void cyclicOverflowChainFailsLoudlyOnUniqueCheckDuringInsert() {
     // Mirrors the customer's stack: the spin was reached via checkUniqueIndexKeys while committing a new vertex.
     injectSelfReferentialOverflowChain();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherRangeHeapExhaustionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherRangeHeapExhaustionTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.LongRangeList;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +69,7 @@ class CypherRangeHeapExhaustionTest {
 
   /** The reported PoC: it must fail fast instead of filling the heap. */
   @Test
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void reportedPocIsRejectedWithoutExhaustingHeap() {
     final Throwable thrown = catchThrowable(() -> consume("RETURN range(0, 9999999999) AS v"));
     assertThat(thrown).isNotNull();
@@ -78,7 +79,7 @@ class CypherRangeHeapExhaustionTest {
   }
 
   @Test
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void oversizedRangeIsRejectedInsideUnwindToo() {
     final Throwable thrown = catchThrowable(() -> consume("UNWIND range(0, 9999999999) AS i RETURN count(i) AS c"));
     assertThat(thrown).isNotNull();
@@ -99,15 +100,24 @@ class CypherRangeHeapExhaustionTest {
 
   /**
    * With the limit disabled the range stays usable but must remain lazy: a billion elements would need tens of
-   * GB if materialised, so answering within the timeout is the proof that nothing is copied.
+   * GB if materialised, so answering quickly is the proof that nothing is copied.
+   * <p>
+   * Asserted on the stall-discounted clock rather than by the {@code @Timeout} (issue #6270), so the bound can
+   * stay tight without becoming a coin flip on a stop-the-world pause. The annotation behind it is the hang
+   * detector: a materialised range does not answer late, it does not answer.
    */
   @Test
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void hugeRangeIsLazyWhenTheLimitIsDisabled() {
     database.getConfiguration().setValue(GlobalConfiguration.QUERY_MAX_RANGE_SIZE, -1L);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+
     assertThat(single("RETURN size(range(0, 999999999)) AS r")).isEqualTo(1_000_000_000L);
     assertThat(single("RETURN range(0, 999999999)[123456789] AS r")).isEqualTo(123_456_789L);
     assertThat(single("RETURN 999999998 IN range(0, 999999999) AS r")).isEqualTo(true);
+
+    stopwatch.assertStayedUnder(10_000L, "three constant-cost reads of a lazy range, not a billion-element copy");
   }
 
   /** A range within the limit is not copied into an ArrayList any more. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherRangeHeapExhaustionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherRangeHeapExhaustionTest.java
@@ -102,9 +102,17 @@ class CypherRangeHeapExhaustionTest {
    * With the limit disabled the range stays usable but must remain lazy: a billion elements would need tens of
    * GB if materialised, so answering quickly is the proof that nothing is copied.
    * <p>
-   * Asserted on the stall-discounted clock rather than by the {@code @Timeout} (issue #6270), so the bound can
-   * stay tight without becoming a coin flip on a stop-the-world pause. The annotation behind it is the hang
-   * detector: a materialised range does not answer late, it does not answer.
+   * Only the two reads that are genuinely constant-cost are inside the measured window (issue #6270). {@code size()}
+   * and indexing are answered from start, step and size alone, so they are what a materialised list could not serve
+   * cheaply, and measuring them on the stall-discounted clock makes the bound both tight and immune to a
+   * stop-the-world pause.
+   * <p>
+   * {@code IN} is deliberately OUTSIDE it. {@code InExpression.evaluateTernary} walks the list element by element -
+   * it has to, for Cypher's three-valued logic: a {@code null} anywhere in the list turns a non-match into
+   * {@code null} rather than {@code false}, which {@code List.contains} cannot report - so it is O(n) whether the
+   * range is lazy or not, and its cost says nothing about laziness. Measured: 3 s locally and 20 s on a CI runner
+   * for an element near the end of the range, against 8 ms and 1 ms for the two reads above; a bound around it was
+   * asserting the walk, not the claim. The {@code @Timeout} is what bounds it, as a hang detector.
    */
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
@@ -112,12 +120,11 @@ class CypherRangeHeapExhaustionTest {
     database.getConfiguration().setValue(GlobalConfiguration.QUERY_MAX_RANGE_SIZE, -1L);
 
     final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
-
     assertThat(single("RETURN size(range(0, 999999999)) AS r")).isEqualTo(1_000_000_000L);
     assertThat(single("RETURN range(0, 999999999)[123456789] AS r")).isEqualTo(123_456_789L);
-    assertThat(single("RETURN 999999998 IN range(0, 999999999) AS r")).isEqualTo(true);
+    stopwatch.assertStayedUnder(5_000L, "two constant-cost reads of a lazy range, not a billion-element copy");
 
-    stopwatch.assertStayedUnder(10_000L, "three constant-cost reads of a lazy range, not a billion-element copy");
+    assertThat(single("RETURN 999999998 IN range(0, 999999999) AS r")).isEqualTo(true);
   }
 
   /** A range within the limit is not copied into an ArrayList any more. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCountOptimizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCountOptimizationTest.java
@@ -36,6 +36,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class OpenCypherCountOptimizationTest {
+  /**
+   * The marker {@code TypeCountStep.prettyPrint} emits. Asserting on it is what stops the push-down regressing
+   * silently: a full type scan returns the same count, just slower, so the result assertions alone cannot tell the
+   * two paths apart (issue #6280). The negative cases matter as much as the positive ones - they are what keeps the
+   * push-down from firing where it is not valid.
+   */
+  private static final String TYPE_COUNT_PUSH_DOWN = "TYPE COUNT OPTIMIZATION ";
+
   private Database database;
 
   @BeforeEach
@@ -70,13 +78,7 @@ class OpenCypherCountOptimizationTest {
     assertThat(result.hasNext()).isFalse();
     result.close();
 
-    // TODO: Verify optimization is being used by checking EXPLAIN output
-    // EXPLAIN integration needs to be added separately
-    // final ResultSet explainResult = database.query("opencypher", "EXPLAIN " + query);
-    // assertThat(explainResult.hasNext()).isTrue();
-    // final String plan = explainResult.next().<String>getProperty("plan");
-    // assertThat(plan).contains("TYPE COUNT OPTIMIZATION");
-    // explainResult.close();
+    assertThat(planOf(query)).contains(TYPE_COUNT_PUSH_DOWN + "(Account)");
   }
 
   @Test
@@ -100,6 +102,10 @@ class OpenCypherCountOptimizationTest {
     assertThat(result2.hasNext()).isTrue();
     assertThat(result2.next().<Long>getProperty("cnt")).isEqualTo(50L);
     result2.close();
+
+    // The alias is what the push-down has to carry through; both forms must still take it.
+    assertThat(planOf(query1)).contains(TYPE_COUNT_PUSH_DOWN + "(Person)");
+    assertThat(planOf(query2)).contains(TYPE_COUNT_PUSH_DOWN + "(Person)");
   }
 
   @Test
@@ -115,6 +121,8 @@ class OpenCypherCountOptimizationTest {
     assertThat(result.hasNext()).isTrue();
     assertThat(result.next().<Long>getProperty("count")).isEqualTo(0L);
     result.close();
+
+    assertThat(planOf(query)).contains(TYPE_COUNT_PUSH_DOWN + "(EmptyType)");
   }
 
   @Test
@@ -137,13 +145,7 @@ class OpenCypherCountOptimizationTest {
     assertThat(count).isLessThan(100L); // Some records filtered out
     result.close();
 
-    // TODO: Verify optimization is NOT being used
-    // EXPLAIN integration needs to be added separately
-    // final ResultSet explainResult = database.query("opencypher", "EXPLAIN " + query);
-    // assertThat(explainResult.hasNext()).isTrue();
-    // final String plan = explainResult.next().<String>getProperty("plan");
-    // assertThat(plan).doesNotContain("TYPE COUNT OPTIMIZATION");
-    // explainResult.close();
+    assertThat(planOf(query)).doesNotContain(TYPE_COUNT_PUSH_DOWN);
   }
 
   @Test
@@ -162,13 +164,7 @@ class OpenCypherCountOptimizationTest {
     assertThat(result.hasNext()).isTrue();
     result.close();
 
-    // TODO: Verify optimization is NOT being used
-    // EXPLAIN integration needs to be added separately
-    // final ResultSet explainResult = database.query("opencypher", "EXPLAIN " + query);
-    // assertThat(explainResult.hasNext()).isTrue();
-    // final String plan = explainResult.next().<String>getProperty("plan");
-    // assertThat(plan).doesNotContain("TYPE COUNT OPTIMIZATION");
-    // explainResult.close();
+    assertThat(planOf(query)).doesNotContain(TYPE_COUNT_PUSH_DOWN);
   }
 
   @Test
@@ -194,6 +190,10 @@ class OpenCypherCountOptimizationTest {
     assertThat(result.hasNext()).isTrue();
     assertThat(result.next().<Long>getProperty("count")).isEqualTo(50L);
     result.close();
+
+    // The push-down has to count the whole hierarchy, so it must be the polymorphic counter it delegates to and
+    // not a per-bucket one: the 50 above is what says it counted right, this is what says it counted at all.
+    assertThat(planOf(query)).contains(TYPE_COUNT_PUSH_DOWN + "(Animal)");
   }
 
   @Test
@@ -311,6 +311,18 @@ class OpenCypherCountOptimizationTest {
         rs.next();
       final String plan = rs.getExecutionPlan().get().prettyPrint(0, 2);
       assertThat(plan).contains("COUNT EDGES RETURN");
+    }
+  }
+
+  /**
+   * The plan openCypher would run for {@code query}, obtained with {@code EXPLAIN} rather than {@code PROFILE}
+   * because it must not execute: the negative cases here describe the full scan the push-down was refused for, and
+   * running one to find out it ran is the cost the assertion exists to detect.
+   */
+  private String planOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.getExecutionPlan()).as("EXPLAIN returned no plan for: %s", query).isPresent();
+      return rs.getExecutionPlan().get().prettyPrint(0, 2);
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMatchEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMatchEnhancementsTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Identifiable;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.Result;
@@ -27,7 +28,6 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -907,11 +907,26 @@ public class OpenCypherMatchEnhancementsTest {
     }
   }
 
-  // Issue #3216: benchmark comparing single MATCH (a),(b) WHERE id-pair vs split MATCH clauses; expected to favour split form.
+  /**
+   * Issue #3216: the two ways of binding a pair of nodes by RID must both resolve each node with a direct
+   * {@code lookupByRID} and never scan.
+   * <p>
+   * This test used to time the two forms against each other and assert nothing but that neither elapsed time was
+   * negative (issue #6279). Both halves of that were wrong. The comparison it claimed to make is no longer true -
+   * {@code CypherExecutionPlan.extractIdFilter} lifts an {@code ID(x) = <literal|parameter>} equality out of the
+   * WHERE clause and into the {@code MatchNodeStep} at plan time, which is the fix #3216 was closed on, and it
+   * applies to the single-MATCH form exactly as it does to the split one. And a relative comparison of two
+   * wall-clock measurements is the assertion shape that flakes on a stop-the-world pause, which is why it was
+   * commented out rather than fixed (issue #6260).
+   * <p>
+   * What is asserted instead is the structural property the whole issue is about, visible in the plan and immune
+   * to the machine it runs on: every {@code MATCH NODE} names the RID it was given. The third query is the control
+   * that keeps this honest - the same pattern with a property equality the push-down cannot serve does build the
+   * Cartesian product, and its plan does not carry the marker.
+   */
   @Test
-  @Tag("benchmark")
-  void issue3216_performanceComparisonMatchStrategies() {
-    final Database db = new DatabaseFactory("./target/databases/issue-3216-perf-compare").create();
+  void issue3216_idFilterPushedDownForBothMatchStrategies() {
+    final Database db = new DatabaseFactory("./target/databases/issue-3216-id-pushdown").create();
     try {
       db.getSchema().createVertexType("CHUNK_3216");
       db.getSchema().createVertexType("DOCUMENT_3216");
@@ -919,38 +934,46 @@ public class OpenCypherMatchEnhancementsTest {
       db.getSchema().createEdgeType("in_3216");
 
       final String[] ids = createIssue3216Fixture(db);
-      final String sourceId = ids[0];
-      final String targetId = ids[1];
+      final Map<String, Object> params = Map.of("sourceId", ids[0], "targetId", ids[1]);
 
-      // Method 1: Single MATCH with Cartesian product
-      final long startTime1 = System.currentTimeMillis();
-      db.transaction(() -> {
-        final ResultSet rs = db.query("opencypher",
-            "MATCH (a),(b) WHERE ID(a) = $sourceId and ID(b) = $targetId RETURN a, b",
-            Map.of("sourceId", sourceId, "targetId", targetId));
-        assertThat(rs.hasNext()).isTrue();
-        rs.next();
-      });
-      final long duration1 = System.currentTimeMillis() - startTime1;
+      // Single MATCH with a comma-separated pattern: without the push-down this is a Cartesian product over every
+      // vertex in the database, filtered afterwards.
+      final String singleMatch = "MATCH (a),(b) WHERE ID(a) = $sourceId and ID(b) = $targetId RETURN a, b";
+      // Split MATCH clauses: the form the issue recommends.
+      final String splitMatch = "MATCH (a) WHERE ID(a) = $sourceId MATCH (b) WHERE ID(b) = $targetId RETURN a, b";
 
-      // Method 2: Separate MATCH clauses (should be faster)
-      final long startTime2 = System.currentTimeMillis();
-      db.transaction(() -> {
-        final ResultSet rs = db.query("opencypher",
-            "MATCH (a) WHERE ID(a) = $sourceId MATCH (b) WHERE ID(b) = $targetId RETURN a, b",
-            Map.of("sourceId", sourceId, "targetId", targetId));
-        assertThat(rs.hasNext()).isTrue();
-        rs.next();
-      });
-      final long duration2 = System.currentTimeMillis() - startTime2;
+      for (final String query : new String[] { singleMatch, splitMatch }) {
+        db.transaction(() -> {
+          try (final ResultSet rs = db.query("opencypher", query, params)) {
+            assertThat(rs.hasNext()).isTrue();
+            final Result row = rs.next();
+            assertThat(row.<Identifiable>getProperty("a").getIdentity().toString()).isEqualTo(ids[0]);
+            assertThat(row.<Identifiable>getProperty("b").getIdentity().toString()).isEqualTo(ids[1]);
+            assertThat(rs.hasNext()).isFalse();
+          }
+        });
 
-      // Method 2 should be significantly faster
-      // (commenting out the assertion for now since we're diagnosing the issue)
-      // assertThat(duration2).isLessThan(duration1);
-      assertThat(duration1).isGreaterThanOrEqualTo(0L);
-      assertThat(duration2).isGreaterThanOrEqualTo(0L);
+        final String plan = profiledPlan(db, query, params);
+        assertThat(plan).as("plan of: %s", query).contains("MATCH NODE (a) [id: " + ids[0] + "]");
+        assertThat(plan).as("plan of: %s", query).contains("MATCH NODE (b) [id: " + ids[1] + "]");
+      }
+
+      // Control: a predicate the push-down cannot lift leaves the pattern as the Cartesian product it always was,
+      // so the marker asserted above discriminates rather than being printed unconditionally.
+      final String noPushDown = "MATCH (a),(b) WHERE a.name = 'chunk1' and b.name = 'doc1' RETURN a, b";
+      assertThat(profiledPlan(db, noPushDown, Map.of())).doesNotContain("[id: ");
     } finally {
       db.drop();
+    }
+  }
+
+  /** The plan openCypher actually ran for {@code query}, drained so every step reports. */
+  private static String profiledPlan(final Database db, final String query, final Map<String, Object> params) {
+    try (final ResultSet rs = db.query("opencypher", "PROFILE " + query, params)) {
+      while (rs.hasNext())
+        rs.next();
+      assertThat(rs.getExecutionPlan()).as("PROFILE returned no plan for: %s", query).isPresent();
+      return rs.getExecutionPlan().get().prettyPrint(0, 2);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/IndexDescOrderDuplicateKeysTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/IndexDescOrderDuplicateKeysTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class IndexDescOrderDuplicateKeysTest extends TestHelper {
 
   @Test
-  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void shouldNotLoopWithAdjacentDuplicateKeysOnDescIndexScan() {
     final DocumentType type = database.getSchema().createDocumentType("ProcessExecution");
     type.createProperty("startTime", Type.LONG);

--- a/engine/src/test/java/com/arcadedb/utility/JvmStallMonitor.java
+++ b/engine/src/test/java/com/arcadedb/utility/JvmStallMonitor.java
@@ -69,8 +69,18 @@ final class JvmStallMonitor {
    */
   static final long TOLERANCE_NANOS = TimeUnit.MILLISECONDS.toNanos(10);
 
-  /** Name of the sampler thread, so a test can confirm it is running. */
-  static final String THREAD_NAME = "arcadedb-test-stall-monitor";
+  /**
+   * Name of the sampler thread, so a test can confirm it is running.
+   * <p>
+   * Deliberately outside the engine's own thread namespace (issue #6270): the leak detectors that hunt for engine
+   * background threads scan by name prefix - {@code DatabaseLifecycleBackgroundThreadsTest} collects anything
+   * starting with {@code ArcadeDB}, {@code AsyncExecutor-} or {@code arcadedb-} - and this sampler is a test
+   * utility, not engine machinery. It escapes those scans today only because they skip daemons first, which makes
+   * the safety an accident of one line elsewhere: the obvious future change here is a shutdown path (see the class
+   * comment), and any change that makes the sampler non-daemon would turn a leak detector red pointing at issue
+   * #5418 and the embedder's JVM lifetime, which has nothing to do with either.
+   */
+  static final String THREAD_NAME = "test-jvm-stall-monitor";
 
   private static final AtomicLong ACCUMULATED_STALL_NANOS = new AtomicLong();
 

--- a/engine/src/test/java/com/arcadedb/utility/LockManagerFairnessTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/LockManagerFairnessTest.java
@@ -45,6 +45,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * by {@code LockManagerTest}; this class focuses on the new fairness guarantee and the races a
  * fair-hand-off design must get right (no starvation, no lost lock on grant-vs-timeout, no lost
  * lock on grant-vs-interrupt, cross-thread unlock, infinite-wait).
+ * <p>
+ * The {@code @Timeout} annotations here are hang detectors, sized from each method's own internal budgets plus
+ * room for a stop-the-world pause (issue #6270). The stress methods already give themselves up to 45 s
+ * ({@code done.await(45, SECONDS)}) or 25 s (250 rounds x 100 ms) of honest work, so the previous 30 s and 60 s
+ * values sat below - or barely above - the honest budget once a ~30 s stall is added, and a red run would have
+ * said nothing about the lock manager. Nothing here asserts a latency: what these methods prove is FIFO order,
+ * mutual exclusion and no lost locks, all of them structural.
  */
 class LockManagerFairnessTest {
 
@@ -86,7 +93,7 @@ class LockManagerFairnessTest {
    * each is allowed to fully park before the next starts, so the enqueue order is deterministic.
    */
   @Test
-  @Timeout(30)
+  @Timeout(90)
   void waitersAcquireInFifoOrder() throws Exception {
     final String resource = "fifo";
     final int n = 8;
@@ -127,7 +134,7 @@ class LockManagerFairnessTest {
    * is skipped during hand-off.
    */
   @Test
-  @Timeout(30)
+  @Timeout(90)
   void timedOutWaiterIsSkippedAndQueueSurvives() throws Exception {
     final String resource = "skip";
     lockManager.tryLock(resource, "holder", 0);
@@ -160,7 +167,7 @@ class LockManagerFairnessTest {
    * some workers would lose the wake-up race repeatedly and return NO.
    */
   @Test
-  @Timeout(60)
+  @Timeout(120)
   @Tag("slow")
   void noStarvationUnderHeavyContention() throws Exception {
     final String resource = "hot";
@@ -221,14 +228,14 @@ class LockManagerFairnessTest {
    * re-acquirable, proving the lock was never lost.
    */
   @Test
-  @Timeout(60)
+  @Timeout(120)
   @Tag("slow")
   void grantRacingTimeoutNeverLeaksTheLock() throws Exception {
     final String resource = "race";
     final int rounds = 250;
     // A wider absolute window (100ms vs a few ms) makes scheduling jitter a smaller fraction of the
     // timing, so the grant-vs-timeout race is hit far more often than with a tiny budget - exercising the
-    // interesting grant-just-before-deadline path on healthy machines while staying inside @Timeout(60).
+    // interesting grant-just-before-deadline path on healthy machines while staying inside @Timeout(120).
     final long waiterTimeoutMs = 100;
 
     for (int r = 0; r < rounds; r++) {
@@ -266,7 +273,7 @@ class LockManagerFairnessTest {
    * queue consistent so a subsequent waiter still acquires the lock on release.
    */
   @Test
-  @Timeout(30)
+  @Timeout(90)
   void interruptWhileWaitingReturnsNoAndPreservesFlag() throws Exception {
     final String resource = "interrupt";
     lockManager.tryLock(resource, "holder", 0);
@@ -298,7 +305,7 @@ class LockManagerFairnessTest {
 
   /** Ownership is by requester, not thread: a lock taken on one thread can be released on another. */
   @Test
-  @Timeout(30)
+  @Timeout(90)
   void crossThreadUnlockByRequester() throws Exception {
     final String resource = "session";
     final String session = "session-42";
@@ -324,7 +331,7 @@ class LockManagerFairnessTest {
 
   /** {@code timeout <= 0} waits indefinitely (used by index compaction) and acquires once released. */
   @Test
-  @Timeout(30)
+  @Timeout(90)
   void infiniteWaitAcquiresOnRelease() throws Exception {
     final String resource = "infinite";
     lockManager.tryLock(resource, "holder", 0);
@@ -345,7 +352,7 @@ class LockManagerFairnessTest {
 
   /** The owner re-locking returns ALREADY_ACQUIRED even with waiters queued, and does not enqueue. */
   @Test
-  @Timeout(30)
+  @Timeout(90)
   void reentrantAcquireWithWaitersQueued() throws Exception {
     final String resource = "reentrant";
     lockManager.tryLock(resource, "owner", 0);
@@ -366,7 +373,7 @@ class LockManagerFairnessTest {
 
   /** close() must wake queued waiters; they return NO promptly. */
   @Test
-  @Timeout(30)
+  @Timeout(90)
   void closeWakesWaitersWithNo() throws Exception {
     final String resource = "closing";
     lockManager.tryLock(resource, "holder", 0);
@@ -387,7 +394,7 @@ class LockManagerFairnessTest {
    * per resource across many concurrent rounds.
    */
   @Test
-  @Timeout(60)
+  @Timeout(120)
   @Tag("slow")
   void multiResourceStressNoDeadlockNoLeak() throws Exception {
     final String a = "A";

--- a/engine/src/test/java/com/arcadedb/utility/LongObjectHashMapTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/LongObjectHashMapTest.java
@@ -234,7 +234,7 @@ class LongObjectHashMapTest {
   // SEPARATE_THREAD is required, not cosmetic: the regression this guards is an infinite probe loop,
   // and the default same-thread @Timeout can only report a breach AFTER the method returns - which a
   // spinning loop never does, so the build would hang forever instead of failing.
-  @Timeout(value = 20, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   void removeHeavyWorkloadNeverSaturatesTheTableWithTombstones() {
     final LongObjectHashMap<Integer> m = new LongObjectHashMap<>(16);
 
@@ -266,7 +266,7 @@ class LongObjectHashMapTest {
   // SEPARATE_THREAD is required, not cosmetic: the regression this guards is an infinite probe loop,
   // and the default same-thread @Timeout can only report a breach AFTER the method returns - which a
   // spinning loop never does, so the build would hang forever instead of failing.
-  @Timeout(value = 20, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
   void churnDoesNotGrowCapacityWithoutBound() {
     final LongObjectHashMap<Integer> m = new LongObjectHashMap<>(16);
     for (int i = 0; i < 100_000; i++) {

--- a/engine/src/test/java/com/arcadedb/utility/LongRangeListTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/LongRangeListTest.java
@@ -71,16 +71,26 @@ class LongRangeListTest {
 
   /**
    * A billion-element range must cost nothing: it is only start, step and size. Building the same list eagerly
-   * would need tens of GB of heap, so completing within the timeout is the proof that nothing is materialised.
+   * would need tens of GB of heap, so returning quickly is the proof that nothing is materialised.
+   * <p>
+   * That claim is asserted on the stall-discounted clock rather than by the {@code @Timeout} (issue #6270): every
+   * operation here is O(1) arithmetic, so the honest budget is microseconds and a 5 s discounted bound is three
+   * orders of magnitude tighter than the 10 s annotation it replaces - while being immune to the stop-the-world
+   * pause that made that annotation a coin flip late in a shared-JVM run. The annotation stays behind it as the
+   * hang detector, because a materialised range does not merely take longer, it never finishes.
    */
   @Test
-  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void hugeRangeIsFreeOfHeap() {
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+
     final LongRangeList list = new LongRangeList(0L, 1L, 1_000_000_000);
     assertThat(list.size()).isEqualTo(1_000_000_000);
     assertThat(list.get(999_999_999)).isEqualTo(999_999_999L);
     assertThat(list.contains(123_456_789L)).isTrue();
     assertThat(list.indexOf(123_456_789L)).isEqualTo(123_456_789);
+
+    stopwatch.assertStayedUnder(5_000L, "a constant-cost lazy range, not a materialised billion-element list");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatchTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/StallAwareStopwatchTest.java
@@ -129,6 +129,20 @@ class StallAwareStopwatchTest {
         .isTrue();
   }
 
+  /**
+   * Issue #6270: the sampler must not be named like engine machinery. The leak detectors that hunt for engine
+   * background threads scan by these prefixes, and this thread is a test utility - it escapes them today only
+   * because they skip daemons first, which one edit (a shutdown path making it non-daemon) would undo.
+   */
+  @Test
+  void theSamplerIsNamedOutsideTheEnginesThreadNamespace() {
+    assertThat(JvmStallMonitor.THREAD_NAME)
+        .as("a leak detector scanning for engine threads must not collect the stall sampler")
+        .doesNotStartWith("ArcadeDB")
+        .doesNotStartWith("AsyncExecutor-")
+        .doesNotStartWith("arcadedb-");
+  }
+
   /** Burns wall-clock time without parking, so the window is real for both the stopwatch and the sampler. */
   private static void busyElapse(final long millis) {
     final long untilNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(millis);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1840,14 +1840,19 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       ++resolved;
     }
 
-    final HAServerPlugin.RoutingTable table = selectUnambiguousRouting(protocol, addresses, fromConfig, resolved);
+    // Counted once and handed to both, the way unambiguousPeerAddress already does it: the selection and the
+    // warning ask the same question of the same view, so building the map twice is pure waste on a path that now
+    // runs the warning on every call.
+    final Map<String, int[]> claims = claimsByAddress(addresses, fromConfig, resolved);
+
+    final HAServerPlugin.RoutingTable table = selectUnambiguousRouting(protocol, addresses, fromConfig, resolved,
+        claims);
     // Unconditional, and that is the whole point: the verdict memory is only cleared by a pass that reaches it
     // with nothing to say, so guarding this call on "is it ambiguous now?" left the memory holding the last
     // collision forever. The operator would then fix that collision, hit it again later, and be told nothing -
     // the exact case issue #6297 exists to fix. A clean view renders to the empty verdict, which is what clears
-    // the memory; it costs the two small maps describeAmbiguity builds before it can know that, on a path that
-    // runs per ROUTE request and per refusal, never per row.
-    warnAmbiguousRouting(protocol, addresses, fromConfig, owners, resolved);
+    // the memory.
+    warnAmbiguousRouting(protocol, addresses, fromConfig, owners, resolved, claims);
     return table;
   }
 
@@ -1879,8 +1884,18 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    */
   static HAServerPlugin.RoutingTable selectUnambiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol,
       final String[] addresses, final boolean[] fromConfig, final int count) {
-    final Map<String, int[]> claims = claimsByAddress(addresses, fromConfig, count);
+    return selectUnambiguousRouting(protocol, addresses, fromConfig, count,
+        claimsByAddress(addresses, fromConfig, count));
+  }
 
+  /**
+   * The same, for a caller that has already counted the claims and would otherwise have this method count them a
+   * second time over the same view.
+   *
+   * @param claims the {@link #claimsByAddress} counts for exactly this view
+   */
+  static HAServerPlugin.RoutingTable selectUnambiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol,
+      final String[] addresses, final boolean[] fromConfig, final int count, final Map<String, int[]> claims) {
     if (!identifiesOnePeer(claims.get(addresses[0]), fromConfig[0]))
       return null;
 
@@ -2105,9 +2120,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * the memory. Package-private for testing.
    */
   void warnAmbiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol, final String[] addresses,
-      final boolean[] fromConfig, final RaftPeerId[] owners, final int count) {
-    final String collisions = describeAmbiguity(addresses, fromConfig, owners, count,
-        claimsByAddress(addresses, fromConfig, count));
+      final boolean[] fromConfig, final RaftPeerId[] owners, final int count, final Map<String, int[]> claims) {
+    final String collisions = describeAmbiguity(addresses, fromConfig, owners, count, claims);
     if (!isNewAmbiguityVerdict(routingAmbiguityReported.get(protocol), collisions))
       return;
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2111,6 +2111,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       withheld.computeIfAbsent(addresses[i], a -> new ArrayList<>()).add(String.valueOf(owners[i]));
     }
 
+    // The common case on a correctly declared cluster, and getPeerHttpEndpoints() asks on every request: answer it
+    // without building a renderer that would render nothing.
+    if (withheld.isEmpty())
+      return "";
+
     final StringBuilder collisions = new StringBuilder();
     for (final Map.Entry<String, List<String>> collision : withheld.entrySet()) {
       Collections.sort(collision.getValue());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -2133,6 +2133,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * verdict is reported whatever produced it. A pass that finds no collision clears the memory rather than
    * reporting, so a misconfiguration that is fixed and later reintroduced is announced again.
    * <p>
+   * Deliberately a plain {@code getAndSet} and not a {@code compareAndSet} loop. Two threads arriving with two
+   * DIFFERENT verdicts can both be told "changed" and both log; that is a duplicate warning about a
+   * misconfiguration that really did change, which is the outcome this method exists to produce, and a CAS loop
+   * would only decide which of the two the operator is not told about. The old {@code AtomicBoolean} had the same
+   * race with a worse shape - the loser was silenced permanently rather than for one pass.
+   * <p>
    * Package-private for testing.
    */
   static boolean isNewAmbiguityVerdict(final AtomicReference<String> lastReported, final String collisions) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -89,6 +89,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -154,12 +155,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private final    AtomicBoolean           httpFallbackWarned = new AtomicBoolean(false);
   // Logged at most once: notes that peer HTTPS endpoints are derived from this node's local HTTPS port.
   private final    AtomicBoolean           httpsFallbackWarned = new AtomicBoolean(false);
-  // Logged at most once per protocol, per node (these are this server's latches, like every other one here -
-  // a test that builds several RaftHAServer instances gets a fresh pair each time): warns that a peer-to-peer
-  // endpoint was WITHHELD because two peers resolved to it. Distinct from the two latches above, which fire
-  // whenever an address is derived at all - which a healthy homogeneous StatefulSet also does (issue #6267).
-  private final    AtomicBoolean           httpAmbiguityWarned = new AtomicBoolean(false);
-  private final    AtomicBoolean           httpsAmbiguityWarned = new AtomicBoolean(false);
+  // The last ambiguity verdict logged for this protocol, or null when the most recent pass found none. Warns that
+  // a peer-to-peer endpoint was WITHHELD because two peers resolved to it. Distinct from the two latches above,
+  // which fire whenever an address is derived at all - which a healthy homogeneous StatefulSet also does (issue
+  // #6267). Per node, like every other latch here: a test that builds several RaftHAServer instances gets a fresh
+  // pair each time. See the {@code isNewAmbiguityVerdict} contract for why this is a remembered verdict rather
+  // than a boolean (issue #6297).
+  private final    AtomicReference<String> httpAmbiguityReported  = new AtomicReference<>();
+  private final    AtomicReference<String> httpsAmbiguityReported = new AtomicReference<>();
   // Client-reachable Bolt endpoints (optional object-form 'bolt' field in HA_SERVER_LIST). Advertised
   // in the Bolt ROUTE routing table so neo4j:// drivers can discover leader/followers.
   private final    Map<RaftPeerId, String> boltAddresses      = new HashMap<>();
@@ -168,8 +171,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private final    Map<RaftPeerId, String> grpcAddresses      = new HashMap<>();
   // Logged at most once per protocol: warns operators that routing addresses are derived, not configured.
   private final    Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicBoolean> routingFallbackWarned = createRoutingProtocolLatches();
-  // Logged at most once per protocol: warns that peers resolved to a shared address and were not advertised.
-  private final    Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicBoolean> routingAmbiguityWarned = createRoutingProtocolLatches();
+  // The last routing-ambiguity verdict logged per protocol: warns that peers resolved to a shared address and were
+  // not advertised. Re-reported whenever the verdict changes, see {@code isNewAmbiguityVerdict} (issue #6297).
+  private final    Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicReference<String>> routingAmbiguityReported = createRoutingProtocolVerdicts();
   private final    Map<RaftPeerId, String> peerDisplayNames   = new ConcurrentHashMap<>();
   private final    String                  clusterName;
 
@@ -1805,8 +1809,12 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     // put an ArrayIndexOutOfBoundsException on the Bolt ROUTE path in exactly that window.
     final String[] addresses = new String[peers.size() + 1];
     final boolean[] fromConfig = new boolean[addresses.length];
+    // Carried alongside so the warning can name the peers that collided rather than only say that some did
+    // (issue #6297) - which is also what makes the line usable as the "have I already said this?" key.
+    final RaftPeerId[] owners = new RaftPeerId[addresses.length];
     addresses[0] = writer;
     fromConfig[0] = declared.containsKey(leaderId);
+    owners[0] = leaderId;
     int resolved = 1;
 
     for (final RaftPeer peer : peers) {
@@ -1817,12 +1825,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         continue;
       addresses[resolved] = reader;
       fromConfig[resolved] = declared.containsKey(peer.getId());
+      owners[resolved] = peer.getId();
       ++resolved;
     }
 
     final HAServerPlugin.RoutingTable table = selectUnambiguousRouting(protocol, addresses, fromConfig, resolved);
     if (table == null || table.readers().size() < resolved - 1)
-      warnAmbiguousRouting(protocol);
+      warnAmbiguousRouting(protocol, addresses, fromConfig, owners, resolved);
     return table;
   }
 
@@ -1869,9 +1878,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
 
   /**
    * address -&gt; {peers claiming it, of which declared}. Sized for the group: every caller runs per ROUTE request,
-   * per refusal or per snapshot install, never on a data path.
+   * per refusal or per snapshot install, never on a data path. Package-private for testing.
    */
-  private static Map<String, int[]> claimsByAddress(final String[] addresses, final boolean[] fromConfig,
+  static Map<String, int[]> claimsByAddress(final String[] addresses, final boolean[] fromConfig,
       final int count) {
     final Map<String, int[]> claims = new HashMap<>(count * 2);
     for (int i = 0; i < count; i++) {
@@ -2034,43 +2043,24 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * just collapsed onto one address"; {@link #warnAmbiguousRouting} says exactly this, but about the client
    * routing tables of issue #6183, not about the peer-to-peer endpoints a resync and a cluster verify dial.
    * <p>
-   * Once per protocol rather than once per attempt: the resync and verify paths ask on every attempt, and a
-   * misconfiguration that does not change between attempts should not be re-reported on each one. The latch
-   * lives on this node - one per {@code RaftHAServer}, which in a server process means once for its lifetime -
-   * and never rearms, the same convention {@link #deriveHttpAddressWithWarning} and
-   * {@link #warnAmbiguousRouting} follow, so a membership change that makes a <em>different</em> pair of peers
-   * collide is not logged again - the line names the peers that tripped it first, and a reader chasing a
-   * cluster they know is misconfigured should read {@code httpAddressAmbiguous} from {@code GET
-   * /api/v1/cluster}, which is recomputed per request and always current, rather than the log.
+   * Once per <em>verdict</em> rather than once per attempt: the resync and verify paths ask on every attempt, and
+   * a misconfiguration that has not changed between attempts should not be re-reported on each one. The memory
+   * lives on this node - one per {@code RaftHAServer}, which in a server process means for its lifetime - and it
+   * holds the rendered collision list rather than a boolean, so the operator is told again when a
+   * <em>different</em> set of peers collides (issue #6297). {@code httpAddressAmbiguous} on
+   * {@code GET /api/v1/cluster} remains the always-current view, recomputed per request.
    * <p>
    * Since the one line is all an operator gets, it names <em>every</em> collision this pass found, not just the
    * one the caller asked about: a cluster can have two independent colliding pairs, and reporting one of them
-   * would send the operator to declare two ports and leave the other pair withheld with the log now silent. The
-   * latch is taken only once there is something to say, so a pass that finds nothing does not spend it.
+   * would send the operator to declare two ports and leave the other pair withheld. That is also what makes the
+   * verdict the right memory key - it is the whole picture, so any change to it is a change the operator has not
+   * been told about yet.
    */
   private void warnAmbiguousPeerAddress(final boolean https, final String[] addresses, final boolean[] fromConfig,
       final RaftPeerId[] owners, final int count, final Map<String, int[]> claims) {
-    // address -> the peers whose endpoint it fails to identify. A peer that DECLARED an address others merely
-    // derive to keeps it (declared beats derived), so it is not among them and must not be named as withheld.
-    // Sorted, by address and then by peer, because the group arrives in whatever order Ratis holds it: the
-    // operator gets the same line for the same misconfiguration whichever node logs it.
-    final Map<String, List<String>> withheld = new TreeMap<>();
-    for (int i = 0; i < count; i++) {
-      if (identifiesOnePeer(claims.get(addresses[i]), fromConfig[i]))
-        continue;
-      withheld.computeIfAbsent(addresses[i], a -> new ArrayList<>()).add(owners[i].toString());
-    }
-
-    if (withheld.isEmpty() || !(https ? httpsAmbiguityWarned : httpAmbiguityWarned).compareAndSet(false, true))
+    final String collisions = describeAmbiguity(addresses, fromConfig, owners, count, claims);
+    if (!isNewAmbiguityVerdict(https ? httpsAmbiguityReported : httpAmbiguityReported, collisions))
       return;
-
-    final StringBuilder collisions = new StringBuilder();
-    for (final Map.Entry<String, List<String>> collision : withheld.entrySet()) {
-      Collections.sort(collision.getValue());
-      if (!collisions.isEmpty())
-        collisions.append("; ");
-      collisions.append(String.join(", ", collision.getValue())).append(" -> ").append(collision.getKey());
-    }
 
     final String protocol = https ? "HTTPS" : "HTTP";
     final String field = https ? "https" : "http";
@@ -2083,17 +2073,74 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         protocol, collisions, protocol, protocol, field, GlobalConfiguration.HA_SERVER_LIST.getKey());
   }
 
-  /** Tells the operator, once per protocol, that peers shared an address and what to write to fix it. */
-  private void warnAmbiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol) {
-    if (!routingAmbiguityWarned.get(protocol).compareAndSet(false, true))
+  /**
+   * Tells the operator which peers shared a routing address and what to write to fix it, on the same
+   * report-when-the-verdict-changes contract as its peer-to-peer twin above (issue #6297).
+   */
+  private void warnAmbiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol, final String[] addresses,
+      final boolean[] fromConfig, final RaftPeerId[] owners, final int count) {
+    final String collisions = describeAmbiguity(addresses, fromConfig, owners, count,
+        claimsByAddress(addresses, fromConfig, count));
+    if (!isNewAmbiguityVerdict(routingAmbiguityReported.get(protocol), collisions))
       return;
+
     final String field = routingConfigField(protocol);
     LogManager.instance().log(this, Level.WARNING,
-        "HA %s routing is ambiguous: two or more cluster peers resolved to the same %s address, which two listening "
-            + "sockets cannot both own. The peers that cannot be told apart are not advertised, and nothing is advertised "
-            + "at all when the leader is one of them. Declare each node's %s port explicitly with the "
-            + "'host:{raft:..,%s:..}' object syntax in %s.",
-        protocol.name(), protocol.name(), protocol.name(), field, GlobalConfiguration.HA_SERVER_LIST.getKey());
+        "HA %s routing is ambiguous: %s. Two listening sockets cannot both own one address, so the peers that "
+            + "cannot be told apart are not advertised, and nothing is advertised at all when the leader is one of "
+            + "them. Declare each node's %s port explicitly with the 'host:{raft:..,%s:..}' object syntax in %s.",
+        protocol.name(), collisions, protocol.name(), field, GlobalConfiguration.HA_SERVER_LIST.getKey());
+  }
+
+  /**
+   * Renders every address in a resolved view that fails to identify exactly one peer, as
+   * {@code "peerA, peerB -> host:port; peerC, peerD -> host:port2"}, or the empty string when the view is clean.
+   * <p>
+   * A peer that DECLARED an address others merely derive to keeps it (declared beats derived), so it is not among
+   * them and must not be named as withheld. Sorted, by address and then by peer, because the group arrives in
+   * whatever order Ratis holds it: the operator gets the same line for the same misconfiguration whichever node
+   * logs it, which is also what lets the line double as the memory key in {@link #isNewAmbiguityVerdict}.
+   * Package-private for testing.
+   */
+  static String describeAmbiguity(final String[] addresses, final boolean[] fromConfig, final RaftPeerId[] owners,
+      final int count, final Map<String, int[]> claims) {
+    final Map<String, List<String>> withheld = new TreeMap<>();
+    for (int i = 0; i < count; i++) {
+      if (identifiesOnePeer(claims.get(addresses[i]), fromConfig[i]))
+        continue;
+      withheld.computeIfAbsent(addresses[i], a -> new ArrayList<>()).add(String.valueOf(owners[i]));
+    }
+
+    final StringBuilder collisions = new StringBuilder();
+    for (final Map.Entry<String, List<String>> collision : withheld.entrySet()) {
+      Collections.sort(collision.getValue());
+      if (!collisions.isEmpty())
+        collisions.append("; ");
+      collisions.append(String.join(", ", collision.getValue())).append(" -> ").append(collision.getKey());
+    }
+    return collisions.toString();
+  }
+
+  /**
+   * Whether {@code collisions} - one ambiguity pass rendered by {@link #describeAmbiguity} - says something the
+   * operator has not already been told through {@code lastReported}, which it updates.
+   * <p>
+   * The point of issue #6297: a plain "log this once" latch is right until the operator acts on it. They read the
+   * line, declare the two ports it named, and a different pair of peers - or a peer added at runtime onto an
+   * address already taken - now collides with nothing logged, because the latch is spent. Keying on the verdict
+   * instead of on a membership-change event is both stricter and looser in the directions that matter: a
+   * membership change that leaves the verdict identical says nothing new and stays quiet, and any change to the
+   * verdict is reported whatever produced it. A pass that finds no collision clears the memory rather than
+   * reporting, so a misconfiguration that is fixed and later reintroduced is announced again.
+   * <p>
+   * Package-private for testing.
+   */
+  static boolean isNewAmbiguityVerdict(final AtomicReference<String> lastReported, final String collisions) {
+    if (collisions.isEmpty()) {
+      lastReported.set(null);
+      return false;
+    }
+    return !collisions.equals(lastReported.getAndSet(collisions));
   }
 
   /**
@@ -2183,6 +2230,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     for (final HAServerPlugin.ROUTING_PROTOCOL protocol : HAServerPlugin.ROUTING_PROTOCOL.values())
       latches.put(protocol, new AtomicBoolean(false));
     return latches;
+  }
+
+  /** One remembered ambiguity verdict per client protocol, for the same reason the latches above are per protocol. */
+  private static Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicReference<String>> createRoutingProtocolVerdicts() {
+    final Map<HAServerPlugin.ROUTING_PROTOCOL, AtomicReference<String>> verdicts = new EnumMap<>(
+        HAServerPlugin.ROUTING_PROTOCOL.class);
+    for (final HAServerPlugin.ROUTING_PROTOCOL protocol : HAServerPlugin.ROUTING_PROTOCOL.values())
+      verdicts.put(protocol, new AtomicReference<>());
+    return verdicts;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1790,6 +1790,17 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final RaftPeerId leaderId = getLeaderId();
     if (leaderId == null)
       return null;
+    return routingTableFor(protocol, leaderId);
+  }
+
+  /**
+   * The body of {@link #getRoutingTable}, given the leader rather than reading it from Ratis. Split out so the
+   * warn wiring below can be driven by a test without a live division - {@code getLeaderId()} answers null until
+   * one exists, which is before this method is reached, so the half of the contract that a CLEAN pass carries
+   * (clearing the verdict memory) would otherwise have nothing exercising it. Package-private for testing.
+   */
+  HAServerPlugin.RoutingTable routingTableFor(final HAServerPlugin.ROUTING_PROTOCOL protocol,
+      final RaftPeerId leaderId) {
     // Read once and passed down: the "was this declared or derived?" flag below and the address the resolver
     // returns must come from the same map, or a future second source could make them disagree about a peer.
     final Map<RaftPeerId, String> declared = declaredRoutingAddresses(protocol);
@@ -1830,8 +1841,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     }
 
     final HAServerPlugin.RoutingTable table = selectUnambiguousRouting(protocol, addresses, fromConfig, resolved);
-    if (table == null || table.readers().size() < resolved - 1)
-      warnAmbiguousRouting(protocol, addresses, fromConfig, owners, resolved);
+    // Unconditional, and that is the whole point: the verdict memory is only cleared by a pass that reaches it
+    // with nothing to say, so guarding this call on "is it ambiguous now?" left the memory holding the last
+    // collision forever. The operator would then fix that collision, hit it again later, and be told nothing -
+    // the exact case issue #6297 exists to fix. A clean view renders to the empty verdict, which is what clears
+    // the memory; it costs the two small maps describeAmbiguity builds before it can know that, on a path that
+    // runs per ROUTE request and per refusal, never per row.
+    warnAmbiguousRouting(protocol, addresses, fromConfig, owners, resolved);
     return table;
   }
 
@@ -1981,8 +1997,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       endpoints.put(owners[i], new PeerHttpEndpoint(addresses[i],
           !identifiesOnePeer(claims.get(addresses[i]), fromConfig[i])));
 
-    // No-op unless something is actually ambiguous, and then it names every collision this pass found - which
-    // is more than a per-peer caller can see, since that one asks about one address at a time.
+    // Logs nothing unless something is ambiguous, and then names every collision this pass found. Handed the
+    // clean views too: that is what resets the memory, so the same collision reappearing later is reported again.
     warnAmbiguousPeerAddress(false, addresses, fromConfig, owners, resolved, claims);
 
     return endpoints;
@@ -2024,10 +2040,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     }
 
     final Map<String, int[]> claims = claimsByAddress(addresses, fromConfig, resolved);
+    // Before the verdict on the peer asked about, not after it, and for the same reason getRoutingTable calls it
+    // unconditionally: a pass that finds nothing is the only thing that clears the memory, so returning early
+    // here left it holding a stale collision that silently swallowed the same one when it came back. It also
+    // matches what the warning already claims to be - a report of every collision the pass found, not of the one
+    // address the caller happened to ask about - so a healthy peer in an unhealthy cluster now says so.
+    warnAmbiguousPeerAddress(https, addresses, fromConfig, owners, resolved, claims);
+
     if (identifiesOnePeer(claims.get(address), fromConfig[0]))
       return address;
-
-    warnAmbiguousPeerAddress(https, addresses, fromConfig, owners, resolved, claims);
     return null;
   }
 
@@ -2055,8 +2076,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * would send the operator to declare two ports and leave the other pair withheld. That is also what makes the
    * verdict the right memory key - it is the whole picture, so any change to it is a change the operator has not
    * been told about yet.
+   * <p>
+   * Both callers hand over every resolved view, ambiguous or not, because a clean pass is the only thing that
+   * clears the memory. Package-private for testing.
    */
-  private void warnAmbiguousPeerAddress(final boolean https, final String[] addresses, final boolean[] fromConfig,
+  void warnAmbiguousPeerAddress(final boolean https, final String[] addresses, final boolean[] fromConfig,
       final RaftPeerId[] owners, final int count, final Map<String, int[]> claims) {
     final String collisions = describeAmbiguity(addresses, fromConfig, owners, count, claims);
     if (!isNewAmbiguityVerdict(https ? httpsAmbiguityReported : httpAmbiguityReported, collisions))
@@ -2076,8 +2100,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   /**
    * Tells the operator which peers shared a routing address and what to write to fix it, on the same
    * report-when-the-verdict-changes contract as its peer-to-peer twin above (issue #6297).
+   * <p>
+   * Called on <em>every</em> resolved view, ambiguous or not, because a clean pass is the only thing that clears
+   * the memory. Package-private for testing.
    */
-  private void warnAmbiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol, final String[] addresses,
+  void warnAmbiguousRouting(final HAServerPlugin.ROUTING_PROTOCOL protocol, final String[] addresses,
       final boolean[] fromConfig, final RaftPeerId[] owners, final int count) {
     final String collisions = describeAmbiguity(addresses, fromConfig, owners, count,
         claimsByAddress(addresses, fromConfig, count));

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6267AmbiguousPeerAddressWarningTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6267AmbiguousPeerAddressWarningTest.java
@@ -87,8 +87,9 @@ class Issue6267AmbiguousPeerAddressWarningTest {
 
   /**
    * A cluster with two <em>independent</em> collisions gets both named in the one line it is allowed. Reporting
-   * only the collision the caller happened to ask about would send an operator to declare two ports and leave
-   * the other pair withheld with the log now permanently silent, since the latch does not rearm.
+   * only the collision the caller happened to ask about would send an operator to declare two ports and leave the
+   * other pair withheld and unmentioned - and since the memory is keyed on the line itself (issue #6297), a
+   * partial line would also make the remaining collision look like something already reported.
    */
   @Test
   void oneWarningNamesEveryCollisionItFound() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6297AmbiguityRearmTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6297AmbiguityRearmTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6297: the ambiguity warnings must speak again when the verdict changes.
+ * <p>
+ * A "log this once" latch is right until the operator acts on it: they read the line, declare the two ports it
+ * named, and the next collision - a different pair, or a peer added at runtime onto an address already taken - is
+ * the one nobody is told about, because the latch is spent. Keying on the rendered verdict instead of on a boolean
+ * (or on a membership-change event) reports every change to the picture and stays quiet whenever the picture is
+ * unchanged, whatever the cluster did in between.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6297AmbiguityRearmTest {
+
+  private static final RaftPeerId PEER_A = RaftPeerId.valueOf("peer_a");
+  private static final RaftPeerId PEER_B = RaftPeerId.valueOf("peer_b");
+  private static final RaftPeerId PEER_C = RaftPeerId.valueOf("peer_c");
+  private static final RaftPeerId PEER_D = RaftPeerId.valueOf("peer_d");
+
+  @Test
+  void anUnchangedVerdictIsReportedOnceHoweverOftenItIsAsked() {
+    final AtomicReference<String> reported = new AtomicReference<>();
+    final String verdict = "peer_a, peer_b -> host:2480";
+
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, verdict)).isTrue();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, verdict)).isFalse();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, verdict)).isFalse();
+  }
+
+  /** The case a latch cannot serve: the first collision is fixed, a second one appears, and it must be reported. */
+  @Test
+  void aDifferentCollisionIsReportedEvenAfterOneAlreadyWas() {
+    final AtomicReference<String> reported = new AtomicReference<>();
+
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, "peer_a, peer_b -> host:2480")).isTrue();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, "peer_c, peer_d -> host:2481")).isTrue();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, "peer_c, peer_d -> host:2481")).isFalse();
+  }
+
+  /**
+   * A verdict that grows or shrinks - a third peer joining an existing collision, one of a pair leaving - is a
+   * different picture and gets its own line.
+   */
+  @Test
+  void aCollisionThatGainsOrLosesAPeerIsReportedAgain() {
+    final AtomicReference<String> reported = new AtomicReference<>();
+
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, "peer_a, peer_b -> host:2480")).isTrue();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, "peer_a, peer_b, peer_c -> host:2480")).isTrue();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, "peer_a, peer_b -> host:2480")).isTrue();
+  }
+
+  /**
+   * A clean pass reports nothing and forgets, so the same misconfiguration reintroduced later is announced instead
+   * of being swallowed as "already said".
+   */
+  @Test
+  void aCleanPassSaysNothingAndClearsTheMemory() {
+    final AtomicReference<String> reported = new AtomicReference<>();
+    final String verdict = "peer_a, peer_b -> host:2480";
+
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, verdict)).isTrue();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, "")).isFalse();
+    assertThat(reported.get()).isNull();
+    assertThat(RaftHAServer.isNewAmbiguityVerdict(reported, verdict))
+        .as("the collision came back, so it is news again")
+        .isTrue();
+  }
+
+  /**
+   * The verdict is the memory key, so its rendering has to be stable: peers sorted within an address and addresses
+   * sorted between them, because Ratis hands the group over in whatever order it holds it. Two nodes looking at the
+   * same misconfiguration must produce the same string, or every pass would look like a change.
+   */
+  @Test
+  void theVerdictIsRenderedInAStableOrderWhateverOrderThePeersArriveIn() {
+    final String[] addresses = { "host:2481", "host:2480", "host:2481", "host:2480" };
+    final boolean[] fromConfig = new boolean[4];
+    final RaftPeerId[] owners = { PEER_D, PEER_B, PEER_C, PEER_A };
+
+    assertThat(RaftHAServer.describeAmbiguity(addresses, fromConfig, owners, 4,
+        RaftHAServer.claimsByAddress(addresses, fromConfig, 4)))
+        .isEqualTo("peer_a, peer_b -> host:2480; peer_c, peer_d -> host:2481");
+  }
+
+  /** Declared beats derived: the peer that stated the address owns it, so it is not among the withheld. */
+  @Test
+  void aDeclaredAddressIsNotNamedAsWithheld() {
+    final String[] addresses = { "host:2480", "host:2480", "host:2482" };
+    final boolean[] fromConfig = { true, false, false };
+    final RaftPeerId[] owners = { PEER_A, PEER_B, PEER_C };
+
+    assertThat(RaftHAServer.describeAmbiguity(addresses, fromConfig, owners, 3,
+        RaftHAServer.claimsByAddress(addresses, fromConfig, 3)))
+        .isEqualTo("peer_b -> host:2480");
+  }
+
+  /** A view in which every address identifies its own peer renders to nothing, which is what keeps the log quiet. */
+  @Test
+  void aCleanViewRendersToTheEmptyVerdict() {
+    final String[] addresses = { "host:2480", "host:2481", "host:2482" };
+    final boolean[] fromConfig = new boolean[3];
+    final RaftPeerId[] owners = { PEER_A, PEER_B, PEER_C };
+
+    assertThat(RaftHAServer.describeAmbiguity(addresses, fromConfig, owners, 3,
+        RaftHAServer.claimsByAddress(addresses, fromConfig, 3))).isEmpty();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6297AmbiguityRearmTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6297AmbiguityRearmTest.java
@@ -18,12 +18,19 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
+
 import org.apache.ratis.protocol.RaftPeerId;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Issue #6297: the ambiguity warnings must speak again when the verdict changes.
@@ -130,5 +137,101 @@ class Issue6297AmbiguityRearmTest {
 
     assertThat(RaftHAServer.describeAmbiguity(addresses, fromConfig, owners, 3,
         RaftHAServer.claimsByAddress(addresses, fromConfig, 3))).isEmpty();
+  }
+
+  /**
+   * The wiring, not the decision function: the memory is only cleared by a pass that reaches it with nothing to
+   * say, so a caller that consults the warning ONLY when the current view is already ambiguous can never clear it.
+   * The verdict then stays behind forever and the same collision, reintroduced after the operator fixes it, is
+   * swallowed as "already reported" - which is the case issue #6297 exists to fix, defeated by its own caller.
+   * Both warnings are therefore handed every resolved view, and these two tests are what says so.
+   */
+  @Test
+  void theRoutingCallerHandsOverACleanPassToo() {
+    final CapturingTestLogger log = CapturingTestLogger.install();
+    try {
+      // Declared, distinct gRPC ports: the routing view this server resolves is unambiguous.
+      final RaftHAServer raft = newDetachedServer(
+          "localhost:{raft:2434,grpc:5434},localhost:{raft:2435,grpc:5435},localhost:{raft:2436,grpc:5436}");
+
+      raft.warnAmbiguousRouting(GRPC, COLLIDING, DERIVED, THREE_PEERS, 3);
+      assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING)).as("a collision is reported").isEqualTo(1);
+      raft.warnAmbiguousRouting(GRPC, COLLIDING, DERIVED, THREE_PEERS, 3);
+      assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING)).as("unchanged, so nothing new").isEqualTo(1);
+
+      // The real caller, on a healthy cluster. Nothing is logged - and that is not what is under test: what is
+      // under test is that it REACHED the warning at all, which is the only thing that clears the memory.
+      assertThat(raft.routingTableFor(GRPC, RaftPeerId.valueOf("localhost_2434"))).isNotNull();
+      assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING)).as("a clean pass says nothing").isEqualTo(1);
+
+      raft.warnAmbiguousRouting(GRPC, COLLIDING, DERIVED, THREE_PEERS, 3);
+      assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING))
+          .as("the clean pass cleared the memory, so the collision coming back is news again")
+          .isEqualTo(2);
+    } finally {
+      log.uninstall();
+    }
+  }
+
+  /**
+   * The same for the peer-to-peer endpoint, driven through the public accessor. Over HTTPS on purpose:
+   * {@code getPeerHttpEndpoints} hands over every HTTP view already, so the HTTP memory was being cleared by
+   * accident of that one caller - the HTTPS memory is reached only through the per-peer accessor, which returned
+   * before the warning whenever the peer it was asked about was fine, and so had nothing clearing it at all.
+   */
+  @Test
+  void thePeerAddressCallerHandsOverACleanPassToo() {
+    final CapturingTestLogger log = CapturingTestLogger.install();
+    try {
+      // host:raftPort:httpPort:priority:httpsPort - distinct HTTPS ports, so the HTTPS view is unambiguous.
+      final RaftHAServer raft = newDetachedServer(
+          "localhost:2434:2480:0:2490,localhost:2435:2481:0:2491,localhost:2436:2482:0:2492");
+
+      warnHttps(raft, COLLIDING);
+      assertThat(log.countFormattedContaining(AMBIGUOUS_HTTPS)).isEqualTo(1);
+      warnHttps(raft, COLLIDING);
+      assertThat(log.countFormattedContaining(AMBIGUOUS_HTTPS)).as("unchanged, so nothing new").isEqualTo(1);
+
+      assertThat(raft.getUnambiguousPeerHttpsAddress(RaftPeerId.valueOf("localhost_2435")))
+          .isEqualTo("localhost:2491");
+      assertThat(log.countFormattedContaining(AMBIGUOUS_HTTPS)).as("a clean pass says nothing").isEqualTo(1);
+
+      warnHttps(raft, COLLIDING);
+      assertThat(log.countFormattedContaining(AMBIGUOUS_HTTPS))
+          .as("the clean pass cleared the memory, so the collision coming back is news again")
+          .isEqualTo(2);
+    } finally {
+      log.uninstall();
+    }
+  }
+
+  private static void warnHttps(final RaftHAServer raft, final String[] addresses) {
+    raft.warnAmbiguousPeerAddress(true, addresses, DERIVED, THREE_PEERS, 3,
+        RaftHAServer.claimsByAddress(addresses, DERIVED, 3));
+  }
+
+  private static final HAServerPlugin.ROUTING_PROTOCOL GRPC = HAServerPlugin.ROUTING_PROTOCOL.GRPC;
+
+  /** Peers B and C share an address; A owns its own. */
+  private static final String[]     COLLIDING   = { "host:2480", "host:2490", "host:2490" };
+  private static final boolean[]    DERIVED     = new boolean[3];
+  private static final RaftPeerId[] THREE_PEERS = { PEER_A, PEER_B, PEER_C };
+
+  private static final String AMBIGUOUS_ROUTING = "HA GRPC routing is ambiguous";
+  private static final String AMBIGUOUS_HTTPS   = "HA HTTPS peer endpoints are ambiguous";
+
+  /**
+   * A {@link RaftHAServer} built from {@code serverList} with Ratis never started: the peer group and the declared
+   * addresses are both populated by the constructor, which is all these paths read. The node names itself with the
+   * {@code prefix_N} convention, so it is the FIRST entry of the list.
+   */
+  private static RaftHAServer newDetachedServer(final String serverList) {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, serverList);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getServerName()).thenReturn("ArcadeDB_0");
+
+    return new RaftHAServer(mockServer, config);
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6297AmbiguityRearmTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue6297AmbiguityRearmTest.java
@@ -154,9 +154,9 @@ class Issue6297AmbiguityRearmTest {
       final RaftHAServer raft = newDetachedServer(
           "localhost:{raft:2434,grpc:5434},localhost:{raft:2435,grpc:5435},localhost:{raft:2436,grpc:5436}");
 
-      raft.warnAmbiguousRouting(GRPC, COLLIDING, DERIVED, THREE_PEERS, 3);
+      warnRouting(raft, COLLIDING);
       assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING)).as("a collision is reported").isEqualTo(1);
-      raft.warnAmbiguousRouting(GRPC, COLLIDING, DERIVED, THREE_PEERS, 3);
+      warnRouting(raft, COLLIDING);
       assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING)).as("unchanged, so nothing new").isEqualTo(1);
 
       // The real caller, on a healthy cluster. Nothing is logged - and that is not what is under test: what is
@@ -164,7 +164,7 @@ class Issue6297AmbiguityRearmTest {
       assertThat(raft.routingTableFor(GRPC, RaftPeerId.valueOf("localhost_2434"))).isNotNull();
       assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING)).as("a clean pass says nothing").isEqualTo(1);
 
-      raft.warnAmbiguousRouting(GRPC, COLLIDING, DERIVED, THREE_PEERS, 3);
+      warnRouting(raft, COLLIDING);
       assertThat(log.countFormattedContaining(AMBIGUOUS_ROUTING))
           .as("the clean pass cleared the memory, so the collision coming back is news again")
           .isEqualTo(2);
@@ -203,6 +203,11 @@ class Issue6297AmbiguityRearmTest {
     } finally {
       log.uninstall();
     }
+  }
+
+  private static void warnRouting(final RaftHAServer raft, final String[] addresses) {
+    raft.warnAmbiguousRouting(GRPC, addresses, DERIVED, THREE_PEERS, 3,
+        RaftHAServer.claimsByAddress(addresses, DERIVED, 3));
   }
 
   private static void warnHttps(final RaftHAServer raft, final String[] addresses) {

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -42,6 +42,16 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- StallAwareStopwatch / JvmStallMonitor: wall-clock bounds in this module's tests discount the JVM-wide
+             stall observed inside the measured window (issues #6260, #6270). Test scope only. -->
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-engine</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -43,7 +43,10 @@
         </dependency>
 
         <!-- StallAwareStopwatch / JvmStallMonitor: wall-clock bounds in this module's tests discount the JVM-wide
-             stall observed inside the measured window (issues #6260, #6270). Test scope only. -->
+             stall observed inside the measured window (issues #6260, #6270). Test scope only.
+             NOTE: a test-jar is a package-phase artifact, so this module's tests need a verify/install reactor
+             build (or -am) to resolve it from the working tree - see the build notes in CLAUDE.md.
+             `mvn -pl network test` on its own resolves it from ~/.m2 and can silently run against a stale one. -->
         <dependency>
             <groupId>com.arcadedb</groupId>
             <artifactId>arcadedb-engine</artifactId>

--- a/network/src/test/java/com/arcadedb/remote/RemoteHttpComponentTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteHttpComponentTest.java
@@ -32,6 +32,7 @@ import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.Pair;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1067,15 +1068,14 @@ class RemoteHttpComponentTest {
       try {
         final HttpRequest request = c.createRequestBuilder("GET", c.getUrl("server")).GET().build();
 
-        final long start = System.nanoTime();
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
         assertThatThrownBy(() -> c.sendWithWatchdog(request, 200))
             .isInstanceOf(java.io.IOException.class)
             .hasMessageContaining("watchdog timeout after 200ms");
-        final long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
 
         // Bounded by the explicit 200ms watchdog window (generous margin for scheduling jitter),
         // nowhere near the pre-fix 1000x scaling (which would have meant no timeout at all here).
-        assertThat(elapsedMs).isLessThan(5_000L);
+        stopwatch.assertGaveUpWithin(5_000L, "the explicit 200ms watchdog from the 1000x-scaled one that never fires");
       } finally {
         c.close();
       }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -63,6 +63,16 @@
       <version>${project.parent.version}</version>
       <scope>compile</scope>
     </dependency>
+    <!-- StallAwareStopwatch / JvmStallMonitor: the wall-clock bounds in this module's tests are measured with the
+         JVM-wide stall inside the window discounted, so a stop-the-world pause late in a shared-fork run cannot
+         trip them (issues #6260, #6270). Test scope only. -->
+    <dependency>
+      <groupId>com.arcadedb</groupId>
+      <artifactId>arcadedb-engine</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -65,7 +65,10 @@
     </dependency>
     <!-- StallAwareStopwatch / JvmStallMonitor: the wall-clock bounds in this module's tests are measured with the
          JVM-wide stall inside the window discounted, so a stop-the-world pause late in a shared-fork run cannot
-         trip them (issues #6260, #6270). Test scope only. -->
+         trip them (issues #6260, #6270). Test scope only.
+         NOTE: a test-jar is a package-phase artifact, so this module's tests need a verify/install reactor build
+         (or -am) to resolve it from the working tree - see the build notes in CLAUDE.md. `mvn -pl server test`
+         on its own resolves it from ~/.m2 and can silently run against a stale one. -->
     <dependency>
       <groupId>com.arcadedb</groupId>
       <artifactId>arcadedb-engine</artifactId>

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -246,12 +246,17 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
 
           LogManager.instance().log(this, Level.FINE, "END OF THE TEST: Cleaning test %s...", getClass().getName());
           if (dropDatabasesAtTheEnd())
+            // Ends in exactly the two TestServerHelper calls below - the overrides that exist
+            // (BaseRaftHATest, RaftStorageDirectoryIT) add to it through super, they do not replace it - so
+            // repeating them afterwards only re-walked folders that were already gone. The other branch has to
+            // make them itself: the folders are removed whether or not the databases were dropped.
             deleteDatabaseFolders();
+          else {
+            TestServerHelper.checkActiveDatabases(false);
+            TestServerHelper.deleteDatabaseFolders(getServerCount());
+          }
 
           checkArcadeIsTotallyDown();
-
-          TestServerHelper.checkActiveDatabases(dropDatabasesAtTheEnd());
-          TestServerHelper.deleteDatabaseFolders(getServerCount());
         } finally {
           GlobalConfiguration.resetAll();
           GlobalConfiguration.TEST.setValue(false);

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -249,7 +249,11 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
             // Ends in exactly the two TestServerHelper calls below - the overrides that exist
             // (BaseRaftHATest, RaftStorageDirectoryIT) add to it through super, they do not replace it - so
             // repeating them afterwards only re-walked folders that were already gone. The other branch has to
-            // make them itself: the folders are removed whether or not the databases were dropped.
+            // make them itself: the folders are removed whether or not the databases were dropped, and it cannot
+            // reach them through deleteDatabaseFolders() because that drops the databases first, which is exactly
+            // what a class returning false asked not to happen. So an override of deleteDatabaseFolders() runs
+            // only on this branch - fine today (the one class returning false, ServerReadOnlyDatabasesIT, does not
+            // override it, and the two that do inherit true), and the thing to know before adding a third.
             deleteDatabaseFolders();
           else {
             TestServerHelper.checkActiveDatabases(false);

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -235,24 +235,30 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
         LogManager.instance().log(this, Level.INFO, "END OF THE TEST: Check DBS are identical...");
         checkDatabasesAreIdentical();
       } finally {
-        GlobalConfiguration.resetAll();
+        // Issue #6297: the cleanup runs BEFORE resetAll(), not after. Every path it deletes is resolved from the
+        // live configuration at call time, and SERVER_DATABASE_DIRECTORY is '${arcadedb.server.rootPath}/databases'
+        // over a root path that defaults to null - so a reset first left this deleting '/databases0' while
+        // './target/databases0' (and the .raft-storage under it) survived the teardown that was supposed to remove
+        // it. The reset only has to leave the JVM clean for the next class, which the finally below still does.
+        try {
+          LogManager.instance().log(this, Level.FINE, "TEST: Stopping servers...");
+          stopServers();
 
-        LogManager.instance().log(this, Level.FINE, "TEST: Stopping servers...");
-        stopServers();
+          LogManager.instance().log(this, Level.FINE, "END OF THE TEST: Cleaning test %s...", getClass().getName());
+          if (dropDatabasesAtTheEnd())
+            deleteDatabaseFolders();
 
-        LogManager.instance().log(this, Level.FINE, "END OF THE TEST: Cleaning test %s...", getClass().getName());
-        if (dropDatabasesAtTheEnd())
-          deleteDatabaseFolders();
+          checkArcadeIsTotallyDown();
 
-        checkArcadeIsTotallyDown();
-
-        GlobalConfiguration.TEST.setValue(false);
-        GlobalConfiguration.SERVER_ROOT_PASSWORD.setValue(null);
+          TestServerHelper.checkActiveDatabases(dropDatabasesAtTheEnd());
+          TestServerHelper.deleteDatabaseFolders(getServerCount());
+        } finally {
+          GlobalConfiguration.resetAll();
+          GlobalConfiguration.TEST.setValue(false);
+          GlobalConfiguration.SERVER_ROOT_PASSWORD.setValue(null);
+        }
       }
     }
-
-    TestServerHelper.checkActiveDatabases(dropDatabasesAtTheEnd());
-    TestServerHelper.deleteDatabaseFolders(getServerCount());
   }
 
   protected Database getDatabase(final int serverId) {

--- a/server/src/test/java/com/arcadedb/server/Issue5418ShutdownHookDeadlockTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5418ShutdownHookDeadlockTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server;
 
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -69,14 +70,12 @@ class Issue5418ShutdownHookDeadlockTest {
     assertThat(held.await(10, TimeUnit.SECONDS)).as("the holder must acquire the lock first").isTrue();
 
     try {
-      final long startedAt = System.nanoTime();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       final boolean acquired = ArcadeDBServer.awaitLifecycleLock(lock, 300);
-      final long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
 
       assertThat(acquired).as("the lock is held elsewhere, so the hook must NOT acquire it").isFalse();
       // The point of the fix: it returns. Before it, this call was an unbounded park and the JVM hung.
-      assertThat(elapsedMs).as("the hook must give up near its deadline, not wait forever")
-          .isLessThan(10_000L);
+      stopwatch.assertGaveUpWithin(10_000L, "a 300ms bounded acquisition from the unbounded park that hung the JVM");
     } finally {
       release.countDown();
       holder.join(10_000);

--- a/server/src/test/java/com/arcadedb/server/Issue5470BatchErrorDeliveryIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5470BatchErrorDeliveryIT.java
@@ -20,6 +20,7 @@ package com.arcadedb.server;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -368,7 +369,7 @@ class Issue5470BatchErrorDeliveryIT extends BaseGraphServerTest {
         .POST(HttpRequest.BodyPublishers.ofInputStream(() -> body))
         .build();
 
-    final long start = System.currentTimeMillis();
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
     try (final HttpClient client = HttpClient.newHttpClient()) {
       final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -382,9 +383,9 @@ class Issue5470BatchErrorDeliveryIT extends BaseGraphServerTest {
       // the response to that; it cannot lose the fact that the load failed, and the reason is in the server log.
     }
 
-    assertThat(System.currentTimeMillis() - start)
-        .as("answered or reset, it must resolve at once rather than after the upload")
-        .isLessThan(PROMPT_ANSWER_MS);
+    // Answered or reset, it must resolve at once rather than after the upload.
+    stopwatch.assertGaveUpWithin(PROMPT_ANSWER_MS,
+        "an immediate answer from one that waits out the whole upload first");
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5470BatchStreamStallIT.java
@@ -21,6 +21,7 @@ package com.arcadedb.server;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.graph.GraphBatch;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -171,14 +172,14 @@ class Issue5470BatchStreamStallIT extends BaseGraphServerTest {
       out.write(line.getBytes(StandardCharsets.UTF_8));
       out.flush();
 
-      final long startMs = System.currentTimeMillis();
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
       final BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
       final String statusLine = in.readLine();
-      final long elapsedMs = System.currentTimeMillis() - startMs;
 
       // Either the server answers (preferred: 408 with the counters) or it closes the connection, but it must
       // never wait for the relaxed streaming budget before reacting.
-      assertThat(elapsedMs).isLessThan((long) STREAMING_BUDGET_MS);
+      stopwatch.assertGaveUpWithin((long) STREAMING_BUDGET_MS,
+          "the socket timeout that cuts off a silent client from the relaxed streaming budget");
       if (statusLine != null)
         assertThat(statusLine).contains("408");
     }

--- a/server/src/test/java/com/arcadedb/server/Issue6297TeardownDeletesTestFoldersIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6297TeardownDeletesTestFoldersIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6297: {@code BaseGraphServerTest.endTest()} must actually delete the folders the test wrote to.
+ * <p>
+ * It used to call {@code GlobalConfiguration.resetAll()} first, and every path the cleanup deletes is resolved from
+ * the configuration at call time, so the whole prefix collapsed and the class's own {@code ./target/databasesN}
+ * survived teardown - to be removed, if ever, by the next class's {@code beginTest}. The assertion lives in
+ * {@code @AfterAll} because that is the only hook JUnit runs after {@code @AfterEach}, which is where the teardown is.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6297TeardownDeletesTestFoldersIT extends BaseGraphServerTest {
+  private static String databasePath;
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void theServerWroteWhereTheTeardownWillLookForIt() {
+    databasePath = getDatabasePath(0);
+    assertThat(new File(databasePath)).as("the database the fixture created").exists();
+  }
+
+  @AfterAll
+  static void theTeardownRemovedIt() {
+    assertThat(databasePath).as("the test method must have run").isNotNull();
+    assertThat(new File(databasePath)).as("endTest() left the test's own database behind (issue #6297)")
+        .doesNotExist();
+    assertThat(new File("./target/databases0")).as("endTest() left the server's whole folder behind (issue #6297)")
+        .doesNotExist();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue6297TeardownPathResolutionTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6297TeardownPathResolutionTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6297: {@code TestServerHelper.deleteDatabaseFolders} resolves every path it deletes from the live
+ * configuration, so a caller that resets first does not merely fail to clean up - it asks for a recursive delete of
+ * absolute root-level paths.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6297TeardownPathResolutionTest {
+
+  /**
+   * The trap itself, pinned so it cannot be rediscovered: {@code SERVER_DATABASE_DIRECTORY} defaults to
+   * {@code ${arcadedb.server.rootPath}/databases} over a root path that defaults to {@code null}, and the resolver
+   * substitutes an empty string for an unknown variable rather than failing.
+   */
+  @Test
+  void aResetConfigurationResolvesTheDatabaseDirectoryToTheFilesystemRoot() {
+    GlobalConfiguration.resetAll();
+    final String resolved = GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString();
+
+    assertThat(resolved).isEqualTo("/databases");
+    assertThat(TestServerHelper.isResolvedTestPath(resolved)).isFalse();
+    assertThat(TestServerHelper.isResolvedTestPath(resolved + 0 + File.separator)).isFalse();
+  }
+
+  @Test
+  void theGuardAcceptsEveryShapeATestActuallyConfigures(@TempDir final Path tempDir) {
+    assertThat(TestServerHelper.isResolvedTestPath("./target/databases0" + File.separator)).isTrue();
+    assertThat(TestServerHelper.isResolvedTestPath("target/databases")).isTrue();
+    assertThat(TestServerHelper.isResolvedTestPath(tempDir.resolve("databases").toString())).isTrue();
+
+    assertThat(TestServerHelper.isResolvedTestPath(null)).isFalse();
+    assertThat(TestServerHelper.isResolvedTestPath("")).isFalse();
+    assertThat(TestServerHelper.isResolvedTestPath("   ")).isFalse();
+    assertThat(TestServerHelper.isResolvedTestPath("/")).isFalse();
+    assertThat(TestServerHelper.isResolvedTestPath("/databases")).isFalse();
+  }
+
+  /**
+   * The two orderings, end to end: with the configuration live the per-server folder goes, and with it reset the
+   * same call touches nothing at all instead of walking off to {@code /databases0}.
+   */
+  @Test
+  void deleteDatabaseFoldersCleansWhenResolvedAndRefusesWhenNot(@TempDir final Path tempDir) throws IOException {
+    final Path root = tempDir.resolve("root");
+    final Path server0 = root.resolve("databases0");
+    Files.createDirectories(server0);
+    Files.writeString(server0.resolve("marker.txt"), "issue-6297");
+
+    try {
+      GlobalConfiguration.SERVER_ROOT_PATH.setValue(root.toString());
+      GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue(root.resolve("databases").toString());
+      TestServerHelper.deleteDatabaseFolders(1);
+      assertThat(server0).as("the folder the live configuration names is the one that gets cleaned").doesNotExist();
+
+      Files.createDirectories(server0);
+      Files.writeString(server0.resolve("marker.txt"), "issue-6297");
+
+      GlobalConfiguration.resetAll();
+      TestServerHelper.deleteDatabaseFolders(1);
+      assertThat(server0).as("a cleanup running after the reset must delete nothing rather than delete /databases0")
+          .exists();
+    } finally {
+      GlobalConfiguration.resetAll();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/Issue6297TeardownPathResolutionTest.java
+++ b/server/src/test/java/com/arcadedb/server/Issue6297TeardownPathResolutionTest.java
@@ -58,12 +58,20 @@ class Issue6297TeardownPathResolutionTest {
     assertThat(TestServerHelper.isResolvedTestPath("./target/databases0" + File.separator)).isTrue();
     assertThat(TestServerHelper.isResolvedTestPath("target/databases")).isTrue();
     assertThat(TestServerHelper.isResolvedTestPath(tempDir.resolve("databases").toString())).isTrue();
+    assertThat(TestServerHelper.isResolvedTestPath(tempDir.resolve("databases") + "0" + File.separator)).isTrue();
 
     assertThat(TestServerHelper.isResolvedTestPath(null)).isFalse();
     assertThat(TestServerHelper.isResolvedTestPath("")).isFalse();
     assertThat(TestServerHelper.isResolvedTestPath("   ")).isFalse();
     assertThat(TestServerHelper.isResolvedTestPath("/")).isFalse();
     assertThat(TestServerHelper.isResolvedTestPath("/databases")).isFalse();
+
+    // The suffix is appended before the check, not after it, so these are the strings actually asked about: a
+    // folder the collapsed placeholder named stays refused once the per-server digit and separator are on it, and
+    // a root path that itself collapsed to "/" is refused for its replication folder too.
+    assertThat(TestServerHelper.isResolvedTestPath("/databases" + 0 + File.separator)).isFalse();
+    assertThat(TestServerHelper.isResolvedTestPath("/" + File.separator + "replication")).isFalse();
+    assertThat(TestServerHelper.isResolvedTestPath("./target" + File.separator + "replication")).isTrue();
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/StaticBaseServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/StaticBaseServerTest.java
@@ -46,9 +46,13 @@ public abstract class StaticBaseServerTest {
   @BeforeEach
   public void beginTest() {
     TestServerHelper.checkActiveDatabases();
-    TestServerHelper.deleteDatabaseFolders(5);
 
+    // Issue #6297: the configuration first, THEN the cleanup that resolves its paths. The previous class ends on a
+    // resetAll(), and SERVER_DATABASE_DIRECTORY read from a reset configuration resolves to '/databases' rather than
+    // to './target/databases', so cleaning first deleted nothing this class was about to write to.
     setTestConfiguration();
+
+    TestServerHelper.deleteDatabaseFolders(5);
 
     LogManager.instance().log(StaticBaseServerTest.class, Level.FINE, "Starting test...");
   }

--- a/server/src/test/java/com/arcadedb/server/TestServerHelper.java
+++ b/server/src/test/java/com/arcadedb/server/TestServerHelper.java
@@ -30,6 +30,8 @@ import com.arcadedb.utility.CallableParameterNoReturn;
 import com.arcadedb.utility.FileUtils;
 
 import java.io.File;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.logging.Level;
 
@@ -147,12 +149,67 @@ public final class TestServerHelper {
     assertThat(activeDatabases.isEmpty()).as("Found active databases: " + activeDatabases).isTrue();
   }
 
+  /**
+   * Deletes the folders a server test writes into: the shared {@code ./target/databases}, the per-server
+   * {@code <databaseDirectory>N} for {@code N < totalServers}, and the replication directory under the server root.
+   * <p>
+   * Every path is resolved <b>at call time</b> from the live configuration, so the caller must not have reset it yet.
+   * That is not a style point (issue #6297): {@link GlobalConfiguration#SERVER_DATABASE_DIRECTORY} defaults to
+   * {@code ${arcadedb.server.rootPath}/databases} while {@code SERVER_ROOT_PATH} defaults to {@code null}, and
+   * {@code getValueAsString()} resolves an unknown variable to the empty string instead of failing - so after a
+   * {@code resetAll()} the whole prefix collapses and this method is asked to recursively delete {@code /databases},
+   * {@code /databases0} ... {@code /databasesN}. Those are absolute root-level paths no test ever named, the test's
+   * own {@code ./target/databasesN} survives teardown untouched, and a data volume mounted at {@code /databases0}
+   * would be inside the blast radius. {@link #deleteResolvedFolder} refuses exactly that shape, so a future
+   * reordering degrades to a logged no-op rather than to a recursive delete at the filesystem root.
+   */
   public static void deleteDatabaseFolders(final int totalServers) {
     FileUtils.deleteRecursively(new File("./target/databases/"));
     FileUtils.deleteRecursively(new File("./target/config/"));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + File.separator));
+
+    final String databaseDirectory = GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString();
+    deleteResolvedFolder(databaseDirectory, File.separator);
     for (int i = 0; i < totalServers; ++i)
-      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.separator));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.separator + "replication"));
+      deleteResolvedFolder(databaseDirectory, i + File.separator);
+
+    final String rootPath = GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString();
+    // Unset by default, and the concatenation below would turn that into the literal folder "null/replication".
+    if (rootPath != null)
+      deleteResolvedFolder(rootPath, File.separator + "replication");
+  }
+
+  /**
+   * Recursively deletes {@code prefix + suffix}, unless the prefix did not resolve to anything a test could have
+   * written to - in which case it logs and does nothing. See {@link #deleteDatabaseFolders(int)} for why a prefix
+   * arrives unresolved at all.
+   */
+  private static void deleteResolvedFolder(final String prefix, final String suffix) {
+    if (!isResolvedTestPath(prefix)) {
+      LogManager.instance().log(TestServerHelper.class, Level.SEVERE,
+          "Refusing to delete '%s': the configured path did not resolve, so this is not a test folder. The test "
+              + "configuration was reset before the cleanup that reads it (issue #6297); nothing was deleted, and the "
+              + "folders this call was meant to remove are still on disk.", prefix + suffix);
+      return;
+    }
+    FileUtils.deleteRecursively(new File(prefix + suffix));
+  }
+
+  /**
+   * Whether {@code path} can be a folder a test wrote into. Relative paths always can - every server test configures
+   * {@code ./target/databasesN} - and so can an absolute path with more than one element, which is what a
+   * {@code @TempDir} under the system temp directory looks like. What cannot is a blank path or an absolute one
+   * naming a single root-level folder: no test writes to {@code /databases0}, and that is precisely what an
+   * unresolved {@code ${arcadedb.server.rootPath}} placeholder collapses to. Package-private for testing.
+   */
+  static boolean isResolvedTestPath(final String path) {
+    if (path == null || path.isBlank())
+      return false;
+    try {
+      final Path normalized = Path.of(path).normalize();
+      return !normalized.isAbsolute() || normalized.getNameCount() > 1;
+    } catch (final InvalidPathException e) {
+      // Not a path this platform can even name, so certainly not a folder a test created.
+      return false;
+    }
   }
 }

--- a/server/src/test/java/com/arcadedb/server/TestServerHelper.java
+++ b/server/src/test/java/com/arcadedb/server/TestServerHelper.java
@@ -179,19 +179,25 @@ public final class TestServerHelper {
   }
 
   /**
-   * Recursively deletes {@code prefix + suffix}, unless the prefix did not resolve to anything a test could have
-   * written to - in which case it logs and does nothing. See {@link #deleteDatabaseFolders(int)} for why a prefix
-   * arrives unresolved at all.
+   * Recursively deletes {@code prefix + suffix}, unless that did not resolve to anything a test could have written
+   * to - in which case it logs and does nothing. See {@link #deleteDatabaseFolders(int)} for why a prefix arrives
+   * unresolved at all.
+   * <p>
+   * The whole concatenation is what gets checked, not the prefix alone: the two arguments are what a caller
+   * composes, so validating one of them would leave the verdict depending on an assumption about the other
+   * (today: that appending a digit and a separator can neither make a relative path absolute nor change its
+   * segment count). Checking what is actually about to be deleted has no such precondition to preserve.
    */
   private static void deleteResolvedFolder(final String prefix, final String suffix) {
-    if (!isResolvedTestPath(prefix)) {
+    final String folder = prefix + suffix;
+    if (!isResolvedTestPath(folder)) {
       LogManager.instance().log(TestServerHelper.class, Level.SEVERE,
           "Refusing to delete '%s': the configured path did not resolve, so this is not a test folder. The test "
               + "configuration was reset before the cleanup that reads it (issue #6297); nothing was deleted, and the "
-              + "folders this call was meant to remove are still on disk.", prefix + suffix);
+              + "folders this call was meant to remove are still on disk.", folder);
       return;
     }
-    FileUtils.deleteRecursively(new File(prefix + suffix));
+    FileUtils.deleteRecursively(new File(folder));
   }
 
   /**


### PR DESCRIPTION
Closes #6297, closes #6280, closes #6279, closes #6270.

Four follow-ups from #6267 / #6268. They share an origin - all four are about a test that reports coverage it does not have - so they are fixed together.

## #6297 (1) The teardown resolved its paths from a configuration it had just reset

`BaseGraphServerTest.endTest()` called `GlobalConfiguration.resetAll()` **before** the cleanup. Every path `TestServerHelper.deleteDatabaseFolders()` deletes is resolved at call time from `SERVER_DATABASE_DIRECTORY`, whose default is `${arcadedb.server.rootPath}/databases` over a root path that defaults to `null`, and `getValueAsString()` substitutes the empty string for an unresolvable variable rather than failing. The prefix collapsed, so the cleanup asked for a recursive delete of `/databases`, `/databases0` ... while the test's own `./target/databases0` - and the `.raft-storage` under it - survived teardown untouched.

- The reset moved to the end, inside a `finally` that now also covers the deletes, so a failing `checkDatabasesAreIdentical()` no longer skips the cleanup entirely (that is the cross-class disk-state leak the issue suspected behind the `DynamicMembershipTest` "DB1 5 <> DB2 15").
- `StaticBaseServerTest.beginTest()` had the mirror-image bug - it cleaned before `setTestConfiguration()`, so on the first class in a fork it cleaned `/databases0` too. Configuration first now.
- `TestServerHelper.isResolvedTestPath` refuses a prefix that did not resolve: blank, or absolute and naming a single root-level folder. A relative path (`./target/databasesN`) or a deeper absolute one (a `@TempDir` under the system temp dir) is always allowed. A refusal logs SEVERE and deletes nothing, so a future reordering degrades to a logged no-op instead of a `deleteRecursively` at `/`.

`Issue6297TeardownDeletesTestFoldersIT` asserts in `@AfterAll` - the only hook JUnit runs after `@AfterEach` - that `./target/databases0` is gone. Verified it goes red on the old ordering:

```
[endTest() left the test's own database behind (issue #6297)]
Expecting file: .../server/./target/databases0/graph  not to exist
```

`Issue6297TeardownPathResolutionTest` pins the trap itself (a reset configuration resolves to `/databases`), the guard's accept/refuse set, and both orderings end to end against a `@TempDir`.

## #6297 (2) The warn-once latches never rearmed

Rather than the issue's suggestion (rearm on a committed Raft configuration change), the latch is replaced by **the rendered collision list itself**. That is strictly better in both directions:

- a membership change that leaves the verdict identical says nothing new, and now stays quiet - rearming on the event would re-log the same unchanged misconfiguration on every peer add;
- any change to the verdict is reported, *whatever* caused it - a different pair colliding, a peer added at runtime onto an address already taken, an HTTP port becoming available late - not only the causes someone remembered to hook.

A clean pass clears the memory instead of reporting, so a misconfiguration that is fixed and later reintroduced is announced again. The line already named every collision it found, which is what makes it usable as the key; `warnAmbiguousRouting` now names them too, so the routing warning has both a usable key and a usable message. The *fallback* latches (deriving at all) are deliberately left as booleans - that condition does not change with membership.

`Issue6297AmbiguityRearmTest` covers the rearm contract and the verdict rendering (stable order whatever order Ratis hands the group over in, declared-beats-derived, clean view renders empty).

## #6297 (3) and (4)

Left as tracking entries, deliberately:

- **(3) the next cut of `RESYNC_RETRY_TIMEOUT_MS`** is a decision that needs a handful of `ha-integration-tests` runs at the new 5 s report threshold. There is no code change to make until those runs exist; making one now would be guessing at the number the issue asks to measure.
- **(4) isolating the heavy HA ITs into their own fork** is a build/CI-lane change to a module whose IT suite is already a chronic flake (#5668/#5702). It does not belong in a PR whose other three items are test-assertion fixes: it changes what runs where, so its own regression signal is a series of full-suite runs, not a test.

## #6280 EXPLAIN is no longer the blocker

The TODO said "EXPLAIN integration needs to be added separately". It does not: `OpenCypherQueryEngine` routes an `EXPLAIN ` prefix and `CypherExecutionPlan.explain()` describes the count push-down first, precisely because the push-down replaces the whole chain.

```
EXPLAIN MATCH (a:Account) RETURN COUNT(a) as count
  Using Count Push-Down
  + TYPE COUNT OPTIMIZATION (Account)

EXPLAIN MATCH (a:Account) WHERE a.balance > 5000 RETURN COUNT(a) as count
  Using Cost-Based Query Optimizer
  + NodeByLabelScan(a:Account) [filter: a.balance > 5000]
```

All six commented-out assertions are restored against it (the two negative ones included), and the alias, empty-type and polymorphic cases get one as well - they had none. `EXPLAIN` rather than `PROFILE` on purpose: the negative cases describe the full scan the push-down was refused for, and running one to find out that it ran is the cost the assertion exists to detect.

## #6279 The comparison the test claimed to make is no longer true

`issue3216_performanceComparisonMatchStrategies` asserted `duration >= 0` twice, which cannot fail. Its premise had also expired: `CypherExecutionPlan.extractIdFilter` lifts an `ID(x) = <literal|parameter>` equality out of the WHERE clause into the `MatchNodeStep` at plan time - the fix #3216 was closed on - and it applies to the single-MATCH form exactly as it does to the split one. Restoring `assertThat(duration2).isLessThan(duration1)` would have asserted something false.

Rather than deleting the test, the property it was reaching for is made visible. `MatchNodeStep.prettyPrint` now names the RID it was given, alongside `[index: ]` and `[filter: ]`:

```
+ MATCH NODE (a) [id: #1:0]
+ MATCH NODE (b) [id: #4:0]
+ FILTER WHERE (ID(a) = $sourceId AND ID(b) = $targetId)
```

That is a user-facing improvement in its own right - the resolution of #3216 tells users to write the query so the push-down fires, and until now the plan was the one place that would not say whether it had. The test asserts both forms carry the marker, plus a control query (property equality instead of `ID()`) whose plan does not, so the assertion discriminates rather than being printed unconditionally. Off the `benchmark` lane, since it no longer times anything.

## #6270 The wall-clock and @Timeout pass, outside the engine suite

Four elapsed-time bounds in `server`/`network` now measure through `StallAwareStopwatch`, all of them category 1 (a tripwire between a bounded operation and an unbounded one), all `assertGaveUpWithin`: `Issue5470BatchStreamStallIT`, `Issue5470BatchErrorDeliveryIT`, `Issue5418ShutdownHookDeadlockTest`, `RemoteHttpComponentTest`.

Two premises in the issue were wrong and are worth recording:

- **`HTTPAuthSessionIT` needs nothing.** Its two sites are `elapsedFromCreation() >= 100` (a lower bound, which a stall only makes more true) and a field-presence check. Same for `PostBatchHandlerIT`, whose `elapsedMs >= 0` is a response-field sanity check, not a latency bound.
- **`server` and `network` did not already consume the engine test-jar.** Neither declares it and neither uses `TestHelper`. Added at test scope in both poms - no new external dependency; the artifact is already produced by `engine/pom.xml`.

The `@Timeout` pass covers every engine annotation at 45 s or under. The conclusion differs from the issue's guess in one place, and the difference matters: **`RangeFunctionTest`'s annotations are not the assertion.** What each of those methods regresses to is an unbounded loop or a materialised range, and what each one *claims* is carried by a structural assertion - `containsExactly` on the returned elements, `isInstanceOf(LongRangeList.class)` on the lazy one, `assertThatThrownBy` on the rejected one. None of those can pass while the range is being materialised. So widening the annotation does not weaken the GHSA-xmjm regression test; leaving it at 5 s, three orders of magnitude below the honest budget and well inside the range of the 24 s stalls #6260 was filed on, is what made it a coin flip.

- Hang detectors, sized clear of the honest budget plus a ~30 s stall: `RangeFunctionTest` (5 s/10 s -> 60 s), `IndexDescOrderDuplicateKeysTest`, `LongObjectHashMapTest` (`SEPARATE_THREAD` kept - the regression is an infinite probe loop), `HashIndexOverflowCycleTest`, the two rejection cases in `CypherRangeHeapExhaustionTest`, and `LockManagerFairnessTest`, whose stress methods already give themselves up to 45 s (`done.await(45, SECONDS)`) or 25 s (250 rounds x 100 ms) of honest work and so were sized *below* their own budget once a stall is added.
- The two genuine laziness claims - `LongRangeListTest.hugeRangeIsFreeOfHeap` and `CypherRangeHeapExhaustionTest.hugeRangeIsLazyWhenTheLimitIsDisabled` - are now asserted with `assertStayedUnder` on the discounted clock, which is *tighter* than the annotation it replaces, with the annotation left behind as the hang detector.
- The `server` module's four `@Timeout(60)` in `RangeHeapExhaustionHttpStatusIT` are already generous against a sub-second honest budget: nothing to do.

Finally, the sampler thread is renamed `arcadedb-test-stall-monitor` -> `test-jvm-stall-monitor`, out of the prefix `DatabaseLifecycleBackgroundThreadsTest` scans for leaked engine threads. It was safe only because that loop skips daemons first; a shutdown path making the sampler non-daemon would have turned a leak detector red pointing at #5418. `StallAwareStopwatchTest` now pins the name against all three scanned prefixes.

## Verification

- `Issue6297TeardownDeletesTestFoldersIT` verified red on the pre-fix ordering, green after.
- Green: `engine` `com.arcadedb.query.opencypher.**`, the touched `engine` utility/index/function classes, `ha-raft` unit lane, `server` unit lane, `network` `RemoteHttpComponentTest`, `server` `Issue5470BatchErrorDeliveryIT`.
