### PR TITLE
fix(#6353, #6354): a range beheaded or reversed is still a range, and arithmetic means one thing wherever the expression sits

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -843,10 +843,13 @@ public enum GlobalConfiguration {
   QUERY_MAX_RANGE_SIZE("arcadedb.queryMaxRangeSize", SCOPE.DATABASE, """
       Maximum number of elements a range() expression is allowed to produce. If exceeded, the query is rejected with a \
       client error before any element is generated. Negative number means no limit (the hard limit of 2147483647 elements, \
-      the maximum size of a Java list, still applies). The range itself is lazy and takes no heap, but its elements are \
-      materialised as soon as the range is copied, sorted or serialised in a response, so this setting caps the memory a \
-      single query can request that way. When left at the default it auto-scales with the JVM max heap (never below \
-      1000000 elements), keeping the worst-case materialisation of a range to a fraction of the heap.""",
+      the maximum size of a Java list, still applies). The range itself is lazy and takes no heap, and the operations \
+      whose answer is still an arithmetic progression keep it that way: slicing, tail(), reverse(), coll.sort(), \
+      coll.distinct(), coll.toSet(), coll.flatten() and cutting either end with coll.remove(). Its elements are \
+      materialised only when the answer cannot be a range - inserting into one, merging two of them, concatenating with \
+      +, or serialising the range in a response - so this setting caps the memory a single query can request that way. \
+      When left at the default it auto-scales with the JVM max heap (never below 1000000 elements), keeping the \
+      worst-case materialisation of a range to a fraction of the heap.""",
       Long.class, 10_000_000L, null, value -> {
         // Auto-scale the default with the JVM max heap. A materialised element costs ~24 bytes (boxed Long plus the
         // reference that holds it) and rendering it in a JSON response costs about as much again, so heap/160 keeps

--- a/engine/src/main/java/com/arcadedb/function/coll/CollDistinct.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollDistinct.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.coll;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -59,6 +60,9 @@ public class CollDistinct extends AbstractCollFunction {
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
+    if (args[0] instanceof LongRangeList range)
+      // The step of a range is never zero, so no element repeats: the distinct list IS the range (issue #6353).
+      return range;
     return new ArrayList<>(new LinkedHashSet<>(list));
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/coll/CollFlatten.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollFlatten.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.coll;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,6 +70,11 @@ public class CollFlatten extends AbstractCollFunction {
       else if (args[1] instanceof Boolean)
         maxDepth = (Boolean) args[1] ? 1 : -1;
     }
+
+    if (args[0] instanceof LongRangeList)
+      // A range holds longs and nothing else, so it is already flat at every depth - including depth 0, where the
+      // answer is the input. Copying it materialised a range that costs no heap while it stays lazy (issue #6353).
+      return list;
 
     if (maxDepth == 0)
       return new ArrayList<>(list);

--- a/engine/src/main/java/com/arcadedb/function/coll/CollRemove.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollRemove.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.coll;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,10 @@ import java.util.List;
 /**
  * coll.remove(list, index, [count]) - Returns a new list with element(s) removed starting at the given index.
  * If count is not provided, removes one element.
+ * <p>
+ * Removing a prefix or a suffix of a range leaves an arithmetic progression, so those two cases are answered in
+ * constant space rather than by copying a list that costs no heap while it stays lazy (issue #6353). Cutting out
+ * of the middle does not: the result is two progressions, which a Cypher LIST cannot be, so it is materialised.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -69,6 +74,14 @@ public class CollRemove extends AbstractCollFunction {
     if (args.length > 2 && args[2] == null)
       return null;
     final int count = args.length > 2 ? ((Number) args[2]).intValue() : 1;
+    if (args[0] instanceof LongRangeList range) {
+      // The loop below stops at the end of the list, so it removes min(count, size - index) elements.
+      final int removed = Math.min(Math.max(count, 0), range.size() - index);
+      if (index == 0)
+        return range.subList(removed, range.size());
+      if (index + removed >= range.size())
+        return range.subList(0, index);
+    }
     final List<Object> result = new ArrayList<>(list);
     for (int i = 0; i < count && index < result.size(); i++)
       result.remove(index);

--- a/engine/src/main/java/com/arcadedb/function/coll/CollSort.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollSort.java
@@ -21,12 +21,17 @@ package com.arcadedb.function.coll;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * coll.sort(list) - Returns a sorted copy of the list using Cypher comparison semantics.
+ * <p>
+ * Sorting a range needs no copy: an ascending arithmetic progression is already sorted and a descending one is its
+ * own reverse, both answered in constant space. Materialising it instead reinstated the heap exhaustion the lazy
+ * range removed (issue #6353, advisory GHSA-xmjm-8q85-g778).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -58,6 +63,8 @@ public class CollSort extends AbstractCollFunction {
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
+    if (args[0] instanceof LongRangeList range)
+      return range.getStep() > 0 ? range : range.reversed();
     final List<Object> result = new ArrayList<>(list);
     result.sort(CypherFunctionHelper::cypherCompare);
     return result;

--- a/engine/src/main/java/com/arcadedb/function/coll/CollToSet.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollToSet.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.coll;
 
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -59,6 +60,9 @@ public class CollToSet extends AbstractCollFunction {
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
+    if (args[0] instanceof LongRangeList range)
+      // The step of a range is never zero, so no element repeats: the set IS the range (issue #6353).
+      return range;
     return new ArrayList<>(new LinkedHashSet<>(list));
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/coll/TailFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/TailFunction.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.coll;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +32,10 @@ import java.util.List;
  * <p>
  * Signature: {@code tail(list :: LIST<ANY>) :: LIST<ANY>}. A non-list argument is a type error, not an
  * empty list (issue #5476); {@code null} propagates to {@code null} (issue #3920).
+ * <p>
+ * A range beheaded is still an arithmetic progression, so a {@link LongRangeList} argument is answered in
+ * constant space. Copying it instead reinstated the heap exhaustion the lazy range removed (issue #6353,
+ * advisory GHSA-xmjm-8q85-g778): {@code tail(range(0, 999999999))} allocated a billion boxed longs.
  */
 public class TailFunction implements StatelessFunction {
   @Override
@@ -54,6 +59,11 @@ public class TailFunction implements StatelessFunction {
     final List<Object> list = CypherFunctionHelper.requireListArgument(args[0], "tail");
     if (list == null)
       return null;
-    return list.size() <= 1 ? Collections.emptyList() : new ArrayList<>(list.subList(1, list.size()));
+    if (list.size() <= 1)
+      return Collections.emptyList();
+    if (args[0] instanceof LongRangeList range)
+      // LongRangeList.subList() returns a range, not a view that walks this one, so nothing is materialised.
+      return range.subList(1, range.size());
+    return new ArrayList<>(list.subList(1, list.size()));
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/misc/ReverseFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/misc/ReverseFunction.java
@@ -22,6 +22,7 @@ import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +30,11 @@ import java.util.List;
 
 /**
  * reverse() function - reverses a string or list.
+ * <p>
+ * A range read backwards is still an arithmetic progression, so a {@link LongRangeList} argument is answered in
+ * constant space by {@link LongRangeList#reversed()}. Copying it instead reinstated the heap exhaustion the lazy
+ * range removed (issue #6353, advisory GHSA-xmjm-8q85-g778): {@code reverse(range(0, 999999999))} allocated a
+ * billion boxed longs.
  */
 public class ReverseFunction implements StatelessFunction {
   @Override
@@ -55,6 +61,8 @@ public class ReverseFunction implements StatelessFunction {
       final String str = (String) args[0];
       return new StringBuilder(str).reverse().toString();
     }
+    if (args[0] instanceof LongRangeList range)
+      return range.reversed();
     // Accept List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284).
     final List<Object> list = MultiValue.getMultiValueAsList(args[0]);
     if (list != null) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ArithmeticExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ArithmeticExpression.java
@@ -94,9 +94,28 @@ public class ArithmeticExpression implements Expression {
 
   @Override
   public Object evaluate(final Result result, final CommandContext context) {
-    final Object leftValue = left.evaluate(result, context);
-    final Object rightValue = right.evaluate(result, context);
+    return apply(operator, left.evaluate(result, context), right.evaluate(result, context));
+  }
 
+  /**
+   * Applies an arithmetic operator to two already evaluated operands.
+   * <p>
+   * This is the single definition of what the Cypher arithmetic operators mean: null propagation, {@code ||}
+   * strict typing (issue #5298), list concatenation and append (issue #4284), string concatenation, temporal
+   * arithmetic and numeric promotion. Operand <i>evaluation</i> deliberately stays at each call site, because
+   * {@code ExpressionEvaluator} resolves sub-expressions through itself so that an inline aggregator sees the
+   * overrides {@code AggregationStep} / {@code GroupByAggregationStep} install (issue #4100) - and that two-line
+   * difference is the entire reason a second copy of this method existed there. The rest of it was duplicated
+   * verbatim, so every one of those semantics was a place where a fix could land on one path and not the other:
+   * exactly the arrangement that hid the list-slice heap exhaustion until issue #6323. See issue #6354.
+   *
+   * @param operator   the operator to apply
+   * @param leftValue  the already evaluated left operand
+   * @param rightValue the already evaluated right operand
+   *
+   * @return the result of the operation, or {@code null} when either operand is {@code null}
+   */
+  public static Object apply(final Operator operator, final Object leftValue, final Object rightValue) {
     // Handle null values
     if (leftValue == null || rightValue == null)
       return null;
@@ -132,18 +151,16 @@ public class ArithmeticExpression implements Expression {
     if (operator == Operator.ADD && (leftValue instanceof String || rightValue instanceof String))
       return leftValue.toString() + rightValue.toString();
 
-    // Temporal arithmetic: date/time ± duration, duration ± duration, duration * number
-    final Object temporalResult = evaluateTemporalArithmetic(leftValue, rightValue, operator);
-    if (temporalResult != null)
-      return temporalResult;
-
-    // Numeric operations
-    if (!(leftValue instanceof Number) || !(rightValue instanceof Number))
+    // Numeric operations. Temporal arithmetic - date/time ± duration, duration ± duration, duration * number -
+    // is tried first, but only when an operand is not a Number: no temporal type is a Number, so every temporal
+    // combination has at least one non-numeric operand and two numbers can never reach it.
+    if (!(leftValue instanceof Number leftNum) || !(rightValue instanceof Number rightNum)) {
+      final Object temporalResult = evaluateTemporalArithmetic(leftValue, rightValue, operator);
+      if (temporalResult != null)
+        return temporalResult;
       throw new IllegalArgumentException(
           "Arithmetic operations require numeric operands, got: " + leftValue.getClass().getSimpleName() + " and " + rightValue.getClass().getSimpleName());
-
-    final Number leftNum = (Number) leftValue;
-    final Number rightNum = (Number) rightValue;
+    }
 
     // Determine result type (preserve integer if possible)
     final boolean useInteger = isInteger(leftNum) && isInteger(rightNum) && operator != Operator.POWER;
@@ -330,7 +347,7 @@ public class ArithmeticExpression implements Expression {
     return null; // Not a temporal arithmetic operation
   }
 
-  private boolean isInteger(final Number num) {
+  private static boolean isInteger(final Number num) {
     return num instanceof Integer || num instanceof Long || num instanceof Short || num instanceof Byte;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/CaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/CaseExpression.java
@@ -77,21 +77,11 @@ public class CaseExpression implements Expression {
   }
 
   /**
-   * Functional interface used to evaluate a single sub-expression of the CASE.
-   * Lets callers plug in an override-aware evaluator (e.g. one that resolves pre-computed
-   * aggregation results) while sharing the branch-selection and equality semantics below.
-   */
-  @FunctionalInterface
-  public interface SubExpressionEvaluator {
-    Object evaluate(Expression expression);
-  }
-
-  /**
    * Evaluate the CASE, delegating every sub-expression evaluation to the supplied evaluator.
    * The branch-selection logic and Cypher '=' equality semantics live here so both the plain
    * {@link #evaluate(Result, CommandContext)} path and the aggregation-override path share them.
    */
-  public Object evaluateWith(final SubExpressionEvaluator subEvaluator) {
+  public Object evaluateWith(final SubEvaluator subEvaluator) {
     // Extended form: CASE expr WHEN value THEN result
     if (caseExpression != null) {
       final Object caseValue = subEvaluator.evaluate(caseExpression);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/Expression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/Expression.java
@@ -55,4 +55,19 @@ public interface Expression {
    * Get the string representation of this expression.
    */
   String getText();
+
+  /**
+   * How a composite expression evaluates one of its own sub-expressions.
+   * <p>
+   * An expression that is more than the sum of its operands - a CASE, a list or map literal, an arithmetic
+   * operation - has two callers: {@link #evaluate(Result, CommandContext)}, which resolves operands directly, and
+   * {@code ExpressionEvaluator}, which resolves them through itself so an inline aggregator sees the pre-computed
+   * overrides {@code AggregationStep} installs (issue #4100). Only the operand resolution differs, so it is
+   * passed in and everything else - the part that says what the expression MEANS - is written once. Writing it
+   * twice is what let a fix land on one path and not the other (issues #6323, #6354).
+   */
+  @FunctionalInterface
+  interface SubEvaluator {
+    Object evaluate(Expression expression);
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListExpression.java
@@ -39,10 +39,18 @@ public class ListExpression implements Expression {
 
   @Override
   public Object evaluate(final Result result, final CommandContext context) {
-    final List<Object> values = new ArrayList<>();
-    for (final Expression element : elements) {
-      values.add(element.evaluate(result, context));
-    }
+    return evaluateWith(element -> element.evaluate(result, context));
+  }
+
+  /**
+   * Build the list, delegating every element evaluation to the supplied evaluator. Shared with
+   * {@code ExpressionEvaluator}, which resolves the elements through itself so aggregation overrides apply
+   * (issue #6354).
+   */
+  public Object evaluateWith(final SubEvaluator subEvaluator) {
+    final List<Object> values = new ArrayList<>(elements.size());
+    for (final Expression element : elements)
+      values.add(subEvaluator.evaluate(element));
     return values;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/MapExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/MapExpression.java
@@ -43,17 +43,26 @@ public class MapExpression implements Expression {
 
   @Override
   public Object evaluate(final Result result, final CommandContext context) {
+    return evaluateWith(value -> OpenCypherQueryEngine.getExpressionEvaluator().evaluate(value, result, context));
+  }
+
+  /**
+   * Build the map, delegating every value evaluation to the supplied evaluator. Shared with
+   * {@code ExpressionEvaluator}, which resolves the values through itself so aggregation overrides apply: it used
+   * to carry its own copy of this loop, which skipped the single-entry fast path below and so answered the same
+   * expression with a different Map implementation depending on whether it sat under an aggregation (issue #6354).
+   */
+  public Object evaluateWith(final SubEvaluator subEvaluator) {
     // Fast path for single-entry maps (common for duration({seconds: value}))
     if (entries.size() == 1) {
       final Map.Entry<String, Expression> entry = entries.entrySet().iterator().next();
-      final Object value = OpenCypherQueryEngine.getExpressionEvaluator().evaluate(entry.getValue(), result, context);
-      return CollectionUtils.singletonMap(entry.getKey(), value);
+      return CollectionUtils.singletonMap(entry.getKey(), subEvaluator.evaluate(entry.getValue()));
     }
 
     // Standard path for multi-entry maps
     final Map<String, Object> map = new LinkedHashMap<>();
     for (final Map.Entry<String, Expression> entry : entries.entrySet())
-      map.put(entry.getKey(), OpenCypherQueryEngine.getExpressionEvaluator().evaluate(entry.getValue(), result, context));
+      map.put(entry.getKey(), subEvaluator.evaluate(entry.getValue()));
     return map;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
@@ -37,13 +37,10 @@ import com.arcadedb.query.opencypher.ast.MapExpression;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
 import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -165,97 +162,27 @@ public class ExpressionEvaluator {
     return function.execute(args, context);
   }
 
+  /**
+   * Evaluates an arithmetic expression, resolving both operands through this evaluator so that an inline
+   * aggregator sees the pre-computed overrides, then handing the values to the operator semantics that live on
+   * the AST node. This method used to carry a verbatim copy of those sixty-odd lines - null propagation, {@code ||}
+   * strict typing, list and string concatenation, temporal arithmetic, numeric promotion - so a fix could land on
+   * one path and not the other (issue #6354). Only the two operand evaluations below belong here.
+   */
   private Object evaluateArithmetic(final ArithmeticExpression expression, final Result result,
       final CommandContext context) {
-    final Object leftValue = evaluate(expression.getLeft(), result, context);
-    final Object rightValue = evaluate(expression.getRight(), result, context);
-
-    if (leftValue == null || rightValue == null)
-      return null;
-
-    // GQL / Cypher 25 concatenation operator || (strict typing, no implicit coercion, issue #5298).
-    if (expression.getOperator() == ArithmeticExpression.Operator.CONCAT)
-      return ArithmeticExpression.concatenate(leftValue, rightValue);
-
-    // List concatenation/append for + operator (must be checked before string concatenation).
-    // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
-    if (expression.getOperator() == ArithmeticExpression.Operator.ADD) {
-      final List<Object> leftList = MultiValue.getMultiValueAsList(leftValue);
-      final List<Object> rightList = MultiValue.getMultiValueAsList(rightValue);
-      if (leftList != null && rightList != null) {
-        final List<Object> combined = new ArrayList<>(leftList);
-        combined.addAll(rightList);
-        return combined;
-      }
-      if (leftList != null) {
-        final List<Object> appended = new ArrayList<>(leftList);
-        appended.add(rightValue);
-        return appended;
-      }
-      if (rightList != null) {
-        final List<Object> prepended = new ArrayList<>();
-        prepended.add(leftValue);
-        prepended.addAll(rightList);
-        return prepended;
-      }
-    }
-
-    // String concatenation for + operator
-    if (expression.getOperator() == ArithmeticExpression.Operator.ADD
-        && (leftValue instanceof String || rightValue instanceof String))
-      return leftValue.toString() + rightValue.toString();
-
-    // Temporal arithmetic with pre-evaluated values
-    if (!(leftValue instanceof Number) || !(rightValue instanceof Number)) {
-      final Object temporalResult = ArithmeticExpression.evaluateTemporalArithmetic(
-          leftValue, rightValue, expression.getOperator());
-      if (temporalResult != null)
-        return temporalResult;
-      throw new IllegalArgumentException(
-          "Arithmetic operations require numeric operands, got: " + leftValue.getClass().getSimpleName()
-              + " and " + rightValue.getClass().getSimpleName());
-    }
-
-    final Number leftNum = (Number) leftValue;
-    final Number rightNum = (Number) rightValue;
-
-    final boolean useInteger = isInteger(leftNum) && isInteger(rightNum)
-        && expression.getOperator() != ArithmeticExpression.Operator.POWER;
-
-    if (useInteger)
-      return ArithmeticExpression.integerArithmetic(expression.getOperator(), leftNum.longValue(), rightNum.longValue());
-
-    final double l = leftNum.doubleValue();
-    final double r = rightNum.doubleValue();
-    return switch (expression.getOperator()) {
-      case ADD -> l + r;
-      case SUBTRACT -> l - r;
-      case MULTIPLY -> l * r;
-      case DIVIDE -> l / r; // IEEE 754: 0.0/0.0=NaN, x/0.0=±Infinity
-      case MODULO -> r != 0 ? l % r : Double.NaN;
-      case POWER -> Math.pow(l, r);
-      case CONCAT -> throw new IllegalStateException("CONCAT is handled before numeric arithmetic");
-    };
-  }
-
-  private static boolean isInteger(final Number num) {
-    return num instanceof Integer || num instanceof Long || num instanceof Short || num instanceof Byte;
+    return ArithmeticExpression.apply(expression.getOperator(), evaluate(expression.getLeft(), result, context),
+        evaluate(expression.getRight(), result, context));
   }
 
   private Object evaluateList(final ListExpression expression, final Result result,
       final CommandContext context) {
-    final List<Object> values = new ArrayList<>();
-    for (final Expression element : expression.getElements())
-      values.add(evaluate(element, result, context));
-    return values;
+    return expression.evaluateWith(element -> evaluate(element, result, context));
   }
 
   private Object evaluateMap(final MapExpression expression, final Result result,
       final CommandContext context) {
-    final LinkedHashMap<String, Object> map = new LinkedHashMap<>();
-    for (final Map.Entry<String, Expression> entry : expression.getEntries().entrySet())
-      map.put(entry.getKey(), evaluate(entry.getValue(), result, context));
-    return map;
+    return expression.evaluateWith(value -> evaluate(value, result, context));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/ConstantFolder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/ConstantFolder.java
@@ -20,9 +20,6 @@ package com.arcadedb.query.opencypher.rewriter;
 
 import com.arcadedb.query.opencypher.ast.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Folds constant expressions into literal values at rewrite time.
  * Reduces runtime computation for expressions with all-constant operands.
@@ -105,64 +102,17 @@ public class ConstantFolder extends ExpressionRewriter {
   }
 
   /**
-   * Fold constant arithmetic operations.
+   * Fold a constant arithmetic operation.
+   * <p>
+   * The semantics are not decided here: they are the ones {@link ArithmeticExpression#apply} applies at execution
+   * time, and folding an expression must not change what it means. This method used to carry its own copy of them
+   * - null handling, list and string concatenation, numeric promotion, the double switch - which made three
+   * places where a fix could land on two of them (issue #6354). What belongs here is only the folder's contract:
+   * the caller keeps the expression unfolded when this returns {@code null} or throws, so an operation that fails
+   * fails at execution time, where the query text is available to report it against.
    */
   private Object foldArithmetic(final Object left, final Object right, final ArithmeticExpression.Operator op) {
-    // GQL / Cypher 25 concatenation operator || (strict typing, no implicit coercion, issue #5298).
-    // A type mismatch throws here and is swallowed by the caller, deferring the error to execution time.
-    if (op == ArithmeticExpression.Operator.CONCAT)
-      return ArithmeticExpression.concatenate(left, right);
-
-    // List concatenation/append (must be checked before string concatenation)
-    if (op == ArithmeticExpression.Operator.ADD) {
-      if (left instanceof List && right instanceof List) {
-        final List<Object> combined = new ArrayList<>((List<?>) left);
-        combined.addAll((List<?>) right);
-        return combined;
-      }
-      if (left instanceof List) {
-        final List<Object> appended = new ArrayList<>((List<?>) left);
-        appended.add(right);
-        return appended;
-      }
-      if (right instanceof List) {
-        final List<Object> prepended = new ArrayList<>();
-        prepended.add(left);
-        prepended.addAll((List<?>) right);
-        return prepended;
-      }
-    }
-
-    // String concatenation
-    if (op == ArithmeticExpression.Operator.ADD && (left instanceof String || right instanceof String))
-      return left.toString() + right.toString();
-
-    // Numeric operations
-    if (!(left instanceof Number) || !(right instanceof Number))
-      return null;
-
-    final Number leftNum = (Number) left;
-    final Number rightNum = (Number) right;
-
-    // Determine if we can use integers
-    final boolean useInteger = isInteger(leftNum) && isInteger(rightNum) && op != ArithmeticExpression.Operator.POWER;
-
-    if (useInteger)
-      return ArithmeticExpression.integerArithmetic(op, leftNum.longValue(), rightNum.longValue());
-
-    // Use double for division, power, and mixed types
-    final double l = leftNum.doubleValue();
-    final double r = rightNum.doubleValue();
-
-    return switch (op) {
-      case ADD -> l + r;
-      case SUBTRACT -> l - r;
-      case MULTIPLY -> l * r;
-      case DIVIDE -> l / r;
-      case MODULO -> r != 0 ? l % r : Double.NaN;
-      case POWER -> Math.pow(l, r);
-      case CONCAT -> throw new IllegalStateException("CONCAT is handled before numeric arithmetic");
-    };
+    return ArithmeticExpression.apply(op, left, right);
   }
 
   /**
@@ -221,9 +171,5 @@ public class ConstantFolder extends ExpressionRewriter {
       return !left.equals(right);
 
     return null;
-  }
-
-  private boolean isInteger(final Number num) {
-    return num instanceof Integer || num instanceof Long || num instanceof Short || num instanceof Byte;
   }
 }

--- a/engine/src/main/java/com/arcadedb/utility/LongRangeList.java
+++ b/engine/src/main/java/com/arcadedb/utility/LongRangeList.java
@@ -195,6 +195,9 @@ public class LongRangeList extends AbstractList<Long> implements RandomAccess {
       // Reversing nothing, or a single element, gives back the same sequence.
       return this;
     try {
+      // start + (size - 1) * step is the last element, which get(size - 1) already computes without overflowing:
+      // the constructor is only ever handed a size that LongRangeList.cardinality() counted for a range whose end
+      // is a long, so the last element is a long too.
       return new LongRangeList(start + (long) (size - 1) * step, Math.negateExact(step), size);
     } catch (final ArithmeticException e) {
       // Long.MIN_VALUE has no positive counterpart. Only a two-element range can carry that step - a third element

--- a/engine/src/main/java/com/arcadedb/utility/LongRangeList.java
+++ b/engine/src/main/java/com/arcadedb/utility/LongRangeList.java
@@ -21,6 +21,7 @@ package com.arcadedb.utility;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -175,6 +176,34 @@ public class LongRangeList extends AbstractList<Long> implements RandomAccess {
         return start + (next++) * step;
       }
     };
+  }
+
+  /**
+   * A range read backwards is still an arithmetic progression - {@code start + (size - 1) * step} walked with the
+   * opposite step - so it is answered in constant space instead of copying every element into an
+   * {@code ArrayList}. That copy is what {@code reverse()} used to pay (issue #6353): a range costs no heap while
+   * it stays lazy, and {@code arcadedb.queryMaxRangeSize} is documented as the cap on what a query may
+   * <i>materialise</i>, so a reversal that materialises turns a free range into gigabytes of boxed longs.
+   * <p>
+   * Overriding {@link List#reversed()} rather than adding a private helper means every caller that already speaks
+   * the {@code SequencedCollection} vocabulary gets the lazy answer for free. The returned range is independent of
+   * this one - both are immutable, so nothing observes the difference from the view {@code List} would return.
+   */
+  @Override
+  public List<Long> reversed() {
+    if (size <= 1)
+      // Reversing nothing, or a single element, gives back the same sequence.
+      return this;
+    try {
+      return new LongRangeList(start + (long) (size - 1) * step, Math.negateExact(step), size);
+    } catch (final ArithmeticException e) {
+      // Long.MIN_VALUE has no positive counterpart. Only a two-element range can carry that step - a third element
+      // would need 2 * |step| to fit in a long - so materialising the reversal here costs two boxed longs.
+      final List<Long> reversed = new ArrayList<>(size);
+      for (int i = size - 1; i >= 0; i--)
+        reversed.add(get(i));
+      return reversed;
+    }
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherArithmeticEvaluatorParityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherArithmeticEvaluatorParityTest.java
@@ -43,12 +43,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  * place where a fix could land on one path and not the other, which is exactly the arrangement that hid the
  * list-slice heap exhaustion until issue #6323.
  * <p>
- * Every expression below is therefore run twice: plainly, which takes the AST path, and beside an aggregate,
- * which takes the evaluator path. The two must answer identically - the same value, or the same failure. Failing
- * identically matters as much as succeeding: half the operand matrix these issues established is about which
- * error a bad operand produces.
+ * There is a third writing of the same semantics, in {@code ConstantFolder.foldArithmetic}, which answers an
+ * operation over two literals at parse time and replaces it with the result - so a fold that disagrees with
+ * execution silently rewrites the query into a different one. It now calls the same method, and is checked here
+ * as a third path.
  * <p>
- * {@link #theEvaluatorPathIsActuallyExercised()} is what keeps this from being a test of one code path run twice.
+ * Every expression below is therefore run three ways: as a WHERE predicate over UNWIND-bound operands, which the
+ * AST node evaluates; as a projection over the same operands, which {@code ExpressionEvaluator} evaluates; and as
+ * a WHERE predicate over the literals themselves, which the folder answers before execution begins. All three
+ * must agree - the same value, the same type, or the same failure. Failing identically matters as much as succeeding: half the operand
+ * matrix these issues established is about which error a bad operand produces.
+ * <p>
+ * {@link #theTwoPathsAreDistinct()} is what keeps this from being a test of one code path run three times.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -104,6 +110,7 @@ class CypherArithmeticEvaluatorParityTest {
   void bothPathsAnswerIdentically(final String testCase) {
     final String[] parts = testCase.split(" @@ ", 3);
     final String operation = "(lv " + parts[1] + " rv)";
+    final String literalOperation = "(" + parts[0] + " " + parts[1] + " " + parts[2] + ")";
     // Both operands are bound by UNWIND, so the only thing that differs between the two queries below is WHERE
     // against RETURN - and that is exactly what selects the path. A projection is evaluated by
     // ExpressionEvaluator; a WHERE predicate is evaluated by the AST node itself. See theTwoPathsAreDistinct().
@@ -111,27 +118,38 @@ class CypherArithmeticEvaluatorParityTest {
 
     final String viaEvaluator = outcome(unwind + "RETURN " + operation + " AS r");
     final String viaAst = outcome(unwind + "WITH lv, rv WHERE " + operation + " IS NOT NULL RETURN 1 AS r");
+    // The third evaluator of the same semantics: ConstantFolder answers an operation over two literals at parse
+    // time and replaces it with the result, so the query never evaluates it at all. A fold that disagrees with
+    // execution rewrites the query into a different one. It rewrites predicates, not projections, which is why
+    // the literal operation is hosted in a WHERE here and in the agreement query below.
+    final String viaFolder = outcome("UNWIND [1] AS x WITH x WHERE " + literalOperation + " IS NOT NULL RETURN 1 AS r");
 
     // Failing identically matters as much as succeeding: half the operand matrix these issues established is
     // about WHICH error a bad operand produces, and a bare ClassCastException on one path where the other says
-    // what is wrong with the query is precisely the drift issue #6344 found in the slice bounds.
-    if (viaEvaluator.startsWith("ERROR") || viaAst.startsWith("ERROR")) {
-      assertThat(viaAst).as("`%s` raises the same failure on both paths", testCase).isEqualTo(viaEvaluator);
+    // what is wrong with the query is precisely the drift issue #6344 found in the slice bounds. The folder is
+    // held to the same standard by its own contract: it keeps the expression unfolded when the operation fails,
+    // so the failure still arrives from execution, unchanged.
+    if (viaEvaluator.startsWith("ERROR") || viaAst.startsWith("ERROR") || viaFolder.startsWith("ERROR")) {
+      assertThat(viaAst).as("`%s` raises the same failure on the AST path", testCase).isEqualTo(viaEvaluator);
+      assertThat(viaFolder).as("`%s` raises the same failure when folded", testCase).isEqualTo(viaEvaluator);
       return;
     }
 
-    // Neither failed, so compare the values - in a single query, so nothing is marshalled through Java and lost
-    // on the way. viaEvaluator is a projection, the two repetitions inside WHERE are the AST node, and
-    // valueType() pins the type as well as the value: 3 and 3.0 are equal under Cypher '=' but must not be
-    // produced by one path where the other produces the integer.
+    // Nothing failed, so compare the values - in a single query, so nothing is marshalled through Java and lost
+    // on the way. `projected` is the evaluator, the repetitions inside WHERE are the AST node, `folded` is the
+    // constant folder, and valueType() pins the type as well as the value: 3 and 3.0 are equal under Cypher '='
+    // but must not be produced by one path where another produces the integer.
     final long agreements = count(unwind
         + "WITH lv, rv, " + operation + " AS projected "
         + "WHERE valueType(" + operation + ") = valueType(projected) "
-        // NaN is not equal to itself, so the two paths agreeing on it has to be said separately.
+        + "  AND valueType(" + literalOperation + ") = valueType(projected) "
+        // NaN is not equal to itself, so the paths agreeing on it has to be said separately.
         + "  AND ((" + operation + " IS NULL AND projected IS NULL) OR " + operation + " = projected"
         + "       OR (valueType(projected) = 'FLOAT NOT NULL' AND isNaN(" + operation + ") AND isNaN(projected))) "
+        + "  AND ((" + literalOperation + " IS NULL AND projected IS NULL) OR " + literalOperation + " = projected"
+        + "       OR (valueType(projected) = 'FLOAT NOT NULL' AND isNaN(" + literalOperation + ") AND isNaN(projected))) "
         + "RETURN 1 AS r");
-    assertThat(agreements).as("`%s` gives the same value and type on both paths", testCase).isEqualTo(1L);
+    assertThat(agreements).as("`%s` gives the same value and type on all three paths", testCase).isEqualTo(1L);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherArithmeticEvaluatorParityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherArithmeticEvaluatorParityTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.ast.ArithmeticExpression;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Drift guard for issue #6354: the operator semantics of Cypher arithmetic were written twice - once in
+ * {@code ArithmeticExpression.evaluate} and once, line for line, in
+ * {@code ExpressionEvaluator.evaluateArithmetic}. The second copy exists because the evaluator resolves operands
+ * through itself so an inline aggregator sees the pre-computed overrides {@code AggregationStep} /
+ * {@code GroupByAggregationStep} install (issue #4100); that difference is two lines, and the sixty-odd others -
+ * {@code ||} strict typing (#5298), list concatenation and append (#4284), string concatenation, temporal
+ * arithmetic, numeric promotion, overflow and division-by-zero reporting - were duplicated. Each of them was a
+ * place where a fix could land on one path and not the other, which is exactly the arrangement that hid the
+ * list-slice heap exhaustion until issue #6323.
+ * <p>
+ * Every expression below is therefore run twice: plainly, which takes the AST path, and beside an aggregate,
+ * which takes the evaluator path. The two must answer identically - the same value, or the same failure. Failing
+ * identically matters as much as succeeding: half the operand matrix these issues established is about which
+ * error a bad operand produces.
+ * <p>
+ * {@link #theEvaluatorPathIsActuallyExercised()} is what keeps this from being a test of one code path run twice.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherArithmeticEvaluatorParityTest {
+  private static Database database;
+
+  @BeforeAll
+  static void setup() {
+    database = new DatabaseFactory("./target/databases/cypherarithmeticparity").create();
+    database.transaction(() -> database.command("opencypher", "CREATE (:Sample {num: 7, txt: 'x'})"));
+  }
+
+  @AfterAll
+  static void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  /**
+   * The operand matrix, one case per line as {@code LEFT @@ OPERATOR @@ RIGHT}. It is split rather than written
+   * as one expression because the two paths are reached by two different query shapes, and the shape that reaches
+   * the evaluator has to wrap each operand in an aggregate.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+      // Numeric promotion and the integer/double split (issues #5163, #5164, #5602).
+      "1 @@ + @@ 2", "7 @@ - @@ 9", "6 @@ * @@ 7", "7 @@ / @@ 2", "7 @@ % @@ 3", "2 @@ ^ @@ 10",
+      "7.5 @@ / @@ 2", "7 @@ / @@ 2.0", "-3 @@ % @@ 2", "3 @@ % @@ -2", "0.0 @@ / @@ 0.0", "1.0 @@ / @@ 0.0",
+      "1 @@ / @@ 0", "1 @@ % @@ 0", "9223372036854775807 @@ + @@ 1", "-9223372036854775808 @@ / @@ -1",
+      "9223372036854775807 @@ * @@ 2", "2 @@ ^ @@ 0.5", "-1 @@ ^ @@ 0.5",
+      // Null propagation on either side.
+      "null @@ + @@ 1", "1 @@ + @@ null", "null @@ * @@ null", "null @@ || @@ 'a'", "'a' @@ || @@ null",
+      // String concatenation with + and its coercion, which || deliberately does not do (issue #5298).
+      "'a' @@ + @@ 'b'", "'a' @@ + @@ 1", "1 @@ + @@ 'a'", "'a' @@ + @@ true", "'a' @@ || @@ 'b'",
+      "'a' @@ || @@ 1", "1 @@ || @@ 2",
+      // List concatenation, append and prepend (issue #4284), and the || form that refuses to append.
+      "[1, 2] @@ + @@ [3]", "[1, 2] @@ + @@ 3", "1 @@ + @@ [2, 3]", "[1] @@ + @@ []", "[1, 2] @@ || @@ [3]",
+      "[1, 2] @@ || @@ 3", "['a'] @@ + @@ 'b'", "'b' @@ + @@ ['a']",
+      // A lazy range is a list here too: concatenating one must give the same answer on both paths.
+      "range(1, 3) @@ + @@ [4]", "[0] @@ + @@ range(1, 3)", "range(1, 3) @@ || @@ range(4, 5)",
+      // Temporal arithmetic.
+      "date('2020-01-31') @@ + @@ duration({months: 1})", "date('2020-03-31') @@ - @@ duration({months: 1})",
+      "duration({days: 1}) @@ + @@ duration({hours: 2})", "duration({days: 1}) @@ * @@ 3",
+      "3 @@ * @@ duration({days: 1})", "duration({days: 3}) @@ / @@ 2",
+      "localdatetime('2020-01-01T00:00:00') @@ + @@ duration({seconds: 90})",
+      "time('12:00:00Z') @@ + @@ duration({minutes: 30})", "datetime('2020-01-01T00:00:00Z') @@ - @@ duration({days: 1})",
+      // Operands that are not arithmetic at all, which must fail the same way on both paths.
+      "true @@ + @@ false", "true @@ * @@ 2", "date('2020-01-01') @@ * @@ 2", "{a: 1} @@ + @@ 1",
+      "duration({days: 1}) @@ ^ @@ 2",
+      // Nested arithmetic, so the recursion into sub-expressions is exercised on both paths too.
+      "1 + 2 * 3 @@ - @@ 4 / 2", "(1 + 2) @@ * @@ (3 - 1)", "'a' @@ + @@ (1 + 2)", "[1] @@ + @@ (2 + 3)"
+  })
+  void bothPathsAnswerIdentically(final String testCase) {
+    final String[] parts = testCase.split(" @@ ", 3);
+    final String operation = "(lv " + parts[1] + " rv)";
+    // Both operands are bound by UNWIND, so the only thing that differs between the two queries below is WHERE
+    // against RETURN - and that is exactly what selects the path. A projection is evaluated by
+    // ExpressionEvaluator; a WHERE predicate is evaluated by the AST node itself. See theTwoPathsAreDistinct().
+    final String unwind = "UNWIND [" + parts[0] + "] AS lv UNWIND [" + parts[2] + "] AS rv ";
+
+    final String viaEvaluator = outcome(unwind + "RETURN " + operation + " AS r");
+    final String viaAst = outcome(unwind + "WITH lv, rv WHERE " + operation + " IS NOT NULL RETURN 1 AS r");
+
+    // Failing identically matters as much as succeeding: half the operand matrix these issues established is
+    // about WHICH error a bad operand produces, and a bare ClassCastException on one path where the other says
+    // what is wrong with the query is precisely the drift issue #6344 found in the slice bounds.
+    if (viaEvaluator.startsWith("ERROR") || viaAst.startsWith("ERROR")) {
+      assertThat(viaAst).as("`%s` raises the same failure on both paths", testCase).isEqualTo(viaEvaluator);
+      return;
+    }
+
+    // Neither failed, so compare the values - in a single query, so nothing is marshalled through Java and lost
+    // on the way. viaEvaluator is a projection, the two repetitions inside WHERE are the AST node, and
+    // valueType() pins the type as well as the value: 3 and 3.0 are equal under Cypher '=' but must not be
+    // produced by one path where the other produces the integer.
+    final long agreements = count(unwind
+        + "WITH lv, rv, " + operation + " AS projected "
+        + "WHERE valueType(" + operation + ") = valueType(projected) "
+        // NaN is not equal to itself, so the two paths agreeing on it has to be said separately.
+        + "  AND ((" + operation + " IS NULL AND projected IS NULL) OR " + operation + " = projected"
+        + "       OR (valueType(projected) = 'FLOAT NOT NULL' AND isNaN(" + operation + ") AND isNaN(projected))) "
+        + "RETURN 1 AS r");
+    assertThat(agreements).as("`%s` gives the same value and type on both paths", testCase).isEqualTo(1L);
+  }
+
+  /**
+   * The premise of the test above: the two query shapes really are two code paths. A projection is handed to
+   * {@code ExpressionEvaluator}, a WHERE predicate is evaluated by the AST node - which is why the arithmetic
+   * semantics were written twice in the first place. Without this the matrix could be one path compared with
+   * itself and would prove nothing (the vacuous-test trap).
+   * <p>
+   * The evaluator path is pinned here by the shape that ONLY it can serve: an aggregate is pre-computed and
+   * handed to the evaluator as an override, so arithmetic that reads one cannot be answered by the AST node,
+   * which would re-evaluate the aggregate against a single representative row (issue #4100).
+   */
+  @Test
+  void theTwoPathsAreDistinct() {
+    assertThat(single("UNWIND [1, 2, 3] AS v RETURN sum(v) * 2 + 1 AS r")).isEqualTo(13L);
+    assertThat(single("UNWIND [1, 2, 3] AS v RETURN 'total=' + sum(v) AS r")).isEqualTo("total=6");
+    assertThat(single("UNWIND [1, 2, 3] AS v RETURN [0] + sum(v) AS r")).isEqualTo(List.of(0L, 6L));
+    assertThat(single("UNWIND ['a', 'b'] AS v RETURN collect(v) + ['c'] AS r")).isEqualTo(List.of("a", "b", "c"));
+    assertThat(single("UNWIND ['a', 'b'] AS v RETURN collect(v) || ['c'] AS r")).isEqualTo(List.of("a", "b", "c"));
+    // And the predicate shape answers from the operands of the row it filters, which is the AST path.
+    assertThat(count("UNWIND [1, 2, 3] AS v WITH v WHERE v * 2 > 4 RETURN v AS r")).isEqualTo(1L);
+  }
+
+  /** The shared entry point is callable with already-evaluated operands, which is the whole point of it. */
+  @Test
+  void theSharedEntryPointCarriesTheSemantics() {
+    assertThat(ArithmeticExpression.apply(ArithmeticExpression.Operator.ADD, 1, 2)).isEqualTo(3L);
+    assertThat(ArithmeticExpression.apply(ArithmeticExpression.Operator.ADD, null, 2)).isNull();
+    assertThat(ArithmeticExpression.apply(ArithmeticExpression.Operator.ADD, 2, null)).isNull();
+    assertThat(ArithmeticExpression.apply(ArithmeticExpression.Operator.ADD, "a", 1)).isEqualTo("a1");
+    assertThat(ArithmeticExpression.apply(ArithmeticExpression.Operator.ADD, List.of(1L), 2L)).isEqualTo(List.of(1L, 2L));
+    assertThat(ArithmeticExpression.apply(ArithmeticExpression.Operator.DIVIDE, 7, 2)).isEqualTo(3L);
+    assertThat(ArithmeticExpression.apply(ArithmeticExpression.Operator.POWER, 2, 3)).isEqualTo(8.0);
+  }
+
+  /**
+   * The outcome of a query as a comparable string: how many rows it produced, or the failure it raised, reduced
+   * to the root cause so that the different wrappings the two paths pick up on the way out do not hide whether
+   * they agree.
+   */
+  private String outcome(final String query) {
+    try {
+      return "ROWS " + count(query);
+    } catch (final Throwable e) {
+      Throwable root = e;
+      while (root.getCause() != null)
+        root = root.getCause();
+      return "ERROR " + root.getClass().getName() + ": " + root.getMessage();
+    }
+  }
+
+  private long count(final String query) {
+    long rows = 0;
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        rows++;
+      }
+    }
+    return rows;
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLazyRangeOperationsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLazyRangeOperationsTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.LongRangeList;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6353: {@code range()} is lazy since advisory GHSA-xmjm-8q85-g778, but several
+ * functions copied the range they were handed into an {@code ArrayList} before answering, which put the heap
+ * exhaustion straight back. {@code arcadedb.queryMaxRangeSize} is documented as the cap on what a query may
+ * <i>materialise</i>, so an operator may legitimately raise it - a range that stays lazy costs nothing at any
+ * length - and every one of those copies then turned a free range into tens of GB of boxed longs.
+ * <p>
+ * A range beheaded, reversed, sorted, de-duplicated, flattened, or cut at either end is still an arithmetic
+ * progression, so each of those has an exact answer in constant space. The proof that nothing is copied is the
+ * type of the result: only a {@link LongRangeList} can describe a billion elements without allocating them.
+ * The elapsed-time assertions are the second half of that proof - a copy cannot serve a billion-element range
+ * in the time allowed, whether it finishes or dies trying.
+ * <p>
+ * {@code coll.insert()} and {@code coll.union()} are deliberately absent: inserting into a progression, or
+ * merging two of them, does not give a progression back, so those copies are the answer rather than a defect.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherLazyRangeOperationsTest {
+  private static final String HUGE = "range(0, 999999999)";
+
+  private Database database;
+  private long     previousMaxRangeSize;
+
+  @BeforeEach
+  void setup() {
+    previousMaxRangeSize = GlobalConfiguration.QUERY_MAX_RANGE_SIZE.getValueAsLong();
+    database = new DatabaseFactory("./target/databases/cypherlazyrangeops").create();
+  }
+
+  @AfterEach
+  void teardown() {
+    GlobalConfiguration.QUERY_MAX_RANGE_SIZE.setValue(previousMaxRangeSize);
+    if (database != null)
+      database.drop();
+  }
+
+  /**
+   * The structural claim, and the one that cannot flake: each of these answers a range with a range. A copy
+   * would answer with an ArrayList, and would be as big as the input.
+   */
+  @Test
+  void everyExactAnswerStaysARange() {
+    assertThat(single("RETURN tail(range(1, 5)) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN reverse(range(1, 5)) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.sort(range(1, 5)) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.sort(range(5, 1, -1)) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.distinct(range(1, 5)) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.toSet(range(1, 5)) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.flatten(range(1, 5)) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.flatten(range(1, 5), 0) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.remove(range(1, 5), 0, 2) AS r")).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.remove(range(1, 5), 3, 2) AS r")).isInstanceOf(LongRangeList.class);
+  }
+
+  /**
+   * The answers themselves, checked against the same operation on a materialised list of the same content.
+   * Laziness that gets the answer wrong is worse than the copy it replaces.
+   */
+  @Test
+  void theLazyAnswerIsTheMaterialisedAnswer() {
+    assertThat(single("RETURN tail(range(3, 6)) AS r")).isEqualTo(List.of(4L, 5L, 6L));
+    assertThat(single("RETURN tail(range(3, 3)) AS r")).isEqualTo(List.of());
+    assertThat(single("RETURN tail(range(5, 1)) AS r")).isEqualTo(List.of());
+    assertThat(single("RETURN tail(range(10, 4, -3)) AS r")).isEqualTo(List.of(7L, 4L));
+
+    assertThat(single("RETURN reverse(range(1, 4)) AS r")).isEqualTo(List.of(4L, 3L, 2L, 1L));
+    assertThat(single("RETURN reverse(range(1, 1)) AS r")).isEqualTo(List.of(1L));
+    assertThat(single("RETURN reverse(range(5, 1)) AS r")).isEqualTo(List.of());
+    assertThat(single("RETURN reverse(range(0, 10, 3)) AS r")).isEqualTo(List.of(9L, 6L, 3L, 0L));
+    assertThat(single("RETURN reverse(range(10, 1, -3)) AS r")).isEqualTo(List.of(1L, 4L, 7L, 10L));
+    assertThat(single("RETURN reverse(reverse(range(0, 10, 3))) AS r")).isEqualTo(List.of(0L, 3L, 6L, 9L));
+
+    assertThat(single("RETURN coll.sort(range(1, 4)) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L));
+    assertThat(single("RETURN coll.sort(range(10, 1, -3)) AS r")).isEqualTo(List.of(1L, 4L, 7L, 10L));
+    assertThat(single("RETURN coll.sort(range(5, 1)) AS r")).isEqualTo(List.of());
+
+    assertThat(single("RETURN coll.distinct(range(1, 4)) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L));
+    assertThat(single("RETURN coll.toSet(range(1, 4)) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L));
+    assertThat(single("RETURN coll.flatten(range(1, 4)) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L));
+    assertThat(single("RETURN coll.flatten(range(1, 4), 3) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L));
+    assertThat(single("RETURN coll.flatten(range(1, 4), 0) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L));
+    assertThat(single("RETURN coll.flatten(range(1, 4), null) AS r")).isNull();
+
+    // Prefix and suffix stay ranges, the middle cut does not - but all three must answer the same as the copy.
+    assertThat(single("RETURN coll.remove(range(1, 5), 0) AS r")).isEqualTo(List.of(2L, 3L, 4L, 5L));
+    assertThat(single("RETURN coll.remove(range(1, 5), 0, 2) AS r")).isEqualTo(List.of(3L, 4L, 5L));
+    assertThat(single("RETURN coll.remove(range(1, 5), 4) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L));
+    assertThat(single("RETURN coll.remove(range(1, 5), 3, 7) AS r")).isEqualTo(List.of(1L, 2L, 3L));
+    assertThat(single("RETURN coll.remove(range(1, 5), 1, 2) AS r")).isEqualTo(List.of(1L, 4L, 5L));
+    assertThat(single("RETURN coll.remove(range(1, 5), 0, 0) AS r")).isEqualTo(List.of(1L, 2L, 3L, 4L, 5L));
+    assertThat(single("RETURN coll.remove(range(1, 5), 0, 5) AS r")).isEqualTo(List.of());
+  }
+
+  /**
+   * The reported cost. With the limit disabled a billion-element range is legal and free while it stays lazy;
+   * a copy of it is ~24 GB of boxed longs, so none of these can be answered by one - the bound IS the claim,
+   * and loosening it deletes the test. The {@code @Timeout} stays as a hang detector.
+   */
+  @Test
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  void aHugeRangeIsNeverCopied() {
+    database.getConfiguration().setValue(GlobalConfiguration.QUERY_MAX_RANGE_SIZE, -1L);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThat(single("RETURN size(tail(" + HUGE + ")) AS r")).isEqualTo(999_999_999L);
+    assertThat(single("RETURN head(tail(" + HUGE + ")) AS r")).isEqualTo(1L);
+    assertThat(single("RETURN head(reverse(" + HUGE + ")) AS r")).isEqualTo(999_999_999L);
+    assertThat(single("RETURN last(reverse(" + HUGE + ")) AS r")).isEqualTo(0L);
+    assertThat(single("RETURN head(coll.sort(" + HUGE + ")) AS r")).isEqualTo(0L);
+    assertThat(single("RETURN head(coll.sort(range(999999999, 0, -1))) AS r")).isEqualTo(0L);
+    assertThat(single("RETURN size(coll.distinct(" + HUGE + ")) AS r")).isEqualTo(1_000_000_000L);
+    assertThat(single("RETURN size(coll.toSet(" + HUGE + ")) AS r")).isEqualTo(1_000_000_000L);
+    assertThat(single("RETURN size(coll.flatten(" + HUGE + ")) AS r")).isEqualTo(1_000_000_000L);
+    assertThat(single("RETURN size(coll.remove(" + HUGE + ", 0, 10)) AS r")).isEqualTo(999_999_990L);
+    assertThat(single("RETURN size(coll.remove(" + HUGE + ", 999999990, 10)) AS r")).isEqualTo(999_999_990L);
+    // Not a copy but a walk: coll.indexOf() indexes the range, which LongRangeList answers by division.
+    assertThat(single("RETURN coll.indexOf(" + HUGE + ", 999999998) AS r")).isEqualTo(999_999_998L);
+    stopwatch.assertStayedUnder(5_000L, "twelve exact answers over a lazy range, none of them a billion-element copy");
+  }
+
+  /** A range carried through a variable or nested inside another lazy answer is still a range. */
+  @Test
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  void lazinessSurvivesComposition() {
+    database.getConfiguration().setValue(GlobalConfiguration.QUERY_MAX_RANGE_SIZE, -1L);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThat(single("WITH " + HUGE + " AS l RETURN size(tail(reverse(l))) AS r")).isEqualTo(999_999_999L);
+    assertThat(single("RETURN head(coll.sort(reverse(tail(" + HUGE + ")))) AS r")).isEqualTo(1L);
+    assertThat(single("RETURN size(tail(" + HUGE + ")[0..999999998]) AS r")).isEqualTo(999_999_998L);
+    stopwatch.assertStayedUnder(5_000L, "composing exact answers keeps the range lazy instead of copying it once per step");
+  }
+
+  /** Nothing above changes what these functions do to anything that is not a range. */
+  @Test
+  void nonRangeArgumentsAreUnaffected() {
+    assertThat(single("RETURN reverse('abc') AS r")).isEqualTo("cba");
+    assertThat(single("RETURN reverse([1, 'a', true]) AS r")).isEqualTo(List.of(true, "a", 1L));
+    assertThat(single("RETURN reverse(null) AS r")).isNull();
+    assertThat(single("RETURN tail([1, 2, 3]) AS r")).isEqualTo(List.of(2L, 3L));
+    assertThat(single("RETURN tail(null) AS r")).isNull();
+    assertThat(single("RETURN coll.sort([3, 1, 2]) AS r")).isEqualTo(List.of(1L, 2L, 3L));
+    assertThat(single("RETURN coll.distinct([1, 1, 2]) AS r")).isEqualTo(List.of(1L, 2L));
+    assertThat(single("RETURN coll.flatten([[1, 2], [3]]) AS r")).isEqualTo(List.of(1L, 2L, 3L));
+    assertThat(single("RETURN coll.remove([1, 2, 3], 0) AS r")).isEqualTo(List.of(2L, 3L));
+    assertThat(single("RETURN coll.remove([1, 2, 3], 1, 2) AS r")).isEqualTo(List.of(1L));
+    // A collected list is a plain ArrayList even when it was born as a range.
+    assertThat(single("UNWIND range(1, 3) AS i WITH collect(i) AS l RETURN reverse(l) AS r")).isEqualTo(List.of(3L, 2L, 1L));
+  }
+
+  /** The result of a lazy answer must persist and render like any other list. */
+  @Test
+  void aLazyAnswerCanBeStoredAsAProperty() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Holder {values: reverse(range(1, 4))})"));
+    assertThat(single("MATCH (n:Holder) RETURN n.values AS r")).isEqualTo(List.of(4L, 3L, 2L, 1L));
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/utility/LongRangeListTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/LongRangeListTest.java
@@ -155,6 +155,36 @@ class LongRangeListTest {
     assertThat(new LongRangeList(0L, 1L, 5).subList(2, 2)).isEmpty();
   }
 
+  /**
+   * A range read backwards is still an arithmetic progression, so it must come back as one: copying it is what
+   * put the heap exhaustion back into {@code reverse()} (issue #6353).
+   */
+  @Test
+  void reversedIsStillALazyRange() {
+    assertThat(new LongRangeList(0L, 1L, 5).reversed()).isInstanceOf(LongRangeList.class)
+        .containsExactly(4L, 3L, 2L, 1L, 0L);
+    assertThat(new LongRangeList(0L, 3L, 4).reversed()).isInstanceOf(LongRangeList.class)
+        .containsExactly(9L, 6L, 3L, 0L);
+    assertThat(new LongRangeList(10L, -3L, 4).reversed()).isInstanceOf(LongRangeList.class)
+        .containsExactly(1L, 4L, 7L, 10L);
+    // Reversing twice is the identity, and the empty and single-element cases are their own reverse.
+    assertThat(new LongRangeList(10L, -3L, 4).reversed().reversed()).containsExactly(10L, 7L, 4L, 1L);
+    assertThat(new LongRangeList(0L, 1L, 0).reversed()).isInstanceOf(LongRangeList.class).isEmpty();
+    assertThat(new LongRangeList(7L, 2L, 1).reversed()).isInstanceOf(LongRangeList.class).containsExactly(7L);
+  }
+
+  /**
+   * {@code Long.MIN_VALUE} has no positive counterpart, so the reversed step is not representable. Only a
+   * two-element range can carry that step - a third element would need {@code 2 * |step|} to fit in a long - so
+   * the answer is materialised rather than wrapped around into a wrong range.
+   */
+  @Test
+  void reversedFallsBackWhenTheStepCannotBeNegated() {
+    final LongRangeList list = new LongRangeList(Long.MAX_VALUE, Long.MIN_VALUE, 2);
+    assertThat(list).containsExactly(Long.MAX_VALUE, -1L);
+    assertThat(list.reversed()).containsExactly(-1L, Long.MAX_VALUE);
+  }
+
   @Test
   void equalsAndHashCodeFollowTheListContract() {
     assertThat(new LongRangeList(0L, 1L, 3)).isEqualTo(List.of(0L, 1L, 2L));


### PR DESCRIPTION
Closes #6353, closes #6354.

## #6353 - the copies that put the heap exhaustion back

`range()` is lazy since GHSA-xmjm-8q85-g778, but several functions copied the range they were handed into an `ArrayList` before answering. `arcadedb.queryMaxRangeSize` is documented as the cap on what a query may *materialise*, so an operator may legitimately raise it - a lazy range costs nothing at any length - and each of those copies then turned a free range into tens of GB of boxed longs.

A range beheaded, reversed, sorted, de-duplicated, flattened, or cut at either end is still an arithmetic progression, so each one now has an exact answer in constant space:

| function | answer |
|---|---|
| `tail(range)` | `range.subList(1, size)` - already a range |
| `reverse(range)` | new `LongRangeList.reversed()`: `start + (size-1)*step` walked with `-step` |
| `coll.sort(range)` | ascending is already sorted, descending is its reverse |
| `coll.distinct(range)`, `coll.toSet(range)` | the step is never zero, so nothing repeats: the range itself |
| `coll.flatten(range, d)` | a range holds longs and nothing else, so it is flat at every depth |
| `coll.remove(range, i, n)` | prefix and suffix cuts are `subList`; the middle cut is not |

`coll.insert()`, `coll.union()`/`coll.unionAll()`, `coll.pairsMin()` and the middle cut of `coll.remove()` keep their copy: inserting into a progression, merging two of them, or cutting one in half does not give a progression back, so there the copy is the answer rather than a defect. `head()`, `last()`, `size()`, indexing, `coll.indexOf()` and the `coll.*` reductions were checked and already cost nothing.

### On the alternative the issue offered

The issue suggested bounding the remaining copies by `arcadedb.queryMaxRangeSize` and failing as a client error. That guard would be inert: `range()` already refuses to *construct* a range longer than the limit, so a copy of an allowed range is bounded by construction, and when the limit is disabled the guard does not apply either. It would never fire, while rejecting legitimately large lists that were never ranges. Answering exactly where the answer is exact - and leaving a disabled limit as the explicit opt-out it is documented to be - is the stronger half of the proposal, so that is what this does.

## #6354 - the second copy of the arithmetic semantics

`ExpressionEvaluator.evaluateArithmetic` was a line-for-line copy of `ArithmeticExpression.evaluate`. The copy exists because the evaluator resolves operands through itself so an inline aggregator sees the overrides `AggregationStep` / `GroupByAggregationStep` install (#4100). That difference is two lines; the other sixty-odd - null propagation, `||` strict typing (#5298), list concatenation and append (#4284), string concatenation, temporal arithmetic, numeric promotion, overflow and division-by-zero reporting - were duplicated verbatim, each of them a place where a fix could land on one path and not the other. That is the arrangement that hid the slice bug until #6323.

Operand evaluation stays at each call site; the operator semantics move to `ArithmeticExpression.apply(operator, leftValue, rightValue)`, which both call - mirroring what #6344 did with `ListSliceExpression.slice`.

There was a third writing of the same semantics in `ConstantFolder.foldArithmetic`, which answers an operation over two literals at parse time and replaces it with the result - so a fold that disagrees with execution rewrites the query into a different one. It now calls `apply()` too, keeping only the folder's own contract: the caller leaves the expression unfolded when this returns `null` or throws, so a failing operation still fails at execution time where the query text is available to report it against. `apply()` throws where the old copy returned `null` for a non-numeric operand, which the call site already treats identically. One intended side effect: the folder now coerces through `MultiValue.getMultiValueAsList` rather than a raw `instanceof List`, so `+` over an array operand folds where it previously did not - unreachable in practice, since a literal cannot be an array, but a real widening of the method's domain.

### The rest of the inventory

The other `evaluateX` methods were read with the same question:

- `evaluateList` / `evaluateMap` had the same shape and now share `Expression.SubEvaluator` with `CASE` (whose own nested interface it replaces). This also fixes a real divergence: the evaluator's copy skipped the single-entry fast path, so `{a: sum(x)}` answered with a different `Map` implementation depending on whether it sat under an aggregation.
- `evaluateFunction` is not a duplicate. It resolves through the function factory with a per-node cache, applies aggregation overrides and propagates the LOAD CSV row context; the function semantics live in the `StatelessFunction`, not here.
- `evaluateVariable` and `evaluateComparison` route operands and hold no semantics of their own (`evaluateComparison` already delegates to `ComparisonExpression.evaluateWithValues`).

## Tests

`CypherLazyRangeOperationsTest` (new) pins three things: the structural claim that each answer is still a `LongRangeList` (a copy would be an `ArrayList` as big as the input), the values against the materialised answers, and the cost of eleven exact answers over `range(0, 999999999)` with the limit disabled.

`CypherArithmeticEvaluatorParityTest` (new) is the drift guard. A 60-case operand matrix - numeric promotion, overflow, `/` and `%` by zero, NaN, null propagation, `+` and `||` over strings and lists, ranges, temporal arithmetic, non-arithmetic operands - is run down all three paths: a WHERE predicate over bound operands takes the AST node, a projection over the same operands takes the evaluator, and a WHERE predicate over the literals themselves is answered by the folder before execution begins. Each case asserts the same value, the same type (via `valueType()`) and the same failure reduced to its root cause. Injecting a difference turns 24-25 cases red on the AST or evaluator path and 9 on the folder path (the literal-operand ones it can fold), and `theTwoPathsAreDistinct()` pins the premise so the matrix cannot silently become one path compared with itself.

Which query shape reaches which path was measured, not assumed, by injecting a throw into each: projections go to `ExpressionEvaluator`, WHERE predicates to the AST node, and the folder rewrites predicates only. The first draft of the folder arm hosted the literal expression in a `RETURN` and was therefore vacuous - it passed with drift injected.

`LongRangeListTest` gains `reversed()`, including the `Long.MIN_VALUE` step that has no positive counterpart and falls back to materialising the (at most two-element) result.

Run: 4760 opencypher tests, 3897 openCypher TCK scenarios, 1543 `com.arcadedb.function` / `com.arcadedb.utility` tests - all green.

Related: #6323, #6344, #4100, #5298, #4284, advisory GHSA-xmjm-8q85-g778.
