### PR TITLE
fix(#6314): a component reads its file at the stride that file was written with, and the by-id getOrCreateFile refuses a name it did not create

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.log.LogManager;
 
 import java.io.File;
@@ -442,10 +443,27 @@ public class FileManager {
     }
   }
 
+  /**
+   * The by-<em>id</em> mirror of {@link #getOrCreateFile(String, String, ComponentFile.MODE)}, and it has the same
+   * hazard: it is keyed by the id alone, so an id that is already registered hands that file back whatever
+   * {@code filePath} the caller asked for, and the caller then goes on using a file that is not the one it named.
+   * The by-name half of that pair was closed at the component layer by issue #6283; this one is closed here
+   * (issue #6314), so the guarantee "the file you get back is the file you asked for" belongs to
+   * {@code FileManager} for both keys rather than to whichever caller remembered to check.
+   * <p>
+   * A caller that has to tell "already applied" apart from "diverged" still needs its own branch on the two, and
+   * the HA follower's {@code ArcadeStateMachine.createNewFiles} has one: a matching name is an idempotent replay
+   * it skips, a differing one is a file-id space that has diverged from the leader's, which it turns into the
+   * quarantine-and-resync path (issue #6063). This check therefore fires for nobody today; it is what makes the
+   * next caller not have to re-derive that reasoning. It throws the same {@link SchemaException} that caller does,
+   * so a caller that does reach it is classified exactly as it would have classified itself.
+   *
+   * @throws SchemaException when {@code fileId} is already registered under a different file name
+   */
   public ComponentFile getOrCreateFile(final int fileId, final String filePath) throws IOException {
     ComponentFile file = fileIdMap.get(fileId);
     if (file != null)
-      return file;
+      return checkFileNameMatches(file, filePath);
 
     synchronized (this) {
       file = fileIdMap.get(fileId);
@@ -453,10 +471,25 @@ public class FileManager {
         file = new PaginatedComponentFile(filePath, mode);
         registerFile(file);
         recordCreate(file);
-      }
+      } else
+        checkFileNameMatches(file, filePath);
 
       return file;
     }
+  }
+
+  /**
+   * Asserts that an already-registered file is the one the caller named. The comparison is on the file name and
+   * not on the whole path: the id, page size, version and extension a component addresses its file through all
+   * live in that name, while the directory prefix is the database path both sides already share.
+   */
+  private static ComponentFile checkFileNameMatches(final ComponentFile file, final String filePath) {
+    final String requestedName = new File(filePath).getName();
+    if (!file.getFileName().equals(requestedName))
+      throw new SchemaException(
+          "File id " + file.getFileId() + " is already registered as '" + file.getFileName() + "' but was requested as '"
+              + requestedName + "' ('" + filePath + "')");
+    return file;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
@@ -94,6 +94,18 @@ public abstract class PaginatedComponent extends Component {
           "Component '" + name + "' was built on file id " + fileId + " but the file registered under that name has id "
               + file.getFileId() + " ('" + file.getFilePath() + "')");
 
+    // The same invariant as the id one, on the other field a component uses to address its file (issue #6314): the
+    // page size IS the stride, so a component that disagrees with its file reads page N from N * theWrongNumber.
+    // PageManager resolves every page with the CALLER's page size, and only the snapshot path ever consults the
+    // file's own, so nothing downstream turns that into an exception - it is real bytes at the wrong offset, and
+    // pageCount below is computed from the wrong divisor on top. The page size is baked into the file name, so this
+    // can only be a component that re-derived it from somewhere else (a live configuration value, say) instead of
+    // taking the one ComponentFactory parsed off the name.
+    if (file.getPageSize() != pageSize)
+      throw new IllegalStateException(
+          "Component '" + name + "' was built with page size " + pageSize + " but its file '" + file.getFilePath()
+              + "' has page size " + file.getPageSize());
+
     final long fileSize = file.getSize();
     if (fileSize == 0)
       // NEW FILE, CREATE HEADER PAGE

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
@@ -131,13 +131,19 @@ public class TimeSeriesBucket extends PaginatedComponent {
 
   /**
    * Factory handler for loading existing .tstb files during schema load.
-   * Columns are set later via {@link #setColumns(List)} when the TimeSeries type is initialized.
+   * Columns are set later via {@link #setColumns(List, TimeSeriesTagDictionary)} when the TimeSeries type is
+   * initialized.
+   * <p>
+   * The page size, version and mode {@code ComponentFactory} recovered from the file name are passed straight
+   * through, exactly as {@code LocalBucket}'s handler does (issue #6314). Re-deriving the page size from the live
+   * {@code bucketDefaultPageSize} instead would address every page of an already-written file at a stride that is
+   * not the one it was written with, which is a misaligned read of real bytes and not an exception.
    */
   public static class PaginatedComponentFactoryHandler implements ComponentFactory.PaginatedComponentFactoryHandler {
     @Override
     public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath,
         final int id, final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
-      return new TimeSeriesBucket(database, name, filePath, id, new ArrayList<>(), null);
+      return new TimeSeriesBucket(database, name, filePath, id, mode, pageSize, version, new ArrayList<>(), null);
     }
   }
 
@@ -167,12 +173,17 @@ public class TimeSeriesBucket extends PaginatedComponent {
   }
 
   /**
-   * Opens an existing TimeSeries bucket.
+   * Opens an existing TimeSeries bucket on the id, page size and version its own file name carries.
+   * <p>
+   * The {@code version} is what the file says, not {@link #CURRENT_VERSION}: which row layout this bucket reads is
+   * decided by whether a dictionary was handed to it, so claiming the current version for a file written by a
+   * build that stored tags inline would make {@link #getVersion()} disagree with both the file name and the
+   * layout in use.
    */
   public TimeSeriesBucket(final DatabaseInternal database, final String name, final String filePath, final int id,
-      final List<ColumnDefinition> columns, final TimeSeriesTagDictionary tagDictionary) throws IOException {
-    super(database, name, filePath, id, ComponentFile.MODE.READ_WRITE,
-        database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE), CURRENT_VERSION);
+      final ComponentFile.MODE mode, final int pageSize, final int version, final List<ColumnDefinition> columns,
+      final TimeSeriesTagDictionary tagDictionary) throws IOException {
+    super(database, name, filePath, id, mode, pageSize, version);
     this.tagDictionary = tagDictionary;
     resolveLayout(columns);
   }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -28,6 +28,7 @@ import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.engine.PaginatedComponent;
