### PR TITLE
fix(#6359): a propagated index joins the transaction that wrote the records, a negative literal is a number, and two modules that cannot share a Maven invocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,14 @@ Standard Maven and npm invocations apply. The non-obvious ones, each of which si
 green or spuriously red* run rather than an error that tells you what you did wrong:
 
 - **Run unit tests**: `mvn verify` (use `verify`/`install`, not bare `mvn test`, for a full reactor run: the `arcadedb-gremlin-it` module consumes `arcadedb-gremlin`'s package-phase artifacts (the `shaded` uber-jar and `tests` test-jar), which a `test`-phase build never produces)
+- **Any reactor invocation containing `gremlin` AND a module that consumes its `shaded` jar needs `verify`, not
+  `test`**. That is the same trap as above, and `graphql` is the second module in it: `mvn -o test -pl gremlin,graphql`
+  fails `GraphQLGremlinDirectivesTest` while `mvn -o verify -pl gremlin,graphql` and `mvn -o test -pl graphql` alone are
+  both green. Maven substitutes the reactor module for the `shaded`-classified dependency, the `test` phase never runs
+  the shade plugin, and the plain `target/classes` that stands in for it carries no TinkerPop (the dependency declares
+  a wildcard exclusion so the uber-jar is self-contained). The failure now says so - "the Apache TinkerPop libraries
+  are not on the classpath" - but the surefire summary still shows only "Error on initializing Gremlin query engine",
+  which points at the engine rather than at the build (#6359)
 - **Testing a subset of modules needs `-am`**: `mvn -o -pl server -am test`, not `mvn -o -pl server test`. Without
   `-am` the module is the whole reactor, so it resolves `arcadedb-engine` and friends from `~/.m2` instead of from
   your working tree, and can run against an artifact that predates your edits. If you added or renamed a method this

--- a/docs/6359-rebuild-setting-validation.md
+++ b/docs/6359-rebuild-setting-validation.md
@@ -1,0 +1,45 @@
+# #6359: a REBUILD `WITH` setting is evaluated and validated, where it used to be rendered and coerced
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/6359
+
+## What changed
+
+`REBUILD INDEX` and `REBUILD TYPE` read their `WITH` settings by EVALUATING the setting's expression and
+handing the value to one of two shared readers on `DDLStatement`. Both previously read the expression a
+different way, and both let bad input through silently.
+
+**Numeric settings** (`batchSize`, `maxAttempts`) go through `parsePositiveIntSetting`. It refuses anything
+that is not a whole number of at least one, naming the statement, the setting and the value.
+
+**Boolean settings** (`statsOnly`, `repartition`) go through `parseBooleanSetting`, which accepts a `Boolean`
+or the strings `true` / `false` and refuses everything else with a `CommandSQLParsingException`.
+
+## What that means for a statement that used to work
+
+Three shapes behave differently, and all three used to be accepted:
+
+| statement | before | now |
+|---|---|---|
+| `REBUILD TYPE V WITH batchSize = 1000` | refused, `"got: null"` | runs with a batch size of 1000 |
+| `REBUILD INDEX i WITH batchSize = -1` | `NumberFormatException: For input string: "0 - 1"` | refused, naming `batchSize` and `-1` |
+| `REBUILD INDEX i WITH statsOnly = yes` | silently read as `false`, so the statement did a FULL rebuild | refused, naming `statsOnly` and `yes` |
+
+The first is a plain fix: `REBUILD TYPE`'s numeric setting read `Expression.value`, which is null for every
+numeric literal the parser builds, so it refused every value it was given, legal ones included.
+
+The last is the user-visible one. `Boolean.parseBoolean` answers `false` for anything it does not recognise,
+so a typo in a boolean setting did not fail - it silently selected the OTHER behaviour. For `statsOnly` that
+is the difference between recomputing index statistics and rebuilding the whole index. A statement carrying
+such a typo now reports it instead of quietly doing the more expensive, and different, thing.
+
+## Bound parameters
+
+Evaluating rather than rendering is also what makes a bound parameter work:
+
+```sql
+REBUILD INDEX `V[id]` WITH batchSize = :size
+```
+
+Rendering an expression answers with the placeholder text, which no amount of parsing turns into an integer.
+Evaluation resolves literals and parameters alike, which is how `parseBooleanSetting`'s callers had always
+read their values.

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3312,3 +3312,41 @@ mid-write openable, and there is nothing before it to renumber.
 
 [#6342](https://github.com/ArcadeData/arcadedb/issues/6342)
 [#6341](https://github.com/ArcadeData/arcadedb/issues/6341)
+
+## A `REBUILD` setting is evaluated and validated, so a typo stops selecting the other behaviour (#6359)
+
+`REBUILD INDEX` and `REBUILD TYPE` read their `WITH` settings by evaluating the setting's expression and
+handing the value to one of two shared readers on `DDLStatement`. Both previously read the expression a
+different way, and both let bad input through without saying so.
+
+The user-visible change is the boolean one. `Boolean.parseBoolean` answers `false` for anything it does not
+recognise, so `REBUILD INDEX i WITH statsOnly = yes` did not fail - it silently selected the OTHER behaviour,
+which for `statsOnly` is the difference between recomputing index statistics and rebuilding the entire index.
+Boolean settings now go through `parseBooleanSetting`, which accepts a boolean or `true`/`false` and refuses
+everything else by name. A statement carrying such a typo reports it rather than quietly doing the more
+expensive and different thing.
+
+Two numeric fixes come with it. `REBUILD TYPE ... WITH batchSize` read `Expression.value`, which is null for
+every numeric literal the parser builds, so it refused every value it was given, legal ones included, with
+`got: null`. And `WITH batchSize = -1` reached `Integer.parseInt` as the string `"0 - 1"`, because a unary
+minus was modelled as a subtraction from zero - a raw `NumberFormatException` naming neither the setting nor
+the problem. Numeric settings now go through `parsePositiveIntSetting`, which names the statement, the setting
+and the value, and a negative literal is now the number the user typed (see below).
+
+Evaluating rather than rendering is also what makes `WITH batchSize = :size` resolve a bound parameter:
+rendering an expression answers with the placeholder text, which no amount of parsing turns into an integer.
+
+## A negative literal is a number, and the parentheses a statement was written with survive (#6359)
+
+The SQL parser modelled a unary minus as a subtraction from zero, so the AST for `-1` was `0 - 1` and that is
+what `Expression.toString()` produced. That rendering is not cosmetic: it is what `EXPLAIN` prints, what an
+unaliased projection is named after, and what a statement re-reading one of its own settings parses. The minus
+is now folded into the literal, keeping the exact numeric type the arithmetic used to produce.
+
+Measuring that turned up the same defect for the parentheses a statement was written with, which the renderer
+dropped: `(1 + 2) * 3` rendered as `1 + 2 * 3`, which reads back as 7 rather than 9, and `2 * -1` rendered as
+`2 * 0 - 1`, which reads back as -1 rather than -2. Parentheses are now printed where dropping them could
+change the meaning - around a compound arithmetic operand - and not where they are decoration, so
+`SELECT (name) FROM V` keeps the column name it has always had.
+
+[#6359](https://github.com/ArcadeData/arcadedb/issues/6359)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -178,6 +178,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // getMostRecentFileName(). Every node names the index after the file it holds, so the leader has to
   // follow its own rename or its schema stops matching the followers that rebuilt it from that file.
   private volatile String              indexName;
+  /** The wrapper this bucket sub-index is registered under - see {@link #getTypeIndex()}. */
+  private          TypeIndex           typeIndex;
   protected     LSMVectorIndexMutable  mutable;
   private final ReentrantReadWriteLock lock;
   LSMVectorIndexMetadata metadata; // Package-private for Phase 2 access from ArcadePageVectorValues and
@@ -5340,12 +5342,23 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   @Override
   public void setTypeIndex(final TypeIndex typeIndex) {
-    // Not applicable for this index type
+    this.typeIndex = typeIndex;
   }
 
+  /**
+   * The wrapper this bucket sub-index belongs to, like every other index family answers - {@link
+   * com.arcadedb.index.sparsevector.LSMSparseVectorIndex} included. It used to answer null ("not applicable for this
+   * index type"), which was never true: a vector index IS registered under a {@link TypeIndex}, and the null made two
+   * callers do the wrong thing (issue #6359).
+   * <p>
+   * {@code LocalSchema.dropIndexInternal} skips {@code parentTypeIndex.removeIndexOnBucket(...)} when this is null, so
+   * a dropped vector sub-index stayed listed by its wrapper - a reference to an index that no longer exists, on every
+   * path that drops one. And {@code LocalDocumentType.addSuperType} compares it to decide whether a super type's
+   * index is already propagated to a bucket, so it never recognised one and minted a duplicate on every attempt.
+   */
   @Override
   public TypeIndex getTypeIndex() {
-    return null;
+    return typeIndex;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -2890,6 +2890,15 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       // Unary plus: just return the expression as-is
       return innerExpr;
     } else if (ctx.MINUS() != null) {
+      // A minus applied to a plain numeric literal is folded INTO the literal, so `-1` is the number -1 and not the
+      // subtraction `0 - 1` (issue #6359, item 2). Modelling it as a subtraction is what Expression.toString() then
+      // rendered, and that rendering is read back as text by callers - REBUILD INDEX ... WITH batchSize = -1 reached
+      // Integer.parseInt as the string "0 - 1" - as well as being what EXPLAIN prints and what a projection without
+      // an alias is named after. It is also one evaluation cheaper on every read.
+      final BaseExpression negatedLiteral = tryNegateNumericLiteral(innerExpr);
+      if (negatedLiteral != null)
+        return negatedLiteral;
+
       // Unary minus: create 0 - expression
       // Create a MathExpression with zero and the MINUS operator
       final MathExpression result = new MathExpression();
@@ -2911,6 +2920,48 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     }
 
     throw new CommandSQLParsingException("Unknown unary operator");
+  }
+
+  /**
+   * Folds a unary minus into the numeric literal it applies to, returning the negative literal, or {@code null} when
+   * the operand is anything else - in which case {@link #visitUnary} keeps modelling the negation as {@code 0 - X}.
+   * <p>
+   * Negates the ALREADY-PARSED value rather than re-parsing a {@code "-"}-prefixed text, so the folded literal keeps
+   * exactly the numeric type {@code 0 - X} used to produce ({@code -2147483648} stays a {@code Long}, an
+   * {@code L}-suffixed literal stays a {@code Long}, a bare decimal stays a {@code Float}) and the sign lands
+   * correctly on every literal shape the visitors accept, not only on plain decimal.
+   * <p>
+   * A literal carrying a MODIFIER is left alone: a suffix binds tighter than the sign, so {@code -1.toString()} is
+   * {@code -(1.toString())} and folding it would move the negation inside the call.
+   */
+  private static BaseExpression tryNegateNumericLiteral(final MathExpression expression) {
+    if (!(expression instanceof final BaseExpression base) || base.number == null || base.modifier != null)
+      return null;
+
+    final Number value = base.number.getValue();
+    final Number negated;
+    if (value instanceof final Integer i)
+      negated = -i;
+    else if (value instanceof final Long l)
+      negated = -l;
+    else if (value instanceof final Float f)
+      negated = -f;
+    else if (value instanceof final Double d)
+      negated = -d;
+    else
+      // A magnitude the visitors could not represent as one of the four above has no folded form that is certainly
+      // equivalent, so leave it to the arithmetic.
+      return null;
+
+    final BaseExpression result = new BaseExpression();
+    if (base.number instanceof PInteger)
+      result.number = new PInteger().setValue(negated);
+    else {
+      final PNumber number = new PNumber();
+      number.value = negated;
+      result.number = number;
+    }
+    return result;
   }
 
   /**
@@ -3840,6 +3891,9 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Regular parenthesized expression
     final BaseExpression baseExpr = new BaseExpression();
     baseExpr.expression = (Expression) visit(ctx.expression());
+    // Remember that the parentheses were WRITTEN, so the rendering can put them back - see
+    // BaseExpression#parenthesized. Without it `(1 + 2) * 3` renders as `1 + 2 * 3` (issue #6359, item 2).
+    baseExpr.parenthesized = true;
 
     // Process modifiers if present
     if (CollectionUtils.isNotEmpty(ctx.modifier())) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -44,6 +44,20 @@ public class BaseExpression extends MathExpression {
   public String         string;
   public Modifier       modifier;
   public boolean        isNull = false;
+  /**
+   * True when this node came from a literal {@code ( ... )} in the statement text. {@link #expression} alone cannot
+   * say: the ANTLR builder also parks map literals, array literals and CASE expressions there, and none of those is a
+   * parenthesised block.
+   * <p>
+   * Rendering only - the parentheses are already reflected in the tree SHAPE, so evaluation never consults this. What
+   * it buys is a rendering that means what the statement meant: {@code (1 + 2) * 3} used to render as
+   * {@code 1 + 2 * 3}, which is 7 rather than 9 when read back, and {@code Expression.toString()} is what EXPLAIN
+   * prints, what an unaliased projection is named after, and what a statement that re-reads one of its own settings
+   * parses (issue #6359, item 2).
+   *
+   * @see #rendersParentheses()
+   */
+  public boolean        parenthesized = false;
 
   public BaseExpression() {
   }
@@ -101,15 +115,34 @@ public class BaseExpression extends MathExpression {
       number.toString(params, builder);
     else if (identifier != null)
       identifier.toString(params, builder);
-    else if (expression != null)
+    else if (expression != null) {
+      final boolean parentheses = rendersParentheses();
+      if (parentheses)
+        builder.append('(');
       expression.toString(params, builder);
-    else if (string != null)
+      if (parentheses)
+        builder.append(')');
+    } else if (string != null)
       builder.append(string);
     else if (inputParam != null)
       inputParam.toString(params, builder);
 
     if (modifier != null)
       modifier.toString(params, builder);
+  }
+
+  /**
+   * Whether the written parentheses have to be rendered back, which is only where dropping them could change what the
+   * text means: around a COMPOUND arithmetic expression, whose operators would otherwise be re-associated by the
+   * surrounding precedence - {@code (1 + 2) * 3} flattened to {@code 1 + 2 * 3} is 7 rather than 9.
+   * <p>
+   * Parentheses around anything that already renders as one atom - an identifier, a literal, a function call, a map or
+   * array literal, a CASE block - carry no meaning, and printing them would change the name every unaliased projection
+   * written that way has always had ({@code SELECT (name) FROM V} is a column called {@code name}).
+   */
+  private boolean rendersParentheses() {
+    return parenthesized && expression != null && expression.mathExpression != null
+        && !expression.mathExpression.operators.isEmpty();
   }
 
   public Object execute(final Identifiable currentRecord, final CommandContext context) {
@@ -444,6 +477,8 @@ public class BaseExpression extends MathExpression {
         }
       }
 
+      result.parenthesized = parenthesized;
+
       if (this.modifier != null)
         result.modifier = this.modifier.copy();
 
@@ -469,6 +504,7 @@ public class BaseExpression extends MathExpression {
     result.number = number == null ? null : number.copy();
     result.identifier = identifier == null ? null : identifier.copy();
     result.expression = expression == null ? null : expression.copy();
+    result.parenthesized = parenthesized;
     result.inputParam = inputParam == null ? null : inputParam.copy();
     result.string = string;
     result.setModifier(modifier == null ? null : modifier.copy());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
@@ -95,36 +95,45 @@ public abstract class DDLStatement extends Statement {
   }
 
   /**
-   * Parses a {@code WITH} clause setting that has to be a whole number of at least one, reporting BOTH ways it can
+   * Parses a {@code WITH} clause setting that has to be a whole number of at least one, reporting EVERY way it can
    * fail as a parsing error that names the statement, the setting and the value.
    * <p>
-   * Reads the setting by RENDERING its expression: {@link SimpleNode#value} is null for every numeric literal the
-   * parser builds, so a statement reading it directly refuses every value it is given, including the legal ones - that
-   * is what {@code REBUILD TYPE ... WITH batchSize = 1000} did, failing with "got: null" (issue #6359, item 2).
+   * Takes the EVALUATED value, exactly like {@link #parseBooleanSetting}, so callers pass
+   * {@code expression.execute((Result) null, context)}. Reading the expression any other way does not work: the
+   * {@link SimpleNode#value} field is null for every numeric literal the parser builds, so a statement consulting it
+   * refuses every value it is given including the legal ones - that is what {@code REBUILD TYPE ... WITH batchSize =
+   * 1000} did, failing with "got: null" - and RENDERING the expression instead answers with the placeholder text for
+   * a bound parameter, so {@code WITH batchSize = :size} could never resolve to the number the caller bound. Only
+   * evaluation covers literals and parameters alike (issue #6359, item 2).
    * <p>
    * A value below one is refused rather than coerced: it is not a smaller batch, it is a request that cannot be
    * honoured, and each caller would read it differently - a scan-based index build as "never chunk", a rebuild loop
-   * whose commit cadence is {@code count % batchSize} as a modulo by zero.
+   * whose commit cadence is {@code count % batchSize} as a modulo by zero. A fractional or out-of-int-range number is
+   * refused for the same reason: truncating one would honour a request nobody made.
    * <p>
    * Shares {@link #parseBooleanSetting}'s reasoning: one place for the rules so a statement added later picks them up
    * rather than re-deriving them, and so a raw {@link NumberFormatException} - which names neither the setting nor the
    * problem - cannot escape from any of them.
+   *
+   * @param raw the evaluated value of the setting expression
    */
   protected static int parsePositiveIntSetting(final String statementContext, final String settingName,
-      final Expression value) {
-    final String text = value == null ? null : value.toString().trim();
-
+      final Object raw) {
     Integer parsed = null;
-    if (text != null)
+    if (raw instanceof final Number number) {
+      final double exact = number.doubleValue();
+      if (exact == Math.rint(exact) && exact >= 1 && exact <= Integer.MAX_VALUE)
+        parsed = (int) exact;
+    } else if (raw != null)
       try {
-        parsed = Integer.valueOf(text);
+        parsed = Integer.valueOf(raw.toString().trim());
       } catch (final NumberFormatException notANumber) {
-        // Reported below together with the out-of-range case, so both refusals read the same and both name the value.
+        // Reported below together with every other refusal, so they all read the same and all name the value.
       }
 
     if (parsed == null || parsed < 1)
       throw new CommandSQLParsingException(
-          statementContext + " setting '" + settingName + "' must be a whole number of at least 1, got: " + text);
+          statementContext + " setting '" + settingName + "' must be a whole number of at least 1, got: " + raw);
 
     return parsed;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
@@ -119,22 +119,26 @@ public abstract class DDLStatement extends Statement {
    */
   protected static int parsePositiveIntSetting(final String statementContext, final String settingName,
       final Object raw) {
-    Integer parsed = null;
-    if (raw instanceof final Number number) {
-      final double exact = number.doubleValue();
-      if (exact == Math.rint(exact) && exact >= 1 && exact <= Integer.MAX_VALUE)
-        parsed = (int) exact;
-    } else if (raw != null)
+    Double exact = null;
+    if (raw instanceof final Number number)
+      exact = number.doubleValue();
+    else if (raw != null)
       try {
-        parsed = Integer.valueOf(raw.toString().trim());
+        // Read as a double rather than as an int, so the same value written as TEXT is read the same way: the branch
+        // above already accepts a Double of 5.0, and refusing the string "5.0" while accepting "5" would be an
+        // accident of which branch the value happened to arrive on.
+        exact = Double.valueOf(raw.toString().trim());
       } catch (final NumberFormatException notANumber) {
         // Reported below together with every other refusal, so they all read the same and all name the value.
       }
 
-    if (parsed == null || parsed < 1)
+    // One test for every way this can be wrong - absent, not a number, fractional, out of int range, below one -
+    // because they are one answer: this is not a value the setting can take. Truncating a fractional one would
+    // honour a request nobody made, and NaN fails the whole-number test as surely as 1.5 does.
+    if (exact == null || exact != Math.rint(exact) || exact < 1 || exact > Integer.MAX_VALUE)
       throw new CommandSQLParsingException(
           statementContext + " setting '" + settingName + "' must be a whole number of at least 1, got: " + raw);
 
-    return parsed;
+    return exact.intValue();
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/DDLStatement.java
@@ -93,4 +93,39 @@ public abstract class DDLStatement extends Statement {
     throw new CommandSQLParsingException(
         statementContext + " setting '" + settingName + "' must be true or false, got: " + raw);
   }
+
+  /**
+   * Parses a {@code WITH} clause setting that has to be a whole number of at least one, reporting BOTH ways it can
+   * fail as a parsing error that names the statement, the setting and the value.
+   * <p>
+   * Reads the setting by RENDERING its expression: {@link SimpleNode#value} is null for every numeric literal the
+   * parser builds, so a statement reading it directly refuses every value it is given, including the legal ones - that
+   * is what {@code REBUILD TYPE ... WITH batchSize = 1000} did, failing with "got: null" (issue #6359, item 2).
+   * <p>
+   * A value below one is refused rather than coerced: it is not a smaller batch, it is a request that cannot be
+   * honoured, and each caller would read it differently - a scan-based index build as "never chunk", a rebuild loop
+   * whose commit cadence is {@code count % batchSize} as a modulo by zero.
+   * <p>
+   * Shares {@link #parseBooleanSetting}'s reasoning: one place for the rules so a statement added later picks them up
+   * rather than re-deriving them, and so a raw {@link NumberFormatException} - which names neither the setting nor the
+   * problem - cannot escape from any of them.
+   */
+  protected static int parsePositiveIntSetting(final String statementContext, final String settingName,
+      final Expression value) {
+    final String text = value == null ? null : value.toString().trim();
+
+    Integer parsed = null;
+    if (text != null)
+      try {
+        parsed = Integer.valueOf(text);
+      } catch (final NumberFormatException notANumber) {
+        // Reported below together with the out-of-range case, so both refusals read the same and both name the value.
+      }
+
+    if (parsed == null || parsed < 1)
+      throw new CommandSQLParsingException(
+          statementContext + " setting '" + settingName + "' must be a whole number of at least 1, got: " + text);
+
+    return parsed;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -39,6 +39,7 @@ import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.InternalResultSet;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
@@ -88,12 +89,15 @@ public class RebuildIndexStatement extends DDLStatement {
     boolean statsOnly = false;
     if (!settings.isEmpty()) {
       for (Map.Entry<Expression, Expression> entry : settings.entrySet()) {
+        // Evaluated, not rendered: that is what resolves a bound parameter as well as a literal - see
+        // DDLStatement#parsePositiveIntSetting.
+        final Object settingValue = entry.getValue().execute((Result) null, context);
         if ("batchSize".equalsIgnoreCase(entry.getKey().toString()))
-          batchSize = parsePositiveIntSetting("REBUILD INDEX", "batchSize", entry.getValue());
+          batchSize = parsePositiveIntSetting("REBUILD INDEX", "batchSize", settingValue);
         else if ("maxAttempts".equalsIgnoreCase(entry.getKey().toString()))
-          maxAttempts = parsePositiveIntSetting("REBUILD INDEX", "maxAttempts", entry.getValue());
+          maxAttempts = parsePositiveIntSetting("REBUILD INDEX", "maxAttempts", settingValue);
         else if ("statsOnly".equalsIgnoreCase(entry.getKey().toString()))
-          statsOnly = Boolean.parseBoolean(entry.getValue().toString());
+          statsOnly = parseBooleanSetting("REBUILD INDEX", "statsOnly", settingValue);
         else
           throw new CommandSQLParsingException("Unrecognized setting '" + entry.getKey() + "' in rebuild index statement");
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -71,30 +71,6 @@ public class RebuildIndexStatement extends DDLStatement {
   public RebuildIndexStatement() {
   }
 
-  /**
-   * Reads a setting that has to be a whole number of at least one, reporting BOTH ways it can fail as a parsing error
-   * that names the setting.
-   * <p>
-   * A bare {@code Integer.parseInt} let a {@code NumberFormatException} out carrying the raw rendering of the
-   * expression - {@code WITH batchSize = -1} renders as {@code "0 - 1"} - which names neither the setting nor the
-   * problem. And a value below one is refused rather than coerced: it is not a smaller batch, it is a request that
-   * cannot be honoured, and each index family would read it differently - the scan-based builds as "never chunk", a
-   * vector rebuild not at all, since it chunks by bytes rather than by record count (issue #6324, item 1).
-   */
-  private static int parsePositiveSetting(final String name, final String value) {
-    final int parsed;
-    try {
-      parsed = Integer.parseInt(value.trim());
-    } catch (final NumberFormatException e) {
-      throw new CommandSQLParsingException(
-          "Invalid " + name + " '" + value + "' in rebuild index statement: it must be a whole number of at least 1");
-    }
-    if (parsed < 1)
-      throw new CommandSQLParsingException(
-          "Invalid " + name + " " + parsed + " in rebuild index statement: it must be at least 1");
-    return parsed;
-  }
-
   @Override
   public ResultSet executeDDL(final CommandContext context) {
     // Index (re)build is a schema-maintenance operation, gated by UPDATE_SCHEMA like DROP INDEX. The full-rebuild path
@@ -112,15 +88,12 @@ public class RebuildIndexStatement extends DDLStatement {
     boolean statsOnly = false;
     if (!settings.isEmpty()) {
       for (Map.Entry<Expression, Expression> entry : settings.entrySet()) {
-        // Render the setting value via Expression.toString(): its `value` field can be null depending on how the literal was
-        // parsed (it was for the integer in `WITH batchSize = 1000`), so toString() is the reliable accessor for all literals.
-        final String settingValue = entry.getValue().toString();
         if ("batchSize".equalsIgnoreCase(entry.getKey().toString()))
-          batchSize = parsePositiveSetting("batchSize", settingValue);
+          batchSize = parsePositiveIntSetting("REBUILD INDEX", "batchSize", entry.getValue());
         else if ("maxAttempts".equalsIgnoreCase(entry.getKey().toString()))
-          maxAttempts = parsePositiveSetting("maxAttempts", settingValue);
+          maxAttempts = parsePositiveIntSetting("REBUILD INDEX", "maxAttempts", entry.getValue());
         else if ("statsOnly".equalsIgnoreCase(entry.getKey().toString()))
-          statsOnly = Boolean.parseBoolean(settingValue);
+          statsOnly = Boolean.parseBoolean(entry.getValue().toString());
         else
           throw new CommandSQLParsingException("Unrecognized setting '" + entry.getKey() + "' in rebuild index statement");
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
@@ -84,19 +84,14 @@ public class RebuildTypeStatement extends DDLStatement {
     for (final Map.Entry<Expression, Expression> e : settings.entrySet()) {
       final String key = e.getKey().toString();
       if ("batchSize".equalsIgnoreCase(key)) {
-        final Object raw = e.getValue().value;
-        try {
-          batchSize = Integer.parseInt(raw == null ? "null" : raw.toString());
-        } catch (final NumberFormatException nfe) {
-          throw new CommandSQLParsingException(
-              "REBUILD TYPE setting 'batchSize' must be a positive integer, got: " + raw);
-        }
         // batchSize is the modulus for the in-rebuild commit cadence (count[0] % batchSize == 0). A zero or
         // negative value would either ArithmeticException (mod-zero) or never trip the commit branch (modulo by
-        // a negative still works but the boundary semantics are nonsensical). Reject up front.
-        if (batchSize <= 0)
-          throw new CommandSQLParsingException(
-              "REBUILD TYPE setting 'batchSize' must be a positive integer, got: " + batchSize);
+        // a negative still works but the boundary semantics are nonsensical), so the shared reader refuses it.
+        //
+        // It also reads the setting by RENDERING the expression rather than off Expression.value, which is null for
+        // every numeric literal the parser builds: this used to refuse every batchSize it was given, legal ones
+        // included, with "got: null" (issue #6359, item 2).
+        batchSize = parsePositiveIntSetting("REBUILD TYPE", "batchSize", e.getValue());
       } else if ("repartition".equalsIgnoreCase(key)) {
         // Boolean opt-in. When true, every record whose current bucket no longer matches its
         // partition strategy's hash is deleted from its current bucket and re-inserted into the

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
@@ -88,10 +88,10 @@ public class RebuildTypeStatement extends DDLStatement {
         // negative value would either ArithmeticException (mod-zero) or never trip the commit branch (modulo by
         // a negative still works but the boundary semantics are nonsensical), so the shared reader refuses it.
         //
-        // It also reads the setting by RENDERING the expression rather than off Expression.value, which is null for
-        // every numeric literal the parser builds: this used to refuse every batchSize it was given, legal ones
+        // It also reads the setting by EVALUATING the expression rather than off Expression.value, which is null
+        // for every numeric literal the parser builds: this used to refuse every batchSize it was given, legal ones
         // included, with "got: null" (issue #6359, item 2).
-        batchSize = parsePositiveIntSetting("REBUILD TYPE", "batchSize", e.getValue());
+        batchSize = parsePositiveIntSetting("REBUILD TYPE", "batchSize", e.getValue().execute((Result) null, context));
       } else if ("repartition".equalsIgnoreCase(key)) {
         // Boolean opt-in. When true, every record whose current bucket no longer matches its
         // partition strategy's hash is deleted from its current bucket and re-inserted into the

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -78,17 +78,6 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
         callback, propertyNames, null, batchSize, metadata, build);
   }
 
-  /**
-   * Takes away an index that could not be built. The FULL removal, not just the component's own {@code drop()}: on the
-   * two-transaction path the component is already committed and attached to its type, so leaving it behind would
-   * answer lookups with an empty index. This is the cleanup {@code LocalSchema.createBucketIndex} did while the build
-   * still ran inside it (issue #6324, item 1) - an index that could not be built must be GONE, and the caller told so.
-   */
-  private static void dropPartiallyBuiltIndex(final LocalSchema schema, final Index index) {
-    if (index != null && schema.existsIndex(index.getName()))
-      schema.dropIndex(index.getName());
-  }
-
   @Override
   public Index create() {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -386,7 +386,22 @@ public abstract class IndexBuilder<T extends Index> {
    * yes.
    */
   protected boolean buildSharesCallerTransaction() {
-    if (indexType == null || !indexType.buildCanShareCallerTransaction() || !database.isTransactionActive())
+    return indexType != null && indexType.buildCanShareCallerTransaction() && callerTransactionHasChanges(database);
+  }
+
+  /**
+   * The half of the decision that is about the TRANSACTION rather than about the index family, exposed on its own for
+   * the call site that does not go through a builder at all: {@link LocalDocumentType#addSuperType} propagates a whole
+   * set of a super type's indexes by calling {@link LocalSchema#createBucketIndex} directly, so it asks this once,
+   * before it opens anything, and pairs it with {@code buildCanShareCallerTransaction()} per index. Issue #6359 item 1
+   * is that call site arriving back at the defect #6324 item 1 fixed, and the predicate lives here so a third spelling
+   * of it cannot drift from the other two.
+   * <p>
+   * Timing is the whole trap: inside the component-creation transaction there is ALWAYS one open, it is EMPTY, and the
+   * answer would always be no.
+   */
+  static boolean callerTransactionHasChanges(final DatabaseInternal database) {
+    if (!database.isTransactionActive())
       return false;
     final TransactionContext tx = database.getTransactionIfExists();
     return tx != null && tx.hasChanges();
@@ -403,10 +418,27 @@ public abstract class IndexBuilder<T extends Index> {
    * inside {@code recordFileChanges}.
    */
   protected void buildCreatedIndex(final Index index, final boolean sharesCallerTransaction) {
+    buildCreatedIndex(index, batchSize, sharesCallerTransaction, callback);
+  }
+
+  /** @see #buildCreatedIndex(Index, boolean) - the builder-less form, for the same reason as the predicate above. */
+  static void buildCreatedIndex(final Index index, final int batchSize, final boolean sharesCallerTransaction,
+      final Index.BuildIndexCallback callback) {
     final IndexInternal internal = (IndexInternal) index;
     if (!internal.setStatus(new IndexInternal.INDEX_STATUS[] { IndexInternal.INDEX_STATUS.UNAVAILABLE },
         IndexInternal.INDEX_STATUS.AVAILABLE))
       throw new IndexException("Cannot build the index '" + index.getName() + "' because it is not available");
     internal.build(batchSize, sharesCallerTransaction, callback);
+  }
+
+  /**
+   * Takes away an index that could not be built. The FULL removal, not just the component's own {@code drop()}: on the
+   * two-transaction path the component is already committed and attached to its type, so leaving it behind would
+   * answer lookups with an empty index. This is the cleanup {@code LocalSchema.createBucketIndex} did while the build
+   * still ran inside it (issue #6324, item 1) - an index that could not be built must be GONE, and the caller told so.
+   */
+  static void dropPartiallyBuiltIndex(final LocalSchema schema, final Index index) {
+    if (index != null && schema.existsIndex(index.getName()))
+      schema.dropIndex(index.getName());
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RecordEvents;
 import com.arcadedb.database.RecordEventsRegistry;
 import com.arcadedb.database.TransactionContext;
+import com.arcadedb.database.async.AsyncQuiesce;
 import com.arcadedb.database.bucketselectionstrategy.BucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.RoundRobinBucketSelectionStrategy;
@@ -1961,6 +1962,25 @@ public class LocalDocumentType implements DocumentType {
         //throw new IllegalArgumentException("Property '" + p + "' is already defined in type '" + name + "' or any super types");
       }
 
+    // QUIESCED for the same reason TypeIndexBuilder and BucketIndexBuilder are (issue #6303, item 2), and taken HERE
+    // rather than around the propagation itself: the barrier answers about the past, and a build needs the other half
+    // too - that nothing WRITES during the scan - but recordFileChanges runs under the database WRITE LOCK, which is
+    // the lock an async worker needs to commit its batch. Requested from inside it, the quiescence waits for workers
+    // that cannot proceed until it returns, and gives up 60 seconds later.
+    //
+    // Only when there are indexes to propagate: the schema-load path passes createIndexes=false and scans nothing.
+    // quiesceAsync() reads the executor field rather than calling async(), so a database that never touched the async
+    // API does not grow a thread pool here, and it is reentrant, so a builder reached from below rides on this one.
+    try (final AsyncQuiesce asyncPaused = createIndexes ?
+        ((DatabaseInternal) schema.getDatabase()).quiesceAsync() : () -> {
+    }) {
+      addSuperTypeInternal(superType, createIndexes);
+    }
+
+    return this;
+  }
+
+  private void addSuperTypeInternal(final DocumentType superType, final boolean createIndexes) {
     recordFileChanges(() -> {
       final LocalDocumentType embeddedSuperType = (LocalDocumentType) superType;
 
@@ -2005,6 +2025,7 @@ public class LocalDocumentType implements DocumentType {
         // carries both a vector index and an ordinary one.
         final List<Index> created = new ArrayList<>();
         final List<Index> toBuild = new ArrayList<>();
+
         try {
           // The COMPONENTS are created in a transaction of their OWN. The enclosing recordFileChanges writes the
           // schema entry that names each of them whatever the caller's transaction goes on to do, so the index FILES
@@ -2012,6 +2033,14 @@ public class LocalDocumentType implements DocumentType {
           // rolls back would leave the schema pointing at a file with no pages, which fails on the next write with
           // "the file is invalid".
           database.transaction(() -> {
+            // Emptied on entry, not on declaration: this transaction retries on its own (a NeedRetryException from a
+            // concurrent schema mutation), and a retry re-runs this lambda from scratch. Left to accumulate, the
+            // rolled-back attempt's indexes would be handed to the build alongside the surviving ones, which reports
+            // a failure that has nothing to do with the conflict that caused the retry. TypeIndexBuilder's
+            // equivalent loop is immune because it assigns into a pre-sized array by position.
+            created.clear();
+            toBuild.clear();
+
             for (final TypeIndex index : indexes) {
               if (index.getType() == null) {
                 LogManager.instance().log(this, Level.WARNING,
@@ -2106,6 +2135,5 @@ public class LocalDocumentType implements DocumentType {
 
       return null;
     });
-    return this;
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1480,6 +1480,10 @@ public class LocalDocumentType implements DocumentType {
     final Collection<TypeIndex> existentIndexes = getAllIndexes(true);
 
     if (!existentIndexes.isEmpty()) {
+      // ONE TRANSACTION OF ITS OWN, and unlike the sibling propagation in addSuperType() this one does NOT have to
+      // join the caller's - do not "fix" it by symmetry (issue #6359, item 1). The bucket being indexed here has just
+      // been created, so no transaction can be holding uncommitted writes into it and the scan has nothing to miss;
+      // joining would only cost the build its chunked commit.
       schema.getDatabase().transaction(() -> {
         for (TypeIndex idx : existentIndexes) {
           // getPageSizeForNewFile(), not getPageSize(): this creates a NEW index file, so the page size carried over has
@@ -1961,13 +1965,37 @@ public class LocalDocumentType implements DocumentType {
       indexes.removeAll(indexesByProperties.values());
 
       if (createIndexes) {
+        // The indexes propagated here go over buckets that ALREADY HOLD RECORDS, which is the whole difference
+        // between this call site and the sibling in createBucket() - there the bucket has just been created, so no
+        // transaction can hold uncommitted writes into it and there is nothing for a scan to miss. Here a caller that
+        // inserts and then links a super type in ONE transaction is exactly the shape of issue #6324 item 1: the
+        // records are not committed, so the scan does not see them, and they were saved before the index existed to
+        // stage an entry for. The result was an index that is readable, reported healthy by CHECK DATABASE, and
+        // answers the lookup it exists for with nothing (issue #6359, item 1).
+        //
+        // Decided BEFORE the transactions below, while the answer is still about the transaction that was already
+        // there - see IndexBuilder#buildSharesCallerTransaction, which owns the predicate for every call site.
+        // Per index rather than once, because an index family that cannot use a shared transaction (the vector ones,
+        // whose search path reads through the page cache rather than through the transaction) has to keep building in
+        // one go whatever the caller holds.
+        final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
+        final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
+        final List<Index> toBuild = new ArrayList<>();
         try {
-          schema.getDatabase().transaction(() -> {
+          // The COMPONENTS are created in a transaction of their OWN. The enclosing recordFileChanges writes the
+          // schema entry that names each of them whatever the caller's transaction goes on to do, so the index FILES
+          // have to be committed on the same terms: leaving a first page inside a caller's transaction that later
+          // rolls back would leave the schema pointing at a file with no pages, which fails on the next write with
+          // "the file is invalid".
+          database.transaction(() -> {
             for (final TypeIndex index : indexes) {
               if (index.getType() == null) {
                 LogManager.instance().log(this, Level.WARNING,
                     "Error on creating implicit indexes from super type '" + superType.getName() + "': key types is null");
               } else {
+                final boolean sharesCallerTransaction =
+                    callerTransactionHasChanges && index.getType().buildCanShareCallerTransaction();
+
                 for (int i = 0; i < buckets.size(); i++) {
                   final Bucket bucket = buckets.get(i);
 
@@ -1980,19 +2008,45 @@ public class LocalDocumentType implements DocumentType {
                     }
                   }
 
-                  if (!alreadyCreated)
+                  if (!alreadyCreated) {
                     // Inherit the page size of the index being propagated, like the createBucket() path above does.
                     // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713), and
                     // getPageSizeForNewFile() is the accessor that guarantees the value is legal to create with.
-                    schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(), index.isUnique(),
-                        index.getPageSizeForNewFile(), index.getNullStrategy(), null,
+                    final Index created = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
+                        index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), null,
                         index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
                         IndexBuilder.BUILD_BATCH_SIZE,
-                        index.getMetadata());
+                        index.getMetadata(), !sharesCallerTransaction);
+
+                    if (sharesCallerTransaction)
+                      toBuild.add(created);
+                  }
                 }
               }
             }
           }, false);
+
+          if (!toBuild.isEmpty())
+            // The BUILD then joins the caller's transaction, because a scan reads the transaction it runs in: the
+            // pages that transaction has modified first, the committed ones underneath. That is the only way it sees
+            // records the caller has written and not yet committed, and it makes the entries commit, or roll back,
+            // with the records they describe.
+            //
+            // Cleaned up from a try/catch of its own rather than from the transaction's error callback, because that
+            // callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException raised
+            // inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661), skipping
+            // the callback entirely. And a duplicate is exactly what this build can hit, since it now sees the
+            // caller's own pending writes.
+            try {
+              database.transaction(() -> {
+                for (final Index created : toBuild)
+                  IndexBuilder.buildCreatedIndex(created, IndexBuilder.BUILD_BATCH_SIZE, true, null);
+              }, true);
+            } catch (final RuntimeException e) {
+              for (final Index created : toBuild)
+                IndexBuilder.dropPartiallyBuiltIndex(schema, created);
+              throw e;
+            }
         } catch (final IndexException e) {
           LogManager.instance()
               .log(this, Level.WARNING, "Error on creating implicit indexes from super type '" + superType.getName() + "'", e);

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1996,8 +1996,7 @@ public class LocalDocumentType implements DocumentType {
       // EVERYTHING THAT FOLLOWS THE LINKAGE IS GUARDED BY IT. The three lines above are the link; every step below can
       // still refuse - a paired external bucket that cannot be created, an index propagation that hits a duplicate, an
       // inherited partition the suitability check rejects for this subtype (#5637) - and a refusal that left the link
-      // standing would hand back a type that IS a subtype, with none of what being one implies. Only the propagation
-      // path used to roll it back, so the other two left it half applied.
+      // standing would hand back a type that IS a subtype, with none of what being one implies.
       //
       // Every sub-index the propagation attaches is recorded HERE, outside the propagation's own block, because the
       // steps that can refuse do not all come before it: a strategy the subtype cannot take (#5637) is raised AFTER
@@ -2017,22 +2016,18 @@ public class LocalDocumentType implements DocumentType {
 
         if (createIndexes) {
           // The indexes propagated here go over buckets that ALREADY HOLD RECORDS, which is the whole difference
-          // between this call site and the sibling in createBucket() - there the bucket has just been created, so no
-          // transaction can hold uncommitted writes into it and there is nothing for a scan to miss. Here a caller that
-          // inserts and then links a super type in ONE transaction is exactly the shape of issue #6324 item 1: the
-          // records are not committed, so the scan does not see them, and they were saved before the index existed to
-          // stage an entry for. The result was an index that is readable, reported healthy by CHECK DATABASE, and
-          // answers the lookup it exists for with nothing (issue #6359, item 1).
+          // between this call site and the sibling in createBucket(), where the bucket has just been created and a
+          // scan has nothing to miss. A caller that inserts and then links a super type in ONE transaction must get an
+          // index covering those records; without the split below it gets one that is readable, reported healthy by
+          // CHECK DATABASE, and answers the lookup it exists for with nothing (issues #6324 and #6359, item 1).
           //
           // Decided BEFORE the transactions below, while the answer is still about the transaction that was already
           // there - see IndexBuilder#buildSharesCallerTransaction, which owns the predicate for every call site.
-          // Per index rather than once, because an index family that cannot use a shared transaction (the vector ones,
-          // whose search path reads through the page cache rather than through the transaction) has to keep building in
-          // one go whatever the caller holds. Which is also the LIMIT of what this fixes: a vector index propagated
-          // here is still built inside the component-creation transaction, and that one does not join the caller's, so
-          // it sees the caller's uncommitted writes no more than it did before. Nothing regressed - no vector build
-          // has ever joined a caller's transaction - but "the propagated index now covers uncommitted records" is true
-          // of the families that can share one, not of every family.
+          //
+          // Per index rather than once: a family that cannot share a caller's transaction (the vector ones, whose
+          // search path reads through the page cache rather than through the transaction) keeps building in one go
+          // whatever the caller holds. That is also the LIMIT of this - a propagated vector index does not see the
+          // caller's uncommitted writes, and never has.
           final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
           final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
           // Two lists, because "has to be built later" and "has to be taken away if anything goes wrong" are not the
@@ -2133,19 +2128,17 @@ public class LocalDocumentType implements DocumentType {
 
       } catch (final RuntimeException e) {
         // EVERY sub-index the propagation made goes, not only the ones that still had a build outstanding, and not
-        // only when the propagation is what refused. Done from here rather than from a transaction's error callback
-        // because that callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException
-        // raised inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661 -
-        // retrying would roll back a transaction it does not own), skipping the callback entirely. And a duplicate is
-        // exactly what the build can hit, since it now sees the caller's own pending writes.
+        // only when the propagation is what refused. It cannot hang off a transaction's error callback: inside a
+        // JOINED transaction, LocalDatabase.transaction rethrows a NeedRetryException or a DuplicatedKeyException
+        // immediately rather than calling it (#661), and a duplicate is exactly what this build can hit now that it
+        // sees the caller's pending writes.
         for (final Index subIndex : created)
           IndexBuilder.dropPartiallyBuiltIndex(schema, subIndex);
 
-        // THE LINK GOES BACK, and for the propagation path that is what makes the refusal reach the caller at all:
-        // LocalDatabase.transaction retries a DuplicatedKeyException once (#4959), and on that retry this method
-        // would find the super type ALREADY in superTypes, return early without propagating anything, and let the
-        // transaction COMMIT - handing back a linked super type whose index holds no entry for a single one of the
-        // subtype's records. That is this issue's own defect, reached through the retry rather than through the scan.
+        // THE LINK GOES BACK, which is what makes the refusal reach the caller at all: LocalDatabase.transaction
+        // retries a DuplicatedKeyException once (#4959), and a retry that found the super type already linked would
+        // return early, propagate nothing, and COMMIT - handing back a subtype whose index holds no entry for any of
+        // its records.
         //
         // The paired external buckets ensureExternalBucketsRecursive may have created are deliberately left: they are
         // additive, idempotent, and reused by the next attempt.

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1993,145 +1993,155 @@ public class LocalDocumentType implements DocumentType {
       final List<Integer> linkedBucketIds = cachedPolymorphicBucketIds;
       embeddedSuperType.updatePolymorphicBucketsCache(true, linkedBuckets, linkedBucketIds);
 
-      // IF THE NEWLY-LINKED SUPERTYPE HAS ANY EXTERNAL PROPERTY (OWN OR INHERITED), THIS SUBTYPE MUST OWN PAIRED
-      // EXTERNAL BUCKETS FOR ITS OWN PRIMARY BUCKETS, BECAUSE RECORDS OF THIS SUBTYPE LIVE IN THIS SUBTYPE'S BUCKETS.
-      if (embeddedSuperType.hasExternalProperties())
-        ensureExternalBucketsRecursive();
+      // EVERYTHING THAT FOLLOWS THE LINKAGE IS GUARDED BY IT. The three lines above are the link; every step below can
+      // still refuse - a paired external bucket that cannot be created, an index propagation that hits a duplicate, an
+      // inherited partition the suitability check rejects for this subtype (#5637) - and a refusal that left the link
+      // standing would hand back a type that IS a subtype, with none of what being one implies. Only the propagation
+      // path used to roll it back, so the other two left it half applied.
+      try {
 
-      // CREATE INDEXES AUTOMATICALLY ON PROPERTIES DEFINED IN SUPER TYPES
-      final Collection<TypeIndex> indexes = new ArrayList<>(getAllIndexes(true));
-      indexes.removeAll(indexesByProperties.values());
+        // IF THE NEWLY-LINKED SUPERTYPE HAS ANY EXTERNAL PROPERTY (OWN OR INHERITED), THIS SUBTYPE MUST OWN PAIRED
+        // EXTERNAL BUCKETS FOR ITS OWN PRIMARY BUCKETS, BECAUSE RECORDS OF THIS SUBTYPE LIVE IN THIS SUBTYPE'S BUCKETS.
+        if (embeddedSuperType.hasExternalProperties())
+          ensureExternalBucketsRecursive();
 
-      if (createIndexes) {
-        // The indexes propagated here go over buckets that ALREADY HOLD RECORDS, which is the whole difference
-        // between this call site and the sibling in createBucket() - there the bucket has just been created, so no
-        // transaction can hold uncommitted writes into it and there is nothing for a scan to miss. Here a caller that
-        // inserts and then links a super type in ONE transaction is exactly the shape of issue #6324 item 1: the
-        // records are not committed, so the scan does not see them, and they were saved before the index existed to
-        // stage an entry for. The result was an index that is readable, reported healthy by CHECK DATABASE, and
-        // answers the lookup it exists for with nothing (issue #6359, item 1).
-        //
-        // Decided BEFORE the transactions below, while the answer is still about the transaction that was already
-        // there - see IndexBuilder#buildSharesCallerTransaction, which owns the predicate for every call site.
-        // Per index rather than once, because an index family that cannot use a shared transaction (the vector ones,
-        // whose search path reads through the page cache rather than through the transaction) has to keep building in
-        // one go whatever the caller holds.
-        final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
-        final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
-        // Two lists, because "has to be built later" and "has to be taken away if anything goes wrong" are not the
-        // same set. An index family that cannot share the caller's transaction is built INLINE during component
-        // creation and never reaches toBuild, so a cleanup keyed on toBuild alone would leave it behind, committed
-        // and attached to a type relationship unlinkSuperType has just undone. Reachable whenever a super type
-        // carries both a vector index and an ordinary one.
-        final List<Index> created = new ArrayList<>();
-        final List<Index> toBuild = new ArrayList<>();
+        // CREATE INDEXES AUTOMATICALLY ON PROPERTIES DEFINED IN SUPER TYPES
+        final Collection<TypeIndex> indexes = new ArrayList<>(getAllIndexes(true));
+        indexes.removeAll(indexesByProperties.values());
 
-        try {
-          // The COMPONENTS are created in a transaction of their OWN. The enclosing recordFileChanges writes the
-          // schema entry that names each of them whatever the caller's transaction goes on to do, so the index FILES
-          // have to be committed on the same terms: leaving a first page inside a caller's transaction that later
-          // rolls back would leave the schema pointing at a file with no pages, which fails on the next write with
-          // "the file is invalid".
-          database.transaction(() -> {
-            // Emptied on entry, not on declaration: this transaction retries on its own (a NeedRetryException from a
-            // concurrent schema mutation), and a retry re-runs this lambda from scratch. Left to accumulate, the
-            // rolled-back attempt's indexes would be handed to the build alongside the surviving ones, which reports
-            // a failure that has nothing to do with the conflict that caused the retry. TypeIndexBuilder's
-            // equivalent loop is immune because it assigns into a pre-sized array by position.
-            created.clear();
-            toBuild.clear();
+        if (createIndexes) {
+          // The indexes propagated here go over buckets that ALREADY HOLD RECORDS, which is the whole difference
+          // between this call site and the sibling in createBucket() - there the bucket has just been created, so no
+          // transaction can hold uncommitted writes into it and there is nothing for a scan to miss. Here a caller that
+          // inserts and then links a super type in ONE transaction is exactly the shape of issue #6324 item 1: the
+          // records are not committed, so the scan does not see them, and they were saved before the index existed to
+          // stage an entry for. The result was an index that is readable, reported healthy by CHECK DATABASE, and
+          // answers the lookup it exists for with nothing (issue #6359, item 1).
+          //
+          // Decided BEFORE the transactions below, while the answer is still about the transaction that was already
+          // there - see IndexBuilder#buildSharesCallerTransaction, which owns the predicate for every call site.
+          // Per index rather than once, because an index family that cannot use a shared transaction (the vector ones,
+          // whose search path reads through the page cache rather than through the transaction) has to keep building in
+          // one go whatever the caller holds.
+          final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
+          final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
+          // Two lists, because "has to be built later" and "has to be taken away if anything goes wrong" are not the
+          // same set. An index family that cannot share the caller's transaction is built INLINE during component
+          // creation and never reaches toBuild, so a cleanup keyed on toBuild alone would leave it behind, committed
+          // and attached to a type relationship unlinkSuperType has just undone. Reachable whenever a super type
+          // carries both a vector index and an ordinary one.
+          final List<Index> created = new ArrayList<>();
+          final List<Index> toBuild = new ArrayList<>();
 
-            for (final TypeIndex index : indexes) {
-              if (index.getType() == null) {
-                LogManager.instance().log(this, Level.WARNING,
-                    "Error on creating implicit indexes from super type '" + superType.getName() + "': key types is null");
-              } else {
-                final boolean sharesCallerTransaction =
-                    callerTransactionHasChanges && index.getType().buildCanShareCallerTransaction();
+          try {
+            // The COMPONENTS are created in a transaction of their OWN. The enclosing recordFileChanges writes the
+            // schema entry that names each of them whatever the caller's transaction goes on to do, so the index FILES
+            // have to be committed on the same terms: leaving a first page inside a caller's transaction that later
+            // rolls back would leave the schema pointing at a file with no pages, which fails on the next write with
+            // "the file is invalid".
+            database.transaction(() -> {
+              // Emptied on entry, not on declaration: this transaction retries on its own (a NeedRetryException from a
+              // concurrent schema mutation), and a retry re-runs this lambda from scratch. Left to accumulate, the
+              // rolled-back attempt's indexes would be handed to the build alongside the surviving ones, which reports
+              // a failure that has nothing to do with the conflict that caused the retry. TypeIndexBuilder's
+              // equivalent loop is immune because it assigns into a pre-sized array by position.
+              created.clear();
+              toBuild.clear();
 
-                for (int i = 0; i < buckets.size(); i++) {
-                  final Bucket bucket = buckets.get(i);
+              for (final TypeIndex index : indexes) {
+                if (index.getType() == null) {
+                  LogManager.instance().log(this, Level.WARNING,
+                      "Error on creating implicit indexes from super type '" + superType.getName() + "': key types is null");
+                } else {
+                  final boolean sharesCallerTransaction =
+                      callerTransactionHasChanges && index.getType().buildCanShareCallerTransaction();
 
-                  boolean alreadyCreated = false;
-                  for (IndexInternal idx : getPolymorphicBucketIndexByBucketId(bucket.getFileId(), index.getPropertyNames())) {
-                    final TypeIndex typeIndex = idx.getTypeIndex();
-                    if (typeIndex != null && typeIndex.equals(index)) {
-                      alreadyCreated = true;
-                      break;
+                  for (int i = 0; i < buckets.size(); i++) {
+                    final Bucket bucket = buckets.get(i);
+
+                    boolean alreadyCreated = false;
+                    for (IndexInternal idx : getPolymorphicBucketIndexByBucketId(bucket.getFileId(), index.getPropertyNames())) {
+                      final TypeIndex typeIndex = idx.getTypeIndex();
+                      if (typeIndex != null && typeIndex.equals(index)) {
+                        alreadyCreated = true;
+                        break;
+                      }
                     }
-                  }
 
-                  if (!alreadyCreated) {
-                    // Inherit the page size of the index being propagated, like the createBucket() path above does.
-                    // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713), and
-                    // getPageSizeForNewFile() is the accessor that guarantees the value is legal to create with.
-                    final Index subIndex = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
-                        index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), null,
-                        index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
-                        IndexBuilder.BUILD_BATCH_SIZE,
-                        index.getMetadata(), !sharesCallerTransaction);
+                    if (!alreadyCreated) {
+                      // Inherit the page size of the index being propagated, like the createBucket() path above does.
+                      // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713), and
+                      // getPageSizeForNewFile() is the accessor that guarantees the value is legal to create with.
+                      final Index subIndex = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
+                          index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), null,
+                          index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
+                          IndexBuilder.BUILD_BATCH_SIZE,
+                          index.getMetadata(), !sharesCallerTransaction);
 
-                    created.add(subIndex);
-                    if (sharesCallerTransaction)
-                      toBuild.add(subIndex);
+                      created.add(subIndex);
+                      if (sharesCallerTransaction)
+                        toBuild.add(subIndex);
+                    }
                   }
                 }
               }
-            }
-          }, false);
+            }, false);
 
-          if (!toBuild.isEmpty())
-            // The BUILD then joins the caller's transaction, because a scan reads the transaction it runs in: the
-            // pages that transaction has modified first, the committed ones underneath. That is the only way it sees
-            // records the caller has written and not yet committed, and it makes the entries commit, or roll back,
-            // with the records they describe.
-            database.transaction(() -> {
-              for (final Index subIndex : toBuild)
-                IndexBuilder.buildCreatedIndex(subIndex, IndexBuilder.BUILD_BATCH_SIZE, true, null);
-            }, true);
-        } catch (final RuntimeException e) {
-          // EVERY sub-index this propagation made goes, not only the ones that still had a build outstanding - see
-          // the note on the two lists above. Done here rather than from the transaction's error callback because
-          // that callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException raised
-          // inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661 - retrying
-          // would roll back a transaction it does not own), skipping the callback entirely. And a duplicate is
-          // exactly what this build can hit, since it now sees the caller's own pending writes.
-          for (final Index subIndex : created)
-            IndexBuilder.dropPartiallyBuiltIndex(schema, subIndex);
+            if (!toBuild.isEmpty())
+              // The BUILD then joins the caller's transaction, because a scan reads the transaction it runs in: the
+              // pages that transaction has modified first, the committed ones underneath. That is the only way it sees
+              // records the caller has written and not yet committed, and it makes the entries commit, or roll back,
+              // with the records they describe.
+              database.transaction(() -> {
+                for (final Index subIndex : toBuild)
+                  IndexBuilder.buildCreatedIndex(subIndex, IndexBuilder.BUILD_BATCH_SIZE, true, null);
+              }, true);
+          } catch (final RuntimeException e) {
+            // EVERY sub-index this propagation made goes, not only the ones that still had a build outstanding - see
+            // the note on the two lists above. Done here rather than from the transaction's error callback because
+            // that callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException raised
+            // inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661 - retrying
+            // would roll back a transaction it does not own), skipping the callback entirely. And a duplicate is
+            // exactly what this build can hit, since it now sees the caller's own pending writes.
+            for (final Index subIndex : created)
+              IndexBuilder.dropPartiallyBuiltIndex(schema, subIndex);
 
-          // THE LINK GOES BACK TOO, not only the half-built indexes, and this is what makes the refusal reach the
-          // caller at all. LocalDatabase.transaction retries a DuplicatedKeyException once (#4959); on that retry
-          // this method would find the super type ALREADY in superTypes, return early without propagating anything,
-          // and let the transaction COMMIT - leaving the caller with a linked super type whose index holds no entry
-          // for a single one of the subtype's records. That is the exact defect this issue is about, reached through
-          // the retry instead of through the scan.
-          //
-          // The paired external buckets that ensureExternalBucketsRecursive may have created are deliberately left:
-          // they are additive, idempotent and reused by the next attempt.
-          unlinkSuperType(embeddedSuperType, linkedBuckets, linkedBucketIds);
-
-          // Every failure shape, not only IndexException. The build joins the caller's transaction now, so it can
-          // fail with a DuplicatedKeyException raised on the caller's own pending writes or with a NeedRetryException
-          // - neither of which is an IndexException, and both of which used to reach the caller with no line saying
-          // which super type's propagation they came out of.
-          LogManager.instance()
-              .log(this, Level.WARNING, "Error on creating implicit indexes from super type '" + superType.getName() + "'", e);
-          throw e;
+            // The LINK is handed back by the guard around the whole block, not from here. Every failure shape reaches
+            // it, not only IndexException. The build joins the caller's transaction now, so it can
+            // fail with a DuplicatedKeyException raised on the caller's own pending writes or with a NeedRetryException
+            // - neither of which is an IndexException, and both of which used to reach the caller with no line saying
+            // which super type's propagation they came out of.
+            LogManager.instance()
+                .log(this, Level.WARNING, "Error on creating implicit indexes from super type '" + superType.getName() + "'", e);
+            throw e;
+          }
         }
-      }
 
-      if (!superType.getBucketSelectionStrategy().getName().equalsIgnoreCase(getBucketSelectionStrategy().getName()))
-        // INHERIT THE BUCKET SELECTION STRATEGY FROM THE SUPER TYPE. The enclosing recordFileChanges saves the
-        // schema when it completes, and that write carries this strategy, so the setter does not persist on its own.
+        if (!superType.getBucketSelectionStrategy().getName().equalsIgnoreCase(getBucketSelectionStrategy().getName()))
+          // INHERIT THE BUCKET SELECTION STRATEGY FROM THE SUPER TYPE. The enclosing recordFileChanges saves the
+          // schema when it completes, and that write carries this strategy, so the setter does not persist on its own.
+          //
+          // An inherited partition that is unsuitable for this subtype still refuses here, as it always has: what
+          // changed with issue #5637 is that the refusal now arrives as the SchemaException the suitability check
+          // raises rather than the IllegalArgumentException the binding used to throw. Checked against every caller
+          // of addSuperType - CreateTypeAbstractStatement, AlterTypeStatement's SUPERTYPE branch, TypeBuilder, the
+          // Cypher Labels helper, and LocalSchema's dropType re-attach - and none of them catches either type, so
+          // nothing distinguishes the two. Neither is a CommandParsingException, so the HTTP status is unchanged too.
+          // (AlterTypeStatement's one catch names both, but it guards the BucketSelectionStrategy branch, not this.)
+          setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy(), false);
+
+      } catch (final RuntimeException e) {
+        // THE LINK GOES BACK, and for the propagation path that is what makes the refusal reach the caller at all:
+        // LocalDatabase.transaction retries a DuplicatedKeyException once (#4959), and on that retry this method
+        // would find the super type ALREADY in superTypes, return early without propagating anything, and let the
+        // transaction COMMIT - handing back a linked super type whose index holds no entry for a single one of the
+        // subtype's records. That is this issue's own defect, reached through the retry rather than through the scan.
         //
-        // An inherited partition that is unsuitable for this subtype still refuses here, as it always has: what
-        // changed with issue #5637 is that the refusal now arrives as the SchemaException the suitability check
-        // raises rather than the IllegalArgumentException the binding used to throw. Checked against every caller
-        // of addSuperType - CreateTypeAbstractStatement, AlterTypeStatement's SUPERTYPE branch, TypeBuilder, the
-        // Cypher Labels helper, and LocalSchema's dropType re-attach - and none of them catches either type, so
-        // nothing distinguishes the two. Neither is a CommandParsingException, so the HTTP status is unchanged too.
-        // (AlterTypeStatement's one catch names both, but it guards the BucketSelectionStrategy branch, not this.)
-        setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy(), false);
+        // The paired external buckets ensureExternalBucketsRecursive may have created are deliberately left: they are
+        // additive, idempotent, and reused by the next attempt.
+        unlinkSuperType(embeddedSuperType, linkedBuckets, linkedBucketIds);
+        throw e;
+      }
 
       return null;
     });

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1998,6 +1998,12 @@ public class LocalDocumentType implements DocumentType {
         // one go whatever the caller holds.
         final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
         final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
+        // Two lists, because "has to be built later" and "has to be taken away if anything goes wrong" are not the
+        // same set. An index family that cannot share the caller's transaction is built INLINE during component
+        // creation and never reaches toBuild, so a cleanup keyed on toBuild alone would leave it behind, committed
+        // and attached to a type relationship unlinkSuperType has just undone. Reachable whenever a super type
+        // carries both a vector index and an ordinary one.
+        final List<Index> created = new ArrayList<>();
         final List<Index> toBuild = new ArrayList<>();
         try {
           // The COMPONENTS are created in a transaction of their OWN. The enclosing recordFileChanges writes the
@@ -2030,14 +2036,15 @@ public class LocalDocumentType implements DocumentType {
                     // Inherit the page size of the index being propagated, like the createBucket() path above does.
                     // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713), and
                     // getPageSizeForNewFile() is the accessor that guarantees the value is legal to create with.
-                    final Index created = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
+                    final Index subIndex = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
                         index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), null,
                         index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
                         IndexBuilder.BUILD_BATCH_SIZE,
                         index.getMetadata(), !sharesCallerTransaction);
 
+                    created.add(subIndex);
                     if (sharesCallerTransaction)
-                      toBuild.add(created);
+                      toBuild.add(subIndex);
                   }
                 }
               }
@@ -2049,23 +2056,20 @@ public class LocalDocumentType implements DocumentType {
             // pages that transaction has modified first, the committed ones underneath. That is the only way it sees
             // records the caller has written and not yet committed, and it makes the entries commit, or roll back,
             // with the records they describe.
-            //
-            // Cleaned up from a try/catch of its own rather than from the transaction's error callback, because that
-            // callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException raised
-            // inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661), skipping
-            // the callback entirely. And a duplicate is exactly what this build can hit, since it now sees the
-            // caller's own pending writes.
-            try {
-              database.transaction(() -> {
-                for (final Index created : toBuild)
-                  IndexBuilder.buildCreatedIndex(created, IndexBuilder.BUILD_BATCH_SIZE, true, null);
-              }, true);
-            } catch (final RuntimeException e) {
-              for (final Index created : toBuild)
-                IndexBuilder.dropPartiallyBuiltIndex(schema, created);
-              throw e;
-            }
+            database.transaction(() -> {
+              for (final Index subIndex : toBuild)
+                IndexBuilder.buildCreatedIndex(subIndex, IndexBuilder.BUILD_BATCH_SIZE, true, null);
+            }, true);
         } catch (final RuntimeException e) {
+          // EVERY sub-index this propagation made goes, not only the ones that still had a build outstanding - see
+          // the note on the two lists above. Done here rather than from the transaction's error callback because
+          // that callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException raised
+          // inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661 - retrying
+          // would roll back a transaction it does not own), skipping the callback entirely. And a duplicate is
+          // exactly what this build can hit, since it now sees the caller's own pending writes.
+          for (final Index subIndex : created)
+            IndexBuilder.dropPartiallyBuiltIndex(schema, subIndex);
+
           // THE LINK GOES BACK TOO, not only the half-built indexes, and this is what makes the refusal reach the
           // caller at all. LocalDatabase.transaction retries a DuplicatedKeyException once (#4959); on that retry
           // this method would find the super type ALREADY in superTypes, return early without propagating anything,

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1928,6 +1928,21 @@ public class LocalDocumentType implements DocumentType {
     }
   }
 
+  /**
+   * Undoes the in-memory linkage {@link #addSuperType(DocumentType, boolean)} applies before it propagates the super
+   * type's indexes, so a propagation that fails leaves the type exactly as unlinked as it found it and the next
+   * attempt is a real attempt rather than an early return.
+   *
+   * @param linkedBuckets   the very lists handed to {@code updatePolymorphicBucketsCache} on the way in - the caches
+   *                        are replaced rather than mutated, so removing anything else would not be symmetric
+   */
+  private void unlinkSuperType(final LocalDocumentType superType, final List<Bucket> linkedBuckets,
+      final List<Integer> linkedBucketIds) {
+    superTypes.remove(superType);
+    superType.subTypes.remove(this);
+    superType.updatePolymorphicBucketsCache(false, linkedBuckets, linkedBucketIds);
+  }
+
   DocumentType addSuperType(final DocumentType superType, final boolean createIndexes) {
     checkForSchemaMutation();
     if (this.equals(superType))
@@ -1952,8 +1967,11 @@ public class LocalDocumentType implements DocumentType {
       superTypes.add(embeddedSuperType);
       embeddedSuperType.subTypes.add(this);
 
-      // UPDATE THE LIST OF POLYMORPHIC BUCKETS TREE
-      embeddedSuperType.updatePolymorphicBucketsCache(true, cachedPolymorphicBuckets, cachedPolymorphicBucketIds);
+      // UPDATE THE LIST OF POLYMORPHIC BUCKETS TREE. The lists are captured because the fields are REPLACED rather
+      // than mutated, and unlinkSuperType has to hand back exactly what was handed over.
+      final List<Bucket>  linkedBuckets   = cachedPolymorphicBuckets;
+      final List<Integer> linkedBucketIds = cachedPolymorphicBucketIds;
+      embeddedSuperType.updatePolymorphicBucketsCache(true, linkedBuckets, linkedBucketIds);
 
       // IF THE NEWLY-LINKED SUPERTYPE HAS ANY EXTERNAL PROPERTY (OWN OR INHERITED), THIS SUBTYPE MUST OWN PAIRED
       // EXTERNAL BUCKETS FOR ITS OWN PRIMARY BUCKETS, BECAUSE RECORDS OF THIS SUBTYPE LIVE IN THIS SUBTYPE'S BUCKETS.
@@ -2047,7 +2065,22 @@ public class LocalDocumentType implements DocumentType {
                 IndexBuilder.dropPartiallyBuiltIndex(schema, created);
               throw e;
             }
-        } catch (final IndexException e) {
+        } catch (final RuntimeException e) {
+          // THE LINK GOES BACK TOO, not only the half-built indexes, and this is what makes the refusal reach the
+          // caller at all. LocalDatabase.transaction retries a DuplicatedKeyException once (#4959); on that retry
+          // this method would find the super type ALREADY in superTypes, return early without propagating anything,
+          // and let the transaction COMMIT - leaving the caller with a linked super type whose index holds no entry
+          // for a single one of the subtype's records. That is the exact defect this issue is about, reached through
+          // the retry instead of through the scan.
+          //
+          // The paired external buckets that ensureExternalBucketsRecursive may have created are deliberately left:
+          // they are additive, idempotent and reused by the next attempt.
+          unlinkSuperType(embeddedSuperType, linkedBuckets, linkedBucketIds);
+
+          // Every failure shape, not only IndexException. The build joins the caller's transaction now, so it can
+          // fail with a DuplicatedKeyException raised on the caller's own pending writes or with a NeedRetryException
+          // - neither of which is an IndexException, and both of which used to reach the caller with no line saying
+          // which super type's propagation they came out of.
           LogManager.instance()
               .log(this, Level.WARNING, "Error on creating implicit indexes from super type '" + superType.getName() + "'", e);
           throw e;

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -2028,7 +2028,11 @@ public class LocalDocumentType implements DocumentType {
           // there - see IndexBuilder#buildSharesCallerTransaction, which owns the predicate for every call site.
           // Per index rather than once, because an index family that cannot use a shared transaction (the vector ones,
           // whose search path reads through the page cache rather than through the transaction) has to keep building in
-          // one go whatever the caller holds.
+          // one go whatever the caller holds. Which is also the LIMIT of what this fixes: a vector index propagated
+          // here is still built inside the component-creation transaction, and that one does not join the caller's, so
+          // it sees the caller's uncommitted writes no more than it did before. Nothing regressed - no vector build
+          // has ever joined a caller's transaction - but "the propagated index now covers uncommitted records" is true
+          // of the families that can share one, not of every family.
           final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
           final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
           // Two lists, because "has to be built later" and "has to be taken away if anything goes wrong" are not the

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1998,6 +1998,12 @@ public class LocalDocumentType implements DocumentType {
       // inherited partition the suitability check rejects for this subtype (#5637) - and a refusal that left the link
       // standing would hand back a type that IS a subtype, with none of what being one implies. Only the propagation
       // path used to roll it back, so the other two left it half applied.
+      //
+      // Every sub-index the propagation attaches is recorded HERE, outside the propagation's own block, because the
+      // steps that can refuse do not all come before it: a strategy the subtype cannot take (#5637) is raised AFTER
+      // the indexes are committed and attached to the super type's wrapper, so a cleanup scoped to the propagation
+      // would unlink the type and leave the super type's index pointing at buckets that are no longer its subtype's.
+      final List<Index> created = new ArrayList<>();
       try {
 
         // IF THE NEWLY-LINKED SUPERTYPE HAS ANY EXTERNAL PROPERTY (OWN OR INHERITED), THIS SUBTYPE MUST OWN PAIRED
@@ -2030,7 +2036,6 @@ public class LocalDocumentType implements DocumentType {
           // creation and never reaches toBuild, so a cleanup keyed on toBuild alone would leave it behind, committed
           // and attached to a type relationship unlinkSuperType has just undone. Reachable whenever a super type
           // carries both a vector index and an ordinary one.
-          final List<Index> created = new ArrayList<>();
           final List<Index> toBuild = new ArrayList<>();
 
           try {
@@ -2097,17 +2102,9 @@ public class LocalDocumentType implements DocumentType {
                   IndexBuilder.buildCreatedIndex(subIndex, IndexBuilder.BUILD_BATCH_SIZE, true, null);
               }, true);
           } catch (final RuntimeException e) {
-            // EVERY sub-index this propagation made goes, not only the ones that still had a build outstanding - see
-            // the note on the two lists above. Done here rather than from the transaction's error callback because
-            // that callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException raised
-            // inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661 - retrying
-            // would roll back a transaction it does not own), skipping the callback entirely. And a duplicate is
-            // exactly what this build can hit, since it now sees the caller's own pending writes.
-            for (final Index subIndex : created)
-              IndexBuilder.dropPartiallyBuiltIndex(schema, subIndex);
-
-            // The LINK is handed back by the guard around the whole block, not from here. Every failure shape reaches
-            // it, not only IndexException. The build joins the caller's transaction now, so it can
+            // The indexes and the LINK are both handed back by the guard around the whole block, not from here: this
+            // is not the only step that can refuse after they exist. What is left here is naming which super type's
+            // propagation the failure came out of - for every failure shape, not only IndexException. The build joins the caller's transaction now, so it can
             // fail with a DuplicatedKeyException raised on the caller's own pending writes or with a NeedRetryException
             // - neither of which is an IndexException, and both of which used to reach the caller with no line saying
             // which super type's propagation they came out of.
@@ -2131,6 +2128,15 @@ public class LocalDocumentType implements DocumentType {
           setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy(), false);
 
       } catch (final RuntimeException e) {
+        // EVERY sub-index the propagation made goes, not only the ones that still had a build outstanding, and not
+        // only when the propagation is what refused. Done from here rather than from a transaction's error callback
+        // because that callback is NOT reached on every failure: a NeedRetryException or a DuplicatedKeyException
+        // raised inside a JOINED transaction is rethrown immediately by LocalDatabase.transaction (issue #661 -
+        // retrying would roll back a transaction it does not own), skipping the callback entirely. And a duplicate is
+        // exactly what the build can hit, since it now sees the caller's own pending writes.
+        for (final Index subIndex : created)
+          IndexBuilder.dropPartiallyBuiltIndex(schema, subIndex);
+
         // THE LINK GOES BACK, and for the propagation path that is what makes the refusal reach the caller at all:
         // LocalDatabase.transaction retries a DuplicatedKeyException once (#4959), and on that retry this method
         // would find the super type ALREADY in superTypes, return early without propagating anything, and let the

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -223,6 +223,54 @@ class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
   }
 
   /**
+   * The cleanup covers EVERY sub-index the propagation made, not only the ones that still had a build outstanding.
+   * <p>
+   * An index family that cannot share the caller's transaction - the vector ones, whose search path reads through the
+   * page cache rather than through the transaction - is built INLINE while the components are created, so it never
+   * reaches the list of pending builds. A super type carrying both a vector index and an ordinary one therefore has
+   * one of each, and a cleanup keyed on the pending list alone left the vector sub-index committed and attached to a
+   * type relationship that had just been undone.
+   * <p>
+   * Getting there also required {@link com.arcadedb.index.vector.LSMVectorIndex} to answer which {@code TypeIndex} it
+   * belongs to. It used to answer null, so {@code LocalSchema.dropIndexInternal} never detached a dropped vector
+   * sub-index from its wrapper - on every path that drops one, not only this one - and {@code addSuperType} could not
+   * recognise an already-propagated vector index, minting a second one on the retry.
+   */
+  @Test
+  @Timeout(60)
+  void aRefusalTakesAwayTheIndexesThatWereBuiltInlineToo() {
+    database.transaction(() -> {
+      final DocumentType superType = database.getSchema().createDocumentType("Super", 1);
+      superType.createProperty("id", Type.INTEGER);
+      superType.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Super", "id");
+      database.command("sql",
+          "CREATE INDEX ON Super (embedding) LSM_VECTOR METADATA {\"dimensions\": 4, \"similarity\": \"cosine\"}").close();
+      database.getSchema().createDocumentType("Sub", 1);
+    });
+
+    final int subBucketId = database.getSchema().getType("Sub").getBuckets(false).getFirst().getFileId();
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      for (int i = 0; i < 2; i++) {
+        final MutableDocument v = database.newDocument("Sub");
+        v.set("id", 5);
+        v.set("embedding", new float[] { 1, 2, 3, 4 });
+        v.save();
+      }
+      database.getSchema().getType("Sub").addSuperType("Super");
+    })).isInstanceOf(DuplicatedKeyException.class);
+
+    assertThat(database.getSchema().getType("Sub").getSuperTypes()).isEmpty();
+
+    // BOTH wrappers, because the vector one is the index that was built inline and the whole point of the test.
+    for (final String indexName : new String[] { "Super[id]", "Super[embedding]" })
+      for (final IndexInternal sub : ((TypeIndex) database.getSchema().getIndexByName(indexName)).getIndexesOnBuckets())
+        assertThat(sub.getAssociatedBucketId()).as(indexName + " keeps no sub-index on the subtype's bucket")
+            .isNotEqualTo(subBucketId);
+  }
+
+  /**
    * The sibling call site, {@code LocalDocumentType.createBucket}, is SAFE and must not be "fixed" by symmetry: the
    * bucket it indexes has just been created, so no transaction can hold uncommitted writes into it and there is
    * nothing for the scan to miss. Nailed down here so the property is asserted rather than merely asserted about -

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.index;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #6359, item 1: linking a super type propagates its indexes over buckets that ALREADY hold
@@ -153,6 +155,71 @@ class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
       v.save();
     });
     assertThat(index.get(new Object[] { 7 }).hasNext()).isTrue();
+  }
+
+  /**
+   * The other side of seeing the caller's pending writes: a UNIQUE super-type index propagated over records that
+   * already conflict now REFUSES, where the separate-transaction build silently produced an index missing one of
+   * them. The refusal has to reach the caller, and to leave nothing behind.
+   * <p>
+   * Two cleanups are needed for that, and neither can hang off the transaction's error callback - a
+   * {@code DuplicatedKeyException} raised inside a JOINED transaction is rethrown immediately by
+   * {@code LocalDatabase.transaction} (issue #661 - retrying would roll back a transaction it does not own), so the
+   * callback never runs. The half-built COMPONENTS are already committed and attached to the super type's
+   * {@code TypeIndex} by then, and leaving them would answer the lookup from an index that was never populated. And
+   * the in-memory LINK has to go back as well: the transaction retries a duplicate once (#4959), and on that retry
+   * this method would find the super type already in place, return early without propagating anything, and let the
+   * transaction COMMIT - handing back a linked super type whose index holds no entry for a single one of the
+   * subtype's records, which is this issue's own defect reached through the retry rather than through the scan.
+   */
+  @Test
+  @Timeout(60)
+  void aPropagationThatHitsADuplicateRefusesAndLeavesNeitherIndexNorLinkBehind() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Super", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Super", "id");
+      database.getSchema().createDocumentType("Sub", 1);
+    });
+
+    final int subBucketId = database.getSchema().getType("Sub").getBuckets(false).getFirst().getFileId();
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      for (int i = 0; i < 2; i++) {
+        final MutableDocument v = database.newDocument("Sub");
+        v.set("id", 5);
+        v.save();
+      }
+      database.getSchema().getType("Sub").addSuperType("Super");
+    })).as("the duplicate reaches the caller instead of being swallowed by the retry")
+        .isInstanceOf(DuplicatedKeyException.class);
+
+    assertThat(database.getSchema().getType("Sub").getSuperTypes())
+        .as("a propagation that failed leaves the type as unlinked as it found it").isEmpty();
+    assertThat(database.countType("Sub", false)).as("and the caller's records went with its rollback").isZero();
+
+    // Asked of the SUPER TYPE's index, which is the one a propagated sub-index attaches to: a half-built sub-index
+    // left registered on it would answer `Super[id]` lookups over Sub's bucket with nothing.
+    final TypeIndex propagated = (TypeIndex) database.getSchema().getIndexByName("Super[id]");
+    for (final IndexInternal sub : propagated.getIndexesOnBuckets())
+      assertThat(sub.getAssociatedBucketId()).as("no sub-index survives on the bucket the failed build scanned")
+          .isNotEqualTo(subBucketId);
+
+    // And the index is still the working index of its own type afterwards.
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("Super");
+      v.set("id", 9);
+      v.save();
+    });
+    assertThat(propagated.get(new Object[] { 9 }).hasNext()).isTrue();
+
+    // The link can still be made, once the conflict is gone: the refusal took nothing away permanently.
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("Sub");
+      v.set("id", 11);
+      v.save();
+      database.getSchema().getType("Sub").addSuperType("Super");
+    });
+    assertThat(propagated.get(new Object[] { 11 }).hasNext()).isTrue();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.index;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -305,6 +306,45 @@ class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
     assertThat(propagated.countEntries())
         .as("every record must have an entry, whatever the async side was doing while the index was propagated")
         .isEqualTo(records);
+  }
+
+  /**
+   * The link is handed back on EVERY refusal, not only on the one the index propagation raises.
+   * <p>
+   * Linking a super type applies the linkage first and then does three things that can each still refuse: pairing
+   * external buckets, propagating the indexes, and inheriting the bucket selection strategy. Only the second used to
+   * roll the linkage back, so a refusal from either of the others handed the caller a type that IS a subtype with
+   * none of what being one implies. The shape below is the third: a partition that is legal on the super type and
+   * unsuitable for this subtype, whose own index on the partition key is declared {@code COLLATE CI} (#5637).
+   */
+  @Test
+  @Timeout(60)
+  void aRefusalFromOutsideTheIndexPropagationHandsTheLinkBackToo() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("Super").withTotalBuckets(4).create();
+      database.command("sql", "CREATE PROPERTY Super.k STRING").close();
+      database.command("sql", "CREATE INDEX ON Super (k) UNIQUE").close();
+      database.command("sql", "ALTER TYPE Super BucketSelectionStrategy `partitioned('k')`").close();
+
+      database.getSchema().buildDocumentType().withName("Sub").withTotalBuckets(4).create();
+      database.command("sql", "CREATE PROPERTY Sub.k STRING").close();
+      database.command("sql", "CREATE INDEX ON Sub (k COLLATE CI) UNIQUE").close();
+    });
+
+    assertThatThrownBy(() -> database.transaction(() -> database.getSchema().getType("Sub").addSuperType("Super")))
+        .isInstanceOf(SchemaException.class).hasMessageContaining("COLLATE CI");
+
+    assertThat(database.getSchema().getType("Sub").getSuperTypes())
+        .as("the subtype is as unlinked as the refusal left it").isEmpty();
+    assertThat(database.getSchema().getType("Super").getSubTypes())
+        .as("and so is the super type, on the other side of the same link").isEmpty();
+
+    // The refusal took nothing away permanently: a subtype the partition IS suitable for still links.
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName("Ok").withTotalBuckets(4).create();
+      database.getSchema().getType("Ok").addSuperType("Super");
+    });
+    assertThat(database.getSchema().getType("Ok").getSuperTypes()).hasSize(1);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6359, item 1: linking a super type propagates its indexes over buckets that ALREADY hold
+ * records, so that build has exactly the problem {@code CREATE INDEX} had in issue #6324 - it must see the writes of
+ * the transaction it runs in.
+ * <p>
+ * {@code LocalDocumentType.addSuperType} calls {@code LocalSchema.createBucketIndex} directly instead of going through
+ * {@link com.arcadedb.schema.TypeIndexBuilder} / {@link com.arcadedb.schema.BucketIndexBuilder}, so it kept building in
+ * a transaction of its own: the caller's records are not committed, the scan does not see them, and they were saved
+ * before the index existed to stage an entry for. The result was an index that is readable, reported healthy by
+ * {@code CHECK DATABASE}, and answers the lookup it exists for with nothing.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
+
+  /** The API shape: write into the subtype, then link the super type whose index has to cover those writes. */
+  @Test
+  @Timeout(60)
+  void anIndexPropagatedByAddSuperTypeCoversTheCallersUncommittedRecords() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Super", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Super", "id");
+      database.getSchema().createDocumentType("Sub", 1);
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        final MutableDocument v = database.newDocument("Sub");
+        v.set("id", i);
+        v.save();
+      }
+      database.getSchema().getType("Sub").addSuperType("Super");
+    });
+
+    assertThat(database.countType("Sub", false)).as("the records are there").isEqualTo(10);
+
+    final Index index = database.getSchema().getIndexByName("Super[id]");
+    assertThat(index.countEntries()).as("and so are their index entries").isEqualTo(10);
+    for (int i = 0; i < 10; i++)
+      assertThat(index.get(new Object[] { i }).hasNext()).as("id " + i + " must be found through the index").isTrue();
+  }
+
+  /** The same through SQL, which is how a user reaches it: {@code ALTER TYPE ... SUPERTYPE +...} in one script. */
+  @Test
+  @Timeout(60)
+  void theSameThroughOneSqlScript() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Super", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Super", "id");
+      database.getSchema().createDocumentType("Sub", 1);
+    });
+
+    database.transaction(() -> database.command("sqlscript",
+        "INSERT INTO Sub SET id = 7; ALTER TYPE Sub SUPERTYPE +Super;").close());
+
+    final Index index = database.getSchema().getIndexByName("Super[id]");
+    assertThat(index.countEntries()).isEqualTo(1);
+    assertThat(index.get(new Object[] { 7 }).hasNext()).as("an index that answers the lookup it exists for").isTrue();
+  }
+
+  /**
+   * A record UPDATED in the same transaction is indexed under its new key: the deferred update is parked and only
+   * serialized at commit, so a bucket scan inside the transaction still reads the OLD content unless the build asks
+   * the transaction for the written copy.
+   */
+  @Test
+  @Timeout(60)
+  void aRecordUpdatedInTheSameTransactionIsPropagatedUnderItsNewKey() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Super", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Super", "id");
+      database.getSchema().createDocumentType("Sub", 1);
+    });
+
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("Sub");
+      v.set("id", 1);
+      v.save();
+    });
+
+    database.transaction(() -> {
+      database.command("sql", "UPDATE Sub SET id = 42").close();
+      database.getSchema().getType("Sub").addSuperType("Super");
+    });
+
+    final Index index = database.getSchema().getIndexByName("Super[id]");
+    assertThat(index.countEntries()).isEqualTo(1);
+    assertThat(index.get(new Object[] { 42 }).hasNext()).as("the new key is the one the index answers on").isTrue();
+    assertThat(index.get(new Object[] { 1 }).hasNext()).as("and the old key is not").isFalse();
+  }
+
+  /**
+   * The propagated index COMPONENT is committed on its own, whatever the caller's transaction goes on to do: the
+   * schema entry naming it is written by {@code recordFileChanges} regardless, so an index whose first page was left
+   * in a rolled-back transaction would be a schema entry pointing at a file with no pages, and the next write to it
+   * fails with "the file is invalid".
+   */
+  @Test
+  @Timeout(60)
+  void aPropagatedIndexSurvivesTheRollbackOfTheTransactionThatPropagatedIt() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Super", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Super", "id");
+      database.getSchema().createDocumentType("Sub", 1);
+    });
+
+    database.begin();
+    final MutableDocument doomed = database.newDocument("Sub");
+    doomed.set("id", 1);
+    doomed.save();
+    database.getSchema().getType("Sub").addSuperType("Super");
+    database.rollback();
+
+    assertThat(database.countType("Sub", false)).as("the record went with the rollback").isZero();
+
+    final Index index = database.getSchema().getIndexByName("Super[id]");
+    assertThat(index.countEntries()).as("and the propagated entry with it").isZero();
+
+    // The point of the test: the propagated sub-index is WRITEABLE afterwards, not merely present.
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("Sub");
+      v.set("id", 7);
+      v.save();
+    });
+    assertThat(index.get(new Object[] { 7 }).hasNext()).isTrue();
+  }
+
+  /**
+   * The sibling call site, {@code LocalDocumentType.createBucket}, is SAFE and must not be "fixed" by symmetry: the
+   * bucket it indexes has just been created, so no transaction can hold uncommitted writes into it and there is
+   * nothing for the scan to miss. Nailed down here so the property is asserted rather than merely asserted about -
+   * the records already in the type's OTHER buckets keep their entries, and the new bucket gets its own sub-index.
+   */
+  @Test
+  @Timeout(60)
+  void addingABucketToAPopulatedTypeInsideATransactionKeepsTheIndexComplete() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("V", 1);
+      type.createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++) {
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", i);
+        v.save();
+      }
+    });
+
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", 100);
+      v.save();
+      database.command("sql", "ALTER TYPE V BUCKET +V_extra").close();
+    });
+
+    final Index index = database.getSchema().getIndexByName("V[id]");
+    assertThat(index.countEntries()).isEqualTo(6);
+    for (int i = 0; i < 5; i++)
+      assertThat(index.get(new Object[] { i }).hasNext()).as("id " + i).isTrue();
+    assertThat(index.get(new Object[] { 100 }).hasNext()).as("the record written in the same transaction").isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -281,6 +281,11 @@ class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
    * record an async worker saves in the window between the barrier and the sub-index's registration is in neither the
    * scan nor the index, which is the same gap this propagation exists to close, reopened for async writers. This is
    * the end-to-end shape: the executor is genuinely busy while the super type is linked.
