### PR TITLE
fix(#6401): a hash code is a property of the value, and an expression's value is every field that carries one

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -591,9 +591,18 @@ public class BaseExpression extends MathExpression {
       this.identifier.extractSubQueries(collector);
   }
 
+  /**
+   * Every field that carries a VALUE, which is what identity means here: two nodes are the same node when they mean
+   * the same thing. {@link #number} and {@link #expression} used to be missing, and they are the two that hold a
+   * numeric literal and a wrapped sub-expression - so for {@code 1} and {@code 2} all the remaining fields are
+   * {@code null}/{@code false} and the two parsed forms compared EQUAL (issue #6401, item 3).
+   * <p>
+   * {@link #parenthesized} is deliberately out: it is rendering-only - the parentheses are already in the tree SHAPE -
+   * so two nodes that differ in it alone mean the same thing.
+   */
   @Override
   protected Object[] getIdentityElements() {
-    return new Object[] { identifier, inputParam, string, modifier, isNull };
+    return new Object[] { number, identifier, expression, inputParam, string, modifier, isNull };
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
@@ -586,9 +586,20 @@ public class Expression extends SimpleNode {
     }
   }
 
+  /**
+   * The same rule {@link BaseExpression#getIdentityElements()} follows, applied to the fields {@link #execute} reads:
+   * every one of them, in the order that method consults them.
+   * <p>
+   * {@link #whereCondition} and the inherited {@code value} slot used to be missing, and both carry a value -
+   * {@code execute} returns them. {@code value} is what the three {@code WITH ...} settings builders park a setting
+   * NAME in ({@code IMPORT}, {@code EXPORT} and {@code BACKUP DATABASE}), so with it left out every setting key in
+   * one of those statements was a node whose remaining fields are all {@code null}/{@code false} - which is to say
+   * every key was {@code equals()} to every other key (issue #6401, item 3).
+   */
   @Override
   protected Object[] getIdentityElements() {
-    return new Object[] { isNull, singleQuotes, doubleQuotes, rid, mathExpression, arrayConcatExpression, json, booleanValue };
+    return new Object[] { isNull, singleQuotes, doubleQuotes, rid, mathExpression, whereCondition, arrayConcatExpression, json,
+        booleanValue, value };
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/PNumber.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/PNumber.java
@@ -39,5 +39,15 @@ public class PNumber extends SimpleNode {
     result.value = value;
     return result;
   }
+
+  /**
+   * The literal's value IS the node: without this the default identity applies and two parses of the same {@code 1}
+   * are different nodes, which would make listing {@code number} among {@link BaseExpression}'s identity elements
+   * say "not equal" for every literal (issue #6401, item 3). {@link PInteger} has always done the same.
+   */
+  @Override
+  protected Object[] getIdentityElements() {
+    return new Object[] { value };
+  }
 }
 /* JavaCC - OriginalChecksum=ebedbca280f59eb8ba8f21dc6132ba10 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
@@ -20,6 +20,7 @@
 /* JavaCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=O,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_USERTYPE_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -132,6 +133,15 @@ public abstract class SimpleNode implements Node {
     return true;
   }
 
+  /**
+   * The other half of {@link #equals(Object)}, and it has to be computed over the same thing: the CONTENTS of
+   * {@code getIdentityElements()}, element by element, exactly as the comparison above walks them.
+   * <p>
+   * {@link Arrays#hashCode(Object[])} is what does that. {@code Objects.hashCode(elements)} - which is what used to
+   * be here - has no varargs overload to bind to, so the array bound to {@code Objects.hashCode(Object)} and the
+   * answer was the array's IDENTITY hash: a fresh one on every call, since {@code getIdentityElements()} allocates,
+   * so a node did not even agree with itself twice in a row (issue #6401, item 4).
+   */
   @Override
   public int hashCode() {
     final Object[] elements = getIdentityElements();
@@ -139,7 +149,7 @@ public abstract class SimpleNode implements Node {
       // NOT IMPLEMENTED, USE THE DEFAULT IMPLEMENTATION
       return super.hashCode();
 
-    return Objects.hashCode(elements);
+    return Arrays.hashCode(elements);
   }
 
   protected Object[] getIdentityElements() {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ValueExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ValueExpression.java
@@ -34,6 +34,14 @@ import java.util.Map;
 /**
  * this class is only used by the query executor to store pre-calculated values and store them in a temporary AST. It's not produced
  * by parsing
+ * <p>
+ * It carries its whole meaning in the inherited {@code value} slot, so it inherits {@link Expression}'s identity
+ * unchanged and is compared by that value: two nodes wrapping the same pre-calculated value are the same node, and two
+ * wrapping different ones are not. Before {@code value} joined that identity every {@code ValueExpression} was
+ * {@code equals()} to every other one (issue #6401, item 3). The consequence to keep in mind is that the identity is
+ * only as well-behaved as the WRAPPED object's own {@code equals}/{@code hashCode}: nothing here stops a caller from
+ * pre-calculating a mutable value, so a node put in a hash-based collection and then mutated behaves like any other
+ * key mutated after insertion. No such collection exists today.
  */
 public class ValueExpression extends Expression {
   public ValueExpression(final Object val) {

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1980,23 +1980,36 @@ public class LocalDocumentType implements DocumentType {
     return this;
   }
 
+  /**
+   * Applies the linkage, then the three steps that make being a subtype mean something - and hands the linkage back
+   * if any of them refuses.
+   * <p>
+   * The ordering constraints below are load-bearing and are the checklist any change here has to keep:
+   * <ul>
+   *   <li>the async quiescence is taken by the CALLER, outside {@code recordFileChanges}: that runs under the
+   *       database write lock, which is the lock an async worker needs to commit;</li>
+   *   <li>{@link IndexBuilder#callerTransactionHasChanges} is asked BEFORE any transaction of ours opens, while the
+   *       answer is still about the transaction that was already there;</li>
+   *   <li>{@code created} is declared HERE, outside the propagation, because a step that refuses AFTER the indexes
+   *       are committed still has to take them away;</li>
+   *   <li>both lists are emptied on entry to the component transaction's lambda, which retries internally.</li>
+   * </ul>
+   */
   private void addSuperTypeInternal(final DocumentType superType, final boolean createIndexes) {
     recordFileChanges(() -> {
       final LocalDocumentType embeddedSuperType = (LocalDocumentType) superType;
 
-      superTypes.add(embeddedSuperType);
-      embeddedSuperType.subTypes.add(this);
-
-      // UPDATE THE LIST OF POLYMORPHIC BUCKETS TREE. The lists are captured because the fields are REPLACED rather
-      // than mutated, and unlinkSuperType has to hand back exactly what was handed over.
+      // The lists are captured because the fields are REPLACED rather than mutated, and unlinkSuperType has to hand
+      // back exactly what was handed over.
       final List<Bucket>  linkedBuckets   = cachedPolymorphicBuckets;
       final List<Integer> linkedBucketIds = cachedPolymorphicBucketIds;
-      embeddedSuperType.updatePolymorphicBucketsCache(true, linkedBuckets, linkedBucketIds);
 
-      // EVERYTHING THAT FOLLOWS THE LINKAGE IS GUARDED BY IT. The three lines above are the link; every step below can
-      // still refuse - a paired external bucket that cannot be created, an index propagation that hits a duplicate, an
-      // inherited partition the suitability check rejects for this subtype (#5637) - and a refusal that left the link
-      // standing would hand back a type that IS a subtype, with none of what being one implies.
+      linkSuperType(embeddedSuperType, linkedBuckets, linkedBucketIds);
+
+      // EVERYTHING THAT FOLLOWS THE LINKAGE IS GUARDED BY IT. Every step below can still refuse - a paired external
+      // bucket that cannot be created, an index propagation that hits a duplicate, an inherited partition the
+      // suitability check rejects for this subtype (#5637) - and a refusal that left the link standing would hand
+      // back a type that IS a subtype, with none of what being one implies.
       //
       // Every sub-index the propagation attaches is recorded HERE, outside the propagation's own block, because the
       // steps that can refuse do not all come before it: a strategy the subtype cannot take (#5637) is raised AFTER
@@ -2004,128 +2017,7 @@ public class LocalDocumentType implements DocumentType {
       // would unlink the type and leave the super type's index pointing at buckets that are no longer its subtype's.
       final List<Index> created = new ArrayList<>();
       try {
-
-        // IF THE NEWLY-LINKED SUPERTYPE HAS ANY EXTERNAL PROPERTY (OWN OR INHERITED), THIS SUBTYPE MUST OWN PAIRED
-        // EXTERNAL BUCKETS FOR ITS OWN PRIMARY BUCKETS, BECAUSE RECORDS OF THIS SUBTYPE LIVE IN THIS SUBTYPE'S BUCKETS.
-        if (embeddedSuperType.hasExternalProperties())
-          ensureExternalBucketsRecursive();
-
-        // CREATE INDEXES AUTOMATICALLY ON PROPERTIES DEFINED IN SUPER TYPES
-        final Collection<TypeIndex> indexes = new ArrayList<>(getAllIndexes(true));
-        indexes.removeAll(indexesByProperties.values());
-
-        if (createIndexes) {
-          // The indexes propagated here go over buckets that ALREADY HOLD RECORDS, which is the whole difference
-          // between this call site and the sibling in createBucket(), where the bucket has just been created and a
-          // scan has nothing to miss. A caller that inserts and then links a super type in ONE transaction must get an
-          // index covering those records; without the split below it gets one that is readable, reported healthy by
-          // CHECK DATABASE, and answers the lookup it exists for with nothing (issues #6324 and #6359, item 1).
-          //
-          // Decided BEFORE the transactions below, while the answer is still about the transaction that was already
-          // there - see IndexBuilder#buildSharesCallerTransaction, which owns the predicate for every call site.
-          //
-          // Per index rather than once: a family that cannot share a caller's transaction (the vector ones, whose
-          // search path reads through the page cache rather than through the transaction) keeps building in one go
-          // whatever the caller holds. That is also the LIMIT of this - a propagated vector index does not see the
-          // caller's uncommitted writes, and never has.
-          final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
-          final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
-          // Two lists, because "has to be built later" and "has to be taken away if anything goes wrong" are not the
-          // same set. An index family that cannot share the caller's transaction is built INLINE during component
-          // creation and never reaches toBuild, so a cleanup keyed on toBuild alone would leave it behind, committed
-          // and attached to a type relationship unlinkSuperType has just undone. Reachable whenever a super type
-          // carries both a vector index and an ordinary one.
-          final List<Index> toBuild = new ArrayList<>();
-
-          try {
-            // The COMPONENTS are created in a transaction of their OWN. The enclosing recordFileChanges writes the
-            // schema entry that names each of them whatever the caller's transaction goes on to do, so the index FILES
-            // have to be committed on the same terms: leaving a first page inside a caller's transaction that later
-            // rolls back would leave the schema pointing at a file with no pages, which fails on the next write with
-            // "the file is invalid".
-            database.transaction(() -> {
-              // Emptied on entry, not on declaration: this transaction retries on its own (a NeedRetryException from a
-              // concurrent schema mutation), and a retry re-runs this lambda from scratch. Left to accumulate, the
-              // rolled-back attempt's indexes would be handed to the build alongside the surviving ones, which reports
-              // a failure that has nothing to do with the conflict that caused the retry. TypeIndexBuilder's
-              // equivalent loop is immune because it assigns into a pre-sized array by position.
-              created.clear();
-              toBuild.clear();
-
-              for (final TypeIndex index : indexes) {
-                if (index.getType() == null) {
-                  LogManager.instance().log(this, Level.WARNING,
-                      "Error on creating implicit indexes from super type '" + superType.getName() + "': key types is null");
-                } else {
-                  final boolean sharesCallerTransaction =
-                      callerTransactionHasChanges && index.getType().buildCanShareCallerTransaction();
-
-                  for (int i = 0; i < buckets.size(); i++) {
-                    final Bucket bucket = buckets.get(i);
-
-                    boolean alreadyCreated = false;
-                    for (IndexInternal idx : getPolymorphicBucketIndexByBucketId(bucket.getFileId(), index.getPropertyNames())) {
-                      final TypeIndex typeIndex = idx.getTypeIndex();
-                      if (typeIndex != null && typeIndex.equals(index)) {
-                        alreadyCreated = true;
-                        break;
-                      }
-                    }
-
-                    if (!alreadyCreated) {
-                      // Inherit the page size of the index being propagated, like the createBucket() path above does.
-                      // Hardcoding the LSM default here gave a HASH index a page size it cannot address (#5713), and
-                      // getPageSizeForNewFile() is the accessor that guarantees the value is legal to create with.
-                      final Index subIndex = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
-                          index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), null,
-                          index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
-                          IndexBuilder.BUILD_BATCH_SIZE,
-                          index.getMetadata(), !sharesCallerTransaction);
-
-                      created.add(subIndex);
-                      if (sharesCallerTransaction)
-                        toBuild.add(subIndex);
-                    }
-                  }
-                }
-              }
-            }, false);
-
-            if (!toBuild.isEmpty())
-              // The BUILD then joins the caller's transaction, because a scan reads the transaction it runs in: the
-              // pages that transaction has modified first, the committed ones underneath. That is the only way it sees
-              // records the caller has written and not yet committed, and it makes the entries commit, or roll back,
-              // with the records they describe.
-              database.transaction(() -> {
-                for (final Index subIndex : toBuild)
-                  IndexBuilder.buildCreatedIndex(subIndex, IndexBuilder.BUILD_BATCH_SIZE, true, null);
-              }, true);
-          } catch (final RuntimeException e) {
-            // The indexes and the LINK are both handed back by the guard around the whole block, not from here: this
-            // is not the only step that can refuse after they exist. What is left here is naming which super type's
-            // propagation the failure came out of - for every failure shape, not only IndexException. The build joins the caller's transaction now, so it can
-            // fail with a DuplicatedKeyException raised on the caller's own pending writes or with a NeedRetryException
-            // - neither of which is an IndexException, and both of which used to reach the caller with no line saying
-            // which super type's propagation they came out of.
-            LogManager.instance()
-                .log(this, Level.WARNING, "Error on creating implicit indexes from super type '" + superType.getName() + "'", e);
-            throw e;
-          }
-        }
-
-        if (!superType.getBucketSelectionStrategy().getName().equalsIgnoreCase(getBucketSelectionStrategy().getName()))
-          // INHERIT THE BUCKET SELECTION STRATEGY FROM THE SUPER TYPE. The enclosing recordFileChanges saves the
-          // schema when it completes, and that write carries this strategy, so the setter does not persist on its own.
-          //
-          // An inherited partition that is unsuitable for this subtype still refuses here, as it always has: what
-          // changed with issue #5637 is that the refusal now arrives as the SchemaException the suitability check
-          // raises rather than the IllegalArgumentException the binding used to throw. Checked against every caller
-          // of addSuperType - CreateTypeAbstractStatement, AlterTypeStatement's SUPERTYPE branch, TypeBuilder, the
-          // Cypher Labels helper, and LocalSchema's dropType re-attach - and none of them catches either type, so
-          // nothing distinguishes the two. Neither is a CommandParsingException, so the HTTP status is unchanged too.
-          // (AlterTypeStatement's one catch names both, but it guards the BucketSelectionStrategy branch, not this.)
-          setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy(), false);
-
+        applyPostLinkageSteps(embeddedSuperType, createIndexes, created);
       } catch (final RuntimeException e) {
         // EVERY sub-index the propagation made goes, not only the ones that still had a build outstanding, and not
         // only when the propagation is what refused. It cannot hang off a transaction's error callback: inside a
@@ -2148,5 +2040,169 @@ public class LocalDocumentType implements DocumentType {
 
       return null;
     });
+  }
+
+  /**
+   * The in-memory linkage, and nothing else: the three lines {@link #unlinkSuperType} undoes, kept next to it so the
+   * two stay symmetric.
+   *
+   * @param linkedBuckets the caches captured by the caller, which are the very lists {@code unlinkSuperType} has to
+   *                      hand back - the fields are replaced rather than mutated, so re-reading them later would
+   *                      remove something else
+   */
+  private void linkSuperType(final LocalDocumentType superType, final List<Bucket> linkedBuckets,
+      final List<Integer> linkedBucketIds) {
+    superTypes.add(superType);
+    superType.subTypes.add(this);
+    superType.updatePolymorphicBucketsCache(true, linkedBuckets, linkedBucketIds);
+  }
+
+  /**
+   * The three steps that follow the linkage, in the order they have to run. Each of them can refuse, and the caller's
+   * guard is what turns a refusal into "as unlinked as it found it".
+   *
+   * @param created accumulates every sub-index the propagation commits, so the caller can take them away whichever
+   *                step refuses - including a step that comes after the propagation succeeded
+   */
+  private void applyPostLinkageSteps(final LocalDocumentType superType, final boolean createIndexes,
+      final List<Index> created) {
+    // 1. IF THE NEWLY-LINKED SUPERTYPE HAS ANY EXTERNAL PROPERTY (OWN OR INHERITED), THIS SUBTYPE MUST OWN PAIRED
+    // EXTERNAL BUCKETS FOR ITS OWN PRIMARY BUCKETS, BECAUSE RECORDS OF THIS SUBTYPE LIVE IN THIS SUBTYPE'S BUCKETS.
+    if (superType.hasExternalProperties())
+      ensureExternalBucketsRecursive();
+
+    // 2. CREATE INDEXES AUTOMATICALLY ON PROPERTIES DEFINED IN SUPER TYPES. The schema-load path passes
+    // createIndexes=false: the sub-indexes are already on disk and are read back with the schema.
+    if (createIndexes) {
+      final Collection<TypeIndex> indexes = new ArrayList<>(getAllIndexes(true));
+      indexes.removeAll(indexesByProperties.values());
+      propagateSuperTypeIndexes(superType, indexes, created);
+    }
+
+    // 3. INHERIT THE BUCKET SELECTION STRATEGY FROM THE SUPER TYPE. The enclosing recordFileChanges saves the schema
+    // when it completes, and that write carries this strategy, so the setter does not persist on its own.
+    //
+    // An inherited partition that is unsuitable for this subtype still refuses here, as it always has: what changed
+    // with issue #5637 is that the refusal now arrives as the SchemaException the suitability check raises rather
+    // than the IllegalArgumentException the binding used to throw. Checked against every caller of addSuperType -
+    // CreateTypeAbstractStatement, AlterTypeStatement's SUPERTYPE branch, TypeBuilder, the Cypher Labels helper, and
+    // LocalSchema's dropType re-attach - and none of them catches either type, so nothing distinguishes the two.
+    // Neither is a CommandParsingException, so the HTTP status is unchanged too. (AlterTypeStatement's one catch
+    // names both, but it guards the BucketSelectionStrategy branch, not this.)
+    if (!superType.getBucketSelectionStrategy().getName().equalsIgnoreCase(getBucketSelectionStrategy().getName()))
+      setBucketSelectionStrategy(superType.getBucketSelectionStrategy().copy(), false);
+  }
+
+  /**
+   * Propagates the super type's indexes over THIS type's buckets, which already hold records - the whole difference
+   * between this call site and the sibling in {@link #createBucket}, where the bucket has just been created and a scan
+   * has nothing to miss. A caller that inserts and then links a super type in ONE transaction must get an index
+   * covering those records; without the split below it gets one that is readable, reported healthy by
+   * {@code CHECK DATABASE}, and answers the lookup it exists for with nothing (issues #6324 and #6359, item 1).
+   *
+   * @param created every component this commits, appended for the caller's cleanup: it owns them from the moment they
+   *                exist, because the steps that can still refuse do not all come before this one
+   */
+  private void propagateSuperTypeIndexes(final LocalDocumentType superType, final Collection<TypeIndex> indexes,
+      final List<Index> created) {
+    // Decided BEFORE the transactions below, while the answer is still about the transaction that was already there -
+    // see IndexBuilder#buildSharesCallerTransaction, which owns the predicate for every call site.
+    //
+    // Per index rather than once: a family that cannot share a caller's transaction (the vector ones, whose search
+    // path reads through the page cache rather than through the transaction) keeps building in one go whatever the
+    // caller holds. That is also the LIMIT of this - a propagated vector index does not see the caller's uncommitted
+    // writes, and never has.
+    final DatabaseInternal database = (DatabaseInternal) schema.getDatabase();
+    final boolean callerTransactionHasChanges = IndexBuilder.callerTransactionHasChanges(database);
+
+    // Two lists, because "has to be built later" and "has to be taken away if anything goes wrong" are not the same
+    // set. An index family that cannot share the caller's transaction is built INLINE during component creation and
+    // never reaches toBuild, so a cleanup keyed on toBuild alone would leave it behind, committed and attached to a
+    // type relationship unlinkSuperType has just undone. Reachable whenever a super type carries both a vector index
+    // and an ordinary one.
+    final List<Index> toBuild = new ArrayList<>();
+
+    try {
+      // The COMPONENTS are created in a transaction of their OWN. The enclosing recordFileChanges writes the schema
+      // entry that names each of them whatever the caller's transaction goes on to do, so the index FILES have to be
+      // committed on the same terms: leaving a first page inside a caller's transaction that later rolls back would
+      // leave the schema pointing at a file with no pages, which fails on the next write with "the file is invalid".
+      database.transaction(() -> {
+        // Emptied on entry, not on declaration: this transaction retries on its own (a NeedRetryException from a
+        // concurrent schema mutation), and a retry re-runs this lambda from scratch. Left to accumulate, the
+        // rolled-back attempt's indexes would be handed to the build alongside the surviving ones, which reports a
+        // failure that has nothing to do with the conflict that caused the retry. TypeIndexBuilder's equivalent loop
+        // is immune because it assigns into a pre-sized array by position.
+        created.clear();
+        toBuild.clear();
+
+        for (final TypeIndex index : indexes) {
+          if (index.getType() == null)
+            LogManager.instance().log(this, Level.WARNING,
+                "Error on creating implicit indexes from super type '" + superType.getName() + "': key types is null");
+          else
+            createSubIndexesFor(index, callerTransactionHasChanges && index.getType().buildCanShareCallerTransaction(),
+                created, toBuild);
+        }
+      }, false);
+
+      if (!toBuild.isEmpty())
+        // The BUILD then joins the caller's transaction, because a scan reads the transaction it runs in: the pages
+        // that transaction has modified first, the committed ones underneath. That is the only way it sees records
+        // the caller has written and not yet committed, and it makes the entries commit, or roll back, with the
+        // records they describe.
+        database.transaction(() -> {
+          for (final Index subIndex : toBuild)
+            IndexBuilder.buildCreatedIndex(subIndex, IndexBuilder.BUILD_BATCH_SIZE, true, null);
+        }, true);
+    } catch (final RuntimeException e) {
+      // The indexes and the LINK are both handed back by the caller's guard around the whole post-linkage region, not
+      // from here: this is not the only step that can refuse after they exist. What is left here is naming which super
+      // type's propagation the failure came out of - for every failure shape, not only IndexException. The build joins
+      // the caller's transaction now, so it can fail with a DuplicatedKeyException raised on the caller's own pending
+      // writes or with a NeedRetryException - neither of which is an IndexException, and both of which used to reach
+      // the caller with no line saying which super type's propagation they came out of.
+      LogManager.instance()
+          .log(this, Level.WARNING, "Error on creating implicit indexes from super type '" + superType.getName() + "'", e);
+      throw e;
+    }
+  }
+
+  /**
+   * One super-type index, over every bucket of THIS type that does not already carry it.
+   *
+   * @param sharesCallerTransaction when true the component is created without an inline build and is appended to
+   *                                {@code toBuild}, so the build can join the caller's transaction later and see its
+   *                                pending writes; when false the build runs inline, here and now
+   */
+  private void createSubIndexesFor(final TypeIndex index, final boolean sharesCallerTransaction, final List<Index> created,
+      final List<Index> toBuild) {
+    for (int i = 0; i < buckets.size(); i++) {
+      final Bucket bucket = buckets.get(i);
+
+      boolean alreadyCreated = false;
+      for (final IndexInternal idx : getPolymorphicBucketIndexByBucketId(bucket.getFileId(), index.getPropertyNames())) {
+        final TypeIndex typeIndex = idx.getTypeIndex();
+        if (typeIndex != null && typeIndex.equals(index)) {
+          alreadyCreated = true;
+          break;
+        }
+      }
+
+      if (alreadyCreated)
+        continue;
+
+      // Inherit the page size of the index being propagated, like the createBucket() path above does. Hardcoding the
+      // LSM default here gave a HASH index a page size it cannot address (#5713), and getPageSizeForNewFile() is the
+      // accessor that guarantees the value is legal to create with.
+      final Index subIndex = schema.createBucketIndex(this, index.getKeyTypes(), bucket, name, index.getType(),
+          index.isUnique(), index.getPageSizeForNewFile(), index.getNullStrategy(), null,
+          index.getPropertyNames().toArray(new String[index.getPropertyNames().size()]), index,
+          IndexBuilder.BUILD_BATCH_SIZE, index.getMetadata(), !sharesCallerTransaction);
+
+      created.add(subIndex);
+      if (sharesCallerTransaction)
+        toBuild.add(subIndex);
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6359SuperTypeIndexPropagationTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
@@ -362,6 +363,63 @@ class Issue6359SuperTypeIndexPropagationTest extends TestHelper {
       database.getSchema().getType("Ok").addSuperType("Super");
     });
     assertThat(database.getSchema().getType("Ok").getSuperTypes()).hasSize(1);
+  }
+
+  /**
+   * The FIRST of the three post-linkage steps, and the last arm of that guard nothing asserted: pairing the external
+   * buckets.
+   * <p>
+   * A super type carrying an EXTERNAL property (own or inherited) means every subtype has to own a paired
+   * {@code <primaryBucket>_ext} bucket of its own, because records of a subtype live in the subtype's buckets. That
+   * pairing refuses on its own terms - {@code ensureExternalBucketFor} will not adopt a bucket that is already some
+   * user type's PRIMARY bucket - so no fault injection is needed to reach it: name a primary bucket after the one the
+   * subtype's pairing would want, and the refusal arrives from step one, before an index has been propagated or a
+   * strategy inherited.
+   * <p>
+   * What it pins is that the refusal leaves the type as unlinked as it found it, on BOTH sides of the link, and with
+   * no half-adopted external bucket recorded against it.
+   */
+  @Test
+  @Timeout(60)
+  void aRefusalFromTheExternalBucketPairingHandsTheLinkBackToo() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Super", 1).createProperty("payload", Type.STRING).setExternal(true);
+      database.getSchema().createDocumentType("Sub", 1);
+      database.getSchema().createDocumentType("Squatter", 1);
+    });
+
+    // The name Sub's paired external bucket WOULD take, claimed first as a primary bucket of an unrelated type.
+    final String contended = database.getSchema().getType("Sub").getBuckets(false).getFirst().getName() + "_ext";
+    database.transaction(() -> database.command("sql", "ALTER TYPE Squatter BUCKET +`" + contended + "`").close());
+
+    assertThatThrownBy(() -> database.transaction(() -> database.getSchema().getType("Sub").addSuperType("Super")))
+        .isInstanceOf(SchemaException.class).hasMessageContaining("already a primary bucket of another user type");
+
+    assertThat(database.getSchema().getType("Sub").getSuperTypes())
+        .as("the subtype is as unlinked as the refusal left it").isEmpty();
+    assertThat(database.getSchema().getType("Super").getSubTypes())
+        .as("and so is the super type, on the other side of the same link").isEmpty();
+    assertThat(((LocalDocumentType) database.getSchema().getType("Sub")).hasExternalBuckets())
+        .as("and nothing was half-adopted on the way out").isFalse();
+    assertThat(database.getSchema().getType("Squatter").getBuckets(false).stream().map(Bucket::getName))
+        .as("the contended bucket still belongs to whoever owned it").contains(contended);
+
+    // The refusal took nothing away permanently: with the collision gone, the very same link is made and the pairing
+    // this time creates the bucket it could not adopt.
+    database.transaction(() -> {
+      database.command("sql", "ALTER TYPE Squatter BUCKET -`" + contended + "`").close();
+      database.command("sql", "DROP BUCKET `" + contended + "`").close();
+    });
+    database.transaction(() -> database.getSchema().getType("Sub").addSuperType("Super"));
+
+    assertThat(database.getSchema().getType("Sub").getSuperTypes()).hasSize(1);
+    final LocalDocumentType sub = (LocalDocumentType) database.getSchema().getType("Sub");
+    assertThat(sub.getExternalBucketIdFor(sub.getBuckets(false).getFirst().getFileId()))
+        .as("the inherited EXTERNAL property now has a bucket of its own to write into").isNotNull();
+
+    // And it is a working one, not merely a registered one.
+    database.transaction(() -> database.newDocument("Sub").set("payload", "x".repeat(4096)).save());
+    assertThat(database.countType("Sub", false)).isEqualTo(1);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6401NodeIdentityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6401NodeIdentityTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6401, items 3 and 4: the identity of a parsed node.
+ * <p>
+ * Two independent defects met in the same place. {@link SimpleNode#hashCode()} hashed the ARRAY that
+ * {@code getIdentityElements()} returns rather than its contents, and that array is allocated fresh on every call - so
+ * one node answered a different hash on every call, and two nodes {@code equals()} to each other answered different
+ * hashes, which is the {@link Object#hashCode()} contract broken outright. And the identity of an expression left out
+ * fields that carry its VALUE - {@code number} and {@code expression} on {@link BaseExpression}, {@code whereCondition}
+ * and the inherited {@code value} slot on {@link Expression} - so the parsed forms of {@code SELECT 1} and
+ * {@code SELECT 2} were {@code equals()} to each other, and so was every setting key of a {@code WITH} clause.
+ * <p>
+ * The two are each other's cover: {@code equals()} said yes where it should have said no, and the hash codes said no
+ * to everything, so a {@code HashMap} keyed on a node behaved almost correctly by accident. Fixing either one alone
+ * makes a map worse rather than better, which is why both are here.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6401NodeIdentityTest extends AbstractParserTest {
+
+  private Expression projectionOf(final String query) {
+    return ((SelectStatement) checkRightSyntax(query)).getProjection().getItems().getFirst().expression;
+  }
+
+  /**
+   * The contract, on one object: a hash code is a property of the value, so asking twice has to answer twice the same.
+   * It did not, because {@code Objects.hashCode(Object)} on an {@code Object[]} is the array's IDENTITY hash and the
+   * array is a new one on every call.
+   */
+  @Test
+  void oneNodeAnswersTheSameHashCodeOnEveryCall() {
+    final Expression expression = projectionOf("SELECT 1 FROM V");
+    assertThat(expression.hashCode()).isEqualTo(expression.hashCode());
+
+    final SimpleNode statement = checkRightSyntax("SELECT a, b FROM V WHERE c > 3");
+    assertThat(statement.hashCode()).isEqualTo(statement.hashCode());
+  }
+
+  /** And the other half of the contract: two nodes that are equal answer the same hash code. */
+  @Test
+  void equalNodesAnswerEqualHashCodes() {
+    for (final String query : new String[] { //
+        "SELECT 1 FROM V", //
+        "SELECT a FROM V", //
+        "SELECT a.b[1] FROM V WHERE c = 'x'", //
+        "SELECT (1 + 2) * 3 FROM V", //
+        "SELECT max(a) FROM V GROUP BY b", //
+        "SELECT FROM V WHERE a IN [1, 2, 3]" }) {
+      final SimpleNode one = checkRightSyntax(query);
+      final SimpleNode other = checkRightSyntax(query);
+
+      assertThat(one).as(query).isEqualTo(other);
+      assertThat(one.hashCode()).as(query).isEqualTo(other.hashCode());
+    }
+  }
+
+  /** A bare numeric literal: five of {@code BaseExpression}'s fields are null, and the value lived in the sixth. */
+  @Test
+  void twoDifferentNumericLiteralsAreNotTheSameExpression() {
+    final Expression one = projectionOf("SELECT 1 FROM V");
+    final Expression two = projectionOf("SELECT 2 FROM V");
+
+    assertThat(one).as("1 is not 2").isNotEqualTo(two);
+    assertThat(projectionOf("SELECT 1 FROM V")).as("but 1 is 1").isEqualTo(one);
+  }
+
+  /** The same for the other omitted field: a parenthesised sub-expression parked in {@code expression}. */
+  @Test
+  void twoDifferentWrappedSubExpressionsAreNotTheSameExpression() {
+    final Expression one = projectionOf("SELECT (1 + 2) FROM V");
+    final Expression two = projectionOf("SELECT (3 + 4) FROM V");
+
+    assertThat(one).as("(1 + 2) is not (3 + 4)").isNotEqualTo(two);
+    assertThat(projectionOf("SELECT (1 + 2) FROM V")).as("but (1 + 2) is (1 + 2)").isEqualTo(one);
+  }
+
+  /** Map literals and collections are parked in the same field, so they get the same treatment. */
+  @Test
+  void twoDifferentCollectionLiteralsAreNotTheSameExpression() {
+    assertThat(projectionOf("SELECT [1, 2] FROM V")).isNotEqualTo(projectionOf("SELECT [3, 4] FROM V"));
+    assertThat(projectionOf("SELECT {'a': 1} FROM V")).isNotEqualTo(projectionOf("SELECT {'a': 2} FROM V"));
+  }
+
+  /**
+   * What the contract buys, and the shape the four {@code Map<Expression, Expression> settings} maps in the DDL
+   * statements are built out of: a key put in is a key found back, and putting an equal key twice overwrites rather
+   * than growing a second entry that {@code get()} can never reach.
+   */
+  @Test
+  void anExpressionUsedAsAHashKeyBehavesLikeAKey() {
+    final Map<Expression, Expression> settings = new HashMap<>();
+    settings.put(projectionOf("SELECT batchSize FROM V"), projectionOf("SELECT 1 FROM V"));
+    settings.put(projectionOf("SELECT batchSize FROM V"), projectionOf("SELECT 2 FROM V"));
+
+    assertThat(settings).as("the same setting named twice is ONE setting").hasSize(1);
+    assertThat(settings.get(projectionOf("SELECT batchSize FROM V")))
+        .as("and the last spelling of it wins").isEqualTo(projectionOf("SELECT 2 FROM V"));
+
+    final Set<Expression> distinct = new HashSet<>();
+    distinct.add(projectionOf("SELECT 1 FROM V"));
+    distinct.add(projectionOf("SELECT 1 FROM V"));
+    distinct.add(projectionOf("SELECT 2 FROM V"));
+    assertThat(distinct).as("two different literals are two elements, and two equal ones are one").hasSize(2);
+  }
+
+  /**
+   * {@code PNumber} is the node the literal's value lives in, and it had no identity of its own - so listing
+   * {@code number} among {@code BaseExpression}'s identity elements would have compared two literals by object
+   * identity, which says "not equal" for two parses of the very same statement.
+   */
+  @Test
+  void aNumberNodeComparesByItsValue() {
+    final PNumber one = new PNumber();
+    one.value = 42;
+    final PNumber same = new PNumber();
+    same.value = 42;
+    final PNumber other = new PNumber();
+    other.value = 43;
+
+    assertThat(one).isEqualTo(same);
+    assertThat(one.hashCode()).isEqualTo(same.hashCode());
+    assertThat(one).isNotEqualTo(other);
+    assertThat(one.copy()).as("a copy keeps the identity of what it copied").isEqualTo(one);
+  }
+
+  /**
+   * The shape that turned item 3 from a trap into a live defect once the hash codes started agreeing with
+   * {@code equals()}: {@code IMPORT}, {@code EXPORT} and {@code BACKUP DATABASE} park a setting NAME in the node's
+   * inherited {@code value} slot rather than building an identifier expression out of it, and {@code value} was not
+   * among {@link Expression}'s identity elements - so every key of a {@code WITH} clause was a node whose every
+   * other field is {@code null}/{@code false}, which is to say equal to every other key.
+   */
+  @Test
+  void everySettingKeyOfAWithClauseIsItsOwnKey() {
+    final ImportDatabaseStatement statement = (ImportDatabaseStatement) checkRightSyntax(
+        "IMPORT DATABASE http://www.foo.bar WITH forceDatabaseCreate = true, commitEvery = 10000");
+
+    assertThat(statement.settings).as("two settings are two entries").hasSize(2);
+    assertThat(statement.settings.keySet().stream().map(k -> k.value.toString()))
+        .containsExactlyInAnyOrder("forceDatabaseCreate", "commitEvery");
+  }
+
+  /**
+   * {@code whereCondition} is the other field {@link Expression#execute} reads that identity used to ignore: a
+   * parenthesised boolean condition lives there, and two different ones were the same node.
+   */
+  @Test
+  void twoDifferentInlineConditionsAreNotTheSameExpression() {
+    final Expression one = projectionOf("SELECT (a = 1 AND b = 2) FROM V");
+    final Expression two = projectionOf("SELECT (a = 1 AND b = 3) FROM V");
+
+    assertThat(one.whereCondition).as("the shape under test parks the condition in whereCondition").isNotNull();
+    assertThat(one).isNotEqualTo(two);
+    assertThat(projectionOf("SELECT (a = 1 AND b = 2) FROM V")).isEqualTo(one);
+  }
+
+  /** A node with no identity of its own keeps the default: itself, and stably so. */
+  @Test
+  void aNodeWithoutIdentityElementsStillHonoursTheContract() {
+    final Timeout timeout = new Timeout();
+    assertThat(timeout.hashCode()).isEqualTo(timeout.hashCode());
+    assertThat(timeout).isEqualTo(timeout);
+  }
+}


### PR DESCRIPTION
Closes #6401.

Four follow-ups collected while fixing #6359. Items 3 and 4 turned out to be each other's cover, so they are fixed together.

## Item 4 - `SimpleNode.hashCode()` hashed the ARRAY

There is no `Objects.hashCode(Object...)` overload, so the `Object[]` returned by `getIdentityElements()` bound to
`Objects.hashCode(Object)` and the answer was the array's IDENTITY hash - of an array allocated fresh on every call. So:

- `node.hashCode() != node.hashCode()` across two calls on the same object;
- `a.equals(b)` true while `a.hashCode() != b.hashCode()`, which is the `Object.hashCode` contract broken outright.

`Arrays.hashCode(elements)` is what the code reads as if it says, and it walks the elements exactly as `equals()` a few
lines above does.

## Item 3 - the identity of an expression left out fields that carry its value

- `BaseExpression`: `number` and `expression` were missing, so for a bare numeric literal every listed field is
  `null`/`false` and the parsed forms of `SELECT 1` and `SELECT 2` compared EQUAL. Same for two different wrapped
  sub-expressions.
- `Expression`: `whereCondition` and the inherited `value` slot were missing, and both are read by `execute()`.
  `value` is where the three `WITH ...` settings builders (`IMPORT`, `EXPORT`, `BACKUP DATABASE`) park a setting NAME,
  so every key of a `WITH` clause was a node whose every other field is null - equal to every other key.
- `PNumber` gained an identity of its own, for the same reason `PInteger` has always had one: without it, listing
  `number` on `BaseExpression` would compare two literals by object identity and answer "not equal" for two parses of
  the very same statement.

`parenthesized` is deliberately left out of `BaseExpression`'s identity: it is rendering-only, the parentheses are
already in the tree SHAPE, so two nodes differing in it alone mean the same thing.

**Neither fix is safe alone.** `equals()` said yes where it should have said no, the hash codes said no to everything,
and a `HashMap` keyed on a parsed node came out almost right by accident. Fixing the hash first collapses the five
`Map<Expression, Expression> settings` maps to a single entry - which is precisely what
`ImportDatabaseStatementTestParserTest.copyKeepsTheWithSettings` caught on the first full engine run.

## Item 1 - the external-bucket arm of `addSuperType`'s rollback now has a regression test

It needs no fault injection, contrary to what PR #6364 assumed: `ensureExternalBucketFor` already refuses to adopt a
bucket that is a primary bucket of another user type. Naming a primary bucket after the one the subtype's pairing would
want (`<subtypePrimaryBucket>_ext`) reaches the refusal from step ONE, before an index is propagated or a strategy
inherited. The test pins that the link goes back on both sides, that nothing is half-adopted, and that with the
collision gone the same link is made and the pairing creates the bucket it could not adopt.

Verified non-vacuous: removing the `unlinkSuperType` call from the guard makes it red.

## Item 2 - `addSuperTypeInternal` extracted along its seams

~170 lines with three nesting levels of try/catch, split into `linkSuperType` (symmetric with `unlinkSuperType`),
`applyPostLinkageSteps` (the three steps, numbered), `propagateSuperTypeIndexes` and `createSubIndexesFor`. No behaviour
change. The ordering constraints that were only in comments are now the method's javadoc checklist: the quiescence
outside `recordFileChanges`, the share predicate asked before any transaction opens, `created` declared outside the
propagation, both lists cleared on entry to the retrying lambda.

## Verification

- New `Issue6401NodeIdentityTest` (10 cases): hash stability across calls, equal nodes hash equally, different literals
  / wrapped sub-expressions / collection literals / inline conditions are different nodes, an `Expression` used as a
  hash key behaves like a key, every setting key of a `WITH` clause is its own key, `PNumber` compares by value, and a
  node with no identity elements still honours the contract. Mutation-checked: reverting either `Expression` field
  turns two of them red.
- New `Issue6359SuperTypeIndexPropagationTest#aRefusalFromTheExternalBucketPairingHandsTheLinkBackToo`.
- `engine`: 12764 tests, 0 failures. `server`: 794, 0 failures. `gremlin`/`graphql`/`postgresw`/`mongodbw`/
  `integration`/`console`: green.