### PR TITLE
fix(#6310): relationship uniqueness is scoped to the MATCH clause, not to one pattern part

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2074,11 +2074,11 @@ public class CypherExecutionPlan {
         // For the first hop, use sourceVar; for subsequent hops, use the previous targetVar
         String currentSourceVar = sourceVar;
 
-        // Smart GAV eligibility: for each anonymous hop, check if its edge types overlap
-        // with any other hop's types in the same pattern. If disjoint, null relVar enables
-        // fast path (GAV/CSR). If overlapping, generate an internal anonymous variable to
-        // force edge-loading for cross-hop uniqueness checking.
-        final boolean[] hopNeedsEdgeTracking = computeHopEdgeTrackingNeeds(pathPattern);
+        // Smart GAV eligibility: for each anonymous hop, check whether any other hop of the same MATCH
+        // clause - this pattern part or another one across a comma - could be the same physical edge. If
+        // none can, a null relVar enables the fast path (GAV/CSR). If one can, generate an internal
+        // anonymous variable to force edge-loading, so relationship uniqueness has something to compare.
+        final boolean[] hopNeedsEdgeTracking = computeHopEdgeTrackingNeeds(pathPatterns, patternIndex);
 
         for (int i = 0; i < pathPattern.getRelationshipCount(); i++) {
           final RelationshipPattern relPattern = pathPattern.getRelationship(i);
@@ -2715,8 +2715,8 @@ public class CypherExecutionPlan {
               // For the first hop, use sourceVar; for subsequent hops, use the previous targetVar
               String currentSourceVar = sourceVar;
 
-              // Smart GAV eligibility: same analysis as ordered path
-              final boolean[] hopNeedsEdgeTrackingLegacy = computeHopEdgeTrackingNeeds(pathPattern);
+              // Smart GAV eligibility: same clause-scoped analysis as the ordered path
+              final boolean[] hopNeedsEdgeTrackingLegacy = computeHopEdgeTrackingNeeds(pathPatterns, patternIndex);
 
               for (int i = 0; i < pathPattern.getRelationshipCount(); i++) {
                 final RelationshipPattern relPattern = pathPattern.getRelationship(i);
@@ -4197,83 +4197,80 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * Checks whether an edge variable is actually referenced in the query outside its
-   * MATCH pattern declaration. If the variable appears only in the pattern (e.g.,
-   * {@code [r:KNOWS]}) but is never used elsewhere, it can be treated as anonymous
-   * for GAV/fast-path purposes.
-
-
-
-
-  /**
-   * Determines which hops in a path pattern need edge tracking for Cypher's relationship
-   * uniqueness constraint. A hop needs tracking only if its edge types could overlap with
-   * another hop's types in the same pattern AND the overlapping hops could match the same
-   * physical edge. Two hops with the same edge type but type-disjoint source or target
-   * vertex labels cannot match the same edge.
+   * Determines which hops of one comma-separated pattern part have to bind their edge so that Cypher's
+   * relationship uniqueness can be enforced.
    * <p>
-   * Rules:
+   * Uniqueness is scoped to the whole MATCH clause, not to one pattern part: two parts separated by a comma
+   * are one pattern and may never bind the same relationship (two separate MATCH clauses may - that is the
+   * documented difference between the comma and a second MATCH). The check itself is a comparison against the
+   * edges the row already carries, so a hop that is never asked to bind its edge is invisible to it. Scoping
+   * this analysis to a single part therefore did not merely miss an optimisation, it dropped the constraint:
+   * a part that cannot collide with itself - a single hop, typically - bound nothing, and the hop of a later
+   * part had nothing to compare against (issue #6310).
+   * <p>
+   * A hop is left free - which is what keeps it on the GAV/CSR fast path - only when no other hop in the
+   * clause can be the same physical edge:
    * <ul>
-   *   <li>Single-hop pattern → no tracking needed (no other hop to conflict with)</li>
-   *   <li>Untyped hop (matches all edge types) → always needs tracking</li>
-   *   <li>Typed hop whose types are disjoint from all other hops → no tracking</li>
-   *   <li>Typed hop with type overlap but disjoint vertex labels on the edge endpoints → no tracking</li>
-   *   <li>Typed hop with type overlap and compatible vertex labels → needs tracking</li>
+   *   <li>the only hop in the clause has nothing to collide with;</li>
+   *   <li>two hops whose edge types are disjoint in the schema are always different edges. An edge has
+   *   exactly one type, so a hop's type list is a disjunction: the pair is disjoint only when every
+   *   combination is. Subtyping counts as overlap - {@code [:BASE]} and {@code [:SUB]} both match a
+   *   {@code SUB} edge;</li>
+   *   <li>two hops whose OUT or IN endpoint patterns are type-disjoint cannot be the same edge either,
+   *   whatever their types.</li>
    * </ul>
    *
-   * @param pathPattern the path pattern to analyze
-   * @return boolean array, true at index i if hop i needs edge tracking
+   * @param clausePatterns the comma-separated pattern parts of the MATCH clause being planned
+   * @param patternIndex   index in {@code clausePatterns} of the part being planned
+   *
+   * @return boolean array, true at index i if hop i of that part must bind its edge
    */
-  private boolean[] computeHopEdgeTrackingNeeds(final PathPattern pathPattern) {
-    final int hopCount = pathPattern.getRelationshipCount();
-    final boolean[] needs = new boolean[hopCount];
-    if (hopCount <= 1)
-      return needs; // single-hop: all false
+  private boolean[] computeHopEdgeTrackingNeeds(final List<PathPattern> clausePatterns, final int patternIndex) {
+    final PathPattern pathPattern = clausePatterns.get(patternIndex);
+    final boolean[] needs = new boolean[pathPattern.getRelationshipCount()];
 
-    // Collect edge types per hop (null = untyped, matches all)
-    final List<String>[] hopTypes = new List[hopCount];
-    boolean hasUntyped = false;
-    for (int i = 0; i < hopCount; i++) {
-      final RelationshipPattern rel = pathPattern.getRelationship(i);
-      if (rel.hasTypes())
-        hopTypes[i] = rel.getTypes();
-      else {
-        hopTypes[i] = null;
-        hasUntyped = true;
-      }
-    }
-
-    for (int i = 0; i < hopCount; i++) {
-      if (hopTypes[i] == null) {
-        // Untyped hop: overlaps with everything
-        needs[i] = true;
-        continue;
-      }
-      if (hasUntyped) {
-        // Another hop is untyped → overlaps with us
-        needs[i] = true;
-        continue;
-      }
-      // Check if our types overlap with any other hop's types
-      for (int j = 0; j < hopCount; j++) {
-        if (i == j)
-          continue;
-        // Both typed: check intersection
-        for (final String type : hopTypes[i]) {
-          if (hopTypes[j].contains(type)) {
-            // Same edge type — check if the hops are guaranteed to match different
-            // physical edges based on their vertex endpoint labels
-            if (areHopsDisjointByEndpointLabels(pathPattern, i, j))
-              continue; // Disjoint endpoints → skip this overlap
+    for (int i = 0; i < needs.length; i++) {
+      for (int p = 0; p < clausePatterns.size() && !needs[i]; p++) {
+        final PathPattern other = clausePatterns.get(p);
+        for (int j = 0; j < other.getRelationshipCount(); j++) {
+          if (p == patternIndex && i == j)
+            continue;
+          if (hopsCanMatchTheSameEdge(pathPattern, i, other, j)) {
             needs[i] = true;
             break;
           }
         }
-        if (needs[i])
-          break;
       }
     }
     return needs;
+  }
+
+  /**
+   * Whether two hops of the same MATCH clause could bind the same physical edge, and so have to be compared
+   * against each other for relationship uniqueness. Conservative: it answers yes unless the schema proves
+   * otherwise, because a wrong no silently returns rows Cypher forbids.
+   */
+  private boolean hopsCanMatchTheSameEdge(final PathPattern patternI, final int hopI, final PathPattern patternJ,
+      final int hopJ) {
+    final RelationshipPattern relI = patternI.getRelationship(hopI);
+    final RelationshipPattern relJ = patternJ.getRelationship(hopJ);
+
+    if (relI.hasTypes() && relJ.hasTypes() && edgeTypesAreDisjoint(relI.getTypes(), relJ.getTypes()))
+      return false;
+
+    return !areHopsDisjointByEndpointLabels(patternI, hopI, patternJ, hopJ);
+  }
+
+  /**
+   * Whether no edge in the schema can satisfy both type lists. An edge carries exactly one type, so each list
+   * is a disjunction and the two are disjoint only when every pair of alternatives is.
+   */
+  private boolean edgeTypesAreDisjoint(final List<String> typesI, final List<String> typesJ) {
+    for (final String typeI : typesI)
+      for (final String typeJ : typesJ)
+        if (!labelsAreTypeDisjoint(typeI, typeJ))
+          return false;
+    return true;
   }
 
   /**
@@ -4300,8 +4297,9 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * Checks if two hops with the same edge type are guaranteed to match different physical edges
-   * based on the vertex labels at their edge endpoints.
+   * Checks if two hops of the same MATCH clause - each one identified by its pattern part and its index
+   * inside it, so the pair may straddle a comma - are guaranteed to match different physical edges based
+   * on the vertex labels at their edge endpoints.
    * <p>
    * An edge has exactly one OUT vertex and one IN vertex. If we can prove that the OUT vertex
    * (or IN vertex) for hop i must be of a different type than for hop j, the edges are distinct.
@@ -4313,19 +4311,20 @@ public class CypherExecutionPlan {
    *   <li>BOTH direction: cannot determine mapping → conservative (not disjoint)</li>
    * </ul>
    */
-  private boolean areHopsDisjointByEndpointLabels(final PathPattern pathPattern, final int hopI, final int hopJ) {
-    final Direction dirI = pathPattern.getRelationship(hopI).getDirection();
-    final Direction dirJ = pathPattern.getRelationship(hopJ).getDirection();
+  private boolean areHopsDisjointByEndpointLabels(final PathPattern patternI, final int hopI,
+      final PathPattern patternJ, final int hopJ) {
+    final Direction dirI = patternI.getRelationship(hopI).getDirection();
+    final Direction dirJ = patternJ.getRelationship(hopJ).getDirection();
 
     // BOTH direction: can't determine which node is the edge's OUT/IN vertex
     if (dirI == Direction.BOTH || dirJ == Direction.BOTH)
       return false;
 
     // Map pattern nodes to edge endpoints based on direction
-    final NodePattern edgeOutI = dirI == Direction.OUT ? pathPattern.getNode(hopI) : pathPattern.getNode(hopI + 1);
-    final NodePattern edgeOutJ = dirJ == Direction.OUT ? pathPattern.getNode(hopJ) : pathPattern.getNode(hopJ + 1);
-    final NodePattern edgeInI = dirI == Direction.OUT ? pathPattern.getNode(hopI + 1) : pathPattern.getNode(hopI);
-    final NodePattern edgeInJ = dirJ == Direction.OUT ? pathPattern.getNode(hopJ + 1) : pathPattern.getNode(hopJ);
+    final NodePattern edgeOutI = dirI == Direction.OUT ? patternI.getNode(hopI) : patternI.getNode(hopI + 1);
+    final NodePattern edgeOutJ = dirJ == Direction.OUT ? patternJ.getNode(hopJ) : patternJ.getNode(hopJ + 1);
+    final NodePattern edgeInI = dirI == Direction.OUT ? patternI.getNode(hopI + 1) : patternI.getNode(hopI);
+    final NodePattern edgeInJ = dirJ == Direction.OUT ? patternJ.getNode(hopJ + 1) : patternJ.getNode(hopJ);
 
     // If the OUT vertex labels are type-disjoint, the edges are different
     if (nodeLabelsAreTypeDisjoint(edgeOutI, edgeOutJ))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -4255,6 +4255,10 @@ public class CypherExecutionPlan {
     final RelationshipPattern relI = patternI.getRelationship(hopI);
     final RelationshipPattern relJ = patternJ.getRelationship(hopJ);
 
+    // A hop capped at zero edges - [*0..0] - binds none, so it has nothing to share with anybody.
+    if (bindsNoEdge(relI) || bindsNoEdge(relJ))
+      return false;
+
     if (relI.hasTypes() && relJ.hasTypes() && edgeTypesAreDisjoint(relI.getTypes(), relJ.getTypes()))
       return false;
 
@@ -4344,6 +4348,12 @@ public class CypherExecutionPlan {
 
     // If the IN vertex labels are type-disjoint, the edges are different
     return nodeLabelsAreTypeDisjoint(edgeInI, edgeInJ);
+  }
+
+  /** Whether the hop is pinned to zero edges, and so binds none at all. */
+  private static boolean bindsNoEdge(final RelationshipPattern rel) {
+    final Integer maxHops = rel.getMaxHops();
+    return rel.isVariableLength() && maxHops != null && maxHops == 0;
   }
 
   /** Whether the hop can bind more than one edge, so its declared endpoints are not one edge's endpoints. */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -4309,12 +4309,24 @@ public class CypherExecutionPlan {
    *   <li>OUT direction: edge OUT = source node (node[i]), edge IN = target node (node[i+1])</li>
    *   <li>IN direction: edge OUT = target node (node[i+1]), edge IN = source node (node[i])</li>
    *   <li>BOTH direction: cannot determine mapping → conservative (not disjoint)</li>
+   *   <li>a hop that can span more than one edge: the mapping describes the whole path, not one edge
+   *   → conservative (not disjoint)</li>
    * </ul>
    */
   private boolean areHopsDisjointByEndpointLabels(final PathPattern patternI, final int hopI,
       final PathPattern patternJ, final int hopJ) {
-    final Direction dirI = patternI.getRelationship(hopI).getDirection();
-    final Direction dirJ = patternJ.getRelationship(hopJ).getDirection();
+    final RelationshipPattern relI = patternI.getRelationship(hopI);
+    final RelationshipPattern relJ = patternJ.getRelationship(hopJ);
+
+    // A variable-length hop's endpoint patterns constrain its first and last edge only: everything in
+    // between starts and ends at a node the pattern says nothing about, so proving the declared endpoints
+    // disjoint proves nothing about those edges. Only a hop pinned to a single edge can be argued about
+    // this way; the type proof above stays valid, since every edge of the hop must match its type list.
+    if (spansMoreThanOneEdge(relI) || spansMoreThanOneEdge(relJ))
+      return false;
+
+    final Direction dirI = relI.getDirection();
+    final Direction dirJ = relJ.getDirection();
 
     // BOTH direction: can't determine which node is the edge's OUT/IN vertex
     if (dirI == Direction.BOTH || dirJ == Direction.BOTH)
@@ -4332,6 +4344,14 @@ public class CypherExecutionPlan {
 
     // If the IN vertex labels are type-disjoint, the edges are different
     return nodeLabelsAreTypeDisjoint(edgeInI, edgeInJ);
+  }
+
+  /** Whether the hop can bind more than one edge, so its declared endpoints are not one edge's endpoints. */
+  private static boolean spansMoreThanOneEdge(final RelationshipPattern rel) {
+    if (!rel.isVariableLength())
+      return false;
+    final Integer maxHops = rel.getMaxHops();
+    return maxHops == null || maxHops > 1;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
@@ -214,6 +214,18 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
     assertThat(rows("MATCH (x:V)-[r1:BASE]->(:V), (y:V)-[r2:SUB]->(:V) RETURN x.n AS a, y.n AS c")).isEmpty();
   }
 
+  /**
+   * An undirected hop has no OUT and no IN end to compare, so the endpoint proof has to decline outright.
+   * Were it to guess - reading {@code (x:E)-[]-(y:A)} as if it were written {@code <-}, so that :A is the
+   * edge's OUT vertex - it would find :A disjoint from the other part's :E and "prove" the two hops
+   * distinct. They are not: undirected, this hop walks the very edge the other part matches.
+   */
+  @Test
+  void aBothDirectionHopGetsNoEndpointProof() {
+    // 3 undirected :E-:A edges x 3 (:E)-[]->(:A) edges, less the 3 pairings that are the same edge.
+    assertThat(rows("MATCH (x:E)-[]-(y:A), (p:E)-[]->(q:A) RETURN x.n AS a, p.n AS c")).hasSize(6);
+  }
+
   @Test
   void aZeroLengthHopSharesNoEdgeWithAnybody() {
     // [*0..0] binds no edge, so it neither collides with the other part nor costs it its fast path:

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
@@ -87,6 +87,8 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
 
     // c1 -> e1 -> a1, c2 -> e1 -> a1, c2 -> e2 -> a2, c3 -> e3 -> a3: the join on n0 is what makes it 4 and
     // not 3 x 4, and the two anonymous hops of the single pattern part are always distinct edges.
+    // This asserts the two forms AGREE; the pre-fix 4-vs-2 divergence itself is demonstrated in
+    // CypherWithStarScopeIssue6311Test, which pins the WITH * Cartesian product that caused it.
     assertThat(direct).isEqualTo(4);
     assertThat(materialized).isEqualTo(direct);
   }
@@ -210,6 +212,13 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
     assertThat(rows("CALL { MATCH (x:V)-[r1:BASE]->(:V), (y:V)-[r2:SUB]->(:V) RETURN x.n AS a, y.n AS c } RETURN a, c"))
         .isEmpty();
     assertThat(rows("MATCH (x:V)-[r1:BASE]->(:V), (y:V)-[r2:SUB]->(:V) RETURN x.n AS a, y.n AS c")).isEmpty();
+  }
+
+  @Test
+  void aZeroLengthHopSharesNoEdgeWithAnybody() {
+    // [*0..0] binds no edge, so it neither collides with the other part nor costs it its fast path:
+    // 3 zero-length :C bindings x the 3 (:E)-[]->(:A) edges, nothing removed.
+    assertThat(rows("MATCH (x:C)-[*0..0]->(y), (p:E)-[]->(q:A) RETURN x.n AS a, p.n AS c")).hasSize(9);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
@@ -141,6 +141,34 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
         .isEmpty();
   }
 
+  /**
+   * A variable-length hop's declared endpoints are the endpoints of the whole path, not of any one edge it
+   * binds: everything between the first and the last edge starts and ends at a node the pattern says nothing
+   * about. So {@code (x:C)-[*1..2]->(y:A)} and {@code (p:E)-[]->(q:A)} look endpoint-disjoint on their written
+   * ends - no vertex is both a {@code :C} and an {@code :E} - while the second edge of every path the first
+   * one walks is exactly an edge the second part matches.
+   */
+  @Test
+  void aVariableLengthHopMayNotBorrowAnEdgeFromAnotherPart() {
+    // 4 paths x 3 (:E)-[]->(:A) edges, less the 4 pairings in which they are the same edge.
+    assertThat(rows("MATCH (x:C)-[*1..2]->(y:A), (p:E)-[]->(q:A) RETURN x.n AS a, p.n AS c")).hasSize(8);
+    assertThat(rows(
+        "CALL { MATCH (x:C)-[*1..2]->(y:A), (p:E)-[]->(q:A) RETURN x.n AS a, p.n AS c } RETURN a, c")).hasSize(8);
+  }
+
+  @Test
+  void aShortestPathPartIsHeldToTheSameRule() {
+    assertThat(rows("MATCH p1 = shortestPath((x:C)-[*1..2]->(y:A)), (p:E)-[]->(q:A) RETURN x.n AS a, p.n AS c"))
+        .hasSize(8);
+  }
+
+  @Test
+  void aSingleEdgeVariableLengthHopKeepsTheEndpointProof() {
+    // Capped at one edge, so its written endpoints ARE the edge's and the proof applies again - here it
+    // proves nothing (both ends are :E -> :A), and uniqueness still removes the 3 same-edge pairings.
+    assertThat(rows("MATCH (x:E)-[*1..1]->(y:A), (p:E)-[]->(q:A) RETURN x.n AS a, p.n AS c")).hasSize(6);
+  }
+
   // ---------------------------------------------------------------------------------------------------------
   // The rule stops at the clause boundary, and the fast path it costs must not be paid where it is not owed.
   // ---------------------------------------------------------------------------------------------------------
@@ -182,6 +210,15 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
     assertThat(rows("CALL { MATCH (x:V)-[r1:BASE]->(:V), (y:V)-[r2:SUB]->(:V) RETURN x.n AS a, y.n AS c } RETURN a, c"))
         .isEmpty();
     assertThat(rows("MATCH (x:V)-[r1:BASE]->(:V), (y:V)-[r2:SUB]->(:V) RETURN x.n AS a, y.n AS c")).isEmpty();
+  }
+
+  @Test
+  void aTypeDisjointVariableLengthHopStillMatches() {
+    // The type proof survives the variable length - every edge of a [:R*1..2] hop is an :R - so an :S hop
+    // next to it keeps the fast path and the clause matches in full.
+    database.command("opencypher", "MATCH (a:A {n:'a1'}) CREATE (a)-[:S]->(:D {n:'d1'})");
+    assertThat(rows("MATCH (n0:A)-[:S]->(:D), (x:C)-[:R*1..2]->(y:A) RETURN n0.n AS a, x.n AS c"))
+        .containsExactlyInAnyOrder("a1|c1", "a1|c2", "a1|c2", "a1|c3");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
@@ -248,6 +248,35 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
         .containsExactlyInAnyOrder("a1|c1", "a1|c2", "a2|c2", "a3|c3");
   }
 
+  /**
+   * Which plan runs a clause decides which of the two implementations its uniqueness comes from, so it is
+   * worth pinning rather than assuming. The cost-based optimizer declines every variable-length hop, comma
+   * or no comma - so there is no optimizer-side variable-length path for the guards above to be wrong on,
+   * and a test claiming to cover one would in fact be exercising the traditional plan. A comma clause of
+   * fixed-length hops IS optimized, which is what makes the rest of this class cover both implementations.
+   * <p>
+   * A tripwire, not a preference: when the optimizer does grow variable-length support, this fails, and
+   * whoever adds it is made to answer the uniqueness question on that path too.
+   */
+  @Test
+  void theOptimizerDeclinesVariableLengthHopsButNotCommas() {
+    assertThat(planOf("MATCH (x:C)-[*1..2]->(y:A), (p:E)-[]->(q:A) RETURN x.n AS a"))
+        .contains("Traditional Execution");
+    assertThat(planOf("MATCH p1 = shortestPath((x:C)-[*1..2]->(y:A)), (p:E)-[]->(q:A) RETURN x.n AS a"))
+        .contains("Traditional Execution");
+    assertThat(planOf("MATCH (x:C)-[*1..2]->(y:A) RETURN x.n AS a"))
+        .contains("Traditional Execution");
+    assertThat(planOf("MATCH (n0:A)<-[r1]-(:E), (n3:C)-[]->(:E)-[r2]->(n0) RETURN n0.n AS a"))
+        .doesNotContain("Traditional Execution");
+  }
+
+  private String planOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return String.valueOf(rs.next().<Object>getProperty("executionPlan"));
+    }
+  }
+
   private List<String> rows(final String query) {
     final List<String> out = new ArrayList<>();
     try (final ResultSet rs = database.query("opencypher", query)) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6310: the row count of one MATCH must not depend on the shape of the clauses around it.
+ * <p>
+ * The reported pair - the same {@code OPTIONAL MATCH} read once through {@code WITH *} and once through a
+ * {@code map -> collect -> UNWIND} round trip - was the Cartesian-product defect of issue #6311 and is covered
+ * by {@link CypherWithStarScopeIssue6311Test}; it is pinned again here in the reporter's own spelling because
+ * that spelling routes the MATCH through the traditional (non-optimizer) plan, which #6311's tests do not.
+ * <p>
+ * What the reported invariant also uncovered is a second, independent way the same MATCH could answer
+ * differently depending on which plan ran it: Cypher scopes relationship uniqueness to the whole MATCH clause,
+ * so two comma-separated pattern parts of one clause may never bind the same relationship. The traditional plan
+ * decided per pattern part whether a hop had to bind its edge at all, so a part that could not collide with
+ * itself - typically a single-hop part - bound nothing, and the uniqueness check of a later part had nothing to
+ * compare against. The cost-based optimizer got this right, so the very same MATCH answered 0 rows on its own
+ * and 4 inside a {@code CALL} subquery, after an {@code OPTIONAL}, or next to a named path.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    // Three disjoint C -> E -> A chains, plus one extra C that feeds the first E, so that a pattern which
+    // ignores relationship uniqueness has a strictly larger answer than one which honours it.
+    database.command("opencypher", "CREATE (a1:A {n:'a1'})<-[:R]-(e1:E {n:'e1'})<-[:R]-(c1:C {n:'c1'})");
+    database.command("opencypher", "CREATE (a2:A {n:'a2'})<-[:R]-(e2:E {n:'e2'})<-[:R]-(c2:C {n:'c2'})");
+    database.command("opencypher", "CREATE (a3:A {n:'a3'})<-[:R]-(e3:E {n:'e3'})<-[:R]-(c3:C {n:'c3'})");
+    database.command("opencypher", "MATCH (e:E {n:'e1'}), (c:C {n:'c2'}) CREATE (c)-[:R]->(e)");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The reported pair: materialising the bindings through collect/UNWIND must not change the row count.
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void materializingThroughCollectAndUnwindKeepsTheCardinality() {
+    final long direct = count("""
+        CALL {
+          OPTIONAL MATCH (n0:A), (n3:C)-[]->(:E)-[]->(n0)
+          WITH *
+          UNWIND [1] AS k
+          RETURN count(*) AS rows
+        }
+        RETURN rows""");
+
+    final long materialized = count("""
+        CALL {
+          OPTIONAL MATCH (n0:A), (n3:C)-[]->(:E)-[]->(n0)
+          WITH {n0: n0, n3: n3} AS x
+          WITH collect(x) AS xs
+          UNWIND xs AS x
+          WITH x.n0 AS n0, x.n3 AS n3
+          UNWIND [1] AS k
+          RETURN count(*) AS rows
+        }
+        RETURN rows""");
+
+    // c1 -> e1 -> a1, c2 -> e1 -> a1, c2 -> e2 -> a2, c3 -> e3 -> a3: the join on n0 is what makes it 4 and
+    // not 3 x 4, and the two anonymous hops of the single pattern part are always distinct edges.
+    assertThat(direct).isEqualTo(4);
+    assertThat(materialized).isEqualTo(direct);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Relationship uniqueness spans the comma: the answer may not depend on which plan ran the clause.
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * The only {@code (:E)-[]->(n0:A)} edge for a given {@code n0} is the one {@code r1} already holds, so
+   * {@code r2} can never be a different relationship and the clause matches nothing at all.
+   */
+  private static final String COLLIDING = "MATCH (n0:A)<-[r1]-(:E), (n3:C)-[]->(:E)-[r2]->(n0)";
+
+  @Test
+  void aRelationshipIsNotSharedBetweenTwoCommaSeparatedPatternParts() {
+    assertThat(rows(COLLIDING + " RETURN n0.n AS a, n3.n AS c")).isEmpty();
+  }
+
+  @Test
+  void optionalMatchScopesUniquenessToTheWholeClause() {
+    // An OPTIONAL MATCH that matches nothing still yields its one all-null row.
+    assertThat(rows(COLLIDING.replace("MATCH", "OPTIONAL MATCH") + " RETURN n0.n AS a, n3.n AS c"))
+        .containsExactly("null|null");
+  }
+
+  @Test
+  void aCallSubqueryScopesUniquenessToTheWholeClause() {
+    assertThat(rows("CALL { " + COLLIDING + " RETURN n0.n AS a, n3.n AS c } RETURN a, c")).isEmpty();
+    assertThat(count("CALL { " + COLLIDING + " WITH * UNWIND [1] AS k RETURN count(*) AS rows } RETURN rows"))
+        .isEqualTo(0);
+  }
+
+  @Test
+  void aNamedPathOnOnePartScopesUniquenessToTheWholeClause() {
+    assertThat(rows("MATCH (n0:A)<-[r1]-(:E), p = (n3:C)-[]->(:E)-[r2]->(n0) RETURN n0.n AS a, n3.n AS c"))
+        .isEmpty();
+  }
+
+  @Test
+  void anExistsSubqueryScopesUniquenessToTheWholeClause() {
+    assertThat(rows("""
+        MATCH (n3:C)
+        WHERE EXISTS { MATCH (n0:A)<-[r1]-(:E), (n3)-[]->(:E)-[r2]->(n0) }
+        RETURN n3.n AS a, '' AS c""")).isEmpty();
+  }
+
+  @Test
+  void anonymousHopsAreHeldToTheSameRule() {
+    // Nothing names the relationships, so the plan has to bind them itself to be able to compare them.
+    assertThat(rows("CALL { MATCH (n0:A)<-[]-(:E), (n3:C)-[]->(:E)-[]->(n0) RETURN n0.n AS a, n3.n AS c } RETURN a, c"))
+        .isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The rule stops at the clause boundary, and the fast path it costs must not be paid where it is not owed.
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void twoMatchClausesMayShareTheSameRelationship() {
+    // Uniqueness is per MATCH clause: split across two clauses the same edge is allowed in both.
+    assertThat(rows("MATCH (n0:A)<-[r1]-(:E) MATCH (n3:C)-[]->(:E)-[r2]->(n0) RETURN n0.n AS a, n3.n AS c"))
+        .containsExactlyInAnyOrder("a1|c1", "a1|c2", "a2|c2", "a3|c3");
+  }
+
+  @Test
+  void typeDisjointPartsStillMatch() {
+    // No shared edge is possible between an :S hop and an :R hop, so the clause matches normally.
+    database.command("opencypher", "MATCH (a:A {n:'a1'}) CREATE (a)-[:S]->(:D {n:'d1'})");
+    assertThat(rows("MATCH (n0:A)-[s:S]->(:D), (n3:C)-[]->(:E)-[r:R]->(n0) RETURN n0.n AS a, n3.n AS c"))
+        .containsExactlyInAnyOrder("a1|c1", "a1|c2");
+  }
+
+  @Test
+  void endpointDisjointPartsStillMatch() {
+    // Same edge type on both parts, but no vertex is both an :E and a :C, so the two hops cannot be the
+    // same edge and the clause matches normally.
+    // c2 twice per :A - it has two outgoing :R edges into :E - for the full 3 x 4 product.
+    assertThat(rows("MATCH (:E)-[r1:R]->(n0:A), (n3:C)-[r2:R]->(:E) RETURN n0.n AS a, n3.n AS c"))
+        .containsExactlyInAnyOrder("a1|c1", "a1|c2", "a1|c2", "a1|c3", "a2|c1", "a2|c2", "a2|c2", "a2|c3",
+            "a3|c1", "a3|c2", "a3|c2", "a3|c3");
+  }
+
+  @Test
+  void aSupertypeHopAndASubtypeHopCanBeTheSameEdge() {
+    // An edge of a sub-type matches the super-type pattern too, so [:BASE] and [:SUB] are not disjoint and
+    // the two parts may not both bind the one edge that exists.
+    database.command("sql", "CREATE VERTEX TYPE V");
+    database.command("sql", "CREATE EDGE TYPE BASE");
+    database.command("sql", "CREATE EDGE TYPE SUB EXTENDS BASE");
+    database.command("opencypher", "CREATE (:V {n:'v1'})-[:SUB]->(:V {n:'v2'})");
+
+    assertThat(rows("CALL { MATCH (x:V)-[r1:BASE]->(:V), (y:V)-[r2:SUB]->(:V) RETURN x.n AS a, y.n AS c } RETURN a, c"))
+        .isEmpty();
+    assertThat(rows("MATCH (x:V)-[r1:BASE]->(:V), (y:V)-[r2:SUB]->(:V) RETURN x.n AS a, y.n AS c")).isEmpty();
+  }
+
+  @Test
+  void aSelfContainedSinglePartIsUnaffected() {
+    assertThat(rows("MATCH (n3:C)-[]->(:E)-[]->(n0:A) RETURN n0.n AS a, n3.n AS c"))
+        .containsExactlyInAnyOrder("a1|c1", "a1|c2", "a2|c2", "a3|c3");
+  }
+
+  private List<String> rows(final String query) {
+    final List<String> out = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        out.add(r.<Object>getProperty("a") + "|" + r.<Object>getProperty("c"));
+      }
+    }
+    return out;
+  }
+
+  private long count(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return ((Number) rs.next().getProperty("rows")).longValue();
+    }
+  }
+}


### PR DESCRIPTION
Closes #6310

## The reported pair

The two queries in #6310 - one `OPTIONAL MATCH` read through `WITH *` and the same one read through a `map -> collect -> UNWIND` round trip, answering 4 and 2 on 26.8.1 - are the Cartesian-product defect of #6311, fixed by d02b0c617 (PR #6326) after 26.8.1 was cut. Verified: the reported pair reproduces exactly at `d02b0c617^` and agrees on `main`.

Both spellings now answer the same thing - 2 on the reporter's two-chain graph, 4 on the richer fixture this test uses. Their queries are pinned as a regression test regardless, because that spelling routes the MATCH through the traditional plan, which #6311's tests do not reach.

## The defect this fixes

Generalising the reporter's invariant - *the same MATCH must not answer differently because of the clauses around it* - turned up a second, independent breach of it.

Cypher scopes relationship uniqueness to the whole MATCH clause: two comma-separated pattern parts are one pattern and may never bind the same relationship. That is precisely what distinguishes the comma from a second MATCH clause. The check is a comparison against the edges the row already carries, so a hop that is never asked to bind its edge is invisible to it - and `computeHopEdgeTrackingNeeds` decided that **per pattern part**. A part that could not collide with itself (a single hop, typically) bound nothing, and the hop of a later part had nothing to compare against.

The cost-based optimizer scoped it correctly, so the very same MATCH answered 0 rows on its own and 4 whenever the optimizer declined:

```cypher
// fixture: three C -> E -> A chains, plus one extra C feeding the first E
MATCH (n0:A)<-[r1]-(:E), (n3:C)-[]->(:E)-[r2]->(n0) RETURN n0, n3
```

| form | before | after | Neo4j |
|---|---|---|---|
| plain (optimizer) | 0 | 0 | 0 |
| inside `CALL { ... }` | **4** | 0 | 0 |
| `OPTIONAL MATCH` | **4** | 1 all-null row | 1 all-null row |
| inside `EXISTS { ... }` | **3** | 0 | 0 |
| one part carrying a named path | **4** | 0 | 0 |

`r1` is the only `(:E)-[]->(n0)` edge for a given `n0`, so `r2` can never be a different relationship and the clause matches nothing at all.

## The change

The analysis now runs over every hop of the clause rather than of one part. Both proofs that let a hop stay on the GAV/CSR fast path are kept, and one is sharpened:

- **edge types that cannot both match one edge.** An edge carries exactly one type, so a hop's type list is a disjunction and the pair is disjoint only when every combination is. This was decided by name equality, which read `[:BASE]` and `[:SUB]` as disjoint although a `SUB` edge matches both patterns; it is now the schema's own disjointness test, the one already used for vertex labels.
- **endpoint patterns that are type-disjoint** - unchanged, only generalised so the two hops may straddle a comma.

So `MATCH (n0:A)-[:S]->(:D), (n3:C)-[]->(:E)-[:R]->(n0)` and `MATCH (:E)-[r1:R]->(n0:A), (n3:C)-[r2:R]->(:E)` still take the fast path and still match; a clause with a single hop is untouched.

Also removes an unterminated Javadoc left behind when `isEdgeVariableReferenced` moved to `CypherVariableUsage`.

## Verification

New `CypherMatchClauseUniquenessIssue6310Test` (12 tests): the reported pair, the uniqueness rule across each of the shapes above, the polymorphic super/sub-type case, and four controls that must keep matching - two separate MATCH clauses sharing an edge, the type-disjoint pair, the endpoint-disjoint pair, and a self-contained single part. 6 of the 12 fail without the fix.

Suites run green: the whole `com.arcadedb.query.opencypher` package (8603 tests, including the 3897-scenario openCypher TCK and `GAVEligibilityTest`), and `engine` + `network` + `server` + `bolt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ho2s8oThF2cuitxbMsuD86
