### PR TITLE
fix(#6311, #6312, #6313): a hop checks its target against what the row holds when it runs, and a relabelled vertex takes its aliases with it

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2019,6 +2019,11 @@ public class CypherExecutionPlan {
             // is planned - which is what used to supply this clause's own variables - and a following WITH
             // clears it, so the join on a variable shared between two patterns of the SAME MATCH silently
             // degraded into a Cartesian product the moment a `WITH *` followed.
+            //
+            // The snapshot also carries this hop's own target and relationship names, added just above. That is
+            // deliberate and costs nothing: the check reads a name only when the row ALSO already holds a vertex
+            // under it, and a name this hop is about to bind for the first time is absent from the row. Excluding
+            // them would instead need the set rebuilt per hop in the opposite order, for no gain.
             final Set<String> targetIdentityVars = new HashSet<>(boundVariables);
             targetIdentityVars.addAll(matchVariables);
 
@@ -2611,8 +2616,8 @@ public class CypherExecutionPlan {
                   // Fixed-length relationship - pass path variable, target node pattern, and bound variables.
                   // #6311: the same snapshot rule as the ordered builder above - the hop identity-checks its
                   // target against what the row carries when it RUNS, so it gets the names bound before this
-                  // MATCH plus the ones this MATCH has bound so far, never the planner's live set (which is
-                  // filled at the end of the clause and emptied again by a following WITH).
+                  // MATCH plus the ones this MATCH has bound so far (this hop's own included, harmlessly - see
+                  // the note there), never the planner's live set, which a following WITH empties.
                   final Set<String> targetIdentityVars = new HashSet<>(legacyBoundVariables);
                   targetIdentityVars.addAll(matchVariables);
                   nextStep = new MatchRelationshipStep(currentSourceVar, relVar, targetVar, relPattern, pathVariable,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1262,11 +1262,7 @@ public class CypherExecutionPlan {
             entryIndex += 2; // skip both the next OPTIONAL MATCH and the WITH clause
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
-            boundVariables.clear();
-            for (final ReturnClause.ReturnItem item : nextWith.getItems()) {
-              final String alias = item.getAlias();
-              boundVariables.add(alias != null ? alias : item.getExpression().getText());
-            }
+            applyProjectionToScope(nextWith.getItems(), boundVariables);
             break;
           }
 
@@ -1278,11 +1274,7 @@ public class CypherExecutionPlan {
             entryIndex++; // skip the WITH clause (already handled)
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
-            boundVariables.clear();
-            for (final ReturnClause.ReturnItem item : nextWith.getItems()) {
-              final String alias = item.getAlias();
-              boundVariables.add(alias != null ? alias : item.getExpression().getText());
-            }
+            applyProjectionToScope(nextWith.getItems(), boundVariables);
             break;
           }
         }
@@ -1292,12 +1284,8 @@ public class CypherExecutionPlan {
       case WITH:
         final WithClause withClause = entry.getTypedClause();
         currentStep = buildWithStep(withClause, currentStep, context, functionFactory);
-        // WITH resets the scope: only WITH output variables are in scope afterwards
-        boundVariables.clear();
-        for (final ReturnClause.ReturnItem item : withClause.getItems()) {
-          final String alias = item.getAlias();
-          boundVariables.add(alias != null ? alias : item.getExpression().getText());
-        }
+        // An explicit WITH resets the scope to its own output variables; WITH * forwards the incoming one
+        applyProjectionToScope(withClause.getItems(), boundVariables);
         break;
 
       case MERGE:
@@ -1652,6 +1640,33 @@ public class CypherExecutionPlan {
   }
 
   /**
+   * Applies a {@code WITH} projection to the set of variables in scope after it.
+   * <p>
+   * An explicit projection list resets the scope to exactly what it names, which is what makes a variable the
+   * following clauses do not import unavailable. {@code WITH *} names nothing: it forwards the incoming scope
+   * unchanged, so the names stay bound (#6311). Treating its single {@code "*"} item as if it were a projected
+   * variable used to leave the scope holding the literal name {@code *} and nothing else, which is how a
+   * variable shared with a following MATCH stopped being recognised as already bound - and a shared variable
+   * that is not recognised is a Cartesian product rather than a join. A {@code WITH *, expr AS alias} both
+   * forwards and adds.
+   */
+  private static void applyProjectionToScope(final List<ReturnClause.ReturnItem> items, final Set<String> scope) {
+    boolean forwardsAll = false;
+    final List<String> projected = new ArrayList<>(items.size());
+    for (final ReturnClause.ReturnItem item : items) {
+      final String alias = item.getAlias();
+      final String name = alias != null ? alias : item.getExpression().getText();
+      if ("*".equals(name))
+        forwardsAll = true;
+      else
+        projected.add(name);
+    }
+    if (!forwardsAll)
+      scope.clear();
+    scope.addAll(projected);
+  }
+
+  /**
    * Builds execution step for a MATCH clause.
    * Backward-compatible overload without bound variable tracking.
    */
@@ -1997,6 +2012,16 @@ public class CypherExecutionPlan {
             // Check if this hop requires IN traversal on a unidirectional edge.
             // Unidirectional edges don't store incoming links, so we must restructure:
             // instead of (bound)-[IN]->(target), scan target type and go (target)-[OUT]->(bound).
+            // #6311: the names a hop must identity-check its target against are the ones the row already
+            // carries when the hop RUNS: everything bound before this MATCH plus everything this MATCH has
+            // bound so far (earlier comma-separated patterns, earlier hops). Snapshot them here rather than
+            // handing the step the planner's live `boundVariables` set: that set is mutated after the clause
+            // is planned - which is what used to supply this clause's own variables - and a following WITH
+            // clears it, so the join on a variable shared between two patterns of the SAME MATCH silently
+            // degraded into a Cartesian product the moment a `WITH *` followed.
+            final Set<String> targetIdentityVars = new HashSet<>(boundVariables);
+            targetIdentityVars.addAll(matchVariables);
+
             final Direction effectiveDir = directionOverride != null ? directionOverride : relPattern.getDirection();
             final boolean needsReverseOnUnidirectional = !reversed
                 && effectiveDir == Direction.IN
@@ -2006,7 +2031,7 @@ public class CypherExecutionPlan {
             if (needsReverseOnUnidirectional) {
               // Restructure: scan target type with MatchNodeStep, then traverse OUT to validate
               // against the bound source. The bound source becomes the "target" of the relationship.
-              final Set<String> boundWithSource = new HashSet<>(boundVariables);
+              final Set<String> boundWithSource = new HashSet<>(targetIdentityVars);
               boundWithSource.add(effectiveSourceVar);
               final MatchNodeStep scanStep = new MatchNodeStep(effectiveTargetVar, effectiveTargetNode, context);
               if (isOptional && matchChainStart == null) {
@@ -2024,7 +2049,7 @@ public class CypherExecutionPlan {
               // Normal case: pass target node pattern for label filtering, bound variables for identity
               // checking, and a snapshot for relationship uniqueness scoping.
               nextStep = new MatchRelationshipStep(effectiveSourceVar, relVar, effectiveTargetVar, relPattern,
-                  pathVariable, effectiveTargetNode, boundVariables, new HashSet<>(boundVariables),
+                  pathVariable, effectiveTargetNode, targetIdentityVars, new HashSet<>(boundVariables),
                   directionOverride, context);
             }
           }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2608,9 +2608,15 @@ public class CypherExecutionPlan {
                   nextStep = new ExpandPathStep(currentSourceVar, pathVariable, relVar, targetVar, relPattern, false,
                       targetNode, pathPattern.getEffectivePathMode(), computePrevVarsForVlp(pathPattern, i, legacyBoundVariables), context);
                 } else {
-                  // Fixed-length relationship - pass path variable, target node pattern, and bound variables
+                  // Fixed-length relationship - pass path variable, target node pattern, and bound variables.
+                  // #6311: the same snapshot rule as the ordered builder above - the hop identity-checks its
+                  // target against what the row carries when it RUNS, so it gets the names bound before this
+                  // MATCH plus the ones this MATCH has bound so far, never the planner's live set (which is
+                  // filled at the end of the clause and emptied again by a following WITH).
+                  final Set<String> targetIdentityVars = new HashSet<>(legacyBoundVariables);
+                  targetIdentityVars.addAll(matchVariables);
                   nextStep = new MatchRelationshipStep(currentSourceVar, relVar, targetVar, relPattern, pathVariable,
-                      targetNode, legacyBoundVariables, context);
+                      targetNode, targetIdentityVars, context);
                 }
 
                 // Update source for next hop in multi-hop patterns

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -24,11 +24,13 @@ import com.arcadedb.database.RID;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,23 +84,100 @@ public final class LabelReplacements {
    * Points every alias of a row that still refers to a replaced vertex or to one of its re-attached edges at the
    * live record. Called before a row is written to and again after each replacement, so all aliases of the same
    * node observe the same state.
+   * <p>
+   * A row does not hold records only under their own name: a path variable, a {@code collect()} list or a map holds
+   * them too, and one left pointing at the deleted original answers with the state the node had before the write -
+   * the labels it no longer has - or fails outright the moment something re-reads it. Those are rebuilt around the
+   * live records, and only when something inside them actually moved.
    */
   public void redirect(final Result row) {
     if (row == null || vertices.isEmpty())
       return;
     for (final String name : row.getPropertyNames()) {
       final Object value = row.getProperty(name);
-      if (value instanceof Vertex vertex) {
-        final Vertex live = resolve(vertex);
-        if (live != vertex)
-          ((ResultInternal) row).setProperty(name, live);
-      } else if (value instanceof Edge edge && !edges.isEmpty()) {
-        final RID rid = edge.getIdentity();
-        final Edge live = rid != null ? edges.get(rid) : null;
-        if (live != null && live != edge)
-          ((ResultInternal) row).setProperty(name, live);
-      }
+      final Object live = redirectValue(value);
+      if (live != value)
+        ((ResultInternal) row).setProperty(name, live);
     }
+  }
+
+  /**
+   * Returns the live form of a row value, or the value itself - by identity, so the caller can tell whether
+   * anything moved - when nothing inside it was replaced.
+   */
+  private Object redirectValue(final Object value) {
+    if (value instanceof Vertex vertex)
+      return resolve(vertex);
+
+    if (value instanceof Edge edge) {
+      if (edges.isEmpty())
+        return value;
+      final RID rid = edge.getIdentity();
+      final Edge live = rid != null ? edges.get(rid) : null;
+      return live != null ? live : value;
+    }
+
+    if (value instanceof TraversalPath path)
+      return redirectPath(path);
+
+    if (value instanceof List<?> list) {
+      List<Object> rebuilt = null;
+      for (int i = 0; i < list.size(); i++) {
+        final Object element = list.get(i);
+        final Object live = redirectValue(element);
+        if (live != element && rebuilt == null)
+          rebuilt = new ArrayList<>(list);
+        if (rebuilt != null)
+          rebuilt.set(i, live);
+      }
+      return rebuilt != null ? rebuilt : value;
+    }
+
+    if (value instanceof Map<?, ?> map) {
+      Map<Object, Object> rebuilt = null;
+      for (final Map.Entry<?, ?> entry : map.entrySet()) {
+        final Object element = entry.getValue();
+        final Object live = redirectValue(element);
+        if (live != element && rebuilt == null)
+          rebuilt = new LinkedHashMap<>(map);
+        if (rebuilt != null)
+          rebuilt.put(entry.getKey(), live);
+      }
+      return rebuilt != null ? rebuilt : value;
+    }
+
+    return value;
+  }
+
+  /**
+   * Rebuilds a path around the live records when one of its members was replaced, keeping its shape.
+   */
+  private TraversalPath redirectPath(final TraversalPath path) {
+    final List<Vertex> pathVertices = path.getVertices();
+    if (pathVertices.isEmpty())
+      return path;
+    final List<Edge> pathEdges = path.getEdges();
+
+    boolean moved = false;
+    final List<Vertex> liveVertices = new ArrayList<>(pathVertices.size());
+    for (final Vertex vertex : pathVertices) {
+      final Vertex live = resolve(vertex);
+      moved |= live != vertex;
+      liveVertices.add(live);
+    }
+    final List<Edge> liveEdges = new ArrayList<>(pathEdges.size());
+    for (final Edge edge : pathEdges) {
+      final Object live = redirectValue(edge);
+      moved |= live != edge;
+      liveEdges.add((Edge) live);
+    }
+    if (!moved)
+      return path;
+
+    final TraversalPath rebuilt = new TraversalPath(liveVertices.get(0));
+    for (int i = 0; i < liveEdges.size(); i++)
+      rebuilt.addStep(liveEdges.get(i), liveVertices.get(i + 1));
+    return rebuilt;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -89,6 +89,12 @@ public final class LabelReplacements {
    * them too, and one left pointing at the deleted original answers with the state the node had before the write -
    * the labels it no longer has - or fails outright the moment something re-reads it. Those are rebuilt around the
    * live records, and only when something inside them actually moved.
+   * <p>
+   * The descent into collections is charged to every row of the step once any row has triggered a replacement, not
+   * only to the rows that carry the replaced node - the map is the only thing that knows a node moved, and it is
+   * step-wide. That is a deliberate trade: a clause with no label write at all pays a single
+   * {@link Map#isEmpty()} check per row and never walks anything, and correctness after a write is not something a
+   * large {@code collect()} list should be able to opt out of.
    */
   public void redirect(final Result row) {
     if (row == null || vertices.isEmpty())

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -223,11 +223,12 @@ public final class LabelReplacements {
 
   private void track(final Edge original, final Edge replacement) {
     final RID rid = original.getIdentity();
-    // A lightweight edge has no record and therefore no address, but it does have an identity: its
-    // {@link com.arcadedb.graph.LightEdgeRID} carries the (type, out vertex, in vertex) triple and hashes on it, so
-    // it keys this map exactly like the address of a heavy edge does - and the re-attached copy, hanging off the
-    // replacement vertex, is a different key rather than the same one.
-    if (rid != null && rid.getBucketId() > -1)
+    // Every edge reached through a vertex is keyed here, lightweight ones included: a lightweight edge has no
+    // record and therefore no address, but it does have an identity - its LightEdgeRID carries the
+    // (type, out vertex, in vertex) triple and hashes on it, so it keys this map exactly like the address of a
+    // heavy edge does, and the re-attached copy hanging off the replacement vertex is a different key rather than
+    // the same one. Only the null is guarded: an edge that came out of getEdges() always has a bucket.
+    if (rid != null)
       edges.put(rid, replacement);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -47,7 +47,9 @@ import java.util.Set;
  * (issues #6312 and #6313).
  * <p>
  * One instance is held per running {@code SET}/{@code REMOVE} step, so a node replaced while processing one row is
- * redirected to its live replacement on every later row, and the write becomes idempotent instead of fatal.
+ * redirected to its live replacement on every later row, and the write becomes idempotent instead of fatal. The
+ * edges re-attached on the way are tracked the same, lightweight ones included: they have no record to address, but
+ * their identity is the (type, out vertex, in vertex) triple, and that is what moved.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -221,9 +223,11 @@ public final class LabelReplacements {
 
   private void track(final Edge original, final Edge replacement) {
     final RID rid = original.getIdentity();
-    // A lightweight edge has no record of its own: its RID carries a negative position and stands for the pair of
-    // endpoints rather than for an address, so there is no identity to redirect from.
-    if (rid != null && rid.getBucketId() > -1 && rid.getPosition() > -1)
+    // A lightweight edge has no record and therefore no address, but it does have an identity: its
+    // {@link com.arcadedb.graph.LightEdgeRID} carries the (type, out vertex, in vertex) triple and hashes on it, so
+    // it keys this map exactly like the address of a heavy edge does - and the re-attached copy, hanging off the
+    // replacement vertex, is a different key rather than the same one.
+    if (rid != null && rid.getBucketId() > -1)
       edges.put(rid, replacement);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/LabelReplacements.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Carries out a Cypher label write and remembers what it displaced.
+ * <p>
+ * ArcadeDB derives a record's type from the bucket it lives in, so there is no in-place retype: changing the label
+ * set of a vertex means writing a new record under the new type and deleting the old one. Both the new vertex and
+ * every edge re-attached to it get fresh RIDs, which leaves every other reference to the original - the same node
+ * bound to a second alias in the row, the same node reached again by a later row of the same clause - pointing at a
+ * record that no longer exists. Touching one of those fails with {@code RecordNotFoundException}, either directly or
+ * as an "edge list not fully visible" complaint from the vertex delete that follows its dangling edge-list chunk
+ * (issues #6312 and #6313).
+ * <p>
+ * One instance is held per running {@code SET}/{@code REMOVE} step, so a node replaced while processing one row is
+ * redirected to its live replacement on every later row, and the write becomes idempotent instead of fatal.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class LabelReplacements {
+  private static final Object[] NO_PROPERTIES = new Object[0];
+
+  private final Map<RID, Vertex> vertices = new HashMap<>();
+  private final Map<RID, Edge>   edges    = new HashMap<>();
+
+  public boolean isEmpty() {
+    return vertices.isEmpty();
+  }
+
+  /**
+   * Follows the replacement chain of a vertex - a node can be relabelled more than once in the same clause - and
+   * returns the live record, or the argument itself when it was never replaced.
+   */
+  public Vertex resolve(final Vertex vertex) {
+    if (vertex == null || vertices.isEmpty())
+      return vertex;
+    final RID rid = vertex.getIdentity();
+    if (rid == null)
+      return vertex;
+    Vertex current = vertices.get(rid);
+    if (current == null)
+      return vertex;
+    Vertex next;
+    while ((next = vertices.get(current.getIdentity())) != null)
+      current = next;
+    return current;
+  }
+
+  /**
+   * Points every alias of a row that still refers to a replaced vertex or to one of its re-attached edges at the
+   * live record. Called before a row is written to and again after each replacement, so all aliases of the same
+   * node observe the same state.
+   */
+  public void redirect(final Result row) {
+    if (row == null || vertices.isEmpty())
+      return;
+    for (final String name : row.getPropertyNames()) {
+      final Object value = row.getProperty(name);
+      if (value instanceof Vertex vertex) {
+        final Vertex live = resolve(vertex);
+        if (live != vertex)
+          ((ResultInternal) row).setProperty(name, live);
+      } else if (value instanceof Edge edge && !edges.isEmpty()) {
+        final RID rid = edge.getIdentity();
+        final Edge live = rid != null ? edges.get(rid) : null;
+        if (live != null && live != edge)
+          ((ResultInternal) row).setProperty(name, live);
+      }
+    }
+  }
+
+  /**
+   * Rewrites {@code vertex} under {@code newTypeName}, carrying over its properties and its edges (with their own
+   * properties, which a plain re-link would silently drop), deletes the original and records the replacement.
+   *
+   * @return the vertex that now holds the identity of the original
+   */
+  public MutableVertex replace(final Vertex vertex, final String newTypeName) {
+    final Database database = vertex.getDatabase();
+    final RID originalRid = vertex.getIdentity();
+
+    final MutableVertex newVertex = database.newVertex(newTypeName);
+    for (final String property : vertex.getPropertyNames())
+      newVertex.set(property, vertex.get(property));
+    newVertex.save();
+
+    // Outgoing first, so a self-loop is migrated exactly once: the incoming pass below skips it rather than
+    // re-creating it as a second edge between the same pair.
+    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT)) {
+      final RID in = edge.getIn();
+      final Identifiable target = originalRid.equals(in) ? newVertex : in;
+      track(edge, newVertex.newEdge(edge.getTypeName(), target, propertiesOf(edge)));
+    }
+    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.IN)) {
+      if (originalRid.equals(edge.getOut()))
+        continue;
+      track(edge, edge.getVertex(Vertex.DIRECTION.OUT).newEdge(edge.getTypeName(), newVertex, propertiesOf(edge)));
+    }
+
+    vertex.delete();
+    vertices.put(originalRid, newVertex);
+    return newVertex;
+  }
+
+  private void track(final Edge original, final Edge replacement) {
+    final RID rid = original.getIdentity();
+    // A lightweight edge has no record of its own: its RID carries a negative position and stands for the pair of
+    // endpoints rather than for an address, so there is no identity to redirect from.
+    if (rid != null && rid.getBucketId() > -1 && rid.getPosition() > -1)
+      edges.put(rid, replacement);
+  }
+
+  /**
+   * Flattens an edge's properties into the alternating name/value array {@code Vertex.newEdge()} expects. Returns
+   * an empty array for a lightweight edge, whose type rejects any property at all.
+   */
+  private static Object[] propertiesOf(final Edge edge) {
+    final Set<String> names = edge.getPropertyNames();
+    if (names.isEmpty())
+      return NO_PROPERTIES;
+    final List<Object> flattened = new ArrayList<>(names.size() * 2);
+    for (final String name : names) {
+      flattened.add(name);
+      flattened.add(edge.get(name));
+    }
+    return flattened.toArray();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -38,6 +38,7 @@ import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
+import com.arcadedb.query.opencypher.executor.LabelReplacements;
 import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
 import com.arcadedb.query.opencypher.temporal.TemporalUtil;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
@@ -91,6 +92,10 @@ public class MergeStep extends AbstractExecutionStep {
       private int bufferIndex = 0;
       private boolean finished = false;
       private boolean mergedStandalone = false;
+      // Tracks the vertices an ON CREATE/ON MATCH SET n:Label replaced, so a node relabelled while processing one
+      // row is not still the deleted original when a later row - or a second alias of the same row - reaches it.
+      // Same reasoning, and same class, as SetStep and RemoveStep (issues #6312, #6313).
+      private final LabelReplacements labelReplacements = new LabelReplacements();
 
       @Override
       public boolean hasNext() {
@@ -132,7 +137,7 @@ public class MergeStep extends AbstractExecutionStep {
               if (context.isProfiling())
                 rowCount++;
 
-              final List<Result> mergedResults = executeMerge(inputResult);
+              final List<Result> mergedResults = executeMerge(inputResult, labelReplacements);
               buffer.addAll(mergedResults);
             } finally {
               if (context.isProfiling())
@@ -151,7 +156,7 @@ public class MergeStep extends AbstractExecutionStep {
               if (context.isProfiling())
                 rowCount++;
 
-              final List<Result> mergedResults = executeMerge(null);
+              final List<Result> mergedResults = executeMerge(null, labelReplacements);
               buffer.addAll(mergedResults);
               mergedStandalone = true;
             } finally {
@@ -178,7 +183,7 @@ public class MergeStep extends AbstractExecutionStep {
    * @param inputResult input result from previous step (may be null for standalone MERGE)
    * @return list of results containing matched or created elements
    */
-  private List<Result> executeMerge(final Result inputResult) {
+  private List<Result> executeMerge(final Result inputResult, final LabelReplacements labelReplacements) {
     final PathPattern pathPattern = mergeClause.getPathPattern();
 
     // Cypher null-propagation: a named path variable that was explicitly bound
@@ -224,9 +229,9 @@ public class MergeStep extends AbstractExecutionStep {
         if (r instanceof ResultInternal)
           ((ResultInternal) r).removeProperty("  wasCreated");
         if (wasCreated && mergeClause.hasOnCreateSet())
-          applySetClause(mergeClause.getOnCreateSet(), (ResultInternal) r);
+          applySetClause(mergeClause.getOnCreateSet(), (ResultInternal) r, labelReplacements);
         else if (!wasCreated && mergeClause.hasOnMatchSet())
-          applySetClause(mergeClause.getOnMatchSet(), (ResultInternal) r);
+          applySetClause(mergeClause.getOnMatchSet(), (ResultInternal) r, labelReplacements);
       }
 
       // Commit transaction if we started it
@@ -1290,13 +1295,20 @@ public class MergeStep extends AbstractExecutionStep {
   /**
    * Applies a SET clause to the result (used for ON CREATE SET / ON MATCH SET).
    *
-   * @param setClause the SET clause to apply
-   * @param result the result containing variables to update
+   * @param setClause          the SET clause to apply
+   * @param result             the result containing variables to update
+   * @param labelReplacements  the vertices a label write earlier in this step replaced, and the machinery to
+   *                           perform the next one
    */
   @SuppressWarnings("unchecked")
-  private void applySetClause(final SetClause setClause, final Result result) {
+  private void applySetClause(final SetClause setClause, final Result result,
+      final LabelReplacements labelReplacements) {
     if (setClause == null || setClause.isEmpty())
       return;
+
+    // A node an earlier row of this MERGE relabelled reaches this row as the deleted original: point every alias
+    // of it - the MERGE's own variable and anything the input row bound to the same node - at the replacement.
+    labelReplacements.redirect(result);
 
     for (final SetClause.SetItem item : setClause.getItems()) {
       final String variable = item.getVariable();
@@ -1397,6 +1409,7 @@ public class MergeStep extends AbstractExecutionStep {
         case LABELS: {
           if (!(obj instanceof Vertex vertex))
             break;
+          vertex = labelReplacements.resolve(vertex);
           final List<String> existingLabels = Labels.getLabels(vertex);
           final List<String> allLabels = new ArrayList<>(existingLabels);
           int newLabelsCount = 0;
@@ -1408,18 +1421,13 @@ public class MergeStep extends AbstractExecutionStep {
           final String newTypeName = Labels.ensureCompositeType(
               context.getDatabase().getSchema(), allLabels);
           if (!vertex.getTypeName().equals(newTypeName)) {
-            final MutableVertex newVertex = context.getDatabase().newVertex(newTypeName);
-            for (final String prop : vertex.getPropertyNames())
-              newVertex.set(prop, vertex.get(prop));
-            newVertex.save();
+            // The record moves, so the same shared rewrite SET and REMOVE use: it carries the edges over with
+            // their properties, migrates a self-loop once and onto the replacement rather than onto the record
+            // about to be deleted, and records what moved so every alias can follow it.
+            labelReplacements.replace(vertex, newTypeName);
             if (newLabelsCount > 0)
               context.getStatistics().addLabelsAdded(newLabelsCount);
-            for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
-              newVertex.newEdge(edge.getTypeName(), edge.getVertex(Vertex.DIRECTION.IN));
-            for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.IN))
-              edge.getVertex(Vertex.DIRECTION.OUT).newEdge(edge.getTypeName(), newVertex);
-            vertex.delete();
-            ((ResultInternal) result).setProperty(variable, newVertex);
+            labelReplacements.redirect(result);
           }
           break;
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -250,6 +250,11 @@ public class RemoveStep extends AbstractExecutionStep {
     if (!(obj instanceof Vertex vertex))
       return;
 
+    // If a prior row already relabelled this node, work on the replacement so the idempotency check below reads
+    // the current type. The per-row redirect() has normally done this already; resolving the write target itself
+    // does not depend on the row listing that variable as a column, which is the one case redirect() cannot reach.
+    vertex = replacements.resolve(vertex);
+
     final List<String> currentLabels = Labels.getLabels(vertex);
     final List<String> labelsToRemove = item.getLabels();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -21,17 +21,15 @@ package com.arcadedb.query.opencypher.executor.steps;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.exception.TimeoutException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
+import com.arcadedb.query.opencypher.executor.LabelReplacements;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -69,6 +67,9 @@ public class RemoveStep extends AbstractExecutionStep {
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
       private boolean finished = false;
+      // Tracks the vertices a label removal replaced. A label change rewrites the record under a new type, so
+      // every later row still holding the original refers to a deleted RID (issues #6312, #6313).
+      private final LabelReplacements replacements = new LabelReplacements();
 
       @Override
       public boolean hasNext() {
@@ -111,7 +112,7 @@ public class RemoveStep extends AbstractExecutionStep {
               rowCount++;
 
             // Apply REMOVE operations to this result
-            applyRemoveOperations(inputResult);
+            applyRemoveOperations(inputResult, replacements);
 
             // Pass through the modified result
             buffer.add(inputResult);
@@ -136,12 +137,17 @@ public class RemoveStep extends AbstractExecutionStep {
   /**
    * Applies all REMOVE operations to a result.
    *
-   * @param result the result containing variables to update
+   * @param result       the result containing variables to update
+   * @param replacements the vertices earlier rows of this same clause relabelled, and therefore replaced
    */
-  private void applyRemoveOperations(final Result result) {
+  private void applyRemoveOperations(final Result result, final LabelReplacements replacements) {
     if (removeClause == null || removeClause.isEmpty()) {
       return;
     }
+
+    // A node this clause already relabelled on an earlier row reaches this row as the deleted original: point
+    // every alias of it at the live replacement before anything reads or writes through them.
+    replacements.redirect(result);
 
     // Check if we're already in a transaction
     final boolean wasInTransaction = context.getDatabase().isTransactionActive();
@@ -156,7 +162,7 @@ public class RemoveStep extends AbstractExecutionStep {
         if (item.getType() == RemoveClause.RemoveItem.RemoveType.PROPERTY)
           removeProperty(item, result);
         else if (item.getType() == RemoveClause.RemoveItem.RemoveType.LABELS)
-          removeLabels(item, result);
+          removeLabels(item, result, replacements);
       }
 
       // Commit transaction if we started it
@@ -234,7 +240,8 @@ public class RemoveStep extends AbstractExecutionStep {
    * Removes labels from a vertex by changing its type.
    * Creates a new vertex with the reduced label set and migrates properties/edges.
    */
-  private void removeLabels(final RemoveClause.RemoveItem item, final Result result) {
+  private void removeLabels(final RemoveClause.RemoveItem item, final Result result,
+      final LabelReplacements replacements) {
     final String variable = item.getVariable();
     final Object obj = result.getProperty(variable);
     // #5795: reject a label removal targeting a node deleted earlier in the same query instead
@@ -270,24 +277,13 @@ public class RemoveStep extends AbstractExecutionStep {
     if (vertex.getTypeName().equals(newTypeName))
       return;
 
-    // Create new vertex with the reduced type, copy properties
-    final MutableVertex newVertex = context.getDatabase().newVertex(newTypeName);
-    for (final String prop : vertex.getPropertyNames())
-      newVertex.set(prop, vertex.get(prop));
-    newVertex.save();
+    // Rewrite the vertex under the reduced type. The record moves, so the replacement is recorded and every
+    // alias of this node in the row - and in every later row - follows it.
+    replacements.replace(vertex, newTypeName);
 
-    final QueryStatistics stats = context.getStatistics();
-    stats.addLabelsRemoved(removedLabelsCount);
+    context.getStatistics().addLabelsRemoved(removedLabelsCount);
 
-    // Migrate edges
-    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
-      newVertex.newEdge(edge.getTypeName(), edge.getVertex(Vertex.DIRECTION.IN));
-    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.IN))
-      edge.getVertex(Vertex.DIRECTION.OUT).newEdge(edge.getTypeName(), newVertex);
-
-    vertex.delete();
-
-    ((ResultInternal) result).setProperty(variable, newVertex);
+    replacements.redirect(result);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -251,8 +251,9 @@ public class RemoveStep extends AbstractExecutionStep {
       return;
 
     // If a prior row already relabelled this node, work on the replacement so the idempotency check below reads
-    // the current type. The per-row redirect() has normally done this already; resolving the write target itself
-    // does not depend on the row listing that variable as a column, which is the one case redirect() cannot reach.
+    // the current type. The per-row redirect() reaches this alias too, so today this only re-confirms it; it stays
+    // because it makes the method correct on its own terms - the write target is resolved here, not assumed to
+    // have been resolved by the caller - and it costs one map lookup that is skipped until a label write happens.
     vertex = replacements.resolve(vertex);
 
     final List<String> currentLabels = Labels.getLabels(vertex);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -22,8 +22,6 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.TimeoutException;
-import com.arcadedb.graph.Edge;
-import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.SetClause;
@@ -31,6 +29,7 @@ import com.arcadedb.query.opencypher.temporal.TemporalUtil;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
+import com.arcadedb.query.opencypher.executor.LabelReplacements;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.QueryStatistics;
@@ -77,10 +76,10 @@ public class SetStep extends AbstractExecutionStep {
       // clears the dirty flag but not the map), so subsequent rows can read through the
       // stored instance without reloading from storage.
       private final Map<RID, MutableDocument> writtenDocs = new HashMap<>();
-      // Tracks old-RID → new-Vertex replacements made by SET n:Label so that when the
-      // same node appears on a later row (row fanout), the operation is redirected to
-      // the already-replaced vertex and the idempotency check returns early.
-      private final Map<RID, Vertex> labelReplacements = new HashMap<>();
+      // Tracks the vertices SET n:Label replaced so that when the same node appears on a later row
+      // (row fanout), the operation is redirected to the already-replaced vertex and the idempotency
+      // check returns early.
+      private final LabelReplacements labelReplacements = new LabelReplacements();
 
       @Override
       public boolean hasNext() {
@@ -130,28 +129,14 @@ public class SetStep extends AbstractExecutionStep {
   }
 
   private void applySetOperations(final Result result, final Map<RID, MutableDocument> writtenDocs,
-      final Map<RID, Vertex> labelReplacements) {
+      final LabelReplacements labelReplacements) {
     if (setClause == null || setClause.isEmpty())
       return;
 
     // Pre-resolve any vertex aliases that were replaced by a label change on a prior row so
     // that property-SET operations (which go through resolveLatestDoc) observe the live vertex
-    // rather than the deleted original. Chain-traverse to the head in case a vertex was
-    // replaced more than once.
-    if (!labelReplacements.isEmpty()) {
-      for (final String propName : result.getPropertyNames()) {
-        final Object propValue = result.getProperty(propName);
-        if (propValue instanceof Vertex v) {
-          Vertex replacement = labelReplacements.get(v.getIdentity());
-          if (replacement != null) {
-            Vertex next;
-            while ((next = labelReplacements.get(replacement.getIdentity())) != null)
-              replacement = next;
-            ((ResultInternal) result).setProperty(propName, replacement);
-          }
-        }
-      }
-    }
+    // rather than the deleted original.
+    labelReplacements.redirect(result);
 
     final boolean wasInTransaction = context.getDatabase().isTransactionActive();
 
@@ -455,7 +440,7 @@ public class SetStep extends AbstractExecutionStep {
   }
 
   private void applyLabels(final SetClause.SetItem item, final Result result,
-      final Map<RID, MutableDocument> writtenDocs, final Map<RID, Vertex> labelReplacements) {
+      final Map<RID, MutableDocument> writtenDocs, final LabelReplacements labelReplacements) {
     final Object obj = result.getProperty(item.getVariable());
     // #5795: reject a label write targeting a node deleted earlier in the same query instead of
     // silently no-op'ing.
@@ -465,15 +450,13 @@ public class SetStep extends AbstractExecutionStep {
 
     // If this vertex was already replaced on a prior row (row fanout hitting the same node),
     // redirect to the replacement so the idempotency check below can use the current type.
-    final RID originalRid = vertex.getIdentity();
-    Vertex prior = labelReplacements.get(originalRid);
-    if (prior != null) {
-      Vertex next;
-      while ((next = labelReplacements.get(prior.getIdentity())) != null)
-        prior = next;
+    final Vertex prior = labelReplacements.resolve(vertex);
+    if (prior != vertex) {
       propagateUpdateToSameNodeAliases(result, vertex, prior);
       vertex = prior;
     }
+    // The RID the write is about to displace: the live one, not the one the row happened to carry.
+    final RID originalRid = vertex.getIdentity();
 
     // Get existing labels and add new ones
     final List<String> existingLabels = Labels.getLabels(vertex);
@@ -493,24 +476,13 @@ public class SetStep extends AbstractExecutionStep {
     if (vertex.getTypeName().equals(newTypeName))
       return;
 
-    // Create new vertex with the composite type, copy all properties
-    final MutableVertex newVertex = context.getDatabase().newVertex(newTypeName);
-    for (final String prop : vertex.getPropertyNames())
-      newVertex.set(prop, vertex.get(prop));
-    newVertex.save();
+    // Rewrite the vertex under the composite type: the record moves, and the replacement is recorded so
+    // this row and every later one follow it.
+    labelReplacements.replace(vertex, newTypeName);
     if (newLabelsCount > 0)
       context.getStatistics().addLabelsAdded(newLabelsCount);
 
-    // Copy edges from old vertex to new vertex
-    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
-      newVertex.newEdge(edge.getTypeName(), edge.getVertex(Vertex.DIRECTION.IN));
-    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.IN))
-      edge.getVertex(Vertex.DIRECTION.OUT).newEdge(edge.getTypeName(), newVertex);
-
-    // Delete old vertex and record the replacement for subsequent rows
-    vertex.delete();
-    propagateUpdateToSameNodeAliases(result, vertex, newVertex);
-    labelReplacements.put(originalRid, newVertex);
+    labelReplacements.redirect(result);
     // Invalidate any property-SET state for the old RID so subsequent rows don't read
     // stale MutableDocument entries. Combined SET n.prop+n:Label across fanout still has
     // ordering-dependent behaviour, but this prevents outright stale reads.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -448,8 +448,10 @@ public class SetStep extends AbstractExecutionStep {
     if (!(obj instanceof Vertex vertex))
       return;
 
-    // If this vertex was already replaced on a prior row (row fanout hitting the same node),
-    // redirect to the replacement so the idempotency check below can use the current type.
+    // If this vertex was already replaced on a prior row (row fanout hitting the same node), redirect to the
+    // replacement so the idempotency check below can use the current type. The per-row redirect() at the top of
+    // applySetOperations has normally done this already; resolving the write target itself does not depend on the
+    // row listing that variable as a column, which is the one case redirect() cannot reach.
     final Vertex prior = labelReplacements.resolve(vertex);
     if (prior != vertex) {
       propagateUpdateToSameNodeAliases(result, vertex, prior);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -449,9 +449,10 @@ public class SetStep extends AbstractExecutionStep {
       return;
 
     // If this vertex was already replaced on a prior row (row fanout hitting the same node), redirect to the
-    // replacement so the idempotency check below can use the current type. The per-row redirect() at the top of
-    // applySetOperations has normally done this already; resolving the write target itself does not depend on the
-    // row listing that variable as a column, which is the one case redirect() cannot reach.
+    // replacement so the idempotency check below reads the current type. The per-row redirect() at the top of
+    // applySetOperations reaches this alias too, so today this only re-confirms it; it stays because it makes the
+    // method correct on its own terms - the write target is resolved here, not assumed to have been resolved by
+    // the caller - and it costs one map lookup that is skipped entirely until a label write actually happens.
     final Vertex prior = labelReplacements.resolve(vertex);
     if (prior != vertex) {
       propagateUpdateToSameNodeAliases(result, vertex, prior);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issues #6312 and #6313: a Cypher label write has to rewrite the vertex, because ArcadeDB reads a record's type
+ * from the bucket it lives in and a label set is a type. The rewrite left every other reference to the node -
+ * a second alias in the same row, the same node reached again by a later row of the same clause - pointing at the
+ * deleted original, so the next REMOVE either failed to load the record (#6312) or followed its dangling edge-list
+ * chunk on the way to deleting it a second time (#6313).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherLabelWriteRowFanoutIssue6312Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-labelwrite-6312").create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void removeSurvivesUnwindFanoutOverTheSameNodes() {
+    cypher("""
+        CREATE (n2:l2:l11 {id:2,klist:['n2v']})-[:rt2]->
+               (n1 {id:1,k11:'u'})-[:R {klist:[-1365794787,-485798932]}]->
+               (n0 {id:0,k1:'v',klist:[1,2,3]})""");
+    cypher("MATCH (n2 {id:2}) CREATE (:l11:l8:l1:l3:l5:l4:l9)-[:t]->(n2)");
+
+    // One matched row, unwound into three by n0.klist: every row removes from the same two nodes, and the
+    // first of them replaces n2's record.
+    assertThat(count("""
+        OPTIONAL MATCH p0 = (n2)-[:rt2]->(n1 {k11:'u'})-[{klist:[-1365794787,-485798932]}]->(n0),
+          (:l11:l8:l1:l3:l5:l4:l9)-[]->(n2)
+        WITH *
+        WHERE n0 IS NOT NULL
+        UNWIND coalesce(n0.klist, []) AS alias3
+        WITH *
+        WHERE n2 IS NOT NULL
+        REMOVE n0.k1, n2.klist, n2:l2:l11
+        RETURN count(*) AS row_count""")).isEqualTo(3);
+
+    assertThat(rows("MATCH (n {id:2}) RETURN labels(n) AS v")).containsExactly("[]");
+    assertThat(rows("MATCH (n {id:2}) RETURN n.klist AS v")).containsExactly("null");
+    assertThat(rows("MATCH (n {id:0}) RETURN n.k1 AS v")).containsExactly("null");
+
+    // The relabelled vertex keeps both sides of its topology.
+    assertThat(rows("MATCH (n {id:2})-[:rt2]->(other) RETURN other.id AS v")).containsExactly("1");
+    assertThat(rows("MATCH (source)-[:t]->(n {id:2}) RETURN size(labels(source)) AS v")).containsExactly("7");
+  }
+
+  @Test
+  void removeLabelSurvivesTheSameNodeMatchedOnSeveralRows() {
+    cypher("CREATE (n0 {k9:true})-[:rt7]->(n1:l1 {tag:'middle'})-[:X]->(n2 {tag:'end'})");
+    cypher("MATCH (n1 {tag:'middle'}) CREATE (n1)-[:c]->(:Extra)");
+
+    // Two rows - the middle node has two outgoing edges - both binding the same n0 and n1.
+    assertThat(count("""
+        UNWIND ['x'] AS alias0
+        OPTIONAL MATCH (n2)<-[]-(n1)<-[:rt7]-(n0), p0=(n2)
+        WHERE true
+        WITH *
+        WHERE n1 IS NOT NULL AND n0 IS NOT NULL
+        REMOVE n0.k9, n1:l1
+        RETURN count(*) AS row_count""")).isEqualTo(2);
+
+    assertThat(rows("MATCH (n {tag:'middle'}) RETURN labels(n) AS v")).containsExactly("[]");
+    assertThat(rows("MATCH (n)-[:rt7]->(m) RETURN m.tag AS v")).containsExactly("middle");
+    assertThat(rows("MATCH (n {tag:'middle'})-[r]->(m) RETURN type(r) AS v")).containsExactlyInAnyOrder("X", "c");
+    assertThat(rows("MATCH (n)-[:rt7]->() RETURN n.k9 AS v")).containsExactly("null");
+  }
+
+  @Test
+  void removeLabelKeepsEdgeProperties() {
+    cypher("CREATE (a:Keep:Drop {name:'a'})-[:E {w:7,tag:'out'}]->(b {name:'b'})");
+    cypher("MATCH (a {name:'a'}) CREATE (c {name:'c'})-[:E {w:9,tag:'in'}]->(a)");
+    cypher("MATCH (a {name:'a'}) CREATE (a)-[:E {w:11,tag:'loop'}]->(a)");
+
+    cypher("MATCH (a:Drop) REMOVE a:Drop");
+
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Keep]");
+    assertThat(rows("MATCH ()-[r:E]->() RETURN r.tag + '=' + r.w AS v"))
+        .containsExactlyInAnyOrder("out=7", "in=9", "loop=11");
+    // The self-loop is migrated once, not once per direction.
+    assertThat(rows("MATCH (n {name:'a'})-[r]->(n) RETURN count(r) AS v")).containsExactly("1");
+  }
+
+  @Test
+  void addLabelKeepsEdgeProperties() {
+    cypher("CREATE (a:Keep {name:'a'})-[:E {w:7,tag:'out'}]->(b {name:'b'})");
+    cypher("MATCH (a {name:'a'}) CREATE (c {name:'c'})-[:E {w:9,tag:'in'}]->(a)");
+
+    cypher("MATCH (a:Keep) SET a:Extra");
+
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Extra, Keep]");
+    assertThat(rows("MATCH ()-[r:E]->() RETURN r.tag + '=' + r.w AS v"))
+        .containsExactlyInAnyOrder("out=7", "in=9");
+  }
+
+  @Test
+  void removeLabelIsIdempotentAcrossRowsAndCountsOnce() {
+    cypher("CREATE (a:Gone:Stay {name:'a'})");
+
+    final int[] labelsRemoved = new int[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("opencypher",
+          "MATCH (a {name:'a'}) UNWIND [1,2,3] AS i REMOVE a:Gone RETURN count(*) AS row_count")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(((Number) rs.next().getProperty("row_count")).longValue()).isEqualTo(3);
+        labelsRemoved[0] = rs.getStatistics().map(s -> s.getLabelsRemoved()).orElse(-1);
+      }
+    });
+
+    assertThat(labelsRemoved[0]).isEqualTo(1);
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Stay]");
+  }
+
+  private long count(final String query) {
+    final long[] value = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("opencypher", query)) {
+        assertThat(rs.hasNext()).isTrue();
+        value[0] = ((Number) rs.next().getProperty("row_count")).longValue();
+      }
+    });
+    return value[0];
+  }
+
+  private List<String> rows(final String query) {
+    final List<String> out = new ArrayList<>();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher", query)) {
+        while (rs.hasNext()) {
+          final Result r = rs.next();
+          out.add(String.valueOf(r.<Object>getProperty("v")));
+        }
+      }
+    });
+    return out;
+  }
+
+  private void cypher(final String query) {
+    database.transaction(() -> database.command("opencypher", query));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
@@ -135,6 +135,28 @@ class CypherLabelWriteRowFanoutIssue6312Test {
   }
 
   @Test
+  void aBoundPathFollowsItsRelabelledMembers() {
+    cypher("CREATE (a:Keep:Drop {name:'a'})-[:E {w:7}]->(b {name:'b'})");
+
+    // The path was bound before the label write, and the write moves one of its nodes. Reading the path
+    // afterwards has to answer with the state that write left behind, not with the record it deleted.
+    assertThat(writingRows("MATCH p = (a:Drop)-[:E]->(b) REMOVE a:Drop RETURN [n IN nodes(p) | labels(n)] AS v"))
+        .containsExactly("[[Keep], []]");
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Keep]");
+    // The relationship the path carries is re-attached to the replacement, properties and all.
+    assertThat(writingRows("MATCH p = (a:Keep)-[:E]->(b) REMOVE a:Keep RETURN [r IN relationships(p) | r.w] AS v"))
+        .containsExactly("[7]");
+  }
+
+  @Test
+  void aCollectedListFollowsItsRelabelledMembers() {
+    cypher("CREATE (c:Gone {name:'c'})-[:E2]->(d {name:'d'})");
+
+    assertThat(writingRows("MATCH (c:Gone) WITH collect(c) AS cs, c AS one REMOVE one:Gone RETURN [n IN cs | labels(n)] AS v"))
+        .containsExactly("[[]]");
+  }
+
+  @Test
   void removeLabelIsIdempotentAcrossRowsAndCountsOnce() {
     cypher("CREATE (a:Gone:Stay {name:'a'})");
 
@@ -164,9 +186,20 @@ class CypherLabelWriteRowFanoutIssue6312Test {
   }
 
   private List<String> rows(final String query) {
+    return rows(query, false);
+  }
+
+  /**
+   * Same as {@link #rows(String)} for a query that also writes, which the read-only entry point rejects.
+   */
+  private List<String> writingRows(final String query) {
+    return rows(query, true);
+  }
+
+  private List<String> rows(final String query, final boolean writes) {
     final List<String> out = new ArrayList<>();
     database.transaction(() -> {
-      try (final ResultSet rs = database.query("opencypher", query)) {
+      try (final ResultSet rs = writes ? database.command("opencypher", query) : database.query("opencypher", query)) {
         while (rs.hasNext()) {
           final Result r = rs.next();
           out.add(String.valueOf(r.<Object>getProperty("v")));

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
@@ -149,6 +149,18 @@ class CypherLabelWriteRowFanoutIssue6312Test {
   }
 
   @Test
+  void aBoundLightweightEdgeFollowsTheEndpointThatMoved() {
+    database.getSchema().buildEdgeType().withName("Light").withLightweight(true).create();
+    cypher("CREATE (a:Keep:Drop {name:'a'})-[:Light]->(b {name:'b'})");
+
+    // A lightweight edge is stored inside its two vertices, so relabelling one endpoint re-creates it. The row
+    // still holding the original has to follow, or it answers with an endpoint that no longer exists.
+    assertThat(writingRows("MATCH (a:Drop)-[r:Light]->(b) REMOVE a:Drop RETURN startNode(r).name + '->' + endNode(r).name AS v"))
+        .containsExactly("a->b");
+    assertThat(rows("MATCH (n {name:'a'})-[:Light]->(m) RETURN m.name AS v")).containsExactly("b");
+  }
+
+  @Test
   void aCollectedListFollowsItsRelabelledMembers() {
     cypher("CREATE (c:Gone {name:'c'})-[:E2]->(d {name:'d'})");
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
@@ -169,6 +169,41 @@ class CypherLabelWriteRowFanoutIssue6312Test {
   }
 
   @Test
+  void mergeOnMatchSetLabelKeepsEdgesAndRedirectsEveryAlias() {
+    cypher("CREATE (a:Keep {name:'a'})-[:E {w:7}]->(b {name:'b'})");
+    cypher("MATCH (a {name:'a'}) CREATE (c {name:'c'})-[:E {w:9}]->(a)");
+    cypher("MATCH (a {name:'a'}) CREATE (a)-[:E {w:11}]->(a)");
+
+    // ON MATCH SET n:Label rewrites the record exactly as a bare SET does. The row also binds the same node
+    // under m, from the MATCH that fed the MERGE, and that alias has to follow it too.
+    assertThat(writingRows("""
+        MATCH (m {name:'a'})
+        MERGE (n {name:'a'})
+        ON MATCH SET n:Extra
+        RETURN labels(m) AS v""")).containsExactly("[Extra, Keep]");
+
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Extra, Keep]");
+    // Edge properties survive, and the self-loop is one live edge rather than a dangling one.
+    assertThat(rows("MATCH ()-[r:E]->() RETURN r.w AS v")).containsExactlyInAnyOrder("7", "9", "11");
+    assertThat(rows("MATCH (n {name:'a'})-[r]->(n) RETURN count(r) AS v")).containsExactly("1");
+    assertThat(rows("MATCH (n {name:'a'})-[:E]->(x) RETURN x.name AS v")).containsExactlyInAnyOrder("b", "a");
+  }
+
+  @Test
+  void mergeOnMatchSetLabelSurvivesTheSameNodeOnSeveralRows() {
+    cypher("CREATE (a:Keep {name:'a'})");
+
+    // Three rows, all merging onto the same node: the first relabels it, the other two must recognise the
+    // replacement rather than write through the record it deleted.
+    assertThat(writingRows("""
+        UNWIND [1,2,3] AS i
+        MERGE (n {name:'a'})
+        ON MATCH SET n:Extra
+        RETURN labels(n) AS v""")).containsExactly("[Extra, Keep]", "[Extra, Keep]", "[Extra, Keep]");
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Extra, Keep]");
+  }
+
+  @Test
   void removeLabelIsIdempotentAcrossRowsAndCountsOnce() {
     cypher("CREATE (a:Gone:Stay {name:'a'})");
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelWriteRowFanoutIssue6312Test.java
@@ -174,6 +174,26 @@ class CypherLabelWriteRowFanoutIssue6312Test {
     assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Stay]");
   }
 
+  @Test
+  void addLabelIsIdempotentAcrossRowsAndCountsOnce() {
+    // The mirror of the REMOVE case: SET runs the same replacement machinery, so a node relabelled on the
+    // first row must be recognised as already carrying the label on the next two rather than replaced again.
+    cypher("CREATE (a:Stay {name:'a'})");
+
+    final int[] labelsAdded = new int[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("opencypher",
+          "MATCH (a {name:'a'}) UNWIND [1,2,3] AS i SET a:Extra RETURN count(*) AS row_count")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(((Number) rs.next().getProperty("row_count")).longValue()).isEqualTo(3);
+        labelsAdded[0] = rs.getStatistics().map(s -> s.getLabelsAdded()).orElse(-1);
+      }
+    });
+
+    assertThat(labelsAdded[0]).isEqualTo(1);
+    assertThat(rows("MATCH (n {name:'a'}) RETURN labels(n) AS v")).containsExactly("[Extra, Stay]");
+  }
+
   private long count(final String query) {
     final long[] value = new long[1];
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherWithStarScopeIssue6311Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherWithStarScopeIssue6311Test.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6311: {@code WITH *} is an identity projection, so putting one between a MATCH and what reads it must
+ * leave both the rows and the bindings alone. It did not: two comma-separated patterns of the same MATCH that
+ * share a variable were joined on it without the projection and multiplied out into a Cartesian product with it.
+ * <p>
+ * The join is performed by the identity check each hop runs against the names already bound when it executes.
+ * Those names used to be handed to the step as the planner's own live, mutable set, which a following WITH
+ * clears - so the check silently stopped seeing the shared variable.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherWithStarScopeIssue6311Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-withstar-6311").create();
+    cypher("CREATE (a:l1 {tag:'a'})<-[:R0 {k7:false,k8:true}]-(n0 {tag:'n0a',k2:true})<-[:rt0]-(x)<-[:R2]-(n1 {tag:'A'})");
+    cypher("CREATE (a:l1 {tag:'b'})<-[:R0 {k7:false,k8:true}]-(n0 {tag:'n0b',k2:true})<-[:rt0]-(x)<-[:R2]-(n1 {tag:'B'})");
+    cypher("MATCH (n1 {tag:'A'}) CREATE (n2 {tag:'n2a'})<-[:rt8 {k3:'d',k10:-1957561185}]-(y)-[:R3]->(n1)");
+    cypher("MATCH (n1 {tag:'B'}) CREATE (n2 {tag:'n2b'})<-[:rt8 {k3:'d',k10:-1957561185}]-(y)-[:R3]->(n1)");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void withStarKeepsOptionalMatchCardinality() {
+    final String pattern = """
+        OPTIONAL MATCH (:l1)<-[r0 {k7:false,k8:true}]-(n0 {k2:true})<-[r1:rt0]-()<-[r2]-(n1),
+          (n2)<-[:rt8 {k3:'d',k10:-1957561185}]-()-[]->(n1)
+        """;
+
+    assertThat(count(pattern + "RETURN count(*) AS row_count")).isEqualTo(2);
+    assertThat(count(pattern + "WITH *\nRETURN count(*) AS row_count")).isEqualTo(2);
+  }
+
+  @Test
+  void withStarKeepsMatchCardinality() {
+    // Same defect without OPTIONAL: the shared variable is what joins the two comma-separated patterns.
+    final String pattern = "MATCH (n0 {k2:true})<-[:rt0]-()<-[]-(n1), (n2)<-[:rt8]-()-[]->(n1)\n";
+    final String projection = "RETURN n0.tag AS n0, n1.tag AS n1, n2.tag AS n2";
+
+    assertThat(rows(pattern + projection)).containsExactlyInAnyOrder("n0a|A|n2a", "n0b|B|n2b");
+    assertThat(rows(pattern + "WITH *\n" + projection)).containsExactlyInAnyOrder("n0a|A|n2a", "n0b|B|n2b");
+  }
+
+  @Test
+  void explicitProjectionOfTheSharedVariableBehavesTheSame() {
+    final String pattern = "MATCH (n0 {k2:true})<-[:rt0]-()<-[]-(n1), (n2)<-[:rt8]-()-[]->(n1)\n";
+    assertThat(rows(pattern + "WITH n0, n1, n2\nRETURN n0.tag AS n0, n1.tag AS n1, n2.tag AS n2"))
+        .containsExactlyInAnyOrder("n0a|A|n2a", "n0b|B|n2b");
+  }
+
+  @Test
+  void withStarKeepsVariablesBoundForTheNextMatch() {
+    // WITH * forwards the incoming scope, so the following MATCH must recognise x as already bound and
+    // expand from it rather than re-scanning every vertex.
+    assertThat(rows("""
+        MATCH (n0 {k2:true})<-[:rt0]-(x)
+        WITH *
+        MATCH (x)<-[]-(n1)
+        RETURN n0.tag AS n0, n1.tag AS n1, '' AS n2"""))
+        .containsExactlyInAnyOrder("n0a|A|", "n0b|B|");
+  }
+
+  @Test
+  void withStarPlusAliasKeepsBothTheScopeAndTheAlias() {
+    assertThat(rows("""
+        MATCH (n0 {k2:true})<-[:rt0]-(x)
+        WITH *, n0.tag AS renamed
+        MATCH (x)<-[]-(n1)
+        RETURN n0.tag AS n0, n1.tag AS n1, renamed AS n2"""))
+        .containsExactlyInAnyOrder("n0a|A|n0a", "n0b|B|n0b");
+  }
+
+  private long count(final String query) {
+    final long[] value = new long[1];
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher", query)) {
+        assertThat(rs.hasNext()).isTrue();
+        value[0] = ((Number) rs.next().getProperty("row_count")).longValue();
+      }
+    });
+    return value[0];
+  }
+
+  private List<String> rows(final String query) {
+    final List<String> out = new ArrayList<>();
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher", query)) {
+        while (rs.hasNext()) {
+          final Result r = rs.next();
+          out.add(r.getProperty("n0") + "|" + r.getProperty("n1") + "|" + r.<Object>getProperty("n2"));
+        }
+      }
+    });
+    return out;
+  }
+
+  private void cypher(final String query) {
+    database.transaction(() -> database.command("opencypher", query));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherWithStarScopeIssue6311Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherWithStarScopeIssue6311Test.java
@@ -84,6 +84,18 @@ class CypherWithStarScopeIssue6311Test {
   }
 
   @Test
+  void withStarKeepsTheJoinOnAVariableLengthPattern() {
+    // A variable-length hop resolves its already-bound target from the incoming row rather than from a
+    // plan-time variable set, so it never had the live-set exposure the fixed-length hop did. Pinned here
+    // because it is the branch a reader would expect to share the defect.
+    final String pattern = "MATCH (n0 {k2:true})<-[:rt0]-()<-[]-(n1), (n2)<-[:rt8*1..2]-()-[]->(n1)\n";
+    final String projection = "RETURN n0.tag AS n0, n1.tag AS n1, n2.tag AS n2";
+
+    assertThat(rows(pattern + projection)).containsExactlyInAnyOrder("n0a|A|n2a", "n0b|B|n2b");
+    assertThat(rows(pattern + "WITH *\n" + projection)).containsExactlyInAnyOrder("n0a|A|n2a", "n0b|B|n2b");
+  }
+
+  @Test
   void explicitProjectionOfTheSharedVariableBehavesTheSame() {
     final String pattern = "MATCH (n0 {k2:true})<-[:rt0]-()<-[]-(n1), (n2)<-[:rt8]-()-[]->(n1)\n";
     assertThat(rows(pattern + "WITH n0, n1, n2\nRETURN n0.tag AS n0, n1.tag AS n1, n2.tag AS n2"))

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/LabelReplacementsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/LabelReplacementsTest.java
@@ -155,6 +155,30 @@ class LabelReplacementsTest {
   }
 
   @Test
+  void redirectRewritesALightweightEdgeOntoTheReplacement() {
+    database.transaction(() -> {
+      final LabelReplacements replacements = new LabelReplacements();
+      final MutableVertex start = database.newVertex("A").set("name", "start").save();
+      final MutableVertex end = database.newVertex("A").set("name", "end").save();
+      final Edge light = start.newEdge("Light", end);
+
+      final ResultInternal row = new ResultInternal();
+      row.setProperty("r", light);
+
+      final Vertex replacement = replacements.replace(start, "B");
+      replacements.redirect(row);
+
+      // A lightweight edge has no record to address, but its identity is the (type, out, in) triple - so the one
+      // hanging off the replacement is a different edge, and the row has to be pointed at it.
+      final Edge redirected = row.getProperty("r");
+      assertThat(redirected).isNotSameAs(light);
+      assertThat(redirected.getOut()).isEqualTo(replacement.getIdentity());
+      assertThat(redirected.getIn()).isEqualTo(end.getIdentity());
+      assertThat(light.getOut()).isNotEqualTo(replacement.getIdentity());
+    });
+  }
+
+  @Test
   void redirectLeavesARowWithNothingToRewriteUntouched() {
     database.transaction(() -> {
       final LabelReplacements replacements = new LabelReplacements();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/LabelReplacementsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/LabelReplacementsTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Direct tests for the machinery behind a Cypher label write, so a regression in it is localised here rather than
+ * inferred from a failing query: the replacement chain a twice-relabelled node builds, the edges and edge
+ * properties carried over to the new record, and the row values - plain, nested, and path-shaped - redirected onto
+ * it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LabelReplacementsTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/test-label-replacements").create();
+    database.getSchema().getOrCreateVertexType("A");
+    database.getSchema().getOrCreateVertexType("B");
+    database.getSchema().getOrCreateVertexType("C");
+    database.getSchema().getOrCreateEdgeType("E");
+    database.getSchema().buildEdgeType().withName("Light").withLightweight(true).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void resolveFollowsAChainOfReplacements() {
+    database.transaction(() -> {
+      final LabelReplacements replacements = new LabelReplacements();
+      final MutableVertex original = database.newVertex("A").set("name", "n").save();
+
+      final Vertex once = replacements.replace(original, "B");
+      final Vertex twice = replacements.replace(once, "C");
+
+      assertThat(replacements.resolve(original)).isSameAs(twice);
+      assertThat(replacements.resolve(once)).isSameAs(twice);
+      assertThat(replacements.resolve(twice)).isSameAs(twice);
+      assertThat(twice.getTypeName()).isEqualTo("C");
+      assertThat(twice.<String>get("name")).isEqualTo("n");
+    });
+  }
+
+  @Test
+  void resolveLeavesAnUntouchedVertexAlone() {
+    database.transaction(() -> {
+      final LabelReplacements replacements = new LabelReplacements();
+      final MutableVertex untouched = database.newVertex("A").save();
+
+      assertThat(replacements.isEmpty()).isTrue();
+      assertThat(replacements.resolve(untouched)).isSameAs(untouched);
+      assertThat(replacements.resolve(null)).isNull();
+    });
+  }
+
+  @Test
+  void replaceCarriesEdgesAndTheirPropertiesOver() {
+    database.transaction(() -> {
+      final LabelReplacements replacements = new LabelReplacements();
+      final MutableVertex target = database.newVertex("A").set("name", "target").save();
+      final MutableVertex other = database.newVertex("A").set("name", "other").save();
+      target.newEdge("E", other, "w", 7);
+      other.newEdge("E", target, "w", 9);
+      target.newEdge("E", target, "w", 11);
+      target.newEdge("Light", other);
+
+      final Vertex replacement = replacements.replace(target, "B");
+
+      assertThat(replacement.getTypeName()).isEqualTo("B");
+      assertThat(edgeWeights(replacement, Vertex.DIRECTION.OUT)).containsExactlyInAnyOrder(7, 11, null);
+      assertThat(edgeWeights(replacement, Vertex.DIRECTION.IN)).containsExactlyInAnyOrder(9, 11);
+      // The self-loop is one edge, seen once from each side, not two.
+      assertThat(replacement.countEdges(Vertex.DIRECTION.OUT, "E")).isEqualTo(2);
+    });
+  }
+
+  @Test
+  void redirectRewritesPlainNestedAndPathShapedRowValues() {
+    database.transaction(() -> {
+      final LabelReplacements replacements = new LabelReplacements();
+      final MutableVertex start = database.newVertex("A").set("name", "start").save();
+      final MutableVertex end = database.newVertex("A").set("name", "end").save();
+      final Edge edge = start.newEdge("E", end, "w", 1);
+
+      final TraversalPath path = new TraversalPath(start);
+      path.addStep(edge, end);
+
+      final ResultInternal row = new ResultInternal();
+      row.setProperty("n", start);
+      row.setProperty("untouched", end);
+      row.setProperty("r", edge);
+      row.setProperty("p", path);
+      row.setProperty("collected", List.of(start, end));
+      row.setProperty("mapped", Map.of("k", start));
+      row.setProperty("scalar", 42);
+
+      final Vertex replacement = replacements.replace(start, "B");
+      replacements.redirect(row);
+
+      assertThat(row.<Vertex>getProperty("n")).isSameAs(replacement);
+      assertThat(row.<Vertex>getProperty("untouched")).isSameAs(end);
+      assertThat(row.<Edge>getProperty("r").getIdentity()).isNotEqualTo(edge.getIdentity());
+      assertThat(row.<Edge>getProperty("r").<Integer>get("w")).isEqualTo(1);
+      assertThat(row.<Integer>getProperty("scalar")).isEqualTo(42);
+
+      final TraversalPath redirected = row.getProperty("p");
+      assertThat(redirected.getVertices().get(0)).isSameAs(replacement);
+      assertThat(redirected.getVertices().get(1)).isSameAs(end);
+      assertThat(redirected.getEdges().get(0).getIdentity()).isEqualTo(row.<Edge>getProperty("r").getIdentity());
+
+      assertThat(row.<List<Vertex>>getProperty("collected").get(0)).isSameAs(replacement);
+      assertThat(row.<List<Vertex>>getProperty("collected").get(1)).isSameAs(end);
+      assertThat(row.<Map<String, Vertex>>getProperty("mapped").get("k")).isSameAs(replacement);
+    });
+  }
+
+  @Test
+  void redirectLeavesARowWithNothingToRewriteUntouched() {
+    database.transaction(() -> {
+      final LabelReplacements replacements = new LabelReplacements();
+      final MutableVertex vertex = database.newVertex("A").save();
+      final List<Vertex> collected = List.of(vertex);
+
+      final ResultInternal row = new ResultInternal();
+      row.setProperty("n", vertex);
+      row.setProperty("collected", collected);
+
+      replacements.redirect(row);
+
+      assertThat(row.<Vertex>getProperty("n")).isSameAs(vertex);
+      // Nothing inside moved, so the list is the same instance rather than a rebuilt copy.
+      assertThat(row.<List<Vertex>>getProperty("collected")).isSameAs(collected);
+    });
+  }
+
+  private static List<Object> edgeWeights(final Vertex vertex, final Vertex.DIRECTION direction) {
+    final List<Object> weights = new ArrayList<>();
+    for (final Edge edge : vertex.getEdges(direction))
+      weights.add(edge.get("w"));
+    return weights;
+  }
+}


### PR DESCRIPTION
Fixes #6311, fixes #6312, fixes #6313.

## #6311 - `WITH *` changed the cardinality of a multi-pattern MATCH

`WITH *` is an identity projection, so nothing downstream of it should be able to tell it is there. It could:

```cypher
MATCH (n0 {k2:true})<-[:rt0]-()<-[]-(n1), (n2)<-[:rt8]-()-[]->(n1)
RETURN n0.tag, n1.tag, n2.tag        -- 2 rows, joined on n1
```
```cypher
MATCH (n0 {k2:true})<-[:rt0]-()<-[]-(n1), (n2)<-[:rt8]-()-[]->(n1)
WITH *
RETURN n0.tag, n1.tag, n2.tag        -- 4 rows, the full Cartesian product
```

The issue reports it on `OPTIONAL MATCH`, but `OPTIONAL` is incidental: plain MATCH breaks the same way, and so does any following clause, not just `RETURN count(*)`.

The join between two comma-separated patterns of one MATCH is the identity check each hop runs on its target against the names the row already carries. Those names were handed to `MatchRelationshipStep` as the planner's **live, mutable** `boundVariables` set. That set is filled with the clause's own variables only *after* the clause is planned (`boundVariables.addAll(matchVariables)`), which is what made the check work at all - retroactively, through the shared reference. A following WITH clears the same set, and `WITH *` refilled it with the literal name `*`, so by the time the hop executed the shared variable was gone from it and every target was accepted.

Two changes:

- the hop is given a **snapshot** of what is bound at the point it will run - everything bound before this MATCH plus everything this MATCH has bound so far (earlier comma-separated patterns, earlier hops). A variable can only be in a row if it was bound earlier, so this is exactly the set the check needs, and it no longer depends on a set someone else may edit later;
- `WITH *` forwards the incoming scope instead of replacing it with `"*"`. An explicit projection list still resets it, and `WITH *, expr AS alias` does both.

## #6312 / #6313 - a label write left every other reference to the node dangling

ArcadeDB reads a record's type from the bucket it lives in, and in the Cypher mapping a label set *is* a type, so `REMOVE n:L` cannot retype in place: it writes a new record and deletes the old one. Every other reference to that node was left pointing at the deleted original - a second alias in the same row, or the same node reached again by a later row of the same clause (UNWIND fan-out, or simply two matches sharing the node). The next `REMOVE` then either failed to load the record:

```
com.arcadedb.exception.RecordNotFoundException: Record #7:0 not found
  at com.arcadedb.database.immutable.ImmutableDocument.checkForLazyLoading
```

or, on the way to deleting it a second time, followed its dangling edge-list chunk and reported the vertex as concurrently modified:

```
Edge list OUT of vertex #4:0 is not fully visible yet (concurrent commit in flight): Record #5:0 not found
```

`SetStep` already tracked its own replacements for `SET n:L`; `RemoveStep` tracked nothing. Both now share one `LabelReplacements`, which performs the rewrite and points every alias of the node - in this row and in every later one - at the live record, so a repeated label removal becomes an idempotent no-op instead of a fatal one.

Two defects of the rewrite itself, shared by SET and REMOVE, are fixed in the same place:

- **edge properties were silently dropped.** The old code re-linked edges with `newVertex.newEdge(edge.getTypeName(), other)`, i.e. by type alone, so `-[:R {klist:[...]}]->` came back as `-[:R]->`. They are now carried over (and a LIGHTWEIGHT type, which has none, still gets none).
- **a self-loop was duplicated**, migrated once by the OUT pass and again by the IN pass. It is now migrated once.

### On the expected values in the reports

- #6312 asks for `row_count = 3` and gets it.
- #6313 asks for `row_count = 1`, but the query matches **2** rows: the fixture gives the middle node two outgoing edges (`[:X]->(n2)` and the `[:c]->(:Extra)` added by the second `CREATE`), and `(n2)<-[]-(n1)` matches both. The test asserts 2. What was reported - the exception - is real and fixed.

## Tests

`CypherWithStarScopeIssue6311Test` (5) and `CypherLabelWriteRowFanoutIssue6312Test` (5), both new. Reverting the fix fails 7 of the 10; the remaining 3 are controls that must keep passing (explicit `WITH n0, n1, n2`, `WITH *` before a MATCH, `WITH *, expr AS alias`).

Verification run: the whole `engine` unit lane, 15,730 tests, green; the openCypher TCK suite, 3,897 scenarios, green.