+   * <p>
+   * The timeout is a HANG DETECTOR and not a latency bound, which is why it is this generous and why the test is not
+   * in the {@code slow} lane: the records are queued rather than awaited, so it runs in milliseconds, but a
+   * quiescence that cannot park a worker gives up only after its own 60-second budget and the failure has to arrive
+   * as that refusal rather than as a timeout.
    */
   @Test
   @Timeout(180)

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -271,6 +271,43 @@ class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
   }
 
   /**
+   * The propagation holds the async workers while it builds, like every other index build does (issue #6303, item 2).
+   * <p>
+   * The barrier answers about the past; a build needs the other half too - that nothing WRITES during the scan. A
+   * record an async worker saves in the window between the barrier and the sub-index's registration is in neither the
+   * scan nor the index, which is the same gap this propagation exists to close, reopened for async writers. This is
+   * the end-to-end shape: the executor is genuinely busy while the super type is linked.
+   */
+  @Test
+  @Timeout(180)
+  void aPropagationRunWhileTheExecutorIsBusyCoversEveryRecord() {
+    final int records = 1_000;
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Super", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Super", "id");
+      database.getSchema().createDocumentType("Sub", 1);
+    });
+    database.async().setParallelLevel(2);
+
+    for (int i = 0; i < records; i++) {
+      final MutableDocument v = database.newDocument("Sub");
+      v.set("id", i);
+      database.async().createRecord(v, null);
+    }
+
+    database.getSchema().getType("Sub").addSuperType("Super");
+
+    database.async().waitCompletion();
+
+    assertThat(database.countType("Sub", false)).isEqualTo(records);
+    final Index propagated = database.getSchema().getIndexByName("Super[id]");
+    assertThat(propagated.countEntries())
+        .as("every record must have an entry, whatever the async side was doing while the index was propagated")
+        .isEqualTo(records);
+  }
+
+  /**
    * The sibling call site, {@code LocalDocumentType.createBucket}, is SAFE and must not be "fixed" by symmetry: the
    * bucket it indexes has just been created, so no transaction can hold uncommitted writes into it and there is
    * nothing for the scan to miss. Nailed down here so the property is asserted rather than merely asserted about -

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.index;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.schema.DocumentType;
@@ -27,6 +28,8 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -338,6 +341,15 @@ class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
         .as("the subtype is as unlinked as the refusal left it").isEmpty();
     assertThat(database.getSchema().getType("Super").getSubTypes())
         .as("and so is the super type, on the other side of the same link").isEmpty();
+
+    // AND the indexes the propagation had already committed go with it. This refusal comes AFTER the propagation
+    // succeeded, so the sub-indexes exist and are attached to the super type's wrapper by the time it is raised;
+    // leaving them would point the super type's index at buckets belonging to a type that is no longer its subtype.
+    final List<Integer> subBucketIds = database.getSchema().getType("Sub").getBuckets(false).stream()
+        .map(Bucket::getFileId).toList();
+    for (final IndexInternal sub : ((TypeIndex) database.getSchema().getIndexByName("Super[k]")).getIndexesOnBuckets())
+      assertThat(subBucketIds).as("no propagated sub-index survives the refusal that followed it")
+          .doesNotContain(sub.getAssociatedBucketId());
 
     // The refusal took nothing away permanently: a subtype the partition IS suitable for still links.
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6359VectorIndexWrapperTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6359VectorIndexWrapperTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6359: a vector bucket sub-index has to answer which {@link TypeIndex} it belongs to.
+ * <p>
+ * {@link LSMVectorIndex#getTypeIndex()} used to answer {@code null}, with the comment "Not applicable for this index
+ * type", which was never true - a vector index IS registered under a wrapper, and every sibling family
+ * ({@code LSMSparseVectorIndex}, {@code LSMTreeIndex}, {@code HashIndex}, ...) has always wired it.
+ * <p>
+ * Asserted here on the DROP path rather than through the {@code addSuperType} scenario that first exposed it, because
+ * this half is the wider one: {@code LocalSchema.dropIndexInternal} skips {@code parentTypeIndex.removeIndexOnBucket}
+ * when the answer is null, so EVERY path that drops a vector sub-index used to leave the wrapper holding a reference
+ * to an index that no longer exists.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6359VectorIndexWrapperTest extends TestHelper {
+
+  /** Two buckets, so dropping one sub-index leaves the wrapper alive to be asked about the other. */
+  @Test
+  @Timeout(60)
+  void aVectorSubIndexNamesItsWrapperAndIsReleasedByItOnDrop() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("V", 2).createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      database.command("sql",
+          "CREATE INDEX ON V (embedding) LSM_VECTOR METADATA {\"dimensions\": 4, \"similarity\": \"cosine\"}").close();
+    });
+
+    final TypeIndex wrapper = (TypeIndex) database.getSchema().getIndexByName("V[embedding]");
+    final IndexInternal[] subIndexes = wrapper.getIndexesOnBuckets();
+    assertThat(subIndexes).as("one sub-index per bucket").hasSize(2);
+
+    for (final IndexInternal sub : subIndexes)
+      assertThat(sub.getTypeIndex()).as("a vector sub-index names the wrapper it was registered under").isSameAs(wrapper);
+
+    final IndexInternal dropped = subIndexes[0];
+    database.getSchema().dropIndex(dropped.getName());
+
+    assertThat(wrapper.getIndexesOnBuckets()).as("and the wrapper lets go of it when it is dropped")
+        .doesNotContain(dropped).hasSize(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.antlr;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.parser.Statement;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6359, item 2: what the parser builds for a negative literal has to render back as that
+ * literal.
+ * <p>
+ * A unary minus used to be modelled as a subtraction from zero, so the AST for {@code -1} was {@code 0 - 1} and that is
+ * what {@code Expression.toString()} produced. The rendering is not cosmetic: it is what EXPLAIN prints, what an
+ * unaliased projection is named after, and what a statement that re-reads one of its own settings parses - which is how
+ * {@code REBUILD INDEX ... WITH batchSize = -1} reached {@code Integer.parseInt} as the string {@code "0 - 1"} and came
+ * back as a raw {@code NumberFormatException} naming neither the setting nor the problem.
+ * <p>
+ * The same round-trip is asserted for the parentheses the statement was written with, which the renderer dropped for
+ * the same reason: {@code (1 + 2) * 3} rendered as {@code 1 + 2 * 3}, which is 7 rather than 9 when read back.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6359NegativeLiteralRenderingTest extends TestHelper {
+
+  private static String render(final String query) {
+    final Statement statement = new SQLAntlrParser(null).parse(query);
+    final StringBuilder builder = new StringBuilder();
+    statement.toString(null, builder);
+    return builder.toString();
+  }
+
+  @Test
+  void aNegativeLiteralRendersAsItself() {
+    assertThat(render("SELECT -1 AS n")).isEqualTo("SELECT -1 AS n");
+    assertThat(render("SELECT -1.5 AS n")).isEqualTo("SELECT -1.5 AS n");
+    assertThat(render("SELECT -2147483648 AS n")).isEqualTo("SELECT -2147483648 AS n");
+    // Already folded before this change, because 9223372036854775808 does not fit a positive long and the sign has to
+    // be applied before the conversion. Asserted so the generalisation cannot regress it.
+    assertThat(render("SELECT -9223372036854775808 AS n")).isEqualTo("SELECT -9223372036854775808 AS n");
+    assertThat(render("SELECT 2 * -1 AS n")).isEqualTo("SELECT 2 * -1 AS n");
+    assertThat(render("SELECT * FROM V WHERE x = -1")).isEqualTo("SELECT * FROM V WHERE x = -1");
+    // A unary plus is still dropped, and a minus applied to something that is not a literal is still a subtraction.
+    assertThat(render("SELECT +1 AS n")).isEqualTo("SELECT 1 AS n");
+    assertThat(render("SELECT -a AS n")).isEqualTo("SELECT 0 - a AS n");
+    // A genuine subtraction is untouched.
+    assertThat(render("SELECT 1 - 1 AS n")).isEqualTo("SELECT 1 - 1 AS n");
+  }
+
+  @Test
+  void theParenthesesTheStatementWasWrittenWithSurviveTheRendering() {
+    assertThat(render("SELECT (1 + 2) * 3 AS n")).isEqualTo("SELECT (1 + 2) * 3 AS n");
+    assertThat(render("SELECT -(1 + 2) AS n")).isEqualTo("SELECT 0 - (1 + 2) AS n");
+    assertThat(render("SELECT (a + b) * c AS n")).isEqualTo("SELECT (a + b) * c AS n");
+    // Parentheses that were NOT written are not invented: precedence already says what this means.
+    assertThat(render("SELECT 1 + 2 * 3 AS n")).isEqualTo("SELECT 1 + 2 * 3 AS n");
+  }
+
+  /**
+   * And parentheses that carry no meaning are not printed either. Only a COMPOUND arithmetic operand can be
+   * re-associated by the precedence around it; around an atom they are decoration, and printing them would rename
+   * every unaliased projection that was written that way - {@code SELECT (name) FROM V} has always been a column
+   * called {@code name}, and {@code SELECT distinct(name)}, which the parser reads as {@code DISTINCT (name)}, with
+   * it.
+   */
+  @Test
+  void parenthesesAroundAnAtomAreNotPrinted() {
+    assertThat(render("SELECT (name) FROM V")).isEqualTo("SELECT name FROM V");
+    assertThat(render("SELECT (a.b) FROM V")).isEqualTo("SELECT a.b FROM V");
+    assertThat(render("SELECT distinct(name) FROM V")).isEqualTo("SELECT DISTINCT name FROM V");
+  }
+
+  /** And the column name a caller reads back is the one it has always been. */
+  @Test
+  void anUnaliasedParenthesisedProjectionKeepsItsName() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1));
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("V");
+      v.set("name", "n1");
+      v.save();
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT (name) FROM V")) {
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("n1");
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT distinct(name) FROM V")) {
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("n1");
+    }
+  }
+
+  /**
+   * The property that matters, stated directly: rendering a parsed statement and parsing the result back must not
+   * change what it computes.
+   */
+  @Test
+  void renderingAndReparsingPreservesTheValue() {
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1));
+    database.transaction(() -> database.newDocument("V").save());
+
+    assertValueSurvivesReparse("SELECT -1 AS n", -1);
+    assertValueSurvivesReparse("SELECT 2 * -1 AS n", -2);
+    assertValueSurvivesReparse("SELECT -1 + 2 AS n", 1);
+    assertValueSurvivesReparse("SELECT -(1 + 2) AS n", -3);
+    assertValueSurvivesReparse("SELECT (1 + 2) * 3 AS n", 9);
+    assertValueSurvivesReparse("SELECT 1 + 2 * 3 AS n", 7);
+    assertValueSurvivesReparse("SELECT -1.5 + 0.5 AS n", -1.0f);
+  }
+
+  private void assertValueSurvivesReparse(final String query, final Object expected) {
+    final String query2 = "SELECT " + query.substring("SELECT ".length()) + " FROM V";
+    try (final ResultSet rs = database.query("sql", query2)) {
+      assertThat(rs.next().<Object>getProperty("n")).as(query).isEqualTo(expected);
+    }
+    final String rendered = render(query) + " FROM V";
+    try (final ResultSet rs = database.query("sql", rendered)) {
+      assertThat(rs.next().<Object>getProperty("n")).as("re-parsed: " + rendered).isEqualTo(expected);
+    }
+  }
+
+  /**
+   * The setting readers see the number the user typed. {@code batchSize = -1} is still refused - a batch below one is
+   * not a smaller batch - but the refusal now names {@code -1} instead of the arithmetic expression the AST used to
+   * carry.
+   */
+  @Test
+  void aNumericSettingIsRefusedByTheValueTheUserTyped() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    });
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", 1);
+      v.save();
+    });
+
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = -1").close())
+        .hasMessageContaining("batchSize").hasMessageContaining("-1")
+        .hasMessageNotContaining("0 - 1");
+
+    assertThatThrownBy(() -> database.command("sql", "REBUILD TYPE V WITH batchSize = -1").close())
+        .hasMessageContaining("batchSize").hasMessageContaining("-1")
+        .hasMessageNotContaining("0 - 1");
+
+    // And a legal one still works, so the guards above are not simply refusing everything.
+    database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = 1000").close();
+    database.command("sql", "REBUILD TYPE V WITH batchSize = 1000").close();
+    assertThat(database.getSchema().getIndexByName("V[id]").get(new Object[] { 1 }).hasNext()).isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
@@ -211,4 +211,24 @@ class Issue6359NegativeLiteralRenderingTest extends TestHelper {
     assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = :size",
         Map.of("size", -1)).close()).hasMessageContaining("batchSize").hasMessageContaining("-1");
   }
