### PR TITLE
fix(#6352): a disjunction picks what to scan, not just its first alternative

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -18,13 +18,19 @@
  */
 package com.arcadedb.query.opencypher;
 
+import com.arcadedb.database.Database;
+import com.arcadedb.database.Record;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.VertexType;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -207,6 +213,98 @@ public final class Labels {
       if (!schema.existsType(labels.get(i)))
         return false;
     return true;
+  }
+
+  /**
+   * The vertex types whose records can satisfy a node pattern's label constraint: every declared vertex type
+   * {@link #matches(DocumentType, List, boolean)} accepts, so a disjunction {@code (n:A|B)} selects the types of
+   * <b>both</b> alternatives and a conjunction {@code (n:A:B)} only the types carrying all of them. An empty label
+   * list selects every vertex type.
+   * <p>
+   * This is the scan-side companion of {@code matches}: deciding a row and deciding what to scan have to say the
+   * same thing about a disjunction, and when they did not, an unbound start node scanned only the first
+   * alternative's type and the alternatives after it silently went missing from the answer (issue #6352).
+   * <p>
+   * The returned types are meant to be iterated <b>non-polymorphically</b>: the list already contains every matching
+   * subtype, so a polymorphic scan of each would visit a subtype once per matching ancestor.
+   *
+   * @param schema      the database schema
+   * @param labels      the labels written on the pattern (already resolved, dynamic labels included)
+   * @param disjunction whether the labels were written as alternatives ({@code A|B}) rather than as a conjunction
+   *
+   * @return the vertex types to scan, empty when nothing in the schema can match
+   */
+  private static List<DocumentType> matchingVertexTypes(final Schema schema, final List<String> labels,
+      final boolean disjunction) {
+    final Collection<? extends DocumentType> allTypes = schema.getTypes();
+    final List<DocumentType> matching = new ArrayList<>(allTypes.size());
+    for (final DocumentType type : allTypes)
+      if (type instanceof VertexType && matches(type, labels, disjunction))
+        matching.add(type);
+    return matching;
+  }
+
+  /**
+   * Walks every vertex that can satisfy a node pattern's label constraint, in one lazy pass and without visiting a
+   * vertex twice, over the types {@code matchingVertexTypes} selects.
+   * <p>
+   * A single label is served by one polymorphic scan of that type, which is the same set of records at the price of
+   * one schema lookup instead of a walk of the whole type list.
+   *
+   * @param database    the database to scan
+   * @param labels      the labels written on the pattern (already resolved, dynamic labels included)
+   * @param disjunction whether the labels were written as alternatives ({@code A|B}) rather than as a conjunction
+   *
+   * @return an iterator over the candidate vertices, empty when nothing in the schema can match
+   */
+  public static Iterator<Record> iterateMatchingVertices(final Database database, final List<String> labels,
+      final boolean disjunction) {
+    final Schema schema = database.getSchema();
+
+    if (labels != null && labels.size() == 1) {
+      final String label = labels.get(0);
+      // A type name that names an edge or document type is not a label: labels and relationship types are separate
+      // namespaces in Cypher, so such a pattern matches no node rather than yielding records that are not vertices.
+      if (!schema.existsType(label) || !(schema.getType(label) instanceof VertexType))
+        return Collections.emptyIterator();
+      return database.iterateType(label, true);
+    }
+
+    final List<DocumentType> types = matchingVertexTypes(schema, labels, disjunction);
+    if (types.isEmpty())
+      return Collections.emptyIterator();
+    if (types.size() == 1)
+      return database.iterateType(types.get(0).getName(), false);
+    return new ChainedTypeIterator(database, types);
+  }
+
+  /**
+   * Walks a list of types one after the other, opening each type's iterator only when the previous one is drained.
+   */
+  private static final class ChainedTypeIterator implements Iterator<Record> {
+    private final Database           database;
+    private final List<DocumentType> types;
+    private       int                nextType = 0;
+    private       Iterator<Record>   current  = Collections.emptyIterator();
+
+    private ChainedTypeIterator(final Database database, final List<DocumentType> types) {
+      this.database = database;
+      this.types = types;
+    }
+
+    @Override
+    public boolean hasNext() {
+      while (!current.hasNext() && nextType < types.size())
+        current = database.iterateType(types.get(nextType++).getName(), false);
+      return current.hasNext();
+    }
+
+    @Override
+    public Record next() {
+      if (!hasNext())
+        throw new NoSuchElementException();
+      return current.next();
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -31,8 +31,6 @@ import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
-import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.VertexType;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -177,25 +175,21 @@ public class PatternComprehensionExpression implements Expression {
   private void traverseUncorrelatedStart(final Result baseResult, final CommandContext context,
       final Result currentResult, final List<Object> resultList, final List<Object> pathElements,
       final NodePattern startNodePattern) {
-    final List<String> startLabels = startNodePattern.getLabels();
-    final Iterable<? extends Record> candidates;
-    if (startLabels != null && !startLabels.isEmpty()) {
-      // Use the first label as the iteration root; remaining labels are checked per vertex.
-      // Polymorphic iteration so subtypes (e.g. composite multi-label types) are visited.
-      final String typeName = startLabels.get(0);
-      if (!context.getDatabase().getSchema().existsType(typeName))
-        return;
-      candidates = () -> context.getDatabase().iterateType(typeName, true);
-    } else {
-      // No label constraint: iterate every vertex type registered in the schema.
-      candidates = collectAllVertices(context);
-    }
+    // The scan visits every vertex type the label constraint can be satisfied by, which for a disjunction
+    // (y:A|B) means the types of both alternatives. Taking the first label as the iteration root left the
+    // per-candidate filter below correct but never handed it a vertex carrying only a later alternative, and an
+    // alternative naming a type nobody created emptied the whole comprehension (issue #6352). The candidate types
+    // come from the rule the pattern anchor uses in MatchNodeStep, so a comprehension and the MATCH spelling of
+    // the same pattern cannot drift apart again.
+    final Iterator<Record> candidates = Labels.iterateMatchingVertices(context.getDatabase(),
+        startNodePattern.getLabels(), startNodePattern.isLabelDisjunction());
 
     // Row reused across every candidate vertex, for the same reason as the edge expansions below:
     // only the node variable changes per candidate, so the enclosing bindings are copied once.
     final ResultInternal whereEvalRow = inlineWhereRow(startNodePattern, currentResult);
 
-    for (final Record record : candidates) {
+    while (candidates.hasNext()) {
+      final Record record = candidates.next();
       if (!(record instanceof Vertex candidate))
         continue;
       if (!matchesStartPattern(candidate, startNodePattern, currentResult, whereEvalRow, context))
@@ -216,33 +210,15 @@ public class PatternComprehensionExpression implements Expression {
   }
 
   /**
-   * Returns true if a vertex matches the start node pattern's labels, inline properties and inline
-   * {@code WHERE} predicate.
+   * Returns true if a candidate vertex matches the start node pattern's inline properties and inline
+   * {@code WHERE} predicate. The labels are not re-checked here: the candidates come from the types the label
+   * constraint selects, so every one of them already carries the labels the pattern asks for (issue #6352).
    */
   private boolean matchesStartPattern(final Vertex vertex, final NodePattern startNodePattern, final Result bindings,
       final ResultInternal whereEvalRow, final CommandContext context) {
-    // A disjunction (n:A|B) accepts any of the labels, a conjunction (n:A:B) requires all - the same meaning the
-    // pattern has when it is written in a MATCH instead of inside a comprehension (issue #6338).
-    if (!Labels.matches(vertex, startNodePattern.getLabels(), startNodePattern.isLabelDisjunction()))
-      return false;
     if (!InlineProperties.matches(vertex, startNodePattern.getProperties(), bindings, context))
       return false;
     return matchesNodeWhereExpression(vertex, startNodePattern, whereEvalRow, context);
-  }
-
-  /**
-   * Collects an Iterable that walks all vertex-typed records in the database.
-   */
-  private static Iterable<Record> collectAllVertices(final CommandContext context) {
-    final List<Record> all = new ArrayList<>();
-    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-      if (!(type instanceof VertexType))
-        continue;
-      final Iterator<Record> it = context.getDatabase().iterateType(type.getName(), false);
-      while (it.hasNext())
-        all.add(it.next());
-    }
-    return all;
   }
 
   private void traverseVariableLength(final Result baseResult, final CommandContext context,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -98,6 +98,9 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
         buffer.clear();
         bufferIndex = 0;
 
+        // Disjunction by construction: the planner only picks this operator for (n:A|B). A one-element list
+        // would scan the same records either way - a single label is one polymorphic scan, and "any of one" and
+        // "all of one" are the same question - so the flag needs no guard tying it to labels.size() > 1.
         if (candidates == null)
           candidates = Labels.iterateMatchingVertices(context.getDatabase(), labels, true);
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -18,15 +18,13 @@
  */
 package com.arcadedb.query.opencypher.executor.operators;
 
-import com.arcadedb.database.Identifiable;
-import com.arcadedb.graph.Vertex;
+import com.arcadedb.database.Record;
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.executor.WorkGuard;
-import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.VertexType;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -46,11 +44,10 @@ import java.util.NoSuchElementException;
  * <ul>
  *   <li>No inline WHERE pushdown (unlike {@link NodeByLabelScan#whereFilter}). Filters are
  *       applied as a separate step; pushdown is a perf optimization tracked separately.</li>
- *   <li>Type iterators are constructed eagerly in {@link #buildMatchingIterators}. Each call
- *       to {@code iterateType} wraps the bucket iterators in a {@code MultiIterator} under
- *       a read lock — the wrapper is cheap and page reads stay lazy inside the bucket
- *       iterators, so eager construction has negligible cost for the typical small label
- *       sets seen in practice.</li>
+ *   <li>Which types to scan is decided by {@code Labels.iterateMatchingVertices}, shared with the
+ *       MATCH anchor and the start of a pattern comprehension so that one disjunction cannot mean
+ *       different things in different places (issues #6338, #6352). Each type's iterator is opened
+ *       only once the previous one is drained.</li>
  *   <li>{@code estimatedCardinality} is inherited from the anchor selector and reflects a
  *       single-label scan (the first label only). The true upper bound for a disjunction
  *       is the sum across all matching types; under-estimation here may bias join-order
@@ -75,8 +72,7 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
     // not enough (issue #6266).
     final WorkGuard guard = WorkGuard.forCommandDeadline(context);
     return new ResultSet() {
-      private Iterator<Identifiable> currentIterator = null;
-      private Iterator<Iterator<Identifiable>> typeIteratorCursor = null;
+      private Iterator<Record> candidates = null;
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
       private boolean finished = false;
@@ -102,32 +98,20 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
         buffer.clear();
         bufferIndex = 0;
 
-        if (typeIteratorCursor == null)
-          typeIteratorCursor = buildMatchingIterators(context).iterator();
+        if (candidates == null)
+          candidates = Labels.iterateMatchingVertices(context.getDatabase(), labels, true);
 
-        while (buffer.size() < n) {
+        while (buffer.size() < n && candidates.hasNext()) {
           guard.check();
-          if (currentIterator == null || !currentIterator.hasNext()) {
-            if (!typeIteratorCursor.hasNext()) {
-              finished = true;
-              return;
-            }
-            currentIterator = typeIteratorCursor.next();
-          }
-          while (buffer.size() < n && currentIterator.hasNext()) {
-            guard.check();
-            final Identifiable identifiable = currentIterator.next();
-            final Vertex vertex = identifiable.asVertex();
-            final ResultInternal result = new ResultInternal();
-            result.setProperty(variable, vertex);
-            buffer.add(result);
-          }
+          final Record record = candidates.next();
+          final ResultInternal result = new ResultInternal();
+          result.setProperty(variable, record.asVertex());
+          buffer.add(result);
         }
 
-        // Mark exhausted eagerly when both the current iterator and the type queue are drained,
-        // avoiding one redundant fetchMore round-trip when a query reads to the end (matching
-        // NodeByLabelScan's pattern).
-        if ((currentIterator == null || !currentIterator.hasNext()) && !typeIteratorCursor.hasNext())
+        // Mark exhausted eagerly when the scan is drained, avoiding one redundant fetchMore
+        // round-trip when a query reads to the end (matching NodeByLabelScan's pattern).
+        if (!candidates.hasNext())
           finished = true;
       }
 
@@ -136,30 +120,6 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
         // No resources to close
       }
     };
-  }
-
-  /**
-   * Builds one iterator per VertexType that is an instance of at least one disjunction label.
-   * The outer loop already enumerates every subtype in the schema, so {@code iterateType} is
-   * called with {@code polymorphic=false} — using {@code true} would duplicate records of
-   * subtypes that match through both the parent type and their own type entry.
-   */
-  private List<Iterator<Identifiable>> buildMatchingIterators(final CommandContext context) {
-    final List<Iterator<Identifiable>> iterators = new ArrayList<>();
-    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-      if (!(type instanceof VertexType))
-        continue;
-      for (final String label : labels) {
-        if (type.instanceOf(label)) {
-          @SuppressWarnings("unchecked")
-          final Iterator<Identifiable> iter =
-              (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(type.getName(), false);
-          iterators.add(iter);
-          break;
-        }
-      }
-    }
-    return iterators;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountUtils.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountUtils.java
@@ -169,9 +169,12 @@ public final class CSRCountUtils {
    * An unlabelled anchor is what {@code MATCH ()-[:TYPE]->() RETURN count(*)} has, and there is no cheaper question
    * to ask a graph. It used to leave every operator with no set to enumerate; "every vertex" is the set it means.
    * Both walks are the one in {@code Labels.iterateMatchingVertices}, which visits no vertex twice and which the
-   * MATCH anchor and the start of a pattern comprehension scan with as well (issue #6352).
+   * MATCH anchor and the start of a pattern comprehension scan with as well (issue #6352). Sharing it also means a
+   * label that names an edge or document type answers with no anchors rather than with records that are not
+   * vertices: labels and relationship types are separate namespaces, the rule the rest of the engine already
+   * applies.
    *
-   * @return an iterator over the anchor vertices, empty when the label is declared on nothing
+   * @return an iterator over the anchor vertices, empty when no vertex type carries the label
    */
   public static Iterator<? extends Identifiable> iterateAnchors(final Database db, final String label) {
     return Labels.iterateMatchingVertices(db, label != null ? List.of(label) : null, false);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountUtils.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CSRCountUtils.java
@@ -25,16 +25,12 @@ import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
-import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.VertexType;
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.utility.IntHashSet;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 /**
  * Shared static utilities for CSR count-push-down operators.
@@ -172,38 +168,13 @@ public final class CSRCountUtils {
    * <p>
    * An unlabelled anchor is what {@code MATCH ()-[:TYPE]->() RETURN count(*)} has, and there is no cheaper question
    * to ask a graph. It used to leave every operator with no set to enumerate; "every vertex" is the set it means.
-   * Subtypes are reached through the labelled iterator's own polymorphism and, in the unlabelled walk, by iterating
-   * each declared vertex type non-polymorphically, so no vertex is visited twice.
+   * Both walks are the one in {@code Labels.iterateMatchingVertices}, which visits no vertex twice and which the
+   * MATCH anchor and the start of a pattern comprehension scan with as well (issue #6352).
    *
    * @return an iterator over the anchor vertices, empty when the label is declared on nothing
    */
   public static Iterator<? extends Identifiable> iterateAnchors(final Database db, final String label) {
-    if (label != null)
-      return db.getSchema().existsType(label) ? db.iterateType(label, true) : Collections.emptyIterator();
-
-    final List<String> vertexTypes = new ArrayList<>();
-    for (final DocumentType type : db.getSchema().getTypes())
-      if (type instanceof VertexType)
-        vertexTypes.add(type.getName());
-
-    return new Iterator<Identifiable>() {
-      private int                              nextType = 0;
-      private Iterator<? extends Identifiable> current  = Collections.emptyIterator();
-
-      @Override
-      public boolean hasNext() {
-        while (!current.hasNext() && nextType < vertexTypes.size())
-          current = db.iterateType(vertexTypes.get(nextType++), false);
-        return current.hasNext();
-      }
-
-      @Override
-      public Identifiable next() {
-        if (!hasNext())
-          throw new NoSuchElementException();
-        return current.next();
-      }
-    };
+    return Labels.iterateMatchingVertices(db, label != null ? List.of(label) : null, false);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -476,86 +476,21 @@ public class MatchNodeStep extends AbstractExecutionStep {
         return Collections.emptyIterator();
       }
 
-      // Multiple labels - the iteration semantics depend on whether the labels are combined
-      // with OR (disjunction, e.g. (n:A|B)) or AND (conjunction, e.g. (n:A:B)).
-      final boolean disjunction = pattern.isLabelDisjunction();
-      final List<Iterator<Identifiable>> iterators = new ArrayList<>();
-      for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-        if (type instanceof VertexType) {
-          boolean matches;
-          if (disjunction) {
-            matches = false;
-            for (final String label : labels) {
-              if (type.instanceOf(label)) {
-                matches = true;
-                break;
-              }
-            }
-          } else {
-            matches = true;
-            for (final String label : labels) {
-              if (!type.instanceOf(label)) {
-                matches = false;
-                break;
-              }
-            }
-          }
-          if (matches) {
-            @SuppressWarnings("unchecked") final Iterator<Identifiable> iter =
-                (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(type.getName(), false);
-            iterators.add(iter);
-          }
-        }
-      }
-      return new ChainedIterator(iterators);
-    } else {
-      // No label specified - iterate ALL vertex types
-      // Get all vertex types from schema and chain their iterators
-      final List<Iterator<Identifiable>> iterators = new ArrayList<>();
-
-      for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-        // Only include vertex types (not edge types or document types)
-        if (type instanceof VertexType) {
-          @SuppressWarnings("unchecked") final Iterator<Identifiable> iter =
-              (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(type.getName(), false);
-          iterators.add(iter);
-        }
-      }
-
-      // Chain all iterators together
-      return new ChainedIterator(iterators);
-    }
-  }
-
-  /**
-   * Iterator that chains multiple iterators together.
-   */
-  private static class ChainedIterator implements Iterator<Identifiable> {
-    private final List<Iterator<Identifiable>> iterators;
-    private       int                          currentIndex = 0;
-
-    public ChainedIterator(final List<Iterator<Identifiable>> iterators) {
-      this.iterators = iterators;
+      // Multiple labels - the iteration semantics depend on whether the labels are combined with OR
+      // (disjunction, e.g. (n:A|B)) or AND (conjunction, e.g. (n:A:B)). Which types that selects is decided by
+      // Labels, the one place that knows what a disjunction means, so a node pattern is scanned the same way
+      // wherever it is written - here as the anchor of a MATCH, or as the start of a pattern comprehension,
+      // which used to take the first label and nothing else (issues #6338, #6352).
+      @SuppressWarnings("unchecked") final Iterator<Identifiable> labelled =
+          (Iterator<Identifiable>) (Object) Labels.iterateMatchingVertices(context.getDatabase(), labels,
+              pattern.isLabelDisjunction());
+      return labelled;
     }
 
-    @Override
-    public boolean hasNext() {
-      while (currentIndex < iterators.size()) {
-        if (iterators.get(currentIndex).hasNext()) {
-          return true;
-        }
-        currentIndex++;
-      }
-      return false;
-    }
-
-    @Override
-    public Identifiable next() {
-      if (!hasNext()) {
-        throw new NoSuchElementException();
-      }
-      return iterators.get(currentIndex).next();
-    }
+    // No label specified - iterate ALL vertex types, which is the same rule with nothing to satisfy.
+    @SuppressWarnings("unchecked") final Iterator<Identifiable> everyVertex =
+        (Iterator<Identifiable>) (Object) Labels.iterateMatchingVertices(context.getDatabase(), labels, false);
+    return everyVertex;
   }
 
   private Iterator<Identifiable> tryPartitionPrunedIterator(final DocumentType type, final String label) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.Record;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
@@ -49,7 +50,6 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.VertexType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1018,38 +1018,20 @@ public class MergeStep extends AbstractExecutionStep {
         ? evaluateProperties(nodePattern.getProperties(), result)
         : null;
 
-    if (!nodePattern.hasLabels()) {
-      for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
-        if (type instanceof VertexType) {
-          @SuppressWarnings("unchecked")
-          final Iterator<Identifiable> iter = (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(type.getName(), false);
-          while (iter.hasNext()) {
-            final Identifiable id = iter.next();
-            if (id instanceof Vertex vertex)
-              if (evaluatedProperties == null || matchesProperties(vertex, evaluatedProperties))
-                matches.add(vertex);
-          }
-        }
-      }
-      return matches;
-    }
+    final List<String> labels = nodePattern.hasLabels() ? nodePattern.getLabels() : null;
 
-    final List<String> labels = nodePattern.getLabels();
-
-    if (labels.size() > 1) {
-      final String firstLabel = labels.get(0);
-      if (!context.getDatabase().getSchema().existsType(firstLabel))
-        return matches;
-      @SuppressWarnings("unchecked")
-      final Iterator<Identifiable> iterator = (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(firstLabel, true);
-      while (iterator.hasNext()) {
-        final Identifiable identifiable = iterator.next();
-        if (identifiable instanceof Vertex vertex) {
-          final List<String> vertexLabels = Labels.getLabels(vertex);
-          if (vertexLabels.containsAll(labels))
-            if (evaluatedProperties == null || matchesProperties(vertex, evaluatedProperties))
-              matches.add(vertex);
-        }
+    if (labels == null || labels.size() > 1) {
+      // No label is every vertex; more than one is a conjunction, MERGE refusing a disjunction outright
+      // (issue #6338). Which types can carry every label is decided by Labels, the one place that knows what a
+      // label list means, instead of scanning the first label and comparing label lists per record: a type
+      // extending a composite carries its labels without listing them as its own supertypes (issue #6352).
+      final Iterator<Record> candidates = Labels.iterateMatchingVertices(context.getDatabase(), labels,
+          nodePattern.isLabelDisjunction());
+      while (candidates.hasNext()) {
+        final Record record = candidates.next();
+        if (record instanceof Vertex vertex)
+          if (evaluatedProperties == null || matchesProperties(vertex, evaluatedProperties))
+            matches.add(vertex);
       }
       return matches;
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1021,10 +1021,13 @@ public class MergeStep extends AbstractExecutionStep {
     final List<String> labels = nodePattern.hasLabels() ? nodePattern.getLabels() : null;
 
     if (labels == null || labels.size() > 1) {
-      // No label is every vertex; more than one is a conjunction, MERGE refusing a disjunction outright
-      // (issue #6338). Which types can carry every label is decided by Labels, the one place that knows what a
-      // label list means, instead of scanning the first label and comparing label lists per record: a type
-      // extending a composite carries its labels without listing them as its own supertypes (issue #6352).
+      // No label is every vertex; more than one is a conjunction. The disjunction flag is passed rather than
+      // hardcoded, but it can only arrive false here: CypherSemanticValidator.checkNoLabelDisjunction refuses
+      // (n:A|B) in MERGE at parse time, because "A or B" says which labels a node MAY have and a write has to
+      // know which type to create (issue #6338). Which types can carry every label is decided by Labels, the one
+      // place that knows what a label list means, instead of scanning the first label and comparing label lists
+      // per record: a type extending a composite carries its labels without listing them as its own supertypes,
+      // and MERGE missed such a node and created a duplicate beside the one MATCH found (issue #6352).
       final Iterator<Record> candidates = Labels.iterateMatchingVertices(context.getDatabase(), labels,
           nodePattern.isLabelDisjunction());
       while (candidates.hasNext()) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionStartLabelScanIssue6352Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionStartLabelScanIssue6352Test.java
@@ -146,6 +146,25 @@ class CypherComprehensionStartLabelScanIssue6352Test {
     assertThat(keys("MATCH (y {k:'sp1'}) RETURN y.k AS k")).containsExactly("sp1");
   }
 
+  @Test
+  void theOptimizerDisjunctionScanReturnsEveryAlternativeToo() {
+    // The MATCH spellings above are answered by whichever path the planner picks; this pins the cost-based one,
+    // whose NodeByLabelDisjunctionScan operator now shares the scan with everything else and lost its own copy
+    // of the walk in the process.
+    final String plan = explain("MATCH (y:Author|Topic) RETURN y.k AS k");
+    assertThat(plan).contains("NodeByLabelDisjunctionScan(y:Author|Topic)");
+
+    assertThat(keys("MATCH (y:Author|Topic) RETURN y.k AS k")).containsExactlyInAnyOrder("a1", "t1", "b1");
+    assertThat(keys("MATCH (y:NoSuchLabel|Topic) RETURN y.k AS k")).containsExactlyInAnyOrder("t1", "b1");
+    assertThat(keys("MATCH (y:NoSuchLabel|NorThisOne) RETURN y.k AS k")).isEmpty();
+  }
+
+  private String explain(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      return rs.getExecutionPlan().get().prettyPrint(0, 2);
+    }
+  }
+
   @SuppressWarnings("unchecked")
   private List<String> listKeys(final String query) {
     try (final ResultSet rs = database.query("opencypher", query)) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionStartLabelScanIssue6352Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionStartLabelScanIssue6352Test.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6352: the start node of a pattern comprehension that binds no outer variable picked its
+ * scan root by taking the first label and nothing else, so {@code [(y:Author|Topic)-->() | y.k]} only ever saw the
+ * {@code :Author} vertices, and an alternative naming a type nobody created emptied the whole comprehension.
+ * <p>
+ * Same failure mode as issue #6338, one code path over: the per-candidate filter honours the disjunction, but a vertex
+ * carrying only the second alternative was never handed to it because it was never scanned. The MATCH spelling of each
+ * query is asserted alongside the comprehension, since the two are the same question and must give the same answer -
+ * which is also what Neo4j does.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherComprehensionStartLabelScanIssue6352Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-comprehension-start-label-6352");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Author {k:'a1'})");
+      database.command("opencypher", "CREATE (:Topic {k:'t1'})");
+      database.command("opencypher", "CREATE (:Sink {k:'s1'})");
+      database.command("opencypher", "CREATE (:Author:Topic {k:'b1'})");
+      database.command("opencypher", "MATCH (a:Author {k:'a1'}), (s:Sink) CREATE (a)-[:E]->(s)");
+      database.command("opencypher", "MATCH (t:Topic {k:'t1'}), (s:Sink) CREATE (t)-[:E]->(s)");
+      database.command("opencypher", "MATCH (b {k:'b1'}), (s:Sink) CREATE (b)-[:E]->(s)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void anUncorrelatedStartScansEveryAlternativeOfADisjunction() {
+    // Only the :Author vertices used to be scanned, so 't1' was missing without any error or warning.
+    assertThat(listKeys("RETURN [(y:Author|Topic)-->() | y.k] AS l")).containsExactlyInAnyOrder("a1", "t1", "b1");
+    assertThat(keys("MATCH (y:Author|Topic)-->() RETURN y.k AS k")).containsExactlyInAnyOrder("a1", "t1", "b1");
+  }
+
+  @Test
+  void anAlternativeTheSchemaDoesNotHaveDoesNotEmptyTheComprehension() {
+    // The first alternative naming a type nobody created took an early return out of the whole comprehension.
+    assertThat(listKeys("RETURN [(y:NoSuchLabel|Topic)-->() | y.k] AS l")).containsExactlyInAnyOrder("t1", "b1");
+    assertThat(listKeys("RETURN [(y:Topic|NoSuchLabel)-->() | y.k] AS l")).containsExactlyInAnyOrder("t1", "b1");
+    assertThat(keys("MATCH (y:NoSuchLabel|Topic)-->() RETURN y.k AS k")).containsExactlyInAnyOrder("t1", "b1");
+  }
+
+  @Test
+  void aDisjunctionOfLabelsNoneOfWhichExistsMatchesNothing() {
+    assertThat(listKeys("RETURN [(y:NoSuchLabel|NorThisOne)-->() | y.k] AS l")).isEmpty();
+  }
+
+  @Test
+  void aConjunctionOnTheUncorrelatedStartStillRequiresEveryLabel() {
+    assertThat(listKeys("RETURN [(y:Author:Topic)-->() | y.k] AS l")).containsExactly("b1");
+    assertThat(keys("MATCH (y:Author:Topic)-->() RETURN y.k AS k")).containsExactly("b1");
+
+    // A conjunction with an alternative the schema does not have can match nothing, unlike a disjunction.
+    assertThat(listKeys("RETURN [(y:Author:NoSuchLabel)-->() | y.k] AS l")).isEmpty();
+  }
+
+  @Test
+  void aSingleLabelStartStillScansItsSubtypesOnly() {
+    // Polymorphic: the Author~Topic composite type is a subtype of both, so it answers to either single label.
+    assertThat(listKeys("RETURN [(y:Author)-->() | y.k] AS l")).containsExactlyInAnyOrder("a1", "b1");
+    assertThat(listKeys("RETURN [(y:Topic)-->() | y.k] AS l")).containsExactlyInAnyOrder("t1", "b1");
+    assertThat(listKeys("RETURN [(y:NoSuchLabel)-->() | y.k] AS l")).isEmpty();
+  }
+
+  @Test
+  void anUnlabelledStartStillScansEveryVertex() {
+    assertThat(listKeys("RETURN [(y)-->() | y.k] AS l")).containsExactlyInAnyOrder("a1", "t1", "b1");
+  }
+
+  @Test
+  void inlinePropertiesAndWhereStillNarrowADisjunctionStart() {
+    assertThat(listKeys("RETURN [(y:Author|Topic {k:'t1'})-->() | y.k] AS l")).containsExactly("t1");
+    assertThat(listKeys("RETURN [(y:Author|Topic WHERE y.k = 'a1')-->() | y.k] AS l")).containsExactly("a1");
+  }
+
+  @Test
+  void aDisjunctionStartWorksInsideACorrelatedComprehensionToo() {
+    // The comprehension is evaluated once per outer row: the start node is still uncorrelated, the target is not.
+    assertThat(listKeys("MATCH (s:Sink) RETURN [(y:Author|Topic)-->(s) | y.k] AS l"))
+        .containsExactlyInAnyOrder("a1", "t1", "b1");
+  }
+
+  @Test
+  void aTypeExtendingACompositeCarriesItsLabelsEverywhere() {
+    // The label constraint is answered by type inheritance, so a type extending the Author~Topic composite is an
+    // Author and a Topic even though neither is listed as its own supertype. MERGE used to compare label lists
+    // instead of asking the type, so it missed such a node and created a duplicate where MATCH found one.
+    database.command("sql", "CREATE VERTEX TYPE Special EXTENDS `Author~Topic`");
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Special SET k = 'sp1'");
+      database.command("opencypher", "MATCH (n {k:'sp1'}), (s:Sink) CREATE (n)-[:E]->(s)");
+    });
+
+    assertThat(keys("MATCH (y:Author:Topic) RETURN y.k AS k")).containsExactlyInAnyOrder("b1", "sp1");
+    assertThat(listKeys("RETURN [(y:Author:Topic)-->() | y.k] AS l")).containsExactlyInAnyOrder("b1", "sp1");
+    assertThat(listKeys("RETURN [(y:Author|Topic)-->() | y.k] AS l"))
+        .containsExactlyInAnyOrder("a1", "t1", "b1", "sp1");
+
+    database.transaction(() -> database.command("opencypher", "MERGE (n:Author:Topic {k:'sp1'})"));
+    assertThat(keys("MATCH (y {k:'sp1'}) RETURN y.k AS k")).containsExactly("sp1");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> listKeys(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return (List<String>) rs.next().getProperty("l");
+    }
+  }
+
+  private List<String> keys(final String query) {
+    final List<String> keys = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        keys.add(row.getProperty("k"));
+      }
+    }
+    return keys;
+  }
+}


### PR DESCRIPTION
Fixes #6352.

## The bug

`PatternComprehensionExpression.traverseUncorrelatedStart` picked the scan root for an **unbound** comprehension start node by taking `getLabels().get(0)`:

| query | before | now |
|---|---|---|
| `RETURN [(y:Author\|Topic)-->() \| y.k]` | `["a1"]` | `["a1","t1"]` |
| `RETURN [(y:NoSuchLabel\|Topic)-->() \| y.k]` | `[]` | `["t1"]` |
| `MATCH (y:Author\|Topic)-->() RETURN collect(y.k)` | `["a1","t1"]` | `["a1","t1"]` |

The per-candidate filter has gone through `Labels.matches` since #6348 and was already correct; a vertex carrying only a later alternative was never handed to it, because it was never scanned. The `existsType(labels.get(0))` early return is the second symptom: an alternative naming a type nobody created emptied the whole comprehension instead of matching nothing, the same shape #6338 fixed one code path over. Silent under-count, no error and no warning.

## The fix

Deciding a row and deciding what to scan have to say the same thing about a disjunction, so the scan side now sits next to the row side in `Labels`:

- `Labels.iterateMatchingVertices(database, labels, disjunction)` walks every vertex type the label constraint accepts, lazily (each type's iterator opens only when the previous one drains) and visiting no vertex twice. A single label keeps the one polymorphic scan it had, so nothing on that path pays for a schema walk.
- The comprehension, the MATCH anchor in `MatchNodeStep`, the `NodeByLabelDisjunctionScan` operator, `CSRCountUtils.iterateAnchors` and `MergeStep.findAllNodes` all route through it, replacing five spellings of one rule with one - which is how the copies #6338 had to reconcile came about in the first place. Net -78 lines.

Two things fall out of the shared path:

- the comprehension no longer re-checks labels per candidate (the scan is label-exact), and its unlabelled walk no longer materialises **every vertex in the database** into an `ArrayList` before iterating;
- MERGE gains the type-inheritance meaning of a conjunction. It compared label lists per record, so `MERGE (n:A:B)` missed a node whose type *extends* the `A~B` composite - `MATCH (n:A:B)` finds that node, and MERGE created a duplicate beside it. Covered by a test that fails on `main`.

## Tests

New `CypherComprehensionStartLabelScanIssue6352Test` (10 tests): both symptoms, both label orders, a disjunction where no alternative exists, the conjunction case (`(y:A:B)`, still requires every label, still empty when one alternative is missing), single-label and unlabelled starts, inline properties and inline `WHERE` on a disjunction start, a correlated comprehension, and the type-extending-a-composite case above. Every disjunction assertion is paired with the MATCH spelling of the same question, which is what Neo4j answers.

4 of the 10 fail on `main`.

Verification: `engine` unit lane green (12517 tests, 0 failures), openCypher TCK suite green (3897, 0 failures).