### PR TITLE
fix(#6339): the space a page gets back is measured where the page is packed, not guessed where a slot is freed

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -3992,6 +3992,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * maximum content size lands on 0 and has its entry dropped, exactly as a page a spill has sealed does.
    * <p>
    * Costs nothing to derive: the sum comes from the ordered record list the compression already built.
+   * <p>
+   * What it trades, stated so the next reader does not take it for an oversight: a record deleted and another
+   * inserted inside the SAME still-open transaction do not see the freed space as a hint, because the page is packed
+   * at commit and not before. The allocator is never given a wrong answer by this - {@code findAvailableSpace}
+   * re-reads every candidate page - only a placement it could have made and did not, and the freed page is offered
+   * from the commit onwards. It was measured before being accepted: an accounting at the free itself, which is the
+   * only thing that could close that window, moved 4 pages out of 239 on a transaction that deletes two thirds of
+   * 4000 records and re-inserts as many, and cost a slot-table scan per freed slot to do it.
    *
    * @param contentEndInPage first free byte of the packed page, i.e. where its free tail starts.
    *

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -5526,10 +5526,16 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // Snapshot keys/values into local arrays so we can safely mutate freeSpaceInPages
     // (put/remove) inside the loop body. The snapshot is bounded by MAX_PAGES_GATHER_STATS (100).
     //
-    // The snapshot is sorted by pageId to preserve the deterministic "fill lowest pageId first"
-    // allocation behavior that the previous TreeMap-backed implementation provided implicitly via
-    // its ordered iteration. Tests like RandomDeleteTest depend on this so that re-inserts after
-    // bulk deletes land at the same RIDs as the original inserts.
+    // The snapshot is sorted by pageId to preserve the deterministic "fill lowest pageId first" allocation behaviour
+    // that the previous TreeMap-backed implementation provided implicitly via its ordered iteration. What it buys is
+    // a REPRODUCIBLE choice among the candidate pages - the same bucket state allocates the same way twice - and the
+    // locality of preferring the pages nearest the front of the file.
+    //
+    // What it does NOT buy, and used to be claimed here (#6339): that a re-insert after a bulk delete lands on the
+    // RID the original insert had. It cannot, and it could not then either - which page is a candidate at all depends
+    // on what the free-space statistics hold at that moment, and this ordering only decides between the pages that
+    // made it into that map. RandomDeleteTest was cited as depending on it and no longer does: it compares the scan
+    // against the records it inserted rather than against the order it inserted them in.
     final int snapSize = freeSpaceInPages.size();
     final int[] snapPageIds = new int[snapSize];
     final int[] snapPageStats = new int[snapSize];

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -1846,9 +1846,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * the ordinary delete would remove. An orphaned continuation chunk (#6294) has no chain left to walk either, and
    * only its own slot to give back.
    * <p>
-   * No page statistics are updated, matching {@code deleteRecordInternal} on the very same markers: both shapes carry
-   * a NEGATIVE size marker, from which the space the slot occupied cannot be derived without reading the record it no
-   * longer describes. The next {@code gatherPageStatistics} measures the page as it now is.
+   * No page statistics are updated here, and since #6339 that is a decision rather than an omission: what the page
+   * has to offer once this slot is gone is settled by the compression the commit runs on it, which reports it
+   * ({@link #compressPageInternal}). Until then the slot is a hole the allocator could not use anyway.
    *
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
@@ -3857,16 +3857,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // Track deleted RID to prevent reuse within the same transaction
         database.getTransaction().addDeletedRecord(rid);
 
-        if (recordSize[0] > -1) {
-          if (reuseSpaceMode.ordinal() >= REUSE_SPACE_MODE.HIGH.ordinal()) {
-            // UPDATE THE STATISTICS
-            final PageAnalysis pageAnalysis = new PageAnalysis(page);
-            pageAnalysis.totalRecordsInPage = recordCountInPage;
-            getFreeSpaceInPage(pageAnalysis);
-            updatePageStatistics(pageId, pageAnalysis.spaceAvailableInCurrentPage, (int) ((recordSize[0] + recordSize[1]) * -1));
-          } else
-            changesFromLastStats.incrementAndGet();
-        }
+        // #6339: the delete no longer tells the free-space statistics anything, because everything it used to tell
+        // them was wrong. It measured the page AFTER zeroing the slot - so the tail the delete had just released was
+        // already in the number - and then subtracted the record's footprint from it, landing back on exactly the
+        // free space the page had BEFORE the delete; mid-page it subtracted a footprint from a tail that had not
+        // moved at all, and could drop the page's entry outright. It also skipped every negative marker, i.e. every
+        // shape that is not a plain record, and tested that marker on `recordSize` AFTER the chunk-chain walk above
+        // had reassigned it to the last chunk of the chain. What the page really has to offer is measured once, on
+        // the packed page, by the compression the commit runs on it (compressPageInternal).
 
       } else {
         // CORRUPTED RECORD: WRITE ZERO AS POINTER TO RECORD. There is no readable pre-image to check the replay
@@ -3940,6 +3938,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         LogManager.instance().log(this, Level.FINE, "Update record count from %d to 0 in page %s", recordCountInPage, page.pageId);
         wipeOutFreeSpace(page, (short) 0);
       }
+      accountCompressedPage(page, contentHeaderSize);
       return;
     }
 
@@ -3973,6 +3972,33 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
     if (forceWipeOut || !holes.isEmpty())
       wipeOutFreeSpace(page, recordCountInPage);
+
+    // #6339: the page's occupancy is settled now, and this is the one place that knows it exactly - the records were
+    // just packed from contentHeaderSize upwards, so their footprints sum to where the free tail begins. Everything
+    // the free-space statistics are told anywhere else is a delta an individual write knows about its own bytes; this
+    // is the whole page, measured, and it is what closes the gap the deltas cannot: a hole in the middle of a page is
+    // NOT free tail while it is a hole - the allocator hands out the tail and nothing else - and it stops being one
+    // right here.
+    int contentEndInPage = contentHeaderSize;
+    for (final int[] record : orderedRecordContentInPage)
+      contentEndInPage += record[1];
+    accountCompressedPage(page, contentEndInPage);
+  }
+
+  /**
+   * Records, in the free-space statistics, the free tail a page has once {@link #compressPageInternal} has packed it
+   * (#6339). The delta convention of {@link #updatePageStatistics} carries an absolute value as
+   * {@code (theSpaceThereIs, 0)}, which is what this is: a measurement, not a change - and a page packed to its
+   * maximum content size lands on 0 and has its entry dropped, exactly as a page a spill has sealed does.
+   * <p>
+   * Costs nothing to derive: the sum comes from the ordered record list the compression already built.
+   *
+   * @param contentEndInPage first free byte of the packed page, i.e. where its free tail starts.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private void accountCompressedPage(final MutablePage page, final int contentEndInPage) {
+    updatePageStatistics(page.getPageId().getPageNumber(), page.getMaxContentSize() - contentEndInPage, 0);
   }
 
   private void wipeOutFreeSpace(final MutablePage page, final short recordCountInPage) throws IOException {
@@ -5132,6 +5158,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         break;
       }
 
+      // #6339: nothing is told to the free-space statistics here, deliberately. The bytes are the page's again, but
+      // the chunk leaves a HOLE that the allocator cannot hand out, and what the page will really have on offer is
+      // settled by the compression the commit runs on it (compressPageInternal, which reports what it packed). A
+      // guess made here would have to be undone there.
       chunkPointer = nextPage.readLong((int) (recordPositionInPage + recordSize[1]) + INT_SERIALIZED_SIZE);
     }
   }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6339FreedSpaceStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6339FreedSpaceStatisticsTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.BucketPageLayoutTestSupport;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6339: freeing a slot gave its bytes back to the PAGE but not to the allocator's free-space statistics, so
+ * the allocator went on passing the page over. The three places that free one - the tail an update drops
+ * ({@code freeChunkChain}), the single slot the {@code check(fix)} repairs give back ({@code freeSlotOnly}), and the
+ * ordinary {@code deleteRecordInternal} - are asserted here together, because they share one answer and it is not at
+ * any of them: a freed slot is a HOLE, which the allocator cannot hand out, and what the page really has to offer is
+ * settled a moment later by the {@code compressPage} the commit runs on every page the transaction modified. That is
+ * the only place that knows a page's packed occupancy exactly, and it now reports it.
+ * <p>
+ * Asserted on the HINT itself and not only through the allocator, for the reason #6154's test already gives: the
+ * allocator re-reads every candidate page through {@code getAvailableSpaceInPage} before using it, so a test driven
+ * through it alone passes whether or not the statistics were ever told. The end-to-end assertions are here too, two
+ * of them, because the hint is a means and page reuse is the end.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6339FreedSpaceStatisticsTest extends BucketPageLayoutTestSupport {
+  private static final String TYPE        = "Freed";
+  /** Big enough to spill into a chain that spans several pages of its own. */
+  private static final String HUGE        = "h".repeat(400 * 1024);
+  /** Small enough to collapse the record back into its own slot, freeing the whole chain (#6178). */
+  private static final String TINY        = "t";
+  /** A record that comfortably fits a page but cannot share one with many of its kind. */
+  private static final String MEDIUM      = "m".repeat(8 * 1024);
+  /** The filler {@code fillFirstPage} writes, and therefore what deleting one of its records gives the page back. */
+  private static final int    FILLER_SIZE = 8 * 1024;
+
+  /**
+   * The chain an update drops. Every page the continuation chunks had to themselves is empty once the record shrinks,
+   * and the statistics must offer the whole of it again - not the nothing they offered while the chunk was there.
+   */
+  @Test
+  void theTailAFreedChainReleasesIsOfferedAgain() {
+    final RID big = createSpilledRecord();
+    final LocalBucket bucket = bucketOf(TYPE);
+    final int totalPages = bucket.getTotalPages();
+    assertThat(totalPages).as("the fixture must really span several pages of continuation chunks").isGreaterThan(3);
+
+    database.transaction(() -> big.asDocument(true).modify().set("v", TINY).save());
+
+    assertThat((Long) bucketStats(TYPE).get("totalChunks")).as("the shrink must free the whole chain").isZero();
+
+    for (int pageId = 1; pageId < totalPages; pageId++)
+      assertThat(bucket.getFreeSpaceHintForPage(pageId))
+          .as("page " + pageId + " holds nothing at all once the chain is freed, so the whole of it must be offered")
+          .isEqualTo(wholeUsablePage(bucket));
+
+    database.transaction(() -> assertThat(big.asDocument(true).getString("v")).isEqualTo(TINY));
+    checkDatabase();
+  }
+
+  /**
+   * What the hint is FOR. The pages a freed chain released must take new records instead of the bucket growing a page
+   * per record - which is what happened while the statistics still described those pages as full, because
+   * {@code findAvailableSpaceFromStatistics} never even offered them as candidates.
+   * <p>
+   * The last page is deliberately kept occupied by a second record's tail: it is the one page the allocator reaches
+   * without the statistics at all ({@code findAvailableSpace} falls back to it), so a fixture whose last page were
+   * empty would pass with the statistics still wrong.
+   */
+  @Test
+  void thePagesAFreedChainReleasesAreHandedToNewRecords() {
+    final RID big = createSpilledRecord();
+    final RID[] second = new RID[1];
+    database.transaction(() -> second[0] = database.newDocument(TYPE).set("v", HUGE).save().getIdentity());
+
+    final LocalBucket bucket = bucketOf(TYPE);
+    database.transaction(() -> big.asDocument(true).modify().set("v", TINY).save());
+
+    final int pagesAfterTheShrink = bucket.getTotalPages();
+
+    // Sixteen 8 KB records: far more than the free tail of the pages the second record left unfilled, and far less
+    // than the space the first record's chain gave back.
+    database.transaction(() -> {
+      for (int i = 0; i < 16; i++)
+        database.newDocument(TYPE).set("v", MEDIUM).save();
+    });
+
+    assertThat(bucket.getTotalPages())
+        .as("the released pages must host the new records rather than the bucket growing fresh ones")
+        .isEqualTo(pagesAfterTheShrink);
+
+    database.transaction(() -> {
+      assertThat(big.asDocument(true).getString("v")).isEqualTo(TINY);
+      assertThat(second[0].asDocument(true).getString("v")).isEqualTo(HUGE);
+    });
+    checkDatabase();
+  }
+
+  /**
+   * The repair path, {@code freeSlotOnly}: the orphaned-chunk sweep of {@code check(fix)} (#6294) gives a slot back
+   * and nothing else. It is an admin operation, so the cost of deriving what it released is irrelevant - and the
+   * bucket it runs on is precisely the one whose space accounting nobody has been keeping.
+   */
+  @Test
+  void theSlotsTheOrphanedChunkSweepReclaimsAreOfferedAgain() {
+    final RID big = createSpilledRecord();
+    final LocalBucket bucket = bucketOf(TYPE);
+    final int totalPages = bucket.getTotalPages();
+
+    // Cut the chain off at the head: every chunk behind it becomes an orphan, exactly as a corrupted continuation
+    // pointer leaves them.
+    database.transaction(() -> onSlot(big, page -> {
+      // [marker:1][chunkSize:int][nextChunkPointer:long][content...]
+      page.writeLong(recordOffsetOf(page, big) + 1 + Binary.INT_SERIALIZED_SIZE, Integer.MAX_VALUE);
+      return 0L;
+    }));
+
+    final Result fixed = checkDatabaseRow(true);
+    assertThat(numberProperty(fixed, "orphanedChunksReclaimed")).as("the sweep must have run: " + fixed.toJSON())
+        .isPositive();
+
+    for (int pageId = 1; pageId < totalPages; pageId++)
+      assertThat(bucket.getFreeSpaceHintForPage(pageId))
+          .as("page " + pageId + " was reclaimed whole, so the whole of it must be offered")
+          .isEqualTo(wholeUsablePage(bucket));
+  }
+
+  /**
+   * The ordinary delete, which had the same defect with the sign the other way round: it measured the page AFTER
+   * zeroing the slot - so the tail the delete had just released was already in the number - and then subtracted the
+   * record's footprint from it, landing back on exactly the free space the page had BEFORE the delete. A page emptied
+   * by deleting its records was therefore never offered any of them back.
+   */
+  @Test
+  void theTailAPlainDeleteReleasesIsOfferedAgain() {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING));
+
+    final LocalBucket bucket = bucketOf(TYPE);
+    final RID last = fillFirstPage(TYPE);
+    final int hintWhileFull = bucket.getFreeSpaceHintForPage(0);
+
+    database.transaction(() -> last.asDocument(true).delete());
+
+    assertThat(bucket.getFreeSpaceHintForPage(0))
+        .as("deleting the page's last record hands its bytes back, and the allocator has to hear all of them")
+        .isGreaterThanOrEqualTo(Math.max(hintWhileFull, 0) + FILLER_SIZE);
+    checkDatabase();
+  }
+
+  /**
+   * The case that decides where the accounting belongs: a slot freed in the MIDDLE of its page is not free tail at
+   * the moment it is freed - the allocator hands out the tail and nothing else - so a number produced at the free
+   * would be a guess, and a hint bigger than what the page can hand out costs the allocator a wasted candidate on
+   * every probe. One line later the commit's compression closes the hole and the bytes are genuinely on offer, which
+   * is exactly where they are now reported, and the assertion is on the whole record's worth of them.
+   */
+  @Test
+  void aSlotFreedInTheMiddleOfItsPageIsAccountedByTheCompressionThatClosesTheHole() {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING));
+
+    final RID[] first = new RID[1];
+    database.transaction(() -> first[0] = database.newDocument(TYPE).set("v", MEDIUM).save().getIdentity());
+    fillFirstPage(TYPE);
+
+    final LocalBucket bucket = bucketOf(TYPE);
+    final int hintBefore = bucket.getFreeSpaceHintForPage(0);
+
+    database.transaction(() -> first[0].asDocument(true).delete());
+
+    assertThat(bucket.getFreeSpaceHintForPage(0))
+        .as("the hole the commit packed away is free tail now, and all of it must be on offer")
+        .isGreaterThanOrEqualTo(Math.max(hintBefore, 0) + MEDIUM.length());
+    checkDatabase();
+  }
+
+  /**
+   * The delete workload end to end, which is what the commit-time half of the accounting is worth: churn that removes
+   * two records out of three and puts back exactly as many must leave the bucket roughly the size it was, instead of
+   * growing it by every page the allocator could not see the free space in.
+   * <p>
+   * The bound is deliberately loose - the allocator packs by best fit and a re-inserted record need not land where
+   * the deleted one was - but it is far below what the bucket did before: measured on this fixture, 143 pages became
+   * 238 with the statistics unfixed and 171 with them fixed.
+   */
+  @Test
+  void deleteChurnDoesNotGrowTheBucketByThePagesItFreed() {
+    final int records = 4_000;
+    final String payload = "c".repeat(2_000);
+
+    final RID[] rids = new RID[records];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING);
+      for (int i = 0; i < records; i++)
+        rids[i] = database.newDocument(TYPE).set("v", payload).save().getIdentity();
+    });
+
+    final LocalBucket bucket = bucketOf(TYPE);
+    final int pagesAfterTheLoad = bucket.getTotalPages();
+    assertThat(pagesAfterTheLoad).as("the fixture must span enough pages for the churn to show").isGreaterThan(64);
+
+    database.transaction(() -> {
+      for (int i = 0; i < records; i++)
+        if (i % 3 != 0)
+          rids[i].asDocument(true).delete();
+    });
+
+    final int reinserted = records - (records + 2) / 3;
+    database.transaction(() -> {
+      for (int i = 0; i < reinserted; i++)
+        database.newDocument(TYPE).set("v", payload).save();
+    });
+
+    assertThat(bucket.getTotalPages())
+        .as("the pages the deletes emptied must take the new records back")
+        .isLessThan(pagesAfterTheLoad * 3 / 2);
+    assertThat(countRecords(TYPE)).as("and nothing may be lost on the way").isEqualTo(records);
+    checkDatabase();
+  }
+
+  /** A record big enough to spill into a chain of its own, on a bucket that holds nothing else. */
+  private RID createSpilledRecord() {
+    final RID[] big = new RID[1];
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING);
+      big[0] = database.newDocument(TYPE).set("v", HUGE).save().getIdentity();
+    });
+
+    final Map<String, Object> layout = bucketStats(TYPE);
+    assertThat((Long) layout.get("totalChunks")).as("the fixture must really be a chain: " + layout).isPositive();
+    return big[0];
+  }
+
+  /** What an EMPTY page of this bucket has to offer: everything past the page header and the slot table. */
+  private static int wholeUsablePage(final LocalBucket bucket) {
+    return bucket.getPageSize() - BasePage.PAGE_HEADER_SIZE - bucket.contentHeaderSize;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6339FreedSpaceStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6339FreedSpaceStatisticsTest.java
@@ -23,6 +23,8 @@ import com.arcadedb.database.BucketPageLayoutTestSupport;
 import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -236,6 +238,36 @@ class Issue6339FreedSpaceStatisticsTest extends BucketPageLayoutTestSupport {
         .as("the pages the deletes emptied must take the new records back")
         .isLessThan(pagesAfterTheLoad * 3 / 2);
     assertThat(countRecords(TYPE)).as("and nothing may be lost on the way").isEqualTo(records);
+    checkDatabase();
+  }
+
+  /**
+   * The other way into the same accounting: {@code CHECK DATABASE ... COMPRESS} walks every page of every bucket and
+   * compresses it with {@code forceWipeOut}, which the commit path never does. Because that walk measures each page it
+   * touches, it also REPAIRS a free-space entry that has drifted - which is what this asserts, by planting a wrong one
+   * first. Without the plant the assertion would hold whether or not the compression reported anything, since the
+   * pages a commit leaves behind are already packed and already accounted.
+   */
+  @Test
+  void checkDatabaseCompressRemeasuresThePagesItWalks() {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING));
+
+    final LocalBucket bucket = bucketOf(TYPE);
+    sealFirstPage(TYPE);
+    assertThat(bucket.getFreeSpaceHintForPage(0)).as("a page a spill has sealed has nothing left to offer")
+        .isEqualTo(-1);
+
+    // Tell the allocator page 0 is half empty. It is not: the spill took its last byte.
+    final JSONArray planted = new JSONArray();
+    planted.put(new JSONObject().put("id", 0).put("free", wholeUsablePage(bucket) / 2));
+    bucket.setPageStatistics(planted);
+    assertThat(bucket.getFreeSpaceHintForPage(0)).as("the fixture must really have planted a wrong entry").isPositive();
+
+    database.command("sql", "check database compress").close();
+
+    assertThat(bucket.getFreeSpaceHintForPage(0))
+        .as("the compress walked page 0 and must have replaced the drifted entry with what it measured")
+        .isEqualTo(-1);
     checkDatabase();
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/RandomDeleteTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/RandomDeleteTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -87,7 +88,22 @@ class RandomDeleteTest extends TestHelper {
     for (Iterator<Record> it = db.iterateType(TYPE, true); it.hasNext(); )
       found.add(it.next().asVertex().getIdentity());
 
-    assertThat(found).isEqualTo(rids);
+    // The scan must return exactly the records that were inserted - every one of them, once each, and nothing else.
+    // Compared as a SET (both sides sorted by position, which also catches a record handed out twice) and not in the
+    // order they were inserted, because that order is not a property of anything: a scan walks a bucket in PHYSICAL
+    // order, a RID is a physical position, and a record inserted into space a delete gave back lands wherever that
+    // space is rather than after the last record written.
+    //
+    // Until #6339 the two orders did coincide, and only because the allocator could not see the space this test's own
+    // mass delete had freed: the free-space statistics were never told, so every re-insert appended to the end of the
+    // bucket and the bucket grew by another 100k slots per cycle. Asserting insertion order here was therefore
+    // asserting that nothing was reused - the defect - so the order goes and the identity of the records stays.
+    final List<RID> foundByPosition = new ArrayList<>(found);
+    final List<RID> insertedByPosition = new ArrayList<>(rids);
+    foundByPosition.sort(Comparator.comparingLong(RID::getPosition));
+    insertedByPosition.sort(Comparator.comparingLong(RID::getPosition));
+    assertThat(foundByPosition).hasSameSizeAs(insertedByPosition);
+    assertThat(foundByPosition).isEqualTo(insertedByPosition);
 
     assertThat(db.countType(TYPE, true)).isEqualTo(rids.size());
   }