+
+  /**
+   * One value, read the same way whichever shape it arrives in. A whole number is a whole number written as an
+   * integer, as a decimal, or as text; a fractional one is not a batch size in any of them, and truncating it would
+   * honour a request nobody made.
+   */
+  @Test
+  void aNumericSettingReadsOneValueTheSameWayInEveryShapeItArrivesIn() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    });
+
+    for (final String accepted : new String[] { "1000", "1000.0", "'1000'" })
+      database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = " + accepted).close();
+
+    for (final String refused : new String[] { "1000.5", "'1000.5'", "'not a number'", "0" })
+      assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = " + refused).close())
+          .as(refused).hasMessageContaining("batchSize");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
@@ -26,6 +26,8 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -169,5 +171,31 @@ class Issue6359NegativeLiteralRenderingTest extends TestHelper {
     database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = 1000").close();
     database.command("sql", "REBUILD TYPE V WITH batchSize = 1000").close();
     assertThat(database.getSchema().getIndexByName("V[id]").get(new Object[] { 1 }).hasNext()).isTrue();
+  }
+
+  /**
+   * A numeric setting is read by EVALUATING its expression, not by rendering it, so a BOUND PARAMETER resolves to the
+   * number the caller bound. Rendering answers with the placeholder text, which no amount of parsing turns into an
+   * integer - the reason the reader takes the evaluated value, exactly like the boolean one next to it.
+   */
+  @Test
+  void aNumericSettingAcceptsABoundParameter() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+    });
+    database.transaction(() -> {
+      final MutableDocument v = database.newDocument("V");
+      v.set("id", 1);
+      v.save();
+    });
+
+    database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = :size", Map.of("size", 1000)).close();
+    database.command("sql", "REBUILD TYPE V WITH batchSize = :size", Map.of("size", 1000)).close();
+    assertThat(database.getSchema().getIndexByName("V[id]").get(new Object[] { 1 }).hasNext()).isTrue();
+
+    // And a bound value that is not a legal batch size is refused by that value, not by its placeholder.
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `V[id]` WITH batchSize = :size",
+        Map.of("size", -1)).close()).hasMessageContaining("batchSize").hasMessageContaining("-1");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/antlr/Issue6359NegativeLiteralRenderingTest.java
@@ -95,6 +95,19 @@ class Issue6359NegativeLiteralRenderingTest extends TestHelper {
     assertThat(render("SELECT distinct(name) FROM V")).isEqualTo("SELECT DISTINCT name FROM V");
   }
 
