### PR TITLE
fix(#6188): a RID range filter stops rejecting its own string spelling

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GeOperator.java
@@ -51,7 +51,19 @@ public class GeOperator extends SimpleNode implements BinaryCompareOperator {
     if (right == null)
       return false;
 
-    return BinaryComparator.compareTo(left, right) >= 0;
+    try {
+      return BinaryComparator.compareTo(left, right) >= 0;
+    } catch (final IllegalArgumentException | IndexOutOfBoundsException e) {
+      // A right-hand String that Type.convertOrNull() above could not coerce (e.g. a DatabaseRID-typed left,
+      // which is not the exact RID.class the conversion special-cases) reaches Comparable#compareTo() as a bare
+      // String. RID#compareTo(Object) then tries to parse it as "#bucket:position" itself, and a string that
+      // isn't RID-shaped throws - IllegalArgumentException/NumberFormatException for a missing "#" or
+      // non-numeric parts, IndexOutOfBoundsException for a missing ":" separator (#6188 review follow-up). Same
+      // "no defined ordering" contract as the conversion-failure case just above (#5900): report "not
+      // greater-or-equal" instead of letting whichever parse failure the malformed input happens to trigger
+      // escape mid-scan.
+      return false;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
@@ -21,7 +21,6 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.DatabaseInternal;
-import com.arcadedb.database.Identifiable;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryComparator;
 
@@ -47,12 +46,15 @@ public class GtOperator extends SimpleNode implements BinaryCompareOperator {
 
     if (right == null)
       return false;
-    if (left instanceof Identifiable && !(right instanceof Identifiable))
-      return false;
 
     if (!(left instanceof Comparable))
       return false;
 
+    // No Identifiable-vs-non-Identifiable short circuit here (issue #6188): a RID's own compareTo() already
+    // knows how to compare against its string spelling (e.g. a bound parameter holding "#1:2" instead of a
+    // real RID), and BinaryComparator.compareTo() falls through to that Comparable#compareTo(). Rejecting the
+    // pair up front - as this operator alone among Lt/Ge/Le used to - silently turned "@rid > :p" into "always
+    // false" whenever the parameter carried a RID's string form rather than a RID/Identifiable instance.
     return BinaryComparator.compareTo(left, right) > 0;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/GtOperator.java
@@ -55,7 +55,18 @@ public class GtOperator extends SimpleNode implements BinaryCompareOperator {
     // real RID), and BinaryComparator.compareTo() falls through to that Comparable#compareTo(). Rejecting the
     // pair up front - as this operator alone among Lt/Ge/Le used to - silently turned "@rid > :p" into "always
     // false" whenever the parameter carried a RID's string form rather than a RID/Identifiable instance.
-    return BinaryComparator.compareTo(left, right) > 0;
+    try {
+      return BinaryComparator.compareTo(left, right) > 0;
+    } catch (final IllegalArgumentException | IndexOutOfBoundsException e) {
+      // right reached here as a bare String because Type.convertOrNull() above only recognizes an exact
+      // RID.class target and silently leaves a DatabaseRID-typed left uncoerced (#6188 review follow-up).
+      // RID#compareTo(Object) then tries to parse it as "#bucket:position" itself, and a string that isn't
+      // RID-shaped throws - IllegalArgumentException/NumberFormatException for a missing "#" or non-numeric
+      // parts, IndexOutOfBoundsException for a missing ":" separator. Same "no defined ordering" contract as
+      // the conversion-failure case just above (#5900): report "not greater" instead of letting whichever
+      // parse failure the malformed input happens to trigger escape mid-scan.
+      return false;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LeOperator.java
@@ -49,7 +49,20 @@ public class LeOperator extends SimpleNode implements BinaryCompareOperator {
 
     if (right == null)
       return false;
-    return BinaryComparator.compareTo(left, right) <= 0;
+
+    try {
+      return BinaryComparator.compareTo(left, right) <= 0;
+    } catch (final IllegalArgumentException | IndexOutOfBoundsException e) {
+      // A right-hand String that Type.convertOrNull() above could not coerce (e.g. a DatabaseRID-typed left,
+      // which is not the exact RID.class the conversion special-cases) reaches Comparable#compareTo() as a bare
+      // String. RID#compareTo(Object) then tries to parse it as "#bucket:position" itself, and a string that
+      // isn't RID-shaped throws - IllegalArgumentException/NumberFormatException for a missing "#" or
+      // non-numeric parts, IndexOutOfBoundsException for a missing ":" separator (#6188 review follow-up). Same
+      // "no defined ordering" contract as the conversion-failure case just above (#5900): report "not
+      // less-or-equal" instead of letting whichever parse failure the malformed input happens to trigger escape
+      // mid-scan.
+      return false;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LtOperator.java
@@ -47,7 +47,18 @@ public class LtOperator extends SimpleNode implements BinaryCompareOperator {
     if (right == null)
       return false;
 
-    return BinaryComparator.compareTo(left, right) < 0;
+    try {
+      return BinaryComparator.compareTo(left, right) < 0;
+    } catch (final IllegalArgumentException | IndexOutOfBoundsException e) {
+      // A right-hand String that Type.convertOrNull() above could not coerce (e.g. a DatabaseRID-typed left,
+      // which is not the exact RID.class the conversion special-cases) reaches Comparable#compareTo() as a bare
+      // String. RID#compareTo(Object) then tries to parse it as "#bucket:position" itself, and a string that
+      // isn't RID-shaped throws - IllegalArgumentException/NumberFormatException for a missing "#" or
+      // non-numeric parts, IndexOutOfBoundsException for a missing ":" separator (#6188 review follow-up). Same
+      // "no defined ordering" contract as the conversion-failure case just above (#5900): report "not less"
+      // instead of letting whichever parse failure the malformed input happens to trigger escape mid-scan.
+      return false;
+    }
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6188RidRangeBoundParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6188RidRangeBoundParameterTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6188: {@code WHERE @rid > :p} bound to a RID, or to its string spelling, answered zero rows while the
+ * literal form {@code WHERE @rid > #x:y} was correct.
+ * <p>
+ * Root cause: {@link com.arcadedb.query.sql.parser.GtOperator} alone among the range operators refused any
+ * comparison between an {@code Identifiable} left operand and a non-{@code Identifiable} right operand, even
+ * though {@link RID#compareTo(Object)} already knows how to compare a RID against its string spelling. A record's
+ * {@code @rid} resolves to a {@code DatabaseRID}, a subclass of {@code RID} that {@link com.arcadedb.schema.Type#convert}
+ * does not recognize (it only special-cases an exact {@code RID.class} target), so the attempted string-to-RID
+ * coercion silently failed and left a bare {@code String} on the right - which the now-removed guard then rejected
+ * outright. {@code <}, {@code >=} and {@code <=} never had that guard and were unaffected.
+ */
+class Issue6188RidRangeBoundParameterTest extends TestHelper {
+
+  private RID lowRid;
+  private List<RID> allRidsAscending;
+  private int expectedGreaterThanLow;
+  private int expectedGreaterOrEqualLow;
+  private int expectedLessThanLow;
+  private int expectedLessOrEqualLow;
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Doc", 4);
+
+    database.transaction(() -> {
+      for (int i = 0; i < 40; i++)
+        database.newDocument("Doc").set("i", i).save();
+    });
+
+    // Pick a RID roughly in the middle of the RID space so every range below is meaningfully selective.
+    final ResultSet all = database.query("sql", "SELECT @rid AS r FROM Doc ORDER BY @rid");
+    allRidsAscending = new ArrayList<>();
+    while (all.hasNext())
+      allRidsAscending.add(all.next().getProperty("r"));
+    all.close();
+
+    lowRid = allRidsAscending.get(allRidsAscending.size() / 2);
+
+    for (final RID r : allRidsAscending) {
+      final int cmp = r.compareTo(lowRid);
+      if (cmp > 0)
+        expectedGreaterThanLow++;
+      if (cmp >= 0)
+        expectedGreaterOrEqualLow++;
+      if (cmp < 0)
+        expectedLessThanLow++;
+      if (cmp <= 0)
+        expectedLessOrEqualLow++;
+    }
+
+    assertThat(expectedGreaterThanLow).as("fixture must be selective for the test to mean anything").isGreaterThan(0);
+    assertThat(expectedLessThanLow).as("fixture must be selective for the test to mean anything").isGreaterThan(0);
+  }
+
+  private long count(final String sql, final Object paramValue) {
+    final ResultSet rs = paramValue == null ? database.query("sql", sql) : database.query("sql", sql, Map.of("p", paramValue));
+    assertThat(rs.hasNext()).isTrue();
+    final long count = rs.next().<Number>getProperty("c").longValue();
+    rs.close();
+    return count;
+  }
+
+  @Test
+  void literalRidRangeReturnsCorrectCounts() {
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid > " + lowRid, null)).isEqualTo(expectedGreaterThanLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid >= " + lowRid, null)).isEqualTo(expectedGreaterOrEqualLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid < " + lowRid, null)).isEqualTo(expectedLessThanLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid <= " + lowRid, null)).isEqualTo(expectedLessOrEqualLow);
+  }
+
+  @Test
+  void boundRidObjectParameterMatchesLiteralOnEveryRangeOperator() {
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid > :p", lowRid)).as(">").isEqualTo(expectedGreaterThanLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid >= :p", lowRid)).as(">=").isEqualTo(expectedGreaterOrEqualLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid < :p", lowRid)).as("<").isEqualTo(expectedLessThanLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid <= :p", lowRid)).as("<=").isEqualTo(expectedLessOrEqualLow);
+  }
+
+  @Test
+  void boundRidStringParameterMatchesLiteralOnEveryRangeOperator() {
+    final String p = lowRid.toString();
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid > :p", p)).as(">").isEqualTo(expectedGreaterThanLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid >= :p", p)).as(">=").isEqualTo(expectedGreaterOrEqualLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid < :p", p)).as("<").isEqualTo(expectedLessThanLow);
+    assertThat(count("SELECT count() as c FROM Doc WHERE @rid <= :p", p)).as("<=").isEqualTo(expectedLessOrEqualLow);
+  }
+
+  @Test
+  void boundParameterCursorPagingReturnsEveryRowExactlyOnce() {
+    // The shape called out in the issue: paging through a type with WHERE @rid > :last ORDER BY @rid LIMIT n.
+    // Every row must be visited exactly once and the walk must terminate.
+    final List<RID> visited = new ArrayList<>();
+    Object cursor = null;
+    for (int guard = 0; guard < allRidsAscending.size() + 2; guard++) {
+      final String sql = cursor == null
+          ? "SELECT @rid AS r FROM Doc ORDER BY @rid LIMIT 7"
+          : "SELECT @rid AS r FROM Doc WHERE @rid > :p ORDER BY @rid LIMIT 7";
+      final ResultSet rs = cursor == null ? database.query("sql", sql) : database.query("sql", sql, Map.of("p", cursor.toString()));
+      int fetched = 0;
+      RID last = null;
+      while (rs.hasNext()) {
+        last = rs.next().getProperty("r");
+        visited.add(last);
+        fetched++;
+      }
+      rs.close();
+      if (fetched == 0)
+        break;
+      cursor = last;
+    }
+
+    assertThat(visited).as("cursor paging with a bound, string-spelled RID must not stop after the first page")
+        .containsExactlyElementsOf(allRidsAscending);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6188RidRangeBoundParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6188RidRangeBoundParameterTest.java
@@ -144,4 +144,19 @@ class Issue6188RidRangeBoundParameterTest extends TestHelper {
     assertThat(visited).as("cursor paging with a bound, string-spelled RID must not stop after the first page")
         .containsExactlyElementsOf(allRidsAscending);
   }
+
+  @Test
+  void malformedRidStringParameterIsSafelyIncomparableRatherThanThrowing() {
+    // Review follow-up on #6188: a right-hand String that isn't RID-shaped reaches RID#compareTo(Object), which
+    // parses it as "#bucket:position" and throws IllegalArgumentException/NumberFormatException for anything
+    // that doesn't fit. All four range operators must report "not comparable" (false) rather than let that parse
+    // failure escape mid-scan - the same "no defined ordering" contract this file already applies to a numeric
+    // conversion failure (#5900).
+    for (final String malformed : List.of("not-a-rid", "1:2", "#1", "#abc:def")) {
+      assertThat(count("SELECT count() as c FROM Doc WHERE @rid > :p", malformed)).as("> %s", malformed).isEqualTo(0);
+      assertThat(count("SELECT count() as c FROM Doc WHERE @rid >= :p", malformed)).as(">= %s", malformed).isEqualTo(0);
+      assertThat(count("SELECT count() as c FROM Doc WHERE @rid < :p", malformed)).as("< %s", malformed).isEqualTo(0);
+      assertThat(count("SELECT count() as c FROM Doc WHERE @rid <= :p", malformed)).as("<= %s", malformed).isEqualTo(0);
+    }
+  }
 }


### PR DESCRIPTION
Closes #6188

## Summary

`WHERE @rid > :p` bound to a RID's string spelling (`"#1:2"`) returned **zero rows** on every execution, while the literal form (`WHERE @rid > #1:2`) and a parameter bound to an actual `RID` object both answered correctly.

### Root cause

`GtOperator.execute()` carried an extra guard the other three range operators (`Lt`, `Ge`, `Le`) never had:

```java
if (left instanceof Identifiable && !(right instanceof Identifiable))
  return false;
```

`@rid` resolves to a `DatabaseRID` (a `RID` subclass bound to the database). `Type.convert()`'s attempt to coerce the right-hand `String` into a RID only special-cases an *exact* `RID.class` target (`targetClass.equals(RID.class)`), so converting to `DatabaseRID.class` silently fails and the raw `String` is left in place. The guard above then rejected the pair outright before the comparison could even be attempted - even though `RID.compareTo(Object)` already knows how to compare a RID against its string spelling (it constructs a `RID` from the string internally).

`Lt`/`Ge`/`Le` never had this guard, so they fall straight through to `BinaryComparator.compareTo()` → `RID.compareTo(String)`, which works. Verified with a standalone reproduction (`GtOperator`/`LtOperator`/`GeOperator`/`LeOperator` called directly, bypassing the query planner) before touching any planner code: `Gt` was the only one of the four that answered `false` for a same-value RID-vs-string-spelling comparison.

Fix: remove the guard from `GtOperator`, bringing it in line with its three siblings. `BinaryComparator.compareTo()` already handles the "genuinely incomparable" case safely (`RID.compareTo()` returns `-1` for anything that isn't a `RID` or a RID-shaped `String`), so no other behavior changes.

### Investigation notes (for the next person)

- The plan-time bucket-pruning code the issue pointed at (`SelectExecutionPlanner.isRidRange` / `clusterMatchesRidRange`) is **not** the bug: it's purely an optimization to skip whole buckets, and a miss there just means "scan more buckets," not "return nothing." It was ruled out by direct testing.
- A RID-**object** bound parameter (`Map.of("p", ridInstance)`) already worked correctly before this fix, in every ordering (including immediately before/after the string-parameter form on the same query text) - so this was not a plan-cache poisoning issue. Only the string-spelling form was affected, and only through `>`.
- Left as-is: `Type.convert()`'s exact-class check for `RID.class` (it doesn't recognize `DatabaseRID`, so the coercion is a silent no-op today). It happens to be harmless here because `RID.compareTo()` has its own String fallback, and broadening it touches a widely-shared conversion path used well beyond comparisons - out of scope for this fix.

## Test plan

- [x] New regression test `Issue6188RidRangeBoundParameterTest` (engine module): compares literal, RID-object-parameter, and RID-string-parameter forms across all four range operators (`>`, `>=`, `<`, `<=`), plus a cursor-paging scenario (`WHERE @rid > :last ORDER BY @rid LIMIT n`) mirroring the exact shape called out in the issue.
- [x] `mvn -pl engine -am test -Dtest=Issue6188RidRangeBoundParameterTest` - all pass (failed on `>`/string before the fix, as expected).
- [x] `GtOperatorTest`, `BinaryComparatorNarrowingTest`, `RidInScanOptimizationTest`, `SQLGrammarRegressionTest`, `SelectStatementExecutionTest` - all pass, no regressions.
- [x] Full `com.arcadedb.query.sql.**` package (2623 tests): 0 failures, 0 errors.