### PR TITLE
fix(#6186): MathExpression.isLiteral()'s javadoc no longer names a shape that folds

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -1108,10 +1108,9 @@ public class MathExpression extends SimpleNode {
 
   /**
    * A compound arithmetic expression is a literal one only when every one of its operands is. A subclass that keeps
-   * its operands outside {@link #childExpressions} - an array literal, a CASE, the arithmetic parenthesis of
-   * {@code (1) = 0} - would inherit the {@code false} an empty operand list gives, which is the safe answer but a
-   * missed fold; each of those overrides this and answers for itself. A node this walker cannot see into is never
-   * mistaken for a literal.
+   * its operands outside {@link #childExpressions} - an array literal, a CASE - would inherit the {@code false} an
+   * empty operand list gives, which is the safe answer but a missed fold; each of those overrides this and answers
+   * for itself. A node this walker cannot see into is never mistaken for a literal.
    *
    * @see Expression#isLiteral(boolean)
    */

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConstantFalseFilterFoldingTest.java
@@ -318,6 +318,25 @@ class ConstantFalseFilterFoldingTest extends TestHelper {
     rs.close();
   }
 
+  @Test
+  void anArithmeticParenthesisFoldsAtAnyNestingDepth() {
+    // MathExpression.isLiteral()'s javadoc names an array literal and a CASE as the shapes whose operands sit
+    // outside childExpressions and would be missed folds without their own override; an arithmetic parenthesis is
+    // NOT one of them (issue #6186) - ParenthesisExpression's own isLiteral() override answers for it too, so
+    // nesting one, or wrapping it in further arithmetic, still folds
+    assertNoScan(planOf("SELECT FROM Character WHERE (1) = 0"));
+    assertNoScan(planOf("SELECT FROM Character WHERE (1+1) = 0"));
+    assertNoScan(planOf("SELECT FROM Character WHERE (1+1)*2 = 0"));
+  }
+
+  @Test
+  void anArrayLiteralAccessAndACaseAreNotFoldedYet() {
+    // the two shapes MathExpression.isLiteral()'s javadoc does name: pinned here so the comment cannot drift the
+    // other way either. Both are SCAN WITH FILTER today, not EMPTY RESULT - unlike the arithmetic parenthesis above
+    assertScan(planOf("SELECT FROM Character WHERE [1,2][0] = 0"));
+    assertScan(planOf("SELECT FROM Character WHERE (CASE WHEN 1=1 THEN 1 ELSE 2 END) = 0"));
+  }
+
   private ExecutionPlan planOf(final String sql, final Object... params) {
     try (final ResultSet rs = params.length == 0 ? database.query("sql", sql) : database.query("sql", sql, params)) {
       return rs.getExecutionPlan().orElseThrow();


### PR DESCRIPTION
## What does this PR do?

Corrects the javadoc on `MathExpression.isLiteral(boolean)` and pins the behaviour it describes with a regression test.

The comment listed three subclasses whose operands live outside `childExpressions` and would therefore be missed folds without their own `isLiteral(boolean)` override: an array literal, a CASE, and "the arithmetic parenthesis of `(1) = 0`". The third example is wrong. Measured on the merged code:

```
SELECT FROM C WHERE (1) = 0        -> + EMPTY RESULT (folds)
SELECT FROM C WHERE (1+1) = 0      -> + EMPTY RESULT (folds)
SELECT FROM C WHERE (1+1)*2 = 0    -> + EMPTY RESULT (folds)

SELECT FROM C WHERE [1,2][0] = 0   -> + SCAN WITH FILTER ... [1, 2][0] = 0
SELECT FROM C WHERE (CASE WHEN 1=1 THEN 1 ELSE 2 END) = 0
                                    -> + SCAN WITH FILTER ... CASE WHEN 1 = 1 THEN 1 ELSE 2 END = 0
```

An arithmetic parenthesis folds; the array literal and the CASE are the shapes that currently do not. The line was added in #6181/#6182 in response to a review observation that turned out to be untested. This PR:

1. Drops the parenthesis example from the javadoc list, keeping the array literal and the CASE.
2. Adds two tests to `ConstantFalseFilterFoldingTest` pinning both sides of the behaviour the comment now describes - the arithmetic-parenthesis shapes that fold (`(1) = 0`, `(1+1) = 0`, `(1+1)*2 = 0`) and the array-literal/CASE shapes that do not - so a future edit to the comment can't drift from measured behaviour again without a test going red.

No behavioural change. Whether the array-literal and CASE shapes *should* also fold is a separate, un-filed question - out of scope here since this issue is doc-only.

## Motivation

Closes #6186 - the javadoc drifted from the actual behaviour of the code it documents, which is worse than no comment at all because it actively misleads the next reader.

## Related issues

Closes #6186
Spun out of #6181 / #6182, where the inaccurate line was introduced.

## Additional Notes

Verified by running `ConstantFalseFilterFoldingTest` (26 tests, including the 2 new ones) and `Issue6179LiteralExpressionTest` (11 tests) - both green - plus a full `test-compile` of the `engine` module.

## Test plan

- [x] `mvn -pl engine -am test -Dtest=ConstantFalseFilterFoldingTest` - 26/26 pass, including the two new tests pinning the folding and non-folding shapes
- [x] `mvn -pl engine -am test -Dtest=Issue6179LiteralExpressionTest` - 11/11 pass (no regression in the neighbouring `isLiteral`/`isEarlyCalculated` coverage)
- [x] `mvn -pl engine -am test-compile` - full module compiles clean

## Checklist

- [x] I have run the build using `mvn clean package` command (targeted module build; see Test plan)
- [x] My unit tests cover both failure and success scenarios