### PR DESCRIPTION
Fixes #6339.

## What was wrong

Freeing a slot gave its bytes back to the page and told the allocator's free-space statistics nothing, so
`findAvailableSpace` went on passing the page over. Three places free one and none of them accounted for it:
`freeChunkChain` (the whole tail an update drops), `freeSlotOnly` (the dangling-pointer and orphaned-chunk repairs of
`check(fix)`), and `deleteRecordInternal`.

It mattered little while an ordinary update hardly ever freed a chunk. #6319 changed that: on the workload measured
there, 14719 chunks are now freed where none were before, and every one of them was space the allocator was not told
about on a perfectly healthy bucket.

Reproduced by asserting on the hint itself: after a chunked record shrinks, `getFreeSpaceHintForPage` answers `-1` for
every page its continuation chunks had to themselves, although those pages now hold nothing at all.

## Two things the issue does not have

**The ordinary delete had the same defect, with every sign wrong.** `deleteRecordInternal` measured the page *after*
zeroing the slot - so the tail the delete had just released was already in the number - and then subtracted the
record's footprint from it, landing back on exactly the free space the page had *before* the delete. Mid-page it
subtracted a footprint from a tail that had not moved at all, and could drop the page's entry outright. It also
skipped every negative marker (every shape that is not a plain record), and tested that marker on `recordSize`, which
the chunk-chain walk above it reassigns to the last chunk of the chain.

