### PR TITLE
fix(#6340): a component takes its file's mode too, the version joins the guards it belongs with, and CHECK DATABASE can finally read a TimeSeries file

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
@@ -137,6 +137,24 @@ public class ComponentFile {
     return version;
   }
 
+  /**
+   * The mode this file is open in, which selects the {@code RandomAccessFile} open string and nothing else.
+   * <p>
+   * Exposed (issue #6340) so that a component built on an <em>already-registered</em> file can take every file
+   * property from that file rather than four from the file and one from a guess. The id, the page size and the
+   * version already had accessors, and each of them is now taken from the file by the callers in that position
+   * (issues #6283 and #6314); the mode was the only one left with nothing to read it back out of, which is why
+   * {@code TimeSeriesTagDictionary}'s build-on-an-existing-file constructor had to hard-code {@code READ_WRITE}.
+   * <p>
+   * It is a property OF THE FILE and not of the component asking: {@link FileManager} opens every file it scans
+   * with the database's own mode and {@link FileManager#getOrCreateFile} hands a registered file back instead of
+   * reopening it, so this is the mode a second view is going to get whatever it asks for - which is precisely why
+   * that method now refuses to hand back a file open in a different one.
+   */
+  public MODE getMode() {
+    return mode;
+  }
+
   public long calculateChecksum() throws IOException {
     final CRC32 crc = new CRC32();
     final String fileContent = FileUtils.readFileAsString(osFile);

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.RecordNotFoundException;
@@ -37,6 +38,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.LocalEdgeType;
+import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.LocalVertexType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.BinarySerializer;
@@ -188,6 +190,14 @@ public class DatabaseChecker {
     result.put("deletedRecordsAfterFix", new LinkedHashSet<>());
     result.put("corruptedRecords", new LinkedHashSet<>());
     result.put("corruptedIndexes", new LinkedHashSet<>());
+    // Issue #6340: the TimeSeries pass, seeded like every other family so a clean run publishes zeros rather than
+    // omitting the keys - "did this run look at the TimeSeries files at all?" has to be answerable from the result
+    // of every run, and a database with no TimeSeries type answers it with zeros rather than with silence.
+    result.put("corruptedTimeSeries", new LinkedHashSet<String>());
+    result.put("totalTimeSeriesTypes", 0L);
+    result.put("totalTimeSeriesShards", 0L);
+    result.put("totalTimeSeriesSamples", 0L);
+    result.put("totalTimeSeriesSealedBlocks", 0L);
     result.put("totalWarnings", 0L);
     result.put("totalCorruptedRecords", 0L);
     result.put("distinctMissingReferences", 0L);
@@ -208,6 +218,11 @@ public class DatabaseChecker {
     final List<DocumentType> edgeTypes = new ArrayList<>();
     final List<DocumentType> vertexTypes = new ArrayList<>();
     final List<DocumentType> documentTypes = new ArrayList<>();
+    // Issue #6340: a TimeSeries type is a LocalDocumentType and used to land in documentTypes, where the per-type
+    // pass found it had no record buckets and did nothing - which is the whole reason CHECK DATABASE had no
+    // TimeSeries coverage. Its data is not in record buckets: it is in the .tstb/.tstd components the schema
+    // registers as files and in the .ts.sealed files outside the paginated layer, so it gets its own pass.
+    final List<LocalTimeSeriesType> timeSeriesTypes = new ArrayList<>();
     for (final DocumentType type : database.getSchema().getTypes()) {
       if (types != null && !types.isEmpty() && (type == null || !types.contains(type.getName())))
         continue;
@@ -215,6 +230,8 @@ public class DatabaseChecker {
         edgeTypes.add(type);
       else if (type instanceof LocalVertexType)
         vertexTypes.add(type);
+      else if (type instanceof LocalTimeSeriesType tsType)
+        timeSeriesTypes.add(tsType);
       else
         documentTypes.add(type);
     }
@@ -268,6 +285,10 @@ public class DatabaseChecker {
       currentStep = 0;
       totalSteps = edgeTypes.size() + vertexTypes.size() + documentTypes.size() // per-type checks
           + 3 // buckets + external properties + indexes
+          // #6340: ONE step for all TimeSeries types, and only when the database has any. A step per type would
+          // change the plan of every database that has none, which is what every existing progress expectation
+          // was written against; a step that is not there costs nobody anything.
+          + (timeSeriesTypes.isEmpty() ? 0 : 1)
           + (reclaimOrphanedSegments ? 1 : 0)
           + (fix ? 1 : 0) // rebuild affected indexes
           + (compress ? 1 : 0);
@@ -288,6 +309,8 @@ public class DatabaseChecker {
       }
 
       checkDocuments(documentTypes);
+
+      checkTimeSeries(timeSeriesTypes);
 
       checkBuckets(result);
 
@@ -623,6 +646,91 @@ public class DatabaseChecker {
 
       stepComplete();
     }
+  }
+
+  /**
+   * Validates the storage of every TimeSeries type in scope (issue #6340).
+   * <p>
+   * <b>Why this pass exists.</b> Before it, {@code DatabaseChecker} contained no reference to TimeSeries at all -
+   * not to {@code .tstb}, not to {@code .tstd}, not to {@code .ts.sealed}. The checker walks record buckets and
+   * indexes; a TimeSeries type has neither, since {@code LocalTimeSeriesType} registers its shards with the schema
+   * as FILES rather than as a type's record buckets and its compacted data does not go through the paginated layer
+   * at all. So a type falling into the document arm had nothing to scan, and every one of the three on-disk
+   * formats TimeSeries owns - the mutable bucket, the sealed store, the tag dictionary, the last two with their
+   * own magics, headers and CRCs - was outside the reach of the only tool whose job is to find damage in them.
+   * That was not an abstract gap: #6314 fixed a bug that wrote real rows to disk at the wrong stride, and nothing
+   * in the engine could detect a file left in that state, because the header a mismatched session also wrote
+   * counts rows the pages no longer hold.
+   * <p>
+   * <b>Report-only, in both modes.</b> There is no {@code FIX} arm and the omission is deliberate rather than
+   * unfinished. A record bucket can be repaired because its records are self-describing and its indexes are
+   * derivable from them; a sealed store is append-only columnar data whose blocks are the only copy, so "repair"
+   * would mean deciding which samples to discard - a question that needs answering before code, not after. What
+   * this pass does is make the state visible, which is the part that was missing entirely.
+   * <p>
+   * <b>Scoped by TYPE and by nothing else.</b> The type filter has already been applied by the caller's
+   * classification, so naming a type checks that type's files and nothing else, exactly as it does for a document
+   * type. A BUCKET scope does not narrow this pass and cannot: a TimeSeries shard is not a bucket, so there is
+   * nothing for a bucket name to select - the same reason {@link #checkIndexes} is not narrowed by BUCKET either.
+   * A RECORD scope never reaches here, since that branch skips every database-wide pass.
+   * <p>
+   * ONE step for all types rather than one per type, so a database with no TimeSeries type keeps the step plan it
+   * had. The per-type progress is the tick.
+   */
+  private void checkTimeSeries(final List<LocalTimeSeriesType> timeSeriesTypes) {
+    if (timeSeriesTypes.isEmpty())
+      return;
+
+    if (verboseLevel > 0)
+      LogManager.instance().log(this, Level.INFO, "Checking TimeSeries types...");
+
+    stepBegin("Checking TimeSeries", timeSeriesTypes.size());
+
+    final Set<String> corrupted = new LinkedHashSet<>();
+    long totalShards = 0;
+    long totalSamples = 0;
+    long totalSealedBlocks = 0;
+
+    for (final LocalTimeSeriesType type : timeSeriesTypes) {
+      stepTick();
+
+      final TimeSeriesEngine engine = type.getEngine();
+      if (engine == null) {
+        // The type is in the schema but its engine never initialised, so its files were never opened. Reported
+        // rather than skipped: a type nothing can read is exactly the kind of thing this check is asked about.
+        addWarning("timeseries '" + type.getName() + "': the storage engine is not initialised, so none of its "
+            + "files could be read");
+        corrupted.add(type.getName());
+        continue;
+      }
+
+      try {
+        totalShards += engine.getShardCount();
+        for (int i = 0; i < engine.getShardCount(); i++)
+          totalSealedBlocks += engine.getShard(i).getSealedStore().getBlockCount();
+        totalSamples += engine.countSamples();
+
+        final List<String> problems = engine.checkIntegrity();
+        if (!problems.isEmpty()) {
+          corrupted.add(type.getName());
+          for (final String problem : problems)
+            addWarning("timeseries '" + type.getName() + "': " + problem);
+        }
+      } catch (final Exception e) {
+        // Same shape as the index arm: a check that cannot complete is itself a finding, never a reason to
+        // abandon the rest of the run.
+        addWarning("timeseries '" + type.getName() + "': integrity check failed: " + e.getMessage());
+        corrupted.add(type.getName());
+      }
+    }
+
+    ((LinkedHashSet<String>) result.get("corruptedTimeSeries")).addAll(corrupted);
+    result.put("totalTimeSeriesTypes", (long) timeSeriesTypes.size());
+    result.put("totalTimeSeriesShards", totalShards);
+    result.put("totalTimeSeriesSamples", totalSamples);
+    result.put("totalTimeSeriesSealedBlocks", totalSealedBlocks);
+
+    stepComplete();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -705,15 +705,18 @@ public class DatabaseChecker {
       }
 
       try {
-        totalShards += engine.getShardCount();
-        for (int i = 0; i < engine.getShardCount(); i++)
-          totalSealedBlocks += engine.getShard(i).getSealedStore().getBlockCount();
-        totalSamples += engine.countSamples();
+        // ONE walk over the type's shards, not three: the report carries the totals this pass publishes alongside
+        // the findings, with each shard measuring itself inside the same lock window it checks itself in - so the
+        // numbers and the verdict describe one instant rather than three.
+        final TimeSeriesEngine.IntegrityReport report = engine.checkIntegrity();
 
-        final List<String> problems = engine.checkIntegrity();
-        if (!problems.isEmpty()) {
+        totalShards += report.shards();
+        totalSamples += report.samples();
+        totalSealedBlocks += report.sealedBlocks();
+
+        if (!report.problems().isEmpty()) {
           corrupted.add(type.getName());
-          for (final String problem : problems)
+          for (final String problem : report.problems())
             addWarning("timeseries '" + type.getName() + "': " + problem);
         }
       } catch (final Exception e) {

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -424,16 +424,42 @@ public class FileManager {
     return fileNameMap.get(componentName);
   }
 
+  /**
+   * Returns the file registered under {@code fileName}, opening and registering one at {@code filePath} when there
+   * is none. This is the by-<em>name</em> half of the pair; {@link #getOrCreateFile(int, String)} is the by-id one.
+   * <p>
+   * <b>The mode is a request the caller is entitled to, not a hint (issue #6340.)</b> On a hit this used to hand
+   * the registered file back whatever mode it carried, which is the third member of the family the by-name id
+   * check (#6283) and the by-id name check (#6314) closed: the caller asks for one thing and is handed another.
+   * The direction that matters is the quiet one - a caller asking for {@code READ_ONLY} and being given a
+   * {@code READ_WRITE} file gets a WEAKER guarantee than it asked for, with nothing anywhere saying so, and
+   * mode is the one file property whose whole purpose is to be a guarantee.
+   * <p>
+   * Reopening the file to satisfy the request is deliberately not what happens instead. The mode selects the
+   * {@code RandomAccessFile} open string ({@code PaginatedComponentFile.open}) and a registered file is shared by
+   * every component addressing it, so "upgrading" one would change the channel under readers that had asked for
+   * the narrower one - trading a loud refusal for a silent widening, which is the very shape being removed here.
+   * <p>
+   * <b>Nothing reaches this today, and that is a statement rather than an assumption.</b> This overload has
+   * exactly one caller, {@code PaginatedComponent}'s constructor, and a hit on it survives the file-id guard
+   * there only when the component was deliberately built on the registered file's own id - which today means
+   * {@code TimeSeriesTagDictionary}'s build-on-an-existing-file constructor, and that one now takes the mode
+   * from the file too ({@link ComponentFile#getMode()}). Every other component reaches this on the miss path,
+   * where the file is opened with the mode asked for and agrees by construction. The guard is what keeps the
+   * next caller from having to re-derive that.
+   *
+   * @throws IllegalStateException when a file is already registered under {@code fileName} in a different mode
+   */
   public ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.MODE mode)
       throws IOException {
     ComponentFile file = fileNameMap.get(fileName);
     if (file != null)
-      return file;
+      return checkModeMatches(file, mode);
 
     synchronized (this) {
       file = fileNameMap.get(fileName);
       if (file != null)
-        return file;
+        return checkModeMatches(file, mode);
 
       file = new PaginatedComponentFile(filePath, mode);
       registerFile(file);
@@ -489,6 +515,23 @@ public class FileManager {
       throw new SchemaException(
           "File id " + file.getFileId() + " is already registered as '" + file.getFileName() + "' but was requested as '"
               + requestedName + "' ('" + filePath + "')");
+    return file;
+  }
+
+  /**
+   * Asserts that an already-registered file is open in the mode the caller asked for (issue #6340). Thrown as an
+   * {@link IllegalStateException} and not as the {@link SchemaException} its by-id sibling above raises, because the
+   * two say different things: a file name that does not match is a file-id space that has diverged from the
+   * leader's, which the HA follower turns into a quarantine-and-resync, while a mode that does not match is a caller
+   * asking for a guarantee the shared file cannot give it - a programming error on the same footing as the file-id
+   * and page-size guards in {@code PaginatedComponent}, which is this overload's only caller and which throws
+   * exactly this.
+   */
+  private static ComponentFile checkModeMatches(final ComponentFile file, final ComponentFile.MODE mode) {
+    if (file.getMode() != mode)
+      throw new IllegalStateException(
+          "File '" + file.getFileName() + "' is already open in mode " + file.getMode() + " but was requested in mode "
+              + mode + " ('" + file.getFilePath() + "')");
     return file;
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
@@ -106,6 +106,24 @@ public abstract class PaginatedComponent extends Component {
           "Component '" + name + "' was built with page size " + pageSize + " but its file '" + file.getFilePath()
               + "' has page size " + file.getPageSize());
 
+    // The third and last fact baked into a component file's name - 'name.fileId.pageSize.vVersion.ext' - and so the
+    // third guard of the same set (issue #6340). It decides how the pages are INTERPRETED where the other two decide
+    // where they are: a LocalBucket version selects the record-header layout, a TimeSeriesBucket version selects
+    // whether a TAG column is a 4-byte dictionary id or an inline string, and reading one as the other is a
+    // misinterpretation of real bytes rather than an exception - the same failure shape as the page size.
+    //
+    // THIS IS A TRIPWIRE AND NOT A COMPATIBILITY GATE, and the difference is worth stating because #6314 had to
+    // work through it twice: every load constructor passes the version ComponentFactory parsed OFF THE FILE NAME
+    // straight through, and every creation path bakes the version it was given into the name it generates, so a
+    // component and its file agree by construction whatever build wrote the file. An old database therefore cannot
+    // trip this. What can is a component that re-derived its version from somewhere other than its file - claiming
+    // CURRENT_VERSION for a file whose name says otherwise, which is exactly the defect #6314 removed from the two
+    // TimeSeries factory handlers and exactly what nobody should reintroduce.
+    if (file.getVersion() != version)
+      throw new IllegalStateException(
+          "Component '" + name + "' was built with version " + version + " but its file '" + file.getFilePath()
+              + "' has version " + file.getVersion());
+
     final long fileSize = file.getSize();
     if (fileSize == 0)
       // NEW FILE, CREATE HEADER PAGE

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
@@ -1093,11 +1093,16 @@ public class TimeSeriesBucket extends PaginatedComponent {
     long samples = 0;
     long minTs = Long.MAX_VALUE;
     long maxTs = Long.MIN_VALUE;
+    // Whether every page page 0 announces was actually read. The three totals below are statements about ALL of
+    // them, so a walk that stopped at page N cannot make any of them: what it accumulated is a prefix, and
+    // reporting a prefix as the whole restates one finding as four.
+    boolean walkedEveryPage = true;
     for (int pageNumber = 1; pageNumber <= dataPageCount; pageNumber++) {
       final BasePage dataPage = readPageIfPresent(pageNumber);
       if (dataPage == null) {
         problems.add("page 0 declares " + dataPageCount + " data page(s) but page " + pageNumber
             + " is not in the file: the samples it should hold are unreadable");
+        walkedEveryPage = false;
         break;
       }
 
@@ -1105,6 +1110,8 @@ public class TimeSeriesBucket extends PaginatedComponent {
       if (maxSamplesPerPage > 0 && count > maxSamplesPerPage) {
         problems.add("data page " + pageNumber + " declares " + count + " sample(s), more than the "
             + maxSamplesPerPage + " a " + pageSize + "-byte page holds at this type's " + rowSize + "-byte stride");
+        // The count is not usable, so neither is any total it would go into.
+        walkedEveryPage = false;
         continue;
       }
 
@@ -1117,6 +1124,7 @@ public class TimeSeriesBucket extends PaginatedComponent {
       if (pageMinTs > pageMaxTs) {
         problems.add("data page " + pageNumber + " declares min timestamp " + pageMinTs + " above its max timestamp "
             + pageMaxTs);
+        walkedEveryPage = false;
         continue;
       }
       if (pageMinTs < minTs)
@@ -1124,6 +1132,9 @@ public class TimeSeriesBucket extends PaginatedComponent {
       if (pageMaxTs > maxTs)
         maxTs = pageMaxTs;
     }
+
+    if (!walkedEveryPage)
+      return problems;
 
     if (samples != declaredSamples)
       problems.add("page 0 declares " + declaredSamples + " sample(s) but its " + dataPageCount

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesBucket.java
@@ -1005,23 +1005,138 @@ public class TimeSeriesBucket extends PaginatedComponent {
    * hit, the page having just been loaded.
    */
   private BasePage readHeaderPage() throws IOException {
-    final PageId headerPageId = new PageId(database, fileId, 0);
+    final BasePage headerPage = readPageIfPresent(0);
+    return headerPage != null && headerPage.readInt(HEADER_MAGIC_OFFSET) == MAGIC_VALUE ? headerPage : null;
+  }
+
+  /**
+   * Resolves one page of this bucket for reading, or {@code null} when the file does not carry it. The two rules
+   * {@link #readHeaderPage()} documents at length - never fabricate the page, never gate on {@link #getTotalPages()}
+   * - are properties of this resolution and not of page 0, so they live here and page 0 only adds the magic test
+   * on top.
+   */
+  private BasePage readPageIfPresent(final int pageNumber) throws IOException {
+    final PageId pageId = new PageId(database, fileId, pageNumber);
     final TransactionContext tx = database.getTransactionIfExists();
     final boolean inTransaction = tx != null && tx.isActive();
 
-    BasePage headerPage;
-    if (inTransaction && tx.hasPageForRecord(headerPageId))
-      headerPage = tx.getPage(headerPageId, pageSize);
+    BasePage page;
+    if (inTransaction && tx.hasPageForRecord(pageId))
+      page = tx.getPage(pageId, pageSize);
     else {
       // (isNew=true, createIfNotExists=false): the pair that answers "absent" with null instead of creating the
       // page, as TimeSeriesTagDictionary.readStoredHeader() does. With isNew=false the page manager would throw
       // on a page that is not there.
-      headerPage = database.getPageManager().getImmutablePage(headerPageId, pageSize, true, false);
-      if (headerPage != null && inTransaction)
-        headerPage = tx.getPage(headerPageId, pageSize);
+      page = database.getPageManager().getImmutablePage(pageId, pageSize, true, false);
+      if (page != null && inTransaction)
+        page = tx.getPage(pageId, pageSize);
     }
 
-    return headerPage != null && headerPage.readInt(HEADER_MAGIC_OFFSET) == MAGIC_VALUE ? headerPage : null;
+    return page;
+  }
+
+  /**
+   * Validates everything the mutable row format asserts about itself and returns one line per problem, empty when
+   * there is none - the shape {@code IndexInternal.checkIntegrity()} uses, so {@code DatabaseChecker} folds the
+   * answers of every storage kind the same way (issue #6340).
+   * <p>
+   * <b>The counters are the point.</b> Page 0 declares a sample count, a min and a max timestamp and a data page
+   * count, and every one of them is maintained exactly by {@link #appendSamples} and recomputed exactly by
+   * {@code clearDataPagesUpTo}, so each is reconcilable against the pages themselves. That is what makes this able
+   * to see the damage issue #6314 left behind: a session that wrote at the wrong stride put real rows at offsets
+   * this bucket will never look at again, and the header it also wrote counts them - so the sum over the data
+   * pages comes up short of the number page 0 claims, which is a statement no other reader ever makes.
+   * <p>
+   * Only page headers are read - 18 bytes at the front of each data page - and no row is decoded. That bounds the
+   * pass at one page read per data page, which is strictly cheaper than the record scan {@code checkBuckets}
+   * already runs over every record bucket.
+   */
+  public List<String> checkIntegrity() throws IOException {
+    final List<String> problems = new ArrayList<>();
+
+    final long fileSize = file.getSize();
+    if (fileSize % pageSize != 0)
+      problems.add("the file is " + fileSize + " bytes, which is not a whole number of " + pageSize
+          + "-byte pages: it was written at a different page size, or its tail was truncated");
+
+    final BasePage headerPage = readHeaderPage();
+    if (headerPage == null) {
+      if (fileSize > 0)
+        problems.add("the file holds " + fileSize + " bytes but page 0 does not carry the 'TSBC' magic: the header "
+            + "page is missing or was overwritten, so nothing can say what the rest of the file holds");
+      return problems;
+    }
+
+    final int formatVersion = headerPage.readByte(HEADER_FORMAT_VERSION_OFFSET) & 0xFF;
+    if (formatVersion != version)
+      problems.add("page 0 declares mutable row format version " + formatVersion + " but the file name says version "
+          + version + ": the two decide whether a TAG column is a 4-byte dictionary id or an inline string");
+
+    final int declaredColumns = headerPage.readShort(HEADER_COLUMN_COUNT_OFFSET) & 0xFFFF;
+    if (!columns.isEmpty() && declaredColumns != columns.size())
+      problems.add("page 0 declares " + declaredColumns + " column(s) but the schema declares " + columns.size());
+
+    final int dataPageCount = headerPage.readInt(HEADER_DATA_PAGE_COUNT);
+    if (dataPageCount < 0) {
+      problems.add("page 0 declares a negative data page count of " + dataPageCount);
+      return problems;
+    }
+
+    final long declaredSamples = headerPage.readLong(HEADER_SAMPLE_COUNT_OFFSET);
+    final long declaredMinTs = headerPage.readLong(HEADER_MIN_TS_OFFSET);
+    final long declaredMaxTs = headerPage.readLong(HEADER_MAX_TS_OFFSET);
+
+    // A component-factory stub has no columns until the type hands them over, and without them there is no stride
+    // and so no per-page sample ceiling to test against. The counters below are still reconcilable.
+    final int maxSamplesPerPage = columns.isEmpty() ? -1 : getMaxSamplesPerPage();
+
+    long samples = 0;
+    long minTs = Long.MAX_VALUE;
+    long maxTs = Long.MIN_VALUE;
+    for (int pageNumber = 1; pageNumber <= dataPageCount; pageNumber++) {
+      final BasePage dataPage = readPageIfPresent(pageNumber);
+      if (dataPage == null) {
+        problems.add("page 0 declares " + dataPageCount + " data page(s) but page " + pageNumber
+            + " is not in the file: the samples it should hold are unreadable");
+        break;
+      }
+
+      final int count = dataPage.readShort(DATA_SAMPLE_COUNT_OFFSET) & 0xFFFF;
+      if (maxSamplesPerPage > 0 && count > maxSamplesPerPage) {
+        problems.add("data page " + pageNumber + " declares " + count + " sample(s), more than the "
+            + maxSamplesPerPage + " a " + pageSize + "-byte page holds at this type's " + rowSize + "-byte stride");
+        continue;
+      }
+
+      samples += count;
+      if (count == 0)
+        continue;
+
+      final long pageMinTs = dataPage.readLong(DATA_MIN_TS_OFFSET);
+      final long pageMaxTs = dataPage.readLong(DATA_MAX_TS_OFFSET);
+      if (pageMinTs > pageMaxTs) {
+        problems.add("data page " + pageNumber + " declares min timestamp " + pageMinTs + " above its max timestamp "
+            + pageMaxTs);
+        continue;
+      }
+      if (pageMinTs < minTs)
+        minTs = pageMinTs;
+      if (pageMaxTs > maxTs)
+        maxTs = pageMaxTs;
+    }
+
+    if (samples != declaredSamples)
+      problems.add("page 0 declares " + declaredSamples + " sample(s) but its " + dataPageCount
+          + " data page(s) hold " + samples);
+
+    if (samples > 0) {
+      if (declaredMinTs != minTs)
+        problems.add("page 0 declares min timestamp " + declaredMinTs + " but its data pages hold " + minTs);
+      if (declaredMaxTs != maxTs)
+        problems.add("page 0 declares max timestamp " + declaredMaxTs + " but its data pages hold " + maxTs);
+    }
+
+    return problems;
   }
 
   void initHeaderPage() throws IOException {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -708,6 +708,14 @@ public class TimeSeriesEngine implements AutoCloseable {
   }
 
   /**
+   * What this type's integrity check found and what it was looking at (issue #6340). {@code CHECK DATABASE}
+   * reports both: a caller reading a sample total of zero on a type that holds millions could not otherwise tell
+   * "checked and clean" from "not looked at", which is the state this whole pass exists to end.
+   */
+  public record IntegrityReport(List<String> problems, int shards, long samples, long sealedBlocks) {
+  }
+
+  /**
    * Validates every file this type stores data in - each shard's mutable bucket and sealed store, plus the shared
    * tag dictionary - and returns one line per problem, empty when there is none (issue #6340).
    * <p>
@@ -718,21 +726,31 @@ public class TimeSeriesEngine implements AutoCloseable {
    * storage component in the engine was covered; these three formats, each with its own magic, header and (for the
    * sealed store) CRCs, were not.
    * <p>
+   * Every shard is visited ONCE, and the totals come back with the verdict rather than being gathered by a second
+   * and third walk over the same shards: each shard measures itself inside the same lock window it checks itself
+   * in, so the numbers and the findings describe one instant instead of three.
+   * <p>
    * Each line names the shard it came from, since a type has as many of each file as it has shards and an operator
    * acting on a finding needs to know which one to act on.
    */
-  public List<String> checkIntegrity() throws IOException {
+  public IntegrityReport checkIntegrity() throws IOException {
     final List<String> problems = new ArrayList<>();
+    long samples = 0;
+    long sealedBlocks = 0;
 
-    for (final TimeSeriesShard shard : shards)
-      for (final String problem : shard.checkIntegrity())
+    for (final TimeSeriesShard shard : shards) {
+      final TimeSeriesShard.IntegrityReport report = shard.checkIntegrity();
+      for (final String problem : report.problems())
         problems.add("shard " + shard.getShardIndex() + " " + problem);
+      samples += report.samples();
+      sealedBlocks += report.sealedBlocks();
+    }
 
     if (tagDictionary != null)
       for (final String problem : tagDictionary.checkIntegrity())
         problems.add("tag dictionary: " + problem);
 
-    return problems;
+    return new IntegrityReport(problems, shardCount, samples, sealedBlocks);
   }
 
   public int getShardCount() {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -707,6 +707,34 @@ public class TimeSeriesEngine implements AutoCloseable {
     return total;
   }
 
+  /**
+   * Validates every file this type stores data in - each shard's mutable bucket and sealed store, plus the shared
+   * tag dictionary - and returns one line per problem, empty when there is none (issue #6340).
+   * <p>
+   * This is what {@code CHECK DATABASE} calls, and until it existed the tool had no reference to TimeSeries at
+   * all: the checker walks record buckets and indexes, and a TimeSeries type has neither - its mutable data lives
+   * in {@code .tstb}/{@code .tstd} components registered with the schema as files rather than as a type's record
+   * buckets, and its compacted data in {@code .ts.sealed} files outside the paginated layer entirely. Every other
+   * storage component in the engine was covered; these three formats, each with its own magic, header and (for the
+   * sealed store) CRCs, were not.
+   * <p>
+   * Each line names the shard it came from, since a type has as many of each file as it has shards and an operator
+   * acting on a finding needs to know which one to act on.
+   */
+  public List<String> checkIntegrity() throws IOException {
+    final List<String> problems = new ArrayList<>();
+
+    for (final TimeSeriesShard shard : shards)
+      for (final String problem : shard.checkIntegrity())
+        problems.add("shard " + shard.getShardIndex() + " " + problem);
+
+    if (tagDictionary != null)
+      for (final String problem : tagDictionary.checkIntegrity())
+        problems.add("tag dictionary: " + problem);
+
+    return problems;
+  }
+
   public int getShardCount() {
     return shardCount;
   }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -1673,9 +1673,12 @@ public class TimeSeriesSealedStore implements AutoCloseable {
         return problems;
       }
 
-      final ByteBuffer headerBuf = ByteBuffer.allocate(HEADER_SIZE);
-      indexChannel.read(headerBuf, 0);
-      headerBuf.flip();
+      // Through readBytes() rather than a bare indexChannel.read(): a FileChannel may legally return fewer bytes
+      // than asked for - not merely theoretical on a network filesystem - and the buffer's untouched tail is
+      // zeros. Anywhere else that costs a retry; HERE it would turn "the read came up short" into a header or a
+      // CRC that does not match, which is a false accusation of corruption made by the very code whose job is to
+      // tell corruption from health. readBytes() loops and throws at a real end of file.
+      final ByteBuffer headerBuf = ByteBuffer.wrap(readBytes(0, HEADER_SIZE));
 
       final int magic = headerBuf.getInt();
       if (magic != MAGIC_VALUE) {
@@ -1771,10 +1774,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
         // Both sides therefore come from the file: the bytes from blockStart, and the CRC from where the writer
         // put it, immediately after the data.
         final int blockSize = (int) (endOfData - blockStart);
-        final ByteBuffer storedCrcBuf = ByteBuffer.allocate(4);
-        indexChannel.read(storedCrcBuf, endOfData);
-        storedCrcBuf.flip();
-        final int storedCRC = storedCrcBuf.getInt();
+        final int storedCRC = ByteBuffer.wrap(readBytes(endOfData, 4)).getInt();
 
         final CRC32 crc = new CRC32();
         crc.update(readBytes(blockStart, blockSize));

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -1643,6 +1643,171 @@ public class TimeSeriesSealedStore implements AutoCloseable {
   }
 
   /**
+   * Validates everything this format asserts about itself and returns one line per problem, empty when there is
+   * none - the shape {@code IndexInternal.checkIntegrity()} uses, so {@code DatabaseChecker} folds the answers of
+   * every storage kind the same way (issue #6340).
+   * <p>
+   * <b>This is what {@code CHECK DATABASE} had no way to look at.</b> The checker walks record buckets and indexes;
+   * a sealed store is neither, so until now the whole of a TimeSeries type's compacted data - which is most of its
+   * data - was outside the reach of the tool whose job is to answer "is this database intact".
+   * <p>
+   * <b>It verifies the block CRCs, and that is the expensive part.</b> Every block carries a CRC32 over its
+   * metadata and its compressed columns, and it is checked lazily on the first read of that block, so a block never
+   * read is a block never verified. Doing it here reads the whole file once, sequentially, which is the same cost
+   * class as the record scan {@code checkBuckets} already runs over every bucket and is the only thing that
+   * actually answers the question. Rows are deliberately NOT decompressed: the CRC covers the same bytes for a
+   * fraction of the CPU, and what a repair would mean for an append-only store is a separate question.
+   * <p>
+   * The on-disk header is compared against the scanned directory only when it is not dirty. {@code appendBlock}
+   * marks it dirty and {@link #flushHeader} rewrites it, so between the two the header legitimately under-reports
+   * the blocks the file already holds and comparing them would report a healthy store as damaged.
+   */
+  public List<String> checkIntegrity() throws IOException {
+    final List<String> problems = new ArrayList<>();
+
+    directoryLock.readLock().lock();
+    try {
+      final long fileLength = indexFile.length();
+      if (fileLength < HEADER_SIZE) {
+        problems.add("the file is " + fileLength + " bytes, shorter than its " + HEADER_SIZE + "-byte header");
+        return problems;
+      }
+
+      final ByteBuffer headerBuf = ByteBuffer.allocate(HEADER_SIZE);
+      indexChannel.read(headerBuf, 0);
+      headerBuf.flip();
+
+      final int magic = headerBuf.getInt();
+      if (magic != MAGIC_VALUE) {
+        problems.add("the header does not start with the 'TSIX' magic (found 0x" + Integer.toHexString(magic)
+            + "): the file is not a sealed store, or its first bytes were overwritten");
+        return problems;
+      }
+
+      final int version = headerBuf.get() & 0xFF;
+      if (version != CURRENT_VERSION)
+        problems.add("the header declares format version " + version + ", but this build writes and reads version "
+            + CURRENT_VERSION);
+
+      final int colCount = headerBuf.getShort() & 0xFFFF;
+      if (colCount != columns.size())
+        problems.add("the header declares " + colCount + " column(s) but the schema declares " + columns.size());
+
+      final int storedBlockCount = headerBuf.getInt();
+      final long storedMinTs = headerBuf.getLong();
+      final long storedMaxTs = headerBuf.getLong();
+
+      if (!headerDirty && storedBlockCount != blockDirectory.size())
+        problems.add("the header declares " + storedBlockCount + " block(s) but scanning the file found "
+            + blockDirectory.size());
+
+      long computedMinTs = Long.MAX_VALUE;
+      long computedMaxTs = Long.MIN_VALUE;
+      // Where the next block's metadata must start. Blocks are written back to back from the header onwards, so
+      // this is the only description of a block's start that holds for EVERY entry in the directory: the
+      // BlockEntry.blockStartOffset field is populated by loadDirectory() alone, and a block appended by this
+      // process carries 0 in it (see the CRC comment below).
+      long blockStart = HEADER_SIZE;
+      // Whether the walk reached the end of the directory. The two totals below and the trailing-bytes check are
+      // both statements about ALL the blocks, so a walk that stopped at block N cannot make either of them: what
+      // it accumulated is a prefix, and reporting a prefix as the whole would turn one finding into three.
+      boolean walkedEveryBlock = true;
+
+      for (int i = 0; i < blockDirectory.size(); i++) {
+        final BlockEntry entry = blockDirectory.get(i);
+
+        if (entry.sampleCount <= 0)
+          problems.add("block " + i + " (offset " + blockStart + ") declares " + entry.sampleCount + " sample(s)");
+        if (entry.minTimestamp > entry.maxTimestamp)
+          problems.add("block " + i + " (offset " + blockStart + ") declares min timestamp " + entry.minTimestamp
+              + " above its max timestamp " + entry.maxTimestamp);
+
+        boolean sizesUsable = true;
+        for (int c = 0; c < entry.columnSizes.length; c++)
+          if (entry.columnSizes[c] < 0) {
+            problems.add("block " + i + " (offset " + blockStart + ") declares a negative size " + entry.columnSizes[c]
+                + " for column " + c);
+            sizesUsable = false;
+          }
+
+        // The metadata sits between the block's start and its first column, so a first column at or before the
+        // start means the directory and the file disagree about where this block is - and every offset after it
+        // is then meaningless, which is why the walk stops rather than carrying on.
+        if (sizesUsable && entry.columnOffsets[0] <= blockStart) {
+          problems.add("block " + i + " places its first column at " + entry.columnOffsets[0]
+              + ", at or before the " + blockStart + " where the block itself starts");
+          sizesUsable = false;
+        }
+
+        if (!sizesUsable) {
+          walkedEveryBlock = false;
+          break;
+        }
+
+        final long endOfData =
+            entry.columnOffsets[entry.columnSizes.length - 1] + entry.columnSizes[entry.columnSizes.length - 1];
+        if (endOfData + 4 > fileLength) {
+          problems.add("block " + i + " (offset " + blockStart + ") ends at " + (endOfData + 4)
+              + ", past the end of a file of " + fileLength + " bytes: it was truncated");
+          walkedEveryBlock = false;
+          break;
+        }
+
+        if (entry.minTimestamp < computedMinTs)
+          computedMinTs = entry.minTimestamp;
+        if (entry.maxTimestamp > computedMaxTs)
+          computedMaxTs = entry.maxTimestamp;
+
+        // Recomputed from the FILE, not delegated to validateBlockCRC() and not compared against entry.storedCRC.
+        // Two reasons, and both are about a check having to actually look:
+        //  - validateBlockCRC() returns early for a block whose flag is already set, which is right for a read (a
+        //    block is immutable once written, so paying twice buys nothing) and wrong here: a second CHECK DATABASE
+        //    in the same process would answer "clean" without having read a byte.
+        //  - blockStartOffset and storedCRC are populated by loadDirectory() alone, i.e. only for blocks this
+        //    process found on disk when it opened the file. A block appended by THIS process has both on disk and
+        //    zero in the fields, with crcValidated pre-set to true because a block just written needs no checking
+        //    - so it is precisely the block a check must not take memory's word about. Nothing reads those two
+        //    fields for such a block today, which is why the gap is latent rather than a defect.
+        // Both sides therefore come from the file: the bytes from blockStart, and the CRC from where the writer
+        // put it, immediately after the data.
+        final int blockSize = (int) (endOfData - blockStart);
+        final ByteBuffer storedCrcBuf = ByteBuffer.allocate(4);
+        indexChannel.read(storedCrcBuf, endOfData);
+        storedCrcBuf.flip();
+        final int storedCRC = storedCrcBuf.getInt();
+
+        final CRC32 crc = new CRC32();
+        crc.update(readBytes(blockStart, blockSize));
+        if ((int) crc.getValue() != storedCRC)
+          problems.add("block " + i + ": CRC mismatch at offset " + blockStart + " (stored=0x"
+              + Integer.toHexString(storedCRC) + ", computed=0x" + Integer.toHexString((int) crc.getValue())
+              + "): its metadata or its compressed columns are not the bytes that were written");
+
+        blockStart = endOfData + 4;
+      }
+
+      if (walkedEveryBlock && !headerDirty && !blockDirectory.isEmpty()) {
+        if (storedMinTs != computedMinTs)
+          problems.add("the header declares global min timestamp " + storedMinTs + " but the blocks hold "
+              + computedMinTs);
+        if (storedMaxTs != computedMaxTs)
+          problems.add("the header declares global max timestamp " + storedMaxTs + " but the blocks hold "
+              + computedMaxTs);
+      }
+
+      if (walkedEveryBlock && blockStart != fileLength)
+        // The directory scan stops at the first thing that is not a block magic, so a partial block left by an
+        // interrupted append is invisible to every other reader: it is neither used nor reported. Say so.
+        problems.add((fileLength - blockStart) + " byte(s) follow the last readable block and belong to no "
+            + "block: the tail of a write that did not complete. They are ignored by every read path");
+    } finally {
+      directoryLock.readLock().unlock();
+    }
+
+    return problems;
+  }
+
+  /**
    * Returns how many times {@link #downsampleBlocks} actually rewrote the sealed file. A steady-state
    * maintenance cycle (nothing new old enough to reduce) must not increment this. Used by regression tests
    * to assert downsampling idempotency (issue #4599).

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -956,18 +956,30 @@ public class TimeSeriesShard implements AutoCloseable {
    * Validates both halves of this shard - the mutable bucket's pages and the sealed store's blocks - and returns
    * one line per problem, empty when there is none, together with what the two halves hold (issue #6340).
    * <p>
-   * <b>The locks are what make the answer worth having.</b> Every counter checked on either side is reconciled
-   * against the bytes it describes, and both are maintained live: an append raises the mutable header's sample
-   * count and a compaction moves rows from one half to the other. Reading them without holding anything would
-   * report a healthy shard as damaged whenever a write landed between the counter and the walk, which is the
-   * failure mode that makes a check nobody trusts. {@link #appendLock} first and then the compaction READ lock,
-   * the order {@link #appendSamples(TimeSeriesRowSource)} takes them in and the one that keeps this free of the
-   * inversion the class comment warns about; queries are unaffected, since they take the same read lock.
+   * <b>Two windows, and which work goes in which is the whole design here.</b>
    * <p>
-   * The sample and block totals are taken inside that same window, which is why they are returned from here rather
-   * than read off the shard afterwards: a compaction landing in between moves rows from the mutable half to the
-   * sealed one, so a total gathered separately describes neither the state the walk checked nor any other single
-   * instant.
+   * The SHORT window holds {@link #appendLock} and then the compaction READ lock - the order
+   * {@link #appendSamples(TimeSeriesRowSource)} takes them in, and the one that keeps this free of the inversion
+   * the class comment warns about. It covers the mutable bucket's check and BOTH totals. It has to: the mutable
+   * header's counters are raised by every append and recomputed by every compaction, so reconciling them against
+   * the pages without holding anything would report a healthy shard as damaged whenever a write landed in
+   * between, and a total taken outside it would describe neither the state the walk checked nor any other single
+   * instant, since a compaction moves rows from one half to the other. That window is bounded by the mutable
+   * bucket's page count and reads page headers only.
+   * <p>
+   * The sealed store's check runs OUTSIDE both, under nothing but its own {@code directoryLock} read lock, which
+   * it takes itself. That is the expensive half - it CRC32s the whole {@code .ts.sealed} file - and holding the
+   * append lock across it would stall ingestion on this shard for the length of a sequential read of the largest
+   * file the type owns. It does not need them: a sealed block is immutable once written, and every path that
+   * mutates the file ({@code appendBlock}, {@code commitTempCompactionFile}, {@code truncateBefore},
+   * {@code downsampleBlocks}, {@code truncateToBlockCount}, {@code installSealedFileBytes}) takes that same
+   * directory WRITE lock, so the read lock alone already excludes all of them. Layering the shard's locks on top
+   * bought no consistency and cost writers the whole scan.
+   * <p>
+   * The consequence, stated rather than left to be discovered: a compaction may run between the two windows, so
+   * the sealed store the second half checks can hold blocks the totals did not count. That is the right trade -
+   * the totals are a report of what was there and the findings are a verdict on what is there, and a compaction
+   * moving rows between two halves that are BOTH being reported cannot invent or lose a sample.
    * <p>
    * Each problem is prefixed with which half of the shard it came from, because the two are different files with
    * different formats and different repairs: the mutable bucket is replicated page-by-page under HA while the
@@ -975,6 +987,8 @@ public class TimeSeriesShard implements AutoCloseable {
    */
   public IntegrityReport checkIntegrity() throws IOException {
     final List<String> problems = new ArrayList<>();
+    final long samples;
+    final long sealedBlocks;
 
     appendLock.lock();
     try {
@@ -982,17 +996,20 @@ public class TimeSeriesShard implements AutoCloseable {
       try {
         for (final String problem : mutableBucket.checkIntegrity())
           problems.add("mutable bucket: " + problem);
-        for (final String problem : sealedStore.checkIntegrity())
-          problems.add("sealed store: " + problem);
 
-        return new IntegrityReport(problems, mutableBucket.getSampleCount() + sealedStore.getTotalSampleCount(),
-            sealedStore.getBlockCount());
+        samples = mutableBucket.getSampleCount() + sealedStore.getTotalSampleCount();
+        sealedBlocks = sealedStore.getBlockCount();
       } finally {
         compactionLock.readLock().unlock();
       }
     } finally {
       appendLock.unlock();
     }
+
+    for (final String problem : sealedStore.checkIntegrity())
+      problems.add("sealed store: " + problem);
+
+    return new IntegrityReport(problems, samples, sealedBlocks);
   }
 
   public TimeSeriesBucket getMutableBucket() {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -943,6 +943,43 @@ public class TimeSeriesShard implements AutoCloseable {
     }
   }
 
+  /**
+   * Validates both halves of this shard - the mutable bucket's pages and the sealed store's blocks - and returns
+   * one line per problem, empty when there is none (issue #6340).
+   * <p>
+   * <b>The locks are what make the answer worth having.</b> Every counter checked on either side is reconciled
+   * against the bytes it describes, and both are maintained live: an append raises the mutable header's sample
+   * count and a compaction moves rows from one half to the other. Reading them without holding anything would
+   * report a healthy shard as damaged whenever a write landed between the counter and the walk, which is the
+   * failure mode that makes a check nobody trusts. {@link #appendLock} first and then the compaction READ lock,
+   * the order {@link #appendSamples(TimeSeriesRowSource)} takes them in and the one that keeps this free of the
+   * inversion the class comment warns about; queries are unaffected, since they take the same read lock.
+   * <p>
+   * Each problem is prefixed with which half of the shard it came from, because the two are different files with
+   * different formats and different repairs: the mutable bucket is replicated page-by-page under HA while the
+   * sealed store is derived and rebuilt locally by each node's own compaction.
+   */
+  public List<String> checkIntegrity() throws IOException {
+    final List<String> problems = new ArrayList<>();
+
+    appendLock.lock();
+    try {
+      compactionLock.readLock().lock();
+      try {
+        for (final String problem : mutableBucket.checkIntegrity())
+          problems.add("mutable bucket: " + problem);
+        for (final String problem : sealedStore.checkIntegrity())
+          problems.add("sealed store: " + problem);
+      } finally {
+        compactionLock.readLock().unlock();
+      }
+    } finally {
+      appendLock.unlock();
+    }
+
+    return problems;
+  }
+
   public TimeSeriesBucket getMutableBucket() {
     return mutableBucket;
   }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -944,8 +944,17 @@ public class TimeSeriesShard implements AutoCloseable {
   }
 
   /**
+   * What one shard's integrity check found and what it was looking at: the problems, empty when there are none,
+   * and the size of the thing they are a verdict on. The two travel together deliberately (issue #6340) - a
+   * caller asking the shard separately for its sample count would be told about a different instant than the one
+   * the verdict describes, and would visit the shard three times to learn it.
+   */
+  public record IntegrityReport(List<String> problems, long samples, long sealedBlocks) {
+  }
+
+  /**
    * Validates both halves of this shard - the mutable bucket's pages and the sealed store's blocks - and returns
-   * one line per problem, empty when there is none (issue #6340).
+   * one line per problem, empty when there is none, together with what the two halves hold (issue #6340).
    * <p>
    * <b>The locks are what make the answer worth having.</b> Every counter checked on either side is reconciled
    * against the bytes it describes, and both are maintained live: an append raises the mutable header's sample
@@ -955,11 +964,16 @@ public class TimeSeriesShard implements AutoCloseable {
    * the order {@link #appendSamples(TimeSeriesRowSource)} takes them in and the one that keeps this free of the
    * inversion the class comment warns about; queries are unaffected, since they take the same read lock.
    * <p>
+   * The sample and block totals are taken inside that same window, which is why they are returned from here rather
+   * than read off the shard afterwards: a compaction landing in between moves rows from the mutable half to the
+   * sealed one, so a total gathered separately describes neither the state the walk checked nor any other single
+   * instant.
+   * <p>
    * Each problem is prefixed with which half of the shard it came from, because the two are different files with
    * different formats and different repairs: the mutable bucket is replicated page-by-page under HA while the
    * sealed store is derived and rebuilt locally by each node's own compaction.
    */
-  public List<String> checkIntegrity() throws IOException {
+  public IntegrityReport checkIntegrity() throws IOException {
     final List<String> problems = new ArrayList<>();
 
     appendLock.lock();
@@ -970,14 +984,15 @@ public class TimeSeriesShard implements AutoCloseable {
           problems.add("mutable bucket: " + problem);
         for (final String problem : sealedStore.checkIntegrity())
           problems.add("sealed store: " + problem);
+
+        return new IntegrityReport(problems, mutableBucket.getSampleCount() + sealedStore.getTotalSampleCount(),
+            sealedStore.getBlockCount());
       } finally {
         compactionLock.readLock().unlock();
       }
     } finally {
       appendLock.unlock();
     }
-
-    return problems;
   }
 
   public TimeSeriesBucket getMutableBucket() {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -653,6 +653,10 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
 
     final int capacity = pageSize - BasePage.PAGE_HEADER_SIZE - DATA_ENTRIES_OFFSET;
     int entries = 0;
+    // Whether every page page 0 announces was walked to its end. The total below is a statement about ALL of them,
+    // so a walk that stopped partway cannot make it: what it counted is a prefix, and reporting a prefix as the
+    // whole restates one finding as two.
+    boolean walkedEveryEntry = true;
 
     for (int pageNumber = 1; pageNumber <= declaredPages; pageNumber++) {
       final BasePage page = database.getPageManager()
@@ -660,6 +664,7 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       if (page == null) {
         problems.add("page 0 declares " + declaredPages + " data page(s) but page " + pageNumber
             + " is not in the file: every id stored on it is unresolvable");
+        walkedEveryEntry = false;
         break;
       }
 
@@ -668,6 +673,7 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       if (pageEntries < 0 || pageUsed < 0 || pageUsed > capacity) {
         problems.add("data page " + pageNumber + " declares " + pageEntries + " entries over " + pageUsed
             + " byte(s), which a page of capacity " + capacity + " cannot hold");
+        walkedEveryEntry = false;
         continue;
       }
 
@@ -680,12 +686,14 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
         if (offset + 2 > pageUsed) {
           problems.add("data page " + pageNumber + " declares " + pageEntries + " entries but only " + walked
               + " fit in the " + pageUsed + " byte(s) it declares as used");
+          walkedEveryEntry = false;
           break;
         }
         final int length = page.readShort(DATA_ENTRIES_OFFSET + offset) & 0xFFFF;
         if (length > TimeSeriesBucket.MAX_STRING_BYTES || offset + 2 + length > pageUsed) {
           problems.add("entry " + walked + " of data page " + pageNumber + " declares a length of " + length
               + " byte(s), which runs past the " + pageUsed + " byte(s) the page declares as used");
+          walkedEveryEntry = false;
           break;
         }
         offset += 2 + length;
@@ -694,7 +702,7 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
       entries += walked;
     }
 
-    if (entries != declaredEntries)
+    if (walkedEveryEntry && entries != declaredEntries)
       problems.add("page 0 declares " + declaredEntries + " entries but its " + declaredPages
           + " data page(s) hold " + entries + ": the ids above " + entries + " resolve to nothing");
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesTagDictionary.java
@@ -182,14 +182,15 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
   }
 
   /**
-   * Opens a second view over a file that is ALREADY registered with the file manager, taking the id, the page size
-   * and the version from that file rather than re-deriving any of them (issue #6314). Every one of the three is a
-   * property of the file and of nothing else, so this is the only form a caller in that position should need.
+   * Opens a second view over a file that is ALREADY registered with the file manager, taking the id, the page size,
+   * the version AND the mode from that file rather than re-deriving any of them (issues #6314 and #6340). Every one
+   * of the four is a property of the file and of nothing else, so this is the only form a caller in that position
+   * should need - and the mode was the last one still guessed here, hard-coded to {@code READ_WRITE} in the middle
+   * of three values that were read off the file, because {@code ComponentFile} had no accessor for it.
    */
   public TimeSeriesTagDictionary(final DatabaseInternal database, final String name, final PaginatedComponentFile file)
       throws IOException {
-    this(database, name, file.getFilePath(), file.getFileId(), ComponentFile.MODE.READ_WRITE, file.getPageSize(),
-        file.getVersion());
+    this(database, name, file.getFilePath(), file.getFileId(), file.getMode(), file.getPageSize(), file.getVersion());
   }
 
   /**
@@ -591,6 +592,113 @@ public class TimeSeriesTagDictionary extends PaginatedComponent {
    */
   public void setMaxSize(final int maxSize) {
     this.maxSize = maxSize;
+  }
+
+  /**
+   * Validates everything this format asserts about itself and returns one line per problem, empty when there is
+   * none - the shape {@code IndexInternal.checkIntegrity()} uses, so {@code DatabaseChecker} folds the answers of
+   * every storage kind the same way (issue #6340).
+   * <p>
+   * What it can find that nothing else does: a dictionary is the only thing that can turn a 4-byte id in a
+   * mutable row back into the tag it stands for, so a truncated or unwalkable one does not fail a query - it makes
+   * every tag written since the damage read back as {@code null}, silently, on every row. The entry count in page
+   * 0 and the per-page counters are reconcilable against the entries themselves, which is what lets that be said
+   * before a reader trips over it.
+   * <p>
+   * The walk is the same one {@link #load(StoredHeader)} does and costs the same: one page read per data page,
+   * with the entries decoded only far enough to step over them.
+   * <p>
+   * Held under {@link #internLock} for the same reason the shard check holds its append lock: the counters are
+   * raised by a live writer, so reading page 0 and then walking the pages without it would report a healthy
+   * dictionary as short by exactly the entries an intern committed in between. Interning is contended only during
+   * warm-up, so this blocks nothing in steady state.
+   */
+  public List<String> checkIntegrity() throws IOException {
+    internLock.lock();
+    try {
+      return checkIntegrityUnderLock();
+    } finally {
+      internLock.unlock();
+    }
+  }
+
+  private List<String> checkIntegrityUnderLock() throws IOException {
+    final List<String> problems = new ArrayList<>();
+
+    final long fileSize = getComponentFile().getSize();
+    if (fileSize % pageSize != 0)
+      problems.add("the file is " + fileSize + " bytes, which is not a whole number of " + pageSize
+          + "-byte pages: it was written at a different page size, or its tail was truncated");
+
+    final BasePage headerPage = database.getPageManager()
+        .getImmutablePage(new PageId(database, fileId, 0), pageSize, true, false);
+    if (headerPage == null || headerPage.readInt(HEADER_MAGIC_OFFSET) != MAGIC_VALUE) {
+      if (fileSize > 0)
+        problems.add("the file holds " + fileSize + " bytes but page 0 does not carry the 'TSTD' magic: the header "
+            + "page is missing or was overwritten, so every tag id in this type's rows is unresolvable");
+      return problems;
+    }
+
+    final int formatVersion = headerPage.readByte(HEADER_FORMAT_VERSION_OFFSET) & 0xFF;
+    if (formatVersion != version)
+      problems.add("page 0 declares format version " + formatVersion + " but the file name says version " + version);
+
+    final int declaredEntries = headerPage.readInt(HEADER_ENTRY_COUNT_OFFSET);
+    final int declaredPages = headerPage.readInt(HEADER_DATA_PAGE_COUNT);
+    if (declaredEntries < 0 || declaredPages < 0) {
+      problems.add("page 0 declares " + declaredEntries + " entries over " + declaredPages
+          + " data page(s), and a count cannot be negative");
+      return problems;
+    }
+
+    final int capacity = pageSize - BasePage.PAGE_HEADER_SIZE - DATA_ENTRIES_OFFSET;
+    int entries = 0;
+
+    for (int pageNumber = 1; pageNumber <= declaredPages; pageNumber++) {
+      final BasePage page = database.getPageManager()
+          .getImmutablePage(new PageId(database, fileId, pageNumber), pageSize, true, false);
+      if (page == null) {
+        problems.add("page 0 declares " + declaredPages + " data page(s) but page " + pageNumber
+            + " is not in the file: every id stored on it is unresolvable");
+        break;
+      }
+
+      final int pageEntries = page.readInt(DATA_ENTRY_COUNT_OFFSET);
+      final int pageUsed = page.readInt(DATA_USED_BYTES_OFFSET);
+      if (pageEntries < 0 || pageUsed < 0 || pageUsed > capacity) {
+        problems.add("data page " + pageNumber + " declares " + pageEntries + " entries over " + pageUsed
+            + " byte(s), which a page of capacity " + capacity + " cannot hold");
+        continue;
+      }
+
+      // Walked rather than trusted: the counters and the bytes have to agree, and it is the bytes a reader
+      // actually steps through - an entry whose length prefix overruns the used region makes every entry after
+      // it on the page resolve to something else.
+      int offset = 0;
+      int walked = 0;
+      while (walked < pageEntries) {
+        if (offset + 2 > pageUsed) {
+          problems.add("data page " + pageNumber + " declares " + pageEntries + " entries but only " + walked
+              + " fit in the " + pageUsed + " byte(s) it declares as used");
+          break;
+        }
+        final int length = page.readShort(DATA_ENTRIES_OFFSET + offset) & 0xFFFF;
+        if (length > TimeSeriesBucket.MAX_STRING_BYTES || offset + 2 + length > pageUsed) {
+          problems.add("entry " + walked + " of data page " + pageNumber + " declares a length of " + length
+              + " byte(s), which runs past the " + pageUsed + " byte(s) the page declares as used");
+          break;
+        }
+        offset += 2 + length;
+        walked++;
+      }
+      entries += walked;
+    }
+
+    if (entries != declaredEntries)
+      problems.add("page 0 declares " + declaredEntries + " entries but its " + declaredPages
+          + " data page(s) hold " + entries + ": the ids above " + entries + " resolve to nothing");
+
+    return problems;
   }
 
   // --- Private helpers ---

--- a/engine/src/test/java/com/arcadedb/engine/Issue6340ComponentFileAgreementTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6340ComponentFileAgreementTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6340, items 1 to 3: the last three places where a component and the file it holds could disagree about a
+ * property that belongs to the file.
+ * <p>
+ * The set is the one issues #6283 (the file id) and #6314 (the page size, and the by-id name check) have been
+ * closing one member at a time: a component built on an already-registered file must take EVERY file property from
+ * that file, and the agreement must live in the API rather than in whoever remembered to check.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6340ComponentFileAgreementTest extends TestHelper {
+
+  /**
+   * Item 1: the mode was the one file property with no accessor, so a component built on an existing file had to
+   * guess it while reading the other four off the file.
+   */
+  @Test
+  void aRegisteredFileReportsTheModeItWasOpenedWith() {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    for (final ComponentFile file : db.getFileManager().getFiles())
+      if (file != null)
+        assertThat(file.getMode()).isEqualTo(ComponentFile.MODE.READ_WRITE);
+  }
+
+  /**
+   * Item 2: the by-name {@code getOrCreateFile} consulted the caller's mode only on the miss path, so a hit handed
+   * the registered file back whatever mode it carried. The direction that matters is the quiet one - asking for
+   * READ_ONLY and being given a writable file is a weaker guarantee than the caller requested.
+   */
+  @Test
+  void theByNameGetOrCreateFileRefusesToHandBackAFileOpenInAnotherMode() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final FileManager fileManager = db.getFileManager();
+    final int pageSize = GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger();
+    final String name = "issue6340_mode";
+    final int fileId = fileManager.newFileId();
+    final String fileName = name + "." + fileId + "." + pageSize + ".v" + LocalBucket.CURRENT_VERSION + "."
+        + LocalBucket.BUCKET_EXT;
+    final String filePath = db.getDatabasePath() + File.separator + fileName;
+
+    final ComponentFile created = fileManager.getOrCreateFile(name, filePath, ComponentFile.MODE.READ_WRITE);
+    try {
+      // Asking again in the mode the file carries is the idempotent case and stays idempotent.
+      assertThat(fileManager.getOrCreateFile(name, filePath, ComponentFile.MODE.READ_WRITE)).isSameAs(created);
+
+      assertThatThrownBy(() -> fileManager.getOrCreateFile(name, filePath, ComponentFile.MODE.READ_ONLY))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining(fileName)
+          .hasMessageContaining("already open in mode READ_WRITE")
+          .hasMessageContaining("requested in mode READ_ONLY");
+    } finally {
+      fileManager.dropFile(fileId);
+    }
+  }
+
+  /**
+   * Item 3: the version is the third fact baked into a component file's name and was the only one of the three not
+   * asserted against the file the component ends up holding. It decides how the pages are INTERPRETED, so a
+   * component that carries a different one from its file misreads real bytes rather than raising anything.
+   */
+  @Test
+  void aComponentThatDisagreesWithItsFileAboutTheVersionFailsAtConstruction() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger();
+    final String name = "issue6340_version";
+    final int fileId = db.getFileManager().newFileId();
+    // The file name says version 1 - a paired external-property bucket, which is a real layout with a 256-slot page
+    // table instead of 2048 - while the component below claims LocalBucket.CURRENT_VERSION. That is the shape a
+    // component re-deriving its version from a constant instead of taking the one parsed off the name ends up in.
+    final String filePath =
+        db.getDatabasePath() + File.separator + name + "." + fileId + "." + pageSize + ".v1." + LocalBucket.BUCKET_EXT;
+
+    try {
+      assertThatThrownBy(
+          () -> new LocalBucket(db, name, filePath, fileId, ComponentFile.MODE.READ_WRITE, pageSize,
+              LocalBucket.CURRENT_VERSION))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining(name)
+          .hasMessageContaining("version " + LocalBucket.CURRENT_VERSION)
+          .hasMessageContaining("has version 1");
+    } finally {
+      // As with the id and page-size guards, the construction failed AFTER getOrCreateFile() had registered the
+      // file and nothing reclaims it: deliberate on a path no legitimate caller takes.
+      db.getFileManager().dropFile(fileId);
+    }
+  }
+
+  /**
+   * The guard is a tripwire, not a compatibility gate: a component built with the version its own file name
+   * carries is the legitimate case and must still open, whatever {@code CURRENT_VERSION} happens to be. Every load
+   * path passes the parsed version straight through, so this is the shape every existing database opens in.
+   */
+  @Test
+  void aComponentBuiltOnTheVersionItsFileNameCarriesOpensNormally() throws IOException {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int pageSize = GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getValueAsInteger();
+    final String name = "issue6340_otherversion";
+    final int fileId = db.getFileManager().newFileId();
+    final String filePath =
+        db.getDatabasePath() + File.separator + name + "." + fileId + "." + pageSize + ".v1." + LocalBucket.BUCKET_EXT;
+
+    final LocalBucket bucket = new LocalBucket(db, name, filePath, fileId, ComponentFile.MODE.READ_WRITE, pageSize, 1);
+    try {
+      assertThat(bucket.getVersion()).isEqualTo(1);
+      assertThat(bucket.getComponentFile().getVersion()).isEqualTo(1);
+      assertThat(bucket.getComponentFile().getMode()).isEqualTo(ComponentFile.MODE.READ_WRITE);
+    } finally {
+      bucket.close();
+      db.getFileManager().dropFile(fileId);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6340 (item 4): {@code CHECK DATABASE} had no TimeSeries coverage at all - {@code DatabaseChecker}
+ * contained zero occurrences of {@code TimeSeries}, {@code tstb} or {@code tstd}.
+ * <p>
+ * The checker walks record buckets and indexes. A TimeSeries type has neither: {@code LocalTimeSeriesType}
+ * registers its shards with the schema as FILES rather than as a type's record buckets, and its compacted data
+ * lives in {@code .ts.sealed} files outside the paginated layer entirely. Since {@code LocalTimeSeriesType extends
+ * LocalDocumentType}, such a type fell into the checker's document arm and then had no record bucket to scan - so
+ * the three on-disk formats TimeSeries owns, two of them with their own magics, headers and CRCs, were the only
+ * storage in the engine the integrity check could not see.
+ * <p>
+ * That was not abstract. #6314 fixed a bug that wrote real rows to disk at the wrong stride; the fix stops it
+ * recurring but cannot undo the pages a mismatched session already wrote, and there was no way to detect a file
+ * left in that state. The header such a session also wrote counts rows the pages no longer hold, which is exactly
+ * what {@link #aMutableBucketWhoseHeaderCountsSamplesItsPagesDoNotHoldIsReported()} pins.
+ * <p>
+ * The teardown integrity check is disabled for this class because three of its tests deliberately leave a damaged
+ * file behind; the healthy case asserts cleanliness explicitly instead.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6340TimeSeriesCheckDatabaseTest extends TestHelper {
+
+  private static final int ROWS = 3_000;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  private TimeSeriesEngine createType(final String typeName) {
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    return ((LocalTimeSeriesType) database.getSchema().getType(typeName)).getEngine();
+  }
+
+  private void appendRows(final TimeSeriesEngine engine, final int rows) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + i * 1_000L;
+      columns[0][i] = "host_" + (i % 7);
+      columns[1][i] = (double) i;
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+
+  private Result runCheck() {
+    try (final ResultSet resultSet = database.command("sql", "CHECK DATABASE")) {
+      assertThat(resultSet.hasNext()).isTrue();
+      return resultSet.next();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<String> warningsOf(final Result row) {
+    return (Collection<String>) row.<Collection<?>>getProperty("warnings");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<String> corruptedTypesOf(final Result row) {
+    return (Collection<String>) row.<Collection<?>>getProperty("corruptedTimeSeries");
+  }
+
+  /**
+   * Flips one bit at {@code offset} of {@code file}, which is the least the format has to notice.
+   */
+  private static void flipByteAt(final File file, final long offset) throws IOException {
+    try (final RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+      raf.seek(offset);
+      final int b = raf.read();
+      raf.seek(offset);
+      raf.write(b ^ 0x01);
+    }
+  }
+
+  /**
+   * The pass runs, walks what is there and says so. The counters matter as much as the empty warning list: a
+   * caller reading {@code totalTimeSeriesSamples} as zero on a database that holds three thousand of them would
+   * have no way to tell "checked and clean" from "not looked at", which is the state this whole item was about.
+   * <p>
+   * The sealed block here was appended by THIS process rather than found on disk at open, which is the case whose
+   * block-start offset and stored CRC live only in the file and not in the in-memory directory. Verifying it
+   * against what memory believes reports a healthy store as damaged, so this is the arm that pins it.
+   */
+  @Test
+  void aHealthyTimeSeriesTypeIsWalkedAndReportedClean() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    appendRows(engine, 100);
+
+    final Result row = runCheck();
+
+    assertThat(warningsOf(row)).as("warnings").isEmpty();
+    assertThat(corruptedTypesOf(row)).isEmpty();
+    assertThat(row.<Long>getProperty("totalTimeSeriesTypes")).isEqualTo(1L);
+    assertThat(row.<Long>getProperty("totalTimeSeriesShards")).isEqualTo(1L);
+    assertThat(row.<Long>getProperty("totalTimeSeriesSamples")).isEqualTo(ROWS + 100L);
+    assertThat(row.<Long>getProperty("totalTimeSeriesSealedBlocks")).isGreaterThan(0L);
+  }
+
+  /**
+   * A database with no TimeSeries type answers the question with zeros rather than with silence, and its step plan
+   * is the one it always had - the pass adds no step where there is nothing to check.
+   */
+  @Test
+  void aDatabaseWithoutTimeSeriesReportsZerosRatherThanNothing() {
+    database.getSchema().createDocumentType("Note");
+    database.transaction(() -> database.newDocument("Note").set("i", 1).save());
+
+    final Result row = runCheck();
+
+    assertThat(warningsOf(row)).isEmpty();
+    assertThat(corruptedTypesOf(row)).isEmpty();
+    assertThat(row.<Long>getProperty("totalTimeSeriesTypes")).isZero();
+    assertThat(row.<Long>getProperty("totalTimeSeriesShards")).isZero();
+    assertThat(row.<Long>getProperty("totalTimeSeriesSamples")).isZero();
+    assertThat(row.<Long>getProperty("totalTimeSeriesSealedBlocks")).isZero();
+  }
+
+  /**
+   * The residue of #6314, reproduced in the shape it leaves behind: page 0 counts samples the data pages do not
+   * hold. A session that wrote at the wrong stride put real rows at offsets nothing will address again and
+   * incremented the header for each of them, so the two disagree permanently and no read path ever says so - a
+   * query simply returns fewer rows than were written.
+   */
+  @Test
+  void aMutableBucketWhoseHeaderCountsSamplesItsPagesDoNotHoldIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    final String bucketPath = engine.getShard(0).getMutableBucket().getComponentFile().getFilePath();
+
+    database.close();
+    try {
+      // Page 0's sample counter, at content offset 7 of the header page. Raised rather than lowered so the file
+      // says what a wrong-stride session's file says: more samples counted than the pages can account for.
+      try (final RandomAccessFile raf = new RandomAccessFile(new File(bucketPath), "rw")) {
+        raf.seek(BasePage.PAGE_HEADER_SIZE + 7);
+        raf.writeLong(ROWS + 500L);
+      }
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'") && w.contains("shard 0 mutable bucket")
+        && w.contains("declares " + (ROWS + 500) + " sample(s)") && w.contains("hold " + ROWS));
+  }
+
+  /**
+   * The header page of a mutable bucket is what says how to read everything after it. Without it nothing can, and
+   * before this pass nothing said so either.
+   */
+  @Test
+  void aMutableBucketWithNoHeaderMagicIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, 500);
+    final String bucketPath = engine.getShard(0).getMutableBucket().getComponentFile().getFilePath();
+
+    database.close();
+    try {
+      flipByteAt(new File(bucketPath), BasePage.PAGE_HEADER_SIZE);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'") && w.contains("'TSBC' magic"));
+  }
+
+  /**
+   * Every sealed block carries a CRC32 over its metadata and its compressed columns, and it is verified lazily on
+   * the first read of that block - so a block nothing queries is a block nothing verifies. Checking them here is
+   * what turns "the data is probably fine" into an answer, and it is the reason this pass reads the sealed file
+   * rather than only its header.
+   */
+  @Test
+  void aSealedBlockWhoseBytesChangedFailsItsCRC() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    final File sealed = new File(getDatabasePath(), "Cpu_shard_0.ts.sealed");
+    assertThat(sealed).exists();
+
+    database.close();
+    try {
+      // Inside the last block's compressed data: the final four bytes are that block's stored CRC, and the
+      // directory scan that precedes the check has to still recognise the block for the CRC to be the finding.
+      flipByteAt(sealed, sealed.length() - 8);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'") && w.contains("sealed store")
+        && w.contains("CRC mismatch"));
+
+    // And again, in the same process: the sealed store caches "this block's CRC has been verified" so a read never
+    // pays for it twice, which is right for a read and would make a second check answer "clean" without looking.
+    final Result second = runCheck();
+    assertThat(corruptedTypesOf(second)).containsExactly("Cpu");
+    assertThat(warningsOf(second)).anyMatch(w -> w.contains("CRC mismatch"));
+  }
+
+  /**
+   * A tag dictionary is the only thing that can turn a 4-byte id in a mutable row back into the tag it stands
+   * for. Losing it does not fail a query: every tag reads back as null, on every row, silently.
+   */
+  @Test
+  void aTagDictionaryWithNoHeaderMagicIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, 500);
+    final TimeSeriesTagDictionary dictionary = engine.getTagDictionary();
+    assertThat(dictionary).isNotNull();
+    final String dictionaryPath = dictionary.getComponentFile().getFilePath();
+
+    database.close();
+    try {
+      flipByteAt(new File(dictionaryPath), BasePage.PAGE_HEADER_SIZE);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'") && w.contains("tag dictionary")
+        && w.contains("'TSTD' magic"));
+  }
+
+  /**
+   * The TYPE scope reaches TimeSeries the way it reaches every other type: naming one checks its files and leaves
+   * the other one's alone.
+   */
+  @Test
+  void theTypeScopeSelectsWhichTimeSeriesTypeIsChecked() throws Exception {
+    appendRows(createType("Cpu"), 500);
+    final TimeSeriesEngine memory = createType("Memory");
+    appendRows(memory, 500);
+    final String memoryBucketPath = memory.getShard(0).getMutableBucket().getComponentFile().getFilePath();
+
+    database.close();
+    try {
+      flipByteAt(new File(memoryBucketPath), BasePage.PAGE_HEADER_SIZE);
+    } finally {
+      database = factory.open();
+    }
+
+    try (final ResultSet resultSet = database.command("sql", "CHECK DATABASE TYPE Cpu")) {
+      final Result row = resultSet.next();
+      assertThat(corruptedTypesOf(row)).isEmpty();
+      assertThat(row.<Long>getProperty("totalTimeSeriesTypes")).isEqualTo(1L);
+    }
+
+    try (final ResultSet resultSet = database.command("sql", "CHECK DATABASE TYPE Memory")) {
+      final Result row = resultSet.next();
+      assertThat(corruptedTypesOf(row)).containsExactly("Memory");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6340TimeSeriesCheckDatabaseTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Collection;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -297,5 +298,198 @@ class Issue6340TimeSeriesCheckDatabaseTest extends TestHelper {
       final Result row = resultSet.next();
       assertThat(corruptedTypesOf(row)).containsExactly("Memory");
     }
+  }
+
+  /**
+   * Patches a field of a closed component file's page 0, at {@code contentOffset} bytes past the page header, and
+   * reopens the database. Every damage shape below is one of these: the header is what page 0 asserts about the
+   * rest of the file, so each field is a distinct thing the check has to notice.
+   */
+  private void patchHeaderField(final String filePath, final int contentOffset, final Patch patch) throws Exception {
+    database.close();
+    try (final RandomAccessFile raf = new RandomAccessFile(new File(filePath), "rw")) {
+      raf.seek(BasePage.PAGE_HEADER_SIZE + contentOffset);
+      patch.apply(raf);
+    } finally {
+      database = factory.open();
+    }
+  }
+
+  @FunctionalInterface
+  private interface Patch {
+    void apply(RandomAccessFile raf) throws Exception;
+  }
+
+  /**
+   * The format version byte decides how a row is READ - whether a TAG column is a 4-byte dictionary id or an
+   * inline string - so a page 0 that disagrees with the file name is the one thing that turns every row into a
+   * different row. This is the header half of the guard #6314 added to the component itself.
+   */
+  @Test
+  void aMutableBucketWhoseHeaderVersionDisagreesWithItsFileNameIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, 200);
+
+    patchHeaderField(engine.getShard(0).getMutableBucket().getComponentFile().getFilePath(), 4,
+        raf -> raf.writeByte(TimeSeriesBucket.CURRENT_VERSION + 7));
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'")
+        && w.contains("mutable row format version " + (TimeSeriesBucket.CURRENT_VERSION + 7)));
+  }
+
+  /**
+   * The stride is computed from the schema's columns, so a header claiming a different count means the rows were
+   * written at a width nothing will read them back at.
+   */
+  @Test
+  void aMutableBucketWhoseHeaderColumnCountDisagreesWithTheSchemaIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, 200);
+
+    patchHeaderField(engine.getShard(0).getMutableBucket().getComponentFile().getFilePath(), 5,
+        raf -> raf.writeShort(99));
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'")
+        && w.contains("declares 99 column(s)"));
+  }
+
+  /**
+   * A header announcing data pages the file does not hold, which is the other direction of the #6314 residue: the
+   * samples those pages should carry are simply not there.
+   * <p>
+   * It also pins the ONE-finding rule: the walk stops at the first missing page, so the aggregate "declares X
+   * samples but the pages hold Y" - which the short count would otherwise trip - is deliberately not reported on
+   * top. A single root cause reads as a single finding.
+   */
+  @Test
+  void aMutableBucketAnnouncingDataPagesItDoesNotHaveReportsThatAloneAndOnce() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, 200);
+
+    patchHeaderField(engine.getShard(0).getMutableBucket().getComponentFile().getFilePath(), 40,
+        raf -> raf.writeInt(9_999));
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+
+    final List<String> bucketWarnings = warningsOf(row).stream()
+        .filter(w -> w.contains("timeseries 'Cpu'") && w.contains("mutable bucket")).toList();
+    assertThat(bucketWarnings).hasSize(1);
+    assertThat(bucketWarnings.getFirst()).contains("declares 9999 data page(s) but page");
+  }
+
+  /**
+   * A file that is not a whole number of its own pages was written at a different stride or lost its tail - the
+   * O(1) check that needs no walk at all.
+   */
+  @Test
+  void aMutableBucketFileThatIsNotAWholeNumberOfPagesIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, 200);
+    final String bucketPath = engine.getShard(0).getMutableBucket().getComponentFile().getFilePath();
+
+    database.close();
+    try (final RandomAccessFile raf = new RandomAccessFile(new File(bucketPath), "rw")) {
+      raf.setLength(raf.length() - 16);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'")
+        && w.contains("not a whole number of"));
+  }
+
+  /**
+   * A dictionary whose header claims more entries than its pages hold: every id above what the pages actually
+   * carry resolves to nothing, which a reader experiences as a null tag rather than as an error.
+   */
+  @Test
+  void aTagDictionaryClaimingMoreEntriesThanItsPagesHoldIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, 200);
+    final TimeSeriesTagDictionary dictionary = engine.getTagDictionary();
+    assertThat(dictionary).isNotNull();
+
+    patchHeaderField(dictionary.getComponentFile().getFilePath(), 5, raf -> raf.writeInt(500));
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'") && w.contains("tag dictionary")
+        && w.contains("declares 500 entries"));
+  }
+
+  // NOT TESTED HERE, and the reason is a finding in its own right: corrupting the sealed store's OWN header magic
+  // produces no CHECK DATABASE warning, because TimeSeriesSealedStore's constructor throws on a bad magic,
+  // initEngine() then fails during schema load, and the TimeSeries type DISAPPEARS FROM THE SCHEMA entirely - the
+  // database reopens cleanly with the type simply gone (probed: totalTimeSeriesTypes=0, existsType("Cpu")=false).
+  // A check cannot report a type that is no longer there. That silent disappearance lives in the schema load path
+  // rather than in this pass, and what should happen instead - refuse the open, quarantine the type, or surface it
+  // read-only - is a design question of its own. Left as a follow-up rather than pinned here, because a test
+  // asserting the current behaviour would enshrine it.
+
+  /**
+   * Bytes past the last readable block: the tail of a write that did not complete. The directory scan stops at
+   * the first thing that is not a block magic, so this region is invisible to every other reader - neither used
+   * nor reported - which is exactly why the check has to say it is there.
+   */
+  @Test
+  void bytesFollowingTheLastSealedBlockAreReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    final File sealed = new File(getDatabasePath(), "Cpu_shard_0.ts.sealed");
+
+    database.close();
+    try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
+      raf.seek(raf.length());
+      raf.write(new byte[64]);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'") && w.contains("sealed store")
+        && w.contains("64 byte(s) follow the last readable block"));
+  }
+
+  /**
+   * The sealed header's block count against what scanning the file actually finds. Compared only once the header
+   * is clean on disk, which a close-and-reopen guarantees - while blocks are being appended it legitimately
+   * under-reports, and comparing then would call a healthy store damaged.
+   */
+  @Test
+  void aSealedStoreHeaderMiscountingItsBlocksIsReported() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    final File sealed = new File(getDatabasePath(), "Cpu_shard_0.ts.sealed");
+
+    database.close();
+    try (final RandomAccessFile raf = new RandomAccessFile(sealed, "rw")) {
+      // Block count is the int at offset 7 of the 27-byte header: magic(4) + version(1) + colCount(2).
+      raf.seek(7);
+      raf.writeInt(42);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result row = runCheck();
+
+    assertThat(corruptedTypesOf(row)).containsExactly("Cpu");
+    assertThat(warningsOf(row)).anyMatch(w -> w.contains("timeseries 'Cpu'") && w.contains("sealed store")
+        && w.contains("declares 42 block(s)"));
   }
 }


### PR DESCRIPTION
Closes #6340.

Four items. The first three are the last members of a set issues #6283 and #6314 have been closing one at a
time - a component and the file it holds must agree, and the agreement belongs to the API rather than to
whoever remembered to check. The fourth is the one that left a real defect undetectable.

## Item 1 - `ComponentFile.getMode()`

Added, and used where it was missing: `TimeSeriesTagDictionary`'s build-on-an-existing-file constructor took
the id, the page size and the version off the file and then hard-coded `MODE.READ_WRITE` in the middle of
them, because there was nothing to read the mode back out of. All four now come from the file.

## Item 2 - the by-name `getOrCreateFile` and the caller's mode

The issue asked for a decision, so here it is stated rather than implied: **the mode is a request the caller
is entitled to**, and a hit that cannot satisfy it now throws instead of handing back something else. The
direction that decided it is the quiet one - a caller asking for `READ_ONLY` and being given a `READ_WRITE`
file gets a *weaker* guarantee than it asked for, and mode is the one file property whose whole purpose is to
be a guarantee.

Reopening the file to satisfy the request was considered and rejected: a registered file is shared by every
component addressing it, so upgrading the channel would silently widen it under a reader that had asked for
the narrower one - the same shape being removed, with a worse failure mode.

`IllegalStateException`, not the `SchemaException` its by-id sibling raises: a file *name* mismatch is a
file-id space that diverged from the leader's and an HA follower classifies it as quarantine-and-resync; a
*mode* mismatch is a programming error, on the same footing as the file-id and page-size guards in
`PaginatedComponent`, which is this overload's only caller and which throws exactly this.

Nothing reaches it today, and that is checked rather than assumed - the one caller that legitimately hits a
registered file is the tag dictionary constructor above, which now asks for the file's own mode.

## Item 3 - the version guard

`PaginatedComponent` asserted the file id (#6283) and the page size (#6314) against the file it ends up
holding; the version, the third fact baked into `name.fileId.pageSize.vVersion.ext`, was not. It decides how
the pages are *interpreted* where the other two decide where they are - a `LocalBucket` version selects the
record-header layout, a `TimeSeriesBucket` version selects whether a TAG column is a 4-byte dictionary id or
an inline string - so a disagreement is a misread of real bytes, never an exception.

**A tripwire, not a compatibility gate**, and worth repeating because #6314 had to work through the same
point twice: every load constructor passes the parsed version straight through and every creation path bakes
the version into the name it generates, so a component and its file agree by construction whatever build
wrote the file. `aComponentBuiltOnTheVersionItsFileNameCarriesOpensNormally` pins that.

## Item 4 - `CHECK DATABASE` can now read a TimeSeries file

`DatabaseChecker` had zero references to TimeSeries. It walks record buckets and indexes; a TimeSeries type
has neither - its shards are registered with the schema as *files*, and its compacted data never goes through
the paginated layer - so the type fell into the document arm, found no bucket to scan, and all three of the
formats TimeSeries owns were outside the reach of the only tool whose job is to find damage in them.

Each format now validates itself, in the shape `IndexInternal.checkIntegrity()` already uses:

- **`TimeSeriesBucket`** - page 0's magic, format version against the file name, column count against the
  schema, and then every counter page 0 declares reconciled against the data pages themselves: the sample
  count, the min and the max timestamp, and that the data pages it announces are actually in the file. That
  last set is what makes the residue of #6314 visible: a session that wrote at the wrong stride put real rows
  at offsets nothing will address again and counted them in a header that still does. Page headers only, no
  row decoding.
- **`TimeSeriesTagDictionary`** - page 0's magic and version, and the entries walked the way `load()` walks
  them, so the declared entry count and the bytes have to agree. A truncated dictionary does not fail a query;
  it makes every tag written since the damage read back as `null`, on every row.
- **`TimeSeriesSealedStore`** - header, block directory, offsets against the file length, a trailing region
  that belongs to no block, and **the per-block CRC32**. That last one is the expensive part and it is the
  point: the CRC is verified lazily on first read, so a block nothing queries is a block nothing verifies.
  It is recomputed from the file rather than delegated to `validateBlockCRC()`, so a second `CHECK DATABASE`
  in the same process cannot answer "clean" without having read a byte.

Rows are deliberately *not* decompressed and there is **no `FIX` arm**. A record bucket can be repaired
because its records are self-describing and its indexes derive from them; a sealed store is append-only
columnar data whose blocks are the only copy, so "repair" means deciding which samples to discard - the
design question the issue itself flagged, which wants an answer before code. This change makes the state
visible, which is the part that was missing entirely.

Reported as `corruptedTimeSeries` plus warnings, with `totalTimeSeriesTypes/Shards/Samples/SealedBlocks`
seeded on every run so "was this looked at?" is answerable from a clean result rather than from silence.
Scoped by `TYPE` like every other per-type pass. One progress step for all TimeSeries types and only when the
database has one, so a database without them keeps the step plan every existing expectation was written
against.

## Two things found on the way, neither fixed here

- `BlockEntry.blockStartOffset` and `storedCRC` are populated by `loadDirectory()` alone. A block appended by
  the running process carries both on disk and zero in the fields, with `crcValidated` pre-set to true.
  Nothing reads them for such a block today, so it is latent rather than a defect - but it is why the check
  reads both sides from the file instead of trusting the directory.
- The sealed-store CRC pass reads the whole sealed file. That is the same cost class as the record scan
  `checkBuckets` already runs over every bucket, but on a very large TimeSeries type it is the dominant cost
  of a `CHECK DATABASE`, and whether it should become opt-in is worth deciding once someone has one.

## Verification

- Two new regression tests, 11 cases: `Issue6340ComponentFileAgreementTest` (items 1-3, both the refusal and
  the legitimate case for each guard) and `Issue6340TimeSeriesCheckDatabaseTest` (item 4 - the healthy walk
  with its counters, the #6314 residue shape, a missing bucket header, a missing dictionary header, a flipped
  byte in a sealed block caught twice in a row, the `TYPE` scope, and a database with no TimeSeries type).
- Full `engine` module: 12,474 tests green, which includes every existing TimeSeries test running the new pass
  in its teardown integrity check.
- `ha-raft` `ArcadeStateMachineCreateFilesTest` and the `server` read-only/check-database subset green.