+  /**
+   * Nesting collapses to the one pair that carries the meaning. Each layer is judged on the operand it wraps, so the
+   * layers around an already-parenthesised block wrap something that renders as one atom and print nothing - which
+   * leaves the rendering saying exactly what the expression means, once.
+   */
+  @Test
+  void redundantLayersOfParenthesesCollapseToTheOneThatMatters() {
+    assertThat(render("SELECT ((a + b)) * c AS n")).isEqualTo("SELECT (a + b) * c AS n");
+    assertThat(render("SELECT (((1 + 2))) * 3 AS n")).isEqualTo("SELECT (1 + 2) * 3 AS n");
+    assertThat(render("SELECT -((1 + 2)) AS n")).isEqualTo("SELECT 0 - (1 + 2) AS n");
+    assertThat(render("SELECT ((a)) FROM V")).isEqualTo("SELECT a FROM V");
+  }
+
   /** And the column name a caller reads back is the one it has always been. */
   @Test
   void anUnaliasedParenthesisedProjectionKeepsItsName() {

--- a/gremlin/src/main/java/com/arcadedb/gremlin/query/GremlinQueryEngineFactory.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/query/GremlinQueryEngineFactory.java
@@ -45,8 +45,29 @@ public class GremlinQueryEngineFactory implements QueryEngine.QueryEngineFactory
       return (GremlinQueryEngine) engine;
 
     } catch (final Throwable e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on initializing Gremlin query engine", e);
-      throw new CommandParsingException("Error on initializing Gremlin query engine", e);
+      final String message = "Error on initializing Gremlin query engine" + classpathHint(e);
+      LogManager.instance().log(this, Level.SEVERE, message, e);
+      throw new CommandParsingException(message, e);
     }