**`compressPage` is not an admin operation.** The issue says the space "comes back only when `compressPage` re-flows
the page - i.e. on `CHECK DATABASE ... COMPRESS`". In fact `TransactionContext.commit1stPhase` runs it on *every*
bucket page a transaction modified, after the record writes. The page really does get its bytes back at each commit;
it is only the statistics that never heard.

## The fix, and why it is not where the issue suggests

The issue proposes accounting the free at the free, limited to the case where the freed slot was the page's last
record. That was built first, and then dropped in favour of something simpler and exact.

A freed slot is a **hole**, and the allocator only ever hands out a page's free **tail**. A number produced at the
free is therefore a guess about a page whose occupancy is not settled yet - and it is settled one step later, by that
commit-time `compressPage`. That call already packs the live records from `contentHeaderSize` upwards and already
builds the ordered list of their footprints; summing that list is where the free tail begins, exactly, for every way a
page's occupancy can change - a dropped chunk chain, a repaired slot, a delete, an in-place shrink, a mid-page hole -
and it costs nothing that was not already computed.

So the whole change is one call at the end of `compressPageInternal` (plus its empty-page arm), and
`deleteRecordInternal`'s statistics block removed rather than repaired. The three free sites keep only a comment
saying why they no longer guess.

The free-time version was kept long enough to measure against this one: it moved nothing (530 vs 530 pages, 171 vs
171 - see below) while costing a slot-table scan per freed chunk on the update path. Two mechanisms for one fact, the
cheaper one redundant, so it went.

