### PR TITLE
fix(#6342, #6341): a repair pass gives back the transaction it opened, and the dictionary guard reads the bytes rather than the outcome of a page read

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3262,3 +3262,53 @@ that path keys on is unaffected.
 [#6319](https://github.com/ArcadeData/arcadedb/issues/6319)
 [#6320](https://github.com/ArcadeData/arcadedb/issues/6320)
 [#6314](https://github.com/ArcadeData/arcadedb/issues/6314)
+
+### A repair pass that fails anywhere but its batch commit no longer abandons its transaction (#6342)
+
+Every repair pass of `GraphDatabaseChecker` - the vertex arm, the edge arm and the orphaned-edge-segment
+reclaim - opened a transaction of its own and committed it as the LAST statement of its `try`, with a
+`finally` that filled in the returned counters and nothing else. So the ONE failure that was already safe was
+a batch commit that throws: `LocalDatabase.commit()` disposes its own context in a `finally` whether or not
+the write succeeded, which is what `CheckDatabaseRepairBatchFailureTest` pins. Every OTHER way the body could
+throw - a scan that fails, an unreadable page, an `IllegalStateException` out of a repair - left the pass's
+own transaction open on the thread.
+
+What that costs depends on who is underneath. `CHECK DATABASE` arrives through the HTTP handler with a
+transaction already open, so the pass's own is NESTED on top of it: the handler's cleanup `rollback()` -
+running because of the very exception that caused this - then popped the abandoned nested transaction and
+left the handler's, which is the opposite of what it intended, and the caller was left holding work it
+believes it has just discarded. Embedded, with nothing underneath, the next user of that thread inherited an
+in-flight transaction from a repair that had already failed.
+
+The answer is not `commit()` in a `finally`, and not acting on `database.isTransactionActive()`: under an
+outer transaction that question answers "yes" for somebody else's, so cleaning up on that evidence rolls back
+work the pass never made. `RepairTransaction` - introduced for the bucket repairs of #6320 and now shared by
+all four passes - tracks ownership explicitly, dropping it before each batch commit and taking it back after,
+so the cleanup can only ever touch a transaction the pass itself opened and still holds. A pass that fails
+part-way now rolls back the batch in flight and keeps the ones already committed, which is the semantics
+#6128 gave these repairs in the first place.
+
+### The schema dictionary's truncation guard now reads the bytes, not the outcome of a page read (#6341)
+
+A dictionary page the component's page count claims but that is not really there must stop the load: an empty
+page contributes zero names, so every name after it comes back with an id lower by however many the missing
+page held, and those ids are written inside records. Silently renumbering them is the one outcome that class
+exists to prevent.
+
+The guard inferred "the page is not there" from the page manager refusing the read, and the page manager
+refuses only a page past the END of the file. It cannot refuse a hole INSIDE it - and a hole is exactly what
+the scenario the guard names produces. A partial replication replay writes page N without the ones before it,
+and writing at offset `N * pageSize` extends the file over every page it skipped rather than leaving the file
+short. Those pages read back as zeroes, a zero page declares a content size of zero, and the load took that
+for a legal empty page: no error, no names from it, and every name after it renumbered. Reproduced by
+shipping one replicated dictionary page one further along than the follower expected.
+
+Every dictionary page ever written carries the four-byte legacy counter, on the append path and on the
+whole-file rewrite alike, so a content size below it is not a legal empty page - it is a page nobody wrote.
+`reload()` now says so, which is a statement about the bytes rather than about whether a read happened to
+succeed, and therefore also covers an unwritten image reaching it by any other route. Page 0 keeps its one
+deliberate exemption: materialising it for a file shorter than one page is what keeps a database killed
+mid-write openable, and there is nothing before it to renumber.
+
+[#6342](https://github.com/ArcadeData/arcadedb/issues/6342)
+[#6341](https://github.com/ArcadeData/arcadedb/issues/6341)

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -505,10 +505,29 @@ public class Dictionary extends PaginatedComponent {
           page = database.getPageManager()
               .getImmutablePage(new PageId(database, file.getFileId(), pageNumber), pageSize, false, pageNumber == 0);
         } catch (final IllegalArgumentException e) {
-          throw new DatabaseMetadataException(
-              "Schema dictionary of database '" + database.getName() + "' is truncated: page " + pageNumber + " of " + totalPages
-                  + " is missing. Reading on would silently renumber every name stored after it", e);
+          throw new DatabaseMetadataException(truncatedMessage(pageNumber, totalPages, "is missing"), e);
         }
+
+        // AND THE READ ANSWERING IS NOT THE SAME FACT AS THE PAGE BEING THERE (ISSUE #6341). THE GUARD ABOVE ASKS THE PAGE MANAGER,
+        // WHICH REFUSES ONLY A PAGE PAST THE END OF THE FILE - IT CANNOT REFUSE A HOLE *INSIDE* IT, AND A HOLE IS EXACTLY WHAT THE
+        // SCENARIO THIS CLASS NAMES PRODUCES: A PARTIAL REPLICATION REPLAY WRITES PAGE N WITHOUT THE ONES BEFORE IT, AND WRITING AT
+        // OFFSET N * pageSize EXTENDS THE FILE OVER THE SKIPPED PAGES RATHER THAN LEAVING IT SHORT. THOSE PAGES THEN READ BACK AS
+        // ZEROES, AND A ZERO PAGE DECLARES A CONTENT SIZE OF ZERO - SO THE LOOP BELOW READS NOTHING FROM IT AND EVERY NAME AFTER IT
+        // COMES BACK WITH AN ID LOWER BY HOWEVER MANY THE SKIPPED PAGE HELD. SILENTLY, WHICH IS THE ONE OUTCOME THIS CLASS EXISTS
+        // TO PREVENT.
+        //
+        // EVERY DICTIONARY PAGE EVER WRITTEN CARRIES THE LEGACY COUNTER (updateCounters(), ON BOTH addPage() AND
+        // resetPageForRewrite()), SO A CONTENT SIZE BELOW IT IS NOT A LEGAL EMPTY PAGE: IT IS A PAGE NOBODY WROTE. THAT IS A
+        // STATEMENT ABOUT THE BYTES, NOT ABOUT WHETHER A READ HAPPENED TO SUCCEED, WHICH IS WHY IT ALSO COVERS AN INVENTED OR
+        // OTHERWISE UNWRITTEN IMAGE REACHING HERE BY ANY OTHER ROUTE.
+        //
+        // PAGE 0 IS DELIBERATELY EXEMPT, AND IT IS THE ONE PAGE THAT CAN BE: ITS createIfNotExists ABOVE MATERIALISES PAGE 0 OF A
+        // FILE SHORTER THAN ONE PAGE (KILLED MID-WRITE), WHICH IS WHAT THE SINGLE-PAGE READER DID AND WHAT KEEPS SUCH A DATABASE
+        // OPENABLE. THERE IS NOTHING AFTER IT TO RENUMBER.
+        if (page == null)
+          throw new DatabaseMetadataException(truncatedMessage(pageNumber, totalPages, "is missing"));
+        if (pageNumber > 0 && page.getContentSize() < DICTIONARY_HEADER_SIZE)
+          throw new DatabaseMetadataException(truncatedMessage(pageNumber, totalPages, "was never written"));
 
         page.setBufferPosition(DICTIONARY_HEADER_SIZE);
         while (page.getBufferPosition() < page.getContentSize())
@@ -529,6 +548,16 @@ public class Dictionary extends PaginatedComponent {
 
       this.entries = new Entries(names, size, newDictionaryMap);
     }
+  }
+
+  /**
+   * One wording for both ways a claimed page can fail to be readable content - it is past the end of the file, or it is a hole
+   * inside it - because they are the same fact to whoever reads the message: the dictionary cannot be loaded without moving ids
+   * that are already written inside records.
+   */
+  private String truncatedMessage(final int pageNumber, final int totalPages, final String what) {
+    return "Schema dictionary of database '" + database.getName() + "' is truncated: page " + pageNumber + " of " + totalPages
+        + " " + what + ". Reading on would silently renumber every name stored after it";
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1117,9 +1117,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // #6320: how many pages of repairs one transaction of this pass may accumulate before committing and opening the
     // next. Read once - it is a database-scoped setting and cannot change under a running check - and read here rather
     // than kept in a field because a bucket outlives any number of checks.
-    final RepairTransaction repairTx = new RepairTransaction(fix ?
-            database.getConfiguration().getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES) :
-            0);
+    final RepairTransaction repairTx = new RepairTransaction(database,
+            fix ? RepairTransaction.configuredBatchPages(database) : 0);
 
     if (!fix)
       return checkInternal(verboseLevel, false, repairTx);
@@ -1476,88 +1475,6 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     stats.put("totalErrors", totals.totalErrors);
 
     return stats;
-  }
-
-  /**
-   * The transaction one run of {@link #check(int, boolean)} makes its repairs in, and the only thing that knows
-   * whether that run still OWNS one (#6320).
-   * <p>
-   * <b>The batching.</b> {@link #commitBatchIfFull} commits the repairs made so far and opens the next transaction
-   * once they have dirtied {@code batchPages} pages - the same accounting
-   * {@code GraphDatabaseChecker.commitRepairBatchIfFull} makes over the graph repairs, against the same setting,
-   * {@link GlobalConfiguration#CHECK_DATABASE_REPAIR_BATCH_PAGES}. #6294 bounded the orphaned-chunk sweep with a memory
-   * budget of its own and stopped when it was spent, leaving the rest for the next {@code FIX}; the record repairs of
-   * the same method - four force-deletes in the per-slot loop, each taking its record's page plus every page its chain
-   * touches - were bounded by nothing at all and could reach the {@code OutOfMemoryError} of #4653 through the other
-   * loop. Bounding them the same way would have been the wrong half of the answer twice over: what is scarce is ONE
-   * pool (the transaction's page copies), so two budgets over it cannot both be right; and a repair that stops when the
-   * pool is spent leaves an operator running {@code FIX} over and over to converge. Committing instead gives the pool
-   * back, so one run repairs everything a bucket has wrong, with the memory bounded throughout.
-   * <p>
-   * PAGES, not repairs: the WAL entry carries page images, and how many records a repair touched says nothing about
-   * how many distinct pages it dirtied. {@code TransactionContext.getModifiedPages()} counts modified and new pages,
-   * which is what the entry will hold - and under HA what a Raft entry must stay below (#6128).
-   * <p>
-   * A SOFT ceiling, checked BETWEEN units of repair work and never inside one: a transaction can exceed it by whatever
-   * the unit in flight dirties (a chain repair walking a very long chain). It never interrupts a repair half-way,
-   * which is the property that makes a partial run safe - every record is either repaired or untouched. Set the
-   * configuration to 0 to get the single all-or-nothing transaction back, memory cost included.
-   * <p>
-   * <b>Why ownership is a field and not {@code database.isTransactionActive()}</b>, which is the subtle half: that
-   * question asks whether ANY transaction is on the thread, and the answer is yes for the caller's own whenever this
-   * check runs nested inside one - which through HTTP is every production run. A batch commit that throws has already
-   * disposed its context ({@code LocalDatabase.commit} pops it in a {@code finally} whether or not the write
-   * succeeded), so from that moment this run owns nothing and what is on the thread belongs to the caller. Cleaning
-   * "the" transaction up on that evidence would roll back work this class never made - the other buckets a
-   * {@code CHECK DATABASE FIX} already repaired into the same command transaction, or anything else the caller was
-   * holding (PR review on #6320). Tracked explicitly instead, so the cleanup can only ever touch a transaction this
-   * run opened and still holds.
-   *
-   * @author Luca Garulli (l.garulli@arcadedata.com)
-   */
-  private final class RepairTransaction {
-    private final int     batchPages;
-    private       boolean owned;
-
-    private RepairTransaction(final int batchPages) {
-      this.batchPages = batchPages;
-    }
-
-    /** Opens the transaction the repairs are made in, nested inside whatever the caller has open. */
-    private void begin() {
-      database.begin();
-      owned = true;
-    }
-
-    private void commitBatchIfFull() {
-      if (!owned || batchPages <= 0)
-        return;
-      if (database.getTransaction().getModifiedPages() < batchPages)
-        return;
-
-      // Ownership is dropped BEFORE the commit and taken back after it, and that order is the whole point: see the
-      // class comment. Between these two lines this run owns nothing, which is exactly the state a throwing commit
-      // leaves behind - and the state finish() must not act on.
-      owned = false;
-      database.commit();
-      database.begin();
-      owned = true;
-    }
-
-    /**
-     * Ends the transaction this run opened, if it still holds one. A repair left half-applied is never committed: the
-     * batches before it stay, which is the semantics #6128 gave the graph repairs, and the batch in flight goes back.
-     */
-    private void finish(final boolean completed) {
-      if (!owned)
-        return;
-
-      owned = false;
-      if (completed)
-        database.commit();
-      else
-        database.rollback();
-    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/RepairTransaction.java
+++ b/engine/src/main/java/com/arcadedb/engine/RepairTransaction.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseInternal;
+
+/**
+ * The transaction ONE repair pass of a database check owns, and the batch commits that bound what it may spend.
+ * <p>
+ * Shared by every repair pass of the engine - {@code LocalBucket.check(fix)} (issue #6320) and the three passes of
+ * {@code GraphDatabaseChecker}: the vertex arm, the edge arm and the orphaned-edge-segment reclaim (issue #6342) -
+ * because the rule below is the thing that must not drift apart between them, and it had already been got wrong once
+ * in each direction.
+ * <p>
+ * <b>The budget.</b> {@code arcadedb.checkDatabaseRepairBatchPages} is how many dirtied pages one transaction of a
+ * pass may accumulate before committing and opening the next (issue #6128). PAGES, not repairs: the WAL entry carries
+ * page images, and how many records a repair touched says nothing about how many distinct pages it dirtied.
+ * {@code TransactionContext.getModifiedPages()} counts modified and new pages, which is what the entry will hold - and
+ * under HA what a Raft entry must stay below.
+ * <p>
+ * A SOFT ceiling, checked BETWEEN units of repair work and never inside one: a transaction can exceed it by whatever
+ * the unit in flight dirties. It never interrupts a repair half-way, which is the property that makes a partial run
+ * safe - every record is either repaired or untouched. Set the configuration to 0 to get the single all-or-nothing
+ * transaction back, memory cost included.
+ * <p>
+ * <b>Why ownership is a field and not {@code database.isTransactionActive()}</b>, which is the subtle half: that
+ * question asks whether ANY transaction is on the thread, and the answer is yes for the caller's own whenever a check
+ * runs nested inside one - which through HTTP is every production run. A batch commit that throws has already disposed
+ * its context ({@code LocalDatabase.commit} pops it in a {@code finally} whether or not the write succeeded), so from
+ * that moment the pass owns nothing and what is on the thread belongs to the caller. Cleaning "the" transaction up on
+ * that evidence would roll back work the pass never made - the other buckets a {@code CHECK DATABASE FIX} already
+ * repaired into the same command transaction, or anything else the caller was holding (PR review on #6320). Tracked
+ * explicitly instead, so {@link #finish} can only ever touch a transaction this pass opened and still holds.
+ * <p>
+ * <b>And why {@link #finish} exists at all</b> (issue #6342): a pass used to commit as the LAST statement of its
+ * {@code try}, with a {@code finally} that filled in the returned counters and nothing else. So every way the body
+ * could throw except the batch commit - a scan that fails, an unreadable page, an {@code IllegalStateException} out of
+ * a repair - left the pass's own transaction OPEN on the thread. Nested under the HTTP handler that is worse than a
+ * leak: the handler's own {@code rollback()}, cleaning up after the very exception that caused this, pops the pass's
+ * nested transaction and leaves the handler's, which is the opposite of what it intended.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class RepairTransaction {
+  private final DatabaseInternal database;
+  private final int              batchPages;
+  private       boolean          owned;
+
+  /**
+   * @param batchPages modified-page budget of one batch, {@code <= 0} for a single all-or-nothing transaction.
+   */
+  public RepairTransaction(final DatabaseInternal database, final int batchPages) {
+    this.database = database;
+    this.batchPages = batchPages;
+  }
+
+  /**
+   * The budget a pass of THIS database runs under: read once per pass rather than per repaired record, since it is a
+   * database-scoped setting and cannot change under a running check.
+   */
+  public static int configuredBatchPages(final DatabaseInternal database) {
+    return database.getConfiguration().getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES);
+  }
+
+  /** Opens the transaction the repairs are made in, nested inside whatever the caller has open. */
+  public void begin() {
+    database.begin();
+    owned = true;
+  }
+
+  /**
+   * Commits the batch in flight and opens the next one, once it has dirtied as many pages as the budget allows.
+   * <p>
+   * Only ever legal BETWEEN units of repair work, never inside a {@code scanType}/{@code scan} callback:
+   * {@code LocalDatabase.scanType} holds the database read lock and owns an implicit transaction for the length of the
+   * scan, so committing under it would commit a transaction the scan believes it still owns.
+   * <p>
+   * WHY THIS WORKS UNDER AN OUTER TRANSACTION, which is the linchpin and not obvious: {@code CHECK DATABASE} runs
+   * through the HTTP handler, which wraps the command in its own transaction, so these are NESTED begin/commit pairs.
+   * They are not savepoints. {@code DatabaseContext.DatabaseContextTL.pushTransaction} gives each one a genuinely
+   * separate {@code TransactionContext}, and {@code commit()} runs the full {@code commit1stPhase}/{@code
+   * commit2ndPhase} on THAT context - a real WAL write and, under HA, a real replication round trip. If nesting
+   * deferred the write to the outermost commit instead, the whole batching would be inert: the repair would still
+   * reach Raft as one entry.
+   * <p>
+   * FAILURE PATH: a commit that throws propagates to the caller and leaves no transaction open on the thread -
+   * {@code commit()} disposes its context even when the write fails - which is exactly why ownership is dropped BEFORE
+   * the commit and taken back after it. Between those two lines this pass owns nothing, which is the state
+   * {@link #finish} must not act on. Batches already committed stay committed.
+   */
+  public void commitBatchIfFull() {
+    if (!owned || batchPages <= 0)
+      return;
+    if (database.getTransaction().getModifiedPages() < batchPages)
+      return;
+
+    owned = false;
+    database.commit();
+    database.begin();
+    owned = true;
+  }
+
+  /**
+   * Ends the transaction this pass opened, if it still holds one. A repair left half-applied is never committed: the
+   * batches before it stay, which is the semantics #6128 gave the graph repairs, and the batch in flight goes back.
+   *
+   * @param completed whether the pass reached its end without throwing.
+   */
+  public void finish(final boolean completed) {
+    if (!owned)
+      return;
+
+    owned = false;
+    if (completed)
+      database.commit();
+    else
+      database.rollback();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.RepairTransaction;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
@@ -49,19 +50,24 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli@arcadedata.it)
  */
 public class GraphDatabaseChecker {
-  private final DatabaseInternal database;
-  private final GraphEngine      graphEngine;
+  private final DatabaseInternal  database;
+  private final GraphEngine       graphEngine;
   /**
-   * Modified-page budget of one repair transaction (issue #6128) - see {@link #commitRepairBatchIfFull()}. Read
-   * once per checker rather than per repaired record: it is a database-scoped setting, and re-reading it inside the
-   * repair loops would put a configuration lookup on the per-record path for a value that cannot change under it.
+   * The transaction every pass of this checker makes its repairs in, and the only thing that knows whether the pass
+   * running right now still OWNS one (issue #6342). Shared with {@code LocalBucket.check(fix)} - see
+   * {@link RepairTransaction} for the batching rule and for why ownership cannot be asked of the thread.
+   * <p>
+   * ONE per checker rather than one per pass: the three passes never overlap ({@link #finishPass} clears the
+   * ownership flag before any other can begin one), and its budget is a database-scoped setting read once here rather
+   * than per repaired record, which would put a configuration lookup on the per-record path for a value that cannot
+   * change under a running check.
    */
-  private final int              repairBatchPages;
+  private final RepairTransaction repairTx;
   /**
    * Adjacency-entry budget of {@link AdjacencyProbeCache} (issue #6062), read once per checker for the same reason
-   * as {@link #repairBatchPages}: it is a database-scoped setting and cannot change under a running check.
+   * as {@link #repairTx}'s own budget: it is a database-scoped setting and cannot change under a running check.
    */
-  private final int              adjacencyCacheEntries;
+  private final int               adjacencyCacheEntries;
 
   // Progress reporting (issue #5372): the step identity (name/index/totalSteps) is assigned by the caller
   // (DatabaseChecker owns the step plan); this class emits within-step done/total, throttled to integer
@@ -77,8 +83,7 @@ public class GraphDatabaseChecker {
   public GraphDatabaseChecker(DatabaseInternal database) {
     this.database = database;
     this.graphEngine = database.getGraphEngine();
-    this.repairBatchPages = database.getConfiguration()
-        .getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_REPAIR_BATCH_PAGES);
+    this.repairTx = new RepairTransaction(database, RepairTransaction.configuredBatchPages(database));
     this.adjacencyCacheEntries = database.getConfiguration()
         .getValueAsInteger(GlobalConfiguration.CHECK_DATABASE_ADJACENCY_CACHE_ENTRIES);
   }
@@ -201,7 +206,8 @@ public class GraphDatabaseChecker {
     long orphans = 0;
     long reclaimed = 0;
 
-    database.begin();
+    beginPass();
+    boolean completed = false;
     try {
       // PHASE 1: walk every vertex's chains and mark every reachable segment. LongHashSet keyed by position
       // per bucket keeps the footprint primitive-sized (same approach as the external-property orphan scan).
@@ -279,15 +285,17 @@ public class GraphDatabaseChecker {
         for (final String warning : report.warnings)
           LogManager.instance().log(this, Level.WARNING, "- " + warning);
 
-      database.commit();
-      progressComplete();
+      completed = true;
 
     } finally {
       stats.put("orphanedEdgeSegments", orphans);
       stats.put("orphanedEdgeSegmentsReclaimed", reclaimed);
       stats.put("warnings", report.warnings);
       stats.put("totalWarnings", report.totalWarnings);
+      finishPass(completed);
     }
+
+    progressComplete();
     return stats;
   }
 
@@ -390,15 +398,37 @@ public class GraphDatabaseChecker {
    * FAILURE PATH: a batch commit that throws propagates to the caller and leaves no transaction open on the
    * thread - {@code commit()} disposes its context even when the write fails, so the checker does not have to roll
    * back after it. Batches already committed stay committed, which is the semantic change stated above. Pinned by
-   * {@code CheckDatabaseRepairBatchFailureTest}.
+   * {@code CheckDatabaseRepairBatchFailureTest}. Every OTHER way the body of a pass can throw is what
+   * {@link #finishPass} exists for (issue #6342).
    */
   private void commitRepairBatchIfFull() {
-    if (repairBatchPages <= 0)
-      return;
-    if (database.getTransaction().getModifiedPages() < repairBatchPages)
-      return;
-    database.commit();
-    database.begin();
+    repairTx.commitBatchIfFull();
+  }
+
+  /**
+   * Opens the transaction ONE pass makes its repairs in, nested inside whatever the caller has open.
+   * <p>
+   * Every pass of this class - {@link #checkVertices}, {@link #checkEdges} and
+   * {@link #reclaimOrphanedEdgeSegments} - is bracketed by this and {@link #finishPass}, and the pairing is the whole
+   * of issue #6342: the passes used to commit as the LAST statement of their {@code try}, with a {@code finally} that
+   * filled in the returned counters and nothing else, so any exception raised in the body before that line left the
+   * transaction the pass had opened OPEN on the thread. Under the HTTP handler, which always has one of its own open,
+   * the handler's cleanup {@code rollback()} then popped the pass's nested transaction and left the handler's -
+   * exactly backwards. Embedded, with no outer transaction, the next user of the thread inherited an in-flight
+   * transaction from a repair that had already failed.
+   */
+  private void beginPass() {
+    repairTx.begin();
+  }
+
+  /**
+   * Ends the transaction the pass opened, if it still holds one: committing it when the pass ran to its end, rolling
+   * the batch in flight back when it did not. See {@link RepairTransaction} for why "still holds one" is a flag rather
+   * than {@code database.isTransactionActive()} - under an outer transaction that question answers yes for someone
+   * else's.
+   */
+  private void finishPass(final boolean completed) {
+    repairTx.finish(completed);
   }
 
   /**
@@ -581,7 +611,8 @@ public class GraphDatabaseChecker {
 
     final Map<String, Object> stats = new HashMap<>();
 
-    database.begin();
+    beginPass();
+    boolean completed = false;
     try {
       // The connectivity check of ONE vertex: shared by the type-wide scan and the RECORD-scoped enumeration.
       final Consumer<Record> checkConnectivity = record -> {
@@ -685,7 +716,7 @@ public class GraphDatabaseChecker {
         for (final String warning : report.warnings)
           LogManager.instance().log(this, Level.WARNING, "- " + warning);
 
-      database.commit();
+      completed = true;
 
     } finally {
       putRepairCounters(stats, autoFix.get(), report.prunedDanglingEntries, reconnectedEdges);
@@ -699,6 +730,7 @@ public class GraphDatabaseChecker {
       stats.put("totalCorruptedRecords", report.totalCorrupted);
       stats.put("missingReferences", missingReferences);
       stats.put("missingReferenceErrors", missingReferenceErrors);
+      finishPass(completed);
     }
 
     return stats;
@@ -1545,7 +1577,8 @@ public class GraphDatabaseChecker {
 
     final Map<String, Object> stats = new HashMap<>();
 
-    database.begin();
+    beginPass();
+    boolean completed = false;
 
     try {
       // The endpoint check of ONE edge: shared by the type-wide scan and the RECORD-scoped enumeration.
@@ -1779,7 +1812,7 @@ public class GraphDatabaseChecker {
         for (final String warning : report.warnings)
           LogManager.instance().log(this, Level.WARNING, "- " + warning);
 
-      database.commit();
+      completed = true;
 
     } finally {
       // Same sum as the vertex arm, and prunedDanglingEntries is structurally ZERO here: pruning happens in
@@ -1804,6 +1837,7 @@ public class GraphDatabaseChecker {
       stats.put("totalCorruptedRecords", report.totalCorrupted);
       stats.put("missingReferences", missingReferences);
       stats.put("missingReferenceErrors", missingReferenceErrors);
+      finishPass(completed);
     }
 
     return stats;

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -29,6 +29,7 @@ import com.arcadedb.schema.DocumentType;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -457,14 +458,22 @@ class DictionaryMultiPageTest extends TestHelper {
    * without the ones before it, is how the count gets ahead of the file.
    * <p>
    * Runs against its own database, dropped at the end, because it deliberately leaves the page count inconsistent.
+   * <p>
+   * The FILE's own size is asserted next to the component's page count, and it is not redundant (issue #6341): this test
+   * failed once in a full-suite run with the assertion below reporting nothing raised at all, and the two are the only
+   * premises it rests on. Stating both means the next such run says WHICH one stopped being true instead of leaving that to
+   * be inferred from a guard that did not fire.
    */
   @Test
-  void aDictionaryPageThatIsClaimedButMissingFailsLoudly() {
+  void aDictionaryPageThatIsClaimedButMissingFailsLoudly() throws IOException {
     final Database other = TestHelper.createDatabase(getDatabasePath() + "_claimedButMissing");
     try {
       final Dictionary dictionary = other.getSchema().getDictionary();
       dictionary.getIdByName("aNameOnPageZero", true);
       assertThat(dictionary.getTotalPages()).isEqualTo(1);
+      assertThat(dictionary.getComponentFile().getTotalPages())
+          .as("the premise: the file really holds page 0 and nothing after it")
+          .isEqualTo(1L);
 
       // CLAIM TWO PAGES THAT WERE NEVER WRITTEN
       dictionary.updatePageCount(3);
@@ -473,6 +482,44 @@ class DictionaryMultiPageTest extends TestHelper {
           .isInstanceOf(DatabaseMetadataException.class)
           .hasMessageContaining("is truncated")
           .hasMessageContaining("page 1 of 3");
+    } finally {
+      other.drop();
+    }
+  }
+
+  /**
+   * The other half of the same guarantee, and the shape the page-manager read cannot refuse (issue #6341): a page the count
+   * claims that is a HOLE INSIDE the file rather than one past its end.
+   * <p>
+   * A partial replication replay - the very scenario the guard's own comment names as how the count gets ahead of the file -
+   * leaves a hole rather than a short file: writing page N at offset {@code N * pageSize} extends the file over every page it
+   * skipped. Those pages read back as zeroes, a zero page declares a content size of zero, and the load used to take that for a
+   * legal empty page - zero names from it, and every name after it renumbered down by however many the skipped page held. The
+   * page-manager read answers happily for all of them, because they ARE inside the file: only the bytes say otherwise.
+   * <p>
+   * Runs against its own database, dropped at the end, because it deliberately leaves the dictionary unreadable.
+   */
+  @Test
+  void aDictionaryPageInsideTheFileThatWasNeverWrittenFailsLoudly() {
+    final Database other = TestHelper.createDatabase(getDatabasePath() + "_holeInTheFile");
+    try {
+      final DatabaseInternal db = (DatabaseInternal) other;
+      final Dictionary dictionary = db.getSchema().getDictionary();
+      dictionary.getIdByName("aNameOnPageZero", true);
+
+      final int skipped = dictionary.getTotalPages();   // THE HOLE: NEVER WRITTEN, YET COVERED BY THE FILE AFTERWARDS
+      final int written = skipped + 1;
+
+      assertThatThrownBy(() -> applyReplicatedDictionaryPage(db, dictionary, written, "replicatedName"))
+          .isInstanceOf(DatabaseMetadataException.class)
+          .hasMessageContaining("is truncated")
+          .hasMessageContaining("page " + skipped + " of " + (written + 1))
+          .hasMessageContaining("was never written");
+
+      // AND THE IN-RAM VIEW IS THE ONE FROM BEFORE THE REFUSED LOAD, NOT A HALF-BUILT ONE: reload() PUBLISHES THE NEW SNAPSHOT
+      // ONLY ONCE EVERY PAGE HAS BEEN READ, SO REFUSING TO READ ONE LEAVES THE NAMES ALREADY IN USE RESOLVING AS THEY DID
+      assertThat(dictionary.getIdByName("aNameOnPageZero", false)).isZero();
+      assertThat(dictionary.getNameById(0)).isEqualTo("aNameOnPageZero");
     } finally {
       other.drop();
     }
@@ -490,17 +537,37 @@ class DictionaryMultiPageTest extends TestHelper {
     final int entriesBefore = dictionary.getDictionaryMap().size();
     final int newPageNumber = dictionary.getTotalPages();
 
-    // BUILD THE PAGE IMAGE THE LEADER WOULD HAVE SHIPPED: THE 4 BYTE LEGACY COUNTER FOLLOWED BY ONE NAME
     final String replicated = "replicatedName";
+    assertThat(applyReplicatedDictionaryPage(db, dictionary, newPageNumber, replicated)).isTrue();
+
+    assertThat(dictionary.getTotalPages()).isEqualTo(newPageNumber + 1);
+    assertThat(dictionary.getDictionaryMap()).hasSize(entriesBefore + 1);
+    assertThat(dictionary.getIdByName(replicated, false)).isEqualTo(entriesBefore);
+    assertThat(dictionary.getNameById(entriesBefore)).isEqualTo(replicated);
+
+    // AND THE NEXT LOCALLY ADDED NAME CONTINUES AFTER IT INSTEAD OF OVERWRITING IT
+    assertThat(dictionary.getIdByName("afterReplication", true)).isEqualTo(entriesBefore + 1);
+    assertThat(dictionary.getNameById(entriesBefore)).isEqualTo(replicated);
+  }
+
+  /**
+   * Applies the WAL entry a leader would have shipped for ONE new dictionary page holding ONE name: the 4 byte legacy counter
+   * every page carries, followed by the name. {@code pageNumber} is deliberately the caller's, so a test can ship the page the
+   * follower expects next or one further along - which is what leaves a hole behind it.
+   *
+   * @return what {@code applyChanges} reported, i.e. whether anything was changed.
+   */
+  private boolean applyReplicatedDictionaryPage(final DatabaseInternal db, final Dictionary dictionary, final int pageNumber,
+      final String name) throws Exception {
     final Binary image = new Binary();
     image.putInt(0);
-    image.putBytes(replicated.getBytes(DatabaseFactory.getDefaultCharset()));
+    image.putBytes(name.getBytes(DatabaseFactory.getDefaultCharset()));
     image.flip();
     final byte[] content = image.toByteArray();
 
     final WALFile.WALPage walPage = new WALFile.WALPage();
     walPage.fileId = dictionary.getFileId();
-    walPage.pageNumber = newPageNumber;
+    walPage.pageNumber = pageNumber;
     walPage.currentPageVersion = 1;
     walPage.changesFrom = BasePage.PAGE_HEADER_SIZE;
     walPage.changesTo = BasePage.PAGE_HEADER_SIZE + content.length - 1;
@@ -512,15 +579,6 @@ class DictionaryMultiPageTest extends TestHelper {
     walTx.timestamp = System.currentTimeMillis();
     walTx.pages = new WALFile.WALPage[] { walPage };
 
-    assertThat(db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false)).isTrue();
-
-    assertThat(dictionary.getTotalPages()).isEqualTo(newPageNumber + 1);
-    assertThat(dictionary.getDictionaryMap()).hasSize(entriesBefore + 1);
-    assertThat(dictionary.getIdByName(replicated, false)).isEqualTo(entriesBefore);
-    assertThat(dictionary.getNameById(entriesBefore)).isEqualTo(replicated);
-
-    // AND THE NEXT LOCALLY ADDED NAME CONTINUES AFTER IT INSTEAD OF OVERWRITING IT
-    assertThat(dictionary.getIdByName("afterReplication", true)).isEqualTo(entriesBefore + 1);
-    assertThat(dictionary.getNameById(entriesBefore)).isEqualTo(replicated);
+    return db.getTransactionManager().applyChanges(walTx, Collections.emptyMap(), false);
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairPassTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/CheckDatabaseRepairPassTransactionTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.utility.ProgressCallback;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6342: what each repair pass of {@link GraphDatabaseChecker} leaves on the thread when its body throws
+ * ANYWHERE except in a batch commit.
+ * <p>
+ * {@code CheckDatabaseRepairBatchFailureTest} pins the one failure that was already safe: a batch commit that throws
+ * disposes its own context on the way out ({@code LocalDatabase.commit()} pops it in a {@code finally} whether or not
+ * the write succeeded), so that path really does leave no transaction behind. Every OTHER way the body can throw used
+ * to leave one, because each pass committed as the LAST statement of its {@code try} and the {@code finally} only
+ * filled in the returned counters.
+ * <p>
+ * What that costs depends on who is underneath, and both cases are pinned below. Under an OUTER transaction - which
+ * through the HTTP handler is every production {@code CHECK DATABASE} - the pass's own transaction is nested on top of
+ * it, so the caller's next {@code rollback()}, cleaning up after the very exception that caused this, pops the
+ * abandoned nested one and leaves the caller's: the opposite of what the caller intended. Embedded, with nothing
+ * underneath, the next user of the thread inherits an in-flight transaction from a repair that already failed.
+ * <p>
+ * The failure is injected through the progress callback, which every pass invokes once it has opened its transaction
+ * and before it has finished: it is a plain body throw, it needs no corrupted database to provoke, and it reaches all
+ * three passes the same way - which is the point, since the defect was in the shape they share rather than in any one
+ * of them.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CheckDatabaseRepairPassTransactionTest extends TestHelper {
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+
+  /** Fails the pass the first time it reports progress, which is after it has opened its transaction. */
+  private static final ProgressCallback FAIL_ON_FIRST_REPORT = (stepName, stepIndex, totalSteps, done, total) -> {
+    throw new IllegalStateException("simulated failure inside the repair pass");
+  };
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType(VERTEX_TYPE);
+      database.getSchema().createEdgeType(EDGE_TYPE);
+      final Vertex one = database.newVertex(VERTEX_TYPE).set("name", "one").save();
+      final Vertex two = database.newVertex(VERTEX_TYPE).set("name", "two").save();
+      one.newEdge(EDGE_TYPE, two);
+    });
+  }
+
+  @Test
+  void aVertexPassThatThrowsLeavesTheCallersTransactionAndNoOtherBehind() {
+    assertTheCallersTransactionSurvives(
+        checker -> checker.checkVertices(VERTEX_TYPE, true, 0));
+  }
+
+  @Test
+  void anEdgePassThatThrowsLeavesTheCallersTransactionAndNoOtherBehind() {
+    assertTheCallersTransactionSurvives(
+        checker -> checker.checkEdges(EDGE_TYPE, true, 0));
+  }
+
+  @Test
+  void anOrphanedSegmentReclaimThatThrowsLeavesTheCallersTransactionAndNoOtherBehind() {
+    assertTheCallersTransactionSurvives(
+        checker -> checker.reclaimOrphanedEdgeSegments(0, 10));
+  }
+
+  @Test
+  void aVertexPassThatThrowsWithNoCallerTransactionLeavesTheThreadClean() {
+    assertTheThreadIsLeftClean(checker -> checker.checkVertices(VERTEX_TYPE, true, 0));
+  }
+
+  @Test
+  void anEdgePassThatThrowsWithNoCallerTransactionLeavesTheThreadClean() {
+    assertTheThreadIsLeftClean(checker -> checker.checkEdges(EDGE_TYPE, true, 0));
+  }
+
+  @Test
+  void anOrphanedSegmentReclaimThatThrowsWithNoCallerTransactionLeavesTheThreadClean() {
+    assertTheThreadIsLeftClean(checker -> checker.reclaimOrphanedEdgeSegments(0, 10));
+  }
+
+  /**
+   * The HTTP shape: the pass runs nested inside a transaction it did not open, and the caller cleans up after the
+   * failure exactly as {@code DatabaseAbstractHandler} does.
+   * <p>
+   * The assertion is deliberately behavioural rather than a peek at the transaction stack: what a leaked nested
+   * transaction actually costs is that the caller's own {@code rollback()} lands on it instead, so the caller is left
+   * still holding a transaction it believes it has just rolled back - and the work in it, which the failure means to
+   * discard, is still pending.
+   */
+  private void assertTheCallersTransactionSurvives(final Function<GraphDatabaseChecker, Object> pass) {
+    database.begin();
+
+    // Work the caller has done and which its rollback must discard: if the pass's transaction is the one that goes
+    // back instead, this vertex survives the rollback below.
+    database.newVertex(VERTEX_TYPE).set("name", "workOfTheCaller").save();
+
+    assertThatThrownBy(() -> pass.apply(failingChecker()))
+        .as("a pass that cannot run must reach the caller")
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the caller's own transaction must still be open after the pass failed inside it")
+        .isTrue();
+
+    database.rollback();
+
+    assertThat(database.isTransactionActive())
+        .as("the caller's rollback must clean up the CALLER's transaction, not one the failed pass abandoned on top "
+            + "of it")
+        .isFalse();
+
+    database.transaction(() -> assertThat(database.countType(VERTEX_TYPE, false))
+        .as("the caller's rolled-back work must be gone, so its rollback reached the transaction it was made in")
+        .isEqualTo(2));
+  }
+
+  /** The embedded shape: nothing underneath, so the thread must be left with no transaction at all. */
+  private void assertTheThreadIsLeftClean(final Function<GraphDatabaseChecker, Object> pass) {
+    assertThat(database.isTransactionActive()).as("the fixture must start with a clean thread").isFalse();
+
+    assertThatThrownBy(() -> pass.apply(failingChecker()))
+        .as("a pass that cannot run must reach the caller")
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(database.isTransactionActive())
+        .as("the next user of this thread must not inherit an in-flight transaction from a failed repair")
+        .isFalse();
+
+    // And the database is still usable through it.
+    database.transaction(() -> assertThat(database.countType(VERTEX_TYPE, false)).isEqualTo(2));
+  }
+
+  private GraphDatabaseChecker failingChecker() {
+    return new GraphDatabaseChecker((DatabaseInternal) database)
+        .setProgress(FAIL_ON_FIRST_REPORT, "failing pass", 1, 1);
+  }
+}


### PR DESCRIPTION
Closes #6342, closes #6341.

## #6342 - a pass that fails anywhere but its batch commit abandons its transaction

Every repair pass of `GraphDatabaseChecker` - `checkVertices`, `checkEdges` and
`reclaimOrphanedEdgeSegments` - had this shape:

```java
database.begin();
try {
  ...the whole pass...
  database.commit();
} finally {
  stats.put(...);          // counters only - nothing closes the transaction
}
```

The commit is the LAST statement of the `try`, so the ONE failure that was already safe is a batch commit that
throws: `LocalDatabase.commit()` pops its own context in a `finally` whether or not the write succeeded, which is
what `CheckDatabaseRepairBatchFailureTest` pins. **Every other way the body can throw left the transaction the pass
opened OPEN on the thread**, and `DatabaseChecker` does not close it either.

Both shapes of the cost are now pinned by tests. Under an **outer** transaction - which through the HTTP handler is
every production `CHECK DATABASE` - the pass's own is nested on top of it, so the caller's cleanup `rollback()`,
running because of the very exception that caused this, popped the abandoned nested one and left the caller's: the
caller is left still holding a transaction it believes it has just rolled back, with the work in it still pending.
**Embedded**, with nothing underneath, the next user of the thread inherited an in-flight transaction from a repair
that had already failed.

**The fix is not `commit()` in a `finally`, and not acting on `database.isTransactionActive()`** - that is the bug
PR #6327 had to fix in `LocalBucket.check(fix)`, because under an outer transaction that question answers "yes" for
somebody else's. `RepairTransaction` (introduced there for #6320) moves out of `LocalBucket` into
`com.arcadedb.engine` and is now shared by all four passes: ownership is a flag, dropped before each batch commit and
taken back after, so `finish()` can only ever touch a transaction the pass itself opened and still holds. A pass that
fails part-way rolls back the batch in flight and keeps the ones already committed - the semantics #6128 gave these
repairs in the first place.

## #6341 - the dictionary guard, and what the flake was really evidence of

The issue's own hypothesis does not hold, and it is worth stating rather than quietly working around: a
`PaginatedComponentFile` size that **lags** a page still in the flush queue makes the guard fire MORE readily, not
less (`isNewPage = pageNumber >= file.getTotalPages()`, so a smaller `getTotalPages()` refuses more pages). The
stale-read-cache-across-a-drop theory is dead too - `drop()` and `close()` both purge the read cache, checked
directly. I could not reproduce the flake and do not claim to have explained it.

**What I did find is a hole of exactly the shape the issue worried about, in exactly the scenario the guard's own
comment names.** The guard infers "the page is not there" from the page manager refusing the read, and the page
manager refuses only a page past the END of the file. It cannot refuse a hole INSIDE it - and a partial replication
replay, which the comment names as how the count gets ahead of the file, leaves a hole rather than a short file:
writing page N at offset `N * pageSize` extends the file over every page it skipped. Those pages read back as
zeroes, a zero page declares a content size of zero (`getContentSize()` returns `-8`), and the loop read nothing from
it. No error, and every name after it comes back with an id lower by however many the skipped page held - the one
outcome the class exists to prevent. Reproduced by shipping one replicated dictionary page one further along than the
follower expected:

| | before | after |
|---|---|---|
| `applyChanges` with a skipped dictionary page | silently applied, ids shifted | `DatabaseMetadataException: ... page 1 of 3 was never written` |

Every dictionary page ever written carries the four-byte legacy counter (`updateCounters()`, on both `addPage()` and
`resetPageForRewrite()`), so a content size below it is not a legal empty page - it is a page nobody wrote.
`reload()` now says so. That is a statement about the BYTES rather than about whether a read happened to succeed,
which is why it also covers an unwritten image reaching it by any other route - including whatever answered for page
1 in the flaked run, if that page was an invented one. Page 0 keeps its one deliberate exemption: its
`createIfNotExists` materialises page 0 of a file shorter than one page (killed mid-write), which is what keeps such
a database openable, and there is nothing before it to renumber.

The flaky test also states its second premise explicitly now - the FILE really holds page 0 and nothing after it -
so a recurrence says which premise stopped being true instead of leaving that to be inferred from a guard that did
not fire.

## Tests

New: `CheckDatabaseRepairPassTransactionTest` (6 - the nested and the embedded shape, for each of the three passes;
the failure is injected through the progress callback, which every pass invokes after opening its transaction, so
one mechanism reaches all three), `DictionaryMultiPageTest#aDictionaryPageInsideTheFileThatWasNeverWrittenFailsLoudly`.

Every one of the seven was checked to fail on the pre-fix code - the dictionary one with the identical
`Expecting code to raise a throwable` the flake reported.

Verified: full engine unit lane, **12468 tests, 0 failures, 0 errors**.