+  }
+
+  /**
+   * Names the real problem when the engine could not start because TinkerPop is not on the classpath, rather than
+   * leaving it as a {@code NoClassDefFoundError} buried under a generic message (issue #6359, item 3).
+   * <p>
+   * The way to reach this is not exotic: {@code arcadedb-gremlin}'s plain jar carries no TinkerPop of its own, and a
+   * build that consumes it in place of the {@code shaded} uber-jar - which is what Maven substitutes for a
+   * classified dependency whose module is in the same reactor but has not reached the {@code package} phase - gets
+   * ArcadeDB's Gremlin classes with nothing behind them.
+   */
+  static String classpathHint(final Throwable e) {
+    for (Throwable cause = e; cause != null; cause = cause.getCause())
+      if (cause instanceof NoClassDefFoundError || cause instanceof ClassNotFoundException) {
+        final String missing = cause.getMessage();
+        if (missing != null && missing.contains("tinkerpop"))
+          return ": the Apache TinkerPop libraries are not on the classpath (missing '" + missing.replace('/', '.')
+              + "'). Use the 'shaded' arcadedb-gremlin artifact, or add the TinkerPop dependencies alongside the plain one";
+      }
+    return "";
   }
 }

--- a/gremlin/src/test/java/com/arcadedb/gremlin/query/GremlinQueryEngineFactoryClasspathHintTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/query/GremlinQueryEngineFactoryClasspathHintTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6359, item 3: an engine that could not start because TinkerPop is missing from the
+ * classpath has to say so, instead of leaving a {@code NoClassDefFoundError} under a message that points at the engine.
+ * <p>
+ * The way to reach it is a plain build mistake - consuming {@code arcadedb-gremlin}'s ordinary jar where the
+ * {@code shaded} uber-jar was meant, which is what Maven substitutes for a classified dependency whose module shares
+ * the reactor but has not reached the {@code package} phase.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GremlinQueryEngineFactoryClasspathHintTest {
+
+  @Test
+  void aMissingTinkerPopIsNamedAsAClasspathProblem() {
+    final String hint = GremlinQueryEngineFactory.classpathHint(
+        new RuntimeException("wrapped", new NoClassDefFoundError("org/apache/tinkerpop/gremlin/structure/Graph")));
+
+    assertThat(hint).contains("TinkerPop libraries are not on the classpath");
+    assertThat(hint).as("the missing class is named in the form the user would recognise")
+        .contains("org.apache.tinkerpop.gremlin.structure.Graph");
+    assertThat(hint).contains("shaded");
+  }
+
+  @Test
+  void anUnrelatedFailureAddsNothing() {
+    assertThat(GremlinQueryEngineFactory.classpathHint(new IllegalStateException("no graph for you"))).isEmpty();
+    // A missing class that is NOT TinkerPop is a different problem and must not be mislabelled as this one.
+    assertThat(GremlinQueryEngineFactory.classpathHint(new NoClassDefFoundError("com/example/Whatever"))).isEmpty();
+  }
+}


