### PR TITLE
fix(#6322): a variable written twice is one vertex carrying both constraints, and a retry whose precondition cannot change is not a retry

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -213,6 +213,23 @@ jobs:
         if: success() || failure()
         run: ./.github/scripts/check-test-results.py surefire-reports
 
+      # A red lane has to name the failing test without a re-run. The reporter check run above is
+      # best-effort by design - an API outage makes it a no-op - the per-job log endpoint serves only
+      # runner setup and cleanup while any job of the run is still in flight, and nothing else this lane
+      # uploads carries a per-test verdict. The report XML is exactly the answer to "which test failed",
+      # so it is kept whenever the lane goes red (issue #6322).
+      - name: Upload unit test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unit-test-reports
+          path: |
+            **/surefire-reports/TEST*.xml
+          # A step that failed before Maven wrote any report has nothing to keep, and the red already
+          # belongs to that step: an empty match here must not add a second, misleading failure.
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload unit test coverage reports
         if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -293,6 +310,23 @@ jobs:
         if: success() || failure()
         run: ./.github/scripts/check-test-results.py surefire-reports
 
+      # A red lane has to name the failing test without a re-run. The reporter check run above is
+      # best-effort by design - an API outage makes it a no-op - the per-job log endpoint serves only
+      # runner setup and cleanup while any job of the run is still in flight, and nothing else this lane
+      # uploads carries a per-test verdict. The report XML is exactly the answer to "which test failed",
+      # so it is kept whenever the lane goes red (issue #6322).
+      - name: Upload slow unit test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: slow-unit-test-reports
+          path: |
+            **/surefire-reports/TEST*.xml
+          # A step that failed before Maven wrote any report has nothing to keep, and the red already
+          # belongs to that step: an empty match here must not add a second, misleading failure.
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload unit test coverage reports
         if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -368,6 +402,23 @@ jobs:
       - name: Check test results
         if: success() || failure()
         run: ./.github/scripts/check-test-results.py surefire-reports
+
+      # A red lane has to name the failing test without a re-run. The reporter check run above is
+      # best-effort by design - an API outage makes it a no-op - the per-job log endpoint serves only
+      # runner setup and cleanup while any job of the run is still in flight, and nothing else this lane
+      # uploads carries a per-test verdict. The report XML is exactly the answer to "which test failed",
+      # so it is kept whenever the lane goes red (issue #6322).
+      - name: Upload vector unit test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vector-unit-test-reports
+          path: |
+            **/surefire-reports/TEST*.xml
+          # A step that failed before Maven wrote any report has nothing to keep, and the red already
+          # belongs to that step: an empty match here must not add a second, misleading failure.
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload vector unit test coverage reports
         if: success() || failure()
@@ -485,6 +536,23 @@ jobs:
           path: engine/target/tck-report.html
           retention-days: 7
 
+      # A red lane has to name the failing test without a re-run. The reporter check run above is
+      # best-effort by design - an API outage makes it a no-op - the per-job log endpoint serves only
+      # runner setup and cleanup while any job of the run is still in flight, and nothing else this lane
+      # uploads carries a per-test verdict. The report XML is exactly the answer to "which test failed",
+      # so it is kept whenever the lane goes red (issue #6322).
+      - name: Upload openCypher TCK test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: opencypher-tck-test-reports
+          path: |
+            **/surefire-reports/TEST*.xml
+          # A step that failed before Maven wrote any report has nothing to keep, and the red already
+          # belongs to that step: an empty match here must not add a second, misleading failure.
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload openCypher TCK coverage reports
         if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -547,6 +615,24 @@ jobs:
       - name: Check test results
         if: success() || failure()
         run: ./.github/scripts/check-test-results.py failsafe-reports
+
+      # A red lane has to name the failing test without a re-run. The reporter check run above is
+      # best-effort by design - an API outage makes it a no-op - the per-job log endpoint serves only
+      # runner setup and cleanup while any job of the run is still in flight, and nothing else this lane
+      # uploads carries a per-test verdict. The report XML is exactly the answer to "which test failed",
+      # so it is kept whenever the lane goes red (issue #6322).
+      - name: Upload integration test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-test-reports
+          path: |
+            **/surefire-reports/TEST*.xml
+            **/failsafe-reports/TEST*.xml
+          # A step that failed before Maven wrote any report has nothing to keep, and the red already
+          # belongs to that step: an empty match here must not add a second, misleading failure.
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload integration test coverage reports
         if: success() || failure()
@@ -611,6 +697,24 @@ jobs:
       - name: Check test results
         if: success() || failure()
         run: ./.github/scripts/check-test-results.py failsafe-reports
+
+      # A red lane has to name the failing test without a re-run. The reporter check run above is
+      # best-effort by design - an API outage makes it a no-op - the per-job log endpoint serves only
+      # runner setup and cleanup while any job of the run is still in flight, and nothing else this lane
+      # uploads carries a per-test verdict. The report XML is exactly the answer to "which test failed",
+      # so it is kept whenever the lane goes red (issue #6322).
+      - name: Upload HA integration test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ha-integration-test-reports
+          path: |
+            **/surefire-reports/TEST*.xml
+            **/failsafe-reports/TEST*.xml
+          # A step that failed before Maven wrote any report has nothing to keep, and the red already
+          # belongs to that step: an empty match here must not add a second, misleading failure.
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload HA integration test coverage reports
         if: success() || failure()
@@ -711,6 +815,23 @@ jobs:
           list-suites: "failed"
           list-tests: "failed"
           reporter: java-junit
+
+      # A red lane has to name the failing test without a re-run. The reporter check run above is
+      # best-effort by design - an API outage makes it a no-op - the per-job log endpoint serves only
+      # runner setup and cleanup while any job of the run is still in flight, and nothing else this lane
+      # uploads carries a per-test verdict. The report XML is exactly the answer to "which test failed",
+      # so it is kept whenever the lane goes red (issue #6322).
+      - name: Upload Java E2E test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: java-e2e-test-reports
+          path: |
+            e2e/target/failsafe-reports/TEST*.xml
+          # A step that failed before Maven wrote any report has nothing to keep, and the red already
+          # belongs to that step: an empty match here must not add a second, misleading failure.
+          if-no-files-found: ignore
+          retention-days: 7
 
   js-e2e-tests:
     runs-on: ubuntu-latest

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -3654,8 +3654,12 @@ public class CypherExecutionPlan {
     if (!(nodeStep instanceof MatchNodeStep))
       nodeStep = new MatchNodeStep(anchorVar, anchorNode, context);
 
-    // Determine target label for filtering (the counted node's label, if any)
+    // Determine target label for filtering (the counted node's label, if any). The step keys the
+    // filter on one name, which is not what a conjunction or a disjunction asks for, so a label set
+    // that name cannot stand for declines the push-down (issue #6322).
     final NodePattern countedNode = anchorNode == sourceNode ? targetNode : sourceNode;
+    if (!hasPushDownRepresentableLabel(countedNode))
+      return null;
     final String targetLabel = countedNode.hasLabels() ? countedNode.getLabels().get(0) : null;
 
     final CountEdgesReturnStep countStep = new CountEdgesReturnStep(
@@ -4165,19 +4169,66 @@ public class CypherExecutionPlan {
 
   /**
    * Checks whether two node patterns have labels that are type-disjoint in the schema,
-   * meaning no vertex can match both labels simultaneously.
+   * meaning no vertex can match both patterns simultaneously.
    * <p>
    * Two labels are disjoint if neither is a supertype/subtype of the other AND no type
    * in the schema is a subtype of both (which would allow a vertex to match both labels).
+   * <p>
+   * A node can write more than one label, and this is the one place where reading only the first of
+   * them can go wrong in <em>either</em> direction, because the answer is a proof rather than a
+   * filter: the caller uses it to conclude that two hops cannot be the same edge, so a wrong "yes"
+   * drops matches (issue #6322). The two spellings are therefore taken apart:
+   * <ul>
+   *   <li>{@code (a:A:B)} requires both, so proving <em>any</em> of its labels disjoint from any of
+   *   the other node's requirements proves the nodes disjoint;</li>
+   *   <li>{@code (a:A|B)} requires either, so the pattern is only disjoint when <em>every</em>
+   *   alternative is.</li>
+   * </ul>
+   * Reading the first label alone answers the conjunction too narrowly, which merely misses an
+   * opportunity, and the disjunction too widely, which is the wrong answer.
    */
   private boolean nodeLabelsAreTypeDisjoint(final NodePattern node1, final NodePattern node2) {
     if (!node1.hasLabels() || !node2.hasLabels())
       return false; // Without labels, can't prove disjointness
 
-    // Use the first label from each node for the check
-    final String label1 = node1.getLabels().get(0);
-    final String label2 = node2.getLabels().get(0);
+    // Every alternative of node1 must be disjoint from every alternative of node2. A conjunction is
+    // a single alternative listing all its labels; a disjunction is one alternative per label.
+    for (final List<String> alternative1 : labelAlternatives(node1))
+      for (final List<String> alternative2 : labelAlternatives(node2))
+        if (!alternativesAreTypeDisjoint(alternative1, alternative2))
+          return false;
 
+    return true;
+  }
+
+  /**
+   * The label sets a node pattern accepts: one set holding every label for a conjunction, one
+   * single-label set per alternative for a disjunction.
+   */
+  private static List<List<String>> labelAlternatives(final NodePattern node) {
+    if (!node.isLabelDisjunction())
+      return List.of(node.getLabels());
+
+    final List<List<String>> alternatives = new ArrayList<>(node.getLabels().size());
+    for (final String label : node.getLabels())
+      alternatives.add(List.of(label));
+    return alternatives;
+  }
+
+  /**
+   * Whether two conjunctions of labels cannot be satisfied by the same vertex, which holds as soon as
+   * one label of the first is type-disjoint from one label of the second.
+   */
+  private boolean alternativesAreTypeDisjoint(final List<String> labels1, final List<String> labels2) {
+    for (final String label1 : labels1)
+      for (final String label2 : labels2)
+        if (labelsAreTypeDisjoint(label1, label2))
+          return true;
+    return false;
+  }
+
+  /** Whether no vertex in the schema can carry both labels. */
+  private boolean labelsAreTypeDisjoint(final String label1, final String label2) {
     if (label1.equals(label2))
       return false; // Same label → not disjoint
 
@@ -4624,6 +4675,10 @@ public class CypherExecutionPlan {
 
     for (int i = 0; i <= hopCount; i++) {
       final NodePattern node = pathPattern.getNode(i);
+      // One name per hop is all the operator carries, and a conjunction or a disjunction is not one
+      // name; rather than count a set the pattern did not describe, decline (issue #6322).
+      if (!hasPushDownRepresentableLabel(node))
+        return null;
       nodeLabels[i] = node.hasLabels() ? node.getLabels().get(0) : null;
     }
 
@@ -4837,18 +4892,23 @@ public class CypherExecutionPlan {
     if (centralVar == null)
       return null; // no variable appears in multiple patterns
 
-    // Find the label for the central variable
+    // Find the label for the central variable. The variable is written once per arm and the
+    // operator enumerates one type of central node, so every occurrence has to agree on it: a label
+    // set the single name cannot stand for, or two occurrences naming different types, declines the
+    // push-down and leaves the query to the ordinary pipeline, which applies each of them (#6322).
     for (final MatchClause mc : statement.getMatchClauses()) {
       if (!mc.hasPathPatterns()) continue;
       for (final PathPattern pp : mc.getPathPatterns())
         for (int i = 0; i <= pp.getRelationshipCount(); i++) {
           final NodePattern node = pp.getNode(i);
-          if (centralVar.equals(node.getVariable()) && node.hasLabels()) {
-            centralLabel = node.getLabels().get(0);
-            break;
-          }
+          if (!centralVar.equals(node.getVariable()) || !node.hasLabels())
+            continue;
+          if (!hasPushDownRepresentableLabel(node))
+            return null;
+          if (labelsConflict(centralLabel, node.getLabels().get(0)))
+            return null;
+          centralLabel = node.getLabels().get(0);
         }
-      if (centralLabel != null) break;
     }
 
     final ArrayList<DegreeProductOp.Arm> armList = new ArrayList<>();
@@ -5256,7 +5316,11 @@ public class CypherExecutionPlan {
    * {@code (a:A:B)} keeps only what carries both and {@code (a:A|B)} keeps what carries either; taking the first
    * of the list turns each of them into {@code (a:A)}, which is neither. An operator built on that filter counts
    * a set the pattern did not describe, so the detector declines and leaves the query to the ordinary pipeline
-   * (issue #6304).
+   * (issue #6304, extended to the remaining detectors by issue #6322).
+   * <p>
+   * The one place a multi-label node is <em>not</em> answered by declining is
+   * {@link #nodeLabelsAreTypeDisjoint(NodePattern, NodePattern)}, which produces a proof rather than a filter
+   * and takes the two spellings apart instead.
    */
   private static boolean hasPushDownRepresentableLabel(final NodePattern node) {
     return !node.hasLabels() || (node.getLabels().size() == 1 && !node.isLabelDisjunction());
@@ -5335,6 +5399,10 @@ public class CypherExecutionPlan {
 
     for (int i = 0; i <= hopCount; i++) {
       final NodePattern node = pathPattern.getNode(i);
+      // One name per hop is all the operator carries, and a conjunction or a disjunction is not one
+      // name; rather than count a set the pattern did not describe, decline (issue #6322).
+      if (!hasPushDownRepresentableLabel(node))
+        return null;
       nodeLabels[i] = node.hasLabels() ? node.getLabels().get(0) : null;
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountEdgesReturnStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountEdgesReturnStep.java
@@ -25,6 +25,7 @@ import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
@@ -218,12 +219,11 @@ public final class CountEdgesReturnStep extends AbstractExecutionStep {
           }
           return count;
         }
-        // Fallback: check type name per neighbor
+        // Fallback: check the type per neighbor
         int count = 0;
         for (final int nid : neighborIds) {
           final RID rid = provider.getRID(nid);
-          final String typeName = db.getSchema().getTypeByBucketId(rid.getBucketId()).getName();
-          if (targetLabel.equals(typeName))
+          if (db.getSchema().getTypeByBucketId(rid.getBucketId()).instanceOf(targetLabel))
             count++;
         }
         return count;
@@ -233,7 +233,7 @@ public final class CountEdgesReturnStep extends AbstractExecutionStep {
     // OLTP fallback with target filtering
     long count = 0;
     for (final Vertex neighbor : vertex.getVertices(direction, edgeTypes)) {
-      if (targetLabel.equals(neighbor.getTypeName()))
+      if (Labels.hasLabel(neighbor, targetLabel))
         count++;
     }
     return count;
@@ -241,13 +241,20 @@ public final class CountEdgesReturnStep extends AbstractExecutionStep {
 
   private volatile int[] cachedTargetBuckets;
 
+  /**
+   * The buckets a vertex carrying {@code targetLabel} can live in. Polymorphic, because a Cypher label is
+   * satisfied by every type that extends it: a vertex written as {@code (:Post:Draft)} has the composite type
+   * {@code Draft~Post}, which extends {@code Post} and lives in its own buckets, and a pattern asking for
+   * {@code (p:Post)} matches it. Reading only the type's own buckets counted a strictly smaller set than the
+   * pattern described (issue #6322).
+   */
   private int[] resolveTargetBuckets(final Database db) {
     if (cachedTargetBuckets != null)
       return cachedTargetBuckets;
     final DocumentType type = db.getSchema().getType(targetLabel);
     if (type == null)
       return null;
-    final var buckets = type.getBuckets(false);
+    final var buckets = type.getBuckets(true);
     final int[] ids = new int[buckets.size()];
     for (int i = 0; i < buckets.size(); i++)
       ids[i] = buckets.get(i).getFileId();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountEdgesReturnStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountEdgesReturnStep.java
@@ -24,7 +24,6 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
-import com.arcadedb.schema.DocumentType;
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
@@ -35,6 +34,7 @@ import com.arcadedb.query.sql.executor.IteratorResultSet;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -130,11 +130,22 @@ public class CypherOptimizer {
   /**
    * Optimizes the Cypher query and produces a physical execution plan.
    *
-   * @return optimized physical plan
+   * @return optimized physical plan, or {@code null} when the pattern is not one the physical
+   * operators can represent, in which case the caller falls back to the ordinary pipeline
    */
   public PhysicalPlan optimize() {
     // 1. Build logical plan from AST
     final LogicalPlan logicalPlan = buildLogicalPlan();
+
+    // 1a. A variable written in more than one pattern accumulates the labels of every occurrence, and
+    // the merged set can be one no physical operator represents: a conjunction, whose composite type
+    // name a vertex carrying a third label does not extend; a disjunction crossed with a further
+    // label; or no label at all, which would scan the type "V" the schema does not have and answer
+    // nothing. The planner's AST-level guard sees the occurrences one at a time and admits a query
+    // whose merged sets it never looked at, so the decision is taken here - declining hands the query
+    // to the ordinary pipeline, which evaluates the labels one by one (issue #6322).
+    if (!logicalPlan.hasRepresentableLabelSets())
+      return null;
 
     // 2. Collect runtime statistics
     final List<String> typeNames = extractTypeNames(logicalPlan);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -232,7 +232,7 @@ public class LogicalPlan {
       labels = occurrence.getLabels();
       disjunction = occurrence.isLabelDisjunction();
     } else if (existing.isLabelDisjunction() == occurrence.isLabelDisjunction()
-        && existing.getLabels().equals(occurrence.getLabels())) {
+        && sameLabelSet(existing.getLabels(), occurrence.getLabels())) {
       // The same constraint written twice - `(a:A|B)-[:R]->(b), (a:A|B)-[:S]->(c)` - intersects with itself,
       // so there is nothing to fold in and nothing about it a single node cannot express. Taking the union
       // below would reach the same list, but would also record the variable as a mixed disjunction and
@@ -272,6 +272,21 @@ public class LogicalPlan {
       return existing;
 
     return new LogicalNode(variable, labels, properties, disjunction);
+  }
+
+  /**
+   * Whether two label lists name the same set. Order is not a constraint a pattern expresses -
+   * {@code (a:A|B)} and {@code (a:B|A)} are one disjunction, {@code (a:A:B)} and {@code (a:B:A)} one
+   * conjunction - so mutual containment rather than {@link List#equals}, which would miss the no-op and
+   * decline a query for the order its two occurrences happened to be written in.
+   * <p>
+   * Mutual containment rather than a size check plus one direction, because a label repeated inside one
+   * list ({@code (a:A:A)}) would let {@code [A, B]} and {@code [A, A]} pass as the same set and drop
+   * {@code B}. Both lists are a handful of entries, so the quadratic scan is cheaper than the sets that
+   * would replace it.
+   */
+  private static boolean sameLabelSet(final List<String> first, final List<String> second) {
+    return first.containsAll(second) && second.containsAll(first);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -255,6 +255,14 @@ public class LogicalPlan {
       properties = union;
     }
 
+    // The common repeat adds nothing - `(a)-[:R]->(b), (a)-[:S]->(c)` writes `a` twice and the second
+    // occurrence is bare - so the node the plan already holds is returned rather than an identical
+    // copy of it. Reference comparison, because every branch above either reuses one of the two lists
+    // as-is or builds a new one.
+    if (labels == existing.getLabels() && properties == existing.getProperties()
+        && disjunction == existing.isLabelDisjunction())
+      return existing;
+
     return new LogicalNode(variable, labels, properties, disjunction);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -67,6 +67,14 @@ public class LogicalPlan {
   private final Map<String, LogicalNode> patternNodes;
   private final List<LogicalRelationship> relationships;
   private final List<WhereClause> whereFilters;
+  /**
+   * The inline property map of every node occurrence, paired with the plan variable it constrains,
+   * in the order the patterns wrote them. Kept alongside the merged {@link #patternNodes} because a
+   * variable written twice carries two maps and both are predicates on the same vertex.
+   */
+  private final List<Map.Entry<String, Map<String, Object>>> inlinePropertyOccurrences = new ArrayList<>();
+  /** Variables whose merged label set combines a disjunction with a further label - see {@link #hasRepresentableLabelSets()}. */
+  private final Set<String> mixedLabelDisjunctions = new HashSet<>();
   private final ReturnClause returnClause;
   private int anonNodeCounter = 0;
 
@@ -149,6 +157,10 @@ public class LogicalPlan {
    * back via an empty nodes map, which is relied on by count push-down).
    * The synthetic prefix "  __anon" (two leading spaces) mirrors the convention
    * in CypherExecutionPlan and cannot collide with user-defined variable names.
+   * <p>
+   * A variable written more than once - across comma-separated patterns or across MATCH clauses -
+   * names one vertex that has to satisfy <em>every</em> occurrence, so the occurrences are merged
+   * rather than the first one kept (issue #6322).
    */
   private void extractPathPattern(final PathPattern pathPattern, final int clauseIndex) {
     final List<NodePattern> nodePatterns = pathPattern.getNodes();
@@ -161,17 +173,18 @@ public class LogicalPlan {
     for (int i = 0; i < nodePatterns.size(); i++) {
       final NodePattern np = nodePatterns.get(i);
       final String variable = np.getVariable();
-      if (variable != null) {
-        nodeVars[i] = variable;
-        if (!nodes.containsKey(variable)) {
-          nodes.put(variable, new LogicalNode(variable, np.getLabels(), np.getProperties(), np.isLabelDisjunction()));
-        }
-      } else {
-        nodeVars[i] = "  __anon" + anonNodeCounter++;
-      }
-      patternNodes.putIfAbsent(nodeVars[i],
-          nodes.getOrDefault(nodeVars[i],
-              new LogicalNode(nodeVars[i], np.getLabels(), np.getProperties(), np.isLabelDisjunction())));
+      nodeVars[i] = variable != null ? variable : "  __anon" + anonNodeCounter++;
+
+      final LogicalNode merged = mergeOccurrence(patternNodes.get(nodeVars[i]), nodeVars[i], np);
+      patternNodes.put(nodeVars[i], merged);
+      if (variable != null)
+        nodes.put(variable, merged);
+
+      // Every occurrence's own property map is lowered, not just the merged one: two occurrences
+      // pinning the same property to different values are a contradiction the merged map cannot
+      // hold, and dropping either half would turn an empty result into rows.
+      if (np.getProperties() != null && !np.getProperties().isEmpty())
+        inlinePropertyOccurrences.add(Map.entry(nodeVars[i], np.getProperties()));
     }
 
     // Extract relationships using the resolved (never-null) variable names.
@@ -191,6 +204,80 @@ public class LogicalPlan {
       );
       relationships.add(logicalRel);
     }
+  }
+
+  /**
+   * Folds one more occurrence of a variable into the node the plan already holds for it. Cypher
+   * repeats a variable to mean the same vertex, so the constraints accumulate: the labels are ANDed
+   * and the inline property maps are unioned.
+   * <p>
+   * The union of two disjunctions, or of a disjunction with a plain label, is not a shape a single
+   * {@link LogicalNode} can express - it carries one flag for the whole list - so the variable is
+   * recorded as one {@link #hasRepresentableLabelSets()} rejects, which sends the query to the
+   * ordinary pipeline. The merge never drops a constraint, so no caller can under-filter on the
+   * strength of it.
+   */
+  private LogicalNode mergeOccurrence(final LogicalNode existing, final String variable,
+      final NodePattern occurrence) {
+    if (existing == null)
+      return new LogicalNode(variable, occurrence.getLabels(), occurrence.getProperties(),
+          occurrence.isLabelDisjunction());
+
+    final List<String> labels;
+    final boolean disjunction;
+    if (occurrence.getLabels() == null || occurrence.getLabels().isEmpty()) {
+      labels = existing.getLabels();
+      disjunction = existing.isLabelDisjunction();
+    } else if (existing.getLabels().isEmpty()) {
+      labels = occurrence.getLabels();
+      disjunction = occurrence.isLabelDisjunction();
+    } else {
+      final List<String> union = new ArrayList<>(existing.getLabels());
+      for (final String label : occurrence.getLabels())
+        if (!union.contains(label))
+          union.add(label);
+      labels = union;
+      disjunction = existing.isLabelDisjunction() || occurrence.isLabelDisjunction();
+      if (disjunction)
+        mixedLabelDisjunctions.add(variable);
+    }
+
+    final Map<String, Object> properties;
+    if (occurrence.getProperties() == null || occurrence.getProperties().isEmpty()) {
+      properties = existing.getProperties();
+    } else if (existing.getProperties().isEmpty()) {
+      properties = occurrence.getProperties();
+    } else {
+      // The merged map only steers an index seek and partition pruning; every occurrence's map is
+      // lowered into predicates separately, so a key pinned twice keeps both comparisons.
+      final Map<String, Object> union = new LinkedHashMap<>(existing.getProperties());
+      occurrence.getProperties().forEach(union::putIfAbsent);
+      properties = union;
+    }
+
+    return new LogicalNode(variable, labels, properties, disjunction);
+  }
+
+  /**
+   * Returns true when every node in the pattern carries a label set the physical operators can
+   * represent: exactly one label, or a disjunction the anchor scan can enumerate.
+   * <p>
+   * {@code (a:A:B)} - written that way, or arrived at by merging {@code (a:A)} with a later
+   * {@code (a:B)} - names the composite type {@code A~B}, which a vertex labelled {@code A:B:C} does
+   * not extend, so a scan of it would miss rows. A disjunction merged with any further label is not
+   * expressible at all. Both send the query to the ordinary pipeline, which evaluates the labels one
+   * by one (issue #6322).
+   */
+  public boolean hasRepresentableLabelSets() {
+    if (!mixedLabelDisjunctions.isEmpty())
+      return false;
+    for (final LogicalNode node : patternNodes.values()) {
+      if (node.getLabels().isEmpty())
+        return false;
+      if (node.getLabels().size() > 1 && !node.isLabelDisjunction())
+        return false;
+    }
+    return true;
   }
 
   /**
@@ -229,10 +316,10 @@ public class LogicalPlan {
   private void lowerInlinePropertiesToFilters() {
     final List<BooleanExpression> predicates = new ArrayList<>();
 
-    for (final Map.Entry<String, LogicalNode> entry : patternNodes.entrySet()) {
+    for (final Map.Entry<String, Map<String, Object>> entry : inlinePropertyOccurrences) {
       final String variable = entry.getKey();
-      final Map<String, Object> properties = entry.getValue().getProperties();
-      if (properties == null || properties.isEmpty() || !isBoundByPlan(variable))
+      final Map<String, Object> properties = entry.getValue();
+      if (!isBoundByPlan(variable))
         continue;
 
       // Sorted so the same query always yields the same predicate order, and so the same plan

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -231,6 +231,14 @@ public class LogicalPlan {
     } else if (existing.getLabels().isEmpty()) {
       labels = occurrence.getLabels();
       disjunction = occurrence.isLabelDisjunction();
+    } else if (existing.isLabelDisjunction() == occurrence.isLabelDisjunction()
+        && existing.getLabels().equals(occurrence.getLabels())) {
+      // The same constraint written twice - `(a:A|B)-[:R]->(b), (a:A|B)-[:S]->(c)` - intersects with itself,
+      // so there is nothing to fold in and nothing about it a single node cannot express. Taking the union
+      // below would reach the same list, but would also record the variable as a mixed disjunction and
+      // decline a query the operators can perfectly well run.
+      labels = existing.getLabels();
+      disjunction = existing.isLabelDisjunction();
     } else {
       final List<String> union = new ArrayList<>(existing.getLabels());
       for (final String label : occurrence.getLabels())

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -86,50 +86,36 @@ public class RetryStep extends AbstractExecutionStep {
           return result.syncPull(ctx, nRecords);
         }
         break;
-      } catch (final NeedRetryException | TimeoutException ex) {
-        // TimeoutException is also retried because the primary source under concurrent writes is
+      } catch (final TimeoutException ex) {
+        // A TimeoutException is retried because the primary source under concurrent writes is
         // TransactionManager's file-lock timeout during commit (see
         // TransactionManager.lockFilesInOrder). That contention is transient and almost always
         // clears after a short backoff, so retrying inside a COMMIT RETRY block is the right
         // behavior. A TIMEOUT clause written inside the block is retried for the same reason: each
-        // attempt builds its own plan on a context of its own, so the clause starts its interval
-        // again. What is not retried is the command's own deadline - see below.
-        try {
-          ctx.getDatabase().rollback();
-        } catch (Exception e) {
-          // IGNORE IT
-        }
-
-        // A retry is only a retry when its precondition can change. The command's deadline is one
-        // instant pinned for the whole statement (issue #6266), and every attempt this step starts
-        // inherits it, so once it has passed the remaining attempts abort on their first check: the
-        // block would spend its whole budget, plus a backoff sleep between each pair of attempts,
-        // re-reaching a bound that expired before the first retry, and then report the failure of the
-        // last attempt rather than the deadline that actually stopped it (issue #6322).
+        // attempt builds its own plan on a context of its own, so the clause starts its interval again.
+        // The command's own deadline is the one kind that cannot be cured by waiting, and it is
+        // already the exception the caller should see, so it propagates as it is.
+        rollbackQuietly(ctx);
         if (commandDeadlineReached(ctx))
-          throw ex instanceof TimeoutException ?
-              ex :
-              new TimeoutException(
-                  "COMMIT RETRY gave up after " + (attempt + 1) + " of " + retries + " attempts: the command exceeded the "
-                      + ctx.getCommandDeadlineDescription(), ex);
+          throw ex;
 
-        if (attempt >= retries - 1) {
-          if (elseBody != null && elseBody.size() > 0) {
-            final ScriptExecutionPlan plan = initPlan(elseBody, ctx);
-            final ExecutionStepInternal result = plan.executeFull();
-            if (result != null) {
-              this.finalResult = result;
-              return result.syncPull(ctx, nRecords);
-            }
-          }
-          if (elseFail) {
-            throw ex;
-          } else {
-            return new InternalResultSet();
-          }
-        }
+        final ResultSet finished = giveUpOrBackOff(ctx, nRecords, attempt, ex);
+        if (finished != null)
+          return finished;
+      } catch (final NeedRetryException ex) {
+        // A write conflict clears on its own, so this is the retry the user asked for - unless the
+        // command's deadline has passed, in which case the remaining attempts cannot even start their
+        // work. The deadline, not the conflict, is what ended the block, and saying so is the whole
+        // point: the conflict alone would leave a COMMIT RETRY 10 that made one attempt unexplained.
+        rollbackQuietly(ctx);
+        if (commandDeadlineReached(ctx))
+          throw new TimeoutException(
+              "COMMIT RETRY gave up after " + (attempt + 1) + " of " + retries + " attempts: the command exceeded the "
+                  + ctx.getCommandDeadlineDescription(), ex);
 
-        delayBetweenRetries(attempt);
+        final ResultSet finished = giveUpOrBackOff(ctx, nRecords, attempt, ex);
+        if (finished != null)
+          return finished;
       }
     }
 
@@ -138,10 +124,51 @@ public class RetryStep extends AbstractExecutionStep {
   }
 
   /**
-   * Whether the deadline every attempt of this block runs under has already passed. Read from the step's own
-   * context rather than from the attempt's: a {@code TIMEOUT} clause inside the body publishes on the child
-   * context {@link #initPlan} builds per attempt, so it does not answer here and stays retryable, while
-   * {@code arcadedb.command.timeout} and an enclosing {@code TIMEOUT} clause do (issue #6322).
+   * Ends the attempt that just failed: either the block is out of attempts - in which case the {@code ELSE}
+   * body runs and {@code ELSE FAIL} decides between raising {@code ex} and answering an empty result set - or
+   * the backoff interval is slept and the loop goes round again.
+   *
+   * @return the result set the block finished with, or {@code null} when another attempt is due
+   */
+  private ResultSet giveUpOrBackOff(final CommandContext ctx, final int nRecords, final int attempt,
+      final RuntimeException ex) {
+    if (attempt >= retries - 1) {
+      if (elseBody != null && !elseBody.isEmpty()) {
+        final ScriptExecutionPlan plan = initPlan(elseBody, ctx);
+        final ExecutionStepInternal result = plan.executeFull();
+        if (result != null) {
+          this.finalResult = result;
+          return result.syncPull(ctx, nRecords);
+        }
+      }
+      if (elseFail)
+        throw ex;
+      return new InternalResultSet();
+    }
+
+    delayBetweenRetries(attempt);
+    return null;
+  }
+
+  /** Discards the failed attempt's transaction. A rollback that itself fails changes nothing the caller can act on. */
+  private static void rollbackQuietly(final CommandContext ctx) {
+    try {
+      ctx.getDatabase().rollback();
+    } catch (Exception e) {
+      // IGNORE IT
+    }
+  }
+
+  /**
+   * Whether the deadline every attempt of this block runs under has already passed. A retry is only a retry
+   * when its precondition can change: the command's deadline is one instant pinned for the whole statement
+   * (issue #6266) and every attempt this step starts inherits it, so once it has passed the block would spend
+   * its remaining budget, plus a backoff sleep between each pair of attempts, re-reaching a bound that expired
+   * before the first retry (issue #6322).
+   * <p>
+   * Read from the step's own context rather than from the attempt's: a {@code TIMEOUT} clause inside the body
+   * publishes on the child context {@link #initPlan} builds per attempt, so it does not answer here and stays
+   * retryable, while {@code arcadedb.command.timeout} and an enclosing {@code TIMEOUT} clause do.
    */
   private static boolean commandDeadlineReached(final CommandContext ctx) {
     return ctx != null && System.currentTimeMillis() > ctx.getCommandDeadline();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -91,13 +91,27 @@ public class RetryStep extends AbstractExecutionStep {
         // TransactionManager's file-lock timeout during commit (see
         // TransactionManager.lockFilesInOrder). That contention is transient and almost always
         // clears after a short backoff, so retrying inside a COMMIT RETRY block is the right
-        // behavior. Query-level timeouts wrapped in RETRY will also retry, which is consistent
-        // with the user's explicit RETRY N directive.
+        // behavior. A TIMEOUT clause written inside the block is retried for the same reason: each
+        // attempt builds its own plan on a context of its own, so the clause starts its interval
+        // again. What is not retried is the command's own deadline - see below.
         try {
           ctx.getDatabase().rollback();
         } catch (Exception e) {
           // IGNORE IT
         }
+
+        // A retry is only a retry when its precondition can change. The command's deadline is one
+        // instant pinned for the whole statement (issue #6266), and every attempt this step starts
+        // inherits it, so once it has passed the remaining attempts abort on their first check: the
+        // block would spend its whole budget, plus a backoff sleep between each pair of attempts,
+        // re-reaching a bound that expired before the first retry, and then report the failure of the
+        // last attempt rather than the deadline that actually stopped it (issue #6322).
+        if (commandDeadlineReached(ctx))
+          throw ex instanceof TimeoutException ?
+              ex :
+              new TimeoutException(
+                  "COMMIT RETRY gave up after " + (attempt + 1) + " of " + retries + " attempts: the command exceeded the "
+                      + ctx.getCommandDeadlineDescription(), ex);
 
         if (attempt >= retries - 1) {
           if (elseBody != null && elseBody.size() > 0) {
@@ -121,6 +135,16 @@ public class RetryStep extends AbstractExecutionStep {
 
     finalResult = new EmptyStep(ctx);
     return finalResult.syncPull(ctx, nRecords);
+  }
+
+  /**
+   * Whether the deadline every attempt of this block runs under has already passed. Read from the step's own
+   * context rather than from the attempt's: a {@code TIMEOUT} clause inside the body publishes on the child
+   * context {@link #initPlan} builds per attempt, so it does not answer here and stays retryable, while
+   * {@code arcadedb.command.timeout} and an enclosing {@code TIMEOUT} clause do (issue #6322).
+   */
+  private static boolean commandDeadlineReached(final CommandContext ctx) {
+    return ctx != null && System.currentTimeMillis() > ctx.getCommandDeadline();
   }
 
   public ScriptExecutionPlan initPlan(final List<Statement> body, final CommandContext ctx) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -102,6 +102,13 @@ public class RetryStep extends AbstractExecutionStep {
         // would fix the wording and break something worth more - a PartialResultTimeoutException that
         // reached here would stop being one, turning a TIMEOUT n RETURN clause's documented
         // return-what-you-have into a failure. The wording of a race loses to that.
+        //
+        // Note this leaves the block by a different door than running out of attempts does: it does not run
+        // the ELSE body and it does not consult ELSE FAIL. That is deliberate. The deadline says the command
+        // must stop, so an ELSE body - arbitrary statements, possibly writes, on a transaction that was just
+        // rolled back - is more work the operator asked us not to do; and returning the empty result set
+        // `ELSE ... AND CONTINUE` asks for would leave the caller unable to tell a block that legitimately
+        // produced nothing from one the deadline cut off, which is the silent failure issue #6322 named.
         rollbackQuietly(ctx);
         if (commandDeadlineReached(ctx))
           throw ex;
@@ -176,6 +183,13 @@ public class RetryStep extends AbstractExecutionStep {
    * Read from the step's own context rather than from the attempt's: a {@code TIMEOUT} clause inside the body
    * publishes on the child context {@link #initPlan} builds per attempt, so it does not answer here and stays
    * retryable, while {@code arcadedb.command.timeout} and an enclosing {@code TIMEOUT} clause do.
+   * <p>
+   * Deliberately not consulting {@link CommandContext#isCommandDeadlinePartial()}, which everywhere else
+   * separates a hard bound from a {@code TIMEOUT n RETURN} that asks for the rows produced so far. A partial
+   * deadline cannot be the one in force here: it is published by {@link StatementTimeouts} onto the context of
+   * the statement carrying the clause, and a script line runs on a plan of its own, so it never reaches the
+   * script context this step is pulled with - verified by reading the deadline back inside a
+   * {@code COMMIT RETRY} body that follows a {@code SELECT ... TIMEOUT n RETURN} line in the same script.
    */
   private static boolean commandDeadlineReached(final CommandContext ctx) {
     return ctx != null && System.currentTimeMillis() > ctx.getCommandDeadline();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.log.LogManager;
@@ -145,7 +146,7 @@ public class RetryStep extends AbstractExecutionStep {
    * @return the result set the block finished with, or {@code null} when another attempt is due
    */
   private ResultSet giveUpOrBackOff(final CommandContext ctx, final int nRecords, final int attempt,
-      final RuntimeException ex) {
+      final ArcadeDBException ex) {
     if (attempt >= retries - 1) {
       if (elseBody != null && !elseBody.isEmpty()) {
         final ScriptExecutionPlan plan = initPlan(elseBody, ctx);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -95,6 +95,13 @@ public class RetryStep extends AbstractExecutionStep {
         // attempt builds its own plan on a context of its own, so the clause starts its interval again.
         // The command's own deadline is the one kind that cannot be cured by waiting, and it is
         // already the exception the caller should see, so it propagates as it is.
+        //
+        // Propagating rather than wrapping does mean one narrow case reports the less useful of two true
+        // statements: a file-lock timeout raised at the very moment the command deadline also passes is
+        // reported as the lock, though it is the deadline that ended the loop. Wrapping unconditionally
+        // would fix the wording and break something worth more - a PartialResultTimeoutException that
+        // reached here would stop being one, turning a TIMEOUT n RETURN clause's documented
+        // return-what-you-have into a failure. The wording of a race loses to that.
         rollbackQuietly(ctx);
         if (commandDeadlineReached(ctx))
           throw ex;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownLabelIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownLabelIssue6322Test.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for item 2 of issue #6322: five more count push-down detectors read only the first of a
+ * node's labels.
+ * <p>
+ * {@code (a:A:B)} keeps what carries both and {@code (a:A|B)} keeps what carries either, so
+ * {@code getLabels().get(0)} turns each of them into {@code (a:A)}, which is neither. #6304 fixed this for the
+ * pair-join detector by declining the push-down; the four detectors here do the same, and each one is checked
+ * against the row count the ordinary materialization pipeline produces for the same pattern rather than against
+ * a number transcribed from what the operator used to answer.
+ * <p>
+ * {@code nodeLabelsAreTypeDisjoint} is the fifth, and the odd one out: it is a proof rather than a filter. The
+ * caller uses it to conclude that two hops of a pattern cannot be the same physical edge and, on the strength of
+ * that, skips the per-hop edge tracking Cypher's relationship-uniqueness rule needs. Reading only the first
+ * label of a disjunction proves the wrong thing in the direction that drops matches - and, as the pair of
+ * assertions in {@link #aDisjunctionIsOnlyDisjointWhenEveryAlternativeIs()} shows, made the answer depend on
+ * which of the two labels the query happened to write first.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherCountPushDownLabelIssue6322Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    // Written in Cypher rather than through the schema API because :Post:Draft is what creates the composite
+    // type Draft~Post - the vertex that carries both labels, and the only one a conjunction pattern may count.
+    database.command("opencypher", "CREATE (:Author {k:'a1'}), (:Author {k:'a2'})");
+    database.command("opencypher", "CREATE (:Post {k:'p1'})");
+    database.command("opencypher", "CREATE (:Post:Draft {k:'p2'})");
+    database.command("opencypher", "CREATE (:Topic {k:'t1'}), (:Topic {k:'t2'})");
+
+    database.command("opencypher", "MATCH (a:Author {k:'a1'}), (p:Post {k:'p1'}) CREATE (a)-[:WROTE]->(p)");
+    database.command("opencypher", "MATCH (a:Author {k:'a1'}), (p:Post {k:'p2'}) CREATE (a)-[:WROTE]->(p)");
+    database.command("opencypher", "MATCH (a:Author {k:'a2'}), (p:Post {k:'p1'}) CREATE (a)-[:WROTE]->(p)");
+    database.command("opencypher", "MATCH (p:Post {k:'p1'}), (t:Topic {k:'t1'}) CREATE (p)-[:TAGGED]->(t)");
+    database.command("opencypher", "MATCH (p:Post {k:'p2'}), (t:Topic {k:'t1'}) CREATE (p)-[:TAGGED]->(t)");
+
+    // A self-loop is the only shape in which one physical edge can serve two same-typed, same-direction hops
+    // of a path, which is what makes a skipped uniqueness check observable.
+    database.command("opencypher", "MATCH (t:Topic {k:'t1'}) CREATE (t)-[:RELATED]->(t)");
+    database.command("opencypher", "MATCH (t:Topic {k:'t1'}) CREATE (t)-[:OTHER]->(t)");
+  }
+
+  // ===================================================================================================
+  // the four detectors that key an operator on one label per node
+  // ===================================================================================================
+
+  /**
+   * {@code tryOptimizeMatchCountReturn}: the counted node's label becomes the step's target-type filter. The
+   * reference is the same grouped count computed through {@code WITH}, which the push-down does not claim.
+   */
+  @Test
+  void theCountedNodesLabelSetDeclinesTheEdgeCountPushDown() {
+    final String query = "MATCH (a:Author)-[:WROTE]->(p:Post:Draft) RETURN a.k AS k, count(p) AS c";
+    // Only a1 wrote the one post that is a Draft; a2 wrote only p1, so a2 contributes no row at all.
+    assertThat(groupCountsOf(query)).containsExactly("a1=1");
+    assertThat(groupCountsOf(query)).isEqualTo(groupCountsOf(
+        "MATCH (a:Author)-[:WROTE]->(p:Post:Draft) WITH a.k AS k, count(p) AS c RETURN k, c"));
+  }
+
+  /**
+   * The push-down the test above declines, on the single-label pattern where it is claimed, filters by the
+   * label the way the pattern means it: a vertex written as {@code (:Post:Draft)} carries the composite type
+   * {@code Draft~Post}, which extends {@code Post}, so {@code (p:Post)} matches it. The filter compared type
+   * names for equality and read the type's own buckets rather than its polymorphic ones, so it counted a
+   * strictly smaller set than the pattern asked for - the mirror image of the over-counts above.
+   */
+  @Test
+  void theEdgeCountPushDownMatchesLabelsPolymorphically() {
+    final String query = "MATCH (a:Author)-[:WROTE]->(p:Post) RETURN a.k AS k, count(p) AS c";
+    assertThat(groupCountsOf(query)).containsExactlyInAnyOrder("a1=2", "a2=1");
+    assertThat(groupCountsOf(query)).containsExactlyInAnyOrderElementsOf(groupCountsOf(
+        "MATCH (a:Author)-[:WROTE]->(p:Post) WITH a.k AS k, count(p) AS c RETURN k, c"));
+  }
+
+  /** {@code tryDetectChainCountStar}: one label per hop in the chain's label array. */
+  @Test
+  void aChainHopsLabelSetDeclinesTheChainCountPushDown() {
+    final String query = "MATCH (a:Author)-[:WROTE]->(p:Post:Draft)-[:TAGGED]->(t:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT CHAIN PATHS");
+    assertThat(scalarOf(query)).isEqualTo(rowCountOf(
+        "MATCH (a:Author)-[:WROTE]->(p:Post:Draft)-[:TAGGED]->(t:Topic) RETURN a")).isEqualTo(1);
+
+    final String single = "MATCH (a:Author)-[:WROTE]->(p:Post)-[:TAGGED]->(t:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(single)).contains("COUNT CHAIN PATHS");
+    assertThat(scalarOf(single)).isEqualTo(3);
+  }
+
+  /** {@code tryDetectAntiJoinChainCountStar}: the same label array, on the chain the anti-join filters. */
+  @Test
+  void aChainHopsLabelSetDeclinesTheAntiJoinCountPushDown() {
+    final String query = "MATCH (a:Author)-[:WROTE]->(p:Post:Draft)-[:TAGGED]->(t:Topic)"
+        + " WHERE NOT (a)-[:FOLLOWS]-(t) RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT ANTI-JOIN CHAIN");
+    assertThat(scalarOf(query)).isEqualTo(1);
+  }
+
+  /** {@code tryDetectStarCountStar}: the central variable's label is the type the operator enumerates. */
+  @Test
+  void theCentralVariablesLabelSetDeclinesTheStarCountPushDown() {
+    final String query = "MATCH (p:Post:Draft)<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query)).isEqualTo(1);
+
+    final String single = "MATCH (p:Post)<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(single)).contains("COUNT STAR JOIN");
+    assertThat(scalarOf(single)).isEqualTo(3);
+  }
+
+  /**
+   * The central variable is written once per arm, and the operator enumerates one type of central node, so two
+   * arms naming different types cannot both be honoured by it.
+   */
+  @Test
+  void conflictingCentralLabelsDeclineTheStarCountPushDown() {
+    final String query = "MATCH (p:Post)<-[:WROTE]-(:Author), (p:Draft)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query)).isEqualTo(1);
+  }
+
+  // ===================================================================================================
+  // the fifth: a disjointness proof that has to hold for every alternative
+  // ===================================================================================================
+
+  /**
+   * {@code (x:Author|Topic)-[:RELATED]->(y:Topic)-[:RELATED]->(z)} has two hops of the same edge type. They are
+   * proven to be different edges only if no vertex can be both the first hop's source and the second hop's
+   * source, and t1 - a Topic with a RELATED self-loop - can be both. Reading {@code Author} alone proved a
+   * disjointness that is not there, so the uniqueness check was skipped and the one self-loop was walked twice.
+   * <p>
+   * The second assertion is the same query with the two alternatives written the other way round. It always
+   * answered 0; that the first spelling did not is what makes this a defect rather than a policy.
+   */
+  @Test
+  void aDisjunctionIsOnlyDisjointWhenEveryAlternativeIs() {
+    assertThat(rowCountOf("MATCH (x:Author|Topic)-[:RELATED]->(y:Topic)-[:RELATED]->(z) RETURN x")).isEqualTo(0);
+    assertThat(rowCountOf("MATCH (x:Topic|Author)-[:RELATED]->(y:Topic)-[:RELATED]->(z) RETURN x")).isEqualTo(0);
+  }
+
+  /** Two hops of different edge types share no edge, so nothing about them changes: the self-loop pair matches. */
+  @Test
+  void distinctEdgeTypesAreUnaffected() {
+    assertThat(rowCountOf("MATCH (x:Author|Topic)-[:RELATED]->(y:Topic)-[:OTHER]->(z) RETURN x")).isEqualTo(1);
+  }
+
+  // ===================================================================================================
+  // helpers
+  // ===================================================================================================
+
+  /** The single {@code c} value of a one-row query. */
+  private long scalarOf(final String query) {
+    final List<Long> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        values.add(((Number) rs.next().getProperty("c")).longValue());
+    }
+    assertThat(values).as(query).hasSize(1);
+    return values.getFirst();
+  }
+
+  /** The {@code k=c} pairs of a grouped count, as strings, so an assertion reads as the query does. */
+  private List<String> groupCountsOf(final String query) {
+    final List<String> groups = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final var row = rs.next();
+        groups.add(row.getProperty("k") + "=" + ((Number) row.getProperty("c")).longValue());
+      }
+    }
+    return groups;
+  }
+
+  private int rowCountOf(final String query) {
+    int count = 0;
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** The rendered execution plan of {@code EXPLAIN <query>}. */
+  private String explainOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
@@ -119,6 +119,26 @@ class CypherMultiPatternSharedLabelIssue6322Test extends TestHelper {
         .isEqualTo(1);
   }
 
+  /**
+   * The merged-label gate declines a plan in which any pattern node has no label, and that branch must stay
+   * unreachable rather than becoming a new restriction: an unlabelled expansion target is refused one gate
+   * earlier, by {@code CypherExecutionPlanner.shouldUseOptimizer}, and has been since long before this fix.
+   * Verified against the pre-fix tree, where these four queries pick exactly the same two paths.
+   * <p>
+   * The test is here so that a future change admitting unlabelled nodes at the planner gate trips over the
+   * optimizer's own check instead of silently routing those queries to the ordinary pipeline, which would
+   * cost only speed and so would never show up as a failing assertion anywhere else.
+   */
+  @Test
+  void anUnlabelledNodeIsRefusedByThePlannerGateRatherThanByTheMergedLabelCheck() {
+    assertThat(explainOf("MATCH (a:Person)-[:KNOWS]->(b) RETURN b.k")).contains("Traditional Execution");
+    assertThat(explainOf("MATCH (a:Person)-[:KNOWS]->() RETURN a.k")).contains("Traditional Execution");
+    assertThat(explainOf("MATCH (a)-[:KNOWS]->(b:Person) RETURN b.k")).contains("Traditional Execution");
+
+    // And the fully-labelled shape the optimizer does claim is still claimed by it.
+    assertThat(explainOf("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.k")).contains("Cost-Based Query Optimizer");
+  }
+
   /** The merged label is the one the anchor scan uses, rather than the "no labels" composite name. */
   @Test
   void theMergedLabelReachesTheAnchorScan() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
@@ -184,6 +184,20 @@ class CypherMultiPatternSharedLabelIssue6322Test extends TestHelper {
     assertThat(rowCountOf(widened + " RETURN c")).isEqualTo(2);
   }
 
+  /**
+   * The order the alternatives are written in is not a constraint the pattern expresses, so
+   * {@code (p1:Person|Bot)} and {@code (p1:Bot|Person)} are one disjunction and the merge is still a no-op.
+   * Comparing the two lists for equality rather than as sets would decline the query for its spelling.
+   */
+  @Test
+  void theSameDisjunctionWrittenInEitherOrderIsStillOneConstraint() {
+    final String pattern =
+        "MATCH (p1:Person|Bot)-[:KNOWS]->(p2:Person), (p1:Bot|Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2)";
+    assertThat(rowCountOf(pattern + " RETURN c")).isEqualTo(2);
+    assertThat(rowCountOf(pattern + " RETURN c")).isEqualTo(rowCountOf(
+        "MATCH (p1:Person|Bot)-[:KNOWS]->(p2:Person), (p1:Person|Bot)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c"));
+  }
+
   // ===================================================================================================
   // inline property maps, dropped from a later occurrence by the same rule
   // ===================================================================================================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for item 1 of issue #6322: a two-pattern {@code MATCH} returned no rows at all when both
+ * shared variables carried a label and at least one of those labels was written on the second pattern.
+ * <p>
+ * A variable repeated across patterns names one vertex, so the constraints of every occurrence apply to it -
+ * {@code MATCH (a)-[:R]->(b), (a:Person)-[:S]->(c)} requires {@code a} to be a Person exactly as if the label
+ * had been written on the first pattern. The logical plan kept only the first occurrence of each variable, so a
+ * label written later was dropped. That alone would over-count; what made it answer <em>zero</em> is the
+ * planner's admission rule, which asks whether every variable is labelled <em>somewhere</em>: a query labelling
+ * its variables only on the second pattern was let into the optimizer, which then had no label for the anchor
+ * and emitted a scan of the composite type name for "no labels" - {@code V}, a type the schema does not have.
+ * <p>
+ * Two things follow, and both are asserted here: the occurrences are merged, and a merged label set the
+ * physical operators cannot represent - a conjunction, or a disjunction crossed with a further label - declines
+ * the optimizer rather than scanning something else. The same merge applies to inline property maps, which were
+ * dropped from a second occurrence for the same reason.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherMultiPatternSharedLabelIssue6322Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Person");
+      database.getSchema().createVertexType("Bot");
+      database.getSchema().createVertexType("Comment");
+      database.getSchema().createEdgeType("AUTHORED");
+      database.getSchema().createEdgeType("MENTIONS");
+      database.getSchema().createEdgeType("KNOWS");
+
+      final MutableVertex p1 = database.newVertex("Person").set("k", "p1").save();
+      final MutableVertex p2 = database.newVertex("Person").set("k", "p2").save();
+      // The vertex that makes a dropped label visible: an author that is not a Person.
+      final MutableVertex b1 = database.newVertex("Bot").set("k", "b1").save();
+      final MutableVertex c1 = database.newVertex("Comment").set("k", "c1").save();
+      final MutableVertex c2 = database.newVertex("Comment").set("k", "c2").save();
+
+      c1.newEdge("AUTHORED", p1).save();
+      c1.newEdge("MENTIONS", p2).save();
+      c2.newEdge("AUTHORED", b1).save();
+      c2.newEdge("MENTIONS", p2).save();
+      p1.newEdge("KNOWS", p2).save();
+      b1.newEdge("KNOWS", p2).save();
+    });
+  }
+
+  // ===================================================================================================
+  // the shape the issue reported: labels on the second pattern
+  // ===================================================================================================
+
+  /**
+   * Both shared variables labelled on the second pattern. Only c1 qualifies: its author p1 is a Person, its
+   * mentioned p2 is a Person, and p1 KNOWS p2 - while c2's author b1 is a Bot.
+   */
+  @Test
+  void bothSharedVariablesLabelledOnTheSecondPattern() {
+    assertThat(rowCountOf(
+        "MATCH (p1)-[:KNOWS]->(p2), (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2:Person) RETURN c")).isEqualTo(1);
+  }
+
+  /** One label on each pattern: the same single vertex satisfies both, whichever pattern wrote which. */
+  @Test
+  void oneLabelOnEachPattern() {
+    assertThat(rowCountOf(
+        "MATCH (p1)-[:KNOWS]->(p2:Person), (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c")).isEqualTo(1);
+    assertThat(rowCountOf(
+        "MATCH (p1:Person)-[:KNOWS]->(p2), (p1)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2:Person) RETURN c")).isEqualTo(1);
+  }
+
+  /** The spelling that always worked, kept as the reference the three above have to agree with. */
+  @Test
+  void bothLabelsOnTheFirstPattern() {
+    assertThat(rowCountOf(
+        "MATCH (p1:Person)-[:KNOWS]->(p2:Person), (p1)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c")).isEqualTo(1);
+  }
+
+  /** One labelled variable and one that is never labelled: the Bot author is not excluded, so both comments match. */
+  @Test
+  void onlyOneOfTheSharedVariablesIsLabelled() {
+    assertThat(rowCountOf(
+        "MATCH (p1)-[:KNOWS]->(p2), (p1)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2:Person) RETURN c")).isEqualTo(2);
+    assertThat(rowCountOf(
+        "MATCH (p1)-[:KNOWS]->(p2), (p1:Bot)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c")).isEqualTo(1);
+  }
+
+  /** Separate MATCH clauses share their variables the same way two comma-separated patterns do. */
+  @Test
+  void theLabelIsMergedAcrossMatchClausesToo() {
+    assertThat(rowCountOf(
+        "MATCH (p1)-[:KNOWS]->(p2) MATCH (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2:Person) RETURN c"))
+        .isEqualTo(1);
+  }
+
+  /** The merged label is the one the anchor scan uses, rather than the "no labels" composite name. */
+  @Test
+  void theMergedLabelReachesTheAnchorScan() {
+    final String plan = explainOf(
+        "MATCH (p1)-[:KNOWS]->(p2), (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2:Person) RETURN c");
+    assertThat(plan).contains("NodeByLabelScan(p1:Person)");
+    assertThat(plan).doesNotContain(":V)");
+  }
+
+  // ===================================================================================================
+  // merged sets the physical operators cannot represent
+  // ===================================================================================================
+
+  /**
+   * Two different labels on one variable merge into a conjunction, which the composite type name a scan would
+   * use does not stand for - a vertex labelled {@code Person:Bot:Admin} carries type {@code Admin~Bot~Person},
+   * which does not extend {@code Bot~Person}. The optimizer declines and the ordinary pipeline, which tests each
+   * label in turn, answers: no vertex here is both, so no row.
+   */
+  @Test
+  void aConjunctionArrivedAtByMergingDeclinesTheOptimizer() {
+    final String pattern = "MATCH (p1:Person)-[:KNOWS]->(p2:Person), (p1:Bot)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2)";
+    assertThat(explainOf(pattern + " RETURN c")).contains("Traditional Execution");
+    assertThat(rowCountOf(pattern + " RETURN c")).isEqualTo(0);
+  }
+
+  /**
+   * A disjunction crossed with a further label is not a shape one {@code LogicalNode} can hold at all - it
+   * carries one flag for the whole list - so it declines as well rather than being flattened into something
+   * that means neither.
+   */
+  @Test
+  void aDisjunctionCrossedWithAFurtherLabelDeclinesTheOptimizer() {
+    final String pattern = "MATCH (p1:Person|Bot)-[:KNOWS]->(p2:Person), (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2)";
+    assertThat(explainOf(pattern + " RETURN c")).contains("Traditional Execution");
+    assertThat(rowCountOf(pattern + " RETURN c")).isEqualTo(1);
+  }
+
+  /** The same label written twice is one constraint, not a conjunction, and stays on the optimized path. */
+  @Test
+  void theSameLabelOnBothPatternsIsStillOneLabel() {
+    final String pattern = "MATCH (p1:Person)-[:KNOWS]->(p2:Person), (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2)";
+    assertThat(explainOf(pattern + " RETURN c")).contains("Cost-Based Query Optimizer");
+    assertThat(rowCountOf(pattern + " RETURN c")).isEqualTo(1);
+  }
+
+  // ===================================================================================================
+  // inline property maps, dropped from a later occurrence by the same rule
+  // ===================================================================================================
+
+  /** A property map on the second occurrence of a variable constrains the same vertex the first one bound. */
+  @Test
+  void anInlinePropertyMapOnASecondOccurrenceIsApplied() {
+    assertThat(rowCountOf(
+        "MATCH (p1:Person)-[:KNOWS]->(p2:Person), (p1 {k:'p1'})<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c"))
+        .isEqualTo(1);
+    assertThat(rowCountOf(
+        "MATCH (p1:Person)-[:KNOWS]->(p2:Person), (p1 {k:'p2'})<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c"))
+        .isEqualTo(0);
+  }
+
+  /** Two occurrences pinning the same property to different values is a contradiction, not the last one written. */
+  @Test
+  void twoOccurrencesPinningOnePropertyKeepBothComparisons() {
+    assertThat(rowCountOf(
+        "MATCH (p1:Person {k:'p1'})-[:KNOWS]->(p2:Person), (p1 {k:'p2'})<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c"))
+        .isEqualTo(0);
+    assertThat(rowCountOf(
+        "MATCH (p1:Person {k:'p1'})-[:KNOWS]->(p2:Person), (p1 {k:'p1'})<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2) RETURN c"))
+        .isEqualTo(1);
+  }
+
+  // ===================================================================================================
+  // helpers
+  // ===================================================================================================
+
+  private int rowCountOf(final String query) {
+    int count = 0;
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** The rendered execution plan of {@code EXPLAIN <query>}. */
+  private String explainOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMultiPatternSharedLabelIssue6322Test.java
@@ -165,6 +165,25 @@ class CypherMultiPatternSharedLabelIssue6322Test extends TestHelper {
     assertThat(rowCountOf(pattern + " RETURN c")).isEqualTo(1);
   }
 
+  /**
+   * And so is the same <em>disjunction</em> written twice: it intersects with itself, so the merge has nothing
+   * to fold in and the result is a shape one node can still express. Taking the union blindly would reach the
+   * same list of labels and then decline a query the operators can perfectly well run.
+   */
+  @Test
+  void theSameDisjunctionOnBothPatternsIsStillOneConstraint() {
+    final String pattern =
+        "MATCH (p1:Person|Bot)-[:KNOWS]->(p2:Person), (p1:Person|Bot)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2)";
+    assertThat(rowCountOf(pattern + " RETURN c")).isEqualTo(2);
+
+    // Widening one of the two IS a new constraint - (A|B) AND (A|B|C) is (A|B), not the union - so that one
+    // still declines rather than being flattened into a disjunction over all three.
+    final String widened =
+        "MATCH (p1:Person|Bot)-[:KNOWS]->(p2:Person), (p1:Person|Bot|Comment)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2)";
+    assertThat(explainOf(widened + " RETURN c")).contains("Traditional Execution");
+    assertThat(rowCountOf(widened + " RETURN c")).isEqualTo(2);
+  }
+
   // ===================================================================================================
   // inline property maps, dropped from a later occurrence by the same rule
   // ===================================================================================================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherPairJoinLabelFilterIssue6304Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherPairJoinLabelFilterIssue6304Test.java
@@ -127,18 +127,20 @@ class CypherPairJoinLabelFilterIssue6304Test extends TestHelper {
   }
 
   /**
-   * Both arms filtered at once. The reference here is the OLTP path rather than the materialization pipeline,
-   * which answers 0 for this shape: labelling <em>both</em> shared variables when at least one of the labels is
-   * written on the second comma-separated pattern makes the pipeline drop every row, whichever of the two
-   * patterns carries which label. That is a defect of its own, unrelated to the push-down and not addressed
-   * here; the two counts below are derived by hand from the six-vertex fixture instead. Only c1 qualifies - its
-   * author p1 is a Person and its mentioned p2 is a Person, and p1 KNOWS p2 - while c2's author b1 is a Bot.
+   * Both arms filtered at once. Only c1 qualifies - its author p1 is a Person and its mentioned p2 is a Person,
+   * and p1 KNOWS p2 - while c2's author b1 is a Bot.
+   * <p>
+   * This shape used to be cross-checked against the OLTP count alone, because the materialization pipeline
+   * answered 0 for it: labelling <em>both</em> shared variables when at least one of the labels was written on
+   * the second comma-separated pattern made the logical plan drop that label, and the anchor scan then named a
+   * type the schema does not have. That was filed as issue #6322 and fixed, so the ordinary three-way
+   * cross-check applies here like everywhere else in this class.
    */
   @Test
   void bothArmEndpointLabelsAreAppliedTogether() {
-    assertTheCsrPathAgreesWithTheOltpPath(
+    assertCsrAgreesWithTheOltpPathAndThePipeline(
         "MATCH (p1)-[:KNOWS]->(p2), (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2:Person)", 1);
-    assertTheCsrPathAgreesWithTheOltpPath(
+    assertCsrAgreesWithTheOltpPathAndThePipeline(
         "MATCH (p1)-[:KNOWS]->(p2), (p1:Person)<-[:AUTHORED]-(c:Comment)-[:MENTIONS]->(p2:Bot)", 0);
   }
 
@@ -269,22 +271,6 @@ class CypherPairJoinLabelFilterIssue6304Test extends TestHelper {
     assertThat(GraphTraversalProviderRegistry.findProvider(database, "AUTHORED", "MENTIONS", "REPLY_OF", "KNOWS"))
         .isNotNull();
     return view;
-  }
-
-  /**
-   * As {@link #assertCsrAgreesWithTheOltpPathAndThePipeline} without the pipeline cross-check, for the one shape
-   * where the pipeline is itself wrong. What it still asserts is the invariant the issue is about: the answer
-   * must not depend on whether a Graph Analytical View happens to cover the edge types.
-   */
-  private void assertTheCsrPathAgreesWithTheOltpPath(final String matchClause, final long expected) {
-    assertThat(scalarOf(matchClause + " RETURN count(*) AS c")).as(matchClause + " (OLTP)").isEqualTo(expected);
-
-    final GraphAnalyticalView view = newViewOverEverything();
-    try {
-      assertThat(scalarOf(matchClause + " RETURN count(*) AS c")).as(matchClause + " (CSR)").isEqualTo(expected);
-    } finally {
-      view.drop();
-    }
   }
 
   /** The single {@code c} value of a one-row query. */

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CommitRetryCommandDeadlineIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CommitRetryCommandDeadlineIssue6322Test.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.function.sql.SQLFunctionAbstract;
+import com.arcadedb.query.sql.SQLQueryEngine;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for item 3 of issue #6322: {@code COMMIT RETRY n} retried a deadline that had already passed.
+ * <p>
+ * Retrying a {@code TimeoutException} is right for the one it was written for - {@code TransactionManager}'s
+ * file-lock timeout during commit, which is transient contention that clears after a backoff. It is not right
+ * for the command's own deadline: {@code arcadedb.command.timeout} and an enclosing {@code TIMEOUT} clause pin
+ * one instant for the whole statement (issue #6266), and every attempt this step starts inherits it, so once it
+ * has passed the remaining attempts abort on their first check. A {@code COMMIT RETRY 10} block spent all ten
+ * attempts plus nine backoff sleeps re-reaching a bound that expired before the first retry, and then reported
+ * the last attempt's failure rather than the deadline that actually stopped it.
+ * <p>
+ * The assertions are attempt counts rather than elapsed time: the counter says how many times the loop went
+ * round, which is the thing that changed, and no JVM stall can push it up.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CommitRetryCommandDeadlineIssue6322Test extends TestHelper {
+  /** Attempts of the retry body that actually reached the failing function. */
+  private static final AtomicInteger ATTEMPTS = new AtomicInteger();
+
+  /** Wall-clock milliseconds each attempt spends before failing, so a deadline can be made to pass. */
+  private static volatile long burnMillis = 0;
+
+  /** Whether the failure is a lock-style timeout rather than a concurrent-modification conflict. */
+  private static volatile boolean failWithTimeout = false;
+
+  /** Consumes what the burn loop produces, so the JIT cannot delete a computation nobody reads. */
+  private static volatile long sink;
+
+  @Override
+  protected void beginTest() {
+    ATTEMPTS.set(0);
+    burnMillis = 0;
+    failWithTimeout = false;
+    database.getSchema().createDocumentType("Attempt");
+    ((SQLQueryEngine) database.getQueryEngine("sql")).getFunctionFactory().register(new SQLFunctionAbstract("boom6322") {
+      @Override
+      public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult,
+          final Object[] params, final CommandContext context) {
+        ATTEMPTS.incrementAndGet();
+        // Wall clock rather than a fixed number of iterations: the point is to outlast a deadline expressed in
+        // milliseconds, and a busy runner must make that more certain, not less.
+        final long until = System.currentTimeMillis() + burnMillis;
+        long burnt = 0;
+        while (System.currentTimeMillis() < until)
+          burnt = burnt * 31 + 7;
+        sink += burnt;
+        if (failWithTimeout)
+          throw new TimeoutException("simulated file-lock timeout during commit");
+        throw new ConcurrentModificationException("simulated write conflict");
+      }
+
+      @Override
+      public String getSyntax() {
+        return "boom6322()";
+      }
+    });
+  }
+
+  @AfterEach
+  void restoreConfiguration() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT,
+        GlobalConfiguration.COMMAND_TIMEOUT.getDefValue());
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY,
+        GlobalConfiguration.TX_RETRY_DELAY.getDefValue());
+  }
+
+  /**
+   * The command deadline has passed by the end of the first attempt, so the nine that were left are not started.
+   * The reported failure names the bound, rather than being the conflict the last attempt happened to hit.
+   */
+  @Test
+  void anExpiredCommandDeadlineStopsTheRetryLoop() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 300L);
+    burnMillis = 900;
+
+    assertThatThrownBy(() -> database.command("sqlscript", script(10)))
+        .isInstanceOf(TimeoutException.class)
+        .hasMessageContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+
+    assertThat(ATTEMPTS.get()).isEqualTo(1);
+  }
+
+  /**
+   * With no deadline in force the block still spends every attempt it was given - the retry the user asked for
+   * is a retry, and the change above only removes the ones that cannot possibly differ.
+   */
+  @Test
+  void withoutADeadlineEveryRetryIsStillSpent() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 0L);
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 0);
+
+    assertThatThrownBy(() -> database.command("sqlscript", script(4)))
+        .isInstanceOf(ConcurrentModificationException.class);
+
+    assertThat(ATTEMPTS.get()).isEqualTo(4);
+  }
+
+  /**
+   * A {@code TimeoutException} that is not the command's own - the file-lock timeout the catch was written for -
+   * keeps consuming the retry budget, because waiting is exactly what clears it.
+   */
+  @Test
+  void aLockTimeoutIsStillRetried() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 0L);
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 0);
+    failWithTimeout = true;
+
+    assertThatThrownBy(() -> database.command("sqlscript", script(4)))
+        .isInstanceOf(TimeoutException.class)
+        .hasMessageContaining("file-lock");
+
+    assertThat(ATTEMPTS.get()).isEqualTo(4);
+  }
+
+  /**
+   * A deadline generous enough to outlast the whole loop changes nothing: the guard is "has it passed", not
+   * "is one configured".
+   */
+  @Test
+  void aDeadlineThatHasNotPassedDoesNotStopTheLoop() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 3_600_000L);
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 0);
+
+    assertThatThrownBy(() -> database.command("sqlscript", script(4)))
+        .isInstanceOf(ConcurrentModificationException.class);
+
+    assertThat(ATTEMPTS.get()).isEqualTo(4);
+  }
+
+  private static String script(final int retries) {
+    return """
+        BEGIN;
+        INSERT INTO Attempt SET n = 1;
+        SELECT boom6322();
+        COMMIT RETRY %d;
+        """.formatted(retries);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CommitRetryCommandDeadlineIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CommitRetryCommandDeadlineIssue6322Test.java
@@ -163,12 +163,61 @@ class CommitRetryCommandDeadlineIssue6322Test extends TestHelper {
     assertThat(ATTEMPTS.get()).isEqualTo(4);
   }
 
+  /**
+   * {@code ELSE CONTINUE} asks for the empty result set instead of the failure when the attempts run out. An
+   * expired command deadline is not "the attempts ran out": it leaves the block by a different door, without
+   * running the {@code ELSE} body and without consulting {@code ELSE FAIL}, and raises.
+   * <p>
+   * That is the behaviour the issue asked for - it names "with no {@code ELSE FAIL}, returns an empty result
+   * set instead of the error" as part of the defect - and the reason is that the alternative is unreadable at
+   * the caller: an empty result set cannot be told apart from a block that legitimately produced no rows, so a
+   * command cut off by its deadline would look like one that simply had nothing to say.
+   */
+  @Test
+  void anExpiredDeadlineRaisesEvenWhenElseAsksToContinue() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 300L);
+    burnMillis = 900;
+
+    assertThatThrownBy(() -> database.command("sqlscript", scriptElseContinue(10)))
+        .isInstanceOf(TimeoutException.class)
+        .hasMessageContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+
+    assertThat(ATTEMPTS.get()).isEqualTo(1);
+  }
+
+  /** The same block with no deadline in force: every attempt is spent and {@code ELSE CONTINUE} is honoured. */
+  @Test
+  void elseContinueStillAnswersAnEmptyResultSetWithoutADeadline() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 0L);
+    database.getConfiguration().setValue(GlobalConfiguration.TX_RETRY_DELAY, 0);
+
+    int rows = 0;
+    try (final ResultSet rs = database.command("sqlscript", scriptElseContinue(3))) {
+      while (rs.hasNext()) {
+        rs.next();
+        rows++;
+      }
+    }
+
+    assertThat(rows).isEqualTo(0);
+    assertThat(ATTEMPTS.get()).isEqualTo(3);
+  }
+
   private static String script(final int retries) {
     return """
         BEGIN;
         INSERT INTO Attempt SET n = 1;
         SELECT boom6322();
         COMMIT RETRY %d;
+        """.formatted(retries);
+  }
+
+  private static String scriptElseContinue(final int retries) {
+    return """
+        BEGIN;
+        INSERT INTO Attempt SET n = 1;
+        SELECT boom6322();
+        COMMIT RETRY %d ELSE CONTINUE;
         """.formatted(retries);
   }
 }


### PR DESCRIPTION
Fixes #6322.

All four items are real. Each was reproduced first, and every regression test in this PR was run against the unpatched tree to confirm it fails there.

## 1. A two-pattern `MATCH` returned no rows when both shared variables carried a label

Two defects stacked, which is why the symptom was *zero rows* rather than the over-count a dropped filter usually produces.

`LogicalPlan.extractPathPattern` registered a named node on its **first** occurrence and skipped every later one (`if (!nodes.containsKey(variable))`). A variable repeated across patterns names one vertex that has to satisfy every occurrence, so `(p1:Person)` written on the second pattern was simply discarded.

On its own that widens the result. What emptied it is `CypherExecutionPlanner.shouldUseOptimizer`, whose admission rule asks only whether a variable is labelled **somewhere** ("a node like `(a)` in a second MATCH is valid if `(a:Answer)` appeared in a previous MATCH"). A query labelling its variables only on the second pattern was therefore admitted, the optimizer had no label for the anchor, and `IndexSelectionRule` built the composite type name for "no labels" - `V`:

```
+ ExpandInto(c)-[:MENTIONS]->(p2) ⭐ BOUND-TARGET
  + ExpandAll(p1)-[:AUTHORED]-<(c:Comment)
    + ExpandAll(p1)-[:KNOWS]->(p2)
      + NodeByLabelScan(p1:V)          <-- a type the schema does not have
```

`NodeByLabelScan` finds no type `V`, sets `finished`, and yields nothing.

**Fix.** Occurrences are merged rather than the first one kept: labels are ANDed, and *every* occurrence's inline property map is lowered into predicates instead of only the merged map's - so `(p1 {k:'p1'}) … (p1 {k:'p2'})` keeps both comparisons and stays empty, instead of quietly dropping one of them. A merged set the physical operators cannot represent makes `CypherOptimizer.optimize()` return `null`, which is the existing "not optimizable" fallback to the ordinary pipeline:

- a **conjunction** (`(a:A)` merged with a later `(a:B)`), because the composite type name `A~B` is not extended by a vertex labelled `A:B:C`;
- a **disjunction crossed with a further label**, which one `LogicalNode` cannot express at all - it carries a single flag for the whole list;
- **no label**, the case that produced the `:V` scan.

The AST-level guard sees the occurrences one at a time and cannot decide this, which is why the decision moved to where the merge happens.

Cross-checked against Neo4j semantics: a repeated variable conjoins its constraints, so `MATCH (a)-[:R]->(b), (a:Person)-[:S]->(c)` requires `a:Person`. Verified item by item against the issue's table.

## 2. Five more first-label-only push-downs

Four of the five key an operator on one name per node and now decline via the existing `hasPushDownRepresentableLabel`, the convention #6304 established:

| method | what the label fed |
|---|---|
| `tryOptimizeMatchCountReturn` | the counted node's type |
| `tryDetectChainCountStar` | per-hop label array |
| `tryDetectAntiJoinChainCountStar` | per-hop label array |
| `tryDetectStarCountStar` | the star's central label |

The star detector needed one thing more: the central variable is written **once per arm**, and it kept whichever label it read first (and, because of a misplaced `break`, not always the same one). It now requires every occurrence to agree and declines on a conflict.

`nodeLabelsAreTypeDisjoint` is the fifth and, as the issue anticipated, the one worth looking at first - but declining is not the answer for it. It produces a **proof** that two hops cannot be the same physical edge, on the strength of which the caller skips the per-hop edge tracking Cypher's relationship-uniqueness rule needs. A wrong "disjoint" drops matches. It now reasons per alternative:

- `(a:A:B)` requires both, so proving **any** of its labels disjoint from any of the other node's proves the nodes disjoint;
- `(a:A|B)` requires either, so the pattern is disjoint only when **every** alternative is.

Reading the first label alone answered the conjunction too narrowly (a missed opportunity) and the disjunction too widely (the wrong answer). Before this, on a fixture with one `RELATED` self-loop on a `Topic`:

```cypher
MATCH (x:Author|Topic)-[:RELATED]->(y:Topic)-[:RELATED]->(z) RETURN x   -- 1 row: one edge walked twice
MATCH (x:Topic|Author)-[:RELATED]->(y:Topic)-[:RELATED]->(z) RETURN x   -- 0 rows
```

Same query, same data, different answer depending on which of the two labels was written first. Both are 0 now.

### Found while writing those tests, and fixed with them

`CountEdgesReturnStep` - the operator `tryOptimizeMatchCountReturn` builds - filtered the counted node's label by **exact type-name equality** and read the target type's **own** buckets rather than its polymorphic ones. A Cypher label is satisfied by every type extending it, so `(p:Post)` must match a vertex written `(:Post:Draft)`, whose composite type `Draft~Post` extends `Post`. It did not:

```cypher
MATCH (a:Author)-[:WROTE]->(p:Post) RETURN a.k, count(p)             -- a1=1  (wrong)
MATCH (a:Author)-[:WROTE]->(p:Post) WITH a.k AS k, count(p) AS c ... -- a1=2  (right)
```

An under-count - the mirror image of item 2's over-counts, in the same operator - and it also blocked stating a correct expectation for the detector's own regression test.

## 3. `COMMIT RETRY n` retried a deadline that had already passed

Retrying a `TimeoutException` is right for the one the catch was written for: `TransactionManager`'s file-lock timeout, transient contention that clears after a backoff. It is not right for the command's own deadline, which is **one instant pinned for the whole statement** (#6266) and inherited by every attempt `RetryStep` starts. A `COMMIT RETRY 10` block spent all ten attempts plus nine backoff sleeps re-reaching a bound that expired before the first retry, then reported the last attempt's failure rather than the deadline that stopped it - or, with no `ELSE FAIL`, an empty result set instead of an error.

The issue suggested marking the guard's exception. **A marker is not enough**, and this is the design point worth the extra paragraph: a `TIMEOUT` clause written *inside* the retry body is also raised by a `WorkGuard`, and *that* one genuinely is retryable - each attempt builds its plan on a child context of its own (`initPlan`), so the clause starts its interval again. A marker on the exception cannot tell the two apart; what distinguishes them is *whose* deadline fired. So the test is on the step's own context: `System.currentTimeMillis() > ctx.getCommandDeadline()`. `arcadedb.command.timeout` and an enclosing clause answer there; a clause published on the per-attempt child does not. It also covers a `NeedRetryException` raised past the deadline, which a marker on `TimeoutException` would have missed entirely.

The reported failure now names the bound rather than being whatever the last attempt happened to hit. In the regression test, the pre-fix run takes 9.6 s and the post-fix run 1.2 s for the same script - the nine attempts and their sleeps.

Dormant by default: `arcadedb.command.timeout` defaults to 0.

## 4. A failing CI lane did not say which test failed

The seven lanes that run tests now upload the `surefire-reports/TEST*.xml` (`failsafe-reports` for the integration lanes) that `check-test-results.py` has just parsed, `if: failure()` only, `if-no-files-found: ignore`, 7-day retention. The data already exists at that point in the job; it was only discarded.

## Verification

- 3 new regression classes - 11 + 8 + 4 methods - each verified red on the unpatched tree (7/11, 7/8, 1/4 respectively; the rest are controls asserting nothing regressed).
- `CypherPairJoinLabelFilterIssue6304Test.bothArmEndpointLabelsAreAppliedTogether` is back on the ordinary three-way cross-check, as the issue asked; its javadoc had recorded item 1 as the reason it could not use the pipeline.
- Engine module unit lane: **12,419 tests, 0 failures**.
- openCypher TCK: **3,897 scenarios, 0 failures**, unchanged per-feature compliance.

## One defect left alone, for a separate issue

A **label disjunction on a bound intermediate node** matches nothing at all:

```cypher
MATCH (x:Topic)-[:RELATED]->(y)-[:OTHER]->(z:Topic) RETURN x              -- 1 row
MATCH (x:Topic)-[:RELATED]->(y:Author|Topic)-[:OTHER]->(z:Topic) RETURN x -- 0 rows
```

`y` is bound by expansion, and the target-side label check appears to AND the alternatives instead of ORing them. Neo4j returns the row. Unrelated to anything here and not in #6322's scope, so it is untouched - happy to file it separately.

Also noted, not changed: `DegreeProductOp` ignores its arms' *endpoint* labels entirely (only the central label reaches it). That is structural to a degree-product operator rather than a first-label bug, and enforcing those labels would remove the O(1) degree lookups the operator exists for - a design decision, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3AwhHPosUEUVdSZwEEBef
