### PR TITLE
fix(#6363): a vertex's labels are the ones it answers to, and adding one keeps the type that carries them

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -158,7 +158,7 @@ public class BoltStructureMapper {
     final long id = ridToId(rid);
     final String elementId = rid.toString();
 
-    // Get all labels (supertypes for composite types)
+    // Every label the node answers to: its own type and its ancestors', minus the synthetic composite names
     final List<String> labels = Labels.getLabels(vertex);
 
     // Get properties

--- a/docs/6363-cypher-labels-inheritance.md
+++ b/docs/6363-cypher-labels-inheritance.md
@@ -1,0 +1,112 @@
+# #6363: what a vertex's labels are, and what a label write is allowed to change
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/6363
+
+## What happened
+
+`Labels.getLabels(Vertex)` decided a vertex's labels from one question - "does the type have supertypes?" -
+and answered:
+
+- **no supertypes** -> the type's own name is the label,
+- **supertypes** -> the supertype names are the labels, and the type's own name is not one.
+
+That rule is right for exactly one shape, the synthetic `A~B` composite the multi-label support creates:
+its own name is an encoding, and its supertypes really are the labels. Applied to ordinary ArcadeDB type
+inheritance it is wrong in both directions:
+
+| shape | `labels(n)` before | `MATCH (n:...)` matched |
+|---|---|---|
+| `Manager EXTENDS Employee` | `["Employee"]` | `:Manager` and `:Employee` |
+| `Special EXTENDS ` \`Author~Topic\` | `["Author~Topic"]` | `:Author` and `:Topic` |
+
+So the engine matched a node by a label and then reported a label list not containing it, and an internal
+type name leaked into a result set.
+
+`getLabels` is not only the `labels()` function. `SetStep`, `RemoveStep` and `MergeStep` build the **new**
+type from it, so the wrong list was written back: `MATCH (n:Manager) SET n:Extra` moved the record to a
+freshly invented `Employee~Extra`, and `MATCH (n:Manager)` then returned **0 rows**. Adding a label removed
+one, silently.
+
+## The rule now
+
+Two different questions, two methods, because a relabelling does not want the same answer a reader does.
+
+**`Labels.getLabels`** - what the node answers to. Its own type name and every ancestor's, sorted, minus
+the synthetic composite names. `Manager` -> `[Employee, Manager]`; `Special` -> `[Author, Special, Topic]`;
+a bare `Author~Topic` -> `[Author, Topic]`, exactly as before. The invariant is Neo4j's and is what the fix
+is measured against: **`L IN labels(n)` and `n:L` answer the same question**, before and after a write.
+
+Two names are special and only one of them is filtered here:
+
+- a **composite** name (`A~B`) is an encoding, so the walk goes *through* it to the labels it encodes. A
+  type merely *named* with a `~` but declaring no supertype is a type somebody created and keeps its name.
+- `V`/`Vertex` is the type a node lands in when it carries no label at all, so a node whose **own** type is
+  `V` reports an empty list. A *supertype* called `V` is not filtered: `V` is an ordinary label a query may
+  write, and the openCypher TCK does write it (`CREATE (b:U:V:W:X:Y:Z)`).
+
+**`Labels.getOwnLabels`** - what a relabelling must reproduce. The minimal set that rebuilds the current
+type: the type's own name, or, for a composite, the labels it encodes. `Manager` -> `[Manager]`, *not*
+`[Employee, Manager]`, because `Employee` comes back on its own through the hierarchy and naming it in the
+composite instead of the subtype that carries it is precisely what dropped the subtype.
+
+So `MATCH (n:Manager) SET n:Extra` now builds `Extra~Manager`, extending both. The vertex is still a
+`Manager`, therefore still an `Employee`, and now an `Extra`. Every label predicate that held before the
+write still holds after it.
+
+Adding a label the vertex already answers to - its own, or an inherited one - changes nothing and is not
+counted in `labels-added`. It is not a no-op that hides a failure: the label *is* present afterwards.
+
+## The one thing that cannot be done, and is now said out loud
+
+`REMOVE n:Employee` on a vertex of type `Manager EXTENDS Employee` has no correct outcome. No type the
+vertex could be moved to answers *no* to `:Employee` while still answering *yes* to `:Manager` - the schema
+says one implies the other. The three candidate behaviours were:
+
+- **move it to `Employee`'s sibling-less remainder** (what the old code effectively did, via a label list
+  that had already lost `Manager`): destroys the subtype to satisfy a removal. Worst of the three.
+- **silently do nothing**: leaves `n:Employee` true after `REMOVE n:Employee`, which is the same class of
+  lie this issue is about, one clause over.
+- **refuse, with a message naming both labels**: chosen. `CommandSemanticException` (HTTP 400), because the
+  query is not honourable against this schema and no retry will change that.
+
+Removing a label the vertex simply does not have stays a no-op, as in Neo4j. Removing *both* the subtype
+and the label it implies (`REMOVE n:Manager, n:Employee`) is fine and leaves an unlabelled node: nothing
+that remains implies `Employee`.
+
+This interacts with [#6335](6335-cypher-label-write-cost.md): a label write still moves the record and is
+still O(degree). What changes here is only *which* type it moves to.
+
+## The two small items
+
+**A disjunction's cardinality estimate.** `NodeByLabelDisjunctionScan` scans every type any alternative
+accepts, but its estimate came from the anchor selector's single-label lookup - the first alternative
+alone - so `(n:A|B)` was priced as if only `:A` existed and looked like the cheap side to drive a join
+from. `AnchorSelector` now sums the count over exactly `Labels.matchingVertexTypes`, the same list the scan
+walks, counted non-polymorphically so a subtype answering to two alternatives is charged once. A
+disjunction anchor is also no longer offered an index seek it could never use: `IndexSelectionRule` builds
+the disjunction scan whatever the estimate claims, so claiming a seek only mis-priced the plan it produces.
+
+**`Schema.getTypeOrNull`.** `getType` throws on an absent type, so every caller that could tolerate absence
+wrote `existsType(name) ? getType(name) : null` - two probes of the same map, and an exception used as
+control flow whenever somebody forgot the guard. `Schema` now has a non-throwing accessor. It is a
+`default` method spelled as that same pair, so an out-of-tree `Schema` keeps compiling; `LocalSchema` and
+`RemoteSchema` override it with a single lookup. The `existsType(x) && getType(x) instanceof Y` idiom
+collapses to `getTypeOrNull(x) instanceof Y`.
+
+## Affected components
+
+- `com.arcadedb.query.opencypher.Labels` - `getLabels`, new `getOwnLabels` and `impliedBy`,
+  `matchingVertexTypes` made visible to the cost model
+- `com.arcadedb.query.opencypher.executor.steps.SetStep` / `RemoveStep` / `MergeStep` - the write side
+- `com.arcadedb.query.opencypher.optimizer.AnchorSelector`, `statistics.StatisticsProvider`,
+  `statistics.CostModel` - the disjunction estimate
+- `com.arcadedb.schema.Schema` / `LocalSchema`, `com.arcadedb.remote.RemoteSchema` - `getTypeOrNull`
+
+## Tests
+
+- `CypherLabelsInheritanceIssue6363Test` - the read side under inheritance and under a type extending a
+  composite, `SET`/`REMOVE` on a subtype vertex asserted through `MATCH` and not only through `labels()`,
+  the refused inherited removal, the `V`-as-a-label case, and the plain composite, which must keep behaving
+  exactly as it did
+- `CypherDisjunctionCardinalityIssue6363Test` - the summed estimate pinned through `EXPLAIN`, and
+  `getTypeOrNull` on a present and an absent type

--- a/docs/6363-cypher-labels-inheritance.md
+++ b/docs/6363-cypher-labels-inheritance.md
@@ -38,8 +38,13 @@ is measured against: **`L IN labels(n)` and `n:L` answer the same question**, be
 
 Two names are special and only one of them is filtered here:
 
-- a **composite** name (`A~B`) is an encoding, so the walk goes *through* it to the labels it encodes. A
-  type merely *named* with a `~` but declaring no supertype is a type somebody created and keeps its name.
+- a **composite** name (`A~B`) is an encoding, so the walk goes *through* it to the labels it encodes. Which
+  types those are is decided **structurally**, not by looking for a `~`: a composite's name is exactly the
+  deduplicated, sorted, separator-joined names of its own supertypes, which is what `ensureCompositeType`
+  writes and what nothing else produces. A type somebody created and called `a~b` keeps its name and is a
+  label like any other - under the name heuristic alone it would have lost its own name from `labels()` and,
+  worse, from the set a relabelling rebuilds its type out of, so the next `SET` would have moved the vertex
+  out of it.
 - `V`/`Vertex` is the type a node lands in when it carries no label at all, so a node whose **own** type is
   `V` reports an empty list. A *supertype* called `V` is not filtered: `V` is an ordinary label a query may
   write, and the openCypher TCK does write it (`CREATE (b:U:V:W:X:Y:Z)`).
@@ -106,7 +111,7 @@ collapses to `getTypeOrNull(x) instanceof Y`.
 
 - `CypherLabelsInheritanceIssue6363Test` - the read side under inheritance and under a type extending a
   composite, `SET`/`REMOVE` on a subtype vertex asserted through `MATCH` and not only through `labels()`,
-  the refused inherited removal, the `V`-as-a-label case, and the plain composite, which must keep behaving
-  exactly as it did
+  the refused inherited removal, the `V`-as-a-label and `a~b`-as-a-type-name cases, and the plain composite,
+  which must keep behaving exactly as it did
 - `CypherDisjunctionCardinalityIssue6363Test` - the summed estimate pinned through `EXPLAIN`, and
   `getTypeOrNull` on a present and an absent type

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3,6 +3,37 @@
 This is a living document: fixes, improvements, new features, and breaking changes are collected here as
 they land during the 26.9.1 development cycle, so the release notes are ready at tag time.
 
+## A Cypher node's labels are the ones it answers to, and adding one no longer takes one away (#6363)
+
+`labels()` decided a vertex's labels from a single question - does the type have supertypes - and answered "the
+supertypes" when it did, "its own name" when it did not. That rule fits only the synthetic `A~B` composite the
+multi-label support builds. Under ordinary type inheritance it was wrong in both directions: a vertex of a type
+declared `Manager EXTENDS Employee` reported `["Employee"]`, missing the very label `MATCH (n:Manager)` had just
+matched it by, and a type extending a composite reported the internal `Author~Topic` name and neither label it
+encodes.
+
+The same list is what `SET`, `REMOVE` and `MERGE` build the new type from, so it was written back:
+`MATCH (n:Manager) SET n:Extra` moved the record to a freshly invented `Employee~Extra` and `MATCH (n:Manager)`
+then returned **0 rows**. Adding a label removed one, silently.
+
+`labels(n)` now returns every type name the node is an instance of, sorted, minus the synthetic composite names,
+so `L IN labels(n)` and `n:L` finally answer the same question. A label write is rebuilt from the node's *own*
+labels instead: `SET n:Extra` on a `Manager` builds `Extra~Manager` extending both, so the node stays a `Manager`,
+stays an `Employee`, and gains `Extra`. Adding a label the node already answers to changes nothing and is not
+counted in `labels-added`.
+
+**Breaking change.** `REMOVE n:Employee` on a vertex of type `Manager EXTENDS Employee` is now refused with a
+`CommandSemanticException` (HTTP 400) naming both labels, where it previously appeared to succeed and left the
+node in the wrong type. There is no correct outcome for it: no type the vertex could be moved to answers *no* to
+`:Employee` while still answering *yes* to `:Manager`. Remove the subtype as well (`REMOVE n:Manager, n:Employee`)
+or change the hierarchy in SQL. Removing a label the node simply does not have stays a no-op, as in Neo4j.
+
+Two smaller fixes ride along. A label disjunction anchor `(n:A|B)` was costed as if only `:A` existed while
+`NodeByLabelDisjunctionScan` visited every type any alternative accepts, which biased join ordering towards
+driving from it; the estimate is now summed over exactly the types the scan walks. And `Schema` gained
+`getTypeOrNull(String)`, the non-throwing companion of `getType` that the `existsType(x) ? getType(x) : null`
+pairs all over the engine wanted - a `default` method, so an out-of-tree `Schema` implementation keeps working.
+
 ## A pathologically nested or long Cypher expression is now a parse error, not a StackOverflowError (#5851)
 
 A ~2KB `WHERE` clause with about 1000 nested parentheses crashed the parsing thread with a

--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -105,36 +105,140 @@ public final class Labels {
   }
 
   /**
-   * Gets all labels for a vertex.
+   * Every label a vertex answers to: its own type name and each of its ancestors', sorted alphabetically, with the
+   * synthetic composite names left out. A node whose own type is the base {@code V}/{@code Vertex} carries no label
+   * at all and answers with an empty list.
    * <p>
-   * For composite types (types with multiple supertypes), returns the supertype names
-   * as the labels. For single-label vertices, returns the type name as the sole label.
+   * The set this returns is exactly the set {@link #hasLabel} says yes to, which is the invariant Cypher promises and
+   * the one this used to break (issue #6363): the rule was "supertypes are the labels, unless there are none", written
+   * for the {@code A~B} composite - whose own name is an implementation detail and whose supertypes really are its
+   * labels - and applied to every other shape as well. A vertex of a type declared {@code Manager EXTENDS Employee}
+   * reported {@code [Employee]}, missing the very label {@code MATCH (n:Manager)} had just matched it by, and a type
+   * extending a composite reported the composite's synthetic name instead of the two labels it encodes.
+   * <p>
+   * A composite name never leaves this method: it is an encoding of the labels below it, so the walk goes through it
+   * to its supertypes rather than reporting it. A type that merely happens to be <i>named</i> like a composite but
+   * declares no supertype is a type somebody created, and keeps its name.
    *
    * @param vertex the vertex to get labels from
-   * @return list of labels (sorted alphabetically for composite types)
+   *
+   * @return the vertex's labels, sorted alphabetically, empty for an unlabelled node
    */
   public static List<String> getLabels(final Vertex vertex) {
-    final DocumentType type = vertex.getType();
+    return getLabels(vertex.getType());
+  }
+
+  /**
+   * Type-level form of {@link #getLabels(Vertex)}.
+   */
+  public static List<String> getLabels(final DocumentType type) {
     final String typeName = type.getName();
 
     // If the vertex was created without labels, it has the base "Vertex" type
     // In Cypher, unlabeled nodes have an empty label list
-    if ("Vertex".equals(typeName) || "V".equals(typeName))
+    if (isBaseVertexTypeName(typeName))
       return List.of();
 
     final List<DocumentType> superTypes = type.getSuperTypes();
-
-    if (superTypes.isEmpty()) {
-      // Single-label vertex - type name is the label
+    // The overwhelmingly common case - a vertex of an ordinary type that extends nothing - answers without
+    // allocating a set.
+    if (superTypes.isEmpty())
       return List.of(typeName);
-    }
 
-    // Multi-label vertex - supertypes are the labels
-    final List<String> labels = new ArrayList<>(superTypes.size());
-    for (final DocumentType superType : superTypes)
-      labels.add(superType.getName());
-    Collections.sort(labels);
-    return labels;
+    final Set<String> labels = new TreeSet<>();
+    collectLabels(type, labels);
+    return labels.isEmpty() ? List.of() : new ArrayList<>(labels);
+  }
+
+  /**
+   * Adds {@code type}'s label to {@code out} unless the type is a synthetic composite, then recurses into its
+   * supertypes. A composite with no supertypes is a user type that happens to carry the separator in its name, not
+   * an encoding, so it contributes its name like any other.
+   * <p>
+   * The base vertex name is filtered at the entry point only, never here: {@code V} is a perfectly ordinary label
+   * that a query may write - the openCypher TCK does, in {@code (b:U:V:W:X:Y:Z)} - and a supertype called {@code V}
+   * is one a node genuinely answers to.
+   */
+  private static void collectLabels(final DocumentType type, final Set<String> out) {
+    final String typeName = type.getName();
+    final List<DocumentType> superTypes = type.getSuperTypes();
+    if (!isCompositeTypeName(typeName) || superTypes.isEmpty())
+      out.add(typeName);
+    for (int i = 0; i < superTypes.size(); i++)
+      collectLabels(superTypes.get(i), out);
+  }
+
+  /**
+   * The labels a relabelling has to carry over, which is not the same question as {@link #getLabels}: an inherited
+   * label comes back on its own through the type hierarchy, so naming it again in the new composite would flatten the
+   * hierarchy instead of extending it.
+   * <p>
+   * For a vertex of type {@code Manager EXTENDS Employee} this is {@code [Manager]}, so {@code SET n:Extra} builds
+   * {@code Extra~Manager} extending both - the vertex stays a {@code Manager} and therefore stays an {@code Employee}
+   * too. Deriving the composite from the full label set instead would have built {@code Employee~Extra} and dropped
+   * the subtype, which is what issue #6363 reports. For a composite the answer is the labels it encodes, reached
+   * through its supertypes exactly as before.
+   *
+   * @param vertex the vertex about to be relabelled
+   *
+   * @return the minimal label set that reproduces the vertex's current type, sorted alphabetically
+   */
+  public static List<String> getOwnLabels(final Vertex vertex) {
+    final DocumentType type = vertex.getType();
+    final String typeName = type.getName();
+
+    if (isBaseVertexTypeName(typeName))
+      return List.of();
+    if (!isCompositeTypeName(typeName) || type.getSuperTypes().isEmpty())
+      return List.of(typeName);
+
+    final Set<String> labels = new TreeSet<>();
+    collectOwnLabels(type, labels);
+    return labels.isEmpty() ? List.of() : new ArrayList<>(labels);
+  }
+
+  /**
+   * Walks down through composite types only: an ordinary type stops the walk and contributes its own name, because
+   * its ancestors are reached from it and do not have to be listed alongside it.
+   */
+  private static void collectOwnLabels(final DocumentType type, final Set<String> out) {
+    final String typeName = type.getName();
+    final List<DocumentType> superTypes = type.getSuperTypes();
+    if (!isCompositeTypeName(typeName) || superTypes.isEmpty()) {
+      out.add(typeName);
+      return;
+    }
+    for (int i = 0; i < superTypes.size(); i++)
+      collectOwnLabels(superTypes.get(i), out);
+  }
+
+  /**
+   * Whether a type name is the base vertex type a node lands in when it carries no label at all: such a node is a
+   * Cypher node with an empty label list. Asked of the node's own type only - a supertype with the same name is a
+   * label the node was given and answers to, and is reported like any other.
+   */
+  private static boolean isBaseVertexTypeName(final String typeName) {
+    return "V".equals(typeName) || "Vertex".equals(typeName);
+  }
+
+  /**
+   * Whether a label is still carried by a set of labels, which is what decides if a {@code REMOVE n:Label} can be
+   * honoured: an inherited label cannot be taken away on its own, because every type answering to the subtype that
+   * implies it answers to it too (issue #6363).
+   *
+   * @param schema          the database schema
+   * @param remainingLabels the labels the vertex would keep
+   * @param label           the label being taken away
+   *
+   * @return true when one of the remaining labels names a type that is still an instance of {@code label}
+   */
+  public static boolean impliedBy(final Schema schema, final List<String> remainingLabels, final String label) {
+    for (int i = 0; i < remainingLabels.size(); i++) {
+      final DocumentType type = schema.getTypeOrNull(remainingLabels.get(i));
+      if (type != null && type.instanceOf(label))
+        return true;
+    }
+    return false;
   }
 
   /**
@@ -227,6 +331,9 @@ public final class Labels {
    * <p>
    * The returned types are meant to be iterated <b>non-polymorphically</b>: the list already contains every matching
    * subtype, so a polymorphic scan of each would visit a subtype once per matching ancestor.
+   * <p>
+   * The cost model sums its estimate over this same list, so what a disjunction anchor is costed at and what it
+   * actually visits stay the same set (issue #6363).
    *
    * @param schema      the database schema
    * @param labels      the labels written on the pattern (already resolved, dynamic labels included)
@@ -234,7 +341,7 @@ public final class Labels {
    *
    * @return the vertex types to scan, empty when nothing in the schema can match
    */
-  private static List<DocumentType> matchingVertexTypes(final Schema schema, final List<String> labels,
+  public static List<DocumentType> matchingVertexTypes(final Schema schema, final List<String> labels,
       final boolean disjunction) {
     final Collection<? extends DocumentType> allTypes = schema.getTypes();
     final List<DocumentType> matching = new ArrayList<>(allTypes.size());
@@ -265,7 +372,7 @@ public final class Labels {
       final String label = labels.get(0);
       // A type name that names an edge or document type is not a label: labels and relationship types are separate
       // namespaces in Cypher, so such a pattern matches no node rather than yielding records that are not vertices.
-      if (!schema.existsType(label) || !(schema.getType(label) instanceof VertexType))
+      if (!(schema.getTypeOrNull(label) instanceof VertexType))
         return Collections.emptyIterator();
       return database.iterateType(label, true);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -117,8 +117,9 @@ public final class Labels {
    * extending a composite reported the composite's synthetic name instead of the two labels it encodes.
    * <p>
    * A composite name never leaves this method: it is an encoding of the labels below it, so the walk goes through it
-   * to its supertypes rather than reporting it. A type that merely happens to be <i>named</i> like a composite but
-   * declares no supertype is a type somebody created, and keeps its name.
+   * to its supertypes rather than reporting it. Which types those are is decided structurally, by
+   * {@link #isLabelComposite} - a type somebody created whose name merely contains the separator keeps its name and
+   * is a label like any other.
    *
    * @param vertex the vertex to get labels from
    *
@@ -147,23 +148,21 @@ public final class Labels {
 
     final Set<String> labels = new TreeSet<>();
     collectLabels(type, labels);
-    return labels.isEmpty() ? List.of() : new ArrayList<>(labels);
+    return new ArrayList<>(labels);
   }
 
   /**
    * Adds {@code type}'s label to {@code out} unless the type is a synthetic composite, then recurses into its
-   * supertypes. A composite with no supertypes is a user type that happens to carry the separator in its name, not
-   * an encoding, so it contributes its name like any other.
+   * supertypes.
    * <p>
    * The base vertex name is filtered at the entry point only, never here: {@code V} is a perfectly ordinary label
    * that a query may write - the openCypher TCK does, in {@code (b:U:V:W:X:Y:Z)} - and a supertype called {@code V}
    * is one a node genuinely answers to.
    */
   private static void collectLabels(final DocumentType type, final Set<String> out) {
-    final String typeName = type.getName();
     final List<DocumentType> superTypes = type.getSuperTypes();
-    if (!isCompositeTypeName(typeName) || superTypes.isEmpty())
-      out.add(typeName);
+    if (!isLabelComposite(type, superTypes))
+      out.add(type.getName());
     for (int i = 0; i < superTypes.size(); i++)
       collectLabels(superTypes.get(i), out);
   }
@@ -177,7 +176,7 @@ public final class Labels {
    * {@code Extra~Manager} extending both - the vertex stays a {@code Manager} and therefore stays an {@code Employee}
    * too. Deriving the composite from the full label set instead would have built {@code Employee~Extra} and dropped
    * the subtype, which is what issue #6363 reports. For a composite the answer is the labels it encodes, reached
-   * through its supertypes exactly as before.
+   * through its supertypes exactly as before, and a type that only looks like one by name keeps its name.
    *
    * @param vertex the vertex about to be relabelled
    *
@@ -189,12 +188,12 @@ public final class Labels {
 
     if (isBaseVertexTypeName(typeName))
       return List.of();
-    if (!isCompositeTypeName(typeName) || type.getSuperTypes().isEmpty())
+    if (!isLabelComposite(type, type.getSuperTypes()))
       return List.of(typeName);
 
     final Set<String> labels = new TreeSet<>();
     collectOwnLabels(type, labels);
-    return labels.isEmpty() ? List.of() : new ArrayList<>(labels);
+    return new ArrayList<>(labels);
   }
 
   /**
@@ -202,14 +201,38 @@ public final class Labels {
    * its ancestors are reached from it and do not have to be listed alongside it.
    */
   private static void collectOwnLabels(final DocumentType type, final Set<String> out) {
-    final String typeName = type.getName();
     final List<DocumentType> superTypes = type.getSuperTypes();
-    if (!isCompositeTypeName(typeName) || superTypes.isEmpty()) {
-      out.add(typeName);
+    if (!isLabelComposite(type, superTypes)) {
+      out.add(type.getName());
       return;
     }
     for (int i = 0; i < superTypes.size(); i++)
       collectOwnLabels(superTypes.get(i), out);
+  }
+
+  /**
+   * Whether a type is one this class built to carry several labels, as opposed to a type somebody created whose name
+   * merely contains the separator.
+   * <p>
+   * Asked structurally rather than by name: a composite's name is exactly the deduplicated, sorted, separator-joined
+   * names of its own supertypes, which is what {@link #ensureCompositeType} writes and what nothing else produces.
+   * The name alone cannot answer it - {@code isCompositeTypeName} is a heuristic, and under it a user type called
+   * {@code a~b} that extends anything would have had its own name dropped from both the label list and, worse, from
+   * the set a relabelling rebuilds the type out of.
+   *
+   * @param type       the type to classify
+   * @param superTypes {@code type}'s direct supertypes, passed in because every caller already has them
+   *
+   * @return true when the type is a label composite and its name is therefore an encoding, not a label
+   */
+  private static boolean isLabelComposite(final DocumentType type, final List<DocumentType> superTypes) {
+    // A composite always encodes at least two labels: one label is the type itself, never a composite.
+    if (superTypes.size() < 2 || !isCompositeTypeName(type.getName()))
+      return false;
+    final List<String> superTypeNames = new ArrayList<>(superTypes.size());
+    for (int i = 0; i < superTypes.size(); i++)
+      superTypeNames.add(superTypes.get(i).getName());
+    return type.getName().equals(getCompositeTypeName(superTypeNames));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -48,11 +48,10 @@ import java.util.NoSuchElementException;
  *       MATCH anchor and the start of a pattern comprehension so that one disjunction cannot mean
  *       different things in different places (issues #6338, #6352). Each type's iterator is opened
  *       only once the previous one is drained.</li>
- *   <li>{@code estimatedCardinality} is inherited from the anchor selector and reflects a
- *       single-label scan (the first label only). The true upper bound for a disjunction
- *       is the sum across all matching types; under-estimation here may bias join-order
- *       choices when a disjunction node competes with other anchor candidates. Tracked as
- *       a follow-up rather than fixed in this PR.</li>
+ *   <li>{@code estimatedCardinality} is inherited from the anchor selector, which sums the record count over the
+ *       same types this operator scans. It used to be a single-label estimate - the first alternative only - which
+ *       under-priced a disjunction anchor against every other candidate and biased join ordering towards driving
+ *       from it (issue #6363).</li>
  * </ul>
  */
 public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1394,11 +1394,14 @@ public class MergeStep extends AbstractExecutionStep {
           if (!(obj instanceof Vertex vertex))
             break;
           vertex = labelReplacements.resolve(vertex);
-          final List<String> existingLabels = Labels.getLabels(vertex);
-          final List<String> allLabels = new ArrayList<>(existingLabels);
+          // Same rule as SET: the new type is built from the vertex's OWN labels, so an inherited label is not
+          // re-listed in place of the subtype that carries it, and a label the vertex already answers to adds
+          // nothing (issue #6363).
+          final DocumentType currentType = vertex.getType();
+          final List<String> allLabels = new ArrayList<>(Labels.getOwnLabels(vertex));
           int newLabelsCount = 0;
           for (final String label : item.getLabels())
-            if (!allLabels.contains(label)) {
+            if (!currentType.instanceOf(label) && !allLabels.contains(label)) {
               allLabels.add(label);
               newLabelsCount++;
             }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -282,6 +282,8 @@ public class RemoveStep extends AbstractExecutionStep {
     int removedLabelsCount = 0;
     for (int i = 0; i < labelsToRemove.size(); i++) {
       final String label = labelsToRemove.get(i);
+      // indexOf != i skips a repeat of a label named earlier in the same clause - a linear scan rather than a Set,
+      // because a clause holds a handful of labels and this costs no allocation on a path that usually finds none.
       if (!currentType.instanceOf(label) || labelsToRemove.indexOf(label) != i)
         continue;
       if (Labels.impliedBy(schema, remainingLabels, label))
@@ -302,6 +304,11 @@ public class RemoveStep extends AbstractExecutionStep {
       newTypeName = Labels.ensureCompositeType(schema, remainingLabels);
     }
 
+    // Nothing to do when the reduced type is the type the vertex already has, and this guard has to stay AHEAD of
+    // the statistics update below: the count above asks `instanceOf`, which says yes to a vertex's own composite
+    // name (`REMOVE n:`Author~Topic`` on an Author~Topic vertex), while that name is not one of the labels
+    // `remainingLabels` is built from and so removes nothing. This early return is what keeps such a no-op from
+    // being reported as a removal.
     if (vertex.getTypeName().equals(newTypeName))
       return;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -273,14 +273,16 @@ public class RemoveStep extends AbstractExecutionStep {
     final List<String> remainingLabels = new ArrayList<>(currentLabels);
     remainingLabels.removeAll(labelsToRemove);
 
-    // Count the labels the vertex actually carries - a label it does not have is a no-op, exactly as in Neo4j.
-    // A label it only answers to through a type it keeps is a different matter: no type it could be moved to
-    // answers 'no' to that label and 'yes' to the subtype implying it, so the removal is refused rather than
-    // reported as done and silently not done.
+    // Count the labels the vertex actually carries - a label it does not have is a no-op, exactly as in Neo4j, and
+    // a label named twice in one clause is one label, since a label is set membership and not a count. A label the
+    // vertex only answers to through a type it keeps is a different matter: no type it could be moved to answers
+    // 'no' to that label and 'yes' to the subtype implying it, so the removal is refused rather than reported as
+    // done and silently not done.
     final Schema schema = context.getDatabase().getSchema();
     int removedLabelsCount = 0;
-    for (final String label : labelsToRemove) {
-      if (!currentType.instanceOf(label))
+    for (int i = 0; i < labelsToRemove.size(); i++) {
+      final String label = labelsToRemove.get(i);
+      if (!currentType.instanceOf(label) || labelsToRemove.indexOf(label) != i)
         continue;
       if (Labels.impliedBy(schema, remainingLabels, label))
         throw new CommandSemanticException("Cannot remove label '" + label + "' from a vertex of type '"

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
@@ -34,6 +35,8 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -260,28 +263,41 @@ public class RemoveStep extends AbstractExecutionStep {
     // have been resolved by the caller - and it costs one map lookup that is skipped until a label write happens.
     vertex = replacements.resolve(vertex);
 
-    final List<String> currentLabels = Labels.getLabels(vertex);
+    // The reduced type is rebuilt from the vertex's OWN labels: an inherited one is carried by the subtype that
+    // remains and must not be listed alongside it, or the vertex would be moved out of that subtype (issue #6363).
+    final DocumentType currentType = vertex.getType();
+    final List<String> currentLabels = Labels.getOwnLabels(vertex);
     final List<String> labelsToRemove = item.getLabels();
-
-    // Check how many of the labels to remove actually exist on the vertex
-    int removedLabelsCount = 0;
-    for (final String label : labelsToRemove)
-      if (currentLabels.contains(label))
-        removedLabelsCount++;
-    if (removedLabelsCount == 0)
-      return;
 
     // Compute remaining labels
     final List<String> remainingLabels = new ArrayList<>(currentLabels);
     remainingLabels.removeAll(labelsToRemove);
 
+    // Count the labels the vertex actually carries - a label it does not have is a no-op, exactly as in Neo4j.
+    // A label it only answers to through a type it keeps is a different matter: no type it could be moved to
+    // answers 'no' to that label and 'yes' to the subtype implying it, so the removal is refused rather than
+    // reported as done and silently not done.
+    final Schema schema = context.getDatabase().getSchema();
+    int removedLabelsCount = 0;
+    for (final String label : labelsToRemove) {
+      if (!currentType.instanceOf(label))
+        continue;
+      if (Labels.impliedBy(schema, remainingLabels, label))
+        throw new CommandSemanticException("Cannot remove label '" + label + "' from a vertex of type '"
+            + currentType.getName() + "': the type inherits that label from its hierarchy, so the vertex would still "
+            + "answer to it. Drop the label from the type hierarchy with SQL (ALTER TYPE), or remove the inheriting "
+            + "label too");
+      removedLabelsCount++;
+    }
+    if (removedLabelsCount == 0)
+      return;
+
     final String newTypeName;
     if (remainingLabels.isEmpty()) {
       newTypeName = "V";
-      context.getDatabase().getSchema().getOrCreateVertexType("V");
+      schema.getOrCreateVertexType("V");
     } else {
-      newTypeName = Labels.ensureCompositeType(
-          context.getDatabase().getSchema(), remainingLabels);
+      newTypeName = Labels.ensureCompositeType(schema, remainingLabels);
     }
 
     if (vertex.getTypeName().equals(newTypeName))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -37,6 +37,7 @@ import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -447,12 +448,15 @@ public class SetStep extends AbstractExecutionStep {
     // The RID the write is about to displace: the live one, not the one the row happened to carry.
     final RID originalRid = vertex.getIdentity();
 
-    // Get existing labels and add new ones
-    final List<String> existingLabels = Labels.getLabels(vertex);
-    final List<String> allLabels = new ArrayList<>(existingLabels);
+    // The labels the new type has to be built from are the vertex's OWN labels, not every label it answers to: an
+    // inherited one comes back through the hierarchy, and naming it in the composite instead of the subtype that
+    // carries it would move the vertex out of that subtype (issue #6363). A label the vertex already answers to -
+    // its own, or one it inherits - is already present and adds nothing.
+    final DocumentType currentType = vertex.getType();
+    final List<String> allLabels = new ArrayList<>(Labels.getOwnLabels(vertex));
     int newLabelsCount = 0;
     for (final String label : item.getLabels())
-      if (!allLabels.contains(label)) {
+      if (!currentType.instanceOf(label) && !allLabels.contains(label)) {
         allLabels.add(label);
         newLabelsCount++;
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/AnchorSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/AnchorSelector.java
@@ -144,6 +144,12 @@ public class AnchorSelector {
    * @return anchor selection with cost estimate
    */
   private AnchorSelection evaluateNode(final LogicalNode node, final LogicalPlan plan) {
+    // A label disjunction is served by NodeByLabelDisjunctionScan, which visits every type any alternative accepts
+    // and cannot be driven by an index. Costing it here from the first label alone described a scan that never runs
+    // (issue #6363), so the estimate is summed over exactly the types that scan will walk.
+    if (node.isLabelDisjunction() && node.getLabels().size() > 1)
+      return evaluateDisjunctionNode(node);
+
     final String variable = node.getVariable();
     final String label = node.getFirstLabel();
 
@@ -322,6 +328,20 @@ public class AnchorSelector {
         cost,
         typeCount
     );
+  }
+
+  /**
+   * Costs a label-disjunction anchor as the multi-type scan it will actually be: the record count summed over every
+   * vertex type an alternative accepts, subtypes included and each counted once. Property predicates are left to the
+   * Filter above the anchor - {@code IndexSelectionRule} builds a {@code NodeByLabelDisjunctionScan} for this node
+   * whatever this method decides about indexes, so claiming a seek here would only mis-price the plan it produces.
+   *
+   * @param node the disjunction node being evaluated as an anchor
+   * @return the anchor selection for a full scan of every matching type
+   */
+  private AnchorSelection evaluateDisjunctionNode(final LogicalNode node) {
+    final long rows = statisticsProvider.getMatchingVertexCardinality(node.getLabels(), true);
+    return new AnchorSelection(node.getVariable(), node, costModel.estimateScanCostForRows(rows), rows);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -413,7 +413,7 @@ public class CypherOptimizer {
     final var schema = database.getSchema();
     for (final LogicalRelationship rel : logicalPlan.getRelationships())
       for (final String edgeTypeName : rel.getTypes())
-        if (schema.existsType(edgeTypeName) && schema.getType(edgeTypeName) instanceof EdgeType et && !et.isBidirectional())
+        if (schema.getTypeOrNull(edgeTypeName) instanceof EdgeType et && !et.isBidirectional())
           return true;
     return false;
   }
@@ -439,7 +439,7 @@ public class CypherOptimizer {
 
         boolean bidirectional = true;
         for (final String edgeTypeName : rel.getTypes())
-          if (schema.existsType(edgeTypeName) && schema.getType(edgeTypeName) instanceof EdgeType et && !et.isBidirectional()) {
+          if (schema.getTypeOrNull(edgeTypeName) instanceof EdgeType et && !et.isBidirectional()) {
             bidirectional = false;
             break;
           }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/CostModel.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/CostModel.java
@@ -64,6 +64,17 @@ public class CostModel {
   }
 
   /**
+   * Estimates the cost of a scan whose row count is already known, for the scans that are not one type's worth of
+   * records - a label disjunction visits every type any alternative accepts (issue #6363).
+   *
+   * @param rows the number of records the scan will visit
+   * @return estimated cost
+   */
+  public double estimateScanCostForRows(final long rows) {
+    return rows * SCAN_COST_PER_ROW;
+  }
+
+  /**
    * Estimates the cost of an index seek operation.
    *
    * @param typeName the type name

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/StatisticsProvider.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/StatisticsProvider.java
@@ -24,6 +24,7 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Schema;
@@ -89,11 +90,9 @@ public class StatisticsProvider {
       }
 
       // Skip types that do not exist in the schema (issue #4090).
-      // schema.getType() throws SchemaException for unknown names, so existsType() must be checked first.
-      if (!schema.existsType(typeName))
+      final DocumentType type = schema.getTypeOrNull(typeName);
+      if (type == null)
         continue;
-
-      final DocumentType type = schema.getType(typeName);
 
       // Collect type cardinality using cached O(1) count
       final long recordCount = database.countType(typeName, false);
@@ -199,6 +198,32 @@ public class StatisticsProvider {
   }
 
   /**
+   * The number of records a scan of a node pattern's label constraint will visit: the sum over exactly the types
+   * {@link Labels#matchingVertexTypes} selects, counted non-polymorphically the same way the scan walks them, so no
+   * subtype is charged twice.
+   * <p>
+   * A label disjunction used to be costed as if only its first alternative existed (issue #6363), because the anchor
+   * estimate came from a single-label lookup while the operator scanned every type any alternative accepted. The
+   * under-estimate made a disjunction look like the cheapest side to drive a join from.
+   * <p>
+   * The counts are the engine's cached O(1) bucket counts and are read directly rather than through
+   * {@link #getTypeStatistics}: a matching subtype need not be named in the query, so it need not have been collected.
+   *
+   * @param labels      the labels written on the pattern
+   * @param disjunction whether the labels were written as alternatives ({@code A|B}) rather than as a conjunction
+   *
+   * @return the total record count across the scanned types, 0 when nothing in the schema can match
+   */
+  public long getMatchingVertexCardinality(final List<String> labels, final boolean disjunction) {
+    if (database == null)
+      return 0L;
+    long total = 0;
+    for (final DocumentType type : Labels.matchingVertexTypes(database.getSchema(), labels, disjunction))
+      total += database.countType(type.getName(), false);
+    return total;
+  }
+
+  /**
    * Calculates the average degree (edges per vertex) for a relationship type.
    * <p>
    * Formula: avgDegree = (2 * edgeCount) / (sourceVertexCount + targetVertexCount)
@@ -223,7 +248,7 @@ public class StatisticsProvider {
     }
 
     final Schema schema = database.getSchema();
-    final boolean isEdgeType = schema.existsType(relationshipType) && schema.getType(relationshipType) instanceof EdgeType;
+    final boolean isEdgeType = schema.getTypeOrNull(relationshipType) instanceof EdgeType;
 
     final double avgDegree;
     if (isEdgeType && graphStatisticsCache != null) {
@@ -256,12 +281,8 @@ public class StatisticsProvider {
     final Schema schema = database.getSchema();
 
     // Get edge type statistics
-    if (!schema.existsType(relationshipType))
+    if (!(schema.getTypeOrNull(relationshipType) instanceof EdgeType))
       return 10.0; // Fallback: no edge type found
-    final DocumentType edgeType = schema.getType(relationshipType);
-    if (!(edgeType instanceof EdgeType)) {
-      return 10.0; // Fallback: no edge type found
-    }
 
     final long edgeCount = database.countType(relationshipType, false);
     if (edgeCount == 0) {
@@ -342,7 +363,7 @@ public class StatisticsProvider {
       return meanEdgesPerConnectedPairCache.get(edgeType);
 
     final Schema schema = database.getSchema();
-    final boolean isEdgeType = schema.existsType(edgeType) && schema.getType(edgeType) instanceof EdgeType;
+    final boolean isEdgeType = schema.getTypeOrNull(edgeType) instanceof EdgeType;
 
     final double mean;
     if (isEdgeType && graphStatisticsCache != null) {
@@ -373,7 +394,7 @@ public class StatisticsProvider {
     if (vertexLabel == null)
       return 0;
     final Schema schema = database.getSchema();
-    if (!schema.existsType(vertexLabel) || !(schema.getType(vertexLabel) instanceof VertexType))
+    if (!(schema.getTypeOrNull(vertexLabel) instanceof VertexType))
       return 0;
     return database.countType(vertexLabel, false);
   }
@@ -403,11 +424,7 @@ public class StatisticsProvider {
    */
   private double calculateMeanEdgesPerConnectedPair(final String edgeType) {
     final Schema schema = database.getSchema();
-    if (!schema.existsType(edgeType))
-      return DEFAULT_MEAN_EDGES_PER_CONNECTED_PAIR;
-
-    final DocumentType type = schema.getType(edgeType);
-    if (!(type instanceof EdgeType))
+    if (!(schema.getTypeOrNull(edgeType) instanceof EdgeType))
       return DEFAULT_MEAN_EDGES_PER_CONNECTED_PAIR;
 
     final Set<Map.Entry<RID, RID>> distinctPairs = new HashSet<>();

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1480,6 +1480,11 @@ public class LocalSchema implements Schema {
   }
 
   @Override
+  public LocalDocumentType getTypeOrNull(final String typeName) {
+    return types.get(typeName);
+  }
+
+  @Override
   public String getTypeNameByBucketId(final int bucketId) {
     final DocumentType type = getTypeByBucketId(bucketId);
     return type != null ? type.getName() : null;

--- a/engine/src/main/java/com/arcadedb/schema/Schema.java
+++ b/engine/src/main/java/com/arcadedb/schema/Schema.java
@@ -167,6 +167,22 @@ public interface Schema {
 
   DocumentType getType(String typeName);
 
+  /**
+   * Returns the type with the given name, or {@code null} when the schema does not have it.
+   * <p>
+   * The non-throwing companion of {@link #getType(String)}, for the many callers that can tolerate an absent type and
+   * had to spell it {@code existsType(name) ? getType(name) : null} - two probes of the same map, and an exception
+   * used as control flow if they forgot the guard. The default implementation is exactly that pair, so an
+   * out-of-tree {@link Schema} keeps working; the built-in schemas answer with a single lookup.
+   *
+   * @param typeName name of the type to look up
+   *
+   * @return the type, or {@code null} if no type with that name exists
+   */
+  default DocumentType getTypeOrNull(final String typeName) {
+    return existsType(typeName) ? getType(typeName) : null;
+  }
+
   void dropType(String typeName);
 
   String getTypeNameByBucketId(int bucketId);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionCardinalityIssue6363Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherDisjunctionCardinalityIssue6363Test.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for the two small items of issue #6363: a label disjunction anchor was costed from its first
+ * alternative alone while the operator scanned every type any alternative accepted, and {@link Schema} had no
+ * non-throwing type accessor, so every caller that could tolerate an absent type probed the same map twice.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherDisjunctionCardinalityIssue6363Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-disjunction-cardinality-6363");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.transaction(() -> {
+      // 2 :Author, 3 :Topic, and 4 :Reader vertices - three counts no pair of which sums to a third.
+      for (int i = 0; i < 2; i++)
+        database.command("opencypher", "CREATE (:Author {k:$k})", Map.of("k", "a" + i));
+      for (int i = 0; i < 3; i++)
+        database.command("opencypher", "CREATE (:Topic {k:$k})", Map.of("k", "t" + i));
+      for (int i = 0; i < 4; i++)
+        database.command("opencypher", "CREATE (:Reader {k:$k})", Map.of("k", "r" + i));
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void aDisjunctionAnchorIsCostedOverEveryTypeItScans() {
+    // Was rows=2, the :Author count alone, for a scan that returns 5 rows.
+    assertThat(explain("MATCH (n:Author|Topic) RETURN n.k AS k"))
+        .contains("NodeByLabelDisjunctionScan(n:Author|Topic)")
+        .contains("rows=5");
+    // Order of the alternatives cannot change the estimate any more.
+    assertThat(explain("MATCH (n:Topic|Author) RETURN n.k AS k")).contains("rows=5");
+    assertThat(explain("MATCH (n:Author|Topic|Reader) RETURN n.k AS k")).contains("rows=9");
+  }
+
+  @Test
+  void anAlternativeTheSchemaDoesNotHaveContributesNothingToTheEstimate() {
+    assertThat(explain("MATCH (n:Author|NoSuchLabel) RETURN n.k AS k")).contains("rows=2");
+    assertThat(explain("MATCH (n:NoSuchLabel|NorThisOne) RETURN n.k AS k")).contains("rows=0");
+  }
+
+  @Test
+  void aSubtypeIsCountedOnceAndOnlyThroughTheAlternativesThatAcceptIt() {
+    database.command("sql", "CREATE VERTEX TYPE Special EXTENDS Author, Topic");
+    database.transaction(() -> database.command("sql", "INSERT INTO Special SET k = 'sp1'"));
+
+    // Special answers to both alternatives; it must be added once, not once per ancestor that accepts it.
+    assertThat(explain("MATCH (n:Author|Topic) RETURN n.k AS k")).contains("rows=6");
+  }
+
+  @Test
+  void theEstimateFollowsTheDataItDoesNotStayAtAPlanningTimeGuess() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Topic {k:'t9'})"));
+    assertThat(explain("MATCH (n:Author|Topic) RETURN n.k AS k")).contains("rows=6");
+  }
+
+  @Test
+  void schemaAnswersForAnAbsentTypeWithoutThrowing() {
+    final Schema schema = database.getSchema();
+
+    final DocumentType author = schema.getTypeOrNull("Author");
+    assertThat(author).isNotNull();
+    assertThat(author.getName()).isEqualTo("Author");
+    assertThat(author).isSameAs(schema.getType("Author"));
+
+    assertThat(schema.getTypeOrNull("NoSuchLabel")).isNull();
+    assertThatThrownBy(() -> schema.getType("NoSuchLabel")).hasMessageContaining("NoSuchLabel");
+  }
+
+  private String explain(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      return rs.getExecutionPlan().get().prettyPrint(0, 2);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
@@ -132,6 +132,25 @@ class CypherLabelsInheritanceIssue6363Test {
   }
 
   @Test
+  void removingALabelTheVertexDoesNotHaveIsANoOp() {
+    // The counterpart of the refusal below, and the line between them: a label the vertex does not answer to at all
+    // is simply absent, so removing it does nothing and reports nothing - as in Neo4j. Only a label it DOES answer
+    // to, and would keep answering to, is refused. Covers both an unknown label and one whose type exists but this
+    // vertex is not of.
+    database.transaction(() -> database.command("opencypher", "CREATE (:Extra {k:'x9'})"));
+    final String typeBefore = typeOf("m1");
+
+    assertThat(labelsRemoved("MATCH (n:Manager) REMOVE n:NotPresentAtAll")).isEqualTo(0);
+    assertThat(labelsRemoved("MATCH (n:Manager) REMOVE n:Extra")).isEqualTo(0);
+
+    assertThat(typeOf("m1")).isEqualTo(typeBefore);
+    assertThat(labels("MATCH (n {k:'m1'}) RETURN labels(n) AS l")).containsExactly("Employee", "Manager");
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+    // The absent label did not get a type invented for it on the way past.
+    assertThat(database.getSchema().getTypeOrNull("NotPresentAtAll")).isNull();
+  }
+
+  @Test
   void removingAnInheritedLabelIsRefusedRatherThanSilentlyLyingAboutIt() {
     // Manager IS-A Employee in the schema: no type the vertex could be moved to answers 'no' to :Employee while
     // still answering 'yes' to :Manager. Saying so beats a no-op that leaves n:Employee true after REMOVE n:Employee.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
@@ -151,6 +151,21 @@ class CypherLabelsInheritanceIssue6363Test {
   }
 
   @Test
+  void namingACompositeTypeItselfAsALabelToRemoveChangesNothing() {
+    // The count asks instanceOf, which says yes to a vertex's own composite name, while that name is not one of
+    // the labels the reduced type is rebuilt from - so it removes nothing. The unchanged-type guard is what keeps
+    // that from being reported as a removal, and this pins the pairing so a refactor of either one cannot quietly
+    // start counting a no-op as a change.
+    database.transaction(() -> database.command("opencypher", "CREATE (:Author:Topic {k:'b1'})"));
+
+    assertThat(labelsRemoved("MATCH (n {k:'b1'}) REMOVE n:`Author~Topic`")).isEqualTo(0);
+
+    assertThat(typeOf("b1")).isEqualTo("Author~Topic");
+    assertThat(labels("MATCH (n {k:'b1'}) RETURN labels(n) AS l")).containsExactly("Author", "Topic");
+    assertThat(count("MATCH (n:Author) RETURN count(n) AS c")).isEqualTo(1);
+  }
+
+  @Test
   void removingAnInheritedLabelIsRefusedRatherThanSilentlyLyingAboutIt() {
     // Manager IS-A Employee in the schema: no type the vertex could be moved to answers 'no' to :Employee while
     // still answering 'yes' to :Manager. Saying so beats a no-op that leaves n:Employee true after REMOVE n:Employee.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
@@ -21,12 +21,14 @@ package com.arcadedb.query.opencypher;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.function.ToIntFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -192,6 +194,19 @@ class CypherLabelsInheritanceIssue6363Test {
   }
 
   @Test
+  void aLabelNamedTwiceInOneClauseIsCountedOnce() {
+    // A label is set membership, not a count: naming it twice adds or removes it once, and the reported
+    // labels-added / labels-removed have to say so. ArcadeDB already deduplicates the type the write lands on
+    // (Labels.ensureCompositeType), so only the counters could disagree.
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Manager) SET n:Extra:Extra"));
+    assertThat(labelsAdded("MATCH (n:Manager) SET n:Another:Another")).isEqualTo(1);
+
+    assertThat(labelsRemoved("MATCH (n:Manager) REMOVE n:Extra:Extra")).isEqualTo(1);
+    assertThat(count("MATCH (n:Extra) RETURN count(n) AS c")).isEqualTo(0);
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+  }
+
+  @Test
   void anUnlabelledVertexStillReportsNoLabels() {
     database.transaction(() -> database.command("opencypher", "CREATE ({k:'u1'})"));
     assertThat(labels("MATCH (n {k:'u1'}) RETURN labels(n) AS l")).isEmpty();
@@ -210,6 +225,26 @@ class CypherLabelsInheritanceIssue6363Test {
       assertThat(rs.hasNext()).isTrue();
       return ((Number) rs.next().getProperty("c")).longValue();
     }
+  }
+
+  private int labelsAdded(final String command) {
+    return writeStatistic(command, QueryStatistics::getLabelsAdded);
+  }
+
+  private int labelsRemoved(final String command) {
+    return writeStatistic(command, QueryStatistics::getLabelsRemoved);
+  }
+
+  private int writeStatistic(final String command, final ToIntFunction<QueryStatistics> reader) {
+    final int[] value = new int[] { -1 };
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("opencypher", command)) {
+        while (rs.hasNext())
+          rs.next();
+        value[0] = rs.getStatistics().map(reader::applyAsInt).orElse(-1);
+      }
+    });
+    return value[0];
   }
 
   private String typeOf(final String key) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
@@ -176,6 +176,22 @@ class CypherLabelsInheritanceIssue6363Test {
   }
 
   @Test
+  void aUserTypeWhoseNameMerelyContainsTheSeparatorKeepsIt() {
+    // Whether a type is a composite is decided structurally - its name is exactly the sorted, joined names of its
+    // own supertypes - and not by looking for a tilde. Under the name heuristic alone, a type somebody created and
+    // called 'a~b' would have lost its own name from labels() AND from the set a relabelling rebuilds it out of,
+    // which would have moved the vertex out of it on the next SET.
+    database.command("sql", "CREATE VERTEX TYPE `a~b` EXTENDS Employee");
+    database.transaction(() -> database.command("sql", "INSERT INTO `a~b` SET k = 'x1'"));
+
+    assertThat(labels("MATCH (n {k:'x1'}) RETURN labels(n) AS l")).containsExactly("Employee", "a~b");
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {k:'x1'}) SET n:Extra"));
+    assertThat(count("MATCH (n:`a~b`) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(labels("MATCH (n {k:'x1'}) RETURN labels(n) AS l")).containsExactly("Employee", "Extra", "a~b");
+  }
+
+  @Test
   void anUnlabelledVertexStillReportsNoLabels() {
     database.transaction(() -> database.command("opencypher", "CREATE ({k:'u1'})"));
     assertThat(labels("MATCH (n {k:'u1'}) RETURN labels(n) AS l")).isEmpty();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelsInheritanceIssue6363Test.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6363: {@code labels()} decided a vertex's labels from its supertypes, a rule written for
+ * the synthetic {@code A~B} composite and wrong for every other shape, so a vertex of a type declared with
+ * {@code EXTENDS} reported a label list that did not contain its own type - contradicting the very predicate that
+ * matched it - and a {@code SET n:Extra} rebuilt the composite from that wrong list, relocating the vertex out of its
+ * own subtype.
+ * <p>
+ * The invariant under test is Neo4j's: {@code L IN labels(n)} and {@code n:L} answer the same question, before and
+ * after a label write. Type inheritance is an ArcadeDB extension - Neo4j has no subtypes - so the reference behaviour
+ * to match is that a label a node answers to is a label it reports.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherLabelsInheritanceIssue6363Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-labels-inheritance-6363");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Employee");
+      database.command("sql", "CREATE VERTEX TYPE Manager EXTENDS Employee");
+      database.command("sql", "INSERT INTO Manager SET k = 'm1'");
+      database.command("sql", "INSERT INTO Employee SET k = 'e1'");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void labelsReportsTheVertexOwnTypeAlongsideItsAncestors() {
+    // Used to return ["Employee"]: the subtype's own name was dropped the moment the type had a supertype.
+    assertThat(labels("MATCH (n {k:'m1'}) RETURN labels(n) AS l")).containsExactly("Employee", "Manager");
+    assertThat(labels("MATCH (n {k:'e1'}) RETURN labels(n) AS l")).containsExactly("Employee");
+  }
+
+  @Test
+  void everyReportedLabelIsAlsoMatchedAndEveryMatchedLabelIsReported() {
+    // The contradiction the issue is about: the engine matched :Manager twice over and then reported a label
+    // list without it.
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(count("MATCH (n) WHERE n:Manager RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(count("MATCH (n:Employee) RETURN count(n) AS c")).isEqualTo(2);
+    assertThat(labels("MATCH (n {k:'m1'}) RETURN labels(n) AS l")).contains("Manager");
+  }
+
+  @Test
+  void aTypeExtendingACompositeReportsTheLabelsItEncodesAndNotTheSyntheticName() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Author:Topic {k:'b1'})"));
+    database.command("sql", "CREATE VERTEX TYPE Special EXTENDS `Author~Topic`");
+    database.transaction(() -> database.command("sql", "INSERT INTO Special SET k = 'sp1'"));
+
+    // Used to return ["Author~Topic"], leaking an internal encoding and reporting neither label it encodes.
+    assertThat(labels("MATCH (n {k:'sp1'}) RETURN labels(n) AS l")).containsExactly("Author", "Special", "Topic");
+    // The plain composite is unchanged: its own name is the implementation detail, its supertypes are the labels.
+    assertThat(labels("MATCH (n {k:'b1'}) RETURN labels(n) AS l")).containsExactly("Author", "Topic");
+  }
+
+  @Test
+  void addingALabelToASubtypeVertexDoesNotCostItItsOwnType() {
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Manager) SET n:Extra"));
+
+    // Was 0: the vertex had been moved to a freshly invented Employee~Extra and every :Manager query lost it.
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(count("MATCH (n:Employee) RETURN count(n) AS c")).isEqualTo(2);
+    assertThat(count("MATCH (n:Extra) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(labels("MATCH (n {k:'m1'}) RETURN labels(n) AS l")).containsExactly("Employee", "Extra", "Manager");
+  }
+
+  @Test
+  void addingALabelTheVertexAlreadyAnswersToChangesNothing() {
+    final String typeBefore = typeOf("m1");
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Manager) SET n:Employee"));
+
+    assertThat(typeOf("m1")).isEqualTo(typeBefore);
+    assertThat(labels("MATCH (n {k:'m1'}) RETURN labels(n) AS l")).containsExactly("Employee", "Manager");
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void removingAnOwnLabelFromASubtypeVertexKeepsTheInheritedOnes() {
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Manager) SET n:Extra"));
+    database.transaction(() -> database.command("opencypher", "MATCH (n:Extra) REMOVE n:Extra"));
+
+    assertThat(count("MATCH (n:Extra) RETURN count(n) AS c")).isEqualTo(0);
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(labels("MATCH (n {k:'m1'}) RETURN labels(n) AS l")).containsExactly("Employee", "Manager");
+  }
+
+  @Test
+  void removingAnInheritedLabelIsRefusedRatherThanSilentlyLyingAboutIt() {
+    // Manager IS-A Employee in the schema: no type the vertex could be moved to answers 'no' to :Employee while
+    // still answering 'yes' to :Manager. Saying so beats a no-op that leaves n:Employee true after REMOVE n:Employee.
+    assertThatThrownBy(() -> database.transaction(() -> database.command("opencypher", "MATCH (n:Manager) REMOVE n:Employee")))
+        .hasMessageContaining("Employee")
+        .hasMessageContaining("Manager");
+
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(count("MATCH (n:Employee) RETURN count(n) AS c")).isEqualTo(2);
+  }
+
+  @Test
+  void aPlainCompositeStillBehavesExactlyAsBefore() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Author:Topic {k:'b1'})"));
+    assertThat(labels("MATCH (n {k:'b1'}) RETURN labels(n) AS l")).containsExactly("Author", "Topic");
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {k:'b1'}) SET n:Reader"));
+    assertThat(labels("MATCH (n {k:'b1'}) RETURN labels(n) AS l")).containsExactly("Author", "Reader", "Topic");
+    assertThat(typeOf("b1")).isEqualTo("Author~Reader~Topic");
+
+    database.transaction(() -> database.command("opencypher", "MATCH (n {k:'b1'}) REMOVE n:Author"));
+    assertThat(labels("MATCH (n {k:'b1'}) RETURN labels(n) AS l")).containsExactly("Reader", "Topic");
+    assertThat(typeOf("b1")).isEqualTo("Reader~Topic");
+    assertThat(count("MATCH (n:Author) RETURN count(n) AS c")).isEqualTo(0);
+  }
+
+  @Test
+  void mergeOnCreateSetOfALabelKeepsTheSubtypeToo() {
+    database.transaction(() -> database.command("opencypher", "MERGE (n:Manager {k:'m1'}) ON MATCH SET n:Extra"));
+
+    assertThat(count("MATCH (n:Manager) RETURN count(n) AS c")).isEqualTo(1);
+    assertThat(labels("MATCH (n {k:'m1'}) RETURN labels(n) AS l")).containsExactly("Employee", "Extra", "Manager");
+  }
+
+  @Test
+  void aLabelThatHappensToBeSpelledLikeTheBaseVertexTypeIsStillALabel() {
+    // 'V' is the type an unlabelled node lands in, and it is also a label a query may write - the openCypher TCK
+    // writes it, in (b:U:V:W:X:Y:Z). Only the node's OWN type answers "no labels"; a supertype called V is a label
+    // the node was given and answers to.
+    database.transaction(() -> database.command("opencypher", "CREATE (:U:V:W {k:'v1'})"));
+
+    assertThat(labels("MATCH (n {k:'v1'}) RETURN labels(n) AS l")).containsExactly("U", "V", "W");
+    assertThat(count("MATCH (n:V) RETURN count(n) AS c")).isEqualTo(1);
+  }
+
+  @Test
+  void anUnlabelledVertexStillReportsNoLabels() {
+    database.transaction(() -> database.command("opencypher", "CREATE ({k:'u1'})"));
+    assertThat(labels("MATCH (n {k:'u1'}) RETURN labels(n) AS l")).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> labels(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return (List<String>) rs.next().getProperty("l");
+    }
+  }
+
+  private long count(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private String typeOf(final String key) {
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n {k:'" + key + "'}) RETURN n AS n")) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().<Document>getProperty("n").getTypeName();
+    }
+  }
+}

--- a/mcp/src/main/java/com/arcadedb/mcp/tools/HybridSearchTool.java
+++ b/mcp/src/main/java/com/arcadedb/mcp/tools/HybridSearchTool.java
@@ -510,7 +510,7 @@ public class HybridSearchTool {
       if (name.indexOf('\'') >= 0 || name.indexOf('`') >= 0 || name.indexOf('\\') >= 0)
         throw new IllegalArgumentException(
             "expand.edgeTypes entry '" + name + "' contains a quote or backslash, which is not supported");
-      if (!database.getSchema().existsType(name) || !(database.getSchema().getType(name) instanceof EdgeType))
+      if (!(database.getSchema().getTypeOrNull(name) instanceof EdgeType))
         throw new IllegalArgumentException("Edge type '" + name + "' does not exist. "
             + describeAvailableEdgeTypes(database));
       names.add(name);

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -352,6 +352,12 @@ public class RemoteSchema implements Schema {
   }
 
   @Override
+  public DocumentType getTypeOrNull(final String typeName) {
+    checkSchemaIsLoaded();
+    return types.get(typeName);
+  }
+
+  @Override
   public LocalSchema getEmbedded() {
     return null;
   }


### PR DESCRIPTION
Fixes #6363.

## 1. `labels()` contradicted every label predicate, and a label write relocated the vertex

`Labels.getLabels` decided a vertex's labels from a single question - does the type have supertypes - and
answered "the supertypes" when it did, "its own name" when it did not. That rule fits exactly one shape: the
synthetic `A~B` composite, whose own name is an encoding and whose supertypes really are its labels. Under
ordinary ArcadeDB inheritance it was wrong in both directions.

| shape | `labels(n)` before | after |
|---|---|---|
| `Manager EXTENDS Employee` | `["Employee"]` | `["Employee","Manager"]` |
| `Special EXTENDS` \`Author~Topic\` | `["Author~Topic"]` | `["Author","Special","Topic"]` |
| `CREATE (:Author:Topic)` | `["Author","Topic"]` | unchanged |

`getLabels` is not only the `labels()` function - `SetStep`, `RemoveStep` and `MergeStep` build the **new**
type from it - so the wrong list was written back. `MATCH (n:Manager) SET n:Extra` moved the record to a
freshly invented `Employee~Extra`, and `MATCH (n:Manager)` then returned **0 rows**. Adding a label removed
one, silently, with no error and no warning.

Reading and relabelling are now two questions with two answers:

- **`getLabels`** - every type name the vertex is an `instanceOf`, sorted, minus the synthetic composite
  names. `L IN labels(n)` and `n:L` now answer the same question, which is the invariant Neo4j promises and
  the one the fix is measured against.
- **`getOwnLabels`** - the minimal set that reproduces the current type: `[Manager]`, *not*
  `[Employee, Manager]`. So `SET n:Extra` builds `Extra~Manager` extending both - the vertex stays a
  `Manager`, therefore stays an `Employee`, and gains `Extra`. This is the write-side shape the issue asked
  to confirm before changing anything.
- Adding a label the vertex already answers to (its own, or inherited) changes nothing and is not counted in
  `labels-added`. Not a hidden no-op: the label *is* present afterwards.

`V`/`Vertex` still means "no labels" for a node's **own** type, but is an ordinary label as a supertype -
`V` is a label a query may write, and the openCypher TCK writes it (`CREATE (b:U:V:W:X:Y:Z)`). Getting that
wrong is the one regression this branch caught on itself, and it is now pinned by a test rather than only by
the TCK.

### One decision worth your eye

`REMOVE n:Employee` on a vertex of type `Manager EXTENDS Employee` has **no correct outcome**: no type the
vertex could move to answers "no" to `:Employee` while answering "yes" to `:Manager`. The three candidates
were destroy the subtype (what the old code effectively did), no-op silently (leaves `n:Employee` true after
`REMOVE n:Employee` - the same class of lie this issue is about), or **refuse with a message naming both
labels**. I took the third, as a `CommandSemanticException` (HTTP 400): the query is not honourable against
this schema and no retry changes that. Removing a label the vertex simply does not have stays a no-op, as in
Neo4j, and removing both the subtype and the label it implies works and leaves an unlabelled node. Happy to
switch it to a silent no-op if you prefer the quieter behaviour.

## 2. A disjunction anchor's cardinality

`NodeByLabelDisjunctionScan` scans every type any alternative accepts, but its estimate came from the anchor
selector's single-label lookup - the first alternative alone - so `(n:A|B)` was priced as if only `:A`
existed and looked like the cheap side to drive a join from. `AnchorSelector` now sums the count over exactly
`Labels.matchingVertexTypes`, the same list the scan walks, counted non-polymorphically so a subtype
answering to two alternatives is charged once. A disjunction anchor is also no longer offered an index seek
it could never use: `IndexSelectionRule` builds the disjunction scan whatever the estimate claims, so
claiming a seek only mis-priced the plan it produces.

## 3. `Schema.getTypeOrNull`

The non-throwing accessor the `existsType(x) ? getType(x) : null` pairs wanted. A `default` method spelled as
that same pair, so an out-of-tree `Schema` keeps compiling; `LocalSchema` and `RemoteSchema` override it with
one lookup. The `existsType(x) && getType(x) instanceof Y` idiom collapses to `getTypeOrNull(x) instanceof Y`
at the sites that had it.

## Verification

- `CypherLabelsInheritanceIssue6363Test` (11) and `CypherDisjunctionCardinalityIssue6363Test` (5), new. 8 of
  the first class's assertions fail on `a58038b6`.
- engine unit lane **12600 / 0 failures**
- openCypher TCK **3897 / 0 failures**
- `engine, network, integration, server, mcp, ha, bolt` all green in one run

`docs/6363-cypher-labels-inheritance.md` records the semantics and why the `REMOVE` corner has no third
option.