### PR DESCRIPTION
Closes #6359.

Three findings collected while fixing #6324, none of which was that issue's to fix.

## Item 1 - an index propagated to a super type's existing buckets missed uncommitted records

#6324 made `CREATE INDEX` see the writes of the transaction it runs in, through `TypeIndexBuilder` and
`BucketIndexBuilder`. `LocalDocumentType.addSuperType` uses neither: it calls `LocalSchema.createBucketIndex`
directly, over buckets that **already hold records**, and still built in a transaction of its own. A caller that
inserts and then links a super type in one transaction got exactly #6324's shape back - an index that is readable,
reported healthy by `CHECK DATABASE`, and answers the lookup it exists for with nothing.

It now takes the same two-transaction split: the components are created and committed on their own, then the builds
join the caller's transaction.

The issue offered two shapes for the fix - route the call site through a builder, or write the split a third time.
Neither is what landed, because the first is not free: `BucketIndexBuilder.create()` re-derives the key types from
the type's properties (the propagation has them on the index being propagated), passes `null` for the `TypeIndex` to
attach to (so a propagated sub-index would mint a NEW wrapper on the subtype instead of joining the super type's),
and quiesces the async executor once per call - N full quiesce cycles for one `addSuperType`. What is shared instead
is the three things the split actually needs, now written once in `IndexBuilder`:

- `callerTransactionHasChanges(database)` - the transaction half of the predicate, on its own because this call site
  has to ask it **before** it knows which index families it is about to create;
- `buildCreatedIndex(index, batchSize, shares, callback)` - the `UNAVAILABLE` -> `AVAILABLE` step;
- `dropPartiallyBuiltIndex(schema, index)` - `BucketIndexBuilder`'s private copy is gone.

Timing is the trap this cost the most on: the predicate has to be asked before anything is opened, because inside
the component-creation transaction there is always one, it is empty, and the answer would always be no. Asked from
the wrong place, the fix compiles, passes four of five tests, and does nothing.

The sibling call site in `createBucket()` is left alone deliberately, and now says why: the bucket it indexes has
just been created, so no transaction can hold uncommitted writes into it and there is nothing for the scan to miss.

## Item 2 - a negative numeric literal rendered as an arithmetic expression

A unary minus was modelled as a subtraction from zero, so the AST for `-1` was `0 - 1` and that is what
`Expression.toString()` produced. The rendering is not cosmetic: it is what `EXPLAIN` prints, what an unaliased
projection is named after, and what a statement re-reading one of its own settings parses - `REBUILD INDEX ... WITH
batchSize = -1` reached `Integer.parseInt` as the string `"0 - 1"`.

The minus is now folded into the literal. It negates the **already-parsed** value rather than re-parsing a
`"-"`-prefixed text, so the folded literal keeps exactly the numeric type `0 - X` used to produce (`-2147483648`
stays a `Long`, an `L`-suffixed literal stays a `Long`, a bare decimal stays a `Float`) and the sign lands correctly
on every literal shape the visitors accept, not only on plain decimal. A literal carrying a modifier is left alone,
since a suffix binds tighter than the sign.

Measuring that turned up the other half of the same defect, which the fold alone does not reach: the parentheses a
statement was written with were dropped as well.

| written | rendered before | reads back as |
|---|---|---|
| `SELECT 2 * -1` | `SELECT 2 * 0 - 1` | -1, not -2 |
| `SELECT (1 + 2) * 3` | `SELECT 1 + 2 * 3` | 7, not 9 |
| `SELECT -(1 + 2)` | `SELECT 0 - 1 + 2` | 1, not -3 |

`BaseExpression.expression` could not say on its own whether it held a parenthesised block - the builder also parks
map literals, array literals and CASE expressions there - so the node now records that the parentheses were written,
and prints them only where dropping them could change the meaning: around a **compound** arithmetic operand. Around
an atom they are decoration, and printing them would rename every unaliased projection written that way
(`SELECT (name) FROM V` has always been a column called `name`, and `SELECT distinct(name)`, which the parser reads
as `DISTINCT (name)`, with it).

And the numeric-setting readers are unified on `DDLStatement.parsePositiveIntSetting`, next to the boolean one that
was already shared - the sweep the issue asked for, done by removing the duplicate rather than by fixing each copy.
That also fixes `REBUILD TYPE ... WITH batchSize`, which read `Expression.value` - null for every numeric literal
the parser builds - and so refused every value it was given, legal ones included, with `got: null`.

## Item 3 - `graphql` and `gremlin` could not share one Maven invocation

Pre-existing and invisible in CI, where the lanes run each module separately. Measured cause:

```
Caused by: java.lang.NoClassDefFoundError: org/apache/tinkerpop/gremlin/structure/Graph
```

It is the trap already documented for `arcadedb-gremlin-it`, one module wider. `graphql` consumes
`arcadedb-gremlin`'s `shaded` classifier with a wildcard exclusion, so the uber-jar is self-contained; Maven
substitutes the reactor module for a classified dependency whose module is in the same invocation, the `test` phase
never runs the shade plugin, and the plain `target/classes` that stands in for it carries no TinkerPop.

```
mvn -o test    -pl gremlin,graphql   ->  Tests run: 45, Errors: 2
mvn -o verify  -pl gremlin,graphql   ->  Tests run: 45, Errors: 0
mvn -o test    -pl graphql           ->  Tests run: 45, Errors: 0
```

Inherent to how the artifact is resolved, so it is documented in CLAUDE.md's build-traps section where somebody
running that command will find it. What is fixed is the message: the failure named the engine ("Error on
initializing Gremlin query engine") rather than the classpath, and now names the classpath.

## Checked, and NOT a bug

The issue's last section records that unique-index enforcement was measured and is sound. Nothing to do, not
re-opened.

## Testing

- `Issue6359SuperTypeIndexPropagationTest` (5): the propagation over uncommitted inserts through the API and through
  one SQL script, a record updated in the same transaction indexed under its new key, the propagated component
  surviving a rollback of the transaction that propagated it and still being writeable, and the `createBucket()`
  sibling asserted rather than merely asserted about.
- `Issue6359NegativeLiteralRenderingTest` (6): the rendering of every negative literal shape, the parentheses rule
  both ways, a render-and-reparse round trip asserted on the computed VALUE, the column name of an unaliased
  parenthesised projection, and the setting readers refusing `-1` by the value the user typed.
- `GremlinQueryEngineFactoryClasspathHintTest` (2): the missing-TinkerPop message, and that an unrelated failure -
  including a missing class that is not TinkerPop - is not mislabelled as it.
- `mvn -o -pl engine -am test`: 12587 tests, 0 failures.
- `mvn -o verify -pl gremlin,graphql,server,postgresw -am` and `mvn -o verify -pl gremlin-it -am`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QF6LJaiD6ZRr6oA9WZxVBK