+import com.arcadedb.engine.PaginatedComponentFile;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.schema.Type;
@@ -146,12 +147,16 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   /**
    * Factory handler for loading an existing .tstd file during schema load. The in-RAM mapping is
    * rebuilt later by {@link #load()}, once the component is registered and the file id resolves.
+   * <p>
+   * The page size, version and mode {@code ComponentFactory} recovered from the file name are passed straight
+   * through (issue #6314); see {@link TimeSeriesBucket.PaginatedComponentFactoryHandler} for why re-deriving the
+   * page size from the live configuration instead is a silent misread rather than an exception.
    */
   public static class PaginatedComponentFactoryHandler implements ComponentFactory.PaginatedComponentFactoryHandler {
     @Override
     public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath,
         final int id, final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
-      return new TimeSeriesTagDictionary(database, name, filePath, id);
+      return new TimeSeriesTagDictionary(database, name, filePath, id, mode, pageSize, version);
     }
   }
 
@@ -168,13 +173,23 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   }
 
   /**
-   * Opens an existing tag dictionary.
+   * Opens an existing tag dictionary on the id, page size and version its own file name carries (issue #6314).
    */
-  public TimeSeriesTagDictionary(final DatabaseInternal database, final String name, final String filePath, final int id)
-      throws IOException {
-    super(database, name, filePath, id, ComponentFile.MODE.READ_WRITE,
-        database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE), CURRENT_VERSION);
+  public TimeSeriesTagDictionary(final DatabaseInternal database, final String name, final String filePath, final int id,
+      final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+    super(database, name, filePath, id, mode, pageSize, version);
     this.maxSize = database.getConfiguration().getValueAsInteger(GlobalConfiguration.TIMESERIES_TAG_DICTIONARY_MAX_SIZE);
+  }
+
+  /**
+   * Opens a second view over a file that is ALREADY registered with the file manager, taking the id, the page size
+   * and the version from that file rather than re-deriving any of them (issue #6314). Every one of the three is a
+   * property of the file and of nothing else, so this is the only form a caller in that position should need.
+   */
+  public TimeSeriesTagDictionary(final DatabaseInternal database, final String name, final PaginatedComponentFile file)
+      throws IOException {
+    this(database, name, file.getFilePath(), file.getFileId(), ComponentFile.MODE.READ_WRITE, file.getPageSize(),
+        file.getVersion());
   }
 
   /**
@@ -202,14 +217,16 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       return dictionary;
     }
 
-    // A file already registered under this component name is what this dictionary must be BUILT ON, id and
-    // all. The id-allocating constructor would take a fresh file id from the manager and then be handed
-    // this very file anyway - getOrCreateFile() is keyed by the component name - leaving the component
-    // addressing pages of an id that is not the file it holds, which is unusable in either direction.
+    // A file already registered under this component name is what this dictionary must be BUILT ON, id, page size
+    // and version and all. The id-allocating constructor would take a fresh file id from the manager and then be
+    // handed this very file anyway - getOrCreateFile() is keyed by the component name - leaving the component
+    // addressing pages of an id that is not the file it holds, which is unusable in either direction. The page
+    // size has to come from the same place for the same reason (issue #6314): the live bucketDefaultPageSize is
+    // whatever this run was configured with, not what the file on disk was written at.
     final ComponentFile existingFile = database.getFileManager().getFileByComponentName(name);
 
-    final TimeSeriesTagDictionary dictionary = existingFile != null ?
-        new TimeSeriesTagDictionary(database, name, existingFile.getFilePath(), existingFile.getFileId()) :
+    final TimeSeriesTagDictionary dictionary = existingFile instanceof PaginatedComponentFile pcf ?
+        new TimeSeriesTagDictionary(database, name, pcf) :
         new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + "/" + name);
 
     // Registered BEFORE it is initialised, and it has to be: initHeaderPage() commits, and a commit

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -225,8 +225,19 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
     // whatever this run was configured with, not what the file on disk was written at.
     final ComponentFile existingFile = database.getFileManager().getFileByComponentName(name);
 
-    final TimeSeriesTagDictionary dictionary = existingFile instanceof PaginatedComponentFile pcf ?
-        new TimeSeriesTagDictionary(database, name, pcf) :
+    // "Registered but not paginated" is unreachable today - PaginatedComponentFile is the only ComponentFile the
+    // engine ever constructs - and the branch below is written so it STAYS that way loudly. Falling through to the
+    // create-fresh arm on a registered name would be the silent outcome: it takes a new file id, gets handed this
+    // very file back by name, and dies on the #6283 id guard several frames later with a message about ids that
+    // says nothing about the real cause. This whole change is about turning that class of mismatch into a
+    // statement, so the assumption is one here too rather than an instanceof quietly deciding it.
+    if (existingFile != null && !(existingFile instanceof PaginatedComponentFile))
+      throw new IllegalStateException(
+          "The file registered under component name '" + name + "' is a " + existingFile.getClass().getSimpleName()
+              + " ('" + existingFile.getFilePath() + "'), but a tag dictionary can only be built on a paginated file");
+
+    final TimeSeriesTagDictionary dictionary = existingFile != null ?
+        new TimeSeriesTagDictionary(database, name, (PaginatedComponentFile) existingFile) :
         new TimeSeriesTagDictionary(database, name, database.getDatabasePath() + "/" + name);
 
     // Registered BEFORE it is initialised, and it has to be: initHeaderPage() commits, and a commit

--- a/engine/src/test/java/com/arcadedb/engine/Issue6314FileAgreementTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6314FileAgreementTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.SchemaException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6314, items 1 and 2: the two remaining places where a component and the file it holds could disagree
+ * about how to address that file.
+ * <p>
+ * Item 1's guard is the page-size sibling of the file-id one issue #6283 added to {@link PaginatedComponent}: the
+ * page size IS the stride, so a component that carries a different one from its file reads page N from
+ * {@code N * theWrongNumber} - real bytes at the wrong offset, never an exception, and a {@code pageCount}
+ * computed from the wrong divisor on top.
+ * <p>
+ * Item 2 is the by-id mirror of #6283's by-name hazard, pushed down from the one caller that had it into
+ * {@link FileManager} itself.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6314FileAgreementTest extends TestHelper {
+
+  /**
+   * The file's page size is baked into its name, so this fixture builds the component with a page size the name
+   * does not carry - which is exactly the shape a component re-deriving the value from a live configuration
+   * setting ends up in when that setting changed between two runs.
+   */
+  @Test
+  void aComponentThatDisagreesWithItsFileAboutThePageSizeFailsAtConstruction() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int filePageSize = GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger();
+    final String name = "issue6314_stride";
+    final int fileId = db.getFileManager().newFileId();
+    final String filePath =
+        db.getDatabasePath() + File.separator + name + "." + fileId + "." + filePageSize + ".v" + LocalBucket.CURRENT_VERSION
+            + "." + LocalBucket.BUCKET_EXT;
+
+    try {
+      assertThatThrownBy(
+          () -> new LocalBucket(db, name, filePath, fileId, ComponentFile.MODE.READ_WRITE, filePageSize / 4,
+              LocalBucket.CURRENT_VERSION))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining(name)
+          .hasMessageContaining("page size " + (filePageSize / 4))
+          .hasMessageContaining("has page size " + filePageSize);
+    } finally {
+      // The construction failed AFTER getOrCreateFile() had registered the file, exactly as the file-id guard
+      // leaves it (issue #6283): nothing reclaims it, which is deliberate on a path no legitimate caller takes.
+      db.getFileManager().dropFile(fileId);
+    }
+  }
+
+  /**
+   * The same construction with the page size the file name carries is the legitimate one, and it must still work:
+   * a guard that rejected it would be a guard nobody could open a database through.
+   */
+  @Test
+  void aComponentThatAgreesWithItsFileIsBuiltNormally() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int filePageSize = GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger();
+    final String name = "issue6314_agreed";
+    final int fileId = db.getFileManager().newFileId();
+    final String filePath =
+        db.getDatabasePath() + File.separator + name + "." + fileId + "." + filePageSize + ".v" + LocalBucket.CURRENT_VERSION
+            + "." + LocalBucket.BUCKET_EXT;
+
+    final LocalBucket bucket = new LocalBucket(db, name, filePath, fileId, ComponentFile.MODE.READ_WRITE, filePageSize,
+        LocalBucket.CURRENT_VERSION);
+    try {
+      assertThat(bucket.getPageSize()).isEqualTo(filePageSize);
+      assertThat(bucket.getComponentFile().getPageSize()).isEqualTo(filePageSize);
+      assertThat(bucket.getComponentFile().getFileId()).isEqualTo(fileId);
+    } finally {
+      bucket.close();
+      db.getFileManager().dropFile(fileId);
+    }
+  }
+
+  /**
+   * Item 2: {@code getOrCreateFile(int, String)} is keyed by the id alone, so before the fix an id already
+   * registered handed its file back whatever file name the caller had asked for. The only production caller (the
+   * HA follower's {@code createNewFiles}) checks this itself before calling, which is why nothing was reachable -
+   * the point of the guard is that the guarantee now belongs to the API rather than to whoever remembers.
+   */
+  @Test
+  void theByIdGetOrCreateFileRefusesToHandBackAFileWithAnotherName() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final FileManager fileManager = db.getFileManager();
+    final int fileId = fileManager.newFileId();
+    final String registeredName = "issue6314_registered." + fileId + ".65536.v0.pcf";
+    final String otherName = "issue6314_other." + fileId + ".65536.v0.pcf";
+
+    final ComponentFile created = fileManager.getOrCreateFile(fileId, db.getDatabasePath() + File.separator + registeredName);
+    try {
+      // Asking again for the same file is the idempotent case and stays idempotent.
+      assertThat(fileManager.getOrCreateFile(fileId, db.getDatabasePath() + File.separator + registeredName))
+          .isSameAs(created);
+
+      assertThatThrownBy(() -> fileManager.getOrCreateFile(fileId, db.getDatabasePath() + File.separator + otherName))
+          .isInstanceOf(SchemaException.class)
+          .hasMessageContaining(registeredName)
+          .hasMessageContaining(otherName);
+    } finally {
+      fileManager.dropFile(fileId);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6314TimeSeriesPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6314TimeSeriesPageSizeTest.java
@@ -52,6 +52,25 @@ class Issue6314TimeSeriesPageSizeTest extends TestHelper {
   private static final int REOPEN_PAGE_SIZE = 16_384;
   private static final int ROWS             = 3_000;
 
+  private int savedPageSize;
+
+  /**
+   * Save and restore around every test, the way the other page-size-sensitive tests do (e.g.
+   * {@code EdgeAppendMergeMultiPageChunkTest}). {@code TestHelper.afterTest()} resets the whole configuration
+   * regardless of outcome, so this is not what stops the setting leaking into the next class - it is what stops the
+   * restore from depending on a test body reaching its last line, and {@code endTest()} runs BEFORE the integrity
+   * check and the drop, so those see the default stride rather than whatever arm the test left behind.
+   */
+  @Override
+  protected void beginTest() {
+    savedPageSize = GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger();
+  }
+
+  @Override
+  protected void endTest() {
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(savedPageSize);
+  }
+
   private TimeSeriesEngine createType(final String typeName) {
     database.command("sql", "CREATE TIMESERIES TYPE " + typeName
         + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
@@ -112,8 +131,6 @@ class Issue6314TimeSeriesPageSizeTest extends TestHelper {
     // Appending after the reopen keeps writing at the file's own stride.
     appendRows(reopened, 500);
     assertThat(reopened.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null)).hasSize(ROWS + 500);
-
-    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.reset();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6314TimeSeriesPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6314TimeSeriesPageSizeTest.java
@@ -134,6 +134,39 @@ class Issue6314TimeSeriesPageSizeTest extends TestHelper {
   }
 
   /**
+   * The new {@code PaginatedComponent} guard does NOT turn a database written under a different
+   * {@code bucketDefaultPageSize} into one that refuses to open - which is the natural thing to assume about a
+   * guard added in the same change, and it is worth pinning rather than leaving to be re-derived.
+   * <p>
+   * The guard compares the component against the file it holds, and every load path now takes the page size FROM
+   * that file, so the two agree by construction whatever the configuration happens to say. What the guard catches
+   * is a component that re-derived the value from somewhere else, i.e. the defect this change removes - it is a
+   * programming-error tripwire, not a compatibility gate. A database carrying files at three different strides at
+   * once opens all of them, each at its own.
+   */
+  @Test
+  void reopeningUnderAnyConfiguredPageSizeSucceedsWhateverTheFilesWereWrittenAt() throws Exception {
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(CREATE_PAGE_SIZE);
+    appendRows(createType("Wide"), 200);
+
+    // A second type created at a different stride, so the database now holds files written at BOTH.
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(REOPEN_PAGE_SIZE);
+    appendRows(createType("Narrow"), 200);
+
+    // ...and reopened under a third value that matches neither.
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(32_768);
+    reopenDatabase();
+
+    final TimeSeriesEngine wide = ((LocalTimeSeriesType) database.getSchema().getType("Wide")).getEngine();
+    final TimeSeriesEngine narrow = ((LocalTimeSeriesType) database.getSchema().getType("Narrow")).getEngine();
+
+    assertThat(wide.getShard(0).getMutableBucket().getPageSize()).isEqualTo(CREATE_PAGE_SIZE);
+    assertThat(narrow.getShard(0).getMutableBucket().getPageSize()).isEqualTo(REOPEN_PAGE_SIZE);
+    assertThat(wide.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null)).hasSize(200);
+    assertThat(narrow.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null)).hasSize(200);
+  }
+
+  /**
    * The other half of the pass-through: the component must report the version its file name carries rather than
    * claiming {@code CURRENT_VERSION} for a file that says otherwise. A type created by this build is at
    * {@code CURRENT_VERSION}, and the point of pinning it here is that the value now comes from the file.

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6314TimeSeriesPageSizeTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6314TimeSeriesPageSizeTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6314 (item 1): both TimeSeries factory handlers accepted the page size and the version that
+ * {@code ComponentFactory} had parsed out of the component's own file name and threw them away, re-deriving the
+ * page size from the <em>live</em> {@code arcadedb.bucketDefaultPageSize} instead and hard-coding the version.
+ * <p>
+ * The setting is {@code SCOPE.DATABASE} and user-settable, so no bug was needed to trigger it: change it between
+ * two runs and every {@code .tstb}/{@code .tstd} file reopens at a stride that is not the one it was written
+ * with. Nothing downstream catches that - {@code PageManager} resolves a page with the <em>caller's</em> page
+ * size, i.e. the component's - so page N is read from {@code N * wrongStride} and what comes back is real bytes
+ * at the wrong offset rather than an exception. {@code pageCount = fileSize / pageSize} is off by the same
+ * factor.
+ * <p>
+ * The values are now passed through the way {@code LocalBucket}'s handler always has, and
+ * {@code PaginatedComponent} asserts the agreement between a component and the file it holds on the page size
+ * exactly as issue #6283 made it assert it on the file id.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6314TimeSeriesPageSizeTest extends TestHelper {
+
+  private static final int CREATE_PAGE_SIZE = 65_536;
+  private static final int REOPEN_PAGE_SIZE = 16_384;
+  private static final int ROWS             = 3_000;
+
+  private TimeSeriesEngine createType(final String typeName) {
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    return ((LocalTimeSeriesType) database.getSchema().getType(typeName)).getEngine();
+  }
+
+  private void appendRows(final TimeSeriesEngine engine, final int rows) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + i * 1_000L;
+      columns[0][i] = "host_" + (i % 7);
+      columns[1][i] = (double) i;
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+
+  /**
+   * The end-to-end shape the issue asked for: write under one {@code bucketDefaultPageSize}, reopen under
+   * another. Before the fix the reopened bucket addressed its pages at 16 KB while the file on disk was written
+   * at 64 KB, so the header page - which starts at offset 0 and therefore still read correctly - announced data
+   * pages that were then read from the padding inside real page 0, and the query came back empty.
+   */
+  @Test
+  void aTimeSeriesTypeReopensAtTheStrideItsFileWasWrittenWith() throws Exception {
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(CREATE_PAGE_SIZE);
+
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    assertThat(engine.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null)).hasSize(ROWS);
+    assertThat(engine.getShard(0).getMutableBucket().getPageSize()).isEqualTo(CREATE_PAGE_SIZE);
+
+    // The only thing that changes between the two runs, and it is a supported thing to change.
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.setValue(REOPEN_PAGE_SIZE);
+    reopenDatabase();
+
+    final TimeSeriesEngine reopened = ((LocalTimeSeriesType) database.getSchema().getType("Cpu")).getEngine();
+    final TimeSeriesBucket bucket = reopened.getShard(0).getMutableBucket();
+
+    // The component takes the stride from the file it holds, not from whatever the configuration says today.
+    assertThat(bucket.getPageSize()).isEqualTo(CREATE_PAGE_SIZE);
+    assertThat(bucket.getPageSize()).isEqualTo(bucket.getComponentFile().getPageSize());
+
+    final TimeSeriesTagDictionary dictionary = reopened.getTagDictionary();
+    assertThat(dictionary).isNotNull();
+    assertThat(dictionary.getPageSize()).isEqualTo(CREATE_PAGE_SIZE);
+    assertThat(dictionary.getPageSize()).isEqualTo(dictionary.getComponentFile().getPageSize());
+
+    // And the data is all still there, read from the offsets it was written at.
+    final List<Object[]> rows = reopened.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null);
+    assertThat(rows).hasSize(ROWS);
+    rows.sort((a, b) -> Long.compare((long) a[0], (long) b[0]));
+    for (int i = 0; i < ROWS; i++) {
+      assertThat(rows.get(i)[1]).isEqualTo("host_" + (i % 7));
+      assertThat(rows.get(i)[2]).isEqualTo((double) i);
+    }
+
+    // Appending after the reopen keeps writing at the file's own stride.
+    appendRows(reopened, 500);
+    assertThat(reopened.query(Long.MIN_VALUE, Long.MAX_VALUE, null, null)).hasSize(ROWS + 500);
+
+    GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.reset();
+  }
+
+  /**
+   * The other half of the pass-through: the component must report the version its file name carries rather than
+   * claiming {@code CURRENT_VERSION} for a file that says otherwise. A type created by this build is at
+   * {@code CURRENT_VERSION}, and the point of pinning it here is that the value now comes from the file.
+   */
+  @Test
+  void aReopenedComponentReportsTheVersionItsFileNameCarries() throws Exception {
+    final TimeSeriesEngine engine = createType("Sensor");
+    appendRows(engine, 100);
+
+    reopenDatabase();
+
+    final TimeSeriesEngine reopened = ((LocalTimeSeriesType) database.getSchema().getType("Sensor")).getEngine();
+    final TimeSeriesBucket bucket = reopened.getShard(0).getMutableBucket();
+    assertThat(bucket.getVersion()).isEqualTo(bucket.getComponentFile().getVersion());
+    assertThat(bucket.getVersion()).isEqualTo(TimeSeriesBucket.CURRENT_VERSION);
+
+    final TimeSeriesTagDictionary dictionary = reopened.getTagDictionary();
+    assertThat(dictionary.getVersion()).isEqualTo(dictionary.getComponentFile().getVersion());
+    assertThat(dictionary.getVersion()).isEqualTo(TimeSeriesTagDictionary.CURRENT_VERSION);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java
@@ -170,8 +170,7 @@ class TimeSeriesTagDictionaryTest extends TestHelper {
     writer.internAll(List.of("host_a", "host_b", "host_c"));
 
     final DatabaseInternal db = (DatabaseInternal) database;
-    final TimeSeriesTagDictionary follower = new TimeSeriesTagDictionary(db, "tags_follower",
-        db.getDatabasePath() + "/tags_follower", writer.getFileId());
+    final TimeSeriesTagDictionary follower = new TimeSeriesTagDictionary(db, "tags_follower", writer.getComponentFile());
 
     // Nothing loaded yet: the map is empty but the pages are on disk
     assertThat(follower.size()).isZero();
@@ -194,7 +193,7 @@ class TimeSeriesTagDictionaryTest extends TestHelper {
 
     final DatabaseInternal db = (DatabaseInternal) database;
     final TimeSeriesTagDictionary follower = new TimeSeriesTagDictionary(db, "tags_follower_waves",
-        db.getDatabasePath() + "/tags_follower_waves", writer.getFileId());
+        writer.getComponentFile());
 
     // Wave 1: the reload that the single-wave test already covers
     assertThat(follower.getById(2)).isEqualTo("host_b");
@@ -235,8 +234,7 @@ class TimeSeriesTagDictionaryTest extends TestHelper {
       try {
         final TimeSeriesTagDictionary writer = createDictionary("tags_unflushed");
         writer.internAll(List.of("host_a", "host_b", "host_c"));
-        followerRef.set(new TimeSeriesTagDictionary(db, "tags_unflushed",
-            db.getDatabasePath() + "/tags_unflushed", writer.getFileId()));
+        followerRef.set(new TimeSeriesTagDictionary(db, "tags_unflushed", writer.getComponentFile()));
       } catch (final Throwable t) {
         failure.set(t);
       }

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexSearcherPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexSearcherPoolTest.java
@@ -54,6 +54,15 @@ class LSMVectorIndexSearcherPoolTest {
   private static final int    DIMENSIONS  = 32;
   private static final int    NUM_VECTORS = 2_000;
   private static final int    K           = 10;
+  /**
+   * {@code maxIdle} handed to {@link GraphSearcherPool}, i.e. the number of searchers it aims to keep alive.
+   */
+  private static final int    POOL_SIZE   = 4;
+  /**
+   * Threads releasing into that pool concurrently. Deliberately larger than {@link #POOL_SIZE}: the point is to
+   * exercise the pool while it is over-subscribed.
+   */
+  private static final int    CONCURRENCY = 8;
 
   @BeforeEach
   @AfterEach
@@ -77,7 +86,7 @@ class LSMVectorIndexSearcherPoolTest {
       assertThat(stat(index(db), "pooledGraphSearchers")).as("pooling disabled must keep no searcher alive").isZero();
     }
 
-    GlobalConfiguration.VECTOR_INDEX_SEARCHER_POOL_SIZE.setValue(4);
+    GlobalConfiguration.VECTOR_INDEX_SEARCHER_POOL_SIZE.setValue(POOL_SIZE);
     try (final Database db = new DatabaseFactory(DB_PATH).open()) {
       final LSMVectorIndex index = index(db);
       // Repeat: only the second search onwards can actually reuse a pooled instance.
@@ -96,7 +105,7 @@ class LSMVectorIndexSearcherPoolTest {
     final float[][] vectors = randomVectors(NUM_VECTORS, 5);
     createDatabase(vectors);
 
-    GlobalConfiguration.VECTOR_INDEX_SEARCHER_POOL_SIZE.setValue(4);
+    GlobalConfiguration.VECTOR_INDEX_SEARCHER_POOL_SIZE.setValue(POOL_SIZE);
     try (final Database db = new DatabaseFactory(DB_PATH).open()) {
       final LSMVectorIndex index = index(db);
 
@@ -125,13 +134,13 @@ class LSMVectorIndexSearcherPoolTest {
     final float[][] vectors = randomVectors(NUM_VECTORS, 7);
     createDatabase(vectors);
 
-    GlobalConfiguration.VECTOR_INDEX_SEARCHER_POOL_SIZE.setValue(4);
+    GlobalConfiguration.VECTOR_INDEX_SEARCHER_POOL_SIZE.setValue(POOL_SIZE);
     try (final Database db = new DatabaseFactory(DB_PATH).open()) {
       final LSMVectorIndex index = index(db);
       final float[] query = randomVectors(1, 42)[0];
       final List<RID> expected = searchRids(index, query);
 
-      final ExecutorService pool = Executors.newFixedThreadPool(8);
+      final ExecutorService pool = Executors.newFixedThreadPool(CONCURRENCY);
       try {
         final List<Callable<List<RID>>> tasks = new ArrayList<>();
         for (int i = 0; i < 200; i++)
@@ -144,7 +153,16 @@ class LSMVectorIndexSearcherPoolTest {
         assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
       }
 
-      assertThat(stat(index, "pooledGraphSearchers")).isLessThanOrEqualTo(4);
+      // What the pool promises is that it does not grow WITHOUT BOUND, not that it never exceeds maxIdle:
+      // GraphSearcherPool.release() reads idleCount and increments it without a lock ("racy by design"), so all
+      // CONCURRENCY releasers in flight can read a count below the cap and then all increment. The worst case is
+      // therefore maxIdle - 1 observed by every one of them, i.e. maxIdle + CONCURRENCY - 1, and asserting
+      // maxIdle alone contradicts the contract of the code under test - it failed as "expected 5L to be less
+      // than or equal to 4L" under full-suite CPU contention (issue #6314). "Never share a searcher", the
+      // property this test is named for, is what the per-task result comparison above checks.
+      assertThat(stat(index, "pooledGraphSearchers"))
+          .as("GraphSearcherPool.release() allows a transient overshoot of up to one searcher per concurrent releaser")
+          .isLessThanOrEqualTo(POOL_SIZE + CONCURRENCY - 1L);
     }
   }
 


### PR DESCRIPTION
Fixes #6314.

Three findings from the work on #6283, independent of each other, kept together because they all pull on the same thread: what a component is allowed to believe about the file it was handed.

## Item 1 - the TimeSeries components threw away the page size and version parsed from their own file name

`ComponentFactory` recovers both facts from every component file's name and hands them to the factory handler. `LocalBucket`'s handler passes them straight through, which is what makes a reopen faithful to what was written. Both TimeSeries handlers accepted them and **dropped them**, re-deriving the page size from the *live* `arcadedb.bucketDefaultPageSize` and hard-coding `CURRENT_VERSION` instead. That setting is `SCOPE.DATABASE` and user-settable, so no bug was needed to trigger it: change it between two runs and every `.tstb`/`.tstd` file reopens at a stride that is not its own.

Nothing downstream catches that. `PageManager` resolves a page with the **caller's** page size - i.e. the component's - and the only place that consults the file's own is the snapshot path, so page N is read from `N * theWrongNumber`: real bytes at the wrong offset, not an exception, with `pageCount` computed from the wrong divisor on top.

The issue asked for this to be reproduced end to end first. It is, and it is worse than "misaligned":

> a type written at 64 KB and reopened at 16 KB returned **0 of 3,000 rows**

The header page starts at offset 0 and therefore still read correctly, which is exactly what let it announce data pages that were then read out of the padding inside real page 0.

**Fix.** Both handlers pass page size, version and mode through. `TimeSeriesTagDictionary.openOrCreate()` had the same hazard by a second route the issue did not name - it built on an already-registered file's *id* but on the *configured* page size - and now takes all three from that file, through a constructor that makes it the only available form for a caller in that position. `PaginatedComponent` then asserts the agreement in its constructor, next to the file-id check #6283 added and in the same shape.

On the version: it is now what the file says rather than `CURRENT_VERSION`. Which row layout a bucket reads is decided by whether a dictionary was handed to it, not by this field, so nothing changes behaviourally - the point is that the component should not *claim* the current version for a file whose name says otherwise.

**On the trade the issue flagged.** The issue asked for a deliberate decision about the guard turning an existing mismatched database into "a loud failure at open". Having built it, that framing turns out not to apply to *this* change, and I want to correct it rather than repeat it: the guard compares the component against the file it holds, and after the pass-through fix **every load path takes the page size from that file**, so the two agree by construction whatever `bucketDefaultPageSize` happens to say. The guard cannot fire on a database opened through the normal path - it is a programming-error tripwire for the defect this change removes, not a compatibility gate. The issue's framing described adding the guard *without* the pass-through.

`reopeningUnderAnyConfiguredPageSizeSucceedsWhateverTheFilesWereWrittenAt` pins this: a database carrying files written at 64 KB and at 16 KB, reopened under a third value matching neither, opens both and reads both.

What the fix genuinely cannot undo is data *written* during a mismatched session under an affected build - those pages went to disk at the wrong stride and are scrambled on disk. No guard added here detects that, and none could.

## Item 2 - `FileManager.getOrCreateFile(int, String)` is the by-id mirror of #6283

The invariant lived in its one caller. It is pushed down, so "the file you get back is the file you asked for" belongs to `FileManager` for both keys rather than to whichever caller remembered to check.

Respecting the constraint the issue set out: it throws the same `SchemaException` the HA follower's `createNewFiles` does, so a caller that reaches it is classified exactly as that caller would have classified itself. `createNewFiles` **keeps** its own check, because it has to tell an idempotent replay (same name, skip) from a diverged file-id space (different name, quarantine and full snapshot resync, #6063) - that is a branch, not just a guard, and cannot be replaced by an exception. So `FileManager`'s check fires for nobody today; it is what makes the next caller not have to re-derive the reasoning. No reachable defect existed here and none is claimed.

## Item 3 - `LSMVectorIndexSearcherPoolTest` asserted a bound the pool documents it may exceed

The statistic is `GraphSearcherPool`'s `idleCount`, and `release()` reads it and increments without a lock - *"racy by design: a transient overshoot of one or two searchers is cheaper than a lock on the search path."* With 8 threads releasing into a pool of 4, all 8 can read a count below the cap and then all increment, so the reachable maximum is `maxIdle + concurrency - 1` = 11. The assertion of `<= 4` contradicted the contract of the code under test; it was observed failing as `expected 5L to be less than or equal to 4L` in a full engine suite run, and the class carries no `@Tag`, so it reddens the **default** lane.

Per the issue's request, this asserts what the pool actually promises - that it does not grow without bound - with the two magic numbers named (`POOL_SIZE`, `CONCURRENCY`), the derivation written out, and `GraphSearcherPool.release()` named as the reason. Not a bump to a larger literal. "Never share a searcher", the property the test is named for, is already covered by the per-task result comparison above it.

## Files changed

Main:
- `engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java` - page-size agreement guard
- `engine/src/main/java/com/arcadedb/engine/FileManager.java` - by-id `getOrCreateFile` name check
- `engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java` - pass-through handler + constructor
- `engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java` - pass-through handler, constructor, and `openOrCreate()`

Tests:
- `engine/src/test/java/com/arcadedb/engine/timeseries/Issue6314TimeSeriesPageSizeTest.java` (new)
- `engine/src/test/java/com/arcadedb/engine/Issue6314FileAgreementTest.java` (new)
- `engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexSearcherPoolTest.java`
- `engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionaryTest.java` - moved to the file-carrying constructor

## Verification

- Full `engine` suite (`-DexcludedGroups=benchmark,slow,vector`): **12,340 tests, 0 failures, 0 errors**
- `ha-raft` state machine suite (the only production caller of the changed `FileManager` API): **96 tests, 0 failures**
- The item 1 test fails on `main` with `expected: 65536 but was: 16384` and, with that assertion removed, returns 0 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013az14F8gvbcYips5GqiZfy