## Measured

Page count of one bucket, before and after:

| workload | before | after |
| --- | --- | --- |
| 40 records of ~200 KB churned between 60 KB and 200 KB for ten rounds | 1130 | **530** |
| 4000 records of 2 KB, two thirds deleted and exactly as many re-inserted | 143 -> 238 | 143 -> **171** |

## What accounting at commit trades

A record deleted and another inserted inside the **same still-open transaction** do not see the freed space as an
allocator hint, because the page is packed at commit and not before. The allocator is never given a wrong answer by
this - `findAvailableSpace` re-reads every candidate page - only a placement it could have made and did not, and the
page is offered from the commit onwards. Measured: the free-time accounting, the only thing that could close that
window, moved 4 pages out of 239 on a single transaction that deletes two thirds of 4000 records and re-inserts as
many. Stated on `accountCompressedPage` so the next reader does not take it for an oversight.

## Tests

`Issue6339FreedSpaceStatisticsTest`, seven tests, all four of the failing ones red before the fix:

- the pages a freed chunk chain releases are offered whole again (the issue's case, asserted on the hint);
- and are handed to new records rather than the bucket growing fresh ones (end to end, with the last page deliberately
  kept occupied so the allocator's statistics-free fallback cannot carry the test);
- the slots the orphaned-chunk sweep of `check(fix)` reclaims are offered again;
- the tail a plain delete releases is offered again, all of it;
- a slot freed mid-page is accounted by the compression that closes the hole;
- delete churn does not grow the bucket by the pages it freed;
- `CHECK DATABASE ... COMPRESS` re-measures the pages it walks. That is the second entry point into the same
  accounting - it reaches `compressPage` with `forceWipeOut`, which no commit ever does, and walks every page of every
  bucket rather than the ones a transaction touched, so it does not merely report but REPAIRS a drifted entry. The
  test plants a wrong entry for a page a spill has sealed and asserts the walk replaces it with what it measured;
  without the plant the assertion would hold whether or not the compression reported anything.

Full `engine` suite green: 12469 tests, 0 failures. The `slow` lane (238 tests, which the suite run above excludes)
is green too, after the change below.

## One existing test asserted the defect

`RandomDeleteTest.checkRecords` compared a full scan against the **insertion order** with `isEqualTo`, so it required a
re-insert to land after the last record written. That held only because the allocator could not see the space the
test's own mass delete had freed: every cycle appended another 100k slots instead of reusing the ones it had just
emptied. With the statistics fixed the space really is reused, the re-inserts land in the reclaimed pages, and a scan -
which walks a bucket in physical order, a RID being a physical position - no longer returns them in write order.

The identity of the records is what the check is about and it is kept: both sides are now sorted by position and
compared, which still catches a record lost, one handed out twice, and one the scan invents, with the size asserted
first. Only the ordering requirement goes.

Established rather than assumed, because "the order changed" and "a record went missing" fail the same assertion: the
comparison was temporarily split in two, and the slow-lane run that reproduced the CI failure failed the ORDERED
assertion with the sorted one passing - same 100k records, same multiplicities, different sequence. The class carries
`@Tag("slow")`, which is why the earlier full-suite runs on this branch did not cover it.
