### PR TITLE
fix(#6190): SQLFunction gets a determinism marker the planner can use

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAbsoluteValue.java
@@ -144,4 +144,12 @@ public class SQLFunctionAbsoluteValue extends SQLFunctionMathAbstract {
   public Object getResult() {
     return result;
   }
+
+  /**
+   * Pure math over its single argument, including the deterministic overflow failure (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPow.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPow.java
@@ -75,4 +75,12 @@ public class SQLFunctionPow extends SQLFunctionMathAbstract {
   public Object getResult() {
     return result;
   }
+
+  /**
+   * Pure math over its two arguments (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSquareRoot.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSquareRoot.java
@@ -75,4 +75,12 @@ public class SQLFunctionSquareRoot extends SQLFunctionMathAbstract {
   public Object getResult() {
     return result;
   }
+
+  /**
+   * Pure math over its single argument (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionCoalesce.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionCoalesce.java
@@ -79,4 +79,12 @@ public class SQLFunctionCoalesce extends SQLFunctionAbstract {
   public String getSyntax() {
     return "Returns the first not-null parameter or null if all parameters are null. Syntax: coalesce(<field|value> [,<field|value>]*)";
   }
+
+  /**
+   * A pure selection among its arguments (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionDecode.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionDecode.java
@@ -72,4 +72,13 @@ public class SQLFunctionDecode extends SQLFunctionAbstract {
   public String getSyntax() {
     return "decode(<value>, <format>)";
   }
+
+  /**
+   * A pure base64/base64url decode of its string argument - unlike {@link SQLFunctionEncode}, it never dereferences
+   * a RID (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIf.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIf.java
@@ -86,4 +86,12 @@ public class SQLFunctionIf extends SQLFunctionAbstract {
   public String getSyntax() {
     return "if(<field|value|expression>, <return_value_if_true> [,<return_value_if_false>])";
   }
+
+  /**
+   * A pure selection among its arguments (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfEmpty.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfEmpty.java
@@ -99,4 +99,12 @@ public class SQLFunctionIfEmpty extends SQLFunctionAbstract {
   public String getSyntax() {
     return "Syntax error: ifempty(<field|value>, <return_value_if_empty> [,<return_value_if_not_empty>])";
   }
+
+  /**
+   * A pure selection among its arguments (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfNull.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionIfNull.java
@@ -94,4 +94,12 @@ public class SQLFunctionIfNull extends SQLFunctionAbstract {
   public String getSyntax() {
     return "Syntax error: ifnull(<field|value>, <return_value_if_null> [,<return_value_if_not_null>])";
   }
+
+  /**
+   * A pure selection among its arguments (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionFormat.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionFormat.java
@@ -51,4 +51,9 @@ public class SQLFunctionFormat extends SQLFunctionAbstract {
   public String getSyntax() {
     return "format(<format>, <arg1> [,<argN>]*)";
   }
+
+  // Not marked isDeterministic(): java.lang.String#format resolves grouping/decimal separators and similar
+  // conversions against the JVM's default Locale, which is process-wide mutable state outside the arguments
+  // (issue #6190). A caller relying on locale-sensitive conversions across a `Locale.setDefault()` change must
+  // not have a stale value baked into a cached plan.
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionStrcmpci.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionStrcmpci.java
@@ -73,4 +73,12 @@ public class SQLFunctionStrcmpci extends SQLFunctionAbstract {
   public String getSyntax() {
     return "strcmpci(<arg1>, <arg2>)";
   }
+
+  /**
+   * A pure comparison of its two arguments alone (issue #6190).
+   */
+  @Override
+  public boolean isDeterministic() {
+    return true;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SQLFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SQLFunction.java
@@ -63,4 +63,23 @@ public interface SQLFunction extends RecordFunction {
    */
   @Override
   String getSyntax();
+
+  /**
+   * Whether two calls to this function with the same arguments always return the same result and never read or
+   * write anything outside those arguments - no wall clock, no random source, no counter, no schema/index/record
+   * lookup keyed on something other than a literal argument.
+   * <p>
+   * Defaults to {@code false}. The planner uses this to decide, without ever invoking the function, whether a call
+   * over constant arguments can be folded at plan time ({@code WHERE 1 = abs(-1)}), whether a statement containing
+   * the call can have its execution plan cached and reused across executions, and whether a call in an indexed
+   * equality can be evaluated once at plan time instead of once per invocation site. Getting this wrong in the
+   * {@code true} direction is silent and reaches user data - a function that reads the clock, a random source, or
+   * database state would be baked into a cached plan or invoked at the wrong time - so a function (built-in or
+   * user-defined) opts in explicitly rather than being assumed pure. See issue #6190.
+   *
+   * @return {@code true} only when the function is a pure, total function of its arguments alone
+   */
+  default boolean isDeterministic() {
+    return false;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -394,6 +394,20 @@ public class BaseExpression extends MathExpression {
     return identifier != null && identifier.isLiteral(allowInputParameters);
   }
 
+  /**
+   * @see Expression#isFoldable()
+   */
+  boolean isFoldableFunctionCall() {
+    // a modifier applied to the call's result (`abs(-1).append('x')`) is no longer a bare call
+    if (modifier != null)
+      return false;
+
+    if (expression != null)
+      return expression.isFoldable();
+
+    return identifier != null && identifier.isFoldableFunctionCall();
+  }
+
   @Override
   public boolean isExpand() {
     if (identifier != null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
@@ -187,6 +187,15 @@ public class BaseIdentifier extends SimpleNode {
     return levelZero != null && levelZero.isLiteral(allowInputParameters);
   }
 
+  /**
+   * A suffix is a property or variable reference, never a foldable call.
+   *
+   * @see Expression#isFoldable()
+   */
+  boolean isFoldableFunctionCall() {
+    return levelZero != null && levelZero.isFoldableFunctionCall();
+  }
+
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
       final BaseIdentifier result = new BaseIdentifier();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
@@ -50,8 +50,10 @@ public class BinaryCondition extends BooleanExpression {
   }
 
   /**
-   * Folds the comparison at plan time, but only when both of its operands are written in the statement as literals
-   * ({@code 1 = 0}, {@code 'a' = 'b'}, {@code 1 = 1 + 1}).
+   * Folds the comparison at plan time, but only when both of its operands are foldable: written in the statement as
+   * literals ({@code 1 = 0}, {@code 'a' = 'b'}, {@code 1 = 1 + 1}), or a call to a
+   * {@link com.arcadedb.query.sql.executor.SQLFunction#isDeterministic() deterministic} built-in over foldable
+   * arguments ({@code 1 = abs(-1)}, issue #6190).
    */
   @Override
   public boolean isAlwaysFalse(final CommandContext context) {
@@ -59,8 +61,8 @@ public class BinaryCondition extends BooleanExpression {
   }
 
   /**
-   * The mirror of {@link #isAlwaysFalse(CommandContext)}, folded under the same literal-only restriction: a comparison
-   * whose operands are both written in the statement ({@code 1 = 1}, {@code 'a' = 'a'}, {@code 2 = 1 + 1}) is true for
+   * The mirror of {@link #isAlwaysFalse(CommandContext)}, folded under the same restriction: a comparison whose
+   * operands are both foldable ({@code 1 = 1}, {@code 'a' = 'a'}, {@code 2 = 1 + 1}, {@code 1 = abs(-1)}) is true for
    * every record or for none, and the planner can drop the filter instead of evaluating it once per record.
    */
   @Override
@@ -69,15 +71,16 @@ public class BinaryCondition extends BooleanExpression {
   }
 
   /**
-   * Evaluates the comparison at plan time, but only when both of its operands are written in the statement as literals.
-   * See {@link Expression#isLiteral()} for why a bound parameter and a function call are excluded even though both
-   * could be computed without a record.
+   * Evaluates the comparison at plan time, but only when both of its operands are {@link Expression#isFoldable()
+   * foldable}. See {@link Expression#isLiteral()} for why a bound parameter is excluded even though it could be
+   * computed without a record, and {@link Expression#isFoldable()} for the one function-call shape that is admitted
+   * despite that restriction.
    *
    * @return true when the fold is possible AND its verdict is {@code expected}; false whenever the comparison cannot be
    * folded, which is the conservative answer both callers need
    */
   private boolean literalVerdict(final CommandContext context, final Boolean expected) {
-    if (left == null || right == null || !left.isLiteral() || !right.isLiteral())
+    if (left == null || right == null || !left.isFoldable() || !right.isFoldable())
       return false;
 
     try {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
@@ -198,6 +198,28 @@ public class Expression extends SimpleNode {
     return false;
   }
 
+  /**
+   * Whether the expression is {@link #isLiteral() a literal}, or a bare call to a
+   * {@link com.arcadedb.query.sql.executor.SQLFunction#isDeterministic() deterministic} built-in whose own arguments
+   * are each foldable in turn ({@code abs(-1)}, {@code coalesce(null, 1)}, {@code abs(pow(2, 3))}).
+   * <p>
+   * This is the "constant-folding sibling" that {@link #isLiteral()}'s own javadoc reserves {@code isLiteral} from
+   * becoming: it never invokes the function to decide, it only consults the marker issue #6190 adds
+   * ({@link FunctionCall#isFoldable()}), so it stays safe to call on a statement that is not going to fold at all.
+   * Deliberately narrower than {@link #isEarlyCalculated(CommandContext)} in the same way {@link #isLiteral()} is -
+   * a method call ({@code 'x'.append('y')}), a call whose result depends on an input parameter, or a call this
+   * cannot resolve as a built-in (a user-defined function) is never foldable, whatever its arguments are.
+   *
+   * @see #isLiteral()
+   * @see FunctionCall#isFoldable()
+   */
+  public boolean isFoldable() {
+    if (isLiteral())
+      return true;
+
+    return mathExpression instanceof BaseExpression baseExpression && baseExpression.isFoldableFunctionCall();
+  }
+
   public Identifier getDefaultAlias() {
     final Identifier identifier;
     if (isBaseIdentifier()) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -30,6 +30,7 @@ import com.arcadedb.query.sql.executor.FunctionAggregationContext;
 import com.arcadedb.query.sql.executor.IndexableSQLFunction;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.SQLFunction;
+import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
 import com.arcadedb.function.sql.graph.SQLFunctionMove;
 
 import java.util.ArrayList;
@@ -407,8 +408,66 @@ public class FunctionCall extends SimpleNode {
       param.extractSubQueries(collector);
   }
 
+  /**
+   * A statement containing this call can have its execution plan cached and reused across executions when the call
+   * targets a {@link SQLFunction#isDeterministic() deterministic} built-in and every argument is itself cacheable -
+   * the same requirement {@link SimpleNode#isCacheable()} places on a plain expression tree. Resolved purely against
+   * the built-in registry (see {@link #isDeterministicFunction()}): a name this cannot resolve - a user-defined
+   * function, or any dotted/namespaced call - is conservatively not cacheable, exactly as before this marker
+   * existed. See issue #6190.
+   */
   public boolean isCacheable() {
-    return isGraphFunction();
+    if (isGraphFunction())
+      return true;
+
+    if (!isDeterministicFunction())
+      return false;
+
+    for (final Expression param : params)
+      if (!param.isCacheable())
+        return false;
+
+    return true;
+  }
+
+  /**
+   * Whether this call, and every argument it is applied to, is fixed at parse time: the call targets a
+   * {@link SQLFunction#isDeterministic() deterministic} built-in and each argument is either a literal
+   * ({@link Expression#isLiteral()}) or itself such a call, recursively. Used only to widen constant folding
+   * ({@link BinaryCondition#isAlwaysTrue}/{@code isAlwaysFalse}) to admit a deterministic call over constants
+   * ({@code WHERE 1 = abs(-1)}) without ever invoking the function merely to classify the expression - resolving
+   * {@link #isDeterministicFunction()} reads a marker, it does not call {@link #execute}. Deliberately narrower than
+   * {@link #isEarlyCalculated(CommandContext)}, which admits any function (issue #6179); this is the "constant-
+   * folding sibling" issue #6190 reserves {@link Expression#isLiteral()} from becoming.
+   */
+  public boolean isFoldable() {
+    if (!isDeterministicFunction())
+      return false;
+
+    for (final Expression param : params)
+      if (!param.isFoldable())
+        return false;
+
+    return true;
+  }
+
+  /**
+   * Resolves this call's target purely against the built-in {@link DefaultSQLFunctionFactory} registry - the same
+   * static lookup {@link com.arcadedb.query.sql.SQLQueryEngine#getFunction(String)} consults first, before falling
+   * back to a database-scoped user function library or the unified {@link com.arcadedb.function.FunctionRegistry} of
+   * stateless functions - so both {@link #isCacheable()} and {@link #isFoldable()} can answer without a
+   * {@link CommandContext}. A built-in cannot be shadowed by a same-named user function (the database-scoped lookup
+   * only runs when this one misses), so the two never disagree on a resolvable name. A name this registry does not
+   * hold - a user-defined function, or any function reached only through the unified registry - is conservatively
+   * treated as not deterministic.
+   */
+  private boolean isDeterministicFunction() {
+    try {
+      final SQLFunction function = DefaultSQLFunctionFactory.getInstance().getFunctionInstance(name.getStringValue());
+      return function != null && function.isDeterministic();
+    } catch (final Exception e) {
+      return false;
+    }
   }
 
   private boolean isGraphFunction() {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -23,6 +23,8 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
+import com.arcadedb.function.sql.graph.SQLFunctionMove;
 import com.arcadedb.query.sql.SQLQueryEngine;
 import com.arcadedb.query.sql.executor.AggregationContext;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -30,12 +32,12 @@ import com.arcadedb.query.sql.executor.FunctionAggregationContext;
 import com.arcadedb.query.sql.executor.IndexableSQLFunction;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.SQLFunction;
-import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
-import com.arcadedb.function.sql.graph.SQLFunctionMove;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class FunctionCall extends SimpleNode {
@@ -452,6 +454,16 @@ public class FunctionCall extends SimpleNode {
   }
 
   /**
+   * Determinism is a property of the function's NAME, not of any particular call site or instance - so the answer
+   * is memoized per name here rather than re-resolved (and, for a class-registered built-in, reflectively
+   * re-instantiated) on every {@link #isCacheable()}/{@link #isFoldable()} check, both of which run on every
+   * execution of a statement containing this call, cache hit or not. Safe for the life of the JVM: the built-in
+   * registry {@link #resolveDeterministic(String)} reads is the process-wide {@link DefaultSQLFunctionFactory}
+   * singleton, populated once at construction and never mutated at runtime.
+   */
+  private static final Map<String, Boolean> DETERMINISTIC_FUNCTIONS = new ConcurrentHashMap<>();
+
+  /**
    * Resolves this call's target purely against the built-in {@link DefaultSQLFunctionFactory} registry - the same
    * static lookup {@link com.arcadedb.query.sql.SQLQueryEngine#getFunction(String)} consults first, before falling
    * back to a database-scoped user function library or the unified {@link com.arcadedb.function.FunctionRegistry} of
@@ -462,10 +474,14 @@ public class FunctionCall extends SimpleNode {
    * treated as not deterministic.
    */
   private boolean isDeterministicFunction() {
+    return DETERMINISTIC_FUNCTIONS.computeIfAbsent(name.getStringValue().toLowerCase(Locale.ENGLISH), FunctionCall::resolveDeterministic);
+  }
+
+  private static boolean resolveDeterministic(final String lowercaseName) {
     try {
-      final SQLFunction function = DefaultSQLFunctionFactory.getInstance().getFunctionInstance(name.getStringValue());
+      final SQLFunction function = DefaultSQLFunctionFactory.getInstance().getFunctionInstance(lowercaseName);
       return function != null && function.isDeterministic();
-    } catch (final Exception e) {
+    } catch (final CommandExecutionException e) {
       return false;
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
@@ -200,6 +200,13 @@ public class LevelZeroIdentifier extends SimpleNode {
     return collection != null && collection.isLiteral(allowInputParameters);
   }
 
+  /**
+   * @see Expression#isFoldable()
+   */
+  boolean isFoldableFunctionCall() {
+    return functionCall != null && functionCall.isFoldable();
+  }
+
   public SimpleNode splitForAggregation(final AggregateProjectionSplit aggregateProj, final CommandContext context) {
     if (isAggregate(context)) {
       final LevelZeroIdentifier result = new LevelZeroIdentifier();

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -141,6 +141,52 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
     assertThat(names("SELECT FROM Character WHERE uuid() = 'not-a-uuid'")).isEmpty();
   }
 
+  /**
+   * Issue #6190: {@code SQLFunction#isDeterministic()} lets a call to a marked-pure built-in over literal arguments
+   * fold exactly like a plain literal comparison would - the sibling of {@link #aFilterCallingAFunctionIsNeverFolded()}
+   * for the one shape that is now safe to evaluate at plan time.
+   */
+  @Test
+  void aFilterCallingADeterministicFunctionIsFolded() {
+    assertNoScan(planOf("SELECT FROM Character WHERE abs(-1) = 999"));
+    assertThat(names("SELECT FROM Character WHERE abs(-1) = 999")).isEmpty();
+
+    assertScan(planOf("SELECT FROM Character WHERE abs(-1) = 1"));
+    assertThat(names("SELECT FROM Character WHERE abs(-1) = 1")).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+  }
+
+  /**
+   * The plan-caching consumer of the same marker: a statement whose only function call targets a deterministic
+   * built-in over cacheable arguments is no longer excluded from the plan cache by {@code FunctionCall#isCacheable()}
+   * returning {@code false} unconditionally.
+   */
+  @Test
+  void aStatementWithADeterministicFunctionInTheFilterIsCacheable() {
+    final String sql = "SELECT name FROM Character WHERE age > abs(-1)";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    final long setupMillis = System.currentTimeMillis();
+    while (System.currentTimeMillis() == setupMillis)
+      Thread.onSpinWait();
+
+    assertThat(names(sql)).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+    assertThat(db.getExecutionPlanCache().contains(sql)).as("a deterministic function call must not block plan caching")
+        .isTrue();
+  }
+
+  /**
+   * The mirror of the previous test: a non-deterministic call in the filter still blocks caching, exactly as before
+   * this marker existed.
+   */
+  @Test
+  void aStatementWithANonDeterministicFunctionInTheFilterIsNotCacheable() {
+    final String sql = "SELECT name FROM Character WHERE age > 0 AND uuid() IS NOT NULL";
+    final DatabaseInternal db = (DatabaseInternal) database;
+
+    assertThat(names(sql)).containsExactlyInAnyOrder("Arya", "Jon", "Tyrion");
+    assertThat(db.getExecutionPlanCache().contains(sql)).isFalse();
+  }
+
   @Test
   void limitZeroDoesNotScanItsTarget() {
     final ResultSet rs = database.query("sql", "SELECT name FROM Character LIMIT 0");

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -165,6 +165,8 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
     final String sql = "SELECT name FROM Character WHERE age > abs(-1)";
     final DatabaseInternal db = (DatabaseInternal) database;
 
+    // the type creation in beginTest() invalidates the plan cache with a millisecond-resolution stamp the plan has
+    // to beat: see the sibling guard below and RidInScanOptimizationTest for the same pattern
     final long setupMillis = System.currentTimeMillis();
     while (System.currentTimeMillis() == setupMillis)
       Thread.onSpinWait();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6190FunctionDeterminismTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6190FunctionDeterminismTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6190: before this, nothing on {@link com.arcadedb.query.sql.executor.SQLFunction} told a pure function
+ * ({@code abs}) from one with a side effect or hidden input ({@code uuid}, {@code sysdate}), so the planner could
+ * not cache a plan containing a call, and constant folding refused to reach into one at all - both restrictions are
+ * pinned as the pre-existing behaviour in {@code Issue6179LiteralExpressionTest} and
+ * {@code ConstantFalseFilterFoldingTest#aFilterCallingAFunctionIsNeverFolded}.
+ * <p>
+ * These pin the two consumers that need no live database: {@link FunctionCall#isCacheable()} (plan caching) and
+ * {@link Expression#isFoldable()} (constant folding). The third site the issue names,
+ * {@code BinaryCondition#isIndexAware}'s plan-time probe of an indexed equality, is left unchanged - it cannot use
+ * this same marker without also losing the probe for a bound parameter (also "early calculated" but never a purity
+ * concern), which needs its own predicate; see the PR description.
+ */
+class Issue6190FunctionDeterminismTest extends AbstractParserTest {
+
+  private final CommandContext context = new BasicCommandContext();
+
+  private Expression rightOperandOf(final String query) {
+    final SelectStatement statement = (SelectStatement) checkRightSyntax(query);
+    final BooleanExpression term = statement.whereClause.flatten().getFirst().subBlocks.getFirst();
+    return ((BinaryCondition) term).right;
+  }
+
+  private FunctionCall functionCallIn(final String query) {
+    final Expression expression = rightOperandOf(query);
+    final BaseExpression baseExpression = (BaseExpression) expression.mathExpression;
+    return baseExpression.identifier.levelZero.functionCall;
+  }
+
+  @Test
+  void builtinsMarkedDeterministicAreExactlyTheVerifiedPureOnes() {
+    for (final String call : new String[] { "abs(-1)", "pow(2, 3)", "sqrt(4)", "coalesce(null, 1)", "ifnull(null, 1)",
+        "ifempty('', 'x')", "if(true, 1, 2)", "strcmpci('a', 'A')", "decode('YQ==', 'base64')" }) {
+      assertThat(functionCallIn("select from Foo where a = " + call).isCacheable()).as(call).isTrue();
+    }
+  }
+
+  /**
+   * {@code uuid()}/{@code sysdate()} read a random source / the clock; {@code encode()} can dereference a RID and
+   * read the record store; {@code format()} resolves locale-sensitive conversions against process-wide mutable
+   * state. None of the four may ever be marked deterministic.
+   */
+  @Test
+  void functionsWithHiddenInputsOrSideEffectsAreNeverCacheableOrFoldable() {
+    for (final String call : new String[] { "uuid()", "sysdate()", "encode('a', 'base64')", "format('%d', 1)" }) {
+      final String query = "select from Foo where a = " + call;
+      assertThat(functionCallIn(query).isCacheable()).as(call).isFalse();
+      assertThat(rightOperandOf(query).isFoldable()).as(call).isFalse();
+    }
+  }
+
+  @Test
+  void aUserDefinedOrUnknownFunctionIsConservativelyNotCacheable() {
+    assertThat(functionCallIn("select from Foo where a = thisFunctionDoesNotExist(1)").isCacheable()).isFalse();
+  }
+
+  @Test
+  void aDeterministicCallIsCacheableOnlyWhenItsArgumentsAre() {
+    assertThat(functionCallIn("select from Foo where a = abs(-1)").isCacheable())
+        .as("literal argument").isTrue();
+    assertThat(functionCallIn("select from Foo where a = abs(b)").isCacheable())
+        .as("a property read does not vary the plan shape, so it is cacheable too - like SuffixIdentifier.isCacheable()")
+        .isTrue();
+    assertThat(functionCallIn("select from Foo where a = abs(uuid())").isCacheable())
+        .as("a non-deterministic argument taints the whole call").isFalse();
+  }
+
+  @Test
+  void aGraphTraversalStaysCacheableRegardlessOfDeterminism() {
+    // isCacheable() must not regress the pre-existing graph-traversal exemption (out()/in()/both()/... are not
+    // SQLFunction.isDeterministic()-marked and never will be, since their result depends on the graph, not just
+    // their literal arguments)
+    assertThat(functionCallIn("select from Foo where a = out('E')").isCacheable()).isTrue();
+  }
+
+  @Test
+  void aLiteralIsFoldableAndSoIsANestedDeterministicCall() {
+    for (final String literal : new String[] { "1", "'x'", "true", "1 + 2 * 3" }) {
+      assertThat(rightOperandOf("select from Foo where a = " + literal).isFoldable()).as(literal).isTrue();
+    }
+    assertThat(rightOperandOf("select from Foo where a = abs(-1)").isFoldable())
+        .as("a bare deterministic call over a literal").isTrue();
+    assertThat(rightOperandOf("select from Foo where a = abs(pow(-2, 3))").isFoldable())
+        .as("a deterministic call nested inside another").isTrue();
+  }
+
+  @Test
+  void aPropertyOrInputParameterArgumentIsNeverFoldable() {
+    // isFoldable() feeds a value baked into a CACHED plan, so - like isLiteral() - it must refuse a bound parameter
+    // even though the parameter is resolved before the plan is built
+    assertThat(rightOperandOf("select from Foo where a = abs(b)").isFoldable()).isFalse();
+    assertThat(rightOperandOf("select from Foo where a = abs(:p)").isFoldable()).isFalse();
+  }
+
+  @Test
+  void aMethodCallOnADeterministicFunctionResultIsNotFoldable() {
+    // a modifier applied to the call's result is no longer a bare call; isFoldable() must not walk past it
+    assertThat(rightOperandOf("select from Foo where a = abs(-1).asString()").isFoldable()).isFalse();
+  }
+
+  /**
+   * isFoldable() is a strictly narrower, additive question - it must never replace
+   * {@link Expression#isEarlyCalculated(CommandContext)} (issue #6179), which still answers "computable without a
+   * record" for every function, pure or not. Pinning that for a function call needs a live database (see
+   * {@code Issue6179EarlyCalculatedModifierTest}); the literal case needs none.
+   */
+  @Test
+  void theEarlyCalculatedPredicateAdmitsMoreThanFoldableDoes() {
+    assertThat(rightOperandOf("select from Foo where a = :p").isEarlyCalculated(context))
+        .as("an input parameter is early calculated ...").isTrue();
+    assertThat(rightOperandOf("select from Foo where a = :p").isFoldable())
+        .as("... but never foldable, unlike isLiteral(true)").isFalse();
+  }
+}


### PR DESCRIPTION
Closes #6190

## Summary

Nothing on `SQLFunction` distinguished a pure function (`abs`, `pow`) from one that reads a random source, the clock, or the database (`uuid()`, `sysdate()`), so three places paid for the missing marker: the planner could not cache a plan whose `WHERE` contained any function call, constant folding refused to evaluate a function even over literal arguments, and a function in an indexed equality was invoked at plan time whether or not that was safe.

This adds `SQLFunction#isDeterministic()` (default `false`, matching the issue's "pure built-ins opt in" direction - the safe default when a user-defined function silently becoming foldable/cacheable would be a bad-in-the-wrong-direction, hard-to-notice defect), marks the built-ins verified to read only their own arguments (`abs`, `pow`, `sqrt`, `coalesce`, `ifnull`, `ifempty`, `if`, `decode`, `strcmpci`), and wires the marker into two of the three sites the issue names:

- **`FunctionCall#isCacheable()`**: a call to a deterministic built-in over cacheable arguments no longer forces the whole statement out of the plan cache. Previously *any* function call other than a graph traversal (`out`/`in`/`both`/...) did.
- **`Expression#isFoldable()`**: the "constant-folding sibling" `isLiteral()`'s own javadoc reserved for exactly this marker (see the comment on `Expression#isLiteral()` predating this PR). `BinaryCondition#isAlwaysTrue`/`isAlwaysFalse` now fold a comparison like `1 = abs(-1)`, without ever invoking the function merely to classify the expression - `isFoldable()` only consults `isDeterministic()`, a compile-time-constant getter.

### Excluded from the deterministic list, deliberately

- **`encode()`**: it dereferences a RID and reads the record store when given one, so its result is not a pure function of its literal arguments - the same class of hazard the issue warns a wrong `true` produces.
- **`format()`**: `String.format` resolves grouping/decimal-separator and similar conversions against the JVM's process-wide mutable default `Locale`, which is state outside the arguments.
- **`concat()`** (the `DefaultSQLFunctionFactory` one): it's actually a multi-row aggregate (`SQLAggregatedFunction`), not the two-arg literal-concatenation the issue's example suggests - never a candidate.

### Site 3 (`BinaryCondition#isIndexAware`) is intentionally left unchanged

The issue's third example - `WHERE name = uuid()` invoking `uuid()` once at plan time and once to build the index key - is real, but `isIndexAware`'s eager evaluation is gated on `Expression#isEarlyCalculated()`, which (by design, see issue #6179) also admits a bound parameter. `isFoldable()` correctly *excludes* bound parameters, matching `isLiteral()`'s "never bake this execution's binding into a cached plan" requirement. Reusing `isFoldable()` at that site would silently drop the empty-collection short-circuit for the ordinary `WHERE indexed = :param` shape - a real regression on what is probably the single most common indexed-equality query, in exchange for skipping one extra invocation of a non-deterministic function, which is not a correctness bug today (the issue says as much: "Not urgent... nothing here is a correctness bug"). That site needs its own predicate ("early-calculated minus non-deterministic function calls") rather than reusing either existing one; deferred as a follow-up rather than rushed into this PR.

### Also deferred

- Auditing `SQLMethod` (the issue names it alongside `SQLFunction`) and wiring `MethodCall#isCacheable()` the same way - mechanically identical to what's done here, but a second ~60-entry registry audit (`DefaultSQLMethodFactory`) that deserves its own PR rather than doubling this one's surface.
- Extending the built-in `isDeterministic()` audit to the geo/vector function families - plausibly pure but not individually verified here to the same standard as the ~10 marked in this PR.
- The unified `FunctionRegistry`/`StatelessFunction` catalog (text/math/convert/date/util functions reached through a different code path than `DefaultSQLFunctionFactory`) is untouched; a call resolved only through it is conservatively non-deterministic by default, same as before this PR.

## Test plan

- [x] `Issue6190FunctionDeterminismTest` (new): pins which built-ins are marked deterministic, that a non-deterministic/RID-reading/locale-sensitive function is never marked, that an unknown/user-defined function is conservatively not cacheable, that a deterministic call is cacheable only when its own arguments are, that the pre-existing graph-traversal cacheability exemption is untouched, that `isFoldable()` accepts literals and nested deterministic calls but rejects a property/parameter argument or a modifier applied to the call's result, and that `isFoldable()` stays strictly narrower than `isEarlyCalculated()`.
- [x] `ConstantFalseFilterFoldingTest` (extended): end-to-end - `WHERE abs(-1) = 999` is folded to no-scan/no-rows like a literal comparison would be, the pre-existing `uuid()` non-fold regression test is untouched, a statement with a deterministic function in the filter is confirmed in the execution plan cache, and the mirror case with `uuid()` is confirmed still excluded from it.
- [x] `mvn -pl engine -am compile` - clean.
- [x] `mvn -pl engine -am test` over `com.arcadedb.query.sql.parser.**`, `com.arcadedb.query.sql.executor.**`, `com.arcadedb.query.sql.function.**`, and `com.arcadedb.function.**` (excluding benchmark/slow/vector lanes) - 1884+ tests, 0 failures, 0 errors, including `Issue6179LiteralExpressionTest`, `Issue6179EarlyCalculatedModifierTest`, `PartitionPruningPlannerTest`, and `SelectStatementTest`, the existing tests closest to this change.
