### PR TITLE
fix(#6377, #5290): the Postgres handshake gets a deadline, and a system query stays one however the client spells it

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -72,6 +72,7 @@ import com.arcadedb.utility.Pair;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.Socket;
+import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -108,6 +109,12 @@ public class PostgresNetworkExecutor extends Thread {
   public static final String PG_SERVER_VERSION = "12.0";
 
   private static final int                                            BUFFER_LENGTH    = 32 * 1024;
+  /**
+   * The cap PostgreSQL itself puts on a startup packet ({@code PQ_STARTUP_MSG_LIMIT} in {@code pqcomm.c}).
+   */
+  private static final int                                            MAX_STARTUP_MESSAGE_LENGTH = 10000;
+  /** How often {@link #waitForAMessage} looks for the client's next pre-authentication message. */
+  private static final int                                            WAIT_FOR_MESSAGE_POLL_MS   = 100;
   private static final Map<Long, Pair<Long, PostgresNetworkExecutor>> ACTIVE_SESSIONS  = new ConcurrentHashMap<>();
   /** Bind-message parameter length denoting a NULL value (wire value -1, read unsigned). */
   private static final long                                           NULL_PARAM_LENGTH = 0xFFFFFFFFL;
@@ -122,10 +129,11 @@ public class PostgresNetworkExecutor extends Thread {
   private final Map<String, Object>         connectionProperties  = new HashMap<>();
   private final Set<String>                 ignoreQueriesAppNames = new HashSet<>(//
       List.of("dbvis", "Database Navigator - Pool"));
+  // "SELECT oid, typname FROM pg_type" used to sit here too, so a client that builds its OID-to-name map up
+  // front got an empty one (issue #5290). PostgresTypeCatalog answers it now.
   private final Set<String>                 ignoreQueries         = new HashSet<>(//
       List.of(//
-          "select distinct PRIVILEGE_TYPE as PRIVILEGE_NAME from INFORMATION_SCHEMA.USAGE_PRIVILEGES order by PRIVILEGE_TYPE asc",//
-          "SELECT oid, typname FROM pg_type"));
+          "select distinct PRIVILEGE_TYPE as PRIVILEGE_NAME from INFORMATION_SCHEMA.USAGE_PRIVILEGES order by PRIVILEGE_TYPE asc"));
 
   private volatile boolean shutdown = false;
 
@@ -153,6 +161,31 @@ public class PostgresNetworkExecutor extends Thread {
     this.server = server;
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
     this.database = database;
+
+    // Bound the pre-authentication window (issue #6377). One thread and one file descriptor are committed
+    // per accepted connection, before anyone has proved who they are, and the listener caps neither; without
+    // a read timeout a client that connects and then says nothing - or trickles bytes arbitrarily slowly -
+    // holds both for as long as it likes. Lifted back to infinite once the database is open (see
+    // markAuthenticated), because an authenticated client is expected to keep a long-lived, often idle
+    // connection between statements. This is the same setSoTimeout(NETWORK_SOCKET_TIMEOUT)-then-
+    // setSoTimeout(0) idiom RedisNetworkExecutor (#5912) and BoltNetworkExecutor (#5978) already use.
+    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    if (handshakeTimeout > 0)
+      channel.socket.setSoTimeout(handshakeTimeout);
+  }
+
+  /**
+   * Lifts the pre-authentication read timeout armed in the constructor (issue #6377).
+   */
+  private void markAuthenticated() {
+    try {
+      channel.socket.setSoTimeout(0);
+    } catch (final SocketException e) {
+      // setSoTimeout() only throws on an already-broken/closed socket: there is nothing left to hold open in
+      // that case, so logging and moving on - rather than failing the whole authentication - is safe. The
+      // connection dies on its next read or write either way.
+      LogManager.instance().log(this, Level.FINE, "PSQL: unable to lift the idle read timeout after authentication", e);
+    }
   }
 
   public void close() {
@@ -165,18 +198,28 @@ public class PostgresNetworkExecutor extends Thread {
   public void run() {
     ProtocolContext.set("postgres");
     try {
-      if (!readStartupMessage(true))
+      try {
+        if (!readStartupMessage(true))
+          return;
+
+        writeMessage("request for password", () -> channel.writeUnsignedInt(3), 'R', 8);
+
+        waitForAMessage();
+
+        if (!readMessage("password", (type, length) -> userPassword = readString(), 'p'))
+          return;
+
+        if (!openDatabase())
+          return;
+      } catch (final PostgresProtocolException e) {
+        // A client that never finished the handshake is a non-event: it gets no error message it could read
+        // anyway, and the connection is closed by the enclosing finally.
+        LogManager.instance().log(this, Level.FINE, "PSQL: connection closed before authentication completed: %s", e,
+            e.getMessage());
         return;
+      }
 
-      writeMessage("request for password", () -> channel.writeUnsignedInt(3), 'R', 8);
-
-      waitForAMessage();
-
-      if (!readMessage("password", (type, length) -> userPassword = readString(), 'p'))
-        return;
-
-      if (!openDatabase())
-        return;
+      markAuthenticated();
 
       writeMessage("authentication ok", () -> channel.writeUnsignedInt(0), 'R', 8);
 
@@ -523,6 +566,7 @@ public class PostgresNetworkExecutor extends Thread {
       final long engineStart = System.nanoTime();
       final ResultSet resultSet;
       final String upperCaseText = query.query.toUpperCase(Locale.ENGLISH);
+      final PostgresSystemQuery systemQuery = PostgresSystemQuery.parse(query.query);
       if (upperCaseText.startsWith("SET ")) {
         setConfiguration(query.query);
         resultSet = new IteratorResultSet(createResultSet("STATUS", "Setting ignored").iterator());
@@ -530,12 +574,9 @@ public class PostgresNetworkExecutor extends Thread {
           upperCaseText.startsWith("RELEASE ") ||
           upperCaseText.startsWith("ROLLBACK TO ")) {
         resultSet = new IteratorResultSet(Collections.emptyIterator());
-      } else if ("SELECT VERSION()".equalsIgnoreCase(query.query) ||
-          "SELECT PG_CATALOG.VERSION()".equalsIgnoreCase(query.query))
-        resultSet = new IteratorResultSet(createResultSet("version", buildServerVersionString()).iterator());
-      else if ("SELECT CURRENT_SCHEMA()".equalsIgnoreCase(query.query) ||
-          "SELECT PG_CATALOG.CURRENT_SCHEMA()".equalsIgnoreCase(query.query))
-        resultSet = new IteratorResultSet(createResultSet("current_schema", database.getName()).iterator());
+      } else if (systemQuery != null)
+        resultSet = new IteratorResultSet(
+            createResultSet(systemQuery.columnName, systemQueryValue(systemQuery.function)).iterator());
       else if ("SHOW TRANSACTION ISOLATION LEVEL".equals(upperCaseText)) {
         final Database.TRANSACTION_ISOLATION_LEVEL dbIsolationLevel = database.getTransactionIsolationLevel();
         final String level = dbIsolationLevel.name().replace('_', ' ');
@@ -678,7 +719,7 @@ public class PostgresNetworkExecutor extends Thread {
    * @return A list of results if this is a pg_type query we handle, null otherwise
    */
   private List<Result> handlePgTypeQuery(final String query) {
-    final String upperQuery = query.toUpperCase();
+    final String upperQuery = query.toUpperCase(Locale.ENGLISH);
 
     // Check if this is a pg_type/pg_catalog query
     if (!upperQuery.contains("PG_TYPE") && !upperQuery.contains("PG_CATALOG")) {
@@ -689,105 +730,30 @@ public class PostgresNetworkExecutor extends Thread {
       LogManager.instance().log(this, Level.INFO, "PSQL: handling pg_type query: %s (thread=%s)",
           query, Thread.currentThread().threadId());
 
-    // Handle common JDBC driver queries for array type information
-    // Query pattern: SELECT e.typdelim, e.typname FROM pg_catalog.pg_type t, pg_catalog.pg_type e WHERE t.oid = <oid> AND t.typelem = e.oid
-    // or: SELECT typelem FROM pg_type WHERE oid = <oid>
-    // or: SELECT ... FROM pg_type WHERE typname = '<name>'
+    final Map<String, Object> byOid = PostgresTypeCatalog.lookupByOid(query);
+    if (byOid != null)
+      return Collections.singletonList(new ResultInternal(byOid));
 
-    // Extract OID from the query if present
-    Pattern oidPattern = Pattern.compile("(?:t\\.oid|oid)\\s*=\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
-    Matcher oidMatcher = oidPattern.matcher(query);
+    final Map<String, Object> byName = PostgresTypeCatalog.lookupByName(query);
+    if (byName != null)
+      return byName.isEmpty() ? Collections.emptyList() : Collections.singletonList(new ResultInternal(byName));
 
-    if (oidMatcher.find()) {
-      int oid = Integer.parseInt(oidMatcher.group(1));
-
-      // Map array type OIDs to their element type information
-      // PostgreSQL array types and their element types:
-      // 1007 = int4[] -> 23 = int4, 1009 = text[] -> 25 = text, etc.
-      String elemTypeName = null;
-      String typDelim = ",";
-      int elemOid = 0;
-
-      switch (oid) {
-        case 1007 -> { elemTypeName = "int4"; elemOid = 23; }      // int4[]
-        case 1009 -> { elemTypeName = "text"; elemOid = 25; }      // text[]
-        case 1016 -> { elemTypeName = "int8"; elemOid = 20; }      // int8[]
-        case 1021 -> { elemTypeName = "float4"; elemOid = 700; }   // float4[]
-        case 1022 -> { elemTypeName = "float8"; elemOid = 701; }   // float8[]
-        case 1000 -> { elemTypeName = "bool"; elemOid = 16; }      // bool[]
-        case 1003 -> { elemTypeName = "char"; elemOid = 18; }      // char[]
-        case 199 -> { elemTypeName = "json"; elemOid = 114; }      // json[]
-        case 1043 -> { elemTypeName = "varchar"; elemOid = 0; }    // varchar (not an array)
-        default -> { elemTypeName = "text"; elemOid = 25; }        // Default to text for unknown arrays
-      }
-
-      // Determine what columns the query is requesting
-      final Map<String, Object> map = new HashMap<>();
-
-      if (upperQuery.contains("TYPELEM")) {
-        map.put("typelem", elemOid);
-      }
-      if (upperQuery.contains("TYPDELIM")) {
-        map.put("typdelim", typDelim);
-      }
-      if (upperQuery.contains("TYPNAME") || upperQuery.contains("E.TYPNAME")) {
-        map.put("typname", elemTypeName);
-      }
-      if (upperQuery.contains("TYPARRAY")) {
-        // typarray is the OID of the array type for this scalar type
-        // For scalar types, return the corresponding array OID
-        map.put("typarray", oid);
-      }
-      if (upperQuery.contains("TYPTYPE")) {
-        map.put("typtype", "b"); // 'b' = base type
-      }
-      if (upperQuery.contains("TYPINPUT")) {
-        map.put("typinput", "array_in");
-      }
-
-      // Only return a result if we matched an array type and have data to return
-      if (!map.isEmpty() && elemOid > 0) {
-        final Result result = new ResultInternal(map);
-        return Collections.singletonList(result);
-      }
-    }
-
-    // Handle query by type name pattern
-    Pattern namePattern = Pattern.compile("typname\\s*=\\s*'([^']+)'", Pattern.CASE_INSENSITIVE);
-    Matcher nameMatcher = namePattern.matcher(query);
-    if (nameMatcher.find()) {
-      String typeName = nameMatcher.group(1);
-
-      // Map common type names to their OIDs
-      final Map<String, Object> map = new HashMap<>();
-      switch (typeName.toLowerCase()) {
-        case "_int4" -> { map.put("oid", 1007); map.put("typelem", 23); }
-        case "_int8" -> { map.put("oid", 1016); map.put("typelem", 20); }
-        case "_text" -> { map.put("oid", 1009); map.put("typelem", 25); }
-        case "_float4" -> { map.put("oid", 1021); map.put("typelem", 700); }
-        case "_float8" -> { map.put("oid", 1022); map.put("typelem", 701); }
-        case "_bool" -> { map.put("oid", 1000); map.put("typelem", 16); }
-        case "int4" -> { map.put("oid", 23); map.put("typelem", 0); }
-        case "int8" -> { map.put("oid", 20); map.put("typelem", 0); }
-        case "text" -> { map.put("oid", 25); map.put("typelem", 0); }
-        case "varchar" -> { map.put("oid", 1043); map.put("typelem", 0); }
-        default -> {
-          // Return empty result for unknown types
-          return Collections.emptyList();
-        }
-      }
-
-      if (!map.isEmpty()) {
-        map.put("typname", typeName);
-        map.put("typdelim", ",");
-        final Result result = new ResultInternal(map);
-        return Collections.singletonList(result);
-      }
-    }
+    final List<Result> enumerated = toResults(PostgresTypeCatalog.enumerate(query));
+    if (enumerated != null)
+      return enumerated;
 
     // For other pg_type queries we don't specifically handle, return empty result
     // This prevents errors from trying to query non-existent tables
     return Collections.emptyList();
+  }
+
+  private static List<Result> toResults(final List<Map<String, Object>> rows) {
+    if (rows == null)
+      return null;
+    final List<Result> results = new ArrayList<>(rows.size());
+    for (final Map<String, Object> row : rows)
+      results.add(new ResultInternal(row));
+    return results;
   }
 
   /**
@@ -1720,6 +1686,7 @@ public class PostgresNetworkExecutor extends Thread {
       }
 
       final String upperCaseText = portal.query.toUpperCase(Locale.ENGLISH);
+      final PostgresSystemQuery systemQuery = PostgresSystemQuery.parse(portal.query);
 
       if (portal.query.isEmpty() ||//
           (ignoreQueriesAppNames.contains(connectionProperties.get("application_name")) &&//
@@ -1734,11 +1701,8 @@ public class PostgresNetworkExecutor extends Thread {
       } else if (upperCaseText.startsWith("SET ")) {
         setConfiguration(portal.query);
         portal.ignoreExecution = true;
-      } else if ("SELECT VERSION()".equals(upperCaseText) || "SELECT PG_CATALOG.VERSION()".equals(upperCaseText)) {
-        createResultSet(portal, "version", buildServerVersionString());
-
-      } else if ("SELECT CURRENT_SCHEMA()".equals(upperCaseText) || "SELECT PG_CATALOG.CURRENT_SCHEMA()".equals(upperCaseText)) {
-        createResultSet(portal, "current_schema", database.getName());
+      } else if (systemQuery != null) {
+        createResultSet(portal, systemQuery.columnName, systemQueryValue(systemQuery.function));
 
       } else if ("SHOW TRANSACTION ISOLATION LEVEL".equals(upperCaseText)) {
         final Database.TRANSACTION_ISOLATION_LEVEL dbIsolationLevel = database.getTransactionIsolationLevel();
@@ -1943,6 +1907,21 @@ public class PostgresNetworkExecutor extends Thread {
     connectionProperties.put(paramName, parts[1]);
   }
 
+  /**
+   * The value of an emulated system-information function (issue #5290). {@code current_schema} answers the
+   * database name rather than PostgreSQL's {@code public}, and {@code current_database} answers the same
+   * name: ArcadeDB has one namespace per database, so the distinction PostgreSQL draws between a catalog
+   * and a schema inside it has nothing on this side to map onto, and a client using either to qualify a
+   * name needs the one name that works.
+   */
+  private String systemQueryValue(final PostgresSystemQuery.Function function) {
+    return switch (function) {
+      case VERSION -> buildServerVersionString();
+      case CURRENT_SCHEMA, CURRENT_DATABASE, CURRENT_CATALOG -> database.getName();
+      case CURRENT_USER, SESSION_USER, CURRENT_ROLE, USER -> userName;
+    };
+  }
+
   private String buildServerVersionString() {
     return "PostgreSQL " + PG_SERVER_VERSION + " (ArcadeDB " + Constants.getRawVersion() + ")";
   }
@@ -2007,6 +1986,14 @@ public class PostgresNetworkExecutor extends Thread {
   private boolean readStartupMessage(final boolean no2ssl) {
     try {
       final long len = channel.readUnsignedInt();
+      // The declared length used to be read and then ignored, so the parameter loop below ran until the
+      // client chose to stop it and every pair it sent was retained (issue #6377). PostgreSQL rejects an
+      // over-long startup packet outright rather than counting what is inside it, and this does the same:
+      // one rule bounds the pair count, the total bytes and the time spent reading them, and it is the
+      // client's own declared length that is being held to, not a limit invented here.
+      if (len < 8 || len > MAX_STARTUP_MESSAGE_LENGTH)
+        throw new PostgresProtocolException("Invalid startup message length " + len);
+
       final long protocolVersion = channel.readUnsignedInt();
       if (protocolVersion == 80877103) {
         // REQUEST FOR SSL, NOT SUPPORTED
@@ -2044,35 +2031,56 @@ public class PostgresNetworkExecutor extends Thread {
       }
 
       if (len > 8) {
-        while (readNextByte() != 0) {
-          reuseLastByte();
-
-          final String paramName = readString();
-          final String paramValue = readString();
-
-          switch (paramName) {
-          case "user":
-            userName = paramValue;
-            break;
-          case "database":
-            databaseName = paramValue;
-            break;
-          case "options":
-            // DEPRECATED, IGNORE IT
-            break;
-          case "replication":
-            // NOT SUPPORTED, IGNORE IT
-            break;
-          }
-
-          connectionProperties.put(paramName, paramValue);
-        }
+        final byte[] body = new byte[(int) (len - 8)];
+        channel.readBytes(body);
+        readStartupParameters(body);
       }
     } catch (final IOException e) {
       setErrorInTx();
       throw new PostgresProtocolException("Error on parsing startup message", e);
     }
     return true;
+  }
+
+  /**
+   * Reads the {@code name\0value\0...\0} parameter section of a startup message out of the bytes the
+   * message declared, rather than off the socket until the client sends a terminator (issue #6377).
+   */
+  private void readStartupParameters(final byte[] body) {
+    int pos = 0;
+    while (pos < body.length && body[pos] != 0) {
+      final int nameEnd = indexOfTerminator(body, pos);
+      final String paramName = new String(body, pos, nameEnd - pos, DatabaseFactory.getDefaultCharset());
+      pos = nameEnd + 1;
+
+      final int valueEnd = indexOfTerminator(body, pos);
+      final String paramValue = new String(body, pos, valueEnd - pos, DatabaseFactory.getDefaultCharset());
+      pos = valueEnd + 1;
+
+      switch (paramName) {
+      case "user":
+        userName = paramValue;
+        break;
+      case "database":
+        databaseName = paramValue;
+        break;
+      case "options":
+        // DEPRECATED, IGNORE IT
+        break;
+      case "replication":
+        // NOT SUPPORTED, IGNORE IT
+        break;
+      }
+
+      connectionProperties.put(paramName, paramValue);
+    }
+  }
+
+  private static int indexOfTerminator(final byte[] body, final int from) {
+    for (int i = from; i < body.length; i++)
+      if (body[i] == 0)
+        return i;
+    throw new PostgresProtocolException("Unterminated string in startup message");
   }
 
   /**
@@ -2219,11 +2227,28 @@ public class PostgresNetworkExecutor extends Thread {
     return nextByte = channel.readUnsignedByte();
   }
 
+  /**
+   * Waits for the client's next pre-authentication message to show up, bounded by the same handshake timeout
+   * as the socket reads around it (issue #6377). {@link #readMessage} deliberately does not block - it
+   * returns false when no byte is available yet - so the pre-auth sequence has to see input arrive before it
+   * reads. Unbounded, this loop was the hole the socket timeout could not close: a client that connected,
+   * sent a startup message and then went silent pinned this thread here forever, and no read was ever
+   * outstanding on the socket for a timeout to interrupt.
+   */
   private void waitForAMessage() {
+    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
+    final long deadline = handshakeTimeout > 0 ? System.currentTimeMillis() + handshakeTimeout : Long.MAX_VALUE;
+
     while (!channel.inputHasData()) {
+      if (shutdown)
+        throw new PostgresProtocolException("Connection closed while waiting for the authentication handshake");
+      if (System.currentTimeMillis() > deadline)
+        throw new PostgresProtocolException("Timeout waiting for the client to complete the authentication handshake");
+
       try {
-        Thread.sleep(100);
-      } catch (final InterruptedException interruptedException) {
+        Thread.sleep(WAIT_FOR_MESSAGE_POLL_MS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new PostgresProtocolException("Error on reading from the channel");
       }
     }
@@ -2378,9 +2403,15 @@ public class PostgresNetworkExecutor extends Thread {
   /**
    * Session commands such as {@code SET search_path TO "$user", public} are handled by the protocol itself and never
    * reach the SQL engine, so their double quotes must be left alone.
+   * <p>
+   * The emulated system-information queries are in the same category, and for the same reason: rewriting the
+   * quotes in {@code SELECT current_schema() AS "schema"} left an alias in back-ticks that
+   * {@link PostgresSystemQuery} no longer recognised, and the query fell through to a SQL engine that has no
+   * such function (issue #5290).
    */
   private static boolean isSessionCommand(final String queryText) {
-    return queryText.regionMatches(true, 0, "SET ", 0, 4) || queryText.regionMatches(true, 0, "SHOW ", 0, 5);
+    return queryText.regionMatches(true, 0, "SET ", 0, 4) || queryText.regionMatches(true, 0, "SHOW ", 0, 5)
+        || PostgresSystemQuery.parse(queryText) != null;
   }
 
   private void emptyQueryResponse() {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -730,17 +730,9 @@ public class PostgresNetworkExecutor extends Thread {
       LogManager.instance().log(this, Level.INFO, "PSQL: handling pg_type query: %s (thread=%s)",
           query, Thread.currentThread().threadId());
 
-    final Map<String, Object> byOid = PostgresTypeCatalog.lookupByOid(query);
-    if (byOid != null)
-      return Collections.singletonList(new ResultInternal(byOid));
-
-    final Map<String, Object> byName = PostgresTypeCatalog.lookupByName(query);
-    if (byName != null)
-      return byName.isEmpty() ? Collections.emptyList() : Collections.singletonList(new ResultInternal(byName));
-
-    final List<Result> enumerated = toResults(PostgresTypeCatalog.enumerate(query));
-    if (enumerated != null)
-      return enumerated;
+    final List<Result> rows = toResults(PostgresTypeCatalog.resolve(query));
+    if (rows != null)
+      return rows;
 
     // For other pg_type queries we don't specifically handle, return empty result
     // This prevents errors from trying to query non-existent tables

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresSystemQuery.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresSystemQuery.java
@@ -109,12 +109,13 @@ public class PostgresSystemQuery {
 
     final Function function = Function.valueOf(matcher.group(1).toUpperCase(Locale.ENGLISH));
 
-    // A quoted alias keeps the case the client wrote; an unquoted one is folded to lower case, as
-    // PostgreSQL folds every unquoted identifier.
+    // A quoted alias keeps the case - and the emptiness - the client wrote; an unquoted one is folded to
+    // lower case, as PostgreSQL folds every unquoted identifier. An explicit AS "" is a column named "",
+    // which PostgreSQL allows, and is not the same as having supplied no alias at all.
     final String quotedAlias = matcher.group(2);
     final String bareAlias = matcher.group(3);
     final String columnName;
-    if (quotedAlias != null && !quotedAlias.isEmpty())
+    if (quotedAlias != null)
       columnName = quotedAlias;
     else if (bareAlias != null)
       columnName = bareAlias.toLowerCase(Locale.ENGLISH);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresSystemQuery.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresSystemQuery.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Recognises a {@code SELECT} over one of the niladic PostgreSQL system-information functions this wire
+ * protocol emulates, and reports which function it is and what the resulting column must be called.
+ * <p>
+ * The protocol used to match these queries by string equality against one exact spelling per function, in
+ * two places (the simple-query and the extended-query paths, which had drifted into slightly different
+ * comparisons). Anything a client added around the call - an alias, a trailing semicolon after a space,
+ * a {@code pg_catalog.} prefix on a spelling that was only listed bare - missed the match and fell through
+ * to ArcadeDB's own SQL engine, which answers a different question or none at all (issue #5290):
+ * <ul>
+ * <li>{@code SELECT CURRENT_SCHEMA() AS schema} failed to parse outright, because {@code schema} is a
+ * reserved word in ArcadeDB SQL but only an ordinary alias in PostgreSQL. That is a connect-time query for
+ * some clients, so the tool never got past opening the connection.</li>
+ * <li>{@code SELECT version() AS v} answered with ArcadeDB's own {@code version()} function - the build
+ * string - where the un-aliased spelling answers {@code PostgreSQL 12.0 (ArcadeDB ...)}. A client parsing
+ * the server version out of that reads a version PostgreSQL never had.</li>
+ * </ul>
+ * Recognition therefore happens once, here, over a normalised statement, and both protocol paths share it.
+ * <p>
+ * This class only decides <i>what was asked</i>: the values live in the executor, which is what holds the
+ * database, the authenticated user and the server version.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PostgresSystemQuery {
+  /**
+   * The emulated system-information functions. {@code defaultColumnName} is the column name PostgreSQL
+   * itself gives the expression when the client supplies no alias.
+   */
+  public enum Function {
+    VERSION("version"),
+    CURRENT_SCHEMA("current_schema"),
+    CURRENT_DATABASE("current_database"),
+    CURRENT_CATALOG("current_catalog"),
+    CURRENT_USER("current_user"),
+    SESSION_USER("session_user"),
+    CURRENT_ROLE("current_role"),
+    USER("user");
+
+    public final String defaultColumnName;
+
+    Function(final String defaultColumnName) {
+      this.defaultColumnName = defaultColumnName;
+    }
+  }
+
+  /**
+   * {@code SELECT [pg_catalog.]<function>[()] [[AS] <alias>]}, with the whole statement anchored so that
+   * nothing else can hide in it - a projection list, a FROM, a WHERE - and only the exact shape this class
+   * can answer is claimed. The word boundary after the function name is what keeps {@code SELECT user_id}
+   * from being read as {@code user} aliased to {@code _id}: the alternation would otherwise match the
+   * {@code user} prefix and leave the rest to the alias group.
+   * <p>
+   * The parentheses are optional for every function rather than per-function: PostgreSQL spells some of
+   * these as keywords ({@code current_user}) and some as calls ({@code version()}), and being stricter here
+   * would only reject a query this protocol can still answer correctly.
+   */
+  private static final Pattern SYSTEM_QUERY = Pattern.compile(
+      "^SELECT\\s+(?:PG_CATALOG\\s*\\.\\s*)?"
+          + "(VERSION|CURRENT_SCHEMA|CURRENT_DATABASE|CURRENT_CATALOG|CURRENT_USER|SESSION_USER|CURRENT_ROLE|USER)\\b"
+          + "\\s*(?:\\(\\s*\\))?"
+          + "(?:\\s+(?:AS\\s+)?(?:\"([^\"]*)\"|([A-Za-z_][A-Za-z0-9_$]*)))?\\s*$",
+      Pattern.CASE_INSENSITIVE);
+
+  public final Function function;
+  /** The column to announce in RowDescription: the client's alias when it gave one, else PostgreSQL's own name. */
+  public final String   columnName;
+
+  private PostgresSystemQuery(final Function function, final String columnName) {
+    this.function = function;
+    this.columnName = columnName;
+  }
+
+  /**
+   * Returns the recognised system query, or null when {@code query} is not one - in which case the caller
+   * must go on to the rest of its dispatch, exactly as before.
+   */
+  public static PostgresSystemQuery parse(final String query) {
+    if (query == null)
+      return null;
+
+    final Matcher matcher = SYSTEM_QUERY.matcher(normalize(query));
+    if (!matcher.matches())
+      return null;
+
+    final Function function = Function.valueOf(matcher.group(1).toUpperCase(Locale.ENGLISH));
+
+    // A quoted alias keeps the case the client wrote; an unquoted one is folded to lower case, as
+    // PostgreSQL folds every unquoted identifier.
+    final String quotedAlias = matcher.group(2);
+    final String bareAlias = matcher.group(3);
+    final String columnName;
+    if (quotedAlias != null && !quotedAlias.isEmpty())
+      columnName = quotedAlias;
+    else if (bareAlias != null)
+      columnName = bareAlias.toLowerCase(Locale.ENGLISH);
+    else
+      columnName = function.defaultColumnName;
+
+    return new PostgresSystemQuery(function, columnName);
+  }
+
+  /**
+   * Strips the statement terminator and the whitespace around it. A client is free to send
+   * {@code "SELECT current_schema() ;"} - the simple-query path only removes a semicolon that is the very
+   * last character, which leaves a trailing space behind and used to break the match.
+   */
+  private static String normalize(final String query) {
+    int end = query.length();
+    while (end > 0) {
+      final char c = query.charAt(end - 1);
+      if (c == ';' || Character.isWhitespace(c))
+        --end;
+      else
+        break;
+    }
+    return query.substring(0, end).trim();
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -51,28 +51,36 @@ import java.util.stream.StreamSupport;
  * Represents PostgreSQL data types and provides serialization/deserialization functionality.
  */
 public enum PostgresType {
-  SMALLINT(21, Short.class, 2, value -> Short.parseShort(value)),
-  INTEGER(23, Integer.class, 4, value -> Integer.parseInt(value)),
-  LONG(20, Long.class, 8, value -> Long.parseLong(value)),
-  REAL(700, Float.class, 4, value -> Float.parseFloat(value)),
-  DOUBLE(701, Double.class, 8, value -> Double.parseDouble(value)),
-  CHAR(18, Character.class, 1, value -> value.charAt(0)),
-  BOOLEAN(16, Boolean.class, 1, value -> parseBooleanText(value)),
-  DATE(1082, Date.class, 4, value -> parseDateText(value)),
-  TIMESTAMP(1114, LocalDateTime.class, 8, value -> parseTimestampText(value)),
-  VARCHAR(1043, String.class, -1, value -> value),
-  TEXT(25, String.class, -1, value -> value),
-  BPCHAR(1042, String.class, -1, value -> value),
-  JSON(114, JSONObject.class, -1, PostgresType::parseJsonText),
+  // The three catalog columns after the OID are pg_type's own: typname, typelem (the element type of an
+  // array, 0 for a scalar) and typarray (the array type built on a scalar, 0 for an array). They are the
+  // answer this protocol gives a client that enumerates or looks up pg_type (issue #5290), so they hold
+  // PostgreSQL's real names and OIDs rather than anything ArcadeDB-specific: a client resolves the OID it
+  // was handed in RowDescription against them, and a name that is not Postgres' name resolves to nothing.
+  SMALLINT(21, "int2", 0, 1005, Short.class, 2, value -> Short.parseShort(value)),
+  INTEGER(23, "int4", 0, 1007, Integer.class, 4, value -> Integer.parseInt(value)),
+  LONG(20, "int8", 0, 1016, Long.class, 8, value -> Long.parseLong(value)),
+  REAL(700, "float4", 0, 1021, Float.class, 4, value -> Float.parseFloat(value)),
+  DOUBLE(701, "float8", 0, 1022, Double.class, 8, value -> Double.parseDouble(value)),
+  CHAR(18, "char", 0, 1002, Character.class, 1, value -> value.charAt(0)),
+  BOOLEAN(16, "bool", 0, 1000, Boolean.class, 1, value -> parseBooleanText(value)),
+  DATE(1082, "date", 0, 1182, Date.class, 4, value -> parseDateText(value)),
+  TIMESTAMP(1114, "timestamp", 0, 1115, LocalDateTime.class, 8, value -> parseTimestampText(value)),
+  VARCHAR(1043, "varchar", 0, 1015, String.class, -1, value -> value),
+  TEXT(25, "text", 0, 1009, String.class, -1, value -> value),
+  BPCHAR(1042, "bpchar", 0, 1014, String.class, -1, value -> value),
+  JSON(114, "json", 0, 199, JSONObject.class, -1, PostgresType::parseJsonText),
   // Adding array types with PostgreSQL array type codes
-  ARRAY_INT(1007, Collection.class, -1, value -> parseArrayFromString(value, Integer::parseInt)),
-  ARRAY_CHAR(1003, Collection.class, -1, value -> parseArrayFromString(value, s -> s.charAt(0))),
-  ARRAY_LONG(1016, Collection.class, -1, value -> parseArrayFromString(value, Long::parseLong)),
-  ARRAY_REAL(1021, Collection.class, -1, value -> parseArrayFromString(value, Float::parseFloat)),
-  ARRAY_DOUBLE(1022, Collection.class, -1, value -> parseArrayFromString(value, Double::parseDouble)),
-  ARRAY_TEXT(1009, Collection.class, -1, value -> parseArrayFromString(value, s -> s)),
-  ARRAY_JSON(199, Collection.class, -1, value -> parseArrayFromString(value, s -> s)),
-  ARRAY_BOOLEAN(1000, Collection.class, -1, value -> parseArrayFromString(value, Boolean::parseBoolean));
+  ARRAY_INT(1007, "_int4", 23, 0, Collection.class, -1, value -> parseArrayFromString(value, Integer::parseInt)),
+  // 1002 is "char"[], the array of the single-byte CHAR (OID 18) this enum pairs it with. It used to be
+  // declared as 1003, which in PostgreSQL is name[] - an unrelated type - so a client resolving the OID
+  // this protocol announced for a list of characters was told a type ArcadeDB never produces (issue #5290).
+  ARRAY_CHAR(1002, "_char", 18, 0, Collection.class, -1, value -> parseArrayFromString(value, s -> s.charAt(0))),
+  ARRAY_LONG(1016, "_int8", 20, 0, Collection.class, -1, value -> parseArrayFromString(value, Long::parseLong)),
+  ARRAY_REAL(1021, "_float4", 700, 0, Collection.class, -1, value -> parseArrayFromString(value, Float::parseFloat)),
+  ARRAY_DOUBLE(1022, "_float8", 701, 0, Collection.class, -1, value -> parseArrayFromString(value, Double::parseDouble)),
+  ARRAY_TEXT(1009, "_text", 25, 0, Collection.class, -1, value -> parseArrayFromString(value, s -> s)),
+  ARRAY_JSON(199, "_json", 114, 0, Collection.class, -1, value -> parseArrayFromString(value, s -> s)),
+  ARRAY_BOOLEAN(1000, "_bool", 16, 0, Collection.class, -1, value -> parseArrayFromString(value, Boolean::parseBoolean));
 
   private static final Map<Integer, PostgresType> CODE_MAP = Arrays.stream(values())
       .collect(Collectors.toMap(type -> type.code, type -> type));
@@ -169,15 +177,34 @@ public enum PostgresType {
   }
 
   public final  int                      code;
+  /** pg_type.typname, the name PostgreSQL itself gives {@link #code}. */
+  public final  String                   typeName;
+  /** pg_type.typelem: the OID of the element type for an array type, 0 for a scalar. */
+  public final  int                      elementCode;
+  /** pg_type.typarray: the OID of the array type built on a scalar, 0 for an array type. */
+  public final  int                      arrayCode;
   public final  Class<?>                 cls;
   public final  int                      size;
   private final Function<String, Object> textParser;
 
-  PostgresType(final int code, final Class<?> cls, final int size, Function<String, Object> textParser) {
+  PostgresType(final int code, final String typeName, final int elementCode, final int arrayCode, final Class<?> cls,
+      final int size, Function<String, Object> textParser) {
     this.code = code;
+    this.typeName = typeName;
+    this.elementCode = elementCode;
+    this.arrayCode = arrayCode;
     this.cls = cls;
     this.size = size;
     this.textParser = textParser;
+  }
+
+  /**
+   * Returns the type carrying the given OID, or null when this protocol has no such type. Unlike
+   * {@code deserializeAsText}/{@code deserializeAsBinary}, which reject an unknown OID, a catalog lookup
+   * for a type ArcadeDB cannot produce is a legitimate answer of "no row" rather than an error.
+   */
+  public static PostgresType byCode(final int code) {
+    return CODE_MAP.get(code);
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Answers the {@code pg_type} lookups a PostgreSQL client makes to find out what the OIDs it was handed in
+ * RowDescription actually mean.
+ * <p>
+ * Every answer is derived from {@link PostgresType}, which is the set of types this protocol can produce and
+ * therefore the only set it can honestly describe. The mapping used to be a hand-written switch that had
+ * drifted from the enum - it named the element of OID 1003 as {@code char} while PostgreSQL calls 1003
+ * {@code name[]}, and reported an array type's {@code typarray} as the array's own OID rather than 0 - so a
+ * client resolving a type ArcadeDB had just announced could be told about a different type entirely.
+ * <p>
+ * The third shape, enumeration ({@code SELECT oid, typname FROM pg_type} and friends), used to be answered
+ * with zero rows: the query was on an ignore-list, so a client that builds its whole OID-to-name map up
+ * front - which is how several tools decide how to decode a column - built an empty one and then failed on
+ * the first column whose type it could not name (issue #5290). Enumerating the types this protocol really
+ * produces is both truthful and what such a client needs.
+ * <p>
+ * A shape not recognised here is <b>not</b> guessed at: the caller falls back to an empty result set, which
+ * is the long-standing behaviour for the rest of {@code pg_catalog}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PostgresTypeCatalog {
+  /**
+   * pg_type columns this catalog can produce. A projection naming anything outside this set is declined
+   * whole rather than answered with holes in it.
+   */
+  private static final List<String> COLUMNS = List.of(//
+      "oid", "typname", "typelem", "typarray", "typdelim", "typtype", "typcategory", "typlen", "typinput",//
+      "typnotnull", "typbasetype", "typnamespace", "typrelid");
+
+  /** {@code SELECT <projection> FROM [pg_catalog.]pg_type [alias]} and nothing else - no WHERE, no join, no ORDER BY. */
+  private static final Pattern ENUMERATION = Pattern.compile(
+      "^SELECT\\s+(.+?)\\s+FROM\\s+(?:PG_CATALOG\\s*\\.\\s*)?PG_TYPE(?:\\s+(?:AS\\s+)?[A-Za-z_][A-Za-z0-9_$]*)?\\s*$",
+      Pattern.CASE_INSENSITIVE);
+
+  /** One projection item: an optionally table-qualified column, or {@code *}, with an optional alias. */
+  private static final Pattern PROJECTION_ITEM = Pattern.compile(
+      "^(?:[A-Za-z_][A-Za-z0-9_$]*\\s*\\.\\s*)?([A-Za-z_][A-Za-z0-9_$]*|\\*)"
+          + "(?:\\s+(?:AS\\s+)?(?:\"([^\"]*)\"|([A-Za-z_][A-Za-z0-9_$]*)))?$",
+      Pattern.CASE_INSENSITIVE);
+
+  /** {@code t.oid = 1007} / {@code oid = 1007}: the OID a client wants the element type of. */
+  private static final Pattern OID_FILTER = Pattern.compile("(?:t\\.oid|oid)\\s*=\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
+
+  /** {@code typname = 'int4'}: the type name a client wants the OID of. */
+  private static final Pattern NAME_FILTER = Pattern.compile("typname\\s*=\\s*'([^']+)'", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The types in OID order, so that an enumeration is stable across runs and across JVMs - a client that
+   * caches the answer must not see it reshuffle.
+   */
+  private static final PostgresType[] TYPES_BY_OID = Arrays.stream(PostgresType.values())
+      .sorted(Comparator.comparingInt(t -> t.code))
+      .toArray(PostgresType[]::new);
+
+  private PostgresTypeCatalog() {
+  }
+
+  /**
+   * Answers {@code SELECT ... FROM pg_type} with no filter, returning one row per type this protocol can
+   * produce. Returns null when the query is not a plain enumeration, or when it projects a column this
+   * catalog does not know - the caller then falls back to the other shapes.
+   * <p>
+   * Column order follows the projection list rather than any internal order: a client is free to read a
+   * DataRow positionally, so {@code SELECT oid, typname} and {@code SELECT typname, oid} must not come back
+   * the same way round.
+   */
+  public static List<Map<String, Object>> enumerate(final String query) {
+    final Matcher matcher = ENUMERATION.matcher(query.trim());
+    if (!matcher.matches())
+      return null;
+
+    final List<String> requested = new ArrayList<>();
+    final List<String> aliases = new ArrayList<>();
+    for (final String item : splitProjection(matcher.group(1))) {
+      final Matcher projection = PROJECTION_ITEM.matcher(item.trim());
+      if (!projection.matches())
+        return null;
+
+      final String column = projection.group(1).toLowerCase(Locale.ENGLISH);
+      if ("*".equals(column)) {
+        if (projection.group(2) != null || projection.group(3) != null)
+          // "*" takes no alias; a client that wrote one meant something this catalog is not parsing.
+          return null;
+        for (final String known : COLUMNS) {
+          requested.add(known);
+          aliases.add(known);
+        }
+        continue;
+      }
+
+      if (!COLUMNS.contains(column))
+        return null;
+
+      requested.add(column);
+      final String quotedAlias = projection.group(2);
+      final String bareAlias = projection.group(3);
+      if (quotedAlias != null && !quotedAlias.isEmpty())
+        aliases.add(quotedAlias);
+      else if (bareAlias != null)
+        aliases.add(bareAlias.toLowerCase(Locale.ENGLISH));
+      else
+        aliases.add(column);
+    }
+
+    if (requested.isEmpty())
+      return null;
+
+    final List<Map<String, Object>> rows = new ArrayList<>(TYPES_BY_OID.length);
+    for (final PostgresType type : TYPES_BY_OID) {
+      final Map<String, Object> row = new LinkedHashMap<>(requested.size());
+      for (int i = 0; i < requested.size(); i++)
+        row.put(aliases.get(i), columnValue(type, requested.get(i)));
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  /**
+   * Answers the driver lookup {@code SELECT e.typdelim, e.typname FROM pg_type t, pg_type e WHERE t.oid = ?
+   * AND t.typelem = e.oid} and its variants: the projected {@code typname}/{@code typdelim} describe the
+   * <i>element</i> type of the array whose OID was given, which is what the join in the client's query asks
+   * for. Returns null when the query carries no OID filter, or when the OID is not an array type - a scalar
+   * has no element to report.
+   */
+  public static Map<String, Object> lookupByOid(final String query) {
+    final Matcher matcher = OID_FILTER.matcher(query);
+    if (!matcher.find())
+      return null;
+
+    final int oid = parseOid(matcher.group(1));
+    final PostgresType type = oid < 0 ? null : PostgresType.byCode(oid);
+
+    final PostgresType element;
+    if (type == null)
+      // An OID this protocol does not produce is still answered as text, as it always has been: a driver
+      // that asks about an unknown array is better served by the delimiter and element of the most common
+      // one than by an empty result it has no fallback for.
+      element = PostgresType.TEXT;
+    else if (type.isArrayType())
+      element = PostgresType.byCode(type.elementCode);
+    else
+      // A scalar has no element to report, so this is not a question this shape can answer.
+      return null;
+
+    final String upperQuery = query.toUpperCase(Locale.ENGLISH);
+    final Map<String, Object> row = new LinkedHashMap<>();
+    if (upperQuery.contains("TYPELEM"))
+      row.put("typelem", element.code);
+    if (upperQuery.contains("TYPDELIM"))
+      row.put("typdelim", ",");
+    if (upperQuery.contains("TYPNAME"))
+      row.put("typname", element.typeName);
+    if (upperQuery.contains("TYPARRAY"))
+      row.put("typarray", type != null ? type.arrayCode : 0);
+    if (upperQuery.contains("TYPTYPE"))
+      row.put("typtype", "b"); // 'b' = base type
+    if (upperQuery.contains("TYPINPUT"))
+      row.put("typinput", "array_in");
+
+    return row.isEmpty() ? null : row;
+  }
+
+  /**
+   * Answers {@code SELECT oid, ... FROM pg_type WHERE typname = '<name>'}. Returns null when the query
+   * carries no name filter; returns an empty map - meaning "no such type" - when the name is one this
+   * protocol cannot produce.
+   */
+  public static Map<String, Object> lookupByName(final String query) {
+    final Matcher matcher = NAME_FILTER.matcher(query);
+    if (!matcher.find())
+      return null;
+
+    final String typeName = matcher.group(1).toLowerCase(Locale.ENGLISH);
+    for (final PostgresType type : TYPES_BY_OID) {
+      if (type.typeName.equals(typeName)) {
+        final Map<String, Object> row = new LinkedHashMap<>();
+        row.put("oid", type.code);
+        row.put("typname", type.typeName);
+        row.put("typelem", type.elementCode);
+        row.put("typarray", type.arrayCode);
+        row.put("typdelim", ",");
+        return row;
+      }
+    }
+    return Map.of();
+  }
+
+  private static Object columnValue(final PostgresType type, final String column) {
+    return switch (column) {
+      case "oid" -> type.code;
+      case "typname" -> type.typeName;
+      case "typelem" -> type.elementCode;
+      case "typarray" -> type.arrayCode;
+      case "typdelim" -> ",";
+      case "typtype" -> "b";           // base type: none of these is a composite, a domain or an enum
+      case "typcategory" -> category(type);
+      case "typlen" -> type.size;
+      case "typinput" -> type.isArrayType() ? "array_in" : type.typeName + "in";
+      case "typnotnull" -> Boolean.FALSE;
+      case "typbasetype" -> 0;         // not a domain, so no base type
+      case "typnamespace" -> 11;       // pg_catalog, whose OID is fixed at 11 in PostgreSQL
+      case "typrelid" -> 0;            // not a composite, so no backing relation
+      default -> null;
+    };
+  }
+
+  /** pg_type.typcategory, the one-letter grouping PostgreSQL uses to drive implicit-cast preferences. */
+  private static String category(final PostgresType type) {
+    if (type.isArrayType())
+      return "A";
+    return switch (type) {
+      case BOOLEAN -> "B";
+      case SMALLINT, INTEGER, LONG, REAL, DOUBLE -> "N";
+      case DATE, TIMESTAMP -> "D";
+      case CHAR, VARCHAR, TEXT, BPCHAR -> "S";
+      default -> "U"; // user-defined, which is where PostgreSQL itself files json
+    };
+  }
+
+  /**
+   * A declared OID that does not fit an int is not a type reference, just a number the client wrote; -1
+   * routes it to the unknown-type answer instead of overflowing into some other type's OID.
+   */
+  private static int parseOid(final String text) {
+    try {
+      return Integer.parseInt(text);
+    } catch (final NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  /** Splits a projection list on the commas that separate its items. */
+  private static List<String> splitProjection(final String projection) {
+    return Arrays.asList(projection.split(","));
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -29,21 +29,28 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Answers the {@code pg_type} lookups a PostgreSQL client makes to find out what the OIDs it was handed in
+ * Answers the {@code pg_type} queries a PostgreSQL client makes to find out what the OIDs it was handed in
  * RowDescription actually mean.
  * <p>
  * Every answer is derived from {@link PostgresType}, which is the set of types this protocol can produce and
  * therefore the only set it can honestly describe. The mapping used to be a hand-written switch that had
- * drifted from the enum - it named the element of OID 1003 as {@code char} while PostgreSQL calls 1003
- * {@code name[]}, and reported an array type's {@code typarray} as the array's own OID rather than 0 - so a
- * client resolving a type ArcadeDB had just announced could be told about a different type entirely.
+ * drifted from the enum - it named the element of OID 1003 {@code char} while PostgreSQL calls 1003
+ * {@code name[]}, and reported an array type's {@code typarray} as the array's own OID - so a client
+ * resolving a type ArcadeDB had just announced could be told about a different type entirely.
  * <p>
- * The third shape, enumeration ({@code SELECT oid, typname FROM pg_type} and friends), used to be answered
- * with zero rows: the query was on an ignore-list, so a client that builds its whole OID-to-name map up
- * front - which is how several tools decide how to decode a column - built an empty one and then failed on
- * the first column whose type it could not name (issue #5290). Enumerating the types this protocol really
- * produces is both truthful and what such a client needs.
- * <p>
+ * There are two shapes, and the distinction between them matters:
+ * <ul>
+ * <li>An ordinary {@code SELECT <columns> FROM pg_type [WHERE oid = N | WHERE typname = '...']}, which asks
+ * for the row of the type named by the filter, or for every row when there is no filter. Enumeration used to
+ * be answered with zero rows - the query was on an ignore-list - so a client that builds its whole
+ * OID-to-name map up front built an empty one and then failed on the first column whose type it could not
+ * name (issue #5290). A filtered one used to be answered with a fixed handful of columns that did not
+ * include {@code oid} even when the client had asked for it.</li>
+ * <li>The self-join {@code SELECT e.typdelim, e.typname FROM pg_type t, pg_type e WHERE t.oid = N AND
+ * t.typelem = e.oid} that JDBC drivers use to resolve an array's element type. Here the projected columns
+ * describe a <i>different</i> row from the one the filter selects, which no plain projection can express, so
+ * it is recognised on its own.</li>
+ * </ul>
  * A shape not recognised here is <b>not</b> guessed at: the caller falls back to an empty result set, which
  * is the long-standing behaviour for the rest of {@code pg_catalog}.
  *
@@ -58,9 +65,10 @@ public class PostgresTypeCatalog {
       "oid", "typname", "typelem", "typarray", "typdelim", "typtype", "typcategory", "typlen", "typinput",//
       "typnotnull", "typbasetype", "typnamespace", "typrelid");
 
-  /** {@code SELECT <projection> FROM [pg_catalog.]pg_type [alias]} and nothing else - no WHERE, no join, no ORDER BY. */
-  private static final Pattern ENUMERATION = Pattern.compile(
-      "^SELECT\\s+(.+?)\\s+FROM\\s+(?:PG_CATALOG\\s*\\.\\s*)?PG_TYPE(?:\\s+(?:AS\\s+)?[A-Za-z_][A-Za-z0-9_$]*)?\\s*$",
+  /** {@code SELECT <projection> FROM [pg_catalog.]pg_type [alias] [WHERE <filter>]} and nothing more. */
+  private static final Pattern QUERY = Pattern.compile(
+      "^SELECT\\s+(.+?)\\s+FROM\\s+(?:PG_CATALOG\\s*\\.\\s*)?PG_TYPE(?:\\s+(?:AS\\s+)?[A-Za-z_][A-Za-z0-9_$]*)?"
+          + "(?:\\s+WHERE\\s+(.+?))?\\s*$",
       Pattern.CASE_INSENSITIVE);
 
   /** One projection item: an optionally table-qualified column, or {@code *}, with an optional alias. */
@@ -69,11 +77,27 @@ public class PostgresTypeCatalog {
           + "(?:\\s+(?:AS\\s+)?(?:\"([^\"]*)\"|([A-Za-z_][A-Za-z0-9_$]*)))?$",
       Pattern.CASE_INSENSITIVE);
 
-  /** {@code t.oid = 1007} / {@code oid = 1007}: the OID a client wants the element type of. */
-  private static final Pattern OID_FILTER = Pattern.compile("(?:t\\.oid|oid)\\s*=\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
+  /** A whole WHERE clause selecting one type by OID, e.g. {@code oid = 1007} or {@code t.oid = 1007}. */
+  private static final Pattern OID_ONLY_FILTER = Pattern.compile(
+      "^(?:[A-Za-z_][A-Za-z0-9_$]*\\s*\\.\\s*)?OID\\s*=\\s*(\\d+)$", Pattern.CASE_INSENSITIVE);
 
-  /** {@code typname = 'int4'}: the type name a client wants the OID of. */
-  private static final Pattern NAME_FILTER = Pattern.compile("typname\\s*=\\s*'([^']+)'", Pattern.CASE_INSENSITIVE);
+  /** A whole WHERE clause selecting one type by name, e.g. {@code typname = 'int4'}. */
+  private static final Pattern NAME_ONLY_FILTER = Pattern.compile(
+      "^(?:[A-Za-z_][A-Za-z0-9_$]*\\s*\\.\\s*)?TYPNAME\\s*=\\s*'([^']*)'$", Pattern.CASE_INSENSITIVE);
+
+  /** {@code t.oid = 1007} anywhere in the query: the array whose element type a driver is resolving. */
+  private static final Pattern OID_FILTER = Pattern.compile("(?:[A-Za-z_][A-Za-z0-9_$]*\\.)?oid\\s*=\\s*(\\d+)",
+      Pattern.CASE_INSENSITIVE);
+
+  /**
+   * The correlation {@code t.typelem = e.oid} that marks the driver self-join: it is what says the projected
+   * columns describe the element type rather than the type the OID filter selects.
+   */
+  private static final Pattern ELEMENT_JOIN = Pattern.compile(
+      "typelem\\s*=\\s*[A-Za-z_][A-Za-z0-9_$]*\\s*\\.\\s*oid", Pattern.CASE_INSENSITIVE);
+
+  /** The projection list of a self-join query, which {@link #QUERY} cannot match because of the second table. */
+  private static final Pattern JOIN_PROJECTION = Pattern.compile("^SELECT\\s+(.+?)\\s+FROM\\s", Pattern.CASE_INSENSITIVE);
 
   /**
    * The types in OID order, so that an enumeration is stable across runs and across JVMs - a client that
@@ -87,73 +111,31 @@ public class PostgresTypeCatalog {
   }
 
   /**
-   * Answers {@code SELECT ... FROM pg_type} with no filter, returning one row per type this protocol can
-   * produce. Returns null when the query is not a plain enumeration, or when it projects a column this
-   * catalog does not know - the caller then falls back to the other shapes.
-   * <p>
-   * Column order follows the projection list rather than any internal order: a client is free to read a
-   * DataRow positionally, so {@code SELECT oid, typname} and {@code SELECT typname, oid} must not come back
-   * the same way round.
+   * Answers a pg_type query, or returns null when it is not a shape this catalog can answer. An empty list
+   * is a real answer - "no such type" - and is not the same as null.
    */
-  public static List<Map<String, Object>> enumerate(final String query) {
-    final Matcher matcher = ENUMERATION.matcher(query.trim());
-    if (!matcher.matches())
-      return null;
+  public static List<Map<String, Object>> resolve(final String query) {
+    final List<Map<String, Object>> elementRows = resolveElementJoin(query);
+    if (elementRows != null)
+      return elementRows;
 
-    final List<String> requested = new ArrayList<>();
-    final List<String> aliases = new ArrayList<>();
-    for (final String item : splitProjection(matcher.group(1))) {
-      final Matcher projection = PROJECTION_ITEM.matcher(item.trim());
-      if (!projection.matches())
-        return null;
-
-      final String column = projection.group(1).toLowerCase(Locale.ENGLISH);
-      if ("*".equals(column)) {
-        if (projection.group(2) != null || projection.group(3) != null)
-          // "*" takes no alias; a client that wrote one meant something this catalog is not parsing.
-          return null;
-        for (final String known : COLUMNS) {
-          requested.add(known);
-          aliases.add(known);
-        }
-        continue;
-      }
-
-      if (!COLUMNS.contains(column))
-        return null;
-
-      requested.add(column);
-      final String quotedAlias = projection.group(2);
-      final String bareAlias = projection.group(3);
-      if (quotedAlias != null && !quotedAlias.isEmpty())
-        aliases.add(quotedAlias);
-      else if (bareAlias != null)
-        aliases.add(bareAlias.toLowerCase(Locale.ENGLISH));
-      else
-        aliases.add(column);
-    }
-
-    if (requested.isEmpty())
-      return null;
-
-    final List<Map<String, Object>> rows = new ArrayList<>(TYPES_BY_OID.length);
-    for (final PostgresType type : TYPES_BY_OID) {
-      final Map<String, Object> row = new LinkedHashMap<>(requested.size());
-      for (int i = 0; i < requested.size(); i++)
-        row.put(aliases.get(i), columnValue(type, requested.get(i)));
-      rows.add(row);
-    }
-    return rows;
+    return resolveProjection(query);
   }
 
   /**
    * Answers the driver lookup {@code SELECT e.typdelim, e.typname FROM pg_type t, pg_type e WHERE t.oid = ?
-   * AND t.typelem = e.oid} and its variants: the projected {@code typname}/{@code typdelim} describe the
-   * <i>element</i> type of the array whose OID was given, which is what the join in the client's query asks
-   * for. Returns null when the query carries no OID filter, or when the OID is not an array type - a scalar
-   * has no element to report.
+   * AND t.typelem = e.oid}: the projected columns describe the <i>element</i> type of the array whose OID
+   * was given, which is what the join in the client's query asks for. Returns null when the query is not
+   * that shape.
    */
-  public static Map<String, Object> lookupByOid(final String query) {
+  private static List<Map<String, Object>> resolveElementJoin(final String query) {
+    if (!ELEMENT_JOIN.matcher(query).find())
+      return null;
+
+    final Matcher projection = JOIN_PROJECTION.matcher(query.trim());
+    if (!projection.find())
+      return null;
+
     final Matcher matcher = OID_FILTER.matcher(query);
     if (!matcher.find())
       return null;
@@ -170,50 +152,126 @@ public class PostgresTypeCatalog {
     else if (type.isArrayType())
       element = PostgresType.byCode(type.elementCode);
     else
-      // A scalar has no element to report, so this is not a question this shape can answer.
+      // A scalar has no element, so the join the client wrote selects nothing.
+      return List.of();
+
+    final List<String> requested = new ArrayList<>();
+    final List<String> aliases = new ArrayList<>();
+    if (!parseProjection(projection.group(1), requested, aliases))
       return null;
 
-    final String upperQuery = query.toUpperCase(Locale.ENGLISH);
-    final Map<String, Object> row = new LinkedHashMap<>();
-    if (upperQuery.contains("TYPELEM"))
-      row.put("typelem", element.code);
-    if (upperQuery.contains("TYPDELIM"))
-      row.put("typdelim", ",");
-    if (upperQuery.contains("TYPNAME"))
-      row.put("typname", element.typeName);
-    if (upperQuery.contains("TYPARRAY"))
-      row.put("typarray", type != null ? type.arrayCode : 0);
-    if (upperQuery.contains("TYPTYPE"))
-      row.put("typtype", "b"); // 'b' = base type
-    if (upperQuery.contains("TYPINPUT"))
-      row.put("typinput", "array_in");
+    // Only the columns the client projected, never the ones its WHERE clause happens to mention: the join
+    // condition names both oid and typelem, so reading the columns off the whole query would answer with
+    // fields nobody asked for.
+    final Map<String, Object> row = new LinkedHashMap<>(requested.size());
+    for (int i = 0; i < requested.size(); i++)
+      row.put(aliases.get(i), columnValue(element, requested.get(i)));
 
-    return row.isEmpty() ? null : row;
+    return List.of(row);
   }
 
   /**
-   * Answers {@code SELECT oid, ... FROM pg_type WHERE typname = '<name>'}. Returns null when the query
-   * carries no name filter; returns an empty map - meaning "no such type" - when the name is one this
-   * protocol cannot produce.
+   * Answers {@code SELECT <columns> FROM pg_type [WHERE oid = N | WHERE typname = '...']} by projecting the
+   * requested columns of the matching rows - every row when there is no filter. Returns null when the query
+   * is not that shape, or when it projects a column this catalog does not know.
+   * <p>
+   * Column order follows the projection list rather than any internal order: a client is free to read a
+   * DataRow positionally, so {@code SELECT oid, typname} and {@code SELECT typname, oid} must not come back
+   * the same way round.
    */
-  public static Map<String, Object> lookupByName(final String query) {
-    final Matcher matcher = NAME_FILTER.matcher(query);
-    if (!matcher.find())
+  private static List<Map<String, Object>> resolveProjection(final String query) {
+    final Matcher matcher = QUERY.matcher(query.trim());
+    if (!matcher.matches())
       return null;
 
-    final String typeName = matcher.group(1).toLowerCase(Locale.ENGLISH);
-    for (final PostgresType type : TYPES_BY_OID) {
-      if (type.typeName.equals(typeName)) {
-        final Map<String, Object> row = new LinkedHashMap<>();
-        row.put("oid", type.code);
-        row.put("typname", type.typeName);
-        row.put("typelem", type.elementCode);
-        row.put("typarray", type.arrayCode);
-        row.put("typdelim", ",");
-        return row;
-      }
+    final List<String> requested = new ArrayList<>();
+    final List<String> aliases = new ArrayList<>();
+    if (!parseProjection(matcher.group(1), requested, aliases))
+      return null;
+
+    final List<PostgresType> selected = select(matcher.group(2));
+    if (selected == null)
+      return null;
+
+    final List<Map<String, Object>> rows = new ArrayList<>(selected.size());
+    for (final PostgresType type : selected) {
+      final Map<String, Object> row = new LinkedHashMap<>(requested.size());
+      for (int i = 0; i < requested.size(); i++)
+        row.put(aliases.get(i), columnValue(type, requested.get(i)));
+      rows.add(row);
     }
-    return Map.of();
+    return rows;
+  }
+
+  /**
+   * Fills {@code requested} with the catalog columns the projection names and {@code aliases} with the name
+   * each must be announced under. Returns false when the projection is not one this catalog can answer.
+   */
+  private static boolean parseProjection(final String projection, final List<String> requested,
+      final List<String> aliases) {
+    for (final String item : projection.split(",")) {
+      final Matcher matcher = PROJECTION_ITEM.matcher(item.trim());
+      if (!matcher.matches())
+        return false;
+
+      final String column = matcher.group(1).toLowerCase(Locale.ENGLISH);
+      final String quotedAlias = matcher.group(2);
+      final String bareAlias = matcher.group(3);
+
+      if ("*".equals(column)) {
+        if (quotedAlias != null || bareAlias != null)
+          // "*" takes no alias; a client that wrote one meant something this catalog is not parsing.
+          return false;
+        requested.addAll(COLUMNS);
+        aliases.addAll(COLUMNS);
+        continue;
+      }
+
+      if (!COLUMNS.contains(column))
+        return false;
+
+      requested.add(column);
+      // A quoted alias keeps the case - and the emptiness - the client wrote; an unquoted one is folded to
+      // lower case, as PostgreSQL folds every unquoted identifier.
+      if (quotedAlias != null)
+        aliases.add(quotedAlias);
+      else if (bareAlias != null)
+        aliases.add(bareAlias.toLowerCase(Locale.ENGLISH));
+      else
+        aliases.add(column);
+    }
+
+    return !requested.isEmpty();
+  }
+
+  /**
+   * The rows a WHERE clause selects: every type when there is none, the one type it names, an empty list
+   * when it names a type this protocol cannot produce, or null when the clause is not one of the two forms
+   * this catalog understands.
+   */
+  private static List<PostgresType> select(final String filter) {
+    if (filter == null)
+      return List.of(TYPES_BY_OID);
+
+    final String trimmed = filter.trim();
+
+    final Matcher byOid = OID_ONLY_FILTER.matcher(trimmed);
+    if (byOid.matches()) {
+      final int oid = parseOid(byOid.group(1));
+      final PostgresType type = oid < 0 ? null : PostgresType.byCode(oid);
+      return type == null ? List.of() : List.of(type);
+    }
+
+    final Matcher byName = NAME_ONLY_FILTER.matcher(trimmed);
+    if (byName.matches()) {
+      final String typeName = byName.group(1).toLowerCase(Locale.ENGLISH);
+      for (final PostgresType type : TYPES_BY_OID)
+        if (type.typeName.equals(typeName))
+          return List.of(type);
+      return List.of();
+    }
+
+    return null;
   }
 
   private static Object columnValue(final PostgresType type, final String column) {
@@ -226,12 +284,28 @@ public class PostgresTypeCatalog {
       case "typtype" -> "b";           // base type: none of these is a composite, a domain or an enum
       case "typcategory" -> category(type);
       case "typlen" -> type.size;
-      case "typinput" -> type.isArrayType() ? "array_in" : type.typeName + "in";
+      case "typinput" -> inputFunction(type);
       case "typnotnull" -> Boolean.FALSE;
       case "typbasetype" -> 0;         // not a domain, so no base type
       case "typnamespace" -> 11;       // pg_catalog, whose OID is fixed at 11 in PostgreSQL
       case "typrelid" -> 0;            // not a composite, so no backing relation
       default -> null;
+    };
+  }
+
+  /**
+   * pg_type.typinput, the name of the C function PostgreSQL parses the type's text representation with.
+   * Spelled out rather than synthesised from the type name, because PostgreSQL is not consistent about it:
+   * most are {@code <name>in}, but the temporal types and json take an underscore.
+   */
+  private static String inputFunction(final PostgresType type) {
+    if (type.isArrayType())
+      return "array_in";
+    return switch (type) {
+      case DATE -> "date_in";
+      case TIMESTAMP -> "timestamp_in";
+      case JSON -> "json_in";
+      default -> type.typeName + "in";
     };
   }
 
@@ -258,10 +332,5 @@ public class PostgresTypeCatalog {
     } catch (final NumberFormatException e) {
       return -1;
     }
-  }
-
-  /** Splits a projection list on the commas that separate its items. */
-  private static List<String> splitProjection(final String projection) {
-    return Arrays.asList(projection.split(","));
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue5290ClientCompatibilityIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue5290ClientCompatibilityIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5290: SQL tools speaking the Postgres wire protocol ask a handful of
+ * system-information questions before they will show anything, and ArcadeDB matched each of them against one
+ * exact spelling. Anything a client wrote around the call missed the match and fell through to ArcadeDB's own
+ * SQL engine, which either has no such function or - worse - has a different one under the same name.
+ * <p>
+ * Note on the two failures the report also lists, {@code 'list' object has no attribute 'encode'} for a LIST
+ * column and all-NULL cells for EMBEDDED ones: those come from the client. They are a long-standing bug in
+ * Microsoft's pgtoolsservice (the backend shared by the VS Code and Azure Data Studio PostgreSQL extensions),
+ * which cannot render an array or json column against genuine PostgreSQL either - see
+ * microsoft/azuredatastudio-postgresql#487 and #497. The OIDs ArcadeDB announces for those columns are the
+ * correct ones and every other client decodes them, so they are deliberately left alone; the last test here
+ * pins that down so a future "fix" for that report does not quietly downgrade them to text.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue5290ClientCompatibilityIT extends BaseGraphServerTest {
+
+  private static final int POSTGRES_PORT = 5432;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Postgres:com.arcadedb.postgres.PostgresProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Override
+  protected String getDatabaseName() {
+    return "postgresdb";
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      // The query Beekeeper sends at connect time. "schema" is a reserved word in ArcadeDB SQL, so this
+      // used to fail to parse and the tool never got past opening the connection.
+      "SELECT CURRENT_SCHEMA() AS schema",
+      "SELECT CURRENT_SCHEMA() AS \"schema\"",
+      "select current_schema() as schema" })
+  void currentSchemaAliasedToAReservedWord(final String query) throws Exception {
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery(query)) {
+      assertThat(resultSet.getMetaData().getColumnName(1)).isEqualTo("schema");
+      assertThat(resultSet.next()).isTrue();
+      assertThat(resultSet.getString(1)).isEqualTo(getDatabaseName());
+    }
+  }
+
+  @Test
+  void aliasingVersionStillMeansThePostgresVersion() throws Exception {
+    // ArcadeDB has a version() function of its own that answers the build string. Aliasing the call was
+    // enough to reach it, so a client parsing the server version out of the answer read a version
+    // PostgreSQL never had.
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement()) {
+      for (final String query : new String[] { "SELECT version()", "SELECT version() AS v", "SELECT pg_catalog.version() AS v" })
+        try (final ResultSet resultSet = statement.executeQuery(query)) {
+          assertThat(resultSet.next()).as(query).isTrue();
+          assertThat(resultSet.getString(1)).as(query).startsWith("PostgreSQL " + PostgresNetworkExecutor.PG_SERVER_VERSION);
+        }
+    }
+  }
+
+  @Test
+  void aTrailingSemicolonSeparatedByASpaceIsStillTheSameQuery() throws Exception {
+    // The simple-query path strips a semicolon only when it is the very last character, which left a
+    // trailing space behind and broke the exact-string match.
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery("SELECT current_schema() ;")) {
+      assertThat(resultSet.next()).isTrue();
+      assertThat(resultSet.getString("current_schema")).isEqualTo(getDatabaseName());
+    }
+  }
+
+  @Test
+  void currentDatabaseAndCurrentCatalogAnswerTheDatabaseName() throws Exception {
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement()) {
+      for (final String query : new String[] { "SELECT current_database()", "SELECT current_catalog" })
+        try (final ResultSet resultSet = statement.executeQuery(query)) {
+          assertThat(resultSet.next()).as(query).isTrue();
+          assertThat(resultSet.getString(1)).as(query).isEqualTo(getDatabaseName());
+        }
+    }
+  }
+
+  @Test
+  void currentUserAnswersTheAuthenticatedUser() throws Exception {
+    // It used to answer NULL, which a tool showing "connected as" renders as an empty identity.
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement()) {
+      for (final String query : new String[] { "SELECT current_user", "SELECT session_user", "SELECT current_role AS role" })
+        try (final ResultSet resultSet = statement.executeQuery(query)) {
+          assertThat(resultSet.next()).as(query).isTrue();
+          assertThat(resultSet.getString(1)).as(query).isEqualTo("root");
+        }
+    }
+  }
+
+  @Test
+  void enumeratingPgTypeAnswersTheTypesThisProtocolProduces() throws Exception {
+    // This query was on an ignore-list and answered with zero rows, so a client that builds its whole
+    // OID-to-name map up front built an empty one and then could not name a single column's type.
+    final Map<Integer, String> catalog = new HashMap<>();
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery("SELECT oid, typname FROM pg_type")) {
+      while (resultSet.next())
+        catalog.put(resultSet.getInt("oid"), resultSet.getString("typname"));
+    }
+
+    assertThat(catalog).hasSize(PostgresType.values().length);
+    for (final PostgresType type : PostgresType.values())
+      assertThat(catalog).as(type.name()).containsEntry(type.code, type.typeName);
+  }
+
+  @Test
+  void enumeratingPgTypeKeepsTheProjectionOrderTheClientAskedFor() throws Exception {
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement();
+        final ResultSet resultSet = statement.executeQuery("SELECT typname, oid FROM pg_catalog.pg_type")) {
+      final ResultSetMetaData metaData = resultSet.getMetaData();
+      assertThat(metaData.getColumnName(1)).isEqualTo("typname");
+      assertThat(metaData.getColumnName(2)).isEqualTo("oid");
+      assertThat(resultSet.next()).isTrue();
+    }
+  }
+
+  @Test
+  void listAndEmbeddedColumnsKeepTheirRealOids() throws Exception {
+    // The schema from the report. The client that could not render these has the same trouble with genuine
+    // PostgreSQL; downgrading the OIDs to text to work around it would break every client that can.
+    try (final Connection connection = openConnection(); final Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DOCUMENT TYPE Product IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY Product.sku IF NOT EXISTS STRING");
+      statement.execute("CREATE PROPERTY Product.name IF NOT EXISTS STRING");
+      statement.execute("CREATE VERTEX TYPE Supplier IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY Supplier.name IF NOT EXISTS STRING");
+      statement.execute("CREATE PROPERTY Supplier.certifications IF NOT EXISTS LIST");
+      statement.execute("CREATE PROPERTY Supplier.embedded IF NOT EXISTS EMBEDDED OF Product");
+      statement.execute("CREATE PROPERTY Supplier.embedded_list IF NOT EXISTS LIST OF Product");
+      statement.execute("INSERT INTO Supplier (name, certifications, embedded, embedded_list) VALUES "
+          + "('Berlin Sensors GmbH', 'ISO-9001,RoHS', { \"@type\": \"Product\", \"sku\": \"1234\", \"name\": \"CPU\"}, "
+          + "[{ \"@type\": \"Product\", \"sku\": \"1234\", \"name\": \"CPU\"}])");
+
+      try (final ResultSet resultSet = statement.executeQuery(
+          "SELECT name, certifications, embedded, embedded_list FROM `Supplier`")) {
+        final ResultSetMetaData metaData = resultSet.getMetaData();
+        assertThat(metaData.getColumnTypeName(1)).isEqualTo("varchar");
+        assertThat(metaData.getColumnTypeName(2)).isEqualTo("_text");
+        assertThat(metaData.getColumnTypeName(3)).isEqualTo("json");
+        assertThat(metaData.getColumnTypeName(4)).isEqualTo("json");
+
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getString("name")).isEqualTo("Berlin Sensors GmbH");
+        assertThat(resultSet.getString("certifications")).contains("ISO-9001,RoHS");
+        assertThat(resultSet.getString("embedded")).contains("\"sku\":\"1234\"");
+        assertThat(resultSet.getString("embedded_list")).contains("\"sku\":\"1234\"");
+      }
+    }
+  }
+
+  private Connection openConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    properties.setProperty("preferQueryMode", "simple");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:" + POSTGRES_PORT + "/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6377PreAuthTimeoutIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6377PreAuthTimeoutIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6377: the Postgres wire executor never bounded its pre-authentication phase,
+ * so an unauthenticated client that connected and then said nothing pinned a connection thread and a file
+ * descriptor for as long as it liked - the listener starts one thread per accept and caps neither. The two
+ * sibling wire protocols had already been hardened against exactly this (Redis #5912, Bolt #5978).
+ * <p>
+ * There were two independent ways to hold the connection, and a socket timeout alone only closes one of
+ * them: the blocking read of the startup message, and the poll loop that waits for the password message to
+ * show up (nothing is blocked on the socket there, so no socket timeout can interrupt it). Both are covered
+ * below. The third hole was the startup message itself, whose declared length was read and then ignored
+ * while the parameter loop ran until the client chose to stop it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6377PreAuthTimeoutIT extends PostgresWireProtocolTestBase {
+
+  private static final int POSTGRES_PORT = 5432;
+  /** Lowered so an unbounded phase shows up as a hung test rather than a half-minute one. */
+  private static final int HANDSHAKE_TIMEOUT_MS = 1_000;
+  /**
+   * Safety bound for the client side only, well above the lowered server-side timeout. If this fires
+   * instead of a clean EOF, the server is still holding the idle connection open - which is the bug.
+   */
+  private static final int CLIENT_SAFETY_TIMEOUT_MS = 30_000;
+
+  @Test
+  @Tag("slow")
+  void aConnectionThatNeverSendsAStartupMessageIsClosed() throws Exception {
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(HANDSHAKE_TIMEOUT_MS);
+    try (final Socket socket = openSocket()) {
+      // Never send anything at all: the first read of the startup message blocks on the socket.
+      assertThat(socket.getInputStream().read()).isEqualTo(-1);
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+
+    assertPostgresStillServesClients();
+  }
+
+  @Test
+  @Tag("slow")
+  void aConnectionThatNeverSendsThePasswordIsClosed() throws Exception {
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(HANDSHAKE_TIMEOUT_MS);
+    try (final Socket socket = openSocket()) {
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+
+      // The server answers with an AuthenticationCleartextPassword request and then waits. Never reply.
+      readMessageOfType(in, 'R');
+
+      assertThat(in.read()).isEqualTo(-1);
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+
+    assertPostgresStillServesClients();
+  }
+
+  @Test
+  void aStartupMessageLongerThanPostgresOwnLimitIsRejectedWithoutReadingIt() throws Exception {
+    try (final Socket socket = openSocket()) {
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+      // A declared length above PQ_STARTUP_MSG_LIMIT. Nothing else is sent: the connection must go away on
+      // the strength of the header alone, without waiting for the body it would otherwise try to consume.
+      out.writeInt(10 * 1024 * 1024);
+      out.writeInt(196608); // protocol version 3.0
+      out.flush();
+
+      assertThat(socket.getInputStream().read()).isEqualTo(-1);
+    }
+
+    assertPostgresStillServesClients();
+  }
+
+  @Test
+  void aStartupMessageShorterThanItsOwnHeaderIsRejected() throws Exception {
+    try (final Socket socket = openSocket()) {
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+      out.writeInt(4); // shorter than the 8 bytes the header alone occupies
+      out.writeInt(196608);
+      out.flush();
+
+      assertThat(socket.getInputStream().read()).isEqualTo(-1);
+    }
+
+    assertPostgresStillServesClients();
+  }
+
+  @Test
+  void startupParametersStopAtTheLengthTheClientDeclared() throws Exception {
+    try (final Socket socket = openSocket()) {
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+      // A well-formed startup message, immediately followed by a stream of further "k\0v\0" pairs that the
+      // declared length does not cover. They used to be read and accumulated into the pre-auth connection
+      // properties, because the loop ran until the client sent a terminator rather than until the message
+      // ended; now they are left in the socket buffer and the handshake carries on to the password request.
+      sendStartupMessage(out, "root", getDatabaseName());
+      for (int i = 0; i < 1_000; i++)
+        out.write(new byte[] { 'k', 0, 'v', 0 });
+      out.flush();
+
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      readMessageOfType(in, 'R');
+    }
+
+    assertPostgresStillServesClients();
+  }
+
+  @Test
+  @Tag("slow")
+  void anAuthenticatedConnectionIsNotClosedWhileIdle() throws Exception {
+    // The pre-auth timeout must not keep applying once the database is open: a Postgres client is expected
+    // to keep a long-lived, often idle connection open between statements.
+    GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.setValue(HANDSHAKE_TIMEOUT_MS);
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      assertThat(readSingleInt(statement)).isEqualTo(1);
+
+      Thread.sleep(HANDSHAKE_TIMEOUT_MS * 3L); // well over the lowered pre-auth timeout
+
+      assertThat(readSingleInt(statement)).isEqualTo(1);
+    } finally {
+      GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.reset();
+    }
+  }
+
+  private Socket openSocket() throws Exception {
+    final Socket socket = new Socket();
+    socket.connect(new InetSocketAddress("localhost", POSTGRES_PORT), 5_000);
+    socket.setSoTimeout(CLIENT_SAFETY_TIMEOUT_MS);
+    return socket;
+  }
+
+  private void assertPostgresStillServesClients() throws Exception {
+    // The listener and its per-connection threads must be unharmed by the connections dropped above.
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      assertThat(readSingleInt(statement)).isEqualTo(1);
+    }
+  }
+
+  private static int readSingleInt(final Statement statement) throws Exception {
+    try (final ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+      assertThat(resultSet.next()).isTrue();
+      return resultSet.getInt(1);
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    properties.setProperty("preferQueryMode", "simple");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:" + POSTGRES_PORT + "/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
@@ -483,10 +483,41 @@ class PostgresProtocolIT extends BaseGraphServerTest {
   @Test
   void pgCatalogQuery() throws Exception {
     try (var conn = getConnection(); var st = conn.createStatement()) {
+      // Without the "t.typelem = e.oid" correlation that marks a driver's element-type self-join, this
+      // selects the row of OID 1007 itself, so typname is the array's own name. It used to answer "int4",
+      // the element's name, for every OID filter regardless of whether a join asked for the element - which
+      // is not what PostgreSQL answers here (issue #5290).
       ResultSet rs = st.executeQuery("SELECT typdelim, typname FROM pg_catalog.pg_type WHERE oid = 1007");
       assertThat(rs.next()).isTrue();
       assertThat(rs.getString("typdelim")).isEqualTo(",");
+      assertThat(rs.getString("typname")).isEqualTo("_int4");
+    }
+  }
+
+  @Test
+  void pgCatalogElementTypeSelfJoin() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      // The shape pgjdbc actually sends to resolve an array's element type: here the projection does
+      // describe the element, because the join says so.
+      ResultSet rs = st.executeQuery("SELECT e.typdelim, e.typname FROM pg_catalog.pg_type t, pg_catalog.pg_type e "
+          + "WHERE t.oid = 1007 AND t.typelem = e.oid");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("typdelim")).isEqualTo(",");
       assertThat(rs.getString("typname")).isEqualTo("int4");
+    }
+  }
+
+  @Test
+  void pgTypeQueryReturnsTheOidColumnItWasAskedFor() {
+    // The fixed handful of columns an OID-filtered lookup used to answer with never carried "oid", so a
+    // client selecting by OID got a row missing the very column it selected by (issue #5290).
+    try (var conn = getConnection(); var st = conn.createStatement();
+        ResultSet rs = st.executeQuery("SELECT oid, typname FROM pg_type WHERE oid = 1009")) {
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getInt("oid")).isEqualTo(1009);
+      assertThat(rs.getString("typname")).isEqualTo("_text");
+    } catch (final Exception e) {
+      throw new AssertionError(e);
     }
   }
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSystemQueryTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSystemQueryTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Recognition of the emulated PostgreSQL system-information queries (issue #5290). Before this, each
+ * function was matched by string equality against one exact spelling, so a client that aliased the call or
+ * left a space before the semicolon fell through to ArcadeDB's own SQL engine.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresSystemQueryTest {
+
+  @Test
+  void bareCallUsesPostgresOwnColumnName() {
+    final PostgresSystemQuery query = PostgresSystemQuery.parse("SELECT current_schema()");
+    assertThat(query).isNotNull();
+    assertThat(query.function).isEqualTo(PostgresSystemQuery.Function.CURRENT_SCHEMA);
+    assertThat(query.columnName).isEqualTo("current_schema");
+  }
+
+  @Test
+  void aliasBecomesTheColumnName() {
+    // The query Beekeeper sends at connect time. "schema" is a reserved word in ArcadeDB SQL, so falling
+    // through to the engine failed to parse and the tool never got a connection open.
+    final PostgresSystemQuery query = PostgresSystemQuery.parse("SELECT CURRENT_SCHEMA() AS schema");
+    assertThat(query).isNotNull();
+    assertThat(query.function).isEqualTo(PostgresSystemQuery.Function.CURRENT_SCHEMA);
+    assertThat(query.columnName).isEqualTo("schema");
+  }
+
+  @Test
+  void unquotedAliasIsFoldedToLowerCaseAsPostgresFoldsIdentifiers() {
+    assertThat(PostgresSystemQuery.parse("SELECT current_schema() AS MySchema").columnName).isEqualTo("myschema");
+  }
+
+  @Test
+  void quotedAliasKeepsItsCase() {
+    assertThat(PostgresSystemQuery.parse("SELECT current_schema() AS \"MySchema\"").columnName).isEqualTo("MySchema");
+  }
+
+  @Test
+  void aliasWithoutTheAsKeyword() {
+    assertThat(PostgresSystemQuery.parse("SELECT version() v").columnName).isEqualTo("v");
+  }
+
+  @Test
+  void versionAliasedStillMeansTheEmulatedVersion() {
+    // ArcadeDB has a version() function of its own that answers the build string. Aliasing the call used to
+    // be enough to reach it, so a client parsing the server version read one PostgreSQL never had.
+    final PostgresSystemQuery query = PostgresSystemQuery.parse("SELECT version() AS v");
+    assertThat(query).isNotNull();
+    assertThat(query.function).isEqualTo(PostgresSystemQuery.Function.VERSION);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "SELECT current_schema();", "SELECT current_schema() ;", "  SELECT current_schema()  ;  ",
+      "SELECT current_schema() ;;" })
+  void statementTerminatorAndSurroundingSpaceAreIgnored(final String query) {
+    assertThat(PostgresSystemQuery.parse(query)).isNotNull();
+    assertThat(PostgresSystemQuery.parse(query).function).isEqualTo(PostgresSystemQuery.Function.CURRENT_SCHEMA);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "SELECT pg_catalog.version()", "SELECT PG_CATALOG.VERSION()", "select pg_catalog . version ()" })
+  void catalogQualifiedSpellingsAreTheSameFunction(final String query) {
+    assertThat(PostgresSystemQuery.parse(query).function).isEqualTo(PostgresSystemQuery.Function.VERSION);
+  }
+
+  @Test
+  void keywordFunctionsNeedNoParentheses() {
+    assertThat(PostgresSystemQuery.parse("SELECT current_user").function).isEqualTo(PostgresSystemQuery.Function.CURRENT_USER);
+    assertThat(PostgresSystemQuery.parse("SELECT session_user").function).isEqualTo(PostgresSystemQuery.Function.SESSION_USER);
+    assertThat(PostgresSystemQuery.parse("SELECT current_catalog").function).isEqualTo(PostgresSystemQuery.Function.CURRENT_CATALOG);
+  }
+
+  @Test
+  void everyFunctionCarriesPostgresDefaultOutputName() {
+    for (final PostgresSystemQuery.Function function : PostgresSystemQuery.Function.values())
+      assertThat(PostgresSystemQuery.parse("SELECT " + function.name()).columnName).isEqualTo(function.defaultColumnName);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      // The word boundary after the function name is what keeps a column that merely starts with one of
+      // these names from being read as the function plus an alias.
+      "SELECT user_id",
+      "SELECT versions",
+      "SELECT current_schema_name",
+      // Anything beyond the single expression is not a shape this class can answer.
+      "SELECT version(), 1",
+      "SELECT version FROM sometype",
+      "SELECT current_schema() WHERE 1 = 1",
+      "SELECT max(version) FROM t",
+      "UPDATE t SET version = 1",
+      "" })
+  void queriesThatAreNotASingleSystemCallAreDeclined(final String query) {
+    assertThat(PostgresSystemQuery.parse(query)).isNull();
+  }
+
+  @Test
+  void nullIsDeclinedRatherThanThrown() {
+    assertThat(PostgresSystemQuery.parse(null)).isNull();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresSystemQueryTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresSystemQueryTest.java
@@ -62,6 +62,13 @@ class PostgresSystemQueryTest {
   }
 
   @Test
+  void anExplicitlyEmptyQuotedAliasIsAColumnNamedEmpty() {
+    // PostgreSQL allows AS "" and names the column "". That is not the same as supplying no alias at all,
+    // which is what an emptiness check on the quoted group used to turn it into.
+    assertThat(PostgresSystemQuery.parse("SELECT current_schema() AS \"\"").columnName).isEmpty();
+  }
+
+  @Test
   void aliasWithoutTheAsKeyword() {
     assertThat(PostgresSystemQuery.parse("SELECT version() v").columnName).isEqualTo("v");
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The pg_type answers a PostgreSQL client uses to find out what the OIDs it was handed in RowDescription
+ * mean (issue #5290).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresTypeCatalogTest {
+
+  @Test
+  void enumerationReturnsOneRowPerTypeThisProtocolCanProduce() {
+    // This query used to be on an ignore-list and answered with zero rows, so a client that builds its
+    // whole OID-to-name map up front built an empty one.
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.enumerate("SELECT oid, typname FROM pg_type");
+
+    assertThat(rows).hasSize(PostgresType.values().length);
+    assertThat(rows).allSatisfy(row -> assertThat(row.keySet()).containsExactly("oid", "typname"));
+    assertThat(rows).anySatisfy(row -> {
+      assertThat(row.get("oid")).isEqualTo(PostgresType.TEXT.code);
+      assertThat(row.get("typname")).isEqualTo("text");
+    });
+    assertThat(rows).anySatisfy(row -> {
+      assertThat(row.get("oid")).isEqualTo(PostgresType.ARRAY_TEXT.code);
+      assertThat(row.get("typname")).isEqualTo("_text");
+    });
+  }
+
+  @Test
+  void enumerationIsOrderedByOidSoACachedAnswerNeverReshuffles() {
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.enumerate("SELECT oid FROM pg_type");
+
+    int previous = Integer.MIN_VALUE;
+    for (final Map<String, Object> row : rows) {
+      final int oid = (Integer) row.get("oid");
+      assertThat(oid).isGreaterThan(previous);
+      previous = oid;
+    }
+  }
+
+  @Test
+  void projectionOrderIsTheClientsOrderBecauseADataRowIsReadPositionally() {
+    assertThat(PostgresTypeCatalog.enumerate("SELECT typname, oid FROM pg_type").get(0).keySet())
+        .containsExactly("typname", "oid");
+    assertThat(PostgresTypeCatalog.enumerate("SELECT oid, typname FROM pg_type").get(0).keySet())
+        .containsExactly("oid", "typname");
+  }
+
+  @Test
+  void projectionAliasNamesTheColumn() {
+    assertThat(PostgresTypeCatalog.enumerate("SELECT t.oid AS type_oid, t.typname FROM pg_type t").get(0).keySet())
+        .containsExactly("type_oid", "typname");
+  }
+
+  @Test
+  void starProjectsEveryColumnTheCatalogKnows() {
+    final Map<String, Object> row = PostgresTypeCatalog.enumerate("SELECT * FROM pg_type").get(0);
+    assertThat(row.keySet()).contains("oid", "typname", "typelem", "typarray", "typdelim", "typtype", "typcategory",
+        "typlen", "typinput", "typnotnull", "typbasetype", "typnamespace", "typrelid");
+  }
+
+  @Test
+  void arrayAndScalarRowsDescribeEachOther() {
+    final Map<String, Object> byOid = PostgresTypeCatalog.enumerate("SELECT oid, typelem, typarray, typcategory FROM pg_type")
+        .stream().filter(row -> row.get("oid").equals(PostgresType.ARRAY_TEXT.code)).findFirst().orElseThrow();
+    assertThat(byOid.get("typelem")).isEqualTo(PostgresType.TEXT.code);
+    assertThat(byOid.get("typarray")).isEqualTo(0);   // an array type is not itself the element of one
+    assertThat(byOid.get("typcategory")).isEqualTo("A");
+
+    final Map<String, Object> scalar = PostgresTypeCatalog.enumerate("SELECT oid, typelem, typarray, typcategory FROM pg_type")
+        .stream().filter(row -> row.get("oid").equals(PostgresType.TEXT.code)).findFirst().orElseThrow();
+    assertThat(scalar.get("typelem")).isEqualTo(0);
+    assertThat(scalar.get("typarray")).isEqualTo(PostgresType.ARRAY_TEXT.code);
+    assertThat(scalar.get("typcategory")).isEqualTo("S");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      // A filter is a different question; the OID/name lookups answer those.
+      "SELECT oid FROM pg_type WHERE typname = 'int4'",
+      "SELECT oid FROM pg_type ORDER BY oid",
+      // A column this catalog cannot produce is declined whole rather than answered with a hole in it.
+      "SELECT oid, typcollation FROM pg_type",
+      // Not pg_type at all.
+      "SELECT oid FROM pg_class" })
+  void shapesThisCatalogCannotAnswerAreDeclined(final String query) {
+    assertThat(PostgresTypeCatalog.enumerate(query)).isNull();
+  }
+
+  @Test
+  void oidLookupDescribesTheElementOfTheArrayTheClientAskedAbout() {
+    // The shape pgjdbc sends: SELECT e.typdelim, e.typname FROM pg_type t, pg_type e
+    //                         WHERE t.oid = 1007 AND t.typelem = e.oid
+    final Map<String, Object> row = PostgresTypeCatalog.lookupByOid(
+        "SELECT e.typdelim, e.typname FROM pg_catalog.pg_type t, pg_catalog.pg_type e WHERE t.oid = 1007 AND t.typelem = e.oid");
+
+    assertThat(row).containsEntry("typdelim", ",").containsEntry("typname", "int4");
+  }
+
+  @Test
+  void oidLookupReportsTheElementOid() {
+    assertThat(PostgresTypeCatalog.lookupByOid("SELECT typelem FROM pg_type WHERE oid = 1009"))
+        .containsEntry("typelem", PostgresType.TEXT.code);
+  }
+
+  @Test
+  void aScalarOidHasNoElementToReport() {
+    // It used to be answered with text/25, so a client asking about int4 was told its element was text.
+    assertThat(PostgresTypeCatalog.lookupByOid("SELECT typelem FROM pg_type WHERE oid = 23")).isNull();
+  }
+
+  @Test
+  void anUnknownOidStillFallsBackToTextSoADriverGetsAnAnswerItCanUse() {
+    assertThat(PostgresTypeCatalog.lookupByOid("SELECT typelem, typname FROM pg_type WHERE oid = 987654"))
+        .containsEntry("typelem", PostgresType.TEXT.code).containsEntry("typname", "text");
+  }
+
+  @Test
+  void nameLookupAnswersEveryTypeThisProtocolProduces() {
+    for (final PostgresType type : PostgresType.values()) {
+      final Map<String, Object> row = PostgresTypeCatalog.lookupByName("SELECT oid FROM pg_type WHERE typname = '"
+          + type.typeName + "'");
+      assertThat(row).as(type.name()).containsEntry("oid", type.code).containsEntry("typname", type.typeName);
+    }
+  }
+
+  @Test
+  void nameLookupOfATypeThisProtocolCannotProduceMeansNoRowRatherThanNoAnswer() {
+    assertThat(PostgresTypeCatalog.lookupByName("SELECT oid FROM pg_type WHERE typname = 'hstore'")).isEmpty();
+  }
+
+  @Test
+  void aQueryWithNoFilterIsNotALookup() {
+    assertThat(PostgresTypeCatalog.lookupByOid("SELECT oid, typname FROM pg_type")).isNull();
+    assertThat(PostgresTypeCatalog.lookupByName("SELECT oid, typname FROM pg_type")).isNull();
+  }
+
+  @Test
+  void everyTypeCarriesTheNamePostgresGivesItsOid() {
+    // The names are what a client resolves the announced OID against, so they have to be PostgreSQL's own.
+    assertThat(PostgresType.ARRAY_TEXT.typeName).isEqualTo("_text");
+    assertThat(PostgresType.ARRAY_INT.typeName).isEqualTo("_int4");
+    assertThat(PostgresType.JSON.typeName).isEqualTo("json");
+    // 1002 is "char"[]; 1003, which this used to claim, is name[] - a type ArcadeDB never produces.
+    assertThat(PostgresType.ARRAY_CHAR.code).isEqualTo(1002);
+    assertThat(PostgresType.ARRAY_CHAR.typeName).isEqualTo("_char");
+    assertThat(PostgresType.ARRAY_CHAR.elementCode).isEqualTo(PostgresType.CHAR.code);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
@@ -22,10 +22,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 /**
  * The pg_type answers a PostgreSQL client uses to find out what the OIDs it was handed in RowDescription
@@ -39,7 +41,7 @@ class PostgresTypeCatalogTest {
   void enumerationReturnsOneRowPerTypeThisProtocolCanProduce() {
     // This query used to be on an ignore-list and answered with zero rows, so a client that builds its
     // whole OID-to-name map up front built an empty one.
-    final List<Map<String, Object>> rows = PostgresTypeCatalog.enumerate("SELECT oid, typname FROM pg_type");
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.resolve("SELECT oid, typname FROM pg_type");
 
     assertThat(rows).hasSize(PostgresType.values().length);
     assertThat(rows).allSatisfy(row -> assertThat(row.keySet()).containsExactly("oid", "typname"));
@@ -55,7 +57,7 @@ class PostgresTypeCatalogTest {
 
   @Test
   void enumerationIsOrderedByOidSoACachedAnswerNeverReshuffles() {
-    final List<Map<String, Object>> rows = PostgresTypeCatalog.enumerate("SELECT oid FROM pg_type");
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.resolve("SELECT oid FROM pg_type");
 
     int previous = Integer.MIN_VALUE;
     for (final Map<String, Object> row : rows) {
@@ -67,34 +69,34 @@ class PostgresTypeCatalogTest {
 
   @Test
   void projectionOrderIsTheClientsOrderBecauseADataRowIsReadPositionally() {
-    assertThat(PostgresTypeCatalog.enumerate("SELECT typname, oid FROM pg_type").get(0).keySet())
+    assertThat(PostgresTypeCatalog.resolve("SELECT typname, oid FROM pg_type").get(0).keySet())
         .containsExactly("typname", "oid");
-    assertThat(PostgresTypeCatalog.enumerate("SELECT oid, typname FROM pg_type").get(0).keySet())
+    assertThat(PostgresTypeCatalog.resolve("SELECT oid, typname FROM pg_type").get(0).keySet())
         .containsExactly("oid", "typname");
   }
 
   @Test
   void projectionAliasNamesTheColumn() {
-    assertThat(PostgresTypeCatalog.enumerate("SELECT t.oid AS type_oid, t.typname FROM pg_type t").get(0).keySet())
+    assertThat(PostgresTypeCatalog.resolve("SELECT t.oid AS type_oid, t.typname FROM pg_type t").get(0).keySet())
         .containsExactly("type_oid", "typname");
   }
 
   @Test
   void starProjectsEveryColumnTheCatalogKnows() {
-    final Map<String, Object> row = PostgresTypeCatalog.enumerate("SELECT * FROM pg_type").get(0);
+    final Map<String, Object> row = PostgresTypeCatalog.resolve("SELECT * FROM pg_type").get(0);
     assertThat(row.keySet()).contains("oid", "typname", "typelem", "typarray", "typdelim", "typtype", "typcategory",
         "typlen", "typinput", "typnotnull", "typbasetype", "typnamespace", "typrelid");
   }
 
   @Test
   void arrayAndScalarRowsDescribeEachOther() {
-    final Map<String, Object> byOid = PostgresTypeCatalog.enumerate("SELECT oid, typelem, typarray, typcategory FROM pg_type")
+    final Map<String, Object> byOid = PostgresTypeCatalog.resolve("SELECT oid, typelem, typarray, typcategory FROM pg_type")
         .stream().filter(row -> row.get("oid").equals(PostgresType.ARRAY_TEXT.code)).findFirst().orElseThrow();
     assertThat(byOid.get("typelem")).isEqualTo(PostgresType.TEXT.code);
     assertThat(byOid.get("typarray")).isEqualTo(0);   // an array type is not itself the element of one
     assertThat(byOid.get("typcategory")).isEqualTo("A");
 
-    final Map<String, Object> scalar = PostgresTypeCatalog.enumerate("SELECT oid, typelem, typarray, typcategory FROM pg_type")
+    final Map<String, Object> scalar = PostgresTypeCatalog.resolve("SELECT oid, typelem, typarray, typcategory FROM pg_type")
         .stream().filter(row -> row.get("oid").equals(PostgresType.TEXT.code)).findFirst().orElseThrow();
     assertThat(scalar.get("typelem")).isEqualTo(0);
     assertThat(scalar.get("typarray")).isEqualTo(PostgresType.ARRAY_TEXT.code);
@@ -103,63 +105,100 @@ class PostgresTypeCatalogTest {
 
   @ParameterizedTest
   @ValueSource(strings = {
-      // A filter is a different question; the OID/name lookups answer those.
-      "SELECT oid FROM pg_type WHERE typname = 'int4'",
+      // A filter this catalog does not understand is not guessed at.
+      "SELECT oid FROM pg_type WHERE typtype = 'b' AND typlen > 4",
       "SELECT oid FROM pg_type ORDER BY oid",
       // A column this catalog cannot produce is declined whole rather than answered with a hole in it.
       "SELECT oid, typcollation FROM pg_type",
       // Not pg_type at all.
       "SELECT oid FROM pg_class" })
   void shapesThisCatalogCannotAnswerAreDeclined(final String query) {
-    assertThat(PostgresTypeCatalog.enumerate(query)).isNull();
+    assertThat(PostgresTypeCatalog.resolve(query)).isNull();
   }
 
   @Test
-  void oidLookupDescribesTheElementOfTheArrayTheClientAskedAbout() {
-    // The shape pgjdbc sends: SELECT e.typdelim, e.typname FROM pg_type t, pg_type e
-    //                         WHERE t.oid = 1007 AND t.typelem = e.oid
-    final Map<String, Object> row = PostgresTypeCatalog.lookupByOid(
-        "SELECT e.typdelim, e.typname FROM pg_catalog.pg_type t, pg_catalog.pg_type e WHERE t.oid = 1007 AND t.typelem = e.oid");
+  void aFilterOnOidSelectsThatTypesOwnRow() {
+    // Every column the client projected comes back, the OID it filtered on included. The fixed handful of
+    // columns this used to answer with never carried "oid", so a client that asked for it got a row missing
+    // the very column it selected by.
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.resolve(
+        "SELECT oid, typname, typelem FROM pg_type WHERE oid = 1007");
 
-    assertThat(row).containsEntry("typdelim", ",").containsEntry("typname", "int4");
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0)).containsExactly(entry("oid", 1007), entry("typname", "_int4"),
+        entry("typelem", PostgresType.INTEGER.code));
   }
 
   @Test
-  void oidLookupReportsTheElementOid() {
-    assertThat(PostgresTypeCatalog.lookupByOid("SELECT typelem FROM pg_type WHERE oid = 1009"))
-        .containsEntry("typelem", PostgresType.TEXT.code);
-  }
-
-  @Test
-  void aScalarOidHasNoElementToReport() {
-    // It used to be answered with text/25, so a client asking about int4 was told its element was text.
-    assertThat(PostgresTypeCatalog.lookupByOid("SELECT typelem FROM pg_type WHERE oid = 23")).isNull();
-  }
-
-  @Test
-  void anUnknownOidStillFallsBackToTextSoADriverGetsAnAnswerItCanUse() {
-    assertThat(PostgresTypeCatalog.lookupByOid("SELECT typelem, typname FROM pg_type WHERE oid = 987654"))
-        .containsEntry("typelem", PostgresType.TEXT.code).containsEntry("typname", "text");
-  }
-
-  @Test
-  void nameLookupAnswersEveryTypeThisProtocolProduces() {
+  void aFilterOnTypeNameSelectsThatTypesOwnRow() {
     for (final PostgresType type : PostgresType.values()) {
-      final Map<String, Object> row = PostgresTypeCatalog.lookupByName("SELECT oid FROM pg_type WHERE typname = '"
-          + type.typeName + "'");
-      assertThat(row).as(type.name()).containsEntry("oid", type.code).containsEntry("typname", type.typeName);
+      final List<Map<String, Object>> rows = PostgresTypeCatalog.resolve(
+          "SELECT oid, typname FROM pg_type WHERE typname = '" + type.typeName + "'");
+      assertThat(rows).as(type.name()).hasSize(1);
+      assertThat(rows.get(0)).as(type.name()).containsEntry("oid", type.code).containsEntry("typname", type.typeName);
     }
   }
 
   @Test
-  void nameLookupOfATypeThisProtocolCannotProduceMeansNoRowRatherThanNoAnswer() {
-    assertThat(PostgresTypeCatalog.lookupByName("SELECT oid FROM pg_type WHERE typname = 'hstore'")).isEmpty();
+  void aFilterNamingATypeThisProtocolCannotProduceMeansNoRowRatherThanNoAnswer() {
+    assertThat(PostgresTypeCatalog.resolve("SELECT oid FROM pg_type WHERE typname = 'hstore'")).isEmpty();
+    assertThat(PostgresTypeCatalog.resolve("SELECT oid FROM pg_type WHERE oid = 987654")).isEmpty();
   }
 
   @Test
-  void aQueryWithNoFilterIsNotALookup() {
-    assertThat(PostgresTypeCatalog.lookupByOid("SELECT oid, typname FROM pg_type")).isNull();
-    assertThat(PostgresTypeCatalog.lookupByName("SELECT oid, typname FROM pg_type")).isNull();
+  void theDriverSelfJoinDescribesTheElementOfTheArray() {
+    // The shape pgjdbc sends. Here - and only here - the projected columns describe a different row from
+    // the one the filter selects, which is what the "t.typelem = e.oid" correlation says.
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.resolve(
+        "SELECT e.typdelim, e.typname FROM pg_catalog.pg_type t, pg_catalog.pg_type e WHERE t.oid = 1007 AND t.typelem = e.oid");
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0)).containsExactly(entry("typdelim", ","), entry("typname", "int4"));
+  }
+
+  @Test
+  void theDriverSelfJoinAnswersOnlyWhatItProjected() {
+    // Its WHERE clause names both oid and typelem; reading the columns off the whole query rather than off
+    // the projection would answer with fields nobody asked for.
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.resolve(
+        "SELECT e.typdelim FROM pg_catalog.pg_type t, pg_catalog.pg_type e WHERE t.oid = 1009 AND t.typelem = e.oid");
+
+    assertThat(rows.get(0)).containsExactly(entry("typdelim", ","));
+  }
+
+  @Test
+  void theDriverSelfJoinOnAnUnknownOidStillFallsBackToTextSoADriverGetsAnAnswerItCanUse() {
+    final List<Map<String, Object>> rows = PostgresTypeCatalog.resolve(
+        "SELECT e.typname FROM pg_type t, pg_type e WHERE t.oid = 987654 AND t.typelem = e.oid");
+
+    assertThat(rows.get(0)).containsEntry("typname", "text");
+  }
+
+  @Test
+  void theDriverSelfJoinOnAScalarSelectsNothingBecauseAScalarHasNoElement() {
+    assertThat(PostgresTypeCatalog.resolve(
+        "SELECT e.typname FROM pg_type t, pg_type e WHERE t.oid = 23 AND t.typelem = e.oid")).isEmpty();
+  }
+
+  @Test
+  void inputFunctionsAreSpelledTheWayPostgresSpellsThem() {
+    // Synthesising <name> + "in" is right for most types but not for the temporal ones or json, which
+    // PostgreSQL spells with an underscore.
+    final Map<Integer, Object> byOid = new HashMap<>();
+    for (final Map<String, Object> row : PostgresTypeCatalog.resolve("SELECT oid, typinput FROM pg_type"))
+      byOid.put((Integer) row.get("oid"), row.get("typinput"));
+
+    assertThat(byOid).containsEntry(PostgresType.INTEGER.code, "int4in");
+    assertThat(byOid).containsEntry(PostgresType.BOOLEAN.code, "boolin");
+    assertThat(byOid).containsEntry(PostgresType.DATE.code, "date_in");
+    assertThat(byOid).containsEntry(PostgresType.TIMESTAMP.code, "timestamp_in");
+    assertThat(byOid).containsEntry(PostgresType.JSON.code, "json_in");
+    assertThat(byOid).containsEntry(PostgresType.ARRAY_TEXT.code, "array_in");
+  }
+
+  @Test
+  void anExplicitlyEmptyQuotedAliasIsAColumnNamedEmpty() {
+    assertThat(PostgresTypeCatalog.resolve("SELECT oid AS \"\" FROM pg_type").get(0).keySet()).containsExactly("");
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -1797,7 +1797,7 @@ class PostgresTypeTest {
     assertThat(PostgresType.ARRAY_DOUBLE.code).isEqualTo(1022);
     assertThat(PostgresType.ARRAY_TEXT.code).isEqualTo(1009);
     assertThat(PostgresType.ARRAY_BOOLEAN.code).isEqualTo(1000);
-    assertThat(PostgresType.ARRAY_CHAR.code).isEqualTo(1003);
+    assertThat(PostgresType.ARRAY_CHAR.code).isEqualTo(1002);
     assertThat(PostgresType.ARRAY_JSON.code).isEqualTo(199);
   }
 


### PR DESCRIPTION
Closes #6377
Closes #5290

## #6377 - the pre-authentication phase had no deadline

One thread and one file descriptor are committed per accepted connection, before anyone has proved who they
are, and `PostgresNetworkListener` caps neither. A client that connected and then said nothing held both
indefinitely. Redis (#5912) and Bolt (#5978) were hardened against exactly this; Postgres was not.

There turned out to be **three** ways to hold the connection, and the socket timeout the issue proposes only
closes one of them:

| hole | fix |
|---|---|
| the blocking read of the startup message | `setSoTimeout(NETWORK_SOCKET_TIMEOUT)` in the constructor, lifted to `0` once `openDatabase()` succeeds - the same idiom the two siblings use |
| the poll loop waiting for the password message | `readMessage()` deliberately does **not** block (it returns false when no byte is available), so no read was ever outstanding on the socket for a timeout to interrupt and `waitForAMessage()` spun forever. It now carries the same deadline |
| the startup message itself | its declared length was read and then ignored while the parameter loop ran until the client chose to stop it |

On that last one I went further than the issue suggests. Rather than capping the pair count with a new knob,
the **declared length is enforced**: over PostgreSQL's own `PQ_STARTUP_MSG_LIMIT` (10000) the packet is
rejected on the strength of the header alone, and the parameter section is parsed out of exactly the bytes
the message declared. One rule bounds the pair count, the total bytes *and* the time spent reading them, and
what is being held to is the client's own declared length rather than a limit invented here - which is also
what real PostgreSQL does.

## #5290 - a system query stopped being one as soon as a client decorated it

The emulated system-information queries were matched by **string equality against one exact spelling each**,
in two places (the simple-query and extended-query paths, which had drifted into slightly different
comparisons). Anything a client wrote around the call missed the match and fell through to ArcadeDB's own SQL
engine, which either has no such function or - worse - has a different one under the same name:

| query | before | after |
|---|---|---|
| `SELECT CURRENT_SCHEMA() AS schema` | syntax error (`schema` is reserved in ArcadeDB SQL, an ordinary alias in PostgreSQL) - and this is a **connect-time** query, so Beekeeper never got a connection open | one row, column `schema` |
| `SELECT CURRENT_SCHEMA() AS "schema"` | `Unknown function name 'CURRENT_SCHEMA'` | one row, column `schema` |
| `SELECT version() AS v` | ArcadeDB's own `version()`, i.e. the build string - a client parsing the server version read one PostgreSQL never had | `PostgreSQL 12.0 (ArcadeDB ...)` |
| `SELECT current_schema() ;` | `Unknown function name` (the semicolon strip left a trailing space) | one row |
| `SELECT current_database()` / `current_catalog` | `Unknown function name` | the database name |
| `SELECT current_user` / `session_user` / `current_role` | `NULL` | the authenticated user |
| `SELECT oid, typname FROM pg_type` | **0 rows** (it was on an ignore-list) | one row per type this protocol produces |

Recognition now happens **once**, in the new `PostgresSystemQuery`, over a normalised statement, and both
protocol paths share it. It also joins `isSessionCommand`, so the double quotes in `AS \"schema\"` are no
longer rewritten to back-ticks behind its back.

`pg_type` is answered from `PostgresType`, which is the set of types this protocol can produce and therefore
the only set it can honestly describe. The hand-written switch the new `PostgresTypeCatalog` replaces had
drifted from the enum: it named the element of OID 1003 `char` while PostgreSQL calls 1003 `name[]`, and
reported an array type's `typarray` as the array's own OID. `ARRAY_CHAR` moves from 1003 to **1002**, which
is the `\"char\"[]` it actually means - the wire format is identical (both are text arrays), only the type
name a client resolves it to changes, and it now resolves to one ArcadeDB really produces.

### What is *not* fixed, deliberately

The two remaining failures in the report - `'list' object has no attribute 'encode'` for a LIST column and
all-NULL cells for EMBEDDED ones - come from the client. They are a long-standing bug in Microsoft's
pgtoolsservice (the backend shared by the VS Code and Azure Data Studio PostgreSQL extensions), which cannot
render an array or json column **against genuine PostgreSQL either**: see
microsoft/azuredatastudio-postgresql#487 and #497. The OIDs ArcadeDB announces for those columns are the
correct ones and every other client decodes them, so downgrading them to text to work around a broken client
would break every client that works. `listAndEmbeddedColumnsKeepTheirRealOids` pins that down.

## Verification

- `PostgresSystemQueryTest` (25) and `PostgresTypeCatalogTest` (18) - new unit tests, no server needed
- `Issue5290ClientCompatibilityIT` (10) and `Issue6377PreAuthTimeoutIT` (6) - new ITs over the real pgjdbc
  driver and over a raw socket
- the two timeout tests were confirmed non-vacuous: with the handshake bound disabled they fail with
  `SocketTimeoutException`, exactly as they would have before the fix
- full `postgresw` module green: **303 unit + 139 IT, 0 failures**