### PR TITLE
fix(#6324): an index built inside a transaction indexes what that transaction wrote, and one pool where there were four copies of one

### DIFF
--- a/.claude/skills/engine-concurrency/SKILL.md
+++ b/.claude/skills/engine-concurrency/SKILL.md
@@ -19,7 +19,9 @@ download, i.e. the longest-running thing the HA layer does, and it no longer par
 | Pool | Module | Purpose | Sizing | Saturation policy |
 |---|---|---|---|---|
 | `QueryEngineManager` JVM-wide pool | `engine` | Query-time parallelism: graph algorithms (`parallelForRange`), parallel index scans, anything that forks query work | `arcadedb.queryParallelismPoolThreads` (default `max(2, CPU)`) | Bounded queue (`arcadedb.queryParallelismQueueSize`, default 1024), caller-runs rejection, throttled WARNING (60s window) |
-| `SparseVectorScoringPool` | `engine` | Reserved for per-segment parallel scoring of `LSM_SPARSE_VECTOR` top-K (dispatch wiring deferred to issue #4085) | Hardcoded `max(2, CPU)` threads, 1024 queue; lazy-init via Holder idiom | Bounded queue, caller-runs, throttled WARNING |
+| `SparseVectorScoringPool` | `engine` | Reserved for per-segment parallel scoring of `LSM_SPARSE_VECTOR` top-K (dispatch wiring deferred to issue #4085) | `arcadedb.sparseVectorScoringPoolThreads` (default `max(2, CPU)`), 1024 queue; lazy-init via Holder idiom | Bounded queue, caller-runs, throttled WARNING |
+| `ParallelScanProducerPool` | `engine` | The BLOCKING producer tasks of a parallel bucket scan (`FetchFromTypeExecutionStep.syncPullParallel`) | `arcadedb.parallelScanProducerPoolThreads` (default `max(2, CPU)`) | **Deviation:** unbounded queue and NO caller-runs - caller-runs on a blocking producer is the #4948 self-deadlock. Back-pressure comes from each query's bounded RESULT queue; `queue_depth` is the saturation signal |
+| `AsyncCommandPool` | `engine` | Commands dispatched with `awaitResponse=false` that parse to DDL, which cannot run on an async worker (#6303 item 3) | `arcadedb.asyncCommandPoolThreads` (default `max(2, CPU)`), `arcadedb.asyncCommandQueueSize` (default 1024) | Bounded queue, caller-runs **even on a shut-down pool** (there is no future to cancel and the submitter has already counted the command as in flight), throttled WARNING |
 | `DatabaseAsyncExecutor` | `engine` | Per-database async ops (background scheduled tasks, async commit) | `arcadedb.asyncWorkerThreads` (default `CPU - 1`, min 1) | Bounded queue (`arcadedb.asyncOperationsQueueSize`, default 1024) |
 | `PageManagerFlushThread` | `engine` | Dedicated single thread for paginated-component page writes | 1 thread | Backpressure via `arcadedb.maxRAMForPageRamUsageInMB` |
 | `TransactionManager` Timer | `engine` | Periodic WAL housekeeping | Timer thread | n/a |
@@ -54,10 +56,31 @@ Used sparingly, only for publish-side serialization:
 - Studio surfaces these via the "Executor Pools" card on the Server tab (live numbers).
 - A sustained non-zero `caller_run_fallbacks` indicates pool saturation; the engine logs a throttled WARNING the first time and at most once per 60 s afterward.
 
+## The shared base: `com.arcadedb.utility.DedicatedThreadPool`
+
+The four JVM-wide pools above all extend it (issue #6324, item 4). It owns the `ThreadPoolExecutor` construction, the
+`PoolStats` record the metrics binder reads, and the caller-runs rejection policy with its throttled saturation
+WARNING - all three of which used to exist as four near-identical copies whose wording had already drifted apart.
+
+What a subclass supplies to `super(...)`: the thread-name prefix, the thread count (`autoSizeThreads(configured)` is
+the shared "explicit setting, else cores, floor 2"), the queue capacity (`queueSizeOrDefault`, or `UNBOUNDED_QUEUE`), a
+`SaturationPolicy`, a `WorkerFactory` (`DedicatedThreadPool::plainWorker`, or a lambda that sets a per-worker
+thread-local or subclasses `Thread` so the pool's threads are recognizable by type), the sentence the pool names itself
+by in its warning, what the caller-runs fallback costs ITS callers, and the settings the warning tells the operator to
+raise.
+
+The constructor refuses the two combinations that cannot mean anything: an unbounded queue with a rejection policy
+(it never rejects) and a bounded queue with `SaturationPolicy.NONE` (it must say what happens to a task it refuses).
+That is the checklist below being enforced rather than remembered.
+
+Each pool's REASONS stay in its own class javadoc - why blocking producers may not share a pool with non-blocking
+compute, why dispatched DDL cannot run on an async worker, why a sparse-vector fan-out must not nest.
+
 ## When adding new parallelism to engine code
 
 1. Pick the right home pool (`QueryEngineManager` for query-time, `SparseVectorScoringPool` if scoping to sparse vectors, etc.). If none fits, justify a new pool and add a `PoolMetrics` binding for it.
-2. Bounded queue + caller-runs rejection so the system degrades to single-threaded under load instead of throwing `RejectedExecutionException` to callers.
-3. Throttled WARNING on saturation (60-second window matching the existing pools) so operators notice without getting spammed.
-4. Wire the pool into `PoolMetrics` so the Studio "Executor Pools" card shows it.
-5. If using the JDK common ForkJoinPool is unavoidable in the short term, tag the call site with a `NOTE (concurrency)` comment pointing at this skill so the migration stays tracked.
+2. Extend `DedicatedThreadPool` rather than building a `ThreadPoolExecutor` by hand. It gives points 2-3 below by construction.
+3. Bounded queue + caller-runs rejection so the system degrades to single-threaded under load instead of throwing `RejectedExecutionException` to callers. A deviation (as `ParallelScanProducerPool` has) must be argued in the class javadoc.
+4. Throttled WARNING on saturation (60-second window, `WARN_THROTTLE_INTERVAL_MS`) so operators notice without getting spammed.
+5. Wire the pool into `PoolMetrics` so the Studio "Executor Pools" card shows it.
+6. If using the JDK common ForkJoinPool is unavoidable in the short term, tag the call site with a `NOTE (concurrency)` comment pointing at this skill so the migration stays tracked.

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -380,12 +380,23 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
   }
 
   public static class DatabaseContextTL {
-    public final List<TransactionContext> transactions = new ArrayList<>(3);
-    public       boolean                  asyncMode    = false;
+    public final List<TransactionContext> transactions             = new ArrayList<>(3);
+    /**
+     * Whether the default round-robin bucket strategy picks a bucket PER THREAD for this database, so that concurrent
+     * writers do not compete for the same pages.
+     * <p>
+     * It was called {@code asyncMode}, which is what it is not (issue #6324, note b). It has never meant "this thread
+     * is an async worker": #6303 removed the one place that read it that way ({@code RebuildIndexStatement}, where
+     * the misreading refused exactly the operation that issue set out to give back), and it is set on
+     * {@code AsyncCommandPool} threads, which are deliberately NOT workers. "Is this thread a worker of that
+     * executor" is answered by thread IDENTITY ({@code DatabaseAsyncExecutorImpl.isCurrentThreadOneOfMyWorkers}), and
+     * nothing else should be asked of this flag.
+     */
+    public       boolean                  perThreadBucketSelection = false;
     private      Binary                   temporaryBuffer1;
     private      Binary                   temporaryBuffer2;
-    private      int                      maxNested    = 3;
-    private      SecurityDatabaseUser     currentUser  = null;
+    private      int                      maxNested                = 3;
+    private      SecurityDatabaseUser     currentUser              = null;
     // The stateful client session bound to this thread context (GQL SESSION statements).
     // Set by the protocol owner (HTTP/Bolt) alongside the transaction; null in plain embedded use.
     private      QuerySession             querySession = null;

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1124,7 +1124,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
       if (bucketName == null && record instanceof Document doc)
         bucket = (LocalBucket) doc.getType().getBucketIdByRecord(doc,
-            DatabaseContext.INSTANCE.getContext(databasePath).asyncMode);
+            DatabaseContext.INSTANCE.getContext(databasePath).perThreadBucketSelection);
       else {
         bucket = (LocalBucket) schema.getBucketByName(bucketName);
         // Reject direct writes to internal buckets (e.g. paired external-property buckets). They are infrastructure

--- a/engine/src/main/java/com/arcadedb/database/async/AsyncCommandPool.java
+++ b/engine/src/main/java/com/arcadedb/database/async/AsyncCommandPool.java
@@ -19,15 +19,7 @@
 package com.arcadedb.database.async;
 
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.log.LogManager;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Level;
+import com.arcadedb.utility.DedicatedThreadPool;
 
 /**
  * JVM-wide dedicated executor for the <b>DDL</b> dispatched through the asynchronous API - a
@@ -77,13 +69,7 @@ import java.util.logging.Level;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public final class AsyncCommandPool {
-
-  /** Floor for the auto-sized thread count when {@code arcadedb.asyncCommandPoolThreads} is 0. */
-  private static final int  DEFAULT_THREADS_FLOOR       = 2;
-  private static final int  DEFAULT_QUEUE_SIZE          = 1024;
-  /** At most one saturation WARNING per minute, the same throttle the other engine pools use. */
-  private static final long SATURATION_WARN_INTERVAL_MS = 60_000L;
+public final class AsyncCommandPool extends DedicatedThreadPool {
 
   /**
    * Marks a thread as one of this pool's, so {@code DatabaseAsyncExecutorImpl.waitCompletion} can tell that its
@@ -108,10 +94,6 @@ public final class AsyncCommandPool {
    */
   private static final ThreadLocal<Boolean> POOL_THREAD = new ThreadLocal<>();
 
-  private final ThreadPoolExecutor executor;
-  private final AtomicLong         callerRunCount       = new AtomicLong();
-  private final AtomicLong         lastSaturationWarnMs = new AtomicLong(0L);
-
   /**
    * Initialization-on-demand holder: the pool allocates its threads only when something first asks for it.
    * <p>
@@ -130,65 +112,44 @@ public final class AsyncCommandPool {
   }
 
   private AsyncCommandPool() {
-    final int configuredThreads = GlobalConfiguration.ASYNC_COMMAND_POOL_THREADS.getValueAsInteger();
-    final int threads = configuredThreads > 0 ?
-        configuredThreads :
-        Math.max(DEFAULT_THREADS_FLOOR, Runtime.getRuntime().availableProcessors());
-    final int configuredQueueSize = GlobalConfiguration.ASYNC_COMMAND_QUEUE_SIZE.getValueAsInteger();
-    final int queueSize = configuredQueueSize > 0 ? configuredQueueSize : DEFAULT_QUEUE_SIZE;
-    final AtomicInteger workerSeq = new AtomicInteger();
-
-    final ThreadPoolExecutor pool = new ThreadPoolExecutor(threads, threads, 60L, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(queueSize), r -> {
-      // A PLAIN Thread, and that is the whole point: DatabaseAsyncExecutorImpl recognizes its own workers by
-      // class and owner, so a command running here is - correctly - not one of them, and the barrier it needs
-      // can be satisfied instead of refused.
-      final Thread t = new Thread(() -> {
-        POOL_THREAD.set(Boolean.TRUE);
-        r.run();
-      }, "ArcadeDB-AsyncCommand-" + workerSeq.incrementAndGet());
-      t.setDaemon(true);
-      return t;
-    }, (task, exec) -> runOnCaller(task, queueSize, exec.getMaximumPoolSize()));
-    pool.allowCoreThreadTimeOut(true);
-    this.executor = pool;
+    // Pool construction, the counted-and-throttled saturation warning and the PoolStats all come from
+    // DedicatedThreadPool (issue #6324, item 4). The workers are PLAIN Threads, and that is the whole point:
+    // DatabaseAsyncExecutorImpl recognizes its own workers by class and owner, so a command running here is -
+    // correctly - not one of them, and the barrier it needs can be satisfied instead of refused.
+    //
+    // CALLER_RUNS_EVEN_WHEN_SHUT_DOWN and not plain CALLER_RUNS: there is no future here to cancel and no result to
+    // return, and the submitter has already counted this command as in flight, so a task that is neither run nor
+    // completed leaves that count raised for ever and every later waitCompletion() on that database waits out its
+    // whole budget. Nothing shuts this pool down today; this is the answer that stays correct if something ever does.
+    super("ArcadeDB-AsyncCommand-", autoSizeThreads(GlobalConfiguration.ASYNC_COMMAND_POOL_THREADS.getValueAsInteger()),
+        queueSizeOrDefault(GlobalConfiguration.ASYNC_COMMAND_QUEUE_SIZE.getValueAsInteger()),
+        SaturationPolicy.CALLER_RUNS_EVEN_WHEN_SHUT_DOWN, (body, name) -> new Thread(() -> {
+          POOL_THREAD.set(Boolean.TRUE);
+          body.run();
+        }, name), "Asynchronous command pool",
+        "a caller that asked not to wait for the response will wait for it",
+        GlobalConfiguration.ASYNC_COMMAND_POOL_THREADS, GlobalConfiguration.ASYNC_COMMAND_QUEUE_SIZE);
   }
 
   /**
-   * The caller-runs rejection policy: a saturated pool executes the command on the thread that submitted it.
+   * The submitter is MARKED AS A POOL THREAD FOR THE DURATION, even though the thread is its own.
    * <p>
-   * Package-private and taking its numbers as arguments rather than reading them off the executor, because this is
-   * the path most of the pool's safety argument is ABOUT - the self-deadlock exemption, and the runner's
-   * "touch no transaction and no context we did not create" contract both exist for it - and it is the one a real
-   * pool cannot be made to take on demand without queueing a thousand blocking statements. Driven directly by
-   * {@code AsyncCommandPoolCallerRunsTest}.
+   * The flag means "this thread is currently BEING an asynchronously dispatched command", and everything that reads
+   * it needs that to be true here too: a {@code CREATE INDEX} run inline would otherwise reach the barrier and wait
+   * for the in-flight-command set it is itself a member of. Restored rather than cleared, so a submitter that is
+   * already running one command - a command that dispatches another - is left as it was.
+   * <p>
+   * This override is most of what the pool's safety argument is ABOUT, together with the runner's "touch no
+   * transaction and no context we did not create" contract, and it is a path a real pool cannot be made to take on
+   * demand without queueing a thousand blocking statements first. Driven directly by
+   * {@code AsyncCommandPoolCallerRunsTest} through {@link #runOnCaller}.
    */
-  void runOnCaller(final Runnable task, final int queueCapacity, final int poolThreads) {
-    final long fallbacks = callerRunCount.incrementAndGet();
-    final long now = System.currentTimeMillis();
-    final long last = lastSaturationWarnMs.get();
-    if (now - last > SATURATION_WARN_INTERVAL_MS && lastSaturationWarnMs.compareAndSet(last, now))
-      LogManager.instance().log(AsyncCommandPool.class, Level.WARNING,
-          "Asynchronous command pool saturated: queue full (capacity=%d, threads=%d), running the command on the "
-              + "submitting thread - a caller that asked not to wait for the response will wait for it "
-              + "(cumulative caller-runs fallbacks=%d). Raise '%s' or '%s'", null,
-          queueCapacity, poolThreads, fallbacks,
-          GlobalConfiguration.ASYNC_COMMAND_POOL_THREADS.getKey(), GlobalConfiguration.ASYNC_COMMAND_QUEUE_SIZE.getKey());
-
-    // MARKED AS A POOL THREAD FOR THE DURATION, even though it is the submitter's. The flag means "this thread is
-    // currently BEING an asynchronously dispatched command", and everything that reads it needs that to be true
-    // here too: a CREATE INDEX run inline would otherwise reach the barrier and wait for the in-flight-command set
-    // it is itself a member of. Restored rather than cleared, so a submitter that is already running one command
-    // (a command that dispatches another) is left as it was.
+  @Override
+  protected void runRejectedTask(final Runnable task) {
     final boolean previous = isPoolThread();
     POOL_THREAD.set(Boolean.TRUE);
     try {
-      // Run it UNCONDITIONALLY, including on a shut-down pool - unlike the pools that hand back a Future, which
-      // can cancel one instead. There is no future here to cancel and no result to return: the submitter has
-      // already counted this command as in flight, so a task that is neither run nor completed leaves that count
-      // raised for ever and every later waitCompletion() on that database waits out its whole budget. Nothing
-      // shuts this pool down today; this is the answer that stays correct if something ever does.
-      task.run();
+      super.runRejectedTask(task);
     } finally {
       if (previous)
         POOL_THREAD.set(Boolean.TRUE);
@@ -209,18 +170,4 @@ public final class AsyncCommandPool {
     return Boolean.TRUE.equals(POOL_THREAD.get());
   }
 
-  /** The dedicated executor. Its bounded queue plus caller-runs rejection is the whole back-pressure story. */
-  public ExecutorService getExecutorService() {
-    return executor;
-  }
-
-  /** Live pool statistics for the metrics binder (Studio "Executor Pools" card). */
-  public PoolStats getPoolStats() {
-    return new PoolStats(executor.getPoolSize(), executor.getActiveCount(), executor.getQueue().size(),
-        executor.getQueue().remainingCapacity(), executor.getCompletedTaskCount(), callerRunCount.get());
-  }
-
-  public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
-                          long completedTasks, long callerRunFallbacks) {
-  }
 }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -40,7 +40,6 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.QueryEngine;
-import com.arcadedb.query.QueryEngineManager;
 import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.utility.StringUtils;
 import com.arcadedb.schema.DocumentType;
@@ -647,8 +646,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         // caller passing awaitResponse=false asked not to wait for.
         return false;
 
-      return QueryEngineManager.getInstance().getEngine(task.language, database).classifyDDL(task.command)
-          == QueryEngine.DDLClassification.DDL;
+      // database.getQueryEngine and not QueryEngineManager.getEngine: the former caches the reusable engines per
+      // database, so classifying costs a map lookup rather than a fresh engine object per dispatched command, on the
+      // submitting thread of a caller that asked not to wait for anything.
+      return database.getQueryEngine(task.language).classifyDDL(task.command) == QueryEngine.DDLClassification.DDL;
 
     } catch (final Exception e) {
       LogManager.instance()

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -39,11 +39,8 @@ import com.arcadedb.exception.SchemaException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.log.LogManager;
-import com.arcadedb.query.sql.SQLQueryEngine;
-import com.arcadedb.query.sql.SQLScriptQueryEngine;
-import com.arcadedb.query.sql.parser.DDLStatement;
-import com.arcadedb.query.sql.parser.Statement;
-import com.arcadedb.query.sql.parser.StatementCache;
+import com.arcadedb.query.QueryEngine;
+import com.arcadedb.query.QueryEngineManager;
 import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.utility.StringUtils;
 import com.arcadedb.schema.DocumentType;
@@ -227,7 +224,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     public void run() {
       DatabaseContext.INSTANCE.init(database);
 
-      DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).asyncMode = true;
+      DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).perThreadBucketSelection = true;
       database.getTransaction().setUseWAL(transactionUseWAL);
       database.setWALFlush(transactionSync);
       database.getTransaction().begin(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED); // FORCE THE LOWEST LEVEL
@@ -620,40 +617,39 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * Whether a dispatched command is DDL, and therefore has to run off the workers.
    * <p>
    * The DECISION is always a parse, never a text match - a keyword can appear in a string literal, and routing a
-   * write command off the workers costs the bucket pinning that keeps concurrent writers apart. Only SQL is
-   * classified, because only SQL can be classified cheaply and correctly; a command in another language keeps the
-   * behaviour it has always had, including the #6281 refusal if it turns out to need the barrier, which is an honest
-   * refusal rather than a guess made from a keyword.
+   * write command off the workers costs the bucket pinning that keeps concurrent writers apart. The parse belongs to
+   * the LANGUAGE, so it is asked of the language: {@link QueryEngine#classifyDDL(String)} (issue #6324, item 5).
+   * Until then this method knew about SQL and nothing else, so {@code CREATE INDEX} sent with
+   * {@code awaitResponse=false} worked in SQL and was refused in Cypher - an asymmetry a user met without warning.
+   * <p>
+   * An engine that cannot classify cheaply answers {@link QueryEngine.DDLClassification#UNKNOWN} and its statements
+   * keep the behaviour they have always had, including the #6281 refusal if one turns out to need the barrier, which
+   * is an honest refusal rather than a guess made from a keyword.
    * <p>
    * A statement that does not parse is NOT routed anywhere new: it goes to a worker and fails there, reported through
    * the caller's {@code onError} exactly as before. Classification must never be the thing that changes how an error
    * is delivered.
    * <p>
-   * <b>What it costs, and why the two languages differ.</b> For {@code sql} the parse is a {@link StatementCache}
-   * lookup that execution is about to repeat with the same key, so classification is free. For {@code sqlscript}
-   * there is no such cache - {@code SQLScriptQueryEngine.parseScript} parses every time and execution parses again -
-   * so classifying by parsing alone would make every dispatched script, DDL or not, pay two full parses on the
-   * submitting thread. Hence {@link #mayContainDDL}: a script that does not so much as mention a DDL verb cannot
-   * contain a DDL statement, and is answered without parsing at all.
+   * <b>What it costs.</b> For {@code sql} and {@code cypher} the parse is a statement-cache lookup that execution is
+   * about to repeat with the same key, so classification is free. For {@code sqlscript} there is no such cache -
+   * {@code SQLScriptQueryEngine.parseScript} parses every time and execution parses again - so classifying by parsing
+   * alone would make every dispatched script, DDL or not, pay two full parses on the submitting thread. Hence
+   * {@link #mayContainDDL}: a statement that does not so much as mention a DDL verb cannot be DDL, and is answered
+   * without asking any engine anything.
    */
   private boolean requiresOffWorkerExecution(final DatabaseAsyncCommand task) {
     try {
       if (!mayContainDDL(task.command))
-        // NEITHER LANGUAGE CAN BE DDL WITHOUT ONE OF THE VERBS, so the common case - an ordinary write or read
+        // NO LANGUAGE HERE CAN BE DDL WITHOUT ONE OF THE VERBS, so the common case - an ordinary write or read
         // command - is classified without parsing anything on the submitting thread. It matters for `sql` too, not
         // just for scripts: the statement cache makes the parse free only once it is WARM, and a first dispatch of a
         // fresh statement would otherwise pay a full parse before the task is even queued, which is the one thing a
         // caller passing awaitResponse=false asked not to wait for.
         return false;
 
-      if (SQLQueryEngine.ENGINE_NAME.equalsIgnoreCase(task.language))
-        return database.getStatementCache().get(task.command) instanceof DDLStatement;
+      return QueryEngineManager.getInstance().getEngine(task.language, database).classifyDDL(task.command)
+          == QueryEngine.DDLClassification.DDL;
 
-      if (SQLScriptQueryEngine.ENGINE_NAME.equalsIgnoreCase(task.language)) {
-        for (final Statement statement : SQLScriptQueryEngine.parseScript(task.command, database))
-          if (statement instanceof DDLStatement)
-            return true;
-      }
     } catch (final Exception e) {
       LogManager.instance()
           .log(this, Level.FINE, "Cannot classify asynchronous command %s: scheduling it on a worker", e, task);
@@ -662,18 +658,19 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   }
 
   /**
-   * The cheap half of the script classification: {@code false} means the text cannot contain a DDL statement, so the
-   * parse that would prove it is skipped.
+   * The cheap half of the classification: {@code false} means the text cannot be a DDL statement, so the parse that
+   * would prove it is skipped and no engine is asked.
    * <p>
-   * Sound because it is used ONLY as a negative filter. Every {@code DDLStatement} in the grammar begins with one of
-   * these verbs, so a script containing none of them has no DDL in it and the answer is exact. A false positive - the
-   * word inside a string literal or an identifier - costs nothing but the parse that was being paid unconditionally
-   * before, and the parse then gives the right answer anyway.
+   * Sound because it is used ONLY as a negative filter. Every {@code DDLStatement} in the SQL grammar begins with one
+   * of these verbs, and so do all four Cypher DDL statements ({@code CREATE}/{@code DROP INDEX},
+   * {@code CREATE}/{@code DROP CONSTRAINT}), so a statement containing none of them has no DDL in it and the answer
+   * is exact. A false positive - the word inside a string literal or an identifier - costs nothing but the parse that
+   * was being paid unconditionally before, and the parse then gives the right answer anyway.
    * <p>
-   * <b>The list has to keep up with the grammar</b>, and {@code AsyncDDLKeywordCoverageTest} is what makes that
-   * automatic: it walks every {@code DDLStatement} subclass on the classpath and fails if one begins with a verb that
-   * is not here. A miss would not corrupt anything - the statement would go to a worker and be refused there by
-   * #6281's guard - but it would quietly take back the operation this routing exists to give.
+   * <b>The list has to keep up with the grammars</b>, and {@code AsyncDDLKeywordCoverageTest} is what makes that
+   * automatic: it walks every {@code DDLStatement} subclass on the classpath, and every Cypher DDL kind, and fails if
+   * one begins with a verb that is not here. A miss would not corrupt anything - the statement would go to a worker
+   * and be refused there by #6281's guard - but it would quietly take back the operation this routing exists to give.
    */
   static boolean mayContainDDL(final String script) {
     for (final String keyword : DDL_LEADING_KEYWORDS)
@@ -748,8 +745,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         DatabaseContext.INSTANCE.init(database) :
         existing;
 
-    // asyncMode is set exactly as a worker sets it, because that flag is NOT "am I on an async worker": it is what
-    // makes the default round-robin bucket strategy pick a bucket per THREAD, so concurrent asynchronous writers
+    // perThreadBucketSelection is set exactly as a worker sets it, because that flag is NOT "am I on an async
+    // worker": it is what makes the default round-robin bucket strategy pick a bucket per THREAD, so writers
     // stop competing for the same pages. It matters here even though only DDL is routed to this pool, because a
     // sqlscript carrying one DDL statement brings whatever else it contains with it. What the flag is NOT is a
     // usable answer to "can this thread drain its own queue" - see note b of #6303 and the comment in
@@ -759,8 +756,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // the submitter's own request, so leaving the flag raised would change the bucket selection of everything that
     // request does afterwards - and leaving it alone instead would run this statement under a different rule from
     // the identical one that was not rejected. Same shape as the principal binding in DatabaseAsyncCommand.
-    final boolean previousAsyncMode = dbContext.asyncMode;
-    dbContext.asyncMode = true;
+    final boolean previousBucketSelection = dbContext.perThreadBucketSelection;
+    dbContext.perThreadBucketSelection = true;
     try {
       // Whether the transaction is OURS. On the caller-runs path it may well not be, and then there is nothing to
       // commit and nothing to roll back: the command is part of the submitter's transaction and its owner decides
@@ -798,7 +795,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         if (contextCreated)
           DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
         else
-          dbContext.asyncMode = previousAsyncMode;
+          dbContext.perThreadBucketSelection = previousBucketSelection;
       }
     } finally {
       try {

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.index;
 
-import com.arcadedb.database.BasicDatabase;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
@@ -44,31 +43,29 @@ public interface IndexInternal extends Index {
   enum INDEX_STATUS {UNAVAILABLE, AVAILABLE, COMPACTION_SCHEDULED, COMPACTION_IN_PROGRESS}
 
   /**
-   * The {@code buildIndexBatchSize} that says "this build may not commit anything": it is sharing a transaction it
-   * did not open, so the records it is indexing are the caller's uncommitted work and committing them is the
-   * caller's decision, not the build's (issue #6324, item 1).
+   * Populates the index by SCANNING the records it covers.
    *
-   * @see #commitBuildBatch(DatabaseInternal, long, int)
+   * @param buildIndexBatchSize    records per chunked commit, for the builds that chunk by record count. Never a
+   *                               permission: see {@code sharesCallerTransaction}, which is the one that says whether
+   *                               committing is allowed at all
+   * @param sharesCallerTransaction whether this build is running INSIDE a transaction somebody else opened, which is
+   *                               what lets its scan see records that transaction has written and not committed
+   *                               (issue #6324, item 1). A build that shares a transaction may not commit it, and has
+   *                               to ask that transaction for its own written copy of each scanned record
+   * @param callback               per-record progress callback, or null
    */
-  int BUILD_WITHOUT_CHUNKED_COMMIT = 0;
-
-  long build(int buildIndexBatchSize, BuildIndexCallback callback);
+  long build(int buildIndexBatchSize, boolean sharesCallerTransaction, BuildIndexCallback callback);
 
   /**
-   * The batch size a scan-based build may be given, which is {@code batchSize} only when the build is going to open
-   * the transaction it runs in.
-   * <p>
-   * Written once, and asked BEFORE the build opens anything, because after that point a transaction is always active
-   * and the question can no longer be put. A transaction already open on this thread is a caller's; the build joins
-   * it so its scan can see what that caller has written (issue #6324, item 1), and a build that shares a transaction
-   * may not commit it.
+   * A build that OWNS the transaction it runs in, which is every build reached other than through
+   * {@code IndexBuilder#buildCreatedIndex}: it may commit, and there is no caller's uncommitted work for it to see.
    */
-  static int buildBatchSizeFor(final BasicDatabase database, final int batchSize) {
-    return database.isTransactionActive() ? BUILD_WITHOUT_CHUNKED_COMMIT : batchSize;
+  default long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
+    return build(buildIndexBatchSize, false, callback);
   }
 
   /**
-   * The chunked commit every scan-based {@link #build(int, BuildIndexCallback)} performs: once every
+   * The chunked commit every scan-based {@link #build(int, boolean, BuildIndexCallback)} performs: once every
    * {@code buildIndexBatchSize} records the build's transaction is committed and reopened, so indexing a large bucket
    * does not accumulate every entry of it in one transaction.
    * <p>
@@ -77,19 +74,22 @@ public interface IndexInternal extends Index {
    * transaction opened by a caller - a {@code CREATE INDEX} inside an open transaction, which is where the records
    * being indexed are the caller's own uncommitted writes (issue #6324, item 1). Committing there would publish
    * whatever else that transaction has done, halfway through a DDL statement the caller has not finished, and would
-   * leave the caller holding a transaction object that has already been popped. The builders signal it by passing
-   * {@link #BUILD_WITHOUT_CHUNKED_COMMIT}, which {@link #buildBatchSizeFor} decides.
+   * leave the caller holding a transaction object that has already been popped.
    * <p>
-   * A non-positive batch size is treated the same way rather than as a modulo by zero, which is what the four copies
-   * did with a batch size of 0.
+   * The permission is a PARAMETER OF ITS OWN and never a value of {@code buildIndexBatchSize}. Spelling it as
+   * "batch size 0" would collide with a user-supplied {@code REBUILD INDEX ... WITH batchSize = 0} for any index
+   * family that does not chunk by record count - the vector builds chunk by bytes and would read that literal zero as
+   * the permission. A non-positive batch size is still treated as "no chunking" rather than as a modulo by zero,
+   * which is what the four copies did with it.
    *
-   * @param database            the database whose build transaction is being chunked
-   * @param processedRecords    how many records the build has indexed so far
-   * @param buildIndexBatchSize records per chunk, or {@link #BUILD_WITHOUT_CHUNKED_COMMIT} to never commit
+   * @param database                the database whose build transaction is being chunked
+   * @param processedRecords        how many records the build has indexed so far
+   * @param buildIndexBatchSize     records per chunk; non-positive means no chunking
+   * @param sharesCallerTransaction when true the build owns nothing and commits nothing
    */
   static void commitBuildBatch(final DatabaseInternal database, final long processedRecords,
-      final int buildIndexBatchSize) {
-    if (buildIndexBatchSize <= 0 || processedRecords % buildIndexBatchSize != 0)
+      final int buildIndexBatchSize, final boolean sharesCallerTransaction) {
+    if (sharesCallerTransaction || buildIndexBatchSize <= 0 || processedRecords % buildIndexBatchSize != 0)
       return;
     database.getWrappedDatabaseInstance().commit();
     database.getWrappedDatabaseInstance().begin();
@@ -107,13 +107,18 @@ public interface IndexInternal extends Index {
    * leaving the stale key behind for good. Asking the transaction closes the gap at the only place the two views can
    * disagree.
    * <p>
-   * Costs nothing when there is nothing to correct: with no transaction, or none that wrote this record, it is one
-   * hash lookup returning null and the scanned record is used as-is.
+   * A build that owns its transaction is answered without asking anything: it is on the per-record hot path of every
+   * index build and rebuild in the engine, and there is nothing for a transaction it opened itself to correct.
    *
-   * @param database the database whose transaction may hold a newer copy
-   * @param scanned  the record as the bucket scan produced it
+   * @param database                the database whose transaction may hold a newer copy
+   * @param scanned                 the record as the bucket scan produced it
+   * @param sharesCallerTransaction whether there is a caller's transaction that could hold a newer copy at all
    */
-  static Document buildSourceRecord(final DatabaseInternal database, final Record scanned) {
+  static Document buildSourceRecord(final DatabaseInternal database, final Record scanned,
+      final boolean sharesCallerTransaction) {
+    if (!sharesCallerTransaction)
+      return (Document) scanned;
+
     final TransactionContext tx = database.getTransactionIfExists();
     if (tx != null) {
       final Record written = tx.getWrittenRecord(scanned.getIdentity());

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -18,8 +18,13 @@
  */
 package com.arcadedb.index;
 
+import com.arcadedb.database.BasicDatabase;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.engine.Component;
 import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.Type;
@@ -38,7 +43,85 @@ import java.util.Map;
 public interface IndexInternal extends Index {
   enum INDEX_STATUS {UNAVAILABLE, AVAILABLE, COMPACTION_SCHEDULED, COMPACTION_IN_PROGRESS}
 
+  /**
+   * The {@code buildIndexBatchSize} that says "this build may not commit anything": it is sharing a transaction it
+   * did not open, so the records it is indexing are the caller's uncommitted work and committing them is the
+   * caller's decision, not the build's (issue #6324, item 1).
+   *
+   * @see #commitBuildBatch(DatabaseInternal, long, int)
+   */
+  int BUILD_WITHOUT_CHUNKED_COMMIT = 0;
+
   long build(int buildIndexBatchSize, BuildIndexCallback callback);
+
+  /**
+   * The batch size a scan-based build may be given, which is {@code batchSize} only when the build is going to open
+   * the transaction it runs in.
+   * <p>
+   * Written once, and asked BEFORE the build opens anything, because after that point a transaction is always active
+   * and the question can no longer be put. A transaction already open on this thread is a caller's; the build joins
+   * it so its scan can see what that caller has written (issue #6324, item 1), and a build that shares a transaction
+   * may not commit it.
+   */
+  static int buildBatchSizeFor(final BasicDatabase database, final int batchSize) {
+    return database.isTransactionActive() ? BUILD_WITHOUT_CHUNKED_COMMIT : batchSize;
+  }
+
+  /**
+   * The chunked commit every scan-based {@link #build(int, BuildIndexCallback)} performs: once every
+   * {@code buildIndexBatchSize} records the build's transaction is committed and reopened, so indexing a large bucket
+   * does not accumulate every entry of it in one transaction.
+   * <p>
+   * Written once and shared by all four scan-based builds because the condition under which it must NOT run is the
+   * subtle half, and four copies of it were four chances to get it wrong. It must not run when the build is sharing a
+   * transaction opened by a caller - a {@code CREATE INDEX} inside an open transaction, which is where the records
+   * being indexed are the caller's own uncommitted writes (issue #6324, item 1). Committing there would publish
+   * whatever else that transaction has done, halfway through a DDL statement the caller has not finished, and would
+   * leave the caller holding a transaction object that has already been popped. The builders signal it by passing
+   * {@link #BUILD_WITHOUT_CHUNKED_COMMIT}, which {@link #buildBatchSizeFor} decides.
+   * <p>
+   * A non-positive batch size is treated the same way rather than as a modulo by zero, which is what the four copies
+   * did with a batch size of 0.
+   *
+   * @param database            the database whose build transaction is being chunked
+   * @param processedRecords    how many records the build has indexed so far
+   * @param buildIndexBatchSize records per chunk, or {@link #BUILD_WITHOUT_CHUNKED_COMMIT} to never commit
+   */
+  static void commitBuildBatch(final DatabaseInternal database, final long processedRecords,
+      final int buildIndexBatchSize) {
+    if (buildIndexBatchSize <= 0 || processedRecords % buildIndexBatchSize != 0)
+      return;
+    database.getWrappedDatabaseInstance().commit();
+    database.getWrappedDatabaseInstance().begin();
+  }
+
+  /**
+   * The version of {@code scanned} a scan-based build must index: the transaction's own written copy when it has one,
+   * the page image the scan handed over otherwise.
+   * <p>
+   * A bucket scan reads bytes off pages, and an UPDATE inside a transaction does not touch the page until commit -
+   * it is parked as a deferred update and serialized in the first commit phase, precisely so that repeatedly updating
+   * the same record does not rewrite the page each time. So a build sharing the caller's transaction (issue #6324,
+   * item 1) sees the record's OLD content and would index a key the record no longer has, while the commit-time
+   * serialization removes that same key directly on the index and the build's staged entry is replayed on top of it -
+   * leaving the stale key behind for good. Asking the transaction closes the gap at the only place the two views can
+   * disagree.
+   * <p>
+   * Costs nothing when there is nothing to correct: with no transaction, or none that wrote this record, it is one
+   * hash lookup returning null and the scanned record is used as-is.
+   *
+   * @param database the database whose transaction may hold a newer copy
+   * @param scanned  the record as the bucket scan produced it
+   */
+  static Document buildSourceRecord(final DatabaseInternal database, final Record scanned) {
+    final TransactionContext tx = database.getTransactionIfExists();
+    if (tx != null) {
+      final Record written = tx.getWrittenRecord(scanned.getIdentity());
+      if (written instanceof Document document)
+        return document;
+    }
+    return (Document) scanned;
+  }
 
   boolean compact() throws IOException, InterruptedException;
 

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -644,7 +644,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
     final List<String> propNames = getPropertyNames();
 
     final boolean async =
-        DatabaseContext.INSTANCE.getContext(type.getSchema().getEmbedded().getDatabase().getDatabasePath()).asyncMode;
+        DatabaseContext.INSTANCE.getContext(type.getSchema().getEmbedded().getDatabase().getDatabasePath()).perThreadBucketSelection;
 
     final int bucketIndex = type.getBucketIndexByKeys(propNames, keys, async);
 

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -431,11 +431,12 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   }
 
   @Override
-  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
+  public long build(final int buildIndexBatchSize, final boolean sharesCallerTransaction,
+      final BuildIndexCallback callback) {
     checkIsValid();
     long total = 0;
     for (final IndexInternal index : indexesOnBuckets)
-      total += index.build(buildIndexBatchSize, callback);
+      total += index.build(buildIndexBatchSize, sharesCallerTransaction, callback);
     return total;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -1290,16 +1290,14 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
           typeName + getPropertyNames());
 
       db.scanBucket(bucketName, record -> {
-        db.getIndexer().addToIndex(LSMTreeFullTextIndex.this, record.getIdentity(), (Document) record);
+        final Document source = IndexInternal.buildSourceRecord(db, record);
+        db.getIndexer().addToIndex(LSMTreeFullTextIndex.this, record.getIdentity(), source);
         total.incrementAndGet();
 
-        if (total.get() % buildIndexBatchSize == 0) {
-          db.getWrappedDatabaseInstance().commit();
-          db.getWrappedDatabaseInstance().begin();
-        }
+        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
 
         if (callback != null)
-          callback.onDocumentIndexed((Document) record, total.get());
+          callback.onDocumentIndexed(source, total.get());
 
         return true;
       }, (rid, exception) -> {

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -1274,7 +1274,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * single-property index would store untokenized raw values. So the scan is performed here, indexing through {@code this}.
    */
   @Override
-  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
+  public long build(final int buildIndexBatchSize, final boolean sharesCallerTransaction,
+      final BuildIndexCallback callback) {
     final DatabaseInternal db = underlyingIndex.getMutableIndex().getDatabase();
     final String typeName = getTypeName();
     if (typeName == null)
@@ -1290,11 +1291,11 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
           typeName + getPropertyNames());
 
       db.scanBucket(bucketName, record -> {
-        final Document source = IndexInternal.buildSourceRecord(db, record);
+        final Document source = IndexInternal.buildSourceRecord(db, record, sharesCallerTransaction);
         db.getIndexer().addToIndex(LSMTreeFullTextIndex.this, record.getIdentity(), source);
         total.incrementAndGet();
 
-        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
+        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize, sharesCallerTransaction);
 
         if (callback != null)
           callback.onDocumentIndexed(source, total.get());

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -493,7 +493,8 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
   }
 
   @Override
-  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
+  public long build(final int buildIndexBatchSize, final boolean sharesCallerTransaction,
+      final BuildIndexCallback callback) {
     // Must NOT delegate to underlyingIndex.build(), because that would pass the raw LSMTreeIndex
     // to DocumentIndexer.addToIndex(), bypassing GeoHash tokenization and storing raw WKT keys.
     // Instead, scan the bucket and call this.put() through the indexer so tokenization runs.
@@ -509,11 +510,11 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
     LogManager.instance().log(this, Level.INFO, "Building geospatial index '%s'...", getName());
 
     db.scanBucket(bucketName, record -> {
-      final Document source = IndexInternal.buildSourceRecord(db, record);
+      final Document source = IndexInternal.buildSourceRecord(db, record, sharesCallerTransaction);
       db.getIndexer().addToIndex(LSMTreeGeoIndex.this, record.getIdentity(), source);
       total.incrementAndGet();
 
-      IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
+      IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize, sharesCallerTransaction);
 
       if (callback != null)
         callback.onDocumentIndexed(source, total.get());

--- a/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/geospatial/LSMTreeGeoIndex.java
@@ -509,16 +509,14 @@ public class LSMTreeGeoIndex implements Index, IndexInternal {
     LogManager.instance().log(this, Level.INFO, "Building geospatial index '%s'...", getName());
 
     db.scanBucket(bucketName, record -> {
-      db.getIndexer().addToIndex(LSMTreeGeoIndex.this, record.getIdentity(), (Document) record);
+      final Document source = IndexInternal.buildSourceRecord(db, record);
+      db.getIndexer().addToIndex(LSMTreeGeoIndex.this, record.getIdentity(), source);
       total.incrementAndGet();
 
-      if (total.get() % buildIndexBatchSize == 0) {
-        db.getWrappedDatabaseInstance().commit();
-        db.getWrappedDatabaseInstance().begin();
-      }
+      IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
 
       if (callback != null)
-        callback.onDocumentIndexed((Document) record, total.get());
+        callback.onDocumentIndexed(source, total.get());
 
       return true;
     });

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -386,7 +386,8 @@ public class HashIndex implements IndexInternal {
       final long startTime = System.currentTimeMillis();
 
       db.scanBucket(db.getSchema().getBucketById(metadata.associatedBucketId).getName(), record -> {
-        db.getIndexer().addToIndex(HashIndex.this, record.getIdentity(), (Document) record);
+        final Document source = IndexInternal.buildSourceRecord(db, record);
+        db.getIndexer().addToIndex(HashIndex.this, record.getIdentity(), source);
         total.incrementAndGet();
 
         if (total.get() % 10_000 == 0) {
@@ -396,13 +397,10 @@ public class HashIndex implements IndexInternal {
               name, total.get(), rate);
         }
 
-        if (total.get() % buildIndexBatchSize == 0) {
-          db.getWrappedDatabaseInstance().commit();
-          db.getWrappedDatabaseInstance().begin();
-        }
+        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
 
         if (callback != null)
-          callback.onDocumentIndexed((Document) record, total.get());
+          callback.onDocumentIndexed(source, total.get());
 
         return true;
       }, (rid, exception) -> {

--- a/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/hash/HashIndex.java
@@ -371,7 +371,8 @@ public class HashIndex implements IndexInternal {
   // ─── INDEX INTERNAL ──────────────────────────────────────
 
   @Override
-  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
+  public long build(final int buildIndexBatchSize, final boolean sharesCallerTransaction,
+      final BuildIndexCallback callback) {
     checkIsValid();
     final AtomicLong total = new AtomicLong();
 
@@ -386,7 +387,7 @@ public class HashIndex implements IndexInternal {
       final long startTime = System.currentTimeMillis();
 
       db.scanBucket(db.getSchema().getBucketById(metadata.associatedBucketId).getName(), record -> {
-        final Document source = IndexInternal.buildSourceRecord(db, record);
+        final Document source = IndexInternal.buildSourceRecord(db, record, sharesCallerTransaction);
         db.getIndexer().addToIndex(HashIndex.this, record.getIdentity(), source);
         total.incrementAndGet();
 
@@ -397,7 +398,7 @@ public class HashIndex implements IndexInternal {
               name, total.get(), rate);
         }
 
-        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
+        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize, sharesCallerTransaction);
 
         if (callback != null)
           callback.onDocumentIndexed(source, total.get());

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -936,7 +936,8 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
       final long startTime = System.currentTimeMillis();
 
       db.scanBucket(db.getSchema().getBucketById(metadata.associatedBucketId).getName(), record -> {
-        db.getIndexer().addToIndex(LSMTreeIndex.this, record.getIdentity(), (Document) record);
+        final Document source = IndexInternal.buildSourceRecord(db, record);
+        db.getIndexer().addToIndex(LSMTreeIndex.this, record.getIdentity(), source);
         total.incrementAndGet();
 
         // Periodic progress logging
@@ -947,14 +948,10 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
               name, total.get(), rate);
         }
 
-        if (total.get() % buildIndexBatchSize == 0) {
-          // CHUNK OF 100K
-          db.getWrappedDatabaseInstance().commit();
-          db.getWrappedDatabaseInstance().begin();
-        }
+        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
 
         if (callback != null)
-          callback.onDocumentIndexed((Document) record, total.get());
+          callback.onDocumentIndexed(source, total.get());
 
         return true;
       }, (rid, exception) -> {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -918,7 +918,8 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
     }
   }
 
-  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
+  public long build(final int buildIndexBatchSize, final boolean sharesCallerTransaction,
+      final BuildIndexCallback callback) {
     checkIsValid();
     final AtomicLong total = new AtomicLong();
     final long LOG_INTERVAL = 10000; // Log every 10K records
@@ -936,7 +937,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
       final long startTime = System.currentTimeMillis();
 
       db.scanBucket(db.getSchema().getBucketById(metadata.associatedBucketId).getName(), record -> {
-        final Document source = IndexInternal.buildSourceRecord(db, record);
+        final Document source = IndexInternal.buildSourceRecord(db, record, sharesCallerTransaction);
         db.getIndexer().addToIndex(LSMTreeIndex.this, record.getIdentity(), source);
         total.incrementAndGet();
 
@@ -948,7 +949,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
               name, total.get(), rate);
         }
 
-        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize);
+        IndexInternal.commitBuildBatch(db, total.get(), buildIndexBatchSize, sharesCallerTransaction);
 
         if (callback != null)
           callback.onDocumentIndexed(source, total.get());

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -748,8 +748,9 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
   }
 
   @Override
-  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
-    return underlyingIndex.build(buildIndexBatchSize, callback);
+  public long build(final int buildIndexBatchSize, final boolean sharesCallerTransaction,
+      final BuildIndexCallback callback) {
+    return underlyingIndex.build(buildIndexBatchSize, sharesCallerTransaction, callback);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -20,12 +20,8 @@ package com.arcadedb.index.sparsevector;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.DedicatedThreadPool;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -77,7 +73,7 @@ import java.util.logging.Level;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public final class SparseVectorScoringPool {
+public final class SparseVectorScoringPool extends DedicatedThreadPool {
 
   // Lazy-init via the initialization-on-demand holder idiom. The pool only allocates its
   // ThreadPoolExecutor when something actually calls {@link #getInstance()} - which today is
@@ -89,9 +85,6 @@ public final class SparseVectorScoringPool {
   private static final class Holder {
     static final SparseVectorScoringPool INSTANCE = new SparseVectorScoringPool();
   }
-
-  /** Floor for the auto-sized thread count when {@code SPARSE_VECTOR_SCORING_POOL_THREADS=0}. */
-  private static final int DEFAULT_THREADS_FLOOR = 2;
 
   /**
    * How much caller-side concurrency is treated as enough to keep the pool busy without help:
@@ -134,109 +127,61 @@ public final class SparseVectorScoringPool {
    */
   private static final ThreadLocal<Boolean> POOL_THREAD = new ThreadLocal<>();
 
-  private final ThreadPoolExecutor executor;
   /** Workers claimed by in-flight range fan-outs; see {@link #tryReserveWorkers(int)}. */
-  private final AtomicInteger      reservedWorkers      = new AtomicInteger();
+  private final AtomicInteger reservedWorkers         = new AtomicInteger();
   /** Caller-thread top-K calls in flight JVM-wide, split or not; see {@link #queryStarted()}. */
-  private final AtomicInteger      inFlightQueries      = new AtomicInteger();
+  private final AtomicInteger inFlightQueries         = new AtomicInteger();
   /** Top-K calls running on a worker, i.e. the per-bucket fan-out. Occupy capacity, never split. */
-  private final AtomicInteger      poolThreadQueries    = new AtomicInteger();
+  private final AtomicInteger poolThreadQueries       = new AtomicInteger();
   /** Cumulative queries that were split into RID ranges rather than run on the caller thread. */
-  private final AtomicLong         splitQueries         = new AtomicLong();
-  private final AtomicLong         callerRunCount       = new AtomicLong();
-  // Throttle for the WARNING log emitted on saturation: at most one entry per minute. Same
-  // shape as the QueryEngineManager pool's throttle - operators see one nudge in the console
-  // when scoring starts queueing badly and can correlate against {@link #getPoolStats}.
-  // Millisecond precision is plenty for a 60 000 ms window. Initialised to 0L (not
-  // {@code Long.MIN_VALUE}) so the {@code now - last} subtraction does not overflow on the
-  // first saturation event.
-  private static final long        SATURATION_WARN_INTERVAL_MS = 60_000L;
-  private final AtomicLong         lastSaturationWarnMs = new AtomicLong(0L);
-  private final AtomicLong         lastExplicitSplitWarnMs = new AtomicLong(0L);
+  private final AtomicLong    splitQueries            = new AtomicLong();
+  private final AtomicLong    lastExplicitSplitWarnMs = new AtomicLong(0L);
 
   private SparseVectorScoringPool() {
-    // 0 = auto-size to available cores (with a floor of {@link #DEFAULT_THREADS_FLOOR}). Any
-    // explicit positive value wins, so an operator can pin the pool size to e.g. half the cores
-    // on a box that also runs Gremlin / Polyglot scripts that compete for CPU. Negative values
-    // are coerced to the floor for safety; the configuration validator already rejects them at
-    // GlobalConfiguration parse time, but the coercion here makes test-side bypasses safe too.
-    // A negative configured value silently falling back to a default is exactly the kind of
-    // misconfiguration that hides bad sizing - log it at WARNING so operators see something
-    // when their setting did not stick.
+    // Pool construction, the counted-and-throttled saturation warning and the PoolStats all come from
+    // DedicatedThreadPool (issue #6324, item 4). Caller-runs rather than a RejectedExecutionException: the
+    // alternative would force every caller to implement a fallback path of its own, which is more error-prone than
+    // doing it once, and a fan-out that degrades to single-threaded still returns a correct top-K.
+    super("ArcadeDB-SparseVectorScorer-", resolveThreads(), resolveQueueSize(), SaturationPolicy.CALLER_RUNS,
+        (body, name) -> new Thread(() -> {
+          POOL_THREAD.set(Boolean.TRUE);
+          body.run();
+        }, name), "Sparse-vector scoring pool",
+        "the fan-out degrades to single-threaded per chunk but still returns a correct top-K",
+        GlobalConfiguration.SPARSE_VECTOR_SCORING_POOL_THREADS, GlobalConfiguration.SPARSE_VECTOR_SCORING_QUEUE_SIZE);
+  }
+
+  /**
+   * 0 = auto-size to available cores (with a floor of {@link #DEFAULT_THREADS_FLOOR}). Any explicit positive value
+   * wins, so an operator can pin the pool size to e.g. half the cores on a box that also runs Gremlin / Polyglot
+   * scripts that compete for CPU. Negative values are coerced for safety; the configuration validator already rejects
+   * them at GlobalConfiguration parse time, but the coercion here makes test-side bypasses safe too.
+   * <p>
+   * A negative configured value silently falling back to a default is exactly the kind of misconfiguration that hides
+   * bad sizing, so it is reported at WARNING and an operator whose setting did not stick sees something. Static
+   * because it is an argument to the super constructor, and so runs before there is a pool to log against.
+   */
+  private static int resolveThreads() {
     final int configuredThreads = GlobalConfiguration.SPARSE_VECTOR_SCORING_POOL_THREADS.getValueAsInteger();
     if (configuredThreads < 0)
-      LogManager.instance().log(this, Level.WARNING,
+      LogManager.instance().log(SparseVectorScoringPool.class, Level.WARNING,
           "Sparse-vector scoring pool: negative configured thread count (%d), falling back to auto-size (max(%d, cores))",
           configuredThreads, DEFAULT_THREADS_FLOOR);
-    final int threads = configuredThreads > 0
-        ? configuredThreads
-        : Math.max(DEFAULT_THREADS_FLOOR, Runtime.getRuntime().availableProcessors());
+    return autoSizeThreads(configuredThreads);
+  }
+
+  /** The queue counterpart of {@link #resolveThreads()}, reporting a configured value that did not stick the same way. */
+  private static int resolveQueueSize() {
     final int configuredQueueSize = GlobalConfiguration.SPARSE_VECTOR_SCORING_QUEUE_SIZE.getValueAsInteger();
     if (configuredQueueSize < 0)
-      LogManager.instance().log(this, Level.WARNING,
-          "Sparse-vector scoring pool: negative configured queue size (%d), falling back to default 1024",
-          configuredQueueSize);
-    final int queueSize = configuredQueueSize > 0 ? configuredQueueSize : 1024;
-    final AtomicInteger workerSeq = new AtomicInteger();
-
-    final ThreadPoolExecutor pool = new ThreadPoolExecutor(
-        threads, threads,
-        60L, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(queueSize),
-        r -> {
-          final Thread t = new Thread(() -> {
-            POOL_THREAD.set(Boolean.TRUE);
-            r.run();
-          }, "ArcadeDB-SparseVectorScorer-" + workerSeq.incrementAndGet());
-          t.setDaemon(true);
-          return t;
-        },
-        // CallerRunsPolicy with a fallback counter and throttled WARNING. When the queue is full
-        // we run the task on the submitter; the alternative (throwing RejectedExecutionException)
-        // would force every caller to also implement a fallback path, which is more error-prone
-        // than just doing it once here. The log line nudges operators that the pool needs to
-        // grow; sizing knobs return alongside the dispatch wiring (see follow-up #4085).
-        (task, exec) -> {
-          final long fallbacks = callerRunCount.incrementAndGet();
-          final long now = System.currentTimeMillis();
-          final long last = lastSaturationWarnMs.get();
-          if (now - last > SATURATION_WARN_INTERVAL_MS && lastSaturationWarnMs.compareAndSet(last, now)) {
-            LogManager.instance().log(this, Level.WARNING,
-                "Sparse-vector scoring pool saturated: queue full (capacity=%d, threads=%d), running task on caller thread (cumulative caller-runs fallbacks=%d).",
-                exec.getQueue().remainingCapacity() + exec.getQueue().size(), exec.getMaximumPoolSize(), fallbacks);
-          }
-          if (!exec.isShutdown())
-            task.run();
-          else if (task instanceof RunnableFuture<?> future)
-            // #4961: a task rejected because the pool is shut down would otherwise be neither run
-            // nor completed, leaving any caller blocked in an untimed Future.get() hanging forever.
-            future.cancel(false);
-        });
-    pool.allowCoreThreadTimeOut(true);
-    this.executor = pool;
+      LogManager.instance().log(SparseVectorScoringPool.class, Level.WARNING,
+          "Sparse-vector scoring pool: negative configured queue size (%d), falling back to default %d",
+          configuredQueueSize, DEFAULT_QUEUE_SIZE);
+    return queueSizeOrDefault(configuredQueueSize);
   }
 
   public static SparseVectorScoringPool getInstance() {
     return Holder.INSTANCE;
-  }
-
-  /**
-   * The dedicated executor. Callers that fork query work for parallel scoring should submit
-   * here; the executor's bounded queue + caller-runs rejection policy handles back-pressure
-   * automatically, so callers do not need a "if pool is full, do it inline" branch of their own.
-   */
-  public ExecutorService getExecutorService() {
-    return executor;
-  }
-
-  /**
-   * Configured number of threads for parallel scoring fan-out. Callers can read this to size
-   * a single query's split count - forking more chunks than the pool has threads is wasteful;
-   * forking fewer leaves cores idle. Returns the configured ceiling, not the live worker count
-   * ({@link ThreadPoolExecutor#getPoolSize()} may be lower if no scoring has happened yet).
-   */
-  public int getMaxParallelism() {
-    return executor.getMaximumPoolSize();
   }
 
   /**
@@ -386,7 +331,7 @@ public final class SparseVectorScoringPool {
       return;
     final long now = System.currentTimeMillis();
     final long last = lastExplicitSplitWarnMs.get();
-    if (now - last > SATURATION_WARN_INTERVAL_MS && lastExplicitSplitWarnMs.compareAndSet(last, now))
+    if (now - last > WARN_THROTTLE_INTERVAL_MS && lastExplicitSplitWarnMs.compareAndSet(last, now))
       LogManager.instance().log(this, Level.WARNING,
           "Sparse-vector top-K split into %d ranges by an explicit %s=%d with %d queries in flight (including this one) on a "
               + "%d-thread pool. The adaptive default (0) would have kept this query on its caller thread, and past a handful of "
@@ -440,33 +385,4 @@ public final class SparseVectorScoringPool {
     return reservedWorkers.get();
   }
 
-  public PoolStats getPoolStats() {
-    return new PoolStats(
-        executor.getPoolSize(),
-        executor.getActiveCount(),
-        executor.getQueue().size(),
-        executor.getQueue().remainingCapacity(),
-        executor.getCompletedTaskCount(),
-        callerRunCount.get());
-  }
-
-  /**
-   * Snapshot of the scoring pool's load at one instant. Same shape as
-   * {@link com.arcadedb.query.QueryEngineManager.PoolStats} so a single dashboard can render
-   * both. Sustained growth in {@code callerRunFallbacks} signals that scoring is queueing
-   * faster than the pool can drain it - bump
-   * {@link GlobalConfiguration#SPARSE_VECTOR_SCORING_POOL_THREADS} or
-   * {@link GlobalConfiguration#SPARSE_VECTOR_SCORING_QUEUE_SIZE} to absorb the burst.
-   */
-  public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
-                          long completedTasks, long callerRunFallbacks) {
-  }
-
-  /**
-   * Best-effort shutdown for tests and tooling. Production lifecycle relies on the daemon-thread
-   * default: workers die when the JVM exits, no explicit close is required.
-   */
-  public void close() {
-    executor.shutdownNow();
-  }
 }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -5939,7 +5939,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   @Override
   public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
-    return build(callback, null);
+    // A build that shares the caller's transaction says so by passing BUILD_WITHOUT_CHUNKED_COMMIT, and this build's
+    // chunking is by BYTES rather than by records - so the batch size arrives here as a permission, not as a size
+    // (issue #6324, item 1).
+    return build(callback, null, buildIndexBatchSize != IndexInternal.BUILD_WITHOUT_CHUNKED_COMMIT);
   }
 
   /**
@@ -5952,6 +5955,25 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @return Total number of records indexed
    */
   public long build(final BuildIndexCallback callback, final GraphBuildCallback graphCallback) {
+    return build(callback, graphCallback, true);
+  }
+
+  /**
+   * Build the vector index with optional graph building progress callback.
+   * Uses WAL bypass and transaction chunking for efficient bulk loading.
+   *
+   * @param callback             Callback for document indexing progress
+   * @param graphCallback        Callback for graph building progress
+   * @param chunkedCommitAllowed whether the build owns the transaction it runs in and may therefore commit it
+   *                             periodically to bound its size. False when the build is sharing a transaction opened
+   *                             by a caller - a {@code CREATE INDEX} inside an open transaction - where committing
+   *                             would publish the caller's unfinished work halfway through a DDL statement
+   *                             (issue #6324, item 1)
+   *
+   * @return Total number of records indexed
+   */
+  public long build(final BuildIndexCallback callback, final GraphBuildCallback graphCallback,
+      final boolean chunkedCommitAllowed) {
     final long totalRecords;
 
     lock.writeLock().lock();
@@ -5977,11 +5999,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
           try {
             // PHASE 2: Bulk load vector data with chunking
-            totalRecords = bulkLoadVectorData(callback);
+            totalRecords = bulkLoadVectorData(callback, chunkedCommitAllowed);
 
             // PHASE 3: Build and persist graph with chunking
             if (vectorIndex.size() > 0 && graphState == GraphState.LOADING) {
-              buildGraphWithChunking(graphCallback);
+              buildGraphWithChunking(graphCallback, chunkedCommitAllowed);
             }
 
             // PHASE 4: Final commit and mark READY
@@ -6042,11 +6064,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Bulk load vector data with transaction chunking to avoid memory/size limits.
    * Called during index build with WAL disabled.
    *
-   * @param callback Callback for document indexing progress
+   * @param callback             Callback for document indexing progress
+   * @param chunkedCommitAllowed whether this build owns its transaction and may commit it at a chunk boundary
    *
    * @return Total number of vectors loaded
    */
-  private long bulkLoadVectorData(final BuildIndexCallback callback) {
+  private long bulkLoadVectorData(final BuildIndexCallback callback, final boolean chunkedCommitAllowed) {
     final AtomicInteger total = new AtomicInteger();
     final long LOG_INTERVAL = 10000;
     final long startTime = System.currentTimeMillis();
@@ -6069,7 +6092,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // Scan the bucket and index all documents
     db.scanBucket(db.getSchema().getBucketById(metadata.associatedBucketId).getName(), record -> {
       // Add to index
-      db.getIndexer().addToIndex(LSMVectorIndex.this, record.getIdentity(), (Document) record);
+      final Document source = IndexInternal.buildSourceRecord(db, record);
+      db.getIndexer().addToIndex(LSMVectorIndex.this, record.getIdentity(), source);
       total.incrementAndGet();
 
       // Estimate bytes written (rough approximation)
@@ -6087,7 +6111,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       }
 
       // Chunk boundary: commit and start new transaction
-      if (bytesInCurrentChunk.get() >= chunkSizeBytes) {
+      if (chunkedCommitAllowed && bytesInCurrentChunk.get() >= chunkSizeBytes) {
         LogManager.instance().log(this, Level.INFO,
             "Committing chunk: %.1fMB written, %d vectors...",
             bytesInCurrentChunk.get() / (1024.0 * 1024.0), total.get());
@@ -6100,7 +6124,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       }
 
       if (callback != null)
-        callback.onDocumentIndexed((Document) record, total.get());
+        callback.onDocumentIndexed(source, total.get());
 
       return true;
     });
@@ -6117,17 +6141,23 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Build graph from vectors and persist with chunking support.
    * Called during index build with WAL disabled.
    *
-   * @param graphCallback Callback for graph building progress
+   * @param graphCallback        Callback for graph building progress
+   * @param chunkedCommitAllowed whether this build owns the transaction it runs in and may therefore commit it at a
+   *                             chunk boundary. False when the build joined a caller's transaction (issue #6324,
+   *                             item 1): the graph is then written in one go, which is the same trade the caller
+   *                             already made by opening a transaction around the writes being indexed
    */
-  private void buildGraphWithChunking(final GraphBuildCallback graphCallback) throws IOException {
+  private void buildGraphWithChunking(final GraphBuildCallback graphCallback, final boolean chunkedCommitAllowed)
+      throws IOException {
     LogManager.instance().log(this, Level.INFO,
         "LSM Vector graph building with transaction chunking for: %s", indexName);
 
     final DatabaseInternal db = getDatabase();
 
     // Get chunk size from configuration (default 50MB). Guard against accidental 0/negative to ensure chunked graph
-    // persistence.
-    final long chunkSizeMB = getTxChunkSize();
+    // persistence. Zero when the build may not commit, which is writeGraph's own documented way of saying "no
+    // chunking" and therefore leaves the chunk callback unreachable rather than merely unused.
+    final long chunkSizeMB = chunkedCommitAllowed ? getTxChunkSize() : 0L;
 
     // Track if we started the transaction (for graph building)
     final boolean startedTransaction = db.getTransaction().getStatus() != TransactionContext.STATUS.BEGUN;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -5937,12 +5937,17 @@ public class LSMVectorIndex implements Index, IndexInternal {
     this.metadata = (LSMVectorIndexMetadata) metadata;
   }
 
+  /**
+   * {@code buildIndexBatchSize} is IGNORED here, and deliberately: this build chunks by BYTES
+   * ({@code arcadedb.vectorIndex.txChunkSizeMB}), not by record count, so a record count means nothing to it. The
+   * permission to commit at all arrives as its own parameter (issue #6324, item 1) - reading it off the batch size
+   * would make a user's {@code REBUILD INDEX ... WITH batchSize = 0} silently turn the chunking off for the whole
+   * rebuild.
+   */
   @Override
-  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
-    // A build that shares the caller's transaction says so by passing BUILD_WITHOUT_CHUNKED_COMMIT, and this build's
-    // chunking is by BYTES rather than by records - so the batch size arrives here as a permission, not as a size
-    // (issue #6324, item 1).
-    return build(callback, null, buildIndexBatchSize != IndexInternal.BUILD_WITHOUT_CHUNKED_COMMIT);
+  public long build(final int buildIndexBatchSize, final boolean sharesCallerTransaction,
+      final BuildIndexCallback callback) {
+    return build(callback, null, !sharesCallerTransaction);
   }
 
   /**
@@ -6092,7 +6097,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // Scan the bucket and index all documents
     db.scanBucket(db.getSchema().getBucketById(metadata.associatedBucketId).getName(), record -> {
       // Add to index
-      final Document source = IndexInternal.buildSourceRecord(db, record);
+      // !chunkedCommitAllowed IS "this build shares a transaction it did not open": the two are exact inverses on
+      // every path into this method, and a build that owns its transaction has nothing for that transaction to
+      // correct.
+      final Document source = IndexInternal.buildSourceRecord(db, record, !chunkedCommitAllowed);
       db.getIndexer().addToIndex(LSMVectorIndex.this, record.getIdentity(), source);
       total.incrementAndGet();
 

--- a/engine/src/main/java/com/arcadedb/query/ParallelScanProducerPool.java
+++ b/engine/src/main/java/com/arcadedb/query/ParallelScanProducerPool.java
@@ -19,12 +19,7 @@
 package com.arcadedb.query;
 
 import com.arcadedb.GlobalConfiguration;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import com.arcadedb.utility.DedicatedThreadPool;
 
 /**
  * JVM-wide dedicated executor for the BLOCKING producer tasks of parallel bucket scans
@@ -78,7 +73,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public final class ParallelScanProducerPool {
+public final class ParallelScanProducerPool extends DedicatedThreadPool {
 
   private static final class Holder {
     static final ParallelScanProducerPool INSTANCE = new ParallelScanProducerPool();
@@ -95,60 +90,21 @@ public final class ParallelScanProducerPool {
     }
   }
 
-  /** Floor for the auto-sized thread count. */
-  private static final int DEFAULT_THREADS_FLOOR = 2;
-
-  private final ThreadPoolExecutor executor;
-
   private ParallelScanProducerPool() {
     // 0 = auto-size to available cores (with a floor of DEFAULT_THREADS_FLOOR). An explicit positive value
     // wins, so an operator can cap the pool on very high core-count machines where (cores) blocking
     // producers would be excessive. Negative values are coerced to auto for safety.
-    final int configuredThreads = GlobalConfiguration.PARALLEL_SCAN_PRODUCER_POOL_THREADS.getValueAsInteger();
-    final int threads = configuredThreads > 0
-        ? configuredThreads
-        : Math.max(DEFAULT_THREADS_FLOOR, Runtime.getRuntime().availableProcessors());
-    final AtomicInteger workerSeq = new AtomicInteger();
-
-    final ThreadPoolExecutor pool = new ThreadPoolExecutor(
-        threads, threads,
-        60L, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(), // unbounded ON PURPOSE: see class javadoc
-        r -> {
-          final Thread t = new ProducerThread(r, "ArcadeDB-ParallelScanProducer-" + workerSeq.incrementAndGet());
-          t.setDaemon(true);
-          return t;
-        });
-    pool.allowCoreThreadTimeOut(true);
-    this.executor = pool;
+    //
+    // The one pool here with an UNBOUNDED queue and NO caller-runs policy, which the base class treats as a pair
+    // because a queue that never rejects has nothing to hand back: the deviation, and the #4948 self-deadlock that
+    // forces it, are argued in the class javadoc above. Its PoolStats therefore report queueCapacityRemaining=-1 and
+    // a caller-runs count that stays at zero for ever; queueDepth is this pool's saturation signal.
+    super("ArcadeDB-ParallelScanProducer-", autoSizeThreads(
+            GlobalConfiguration.PARALLEL_SCAN_PRODUCER_POOL_THREADS.getValueAsInteger()),
+        UNBOUNDED_QUEUE, SaturationPolicy.NONE, ProducerThread::new, "Parallel-scan producer pool", null);
   }
 
   public static ParallelScanProducerPool getInstance() {
     return Holder.INSTANCE;
-  }
-
-  /** The dedicated executor for blocking parallel-scan producer tasks. */
-  public ExecutorService getExecutorService() {
-    return executor;
-  }
-
-  /**
-   * Live pool statistics for the metrics binder (Studio "Executor Pools" card).
-   * {@code queueCapacityRemaining} is reported as {@code -1} (not applicable): the task queue is
-   * unbounded by design, and a near-2^31 constant would read oddly next to the bounded pools.
-   * {@code queueDepth} is the saturation signal for this pool.
-   */
-  public PoolStats getPoolStats() {
-    return new PoolStats(
-        executor.getPoolSize(),
-        executor.getActiveCount(),
-        executor.getQueue().size(),
-        -1,
-        executor.getCompletedTaskCount(),
-        0L); // no caller-runs policy on this pool by design (see class javadoc)
-  }
-
-  public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
-                          long completedTasks, long callerRunFallbacks) {
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/QueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngine.java
@@ -68,9 +68,52 @@ public interface QueryEngine {
     QueryEngine getInstance(DatabaseInternal database);
   }
 
+  /**
+   * What a language can say about a statement WITHOUT paying for work its execution will not reuse - see
+   * {@link QueryEngine#classifyDDL(String)}.
+   */
+  enum DDLClassification {
+    /** The statement is DDL in this language. */
+    DDL,
+    /** The statement is definitely not DDL. */
+    NOT_DDL,
+    /**
+     * This engine does not classify statements ahead of running them, so the caller learns nothing and has to fall
+     * back to whatever it does when it cannot tell. The honest default: a wrong guess costs a statement its routing,
+     * and no answer is better than a plausible one.
+     */
+    UNKNOWN
+  }
+
   String getLanguage();
 
   AnalyzedQuery analyze(String query);
+
+  /**
+   * Whether {@code query} is DDL, asked on the thread that DISPATCHED it rather than on the one that will run it
+   * (issue #6324, item 5).
+   * <p>
+   * {@code database.async().command(...)} has to know before it schedules anything: the DDL that builds an index by
+   * SCANNING the data must first make the async executor quiesce, and one of that executor's own workers cannot -
+   * the quiescence enqueues a task on every worker including its own, and only that worker drains its queue. So a
+   * dispatched DDL statement runs on {@code AsyncCommandPool} instead, and everything else stays on the workers,
+   * where a worker's batch transaction and its pinned bucket are worth keeping.
+   * <p>
+   * <b>Why this is a hook and not a branch in the dispatcher.</b> It used to be SQL's private knowledge, so
+   * {@code CREATE INDEX} sent with {@code awaitResponse=false} worked in SQL and was refused in Cypher - an asymmetry
+   * a user meets without warning. It is a hook rather than a keyword match because the DECISION has to be a parse: a
+   * keyword can appear in a string literal, and routing an ordinary write off the workers costs it the bucket pinning
+   * that keeps concurrent writers apart.
+   * <p>
+   * <b>And why {@link DDLClassification#UNKNOWN} is a legitimate answer.</b> Only a language whose parse is already
+   * paid for - a statement cache the execution is about to read again - can answer this for free, and paying for a
+   * full parse (for Gremlin, a Groovy compile) on the submitting thread is exactly what a caller passing
+   * {@code awaitResponse=false} asked not to wait for. An engine that cannot answer cheaply says so, and its
+   * statements keep the behaviour they have always had, #6281's refusal included.
+   */
+  default DDLClassification classifyDDL(final String query) {
+    return DDLClassification.UNKNOWN;
+  }
 
   ResultSet query(String query, ContextConfiguration configuration, Map<String, Object> parameters);
 

--- a/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
@@ -25,15 +25,9 @@ import com.arcadedb.query.java.JavaQueryEngine;
 import com.arcadedb.query.polyglot.PolyglotQueryEngine;
 import com.arcadedb.query.sql.SQLQueryEngine;
 import com.arcadedb.query.sql.SQLScriptQueryEngine;
+import com.arcadedb.utility.DedicatedThreadPool;
 
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 /**
@@ -57,73 +51,27 @@ import java.util.logging.Level;
  * Both run during operational events (bulk import, HA snapshot install) rather than the per-query
  * hot path; migrating them off the common pool is queued as follow-up work.
  */
-public class QueryEngineManager {
+public class QueryEngineManager extends DedicatedThreadPool {
   private static final QueryEngineManager                         INSTANCE        = new QueryEngineManager();
   // #4961: register() is public and may be called after construction while getEngine()/
   // getAvailableLanguages() read the map without locks: registration publishes a new copy
   // (copy-on-write) instead of mutating in place. Registration is rare, reads are hot.
   private volatile     Map<String, QueryEngine.QueryEngineFactory> implementations = new LinkedHashMap<>();
-  private final        ThreadPoolExecutor                          executorService;
-  // Per-pool counter the {@link RejectedExecutionHandler} below increments every time the queue
-  // saturates and the task falls back to the caller. ThreadPoolExecutor itself doesn't expose
-  // a "rejected" count when CallerRunsPolicy is in use (CallerRuns silently runs the task on
-  // the submitter's thread), so we track it ourselves to surface saturation in dashboards.
-  private final        AtomicLong                                  callerRunCount   = new AtomicLong();
-  // Throttle for the WARNING log emitted on saturation: at most one entry per minute, regardless
-  // of how often the queue actually overflows. The metric counter ticks every event so the full
-  // rate is still visible through {@link #getExecutorStats()}; the log line is the
-  // operator-noticing nudge that something needs attention. Millisecond precision is plenty
-  // here - the throttle window is 60 000 ms.
-  // <p>
-  // Initialised to {@code 0L} (not {@code Long.MIN_VALUE}!) so the first {@code now - last}
-  // subtraction returns a sane "very large" positive value and the first saturation always logs.
-  // Using {@code Long.MIN_VALUE} would overflow the subtraction and silently suppress the
-  // first-ever log line.
-  private static final long                                        SATURATION_WARN_INTERVAL_MS = 60_000L;
-  private final        AtomicLong                                  lastSaturationWarnMs        = new AtomicLong(0L);
 
   private QueryEngineManager() {
     // Pool sizing: explicit knob first, then "as many threads as cores (min 2)". Configurable so
     // operators can cap or expand without rebuild; the previous hardcoded {@code max(2, cpuCount)}
     // is preserved as the default behaviour when the knob is left at its default of 0.
-    final int configured = GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS.getValueAsInteger();
-    final int maxThreads = configured > 0 ? configured : Math.max(2, Runtime.getRuntime().availableProcessors());
-    // Bound the queue so a runaway producer can't OOM the JVM. CallerRunsPolicy gives us
-    // graceful degradation: when the queue saturates, the submitter (which was going to block
-    // waiting for the result anyway) runs the task itself - the query loses parallelism but
-    // never fails. We wrap the standard CallerRunsPolicy to also tick {@link #callerRunCount}
-    // for observability.
-    final int queueSize = Math.max(1, GlobalConfiguration.QUERY_PARALLELISM_QUEUE_SIZE.getValueAsInteger());
-    final AtomicInteger workerSeq = new AtomicInteger();
-    final ThreadPoolExecutor pool = new ThreadPoolExecutor(maxThreads, maxThreads, 60L, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(queueSize), r -> {
-      final Thread t = new Thread(r, "ArcadeDB-QueryWorker-" + workerSeq.incrementAndGet());
-      t.setDaemon(true);
-      return t;
-    }, (task, executor) -> {
-      final long fallbacks = callerRunCount.incrementAndGet();
-      // Throttled WARNING. Compare-and-swap ensures only one thread per interval logs - the
-      // others increment the counter and skip the log. The message names the affected pool
-      // and the cumulative fallback count so the operator can grep their console and see at a
-      // glance whether saturation is one bad burst or sustained pressure.
-      final long now = System.currentTimeMillis();
-      final long last = lastSaturationWarnMs.get();
-      if (now - last > SATURATION_WARN_INTERVAL_MS && lastSaturationWarnMs.compareAndSet(last, now)) {
-        LogManager.instance().log(this, Level.WARNING,
-            """
-            Query parallelism pool saturated: queue full (capacity=%d, threads=%d), running task on caller thread (cumulative caller-runs fallbacks=%d). \
-            Consider raising arcadedb.queryParallelismPoolThreads or arcadedb.queryParallelismQueueSize if this persists.""",
-            executor.getQueue().remainingCapacity() + executor.getQueue().size(), executor.getMaximumPoolSize(), fallbacks);
-      }
-      if (!executor.isShutdown())
-        task.run();
-      else if (task instanceof RunnableFuture<?> future)
-        // #4961: a task rejected because the pool is shut down would otherwise be neither run nor
-        // completed, leaving any caller blocked in an untimed Future.get() hanging forever.
-        future.cancel(false);
-    });
-    pool.allowCoreThreadTimeOut(true);
-    executorService = pool;
+    //
+    // Bound the queue so a runaway producer can't OOM the JVM. Caller-runs gives graceful degradation: when the
+    // queue saturates, the submitter - which was going to block waiting for the result anyway - runs the task
+    // itself, so the query loses parallelism but never fails. The construction, the counted-and-throttled
+    // saturation warning and the PoolStats all come from DedicatedThreadPool (issue #6324, item 4).
+    super("ArcadeDB-QueryWorker-", autoSizeThreads(GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS.getValueAsInteger()),
+        Math.max(1, GlobalConfiguration.QUERY_PARALLELISM_QUEUE_SIZE.getValueAsInteger()),
+        SaturationPolicy.CALLER_RUNS, DedicatedThreadPool::plainWorker, "Query parallelism pool",
+        "the query loses its parallelism but never fails",
+        GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS, GlobalConfiguration.QUERY_PARALLELISM_QUEUE_SIZE);
 
     // REGISTER ALL THE SUPPORTED LANGUAGE FROM POLYGLOT ENGINE.
     // Guarded by POLYGLOT_ENGINE_ENABLED: when disabled we skip the iteration completely, so
@@ -179,51 +127,13 @@ public class QueryEngineManager {
     return impl.getInstance(database);
   }
 
-  public ExecutorService getExecutorService() {
-    return executorService;
-  }
-
   /**
-   * Point-in-time snapshot of the query-parallelism pool's load. Used by metrics exporters and
-   * for ad-hoc operational debugging. All five values are read under no lock and are not
-   * mutually consistent (the pool may transition between reads), but each individual reading is
-   * safe.
+   * Point-in-time snapshot of the query-parallelism pool's load, for metrics exporters and ad-hoc operational
+   * debugging. The long-standing name for {@link #getPoolStats()} on this pool, kept because it is what the metrics
+   * binder and the pool's own tests call it.
    */
   public PoolStats getExecutorStats() {
-    return new PoolStats(
-        executorService.getPoolSize(),
-        executorService.getActiveCount(),
-        executorService.getQueue().size(),
-        executorService.getQueue().remainingCapacity(),
-        executorService.getCompletedTaskCount(),
-        callerRunCount.get());
-  }
-
-  /**
-   * Snapshot of the query-parallelism pool counters at one instant.
-   *
-   * @param poolSize         live thread count (workers currently allocated; can be lower than
-   *                         the configured max if no work has needed them yet thanks to
-   *                         {@code allowCoreThreadTimeOut}).
-   * @param activeThreads    threads currently running a task.
-   * @param queueDepth       tasks waiting in the queue.
-   * @param queueCapacityRemaining how many more tasks the queue can accept before triggering
-   *                         the rejection policy. Approaching zero means saturation is imminent
-   *                         and {@code callerRunFallbacks} is about to start ticking.
-   * @param completedTasks   monotonically increasing count of tasks finished by pool threads
-   *                         (excludes tasks that ran on the caller's thread via the rejection
-   *                         policy fallback).
-   * @param callerRunFallbacks number of tasks that the rejection policy redirected to the
-   *                         submitter thread because the queue was full. Sustained growth means
-   *                         the pool is undersized for the workload and queries are losing
-   *                         parallelism (still correct, just slower).
-   */
-  public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
-                          long completedTasks, long callerRunFallbacks) {
-  }
-
-  public void close() {
-    executorService.shutdownNow();
+    return getPoolStats();
   }
 
   public List<String> getAvailableLanguages() {

--- a/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
@@ -63,12 +63,16 @@ public class QueryEngineManager extends DedicatedThreadPool {
     // operators can cap or expand without rebuild; the previous hardcoded {@code max(2, cpuCount)}
     // is preserved as the default behaviour when the knob is left at its default of 0.
     //
-    // Bound the queue so a runaway producer can't OOM the JVM. Caller-runs gives graceful degradation: when the
+    // Bound the queue so a runaway producer can't OOM the JVM, and caller-runs gives graceful degradation: when the
     // queue saturates, the submitter - which was going to block waiting for the result anyway - runs the task
     // itself, so the query loses parallelism but never fails. The construction, the counted-and-throttled
     // saturation warning and the PoolStats all come from DedicatedThreadPool (issue #6324, item 4).
+    //
+    // Sized through the shared queueSizeOrDefault, so a configured 0 falls back to the documented 1024 the way it
+    // does on the other pools, rather than to the max(1, ...) this class used to apply - which collapsed the queue
+    // to a single slot on the very setting meant to size it.
     super("ArcadeDB-QueryWorker-", autoSizeThreads(GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS.getValueAsInteger()),
-        Math.max(1, GlobalConfiguration.QUERY_PARALLELISM_QUEUE_SIZE.getValueAsInteger()),
+        queueSizeOrDefault(GlobalConfiguration.QUERY_PARALLELISM_QUEUE_SIZE.getValueAsInteger()),
         SaturationPolicy.CALLER_RUNS, DedicatedThreadPool::plainWorker, "Query parallelism pool",
         "the query loses its parallelism but never fails",
         GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS, GlobalConfiguration.QUERY_PARALLELISM_QUEUE_SIZE);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -146,6 +146,22 @@ public class OpenCypherQueryEngine implements QueryEngine {
     }
   }
 
+  /**
+   * Free, and that is why Cypher can answer it (issue #6324, item 5): the parse is a {@code CypherStatementCache}
+   * lookup that the execution about to follow repeats with the same key - the same argument that lets SQL answer.
+   * <p>
+   * Before this, {@code CREATE INDEX} dispatched with {@code awaitResponse=false} worked in SQL and was refused in
+   * Cypher, because the routing was SQL's private knowledge. The four Cypher DDL statements -
+   * {@code CREATE}/{@code DROP INDEX} and {@code CREATE}/{@code DROP CONSTRAINT} - are exactly the ones that reach
+   * the index builder, and so exactly the ones that have to run off the async workers.
+   */
+  @Override
+  public DDLClassification classifyDDL(final String query) {
+    return database.getCypherStatementCache().get(query) instanceof CypherDDLStatement ?
+        DDLClassification.DDL :
+        DDLClassification.NOT_DDL;
+  }
+
   @Override
   public ResultSet query(final String query, final ContextConfiguration configuration, final Map<String, Object> parameters) {
     try {

--- a/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLQueryEngine.java
@@ -39,6 +39,7 @@ import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.query.sql.method.DefaultSQLMethodFactory;
 import com.arcadedb.query.sql.parser.Limit;
+import com.arcadedb.query.sql.parser.DDLStatement;
 import com.arcadedb.query.sql.parser.Statement;
 import com.arcadedb.utility.Callable;
 import com.arcadedb.utility.MultiIterator;
@@ -320,6 +321,15 @@ public class SQLQueryEngine implements QueryEngine {
 
   public Statement parse(final String query, final DatabaseInternal database) {
     return database.getStatementCache().get(query);
+  }
+
+  /**
+   * Free, and that is why SQL can answer it (issue #6324, item 5): the parse is a {@code StatementCache} lookup that
+   * the execution about to follow will repeat with the same key.
+   */
+  @Override
+  public DDLClassification classifyDDL(final String query) {
+    return parse(query, database) instanceof DDLStatement ? DDLClassification.DDL : DDLClassification.NOT_DDL;
   }
 
   public static String validateVariableName(String varName) {

--- a/engine/src/main/java/com/arcadedb/query/sql/SQLScriptQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLScriptQueryEngine.java
@@ -126,6 +126,25 @@ public class SQLScriptQueryEngine extends SQLQueryEngine {
     };
   }
 
+  /**
+   * A script routes as a WHOLE, on whether ANY statement in it is DDL: the statements share one transaction and one
+   * thread, so a script cannot be half on a worker and half off it, and the DDL half is what dictates where both can
+   * run (issue #6324, item 5).
+   * <p>
+   * Unlike plain {@code sql} this parse is NOT free - there is no script statement cache, so
+   * {@link #parseScript(String, DatabaseInternal)} parses here and the execution parses again - which is why the
+   * caller asks only once a cheap textual filter has established that a DDL verb appears in the text at all
+   * ({@code DatabaseAsyncExecutorImpl.mayContainDDL}). A script that mentions none cannot contain a DDL statement and
+   * is answered without parsing anything.
+   */
+  @Override
+  public DDLClassification classifyDDL(final String query) {
+    for (final Statement statement : parseScript(query, database))
+      if (statement instanceof DDLStatement)
+        return DDLClassification.DDL;
+    return DDLClassification.NOT_DDL;
+  }
+
   public static List<Statement> parseScript(final String script, final DatabaseInternal database) {
     try {
       return new SQLAntlrParser(database).parseScript(script);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -105,16 +105,17 @@ public class RebuildIndexStatement extends DDLStatement {
     final Database database = context.getDatabase();
 
     // THE REFUSAL OF #2097 IS GONE FROM HERE, and one mechanism is left where there were two (issue #6303, note b).
-    // It tested the DatabaseContext.asyncMode thread-local; the barrier below tests thread IDENTITY
+    // It tested the DatabaseContext.perThreadBucketSelection thread-local; the barrier below tests thread IDENTITY
     // (isCurrentThreadOneOfMyWorkers). Two spellings of one question that agreed while the only thread with the flag
-    // set was a worker - and they were never asking the same question. asyncMode means "pick a bucket per thread so
-    // concurrent asynchronous writers do not compete for the same pages"; identity means "is this the thread that
+    // set was a worker - and they were never asking the same question. perThreadBucketSelection means "pick a
+    // bucket per thread so concurrent asynchronous writers do not compete for the same pages"; identity means
+    // "is this the thread that
     // would have to dequeue my own marker". Only the second one has anything to do with whether the barrier can be
     // satisfied.
     //
     // Since #6303 they disagree, which is what makes the difference concrete: a command dispatched with
-    // awaitResponse=false runs on AsyncCommandPool, which sets asyncMode (it writes concurrently, so it wants the
-    // per-thread bucket) and is NOT a worker (so the barrier CAN be satisfied). Keeping the flag check here would go
+    // awaitResponse=false runs on AsyncCommandPool, which sets perThreadBucketSelection (it writes concurrently, so
+    // it wants the per-thread bucket) and is NOT a worker (so the barrier CAN be satisfied). Keeping the check would
     // on refusing exactly the operation this issue set out to give back.
     //
     // A rebuild that reaches a worker some other way is still refused - by the barrier below, in the same terms and

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -71,6 +71,30 @@ public class RebuildIndexStatement extends DDLStatement {
   public RebuildIndexStatement() {
   }
 
+  /**
+   * Reads a setting that has to be a whole number of at least one, reporting BOTH ways it can fail as a parsing error
+   * that names the setting.
+   * <p>
+   * A bare {@code Integer.parseInt} let a {@code NumberFormatException} out carrying the raw rendering of the
+   * expression - {@code WITH batchSize = -1} renders as {@code "0 - 1"} - which names neither the setting nor the
+   * problem. And a value below one is refused rather than coerced: it is not a smaller batch, it is a request that
+   * cannot be honoured, and each index family would read it differently - the scan-based builds as "never chunk", a
+   * vector rebuild not at all, since it chunks by bytes rather than by record count (issue #6324, item 1).
+   */
+  private static int parsePositiveSetting(final String name, final String value) {
+    final int parsed;
+    try {
+      parsed = Integer.parseInt(value.trim());
+    } catch (final NumberFormatException e) {
+      throw new CommandSQLParsingException(
+          "Invalid " + name + " '" + value + "' in rebuild index statement: it must be a whole number of at least 1");
+    }
+    if (parsed < 1)
+      throw new CommandSQLParsingException(
+          "Invalid " + name + " " + parsed + " in rebuild index statement: it must be at least 1");
+    return parsed;
+  }
+
   @Override
   public ResultSet executeDDL(final CommandContext context) {
     // Index (re)build is a schema-maintenance operation, gated by UPDATE_SCHEMA like DROP INDEX. The full-rebuild path
@@ -92,9 +116,9 @@ public class RebuildIndexStatement extends DDLStatement {
         // parsed (it was for the integer in `WITH batchSize = 1000`), so toString() is the reliable accessor for all literals.
         final String settingValue = entry.getValue().toString();
         if ("batchSize".equalsIgnoreCase(entry.getKey().toString()))
-          batchSize = Integer.parseInt(settingValue);
+          batchSize = parsePositiveSetting("batchSize", settingValue);
         else if ("maxAttempts".equalsIgnoreCase(entry.getKey().toString()))
-          maxAttempts = Integer.parseInt(settingValue);
+          maxAttempts = parsePositiveSetting("maxAttempts", settingValue);
         else if ("statsOnly".equalsIgnoreCase(entry.getKey().toString()))
           statsOnly = Boolean.parseBoolean(settingValue);
         else

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TruncateTypeStatement.java
@@ -173,36 +173,44 @@ public class TruncateTypeStatement extends DDLStatement {
    * {@code dropIndex} is a committed schema change and nothing later can undo it. A subsequent retry/run re-drops
    * and re-empties them.
    * <p>
-   * The rebuild survives the rollback that a failure triggers, and has to: {@code TypeIndexBuilder.create()} goes
-   * through {@code LocalSchema.recordFileChanges}, which persists the schema itself and wraps each per-bucket build
-   * in its own {@code joinCurrent=false} transaction - neither of which the surrounding transaction can take back.
-   * The {@code begin()} below is only there because the build path expects a transaction context to nest from.
+   * The rebuild survives the rollback that a failure triggers, and has to: the {@code dropIndex} above is a committed
+   * schema change that nothing later can undo, so a rebuild discarded with the failing transaction would leave the
+   * type carrying an EMPTY index over records that are all still there.
    *
    * @return the failure to carry on with: the one passed in, or the first rebuild failure when there was none.
    */
   private RuntimeException rebuildIndexes(final Database db, final Schema schema, final List<IndexDefinition> indexDefs,
       RuntimeException deletionFailure) {
     if (indexDefs.isEmpty())
+      // Nothing to rebuild, so the deletion transaction is left exactly as it was for the caller to decide.
       return deletionFailure;
 
-    // Index builds observe disk state rather than the in-flight deletes pending in the current transaction, so
-    // commit + begin makes the empty buckets visible to the upcoming build; otherwise the recreated index would be
-    // populated with the records just logically deleted but not yet flushed.
-    if (deletionFailure == null && db.isTransactionActive()) {
+    // CLOSE OUT THE DELETION TRANSACTION FIRST, in whichever direction the outcome calls for: commit when the deletes
+    // are good, so the build sees the empty buckets instead of repopulating the index with records that are logically
+    // deleted but not yet flushed; roll back when they are not, so it sees the state that is going to survive.
+    //
+    // Either way the rebuild must not run INSIDE a transaction whose fate somebody else is about to decide, because a
+    // build's entries now commit with the transaction it runs in (issue #6324, item 1): a rebuild left in the failing
+    // one would be built and then thrown away with it, leaving the type with the empty index the committed drop had
+    // already reduced it to. Deciding it here is also what leaves TruncateRecordDeleter with no transaction of its
+    // own to close, which is the point.
+    if (db.isTransactionActive()) {
       try {
-        db.commit();
-        db.begin();
+        if (deletionFailure == null)
+          db.commit();
+        else
+          db.rollback();
       } catch (final RuntimeException e) {
-        deletionFailure = e;
+        if (deletionFailure == null)
+          deletionFailure = e;
+        else
+          deletionFailure.addSuppressed(e);
       }
     }
 
-    if (!db.isTransactionActive())
-      db.begin();
-
     // Every definition is attempted, and one that cannot be recreated does not take the others with it. Each
-    // create() commits on its own, so abandoning the loop at the first failure would leave the type missing indexes
-    // that had nothing wrong with them - the opposite of what rebuilding on failure at all is for.
+    // create() opens and commits its own transaction, so abandoning the loop at the first failure would leave the
+    // type missing indexes that had nothing wrong with them - the opposite of what rebuilding on failure at all is for.
     for (final IndexDefinition def : indexDefs) {
       try {
         recreateIndex(schema, def);

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -126,10 +126,9 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
         metadata.typeIndexName = indexName;
       }
 
-      // Read before the transactions below, while the answer can still be "there is none" (issue #6324, item 1):
-      // whether the build joins the caller's transaction, and - if it does - that it may not commit it.
-      final boolean joinCallerTransaction = indexType.buildCanShareCallerTransaction();
-      final int buildBatchSize = joinCallerTransaction ? IndexInternal.buildBatchSizeFor(database, batchSize) : batchSize;
+      // Read before the transactions below, while the answer can still be "there is none" (issue #6324, item 1): a
+      // build shares a transaction only when the caller already had one open and this index family can use it.
+      final boolean sharesCallerTransaction = indexType.buildCanShareCallerTransaction() && database.isTransactionActive();
 
       return schema.recordFileChanges(() -> {
         final AtomicReference<Index> result1 = new AtomicReference<>();
@@ -150,7 +149,7 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
           }
 
           final Index index = schema.createBucketIndex(type, keyTypes, bucket, typeName, indexType, unique, pageSize, nullStrategy,
-              callback, propertyNames, null, buildBatchSize, metadata, false);
+              callback, propertyNames, null, batchSize, metadata, false);
           result1.set(index);
 
           schema.saveConfiguration();
@@ -162,8 +161,8 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
           }
         });
 
-        database.transaction(() -> buildCreatedIndex(result1.get(), buildBatchSize), joinCallerTransaction, maxAttempts,
-            null, error -> {
+        database.transaction(() -> buildCreatedIndex(result1.get(), sharesCallerTransaction), sharesCallerTransaction,
+            maxAttempts, null, error -> {
           // The FULL removal, not just the component's own drop(): unlike a failure inside the creation transaction -
           // which rolls the whole thing back before anything is registered - the component here is already committed
           // and attached to its type, so leaving it behind would answer lookups with an empty index. This is the same

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -63,6 +63,32 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
     return typeName;
   }
 
+  /** Creates the sub-index on this builder's bucket, resolving the bucket from the type by name. */
+  private Index createIndexOnBucket(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
+      final boolean build) {
+    Bucket bucket = null;
+    for (final Bucket b : type.getBuckets(true)) {
+      if (bucketName.equals(b.getName())) {
+        bucket = b;
+        break;
+      }
+    }
+
+    return schema.createBucketIndex(type, keyTypes, bucket, typeName, indexType, unique, pageSize, nullStrategy,
+        callback, propertyNames, null, batchSize, metadata, build);
+  }
+
+  /**
+   * Takes away an index that could not be built. The FULL removal, not just the component's own {@code drop()}: on the
+   * two-transaction path the component is already committed and attached to its type, so leaving it behind would
+   * answer lookups with an empty index. This is the cleanup {@code LocalSchema.createBucketIndex} did while the build
+   * still ran inside it (issue #6324, item 1) - an index that could not be built must be GONE, and the caller told so.
+   */
+  private static void dropPartiallyBuiltIndex(final LocalSchema schema, final Index index) {
+    if (index != null && schema.existsIndex(index.getName()))
+      schema.dropIndex(index.getName());
+  }
+
   @Override
   public Index create() {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
@@ -126,52 +152,44 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
         metadata.typeIndexName = indexName;
       }
 
-      // Read before the transactions below, while the answer can still be "there is none" (issue #6324, item 1): a
-      // build shares a transaction only when the caller already had one open and this index family can use it.
-      final boolean sharesCallerTransaction = indexType.buildCanShareCallerTransaction() && database.isTransactionActive();
+      // Asked before the transactions below, while the answer is still about the transaction that was already there
+      // (issue #6324, item 1). See IndexBuilder#buildSharesCallerTransaction.
+      final boolean sharesCallerTransaction = buildSharesCallerTransaction();
 
       return schema.recordFileChanges(() -> {
         final AtomicReference<Index> result1 = new AtomicReference<>();
+
+        if (!sharesCallerTransaction) {
+          // ONE TRANSACTION, exactly as before issue #6324: with nothing of anybody else's to see, creating and
+          // building in one go is both simpler and one commit cheaper.
+          database.transaction(() -> {
+            result1.set(createIndexOnBucket(schema, type, keyTypes, true));
+            schema.saveConfiguration();
+          }, false, maxAttempts, null, error -> dropPartiallyBuiltIndex(schema, result1.get()));
+          return result1.get();
+        }
 
         // TWO TRANSACTIONS, for the reasons spelled out at the same split in TypeIndexBuilder#create: the component
         // is created and COMMITTED on its own, because the schema entry that names it is written regardless of what
         // the caller's transaction does; the build then joins the caller's transaction, because a scan reads the
         // transaction it runs in and that is the only way it sees records the caller has written and not committed.
         database.transaction(() -> {
-
-          Bucket bucket = null;
-          final List<Bucket> buckets = type.getBuckets(true);
-          for (final Bucket b : buckets) {
-            if (bucketName.equals(b.getName())) {
-              bucket = b;
-              break;
-            }
-          }
-
-          final Index index = schema.createBucketIndex(type, keyTypes, bucket, typeName, indexType, unique, pageSize, nullStrategy,
-              callback, propertyNames, null, batchSize, metadata, false);
-          result1.set(index);
-
+          result1.set(createIndexOnBucket(schema, type, keyTypes, false));
           schema.saveConfiguration();
+        }, false, maxAttempts, null, error -> dropPartiallyBuiltIndex(schema, result1.get()));
 
-        }, false, maxAttempts, null, error -> {
-          final Index indexToRemove = result1.get();
-          if (indexToRemove != null) {
-            ((IndexInternal) indexToRemove).drop();
-          }
-        });
-
-        database.transaction(() -> buildCreatedIndex(result1.get(), sharesCallerTransaction), sharesCallerTransaction,
-            maxAttempts, null, error -> {
-          // The FULL removal, not just the component's own drop(): unlike a failure inside the creation transaction -
-          // which rolls the whole thing back before anything is registered - the component here is already committed
-          // and attached to its type, so leaving it behind would answer lookups with an empty index. This is the same
-          // cleanup LocalSchema.createBucketIndex did when the build still ran inside it (issue #6324, item 1); an
-          // index that could not be built must be GONE, and the caller told so.
-          final Index indexToRemove = result1.get();
-          if (indexToRemove != null && schema.existsIndex(indexToRemove.getName()))
-            schema.dropIndex(indexToRemove.getName());
-        });
+        // Cleaned up from a try/catch of its own rather than from the transaction's error callback, because that
+        // callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException raised inside a
+        // JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661 - retrying would roll
+        // back a transaction it does not own), skipping the callback entirely. And a duplicate is exactly what this
+        // build can now hit, since it sees the caller's own pending writes. buildCreatedIndex has already flipped the
+        // index to AVAILABLE by then, so leaving it behind would register a half-built index that answers queries.
+        try {
+          database.transaction(() -> buildCreatedIndex(result1.get(), true), true, maxAttempts, null, null);
+        } catch (final RuntimeException e) {
+          dropPartiallyBuiltIndex(schema, result1.get());
+          throw e;
+        }
 
         return result1.get();
       });

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -126,8 +126,18 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
         metadata.typeIndexName = indexName;
       }
 
+      // Read before the transactions below, while the answer can still be "there is none" (issue #6324, item 1):
+      // whether the build joins the caller's transaction, and - if it does - that it may not commit it.
+      final boolean joinCallerTransaction = indexType.buildCanShareCallerTransaction();
+      final int buildBatchSize = joinCallerTransaction ? IndexInternal.buildBatchSizeFor(database, batchSize) : batchSize;
+
       return schema.recordFileChanges(() -> {
         final AtomicReference<Index> result1 = new AtomicReference<>();
+
+        // TWO TRANSACTIONS, for the reasons spelled out at the same split in TypeIndexBuilder#create: the component
+        // is created and COMMITTED on its own, because the schema entry that names it is written regardless of what
+        // the caller's transaction does; the build then joins the caller's transaction, because a scan reads the
+        // transaction it runs in and that is the only way it sees records the caller has written and not committed.
         database.transaction(() -> {
 
           Bucket bucket = null;
@@ -140,7 +150,7 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
           }
 
           final Index index = schema.createBucketIndex(type, keyTypes, bucket, typeName, indexType, unique, pageSize, nullStrategy,
-              callback, propertyNames, null, batchSize, metadata);
+              callback, propertyNames, null, buildBatchSize, metadata, false);
           result1.set(index);
 
           schema.saveConfiguration();
@@ -151,6 +161,19 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
             ((IndexInternal) indexToRemove).drop();
           }
         });
+
+        database.transaction(() -> buildCreatedIndex(result1.get(), buildBatchSize), joinCallerTransaction, maxAttempts,
+            null, error -> {
+          // The FULL removal, not just the component's own drop(): unlike a failure inside the creation transaction -
+          // which rolls the whole thing back before anything is registered - the component here is already committed
+          // and attached to its type, so leaving it behind would answer lookups with an empty index. This is the same
+          // cleanup LocalSchema.createBucketIndex did when the build still ran inside it (issue #6324, item 1); an
+          // index that could not be built must be GONE, and the caller told so.
+          final Index indexToRemove = result1.get();
+          if (indexToRemove != null && schema.existsIndex(indexToRemove.getName()))
+            schema.dropIndex(indexToRemove.getName());
+        });
+
         return result1.get();
       });
     }

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -378,11 +378,11 @@ public abstract class IndexBuilder<T extends Index> {
    * puts it back there itself. The window in between is invisible: both halves run under the schema's write lock,
    * inside {@code recordFileChanges}.
    */
-  protected void buildCreatedIndex(final Index index, final int buildBatchSize) {
+  protected void buildCreatedIndex(final Index index, final boolean sharesCallerTransaction) {
     final IndexInternal internal = (IndexInternal) index;
     if (!internal.setStatus(new IndexInternal.INDEX_STATUS[] { IndexInternal.INDEX_STATUS.UNAVAILABLE },
         IndexInternal.INDEX_STATUS.AVAILABLE))
       throw new IndexException("Cannot build the index '" + index.getName() + "' because it is not available");
-    internal.build(buildBatchSize, callback);
+    internal.build(batchSize, sharesCallerTransaction, callback);
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -19,6 +19,7 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
@@ -366,6 +367,29 @@ public abstract class IndexBuilder<T extends Index> {
 
   public JSONObject getUserMetadata() {
     return userMetadata;
+  }
+
+  /**
+   * Whether the build about to run should share the transaction already open on this thread - the decision issue
+   * #6324 item 1 is about, written once here so a third {@link IndexBuilder} subclass cannot get it subtly different.
+   * <p>
+   * Two conditions, and the second is the one that is easy to get wrong. The index family has to be able to use a
+   * shared transaction at all ({@link Schema.INDEX_TYPE#buildCanShareCallerTransaction}); and the open transaction has
+   * to actually HOLD uncommitted work, because that is the entire reason for sharing it. An EMPTY transaction has
+   * nothing for the scan to see, so joining it buys nothing and costs the build its chunked commit - and empty is
+   * exactly what a transaction opened as scaffolding looks like. {@code DatabaseAsyncExecutorImpl.runCommand} opens
+   * one around every dispatched command because {@code requiresActiveTx()} defaults to true, so without this test a
+   * {@code CREATE INDEX} sent with {@code awaitResponse=false} - the case issue #6303 item 3 and #6324 item 5 exist
+   * to make work - would build the whole index in one uncommitted transaction, whatever batch size it was given.
+   * <p>
+   * Asked BEFORE the build opens anything, because afterwards there is always a transaction and the answer is always
+   * yes.
+   */
+  protected boolean buildSharesCallerTransaction() {
+    if (indexType == null || !indexType.buildCanShareCallerTransaction() || !database.isTransactionActive())
+      return false;
+    final TransactionContext tx = database.getTransactionIfExists();
+    return tx != null && tx.hasChanges();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -20,6 +20,7 @@ package com.arcadedb.schema;
 
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.serializer.json.JSONObject;
@@ -365,5 +366,23 @@ public abstract class IndexBuilder<T extends Index> {
 
   public JSONObject getUserMetadata() {
     return userMetadata;
+  }
+
+  /**
+   * Populates an index that was created EMPTY - the second half of the two-transaction split of issue #6324, item 1.
+   * The comment at the build loop in {@link TypeIndexBuilder#create()} says why the two halves cannot share one
+   * transaction.
+   * <p>
+   * The status step is what the split costs. Creating an index without building it parks it at {@code UNAVAILABLE},
+   * so nothing can read a half-populated index, while {@code build()} insists on starting from {@code AVAILABLE} and
+   * puts it back there itself. The window in between is invisible: both halves run under the schema's write lock,
+   * inside {@code recordFileChanges}.
+   */
+  protected void buildCreatedIndex(final Index index, final int buildBatchSize) {
+    final IndexInternal internal = (IndexInternal) index;
+    if (!internal.setStatus(new IndexInternal.INDEX_STATUS[] { IndexInternal.INDEX_STATUS.UNAVAILABLE },
+        IndexInternal.INDEX_STATUS.AVAILABLE))
+      throw new IndexException("Cannot build the index '" + index.getName() + "' because it is not available");
+    internal.build(buildBatchSize, callback);
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -2703,9 +2703,13 @@ public class LocalSchema implements Schema {
 
       indexMap.put(indexName, index);
 
+      // An index created but not populated here is parked UNAVAILABLE, so nothing can read it while it is empty. Two
+      // callers arrive with build=false: the sorted build, which populates every bucket index in one streamed pass
+      // and publishes them together, and the two-transaction split of issue #6324 item 1, which commits the component
+      // on its own before building it inside whatever transaction the caller holds.
       if (!build && !index.setStatus(new IndexInternal.INDEX_STATUS[] { IndexInternal.INDEX_STATUS.AVAILABLE },
           IndexInternal.INDEX_STATUS.UNAVAILABLE))
-        throw new IndexException("Cannot prepare empty index '" + indexName + "' for sorted population");
+        throw new IndexException("Cannot prepare empty index '" + indexName + "' for population");
 
       type.addIndexInternal(index, bucket.getFileId(), propertyNames, propIndex);
 

--- a/engine/src/main/java/com/arcadedb/schema/Schema.java
+++ b/engine/src/main/java/com/arcadedb/schema/Schema.java
@@ -488,6 +488,21 @@ public interface Schema {
   void setExtension(String name, JSONObject value);
 
   enum INDEX_TYPE {
-    LSM_TREE, FULL_TEXT, LSM_VECTOR, LSM_SPARSE_VECTOR, GEOSPATIAL, HASH
+    LSM_TREE, FULL_TEXT, LSM_VECTOR, LSM_SPARSE_VECTOR, GEOSPATIAL, HASH;
+
+    /**
+     * Whether a build of this index type may run INSIDE a transaction opened by whoever is writing, which is what
+     * lets it index the records that transaction has written and not yet committed (issue #6324, item 1).
+     * <p>
+     * True for every index whose build stages its entries on the transaction and whose reads go back through it -
+     * {@code LSM_TREE} and everything layered on it. False for the vector families: their build writes a graph, and
+     * for sparse its segments, as files of their own, and their SEARCH path reads those files through the page cache
+     * rather than through the transaction, so entries left uncommitted are written but not findable. Building them in
+     * a transaction of their own keeps that path whole, at the cost this issue is about - a vector index created in
+     * the same transaction as its inserts still needs those writes committed first - which is the lesser of the two.
+     */
+    public boolean buildCanShareCallerTransaction() {
+      return this != LSM_VECTOR && this != LSM_SPARSE_VECTOR;
+    }
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -409,10 +409,9 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     if (replaced != null)
       existingTypeIndex.drop();
 
-    // Read here because below this line there is ALWAYS a transaction, and the answer is about there not being one
-    // yet: a build shares a transaction only when the caller already had one open and this index family can use it
-    // (issue #6324, item 1).
-    final boolean sharesCallerTransaction = indexType.buildCanShareCallerTransaction() && database.isTransactionActive();
+    // Asked here because below this line there is ALWAYS a transaction, and the answer is about the one that was
+    // already there (issue #6324, item 1). See IndexBuilder#buildSharesCallerTransaction.
+    final boolean sharesCallerTransaction = buildSharesCallerTransaction();
 
     final TypeIndex created;
     // The barrier of #6281, paid at the top of this method, covers what the async side wrote BEFORE the build. This
@@ -436,11 +435,24 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
           for (int idx = 0; idx < buckets.size(); ++idx) {
             final int finalIdx = idx;
 
+            if (!sharesCallerTransaction) {
+              // ONE TRANSACTION, exactly as before issue #6324: with nothing of anybody else's to see, creating and
+              // building in one go is both simpler and one commit per bucket cheaper.
+              database.transaction(() -> {
+
+                final LocalBucket bucket = (LocalBucket) buckets.get(finalIdx);
+
+                indexes[finalIdx] = createBucketIndex(schema, type, keyTypes, bucket, true);
+
+              }, false, maxAttempts, null, null);
+              continue;
+            }
+
             // TWO TRANSACTIONS, and the split is the whole of issue #6324, item 1.
             //
-            // The COMPONENT is created in a transaction of its OWN, always. recordFileChanges writes the schema entry
-            // that names this index as soon as this callback returns, whatever the caller's transaction goes on to
-            // do, so the index FILE has to be committed on the same terms: leaving its first page inside a caller's
+            // The COMPONENT is created in a transaction of its OWN. recordFileChanges writes the schema entry that
+            // names this index as soon as this callback returns, whatever the caller's transaction goes on to do, so
+            // the index FILE has to be committed on the same terms: leaving its first page inside a caller's
             // transaction that later rolls back would leave the schema pointing at a file with no pages, which fails
             // on the next write with "the file is invalid". Committing it also keeps the index usable from a NESTED
             // transaction, which cannot see an outer transaction's uncommitted pages.
@@ -452,14 +464,13 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
             }, false, maxAttempts, null, null);
 
-            // The BUILD joins the caller's transaction when there is one, because a scan reads the transaction it
-            // runs in: the pages that transaction has modified first, the committed ones underneath. That is what
-            // lets it see records the caller has written and not yet committed - `INSERT INTO V SET id = 7;
-            // CREATE INDEX ON V (id)` in one transaction used to end with the record present and NO entry for it,
-            // in neither the scan nor the index - and it makes the entries commit, or roll back, with the records
-            // they describe. The vector families opt out; INDEX_TYPE#buildCanShareCallerTransaction says why.
-            database.transaction(() -> buildCreatedIndex(indexes[finalIdx], sharesCallerTransaction),
-                sharesCallerTransaction, maxAttempts, null, null);
+            // The BUILD then joins the caller's transaction, because a scan reads the transaction it runs in: the
+            // pages that transaction has modified first, the committed ones underneath. That is what lets it see
+            // records the caller has written and not yet committed - `INSERT INTO V SET id = 7;
+            // CREATE INDEX ON V (id)` in one transaction used to end with the record present and NO entry for it, in
+            // neither the scan nor the index - and it makes the entries commit, or roll back, with the records they
+            // describe.
+            database.transaction(() -> buildCreatedIndex(indexes[finalIdx], true), true, maxAttempts, null, null);
           }
 
         return null;

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -409,6 +409,11 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     if (replaced != null)
       existingTypeIndex.drop();
 
+    // Read here because below this line there is always a transaction, and both answers depend on there not being one
+    // yet (issue #6324, item 1): whether the build joins the caller's, and - if it does - that it may not commit it.
+    final boolean joinCallerTransaction = indexType.buildCanShareCallerTransaction();
+    final int buildBatchSize = joinCallerTransaction ? IndexInternal.buildBatchSizeFor(database, batchSize) : batchSize;
+
     final TypeIndex created;
     // The barrier of #6281, paid at the top of this method, covers what the async side wrote BEFORE the build. This
     // covers what it would write DURING it (issue #6303, item 2), and only the first half was ever here:
@@ -430,13 +435,31 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
         } else
           for (int idx = 0; idx < buckets.size(); ++idx) {
             final int finalIdx = idx;
+
+            // TWO TRANSACTIONS, and the split is the whole of issue #6324, item 1.
+            //
+            // The COMPONENT is created in a transaction of its OWN, always. recordFileChanges writes the schema entry
+            // that names this index as soon as this callback returns, whatever the caller's transaction goes on to
+            // do, so the index FILE has to be committed on the same terms: leaving its first page inside a caller's
+            // transaction that later rolls back would leave the schema pointing at a file with no pages, which fails
+            // on the next write with "the file is invalid". Committing it also keeps the index usable from a NESTED
+            // transaction, which cannot see an outer transaction's uncommitted pages.
             database.transaction(() -> {
 
               final LocalBucket bucket = (LocalBucket) buckets.get(finalIdx);
 
-              indexes[finalIdx] = createBucketIndex(schema, type, keyTypes, bucket);
+              indexes[finalIdx] = createBucketIndex(schema, type, keyTypes, bucket, false, buildBatchSize);
 
             }, false, maxAttempts, null, null);
+
+            // The BUILD joins the caller's transaction when there is one, because a scan reads the transaction it
+            // runs in: the pages that transaction has modified first, the committed ones underneath. That is what
+            // lets it see records the caller has written and not yet committed - `INSERT INTO V SET id = 7;
+            // CREATE INDEX ON V (id)` in one transaction used to end with the record present and NO entry for it,
+            // in neither the scan nor the index - and it makes the entries commit, or roll back, with the records
+            // they describe. The vector families opt out; INDEX_TYPE#buildCanShareCallerTransaction says why.
+            database.transaction(() -> buildCreatedIndex(indexes[finalIdx], buildBatchSize), joinCallerTransaction,
+                maxAttempts, null, null);
           }
 
         return null;
@@ -561,14 +584,14 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   }
 
   protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
-      final LocalBucket bucket) {
-    return createBucketIndex(schema, type, keyTypes, bucket, true);
+      final LocalBucket bucket, final boolean build) {
+    return createBucketIndex(schema, type, keyTypes, bucket, build, batchSize);
   }
 
   protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
-      final LocalBucket bucket, final boolean build) {
+      final LocalBucket bucket, final boolean build, final int buildBatchSize) {
     return schema.createBucketIndex(type, keyTypes, bucket, metadata.typeName, indexType, unique, pageSize, nullStrategy, callback,
-        metadata.propertyNames.toArray(new String[0]), null, batchSize,
+        metadata.propertyNames.toArray(new String[0]), null, buildBatchSize,
         metadata, build);
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -409,10 +409,10 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
     if (replaced != null)
       existingTypeIndex.drop();
 
-    // Read here because below this line there is always a transaction, and both answers depend on there not being one
-    // yet (issue #6324, item 1): whether the build joins the caller's, and - if it does - that it may not commit it.
-    final boolean joinCallerTransaction = indexType.buildCanShareCallerTransaction();
-    final int buildBatchSize = joinCallerTransaction ? IndexInternal.buildBatchSizeFor(database, batchSize) : batchSize;
+    // Read here because below this line there is ALWAYS a transaction, and the answer is about there not being one
+    // yet: a build shares a transaction only when the caller already had one open and this index family can use it
+    // (issue #6324, item 1).
+    final boolean sharesCallerTransaction = indexType.buildCanShareCallerTransaction() && database.isTransactionActive();
 
     final TypeIndex created;
     // The barrier of #6281, paid at the top of this method, covers what the async side wrote BEFORE the build. This
@@ -448,7 +448,7 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
               final LocalBucket bucket = (LocalBucket) buckets.get(finalIdx);
 
-              indexes[finalIdx] = createBucketIndex(schema, type, keyTypes, bucket, false, buildBatchSize);
+              indexes[finalIdx] = createBucketIndex(schema, type, keyTypes, bucket, false);
 
             }, false, maxAttempts, null, null);
 
@@ -458,8 +458,8 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
             // CREATE INDEX ON V (id)` in one transaction used to end with the record present and NO entry for it,
             // in neither the scan nor the index - and it makes the entries commit, or roll back, with the records
             // they describe. The vector families opt out; INDEX_TYPE#buildCanShareCallerTransaction says why.
-            database.transaction(() -> buildCreatedIndex(indexes[finalIdx], buildBatchSize), joinCallerTransaction,
-                maxAttempts, null, null);
+            database.transaction(() -> buildCreatedIndex(indexes[finalIdx], sharesCallerTransaction),
+                sharesCallerTransaction, maxAttempts, null, null);
           }
 
         return null;
@@ -585,13 +585,8 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
   protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
       final LocalBucket bucket, final boolean build) {
-    return createBucketIndex(schema, type, keyTypes, bucket, build, batchSize);
-  }
-
-  protected Index createBucketIndex(final LocalSchema schema, final LocalDocumentType type, final Type[] keyTypes,
-      final LocalBucket bucket, final boolean build, final int buildBatchSize) {
     return schema.createBucketIndex(type, keyTypes, bucket, metadata.typeName, indexType, unique, pageSize, nullStrategy, callback,
-        metadata.propertyNames.toArray(new String[0]), null, buildBatchSize,
+        metadata.propertyNames.toArray(new String[0]), null, batchSize,
         metadata, build);
   }
 

--- a/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
+++ b/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
@@ -79,6 +79,30 @@ public abstract class DedicatedThreadPool {
    */
   protected static final long WARN_THROTTLE_INTERVAL_MS = 60_000L;
 
+  protected final ThreadPoolExecutor executor;
+
+  private final SaturationPolicy saturationPolicy;
+  /**
+   * The whole saturation WARNING as a format string, composed ONCE at construction rather than assembled per event.
+   * Two reasons, and the second is the one that matters: a saturating pool is the last place to be concatenating
+   * strings, and the pool's name has to be LITERAL text in the message rather than an argument, or an operator
+   * grepping their console for "Query parallelism pool saturated" - and a log-capturing test doing the same - finds
+   * a bare "%s saturated" instead. Takes exactly three arguments: queue capacity, thread count, cumulative fallbacks.
+   */
+  private final String     saturationWarnMessage;
+  private final boolean    boundedQueue;
+  private final AtomicLong callerRunCount       = new AtomicLong();
+  /**
+   * Initialised to {@code 0L} and not {@code Long.MIN_VALUE}: the throttle below subtracts it from
+   * {@code System.currentTimeMillis()}, and {@code MIN_VALUE} would overflow that subtraction and silently suppress
+   * the first-ever warning - the one that matters most.
+   */
+  private final AtomicLong lastSaturationWarnMs = new AtomicLong(0L);
+
+  // The nested types below are declared AFTER the fields, not at the top where the idiom usually puts them: PMD's
+  // FieldDeclarationsShouldBeAtStartOfClass counts a nested type as the end of the field section and reports every
+  // field that follows one. Same reason AsyncCommandPool keeps its Holder down here.
+
   /** What a pool does with a task its bounded queue refused. */
   public enum SaturationPolicy {
     /**
@@ -124,26 +148,6 @@ public abstract class DedicatedThreadPool {
   public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
                           long completedTasks, long callerRunFallbacks) {
   }
-
-  protected final ThreadPoolExecutor executor;
-
-  private final SaturationPolicy saturationPolicy;
-  /**
-   * The whole saturation WARNING as a format string, composed ONCE at construction rather than assembled per event.
-   * Two reasons, and the second is the one that matters: a saturating pool is the last place to be concatenating
-   * strings, and the pool's name has to be LITERAL text in the message rather than an argument, or an operator
-   * grepping their console for "Query parallelism pool saturated" - and a log-capturing test doing the same - finds
-   * a bare "%s saturated" instead. Takes exactly three arguments: queue capacity, thread count, cumulative fallbacks.
-   */
-  private final String     saturationWarnMessage;
-  private final boolean    boundedQueue;
-  private final AtomicLong callerRunCount       = new AtomicLong();
-  /**
-   * Initialised to {@code 0L} and not {@code Long.MIN_VALUE}: the throttle below subtracts it from
-   * {@code System.currentTimeMillis()}, and {@code MIN_VALUE} would overflow that subtraction and silently suppress
-   * the first-ever warning - the one that matters most.
-   */
-  private final AtomicLong lastSaturationWarnMs = new AtomicLong(0L);
 
   /**
    * @param threadNamePrefix      worker thread names are this plus a per-pool sequence number

--- a/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
+++ b/engine/src/main/java/com/arcadedb/utility/DedicatedThreadPool.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+/**
+ * The shape every JVM-wide dedicated engine executor has in common: the {@link ThreadPoolExecutor} itself, the
+ * {@link PoolStats} the metrics binder reads, and the caller-runs rejection policy with its throttled saturation
+ * WARNING (issue #6324, item 4).
+ * <p>
+ * <b>Why it exists.</b> {@code QueryEngineManager}, {@code SparseVectorScoringPool}, {@code ParallelScanProducerPool}
+ * and {@code AsyncCommandPool} each carried a near-identical copy of all three, down to a {@code PoolStats} record
+ * with the same six components in the same order. The cost had already shown up as drift rather than as a
+ * hypothetical: three copies of the saturation warning, three different sentences, one of which forgot to say which
+ * settings to raise. More usefully than the ~100 lines it removes, this is what lets the {@code engine-concurrency}
+ * skill's checklist for a new pool be ENFORCED instead of remembered - a pool that extends this has a bounded queue,
+ * caller-runs, a throttled warning and a {@code PoolStats} to bind, or it says in its own constructor which of those
+ * it is deliberately not doing.
+ * <p>
+ * <b>What it deliberately does not own.</b> The pools' reasons for existing, which is everything interesting about
+ * them: why blocking producers may not share a pool with non-blocking compute, why a dispatched DDL statement cannot
+ * run on an async worker, why a sparse-vector fan-out must not nest. Those stay in each subclass's javadoc, where a
+ * reader looking for that pool will find them.
+ * <p>
+ * <b>"No JDK common ForkJoinPool" rule.</b> See {@code com.arcadedb.query.QueryEngineManager}'s class javadoc. Every
+ * pool built here exists because of it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public abstract class DedicatedThreadPool {
+
+  /**
+   * The queue capacity that asks for an UNBOUNDED task queue, which also implies {@link SaturationPolicy#NONE}: a
+   * queue that never rejects has nothing to hand back to a caller. Only {@code ParallelScanProducerPool} uses it, and
+   * its class javadoc carries the argument for the deviation.
+   */
+  public static final int UNBOUNDED_QUEUE = 0;
+
+  /** Floor for the auto-sized thread count, i.e. what {@link #autoSizeThreads(int)} gives on a single-core box. */
+  public static final int DEFAULT_THREADS_FLOOR = 2;
+
+  /** Default bounded-queue capacity for a pool whose sizing setting is left at 0. */
+  public static final int DEFAULT_QUEUE_SIZE = 1024;
+
+  /**
+   * At most one WARNING per minute per pool per subject. The counter behind {@link PoolStats#callerRunFallbacks()}
+   * ticks on every saturation event, so the full rate stays visible through the metrics; the log line is only the
+   * nudge that makes an operator go and look.
+   * <p>
+   * Visible to subclasses because a pool with a periodic warning of its own throttles it the same way and to the same
+   * window, and two windows drifting apart is the kind of small inconsistency an operator reads as a clue.
+   */
+  protected static final long WARN_THROTTLE_INTERVAL_MS = 60_000L;
+
+  /** What a pool does with a task its bounded queue refused. */
+  public enum SaturationPolicy {
+    /**
+     * Run it on the thread that submitted it, unless the pool is shut down - a task rejected by a shut-down pool is
+     * neither run nor completed, so any caller blocked in an untimed {@code Future.get()} would hang for ever
+     * (issue #4961); cancelling its future ends the wait instead.
+     */
+    CALLER_RUNS,
+    /**
+     * Run it on the submitting thread ALWAYS, shut-down pool included. For a pool whose tasks hand back no future
+     * there is nothing to cancel and nothing to return, so a task that is neither run nor completed leaves the
+     * submitter's in-flight count raised for ever.
+     */
+    CALLER_RUNS_EVEN_WHEN_SHUT_DOWN,
+    /** No rejection handler at all. Legal only with {@link #UNBOUNDED_QUEUE}, which never rejects. */
+    NONE
+  }
+
+  /** Creates one of a pool's worker threads. The body is already wrapped with whatever the pool sets per worker. */
+  @FunctionalInterface
+  public interface WorkerFactory {
+    Thread newWorker(Runnable body, String name);
+  }
+
+  /**
+   * Point-in-time snapshot of a pool's load, read by the metrics binder ({@code pool=<name>} gauges, Studio's
+   * "Executor Pools" card) and by tests. The six values are read under no lock and are not mutually consistent - the
+   * pool may transition between two of them - but each individual reading is safe.
+   *
+   * @param poolSize               live thread count. Can be below the configured maximum when no work has needed the
+   *                               rest yet, since every pool here allows core threads to time out
+   * @param activeThreads          threads currently running a task
+   * @param queueDepth             tasks waiting in the queue. The saturation signal for an unbounded pool, which has
+   *                               no capacity to run out of
+   * @param queueCapacityRemaining how many more tasks the queue accepts before the rejection policy takes over, or
+   *                               {@code -1} for an unbounded queue - not a near-2^31 constant, which would read
+   *                               oddly next to the bounded pools
+   * @param completedTasks         cumulative tasks finished BY POOL THREADS, so a task that ran on its submitter
+   *                               under caller-runs is counted by the next field and not by this one
+   * @param callerRunFallbacks     cumulative tasks the rejection policy redirected to the submitting thread. Sustained
+   *                               growth means the pool is undersized for the workload
+   */
+  public record PoolStats(int poolSize, int activeThreads, int queueDepth, int queueCapacityRemaining,
+                          long completedTasks, long callerRunFallbacks) {
+  }
+
+  protected final ThreadPoolExecutor executor;
+
+  private final SaturationPolicy saturationPolicy;
+  /**
+   * The whole saturation WARNING as a format string, composed ONCE at construction rather than assembled per event.
+   * Two reasons, and the second is the one that matters: a saturating pool is the last place to be concatenating
+   * strings, and the pool's name has to be LITERAL text in the message rather than an argument, or an operator
+   * grepping their console for "Query parallelism pool saturated" - and a log-capturing test doing the same - finds
+   * a bare "%s saturated" instead. Takes exactly three arguments: queue capacity, thread count, cumulative fallbacks.
+   */
+  private final String     saturationWarnMessage;
+  private final boolean    boundedQueue;
+  private final AtomicLong callerRunCount       = new AtomicLong();
+  /**
+   * Initialised to {@code 0L} and not {@code Long.MIN_VALUE}: the throttle below subtracts it from
+   * {@code System.currentTimeMillis()}, and {@code MIN_VALUE} would overflow that subtraction and silently suppress
+   * the first-ever warning - the one that matters most.
+   */
+  private final AtomicLong lastSaturationWarnMs = new AtomicLong(0L);
+
+  /**
+   * @param threadNamePrefix      worker thread names are this plus a per-pool sequence number
+   * @param threads               core = max thread count, already resolved (see {@link #autoSizeThreads(int)})
+   * @param queueCapacity         bounded-queue capacity, or {@link #UNBOUNDED_QUEUE}
+   * @param saturationPolicy      what happens to a task the queue refuses
+   * @param workerFactory         creates each worker, so a pool can subclass {@link Thread} (to be recognizable by
+   *                              type) or set a thread-local on the worker itself rather than per task
+   * @param poolDescription       how the pool names itself in its saturation warning, e.g. "Query parallelism pool"
+   * @param saturationConsequence what the caller-runs fallback costs THIS pool's callers, appended to the warning, or
+   *                              null when running the task inline costs nothing worth naming
+   * @param sizingSettingKeys     the settings the warning tells the operator to raise
+   */
+  protected DedicatedThreadPool(final String threadNamePrefix, final int threads, final int queueCapacity,
+      final SaturationPolicy saturationPolicy, final WorkerFactory workerFactory, final String poolDescription,
+      final String saturationConsequence, final GlobalConfiguration... sizingSettingKeys) {
+    if (queueCapacity == UNBOUNDED_QUEUE && saturationPolicy != SaturationPolicy.NONE)
+      throw new IllegalArgumentException(
+          "An unbounded queue never rejects, so it cannot have the " + saturationPolicy + " saturation policy");
+    if (queueCapacity != UNBOUNDED_QUEUE && saturationPolicy == SaturationPolicy.NONE)
+      throw new IllegalArgumentException(
+          "A bounded queue must say what happens to the task it refuses: " + threadNamePrefix + " has no policy");
+
+    this.saturationPolicy = saturationPolicy;
+    this.boundedQueue = queueCapacity != UNBOUNDED_QUEUE;
+    this.saturationWarnMessage = poolDescription
+        + " saturated: queue full (capacity=%d, threads=%d), running the task on the submitting thread"
+        + (saturationConsequence != null ? " - " + saturationConsequence : "")
+        + " (cumulative caller-runs fallbacks=%d)." + raiseSettingsAdvice(sizingSettingKeys);
+
+    final AtomicInteger workerSeq = new AtomicInteger();
+    final ThreadPoolExecutor pool = new ThreadPoolExecutor(threads, threads, 60L, TimeUnit.SECONDS,
+        boundedQueue ? new LinkedBlockingQueue<>(queueCapacity) : new LinkedBlockingQueue<>(),
+        r -> {
+          final Thread t = workerFactory.newWorker(r, threadNamePrefix + workerSeq.incrementAndGet());
+          t.setDaemon(true);
+          return t;
+        });
+    if (saturationPolicy != SaturationPolicy.NONE)
+      // Set after construction rather than through the constructor so the handler can capture `this`: the executor
+      // has to exist before a lambda that reads this pool's counters can be built.
+      pool.setRejectedExecutionHandler((task, exec) -> runOnCaller(task, queueCapacity, exec.getMaximumPoolSize()));
+    pool.allowCoreThreadTimeOut(true);
+    this.executor = pool;
+  }
+
+  /**
+   * The auto-sizing every one of these pools shares: an explicit positive setting wins, anything else means "as many
+   * threads as cores, and never fewer than {@link #DEFAULT_THREADS_FLOOR}". A negative value is coerced rather than
+   * refused - {@code GlobalConfiguration} already rejects one at parse time, and the coercion keeps a test-side
+   * bypass safe.
+   */
+  public static int autoSizeThreads(final int configuredThreads) {
+    return configuredThreads > 0 ?
+        configuredThreads :
+        Math.max(DEFAULT_THREADS_FLOOR, Runtime.getRuntime().availableProcessors());
+  }
+
+  /** The bounded-queue counterpart of {@link #autoSizeThreads(int)}: an explicit positive value, or the default. */
+  public static int queueSizeOrDefault(final int configuredQueueSize) {
+    return configuredQueueSize > 0 ? configuredQueueSize : DEFAULT_QUEUE_SIZE;
+  }
+
+  /** The default worker: a plain daemon thread. */
+  public static Thread plainWorker(final Runnable body, final String name) {
+    return new Thread(body, name);
+  }
+
+  /**
+   * The caller-runs rejection policy: count the saturation, report it at most once a minute, and hand the task to
+   * whatever {@link #runRejectedTask(Runnable)} decides.
+   * <p>
+   * Takes its numbers as arguments rather than reading them off the executor because this is the path a real pool
+   * cannot be made to take on demand without queueing a thousand blocking tasks first, and the subclasses whose safety
+   * argument is ABOUT this path drive it directly from their tests.
+   *
+   * @param task          the task the queue refused
+   * @param queueCapacity the queue's capacity, for the message
+   * @param poolThreads   the pool's thread count, for the message
+   */
+  public final void runOnCaller(final Runnable task, final int queueCapacity, final int poolThreads) {
+    final long fallbacks = callerRunCount.incrementAndGet();
+    final long now = System.currentTimeMillis();
+    final long last = lastSaturationWarnMs.get();
+    if (now - last > WARN_THROTTLE_INTERVAL_MS && lastSaturationWarnMs.compareAndSet(last, now))
+      LogManager.instance().log(this, Level.WARNING, saturationWarnMessage, null, queueCapacity, poolThreads, fallbacks);
+
+    runRejectedTask(task);
+  }
+
+  /** " Raise 'a' or 'b' if this persists.", or nothing when the pool has no sizing settings to name. */
+  private static String raiseSettingsAdvice(final GlobalConfiguration[] sizingSettingKeys) {
+    if (sizingSettingKeys.length == 0)
+      return "";
+    final StringBuilder advice = new StringBuilder(" Raise ");
+    for (int i = 0; i < sizingSettingKeys.length; i++) {
+      if (i > 0)
+        advice.append(i == sizingSettingKeys.length - 1 ? " or " : ", ");
+      advice.append('\'').append(sizingSettingKeys[i].getKey()).append('\'');
+    }
+    return advice.append(" if this persists.").toString();
+  }
+
+  /**
+   * Reopens the saturation-warning throttle immediately, so a test can observe the WARNING without waiting out a
+   * window some earlier test in the same JVM already consumed. A test seam, and a deliberate one: the alternative
+   * that was in use - reflection on the private field - breaks silently on a rename, with no compile error to say so.
+   */
+  public void resetSaturationWarningThrottle() {
+    lastSaturationWarnMs.set(0L);
+  }
+
+  /**
+   * Runs a task the queue refused. Overridable for a pool that has to mark the borrowed thread for the duration -
+   * the submitter IS one of this pool's tasks while it runs one, and everything that asks has to get that answer
+   * there too.
+   */
+  protected void runRejectedTask(final Runnable task) {
+    if (saturationPolicy == SaturationPolicy.CALLER_RUNS_EVEN_WHEN_SHUT_DOWN || !executor.isShutdown())
+      task.run();
+    else if (task instanceof RunnableFuture<?> future)
+      future.cancel(false);
+  }
+
+  /** The dedicated executor. Its queue plus its rejection policy are the whole back-pressure story. */
+  public ExecutorService getExecutorService() {
+    return executor;
+  }
+
+  /**
+   * Configured thread ceiling, not the live worker count: a caller sizing a fan-out wants to know how wide the pool
+   * can get, and {@link ThreadPoolExecutor#getPoolSize()} is lower until the threads have been needed.
+   */
+  public int getMaxParallelism() {
+    return executor.getMaximumPoolSize();
+  }
+
+  /** Live pool statistics for the metrics binder and for tests. */
+  public PoolStats getPoolStats() {
+    return new PoolStats(executor.getPoolSize(), executor.getActiveCount(), executor.getQueue().size(),
+        boundedQueue ? executor.getQueue().remainingCapacity() : -1, executor.getCompletedTaskCount(),
+        callerRunCount.get());
+  }
+
+  /**
+   * Best-effort shutdown for tests and tooling. The production lifecycle relies on the daemon-thread default: the
+   * workers die when the JVM exits and nothing has to remember to close anything.
+   */
+  public void close() {
+    executor.shutdownNow();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncDDLKeywordCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncDDLKeywordCoverageTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.database.async;
 
+import com.arcadedb.query.opencypher.ast.CypherDDLStatement;
 import com.arcadedb.query.sql.parser.DDLStatement;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * So the list is not maintained by hand and hope. This walks every {@link DDLStatement} subclass the parser package
  * ships and fails if one begins with a verb the filter does not know - which is the moment somebody adds it, not the
  * moment a user notices their new statement is refused when dispatched asynchronously.
+ * <p>
+ * The filter became cross-language with issue #6324, item 5, so the same guarantee is owed to Cypher: its four DDL
+ * statements go through the same textual pre-filter before the engine is asked to classify them.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -77,6 +81,25 @@ class AsyncDDLKeywordCoverageTest {
     assertThat(uncovered).as(
             "these DDL statements start with a verb DatabaseAsyncExecutorImpl.DDL_LEADING_KEYWORDS does not list, so a "
                 + "script containing one would skip classification and be refused when dispatched asynchronously")
+        .isEmpty();
+  }
+
+  /**
+   * The same guarantee for Cypher (issue #6324, item 5): its DDL is enumerated rather than subclassed, so this walks
+   * {@link CypherDDLStatement.Kind} instead of the classpath. Each kind is named {@code <VERB>_<NOUN>}, and the verb
+   * is what the filter has to know - a fifth kind added with a verb that is not there would be dispatched to a worker
+   * and refused, quietly taking back the operation the routing exists to give.
+   */
+  @Test
+  void everyCypherDDLKindBeginsWithAVerbTheFilterKnows() {
+    final List<String> uncovered = new ArrayList<>();
+    for (final CypherDDLStatement.Kind kind : CypherDDLStatement.Kind.values())
+      if (!DatabaseAsyncExecutorImpl.mayContainDDL(kind.name().substring(0, kind.name().indexOf('_'))))
+        uncovered.add(kind.name());
+
+    assertThat(uncovered).as(
+            "these Cypher DDL kinds start with a verb DatabaseAsyncExecutorImpl.DDL_LEADING_KEYWORDS does not list, so a "
+                + "statement of that kind would skip classification and be refused when dispatched asynchronously")
         .isEmpty();
   }
 

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6324AsyncDispatchedDDLPerLanguageTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6324AsyncDispatchedDDLPerLanguageTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.QueryEngine;
+import com.arcadedb.query.QueryEngineManager;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6324, item 5: the routing that sends dispatched DDL off the async workers stopped being
+ * SQL's private knowledge.
+ * <p>
+ * #6303 gave back {@code CREATE INDEX} / {@code REBUILD INDEX} sent with {@code awaitResponse=false} by routing
+ * statements that parse to DDL onto {@code AsyncCommandPool}, whose threads are not workers of any executor and can
+ * therefore satisfy the barrier a scan-based index build needs. The classification lived in the dispatcher and knew
+ * about {@code sql} and {@code sqlscript} only, so the same statement in Cypher still ran on a worker and was still
+ * refused there by #6281's guard - a refusal rather than the old hang, but an asymmetry a user meets without warning.
+ * <p>
+ * The question is now asked of the LANGUAGE, through {@link QueryEngine#classifyDDL(String)}. Cypher can answer it
+ * for the same reason SQL can - the parse is a statement-cache lookup the execution repeats - and an engine that
+ * cannot answer cheaply says {@code UNKNOWN} and keeps the behaviour it has always had.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6324AsyncDispatchedDDLPerLanguageTest extends TestHelper {
+
+  /** The reported shape in Cypher: {@code CREATE INDEX} sent without waiting for the response. */
+  @Test
+  @Timeout(180)
+  void cypherCreateIndexDispatchedAsynchronouslyBuildsTheIndex() throws Exception {
+    database.transaction(() -> database.getSchema().createVertexType("V", 1).createProperty("id", Type.INTEGER));
+    database.transaction(() -> {
+      for (int i = 0; i < 50; i++)
+        database.newVertex("V").set("id", i).save();
+    });
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<String> ranOn = new AtomicReference<>();
+    final AtomicReference<Exception> failure = new AtomicReference<>();
+    database.async().command("cypher", "CREATE INDEX FOR (n:V) ON (n.id)", new AsyncResultsetCallback() {
+      @Override
+      public void onComplete(final ResultSet rs) {
+        ranOn.set(Thread.currentThread().getName());
+        done.countDown();
+      }
+
+      @Override
+      public void onError(final Exception exception) {
+        failure.compareAndSet(null, exception);
+        done.countDown();
+      }
+    });
+
+    assertThat(done.await(120, TimeUnit.SECONDS)).as("the command must run to an answer, not park").isTrue();
+    assertThat(failure.get()).as("the barrier is satisfiable off the workers, so there is nothing to refuse").isNull();
+    assertThat(ranOn.get()).as("Cypher DDL goes to the same pool SQL DDL does").startsWith("ArcadeDB-AsyncCommand-");
+
+    database.async().waitCompletion();
+
+    assertThat(database.getSchema().getIndexByName("V[id]")).isNotNull();
+    assertThat(database.getSchema().getIndexByName("V[id]").countEntries())
+        .as("and it indexed the records that were already there").isEqualTo(50);
+  }
+
+  /**
+   * The other half, and the half widening the fix would break: an ordinary Cypher WRITE keeps running on a worker,
+   * where its batch transaction and its pinned bucket are. {@code CREATE (n:V ...)} carries the word the cheap filter
+   * looks for, so this is also the case that proves the decision is the parse and not the keyword.
+   */
+  @Test
+  @Timeout(180)
+  void anOrdinaryCypherCreateStillRunsOnAWorker() throws Exception {
+    database.transaction(() -> database.getSchema().createVertexType("V", 1).createProperty("id", Type.INTEGER));
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<String> ranOn = new AtomicReference<>();
+    database.async().command("cypher", "CREATE (n:V {id: 1})", new AsyncResultsetCallback() {
+      @Override
+      public void onComplete(final ResultSet rs) {
+        ranOn.set(Thread.currentThread().getName());
+        done.countDown();
+      }
+
+      @Override
+      public void onError(final Exception exception) {
+        ranOn.set("error: " + exception);
+        done.countDown();
+      }
+    });
+
+    assertThat(done.await(120, TimeUnit.SECONDS)).isTrue();
+    assertThat(ranOn.get()).as("a Cypher write is not DDL and must keep its worker").doesNotStartWith("ArcadeDB-AsyncCommand-");
+
+    database.async().waitCompletion();
+    assertThat(database.countType("V", false)).isEqualTo(1);
+  }
+
+  /** The hook itself, asked directly, for the three languages that answer it and one that does not. */
+  @Test
+  @Timeout(60)
+  void theLanguagesThatCanClassifyDoAndTheOthersSaySo() {
+    database.transaction(() -> database.getSchema().createVertexType("V", 1).createProperty("id", Type.INTEGER));
+
+    final QueryEngineManager engines = QueryEngineManager.getInstance();
+
+    assertThat(engines.getEngine("sql", (DatabaseInternal) database)
+        .classifyDDL("CREATE INDEX ON V (id) UNIQUE")).isEqualTo(QueryEngine.DDLClassification.DDL);
+    assertThat(engines.getEngine("sql", (DatabaseInternal) database)
+        .classifyDDL("INSERT INTO V SET id = 1")).isEqualTo(QueryEngine.DDLClassification.NOT_DDL);
+
+    assertThat(engines.getEngine("sqlscript", (DatabaseInternal) database)
+        .classifyDDL("INSERT INTO V SET id = 1; CREATE INDEX ON V (id) UNIQUE;"))
+        .as("a script routes as a whole, on whether ANY statement in it is DDL")
+        .isEqualTo(QueryEngine.DDLClassification.DDL);
+
+    assertThat(engines.getEngine("cypher", (DatabaseInternal) database)
+        .classifyDDL("CREATE INDEX FOR (n:V) ON (n.id)")).isEqualTo(QueryEngine.DDLClassification.DDL);
+    assertThat(engines.getEngine("cypher", (DatabaseInternal) database)
+        .classifyDDL("CREATE (n:V {id: 1})"))
+        .as("the word CREATE is not the decision: the parse is").isEqualTo(QueryEngine.DDLClassification.NOT_DDL);
+
+    // An engine that cannot classify without paying for a parse execution will not reuse says UNKNOWN rather than
+    // guessing. Asked of a language that ships with the engine module so the assertion does not depend on which
+    // optional modules are on the test classpath.
+    assertThat(engines.getEngine("java", (DatabaseInternal) database).classifyDDL("anything"))
+        .isEqualTo(QueryEngine.DDLClassification.UNKNOWN);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
@@ -243,8 +243,13 @@ class DropIndexTest extends TestHelper {
         v2.save();
       }
 
+      // TOT + 1 and not TOT: the record created further up already holds TOT, and 'id' carries a UNIQUE index. The
+      // duplicate went unnoticed while the rebuilt index was populated in a transaction of its own - the entry for
+      // the pre-existing record was committed separately, so nothing compared the two - and is caught at save() now
+      // that the rebuild shares this transaction (issue #6324, item 1). What this test is about is dropping and
+      // recreating a type and its indexes, so the second record only has to exist.
       final MutableDocument v3 = database.newDocument(TYPE_NAME);
-      v3.set("id", TOT);
+      v3.set("id", TOT + 1);
       v3.save();
 
       assertThat(database.countType(TYPE_NAME, true)).isEqualTo(TOT + 2);

--- a/engine/src/test/java/com/arcadedb/index/Issue6303AsyncDispatchedDDLTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6303AsyncDispatchedDDLTest.java
@@ -161,13 +161,13 @@ class Issue6303AsyncDispatchedDDLTest extends TestHelper {
    * transaction and one thread, so the script cannot be half here and half there, and it is the DDL half that
    * dictates where both can run.
    * <p>
-   * Note what this deliberately does NOT assert. The index ends up with no entry for the record the same script
-   * inserted, because both run in one transaction and the record is therefore uncommitted - and so invisible to the
-   * build's scan - at the moment the index is created, having been saved before the index existed to stage an entry
-   * for. That is how the engine answers this script SYNCHRONOUSLY too (measured: `records=1 entries=0` for the same
-   * text inside one explicit transaction), so it is neither introduced nor worsened here and is out of this issue's
-   * scope; asserting an entry would be asserting a fix this PR does not make. What matters for the routing is
-   * pinned: the script ran off the workers, and both of its statements ran.
+   * The entry for the record the script itself inserted is asserted here as of issue #6324, item 1. It used to be
+   * missing, and this test used to say so in a comment instead of asserting it: both statements share one
+   * transaction, so the record was still uncommitted - and therefore invisible to the build's scan - at the moment
+   * the index was created, having been saved before the index existed to stage an entry for. The build now runs
+   * INSIDE the transaction that is writing rather than opening one of its own, which is what lets the scan see it.
+   * {@code Issue6324SameTransactionIndexBuildTest} covers the shape on its own terms; it is asserted from here too
+   * because this is a route a user actually takes to it.
    */
   @Test
   @Timeout(180)
@@ -201,7 +201,10 @@ class Issue6303AsyncDispatchedDDLTest extends TestHelper {
 
     assertThat(database.countType("V", false)).as("and the non-DDL half of the script still did its work")
         .isEqualTo(1);
-    assertThat(database.getSchema().getIndexByName("V[id]")).as("as did the DDL half").isNotNull();
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index).as("as did the DDL half").isNotNull();
+    assertThat(index.countEntries()).as("and the index knows about the record its own script inserted (#6324)")
+        .isEqualTo(1);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/Issue6324SameTransactionIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6324SameTransactionIndexBuildTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6324, item 1: a {@code CREATE INDEX} that runs in the SAME transaction as the writes it
+ * is supposed to index must index them.
+ * <p>
+ * The build scans the buckets, and a record written by the transaction the build runs in is not on disk yet - so it is
+ * not in the scan. It cannot fall back on staging its own index operation either, because it was saved BEFORE the
+ * index existed to stage one for. The result was an index that is readable, reported healthy by {@code CHECK DATABASE}
+ * and answers {@code WHERE id = 7} with nothing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6324SameTransactionIndexBuildTest extends TestHelper {
+
+  /** The reported shape, verbatim: one script, one transaction, an INSERT then a CREATE INDEX over it. */
+  @Test
+  @Timeout(60)
+  void aScriptThatInsertsThenIndexesInOneTransactionIndexesWhatItInserted() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.transaction(
+        () -> database.command("sqlscript", "INSERT INTO V SET id = 7; CREATE INDEX ON V (id) UNIQUE;").close());
+
+    assertThat(database.countType("V", false)).as("the record is there").isEqualTo(1);
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index.countEntries()).as("and so is its index entry").isEqualTo(1);
+    assertThat(index.get(new Object[] { 7 }).hasNext()).as("an index that answers the lookup it exists for").isTrue();
+  }
+
+  /** The same through the API rather than through SQL: {@code createTypeIndex} inside an open transaction. */
+  @Test
+  @Timeout(60)
+  void aTypeIndexCreatedInsideTheWritersTransactionIndexesTheUncommittedRecords() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", i);
+        v.save();
+      }
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    });
+
+    assertThat(database.countType("V", false)).isEqualTo(10);
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index.countEntries()).isEqualTo(10);
+    for (int i = 0; i < 10; i++)
+      assertThat(index.get(new Object[] { i }).hasNext()).as("id " + i + " must be found through the index").isTrue();
+  }
+
+  /**
+   * The build must still see what the transaction DELETED, not only what it inserted: a record removed in the same
+   * transaction has no business getting an index entry from a scan that has not caught up with the removal.
+   */
+  @Test
+  @Timeout(60)
+  void aRecordDeletedInTheSameTransactionGetsNoIndexEntry() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.transaction(() -> {
+      for (int i = 0; i < 4; i++) {
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", i);
+        v.save();
+      }
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM V WHERE id = 2")) {
+        rs.next().getRecord().get().asDocument().getRecord().delete();
+      }
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    });
+
+    assertThat(database.countType("V", false)).isEqualTo(3);
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index.countEntries()).as("the deleted record must not leave a phantom entry behind").isEqualTo(3);
+    assertThat(index.get(new Object[] { 2 }).hasNext()).as("and must not be answerable through the index").isFalse();
+  }
+
+  /**
+   * And a record UPDATED in the same transaction must be indexed under its new key, not the one still on disk.
+   */
+  @Test
+  @Timeout(60)
+  void aRecordUpdatedInTheSameTransactionIsIndexedUnderItsNewKey() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", 1);
+      v.save();
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT FROM V WHERE id = 1")) {
+        final MutableDocument v = rs.next().getRecord().get().asDocument().modify();
+        v.set("id", 42);
+        v.save();
+      }
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    });
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index.countEntries()).isEqualTo(1);
+    // Asked of the INDEX and not of a SELECT, which would answer the same from a full scan and so would pass
+    // whatever the index holds.
+    assertThat(index.get(new Object[] { 42 }).hasNext()).as("the new key is the one the index answers on").isTrue();
+    assertThat(index.get(new Object[] { 1 }).hasNext()).as("and the old key is not").isFalse();
+  }
+
+  /**
+   * The other half of the split: the index COMPONENT is committed on its own, whatever the caller's transaction goes
+   * on to do.
+   * <p>
+   * The schema entry naming the index is written by {@code recordFileChanges} as soon as the statement returns and
+   * nothing later takes it back, so an index whose first page was left in a transaction that then rolled back would
+   * be a schema entry pointing at a file with no pages - and the next write to it fails with "the file is invalid",
+   * on a database that has been reopened since and has no idea why.
+   */
+  @Test
+  @Timeout(60)
+  void anIndexCreatedInATransactionThatRollsBackIsStillUsable() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.begin();
+    final MutableDocument doomed = database.newDocument("V");
+    doomed.set("id", 1);
+    doomed.save();
+    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    database.rollback();
+
+    assertThat(database.countType("V", false)).as("the record went with the rollback").isZero();
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index).as("the index the schema still names must still be there").isNotNull();
+    assertThat(index.countEntries()).as("and empty, like the type").isZero();
+
+    // The point of the test: the index is WRITEABLE afterwards, not merely present.
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", 7);
+      v.save();
+    });
+    assertThat(index.get(new Object[] { 7 }).hasNext()).isTrue();
+  }
+
+  /**
+   * A NESTED transaction cannot see an outer one's uncommitted pages, so an index created in the outer transaction
+   * has to be committed to be usable from inside a nested one - which is what the component half of the split is
+   * for. The shape is ordinary enough to reach by accident: any test or handler running with an ambient transaction
+   * and a {@code begin()}/{@code commit()} pair inside it.
+   */
+  @Test
+  @Timeout(60)
+  void anIndexCreatedInAnOuterTransactionIsWriteableFromANestedOne() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    database.begin();
+    try {
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+
+      database.begin();
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", 3);
+      v.save();
+      database.commit();
+    } finally {
+      if (database.isTransactionActive())
+        database.commit();
+    }
+
+    assertThat(database.getSchema().getIndexByName("V[id]").get(new Object[] { 3 }).hasNext()).isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6324SameTransactionIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6324SameTransactionIndexBuildTest.java
@@ -19,7 +19,9 @@
 package com.arcadedb.index;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -237,5 +239,101 @@ class Issue6324SameTransactionIndexBuildTest extends TestHelper {
     // A legal one still rebuilds, so the guard above is not simply refusing everything.
     database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = 1").close();
     assertThat(database.getSchema().getIndexByName("V[id]").get(new Object[] { 1 }).hasNext()).isTrue();
+  }
+
+  /**
+   * An EMPTY open transaction is not a reason to share it, and this is the case that makes the distinction matter.
+   * <p>
+   * {@code DatabaseAsyncExecutorImpl.runCommand} opens a transaction around every dispatched command, because
+   * {@code requiresActiveTx()} defaults to true. Keying the decision on "is a transaction active" alone would
+   * therefore make a {@code CREATE INDEX} sent with {@code awaitResponse=false} - the case #6303 item 3 and #6324
+   * item 5 exist to make work - share a transaction that holds nothing, and silently give up the chunked commit its
+   * batch size is meant to guarantee: one uncommitted transaction from the first record to the last. Sharing is
+   * asked of what the transaction CONTAINS, not of whether one exists.
+   */
+  @Test
+  @Timeout(60)
+  void anEmptyOpenTransactionIsNotSharedSoTheBuildKeepsItsChunkedCommit() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+    database.transaction(() -> {
+      for (int i = 0; i < 40; i++) {
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", i);
+        v.save();
+      }
+    });
+
+    // Open, write nothing, build. The build must NOT join: with a batch size of 10 over 40 committed records it
+    // chunk-commits, which it can only do on a transaction of its own.
+    database.begin();
+    final TransactionContext outer = ((DatabaseInternal) database).getTransactionIfExists();
+    assertThat(outer.hasChanges()).as("precondition: the transaction the build is offered is empty").isFalse();
+
+    database.getSchema().buildTypeIndex("V", new String[] { "id" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(true).withBatchSize(10).create();
+
+    assertThat(((DatabaseInternal) database).getTransactionIfExists().hasChanges())
+        .as("a build that did not join left the caller's transaction as empty as it found it").isFalse();
+    database.commit();
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index.countEntries()).isEqualTo(40);
+    for (int i = 0; i < 40; i++)
+      assertThat(index.get(new Object[] { i }).hasNext()).as("id " + i).isTrue();
+  }
+
+  /**
+   * A build that fails must not leave a registered, {@code AVAILABLE}, half-populated index behind - and the failure
+   * that gets there is a {@link com.arcadedb.exception.DuplicatedKeyException} raised mid-scan, which is exactly what
+   * a unique build can now hit, since it sees the caller's own pending writes.
+   * <p>
+   * The path matters: inside a JOINED transaction {@code LocalDatabase.transaction} rethrows a retryable exception
+   * immediately rather than calling the error callback (issue #661 - retrying would roll back a transaction it does
+   * not own), so a cleanup hung off that callback never runs.
+   */
+  @Test
+  @Timeout(60)
+  void aBuildThatFailsOnACallersDuplicateLeavesNoIndexBehind() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      for (int i = 0; i < 2; i++) {
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", 7);
+        v.save();
+      }
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    })).isInstanceOf(Exception.class);
+
+    assertThat(database.getSchema().existsIndex("V[id]"))
+        .as("an index that could not be built must be gone, not registered and empty").isFalse();
+  }
+
+  /**
+   * The same through {@code BucketIndexBuilder}, which is the path that actually lacked the cleanup: it has no
+   * try/catch of its own around the build, unlike {@code TypeIndexBuilder}, so it was relying entirely on the
+   * transaction's error callback - the one {@code LocalDatabase.transaction} skips for a retryable exception raised
+   * inside a joined transaction (issue #661). This is how {@code CHECK DATABASE ... FIX} rebuilds a damaged index.
+   */
+  @Test
+  @Timeout(60)
+  void aBucketIndexBuildThatFailsOnACallersDuplicateLeavesNoIndexBehind() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      for (int i = 0; i < 2; i++) {
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", 7);
+        v.save();
+      }
+      database.getSchema().buildBucketIndex("V", "V_0", new String[] { "id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
+    })).isInstanceOf(Exception.class);
+
+    assertThat(database.getSchema().existsIndex("V[id]"))
+        .as("the half-built sub-index must be dropped, not left registered and AVAILABLE").isFalse();
+    assertThat(database.getSchema().getIndexes())
+        .as("and it must not survive under its own bucket name either")
+        .noneMatch(i -> i.getName().startsWith("V_0_"));
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/Issue6324SameTransactionIndexBuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6324SameTransactionIndexBuildTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #6324, item 1: a {@code CREATE INDEX} that runs in the SAME transaction as the writes it
@@ -204,5 +205,37 @@ class Issue6324SameTransactionIndexBuildTest extends TestHelper {
     }
 
     assertThat(database.getSchema().getIndexByName("V[id]").get(new Object[] { 3 }).hasNext()).isTrue();
+  }
+
+  /**
+   * The permission to commit is a parameter of the build's own, never a value of its batch size.
+   * <p>
+   * It used to be spelled "batch size 0", which collides with a user-supplied
+   * {@code REBUILD INDEX ... WITH batchSize = 0}: for the vector families, which do not chunk by record count at all,
+   * that literal zero would have been read as the permission and turned off the byte-based chunking for the whole
+   * rebuild. The statement refuses the value now, which is the honest answer for every index family - a batch size
+   * below one is not a smaller batch, it is a request that cannot be honoured.
+   */
+  @Test
+  @Timeout(60)
+  void aNonPositiveRebuildBatchSizeIsRefusedRatherThanReadAsAPermission() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+    database.transaction(() -> database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id"));
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", 1);
+      v.save();
+    });
+
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = 0").close())
+        .hasMessageContaining("batchSize");
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = -1").close())
+        .hasMessageContaining("batchSize");
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `V[id]` WITH maxAttempts = 0").close())
+        .hasMessageContaining("maxAttempts");
+
+    // A legal one still rebuilds, so the guard above is not simply refusing everything.
+    database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = 1").close();
+    assertThat(database.getSchema().getIndexByName("V[id]").get(new Object[] { 1 }).hasNext()).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.fulltext;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
@@ -44,6 +45,18 @@ import static org.assertj.core.api.Assertions.within;
  */
 class FullTextBM25CompactionTest extends TestHelper {
 
+  /**
+   * Automatic compaction scheduling off, so this test owns the reservation {@link #forceCompaction()} asserts on
+   * (issue #6324, item 2). The 601 inserts below take the mutable index well past
+   * {@code INDEX_COMPACTION_MIN_PAGES_SCHEDULE}, so the engine schedules a compaction of its own while they run, and
+   * whenever that reservation is still outstanding the test's own {@code scheduleCompaction()} loses the CAS and
+   * {@code compact()} finds nothing to do.
+   */
+  @Override
+  protected void beginTest() {
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+  }
+
   private Map<String, Float> searchScores(final String query) {
     final Map<String, Float> scores = new HashMap<>();
     final ResultSet rs = database.query("sql",
@@ -61,7 +74,12 @@ class FullTextBM25CompactionTest extends TestHelper {
     for (final Index bucketIndex : typeIndex.getIndexesOnBuckets()) {
       if (bucketIndex instanceof LSMTreeFullTextIndex ftIndex) {
         try {
-          ((IndexInternal) ftIndex).scheduleCompaction();
+          // scheduleCompaction() is a RESERVATION - AVAILABLE -> COMPACTION_SCHEDULED by CAS, plus a refusal while
+          // page flushing is suspended - and compact() does nothing at all without it. Asserted rather than discarded
+          // (issue #6324, item 2): a lost reservation used to surface as "the full-text index should have compacted",
+          // which sends the next reader to look at compaction rather than at whatever took the reservation.
+          assertThat(((IndexInternal) ftIndex).scheduleCompaction())
+              .as("compaction must be reserved on '%s' before it can run", ftIndex.getName()).isTrue();
           compacted |= ftIndex.compact();
         } catch (final Exception e) {
           throw new RuntimeException(e);

--- a/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/query/QueryEngineManagerPoolTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -213,8 +212,8 @@ class QueryEngineManagerPoolTest {
    * signal in the server console without spam if the queue saturates briefly. The metric
    * counter still tallies every fallback for dashboards. This test:
    * <ol>
-   *   <li>Resets the throttle's last-warn timestamp via reflection so a previous test in the
-   *       same JVM cannot suppress the WARNING we want to observe.</li>
+   *   <li>Reopens the throttle so a previous test in the same JVM cannot suppress the WARNING we
+   *       want to observe.</li>
    *   <li>Swaps in a capture logger via {@link com.arcadedb.log.LogManager#setLogger} so we
    *       see the WARNING regardless of how the production logger is configured.</li>
    *   <li>Drives a saturation event and asserts the WARNING text is present.</li>
@@ -226,13 +225,9 @@ class QueryEngineManagerPoolTest {
   void saturationLogsThrottledWarning() throws Exception {
     final ExecutorService executor = QueryEngineManager.getInstance().getExecutorService();
 
-    // Reset the throttle so this test does not depend on test ordering.
-    final java.lang.reflect.Field throttleField =
-        QueryEngineManager.class.getDeclaredField("lastSaturationWarnMs");
-    throttleField.setAccessible(true);
-    final AtomicLong throttle =
-        (AtomicLong) throttleField.get(QueryEngineManager.getInstance());
-    throttle.set(0L);
+    // Reset the throttle so this test does not depend on test ordering. Through the pool's own seam rather than by
+    // reflecting on a private field, which a rename would break with no compile error to say so (issue #6324, item 4).
+    QueryEngineManager.getInstance().resetSaturationWarningThrottle();
 
     // Read the pool geometry before swapping the logger, so that the swap is the last thing that
     // happens before the try: nothing between it and the finally can throw and strand the

--- a/engine/src/test/java/com/arcadedb/query/select/SelectParallelIteratorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectParallelIteratorTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.select;/*
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +44,35 @@ public class SelectParallelIteratorTest extends TestHelper {
   // AND THE TIMEOUT TESTS EXERCISE THE STREAMING (NON-EMPTY QUEUE) PATH ONLY
   private static final int SMALL_RECORDS = 1_000;
   private static final int BUCKETS       = 8;
+  /**
+   * A HANG DETECTOR, not a latency bound (issue #6324, item 3). Every wait below has to end, and only some of them
+   * carry a claim about HOW SOON - so this number is deliberately far past anything healthy, and a run that reaches
+   * it has a wedged producer rather than a slow one.
+   */
+  private static final int HANG_DETECTOR_MS = 120_000;
+  /**
+   * The tripwire between "the producers gave up" and "the producers are spinning on a full queue for ever", which is
+   * the whole of #5065. Measured with the JVM-wide stall inside the window discounted, so it can stay this side of
+   * unbounded on a machine running back-to-back suites; the raw form failed at 25.1 s against a 15 s budget on a busy
+   * machine and passed 5/5 on an idle one, which is the coin flip CLAUDE.md's #6260 rule exists to remove.
+   */
+  private static final int GIVE_UP_TRIPWIRE_MS = 15_000;
+
+  /**
+   * The producers must stop rather than run to their unbounded end. Generous is free here: widening the tripwire
+   * cannot turn a passing run red, while narrowing it is what would break.
+   */
+  private void assertProducersGaveUp(final String whatItSeparates) {
+    final StallAwareStopwatch watch = StallAwareStopwatch.start();
+    assertThat(database.async().waitCompletion(HANG_DETECTOR_MS)).as("the producers must return at all").isTrue();
+    watch.assertGaveUpWithin(GIVE_UP_TRIPWIRE_MS, whatItSeparates);
+  }
+
+  /** Liveness only: the scan has to finish. Nothing here claims how quickly, so nothing here is a bound. */
+  private void assertProducersFinished() {
+    assertThat(database.async().waitCompletion(HANG_DETECTOR_MS))
+        .as("the parallel scan must finish rather than hang (liveness guard, not a latency bound)").isTrue();
+  }
 
   public SelectParallelIteratorTest() {
     autoStartTx = false;
@@ -64,7 +94,7 @@ public class SelectParallelIteratorTest extends TestHelper {
   void fullParallelScanReturnsAllRecords() {
     final List<Vertex> result = database.select().fromType("Big").compile().parallel().<Vertex>vertices().toList();
     assertThat(result).hasSize(TOTAL_RECORDS);
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersFinished();
   }
 
   @Test
@@ -72,7 +102,7 @@ public class SelectParallelIteratorTest extends TestHelper {
     final List<Vertex> result = database.select().fromType("Big").limit(10).compile().parallel().<Vertex>vertices().toList();
 
     // THE PRODUCERS MUST STOP ONCE THE LIMIT IS SATISFIED INSTEAD OF SPINNING FOREVER ON THE FULL QUEUE (#5065)
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersGaveUp("a producer that stops at the limit from one that spins on a full queue for ever");
     assertThat(result).hasSize(10);
   }
 
@@ -87,7 +117,7 @@ public class SelectParallelIteratorTest extends TestHelper {
 
     // THE CONSUMER STOPS DRAINING WITHOUT CLOSING (E.G. AN EXCEPTION IN USER CODE): THE PRODUCERS MUST GIVE UP
     // WITHIN THE STALL BOUND (THE SELECT TIMEOUT HERE) INSTEAD OF PINNING THE ASYNC WORKERS AT 100% CPU (#5065)
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersGaveUp("a producer that honours the 1s stall bound from one that pins a worker at 100% CPU");
   }
 
   @Test
@@ -102,7 +132,7 @@ public class SelectParallelIteratorTest extends TestHelper {
     // CLOSE WHILE THE PRODUCERS ARE STILL STREAMING: THE ASYNC WORKERS MUST RETURN WITHIN A BOUND (#5065)
     iterator.close();
 
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersGaveUp("a producer that notices the close from one that keeps browsing its whole bucket");
     assertThat(iterator.hasNext()).isFalse();
   }
 
@@ -110,7 +140,7 @@ public class SelectParallelIteratorTest extends TestHelper {
   void skipIsAppliedOnParallelScan() {
     final List<Vertex> result = database.select().fromType("Big").skip(100).compile().parallel().<Vertex>vertices().toList();
     assertThat(result).hasSize(TOTAL_RECORDS - 100);
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersFinished();
   }
 
   @Test
@@ -120,12 +150,12 @@ public class SelectParallelIteratorTest extends TestHelper {
     final List<Vertex> result = database.select().fromType("Big").skip(100).limit(50).compile().parallel().<Vertex>vertices()
         .toList();
     assertThat(result).hasSize(50);
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersFinished();
 
     final List<Vertex> result2 = database.select().fromType("Big").skip(10).limit(50).compile().parallel().<Vertex>vertices()
         .toList();
     assertThat(result2).hasSize(50);
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersFinished();
   }
 
   @Test
@@ -158,7 +188,7 @@ public class SelectParallelIteratorTest extends TestHelper {
         iterator.next();
     }).isInstanceOf(TimeoutException.class);
 
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersFinished();
   }
 
   @Test
@@ -180,6 +210,6 @@ public class SelectParallelIteratorTest extends TestHelper {
     }
 
     assertThat(fetchedAfterTimeout).isZero();
-    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertProducersFinished();
   }
 }

--- a/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/DedicatedThreadPoolTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the shared base of the engine's dedicated executors (issue #6324, item 4).
+ * <p>
+ * What is worth pinning here is not the {@link java.util.concurrent.ThreadPoolExecutor} - the JDK tests that - but the
+ * things the four copies of this code were getting subtly different, and the two combinations the base refuses so that
+ * a new pool cannot be built without answering the {@code engine-concurrency} checklist.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class DedicatedThreadPoolTest {
+
+  private static final class TestPool extends DedicatedThreadPool {
+    private TestPool(final int queueCapacity, final SaturationPolicy policy) {
+      super("ArcadeDB-DedicatedThreadPoolTest-", 1, queueCapacity, policy, DedicatedThreadPool::plainWorker,
+          "Test pool", "nothing at all", GlobalConfiguration.QUERY_PARALLELISM_POOL_THREADS);
+    }
+  }
+
+  /** An unbounded queue never rejects, so a rejection policy on it is a statement that cannot come true. */
+  @Test
+  void anUnboundedQueueCannotHaveARejectionPolicy() {
+    assertThatThrownBy(() -> new TestPool(DedicatedThreadPool.UNBOUNDED_QUEUE, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("never rejects");
+  }
+
+  /** And a bounded one has to say what happens to the task it refuses - that is the checklist, enforced. */
+  @Test
+  void aBoundedQueueMustDeclareASaturationPolicy() {
+    assertThatThrownBy(() -> new TestPool(4, DedicatedThreadPool.SaturationPolicy.NONE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("no policy");
+  }
+
+  /**
+   * {@code -1}, not a near-2^31 constant that would read oddly next to the bounded pools on the same dashboard row.
+   * {@code ParallelScanProducerPool} used to hard-code this in its own {@code getPoolStats}.
+   */
+  @Test
+  void anUnboundedPoolReportsItsQueueCapacityAsNotApplicable() {
+    final TestPool pool = new TestPool(DedicatedThreadPool.UNBOUNDED_QUEUE, DedicatedThreadPool.SaturationPolicy.NONE);
+    try {
+      assertThat(pool.getPoolStats().queueCapacityRemaining()).isEqualTo(-1);
+      assertThat(pool.getPoolStats().callerRunFallbacks()).as("a pool that cannot reject never falls back").isZero();
+    } finally {
+      pool.close();
+    }
+  }
+
+  /** Caller-runs means exactly that, and the fallback is counted so an operator sees saturation rather than latency. */
+  @Test
+  @Timeout(60)
+  void aRejectedTaskRunsOnTheSubmitterAndIsCounted() {
+    final TestPool pool = new TestPool(4, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
+    try {
+      final AtomicReference<Thread> ranOn = new AtomicReference<>();
+      pool.runOnCaller(() -> ranOn.set(Thread.currentThread()), 4, 1);
+
+      assertThat(ranOn.get()).isSameAs(Thread.currentThread());
+      assertThat(pool.getPoolStats().callerRunFallbacks()).isEqualTo(1);
+    } finally {
+      pool.close();
+    }
+  }
+
+  /**
+   * A task rejected by a SHUT-DOWN pool would otherwise be neither run nor completed, leaving a caller blocked in an
+   * untimed {@code Future.get()} for ever (#4961). Cancelling its future ends the wait instead.
+   */
+  @Test
+  @Timeout(60)
+  void aTaskRejectedByAShutDownPoolHasItsFutureCancelled() {
+    final TestPool pool = new TestPool(4, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS);
+    pool.close();
+
+    final AtomicReference<Boolean> ran = new AtomicReference<>(false);
+    final FutureTask<Void> task = new FutureTask<>(() -> {
+      ran.set(true);
+      return null;
+    });
+    pool.runOnCaller(task, 4, 1);
+
+    assertThat(ran.get()).as("a shut-down pool must not run the task").isFalse();
+    assertThat(task.isCancelled()).as("...and must not leave its caller waiting for a result that never comes").isTrue();
+  }
+
+  /** The same task on a pool that runs it regardless, which is what a pool with no future to cancel needs. */
+  @Test
+  @Timeout(60)
+  void theEvenWhenShutDownPolicyRunsItAnyway() {
+    final TestPool pool = new TestPool(4, DedicatedThreadPool.SaturationPolicy.CALLER_RUNS_EVEN_WHEN_SHUT_DOWN);
+    pool.close();
+
+    final AtomicReference<Boolean> ran = new AtomicReference<>(false);
+    pool.runOnCaller(() -> ran.set(true), 4, 1);
+
+    assertThat(ran.get()).as("the submitter has already counted this as in flight: dropping it strands that count")
+        .isTrue();
+  }
+
+  /** The shared sizing: an explicit positive value wins, anything else is cores with a floor of two. */
+  @Test
+  void sizingTakesTheExplicitValueOrFallsBackToCores() {
+    assertThat(DedicatedThreadPool.autoSizeThreads(7)).isEqualTo(7);
+    assertThat(DedicatedThreadPool.autoSizeThreads(0))
+        .isEqualTo(Math.max(DedicatedThreadPool.DEFAULT_THREADS_FLOOR, Runtime.getRuntime().availableProcessors()));
+    assertThat(DedicatedThreadPool.autoSizeThreads(-3)).as("a negative value is coerced, not honoured")
+        .isEqualTo(Math.max(DedicatedThreadPool.DEFAULT_THREADS_FLOOR, Runtime.getRuntime().availableProcessors()));
+
+    assertThat(DedicatedThreadPool.queueSizeOrDefault(64)).isEqualTo(64);
+    assertThat(DedicatedThreadPool.queueSizeOrDefault(0)).isEqualTo(DedicatedThreadPool.DEFAULT_QUEUE_SIZE);
+    assertThat(DedicatedThreadPool.queueSizeOrDefault(-1)).isEqualTo(DedicatedThreadPool.DEFAULT_QUEUE_SIZE);
+  }
+}


### PR DESCRIPTION
Closes #6324.

Five follow-ups collected while fixing #6303, plus the two smaller notes at the end of that issue.

## Item 1 - `INSERT ...; CREATE INDEX ...` in one transaction left the record unindexed

```sql
INSERT INTO V SET id = 7; CREATE INDEX ON V (id) UNIQUE;
```

run as one script in one transaction ended with `records=1 entries=0`: the build scans the buckets and the record is
not committed yet, and it could not stage an entry of its own either, because it was saved *before* the index existed
to stage one for. The result was an index that is readable, reported healthy by `CHECK DATABASE`, and answers
`WHERE id = 7` with nothing.

The issue offered three answers and preferred "have the build also apply the uncommitted index operations of the
transaction it runs in". **The implemented fix is a better version of that one**: rather than replaying operations
that were never staged, the build now READS through the transaction, which is where the truth about "what records
exist" lives while one is open. Concretely, `CREATE INDEX` became **two transactions instead of one**:

1. the index **component** is created in a transaction of its own and committed, always. The schema entry naming it
   is written by `recordFileChanges` regardless of what the caller's transaction does, so leaving the index file's
   first page inside a transaction that then rolls back would leave the schema pointing at a file with no pages -
   which fails on the next write with *"the file is invalid"*. Committing it also keeps the index usable from a
   NESTED transaction, which cannot see an outer one's uncommitted pages.
2. the **build** joins the caller's transaction when there is one. A bucket scan reads the transaction it runs in -
   its modified pages first, the committed ones underneath - so it now sees the records that transaction has written,
   and the entries commit, or roll back, with the records they describe.

Two things the split needed on top:

- **A build that shares a transaction may not commit it.** All four scan-based builds chunk-committed every
  `batchSize` records; on a shared transaction that publishes the caller's unfinished work halfway through a DDL
  statement. The four copies are now one `IndexInternal.commitBuildBatch`, which also stops treating a batch size of
  0 as a modulo by zero. `LSMVectorIndex`, which chunks by bytes, takes the same permission through its own path.
- **The scan cannot be the only source.** An UPDATE inside a transaction is parked as a deferred update and
  serialized only in the first commit phase, so the page still holds the OLD content. `IndexInternal.buildSourceRecord`
  asks the transaction for its own written copy of each scanned record, which is one hash lookup returning null when
  there is nothing to correct.

**One documented carve-out**: `LSM_VECTOR` and `LSM_SPARSE_VECTOR` builds keep their own transaction
(`Schema.INDEX_TYPE#buildCanShareCallerTransaction`). Their build writes a graph, and for sparse its segments, as
files of their own, and their SEARCH path reads those through the page cache rather than through the transaction - so
entries left uncommitted are written but not findable.

Two callers had to be told about the new rule:

- `TRUNCATE TYPE ... UNSAFE` rebuilds the indexes it dropped, and relied on the rebuild being committed by a
  transaction of its own so it survives the rollback a failed truncate triggers. It now closes out the deletion
  transaction first - commit when the deletes are good, roll back when they are not - and rebuilds outside it.
- `BucketIndexBuilder` (the `CHECK DATABASE ... FIX` path) drops the index fully when the build fails, which is what
  `LocalSchema.createBucketIndex` used to do for it while the build still ran inside that method.

Covered by `Issue6324SameTransactionIndexBuildTest` (insert / delete / update in the same transaction, rollback keeps
the index usable, nested transaction can write to it), and
`Issue6303AsyncDispatchedDDLTest#aScriptMixingDDLAndWritesRunsOffTheWorkersAsAWhole` now asserts the entry its comment
used to explain away.

One test changed rather than fixed: `DropIndexTest.dropAndRecreateTypeWithIndex` was writing a second record with the
same value into a UNIQUE index. The duplicate went unnoticed while the rebuilt index was populated separately;
sharing the transaction catches it at `save()`, which is the documented in-transaction behaviour. The record's id was
changed - the test is about dropping and recreating a type.

## Item 2 - `FullTextBM25CompactionTest` discarded the boolean that says whether it compacted

`scheduleCompaction()` is a reservation (`AVAILABLE -> COMPACTION_SCHEDULED` by CAS), and the engine schedules a
compaction of its own while the test's 601 inserts run. Whenever that reservation was still outstanding the test lost
the CAS, `compact()` had nothing to do, and the run failed with a message about the index rather than about the race.
Automatic scheduling is now off for the test and the reservation is asserted, so a lost race fails as a lost race.

## Item 3 - `SelectParallelIteratorTest` asserted on raw wall-clock time

Nine `waitCompletion(15_000)` assertions, one of which (`abandonedConsumerReleasesWorkersWithinStallBound`) failed at
25.1 s on a busy machine and passed 5/5 on an idle one. Split by what each one is actually for, per CLAUDE.md's #6260
rule: the three that discriminate "the producers gave up" from "the producers are spinning for ever" measure with
`StallAwareStopwatch#assertGaveUpWithin`, and the six that are liveness guards are sized as hang detectors and say so.

## Item 4 - four copies of one thread pool

`QueryEngineManager`, `SparseVectorScoringPool`, `ParallelScanProducerPool` and `AsyncCommandPool` now extend
`com.arcadedb.utility.DedicatedThreadPool`, which owns the executor construction, the `PoolStats` record and the
caller-runs rejection handler with its throttled saturation WARNING. One message shape for all of them, instead of
three that had drifted apart. Each pool's REASONS stay in its own class javadoc.

More useful than the ~150 lines it removes: the constructor now REFUSES the two combinations that cannot mean
anything - an unbounded queue with a rejection policy, and a bounded queue with no policy - so the
`engine-concurrency` checklist is enforced rather than remembered. The skill is updated with the base class, the full
pool inventory and the deviation `ParallelScanProducerPool` documents.

`QueryEngineManagerPoolTest` stopped reflecting on a private field to reset the warning throttle and uses the pool's
own seam, which a rename cannot silently break.

## Item 5 - asynchronously dispatched DDL worked for SQL only

The routing that sends dispatched DDL to `AsyncCommandPool` was SQL's private knowledge, so `CREATE INDEX` sent with
`awaitResponse=false` worked in SQL and was refused in Cypher. It is now a per-language hook,
`QueryEngine#classifyDDL`, answering `DDL` / `NOT_DDL` / `UNKNOWN`. SQL, `sqlscript` and Cypher answer it - all three
from a parse the execution is about to repeat, so it is free - and an engine that would have to pay for a parse (for
Gremlin, a Groovy compile) on the submitting thread says `UNKNOWN` and keeps the behaviour it has always had,
including #6281's refusal. The cheap textual pre-filter is unchanged and now covers both grammars;
`AsyncDDLKeywordCoverageTest` walks the Cypher DDL kinds as well as the SQL statement classes.

## Note (b) - `DatabaseContext.asyncMode` renamed to `perThreadBucketSelection`

It never meant "this thread is an async worker" - #6303 removed the one place that read it that way - and it is set
on `AsyncCommandPool` threads, which are deliberately not workers. The name was the last thing suggesting the old
reading.

## Note (a) - not done, deliberately

`pageFlushQueueMaxPerDatabase` is still not in Micrometer. The issue says it belongs to the same pass as item 2 of
#6087, not to a new issue; recorded here so the trail does not go cold.

## Known gap left open

`LocalDocumentType.addSuperType` and `createBucket` propagate indexes to buckets by calling
`LocalSchema.createBucketIndex` directly, so they still build in a transaction of their own and would miss a caller's
uncommitted records. Same shape as item 1, out of its scope (it is about `CREATE INDEX`), and worth its own
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QF6LJaiD6ZRr6oA9WZxVBK
