### PR TITLE
fix(#6382, #6385, #6388, #6389, #6390, #6393): an operator with no visitor is dropped from the tree, and a mistake in a call is the caller's error, not the server's

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3513,15 +3513,26 @@ never looked at. `sum()` was hardened against non-numeric input in #5799 and its
 `sum` answered cleanly; the guard now lives on `SQLFunctionAbstract` and they all share it. Nulls are still
 skipped, which is the documented aggregation behaviour.
 
+**Behaviour change.** `map()` refuses a non-STRING key, `map(null, 'a')` included, where the raw cast used to
+store `(String) null` and build a map with a key nobody can reference. This is deliberately stricter than the
+`[...].asMap()` method, which converts what it is handed: `map()` takes key/value pairs the caller wrote out one
+by one, so a non-string among them is a mistake in the query worth reporting, while `asMap()` is documented as
+turning an arbitrary list *into* a map.
+
 **Breaking change.** `sysdate()` takes a **zone id** as its only argument, per its documented syntax
 `sysdate([<zoneid>])`, and now applies it: it used to read the zone from the *second* argument, so the
 one-argument form silently dropped it and answered server-local time. A second argument is now refused rather
 than accepted and ignored. Formatting is `.format()`'s job - `sysdate().format('yyyy-MM-dd')` - so a call
 written `sysdate('yyyy-MM-dd')`, which never formatted anything, is now an error naming the unknown zone.
 
-Two resource limits ride along, both reachable from caller-supplied text: the date formatter cache is bounded
-(past the ceiling a formatter is still built, just not remembered), and `format()` refuses a field width over
-a million characters instead of allocating it.
+Three resource limits ride along, all reachable from caller-supplied text: the date formatter cache is bounded
+(past the ceiling a formatter is still built, just not remembered), `format()` refuses a field width over a
+million characters instead of allocating it, and a character index is parsed from a bounded literal rather than
+whatever length the query text carries.
+
+One adjacent defect surfaced with the A* fix and is repaired with it: of the five heuristics on three or more
+axes, `EUCLIDEAN` was the only one that dropped `dFactor`, which nobody could see while every `h(n)` was the
+same number. It now scales like its two-axis twin and like the other four.
 
 [#6382](https://github.com/ArcadeData/arcadedb/issues/6382)
 [#6385](https://github.com/ArcadeData/arcadedb/issues/6385)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3412,3 +3412,56 @@ change the meaning - around a compound arithmetic operand - and not where they a
 `SELECT (name) FROM V` keeps the column name it has always had.
 
 [#6359](https://github.com/ArcadeData/arcadedb/issues/6359)
+
+## The `??` operator returns its left operand again, and a mistake in a function call is answered as one (#6382, #6385, #6388, #6389, #6390, #6393)
+
+The SQL null-coalescing operator `??` always returned its **right** operand, whatever the left one was. The
+grammar declares the alternative and `MathExpression.Operator` carries a working `NULL_COALESCING`, but nothing
+in between built the node: with no visitor for it, ANTLR's default `visitChildren` returns the last child it
+visited, so the left operand was gone from the tree before anything could evaluate it. `'left' ?? 'right'` was
+`'right'`, and `null ?? 'right'` agreed only by coincidence - which is the worst shape for a defect, because a
+projection, a `WHERE` term or a `SET` value written `a ?? fallback` read as "the fallback is always taken". It
+now evaluates left-to-right and short-circuits: the right operand, possibly a function call or a sub-query, is
+not evaluated when the fallback is not taken. `toString()` had no case for the operator either, so the
+rendering lost it too.
+
+The A* heuristic stored the **source** vertex's coordinate where the current node's belongs, for three or more
+axes (the two-axis branch was already right). `h(n)` was therefore the same number for every node - an
+admissible heuristic that guides nothing, so the search did the work of a plain Dijkstra while claiming to be
+informed. `dijkstra` delegates to A*, so any call supplying axis coordinates degraded with it.
+
+`CONTAINSTEXT` on a full-text index split its literal on the first `:` and looked the remainder up as a
+field-qualified key. A single-property index stores unprefixed tokens only, so an ordinary value carrying a
+colon - a time, a timestamp, a `ns:name` - asked for a key the corpus never had and matched **nothing**. A
+colon now introduces a qualifier only when the text before it names an indexed property, and on a
+single-property index it is dropped even then, matching the normalization the Lucene-backed path already
+applied; everything else is literal text handed to the analyzer, which is what the operator documents its
+argument to be.
+
+The rest is one theme across three issues: a raw JDK exception - an HTTP 500 - for ordinary valid input, where
+a typed argument error (HTTP 400) is the answer. `duration(1,'year')`, `ts.timeBucket('0s', ts)`,
+`ts.lag(v,-1,ts)`, `ts.lag(value)` without a timestamp, `date()` with a malformed pattern or unknown zone,
+`[1,null,3].join('-')`, `map(1,'a')`, `[1,2,3,4].asMap()`, `'x'.convert('nope')`, `decode('!!!','base64')`,
+`format('%d','x')`, `max([1,'a'])`, `bool_and([1,2,3])`, `nullField.lastindexof('a')` and
+`'abcdef'.substring(2.5)` each threw, and `bool_and(5)` was worse: it returned a confident `true` for input it
+never looked at. `sum()` was hardened against non-numeric input in #5799 and its siblings were not, so `avg`,
+`variance`/`stddev`/`median`, `percentile` and the time-series aggregates answered a `ClassCastException` where
+`sum` answered cleanly; the guard now lives on `SQLFunctionAbstract` and they all share it. Nulls are still
+skipped, which is the documented aggregation behaviour.
+
+**Breaking change.** `sysdate()` takes a **zone id** as its only argument, per its documented syntax
+`sysdate([<zoneid>])`, and now applies it: it used to read the zone from the *second* argument, so the
+one-argument form silently dropped it and answered server-local time. A second argument is now refused rather
+than accepted and ignored. Formatting is `.format()`'s job - `sysdate().format('yyyy-MM-dd')` - so a call
+written `sysdate('yyyy-MM-dd')`, which never formatted anything, is now an error naming the unknown zone.
+
+Two resource limits ride along, both reachable from caller-supplied text: the date formatter cache is bounded
+(past the ceiling a formatter is still built, just not remembered), and `format()` refuses a field width over
+a million characters instead of allocating it.
+
+[#6382](https://github.com/ArcadeData/arcadedb/issues/6382)
+[#6385](https://github.com/ArcadeData/arcadedb/issues/6385)
+[#6388](https://github.com/ArcadeData/arcadedb/issues/6388)
+[#6389](https://github.com/ArcadeData/arcadedb/issues/6389)
+[#6390](https://github.com/ArcadeData/arcadedb/issues/6390)
+[#6393](https://github.com/ArcadeData/arcadedb/issues/6393)

--- a/engine/src/main/java/com/arcadedb/function/sql/SQLAggregatedFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/SQLAggregatedFunction.java
@@ -19,6 +19,9 @@
 package com.arcadedb.function.sql;
 
 import com.arcadedb.function.AggregatedFunction;
+import com.arcadedb.query.sql.executor.MultiValue;
+
+import java.util.function.Consumer;
 
 /**
  * Abstract base class for SQL aggregate functions (count, sum, avg, min, max, etc.).
@@ -40,6 +43,29 @@ import com.arcadedb.function.AggregatedFunction;
  * @see AggregatedFunction
  */
 public abstract class SQLAggregatedFunction extends SQLFunctionConfigurableAbstract implements AggregatedFunction {
+  /**
+   * Feeds one argument's worth of input to a numeric accumulator: a {@link Number} goes straight in, a collection is
+   * unrolled element by element, a null is skipped, and anything else is a client-facing type error.
+   * <p>
+   * That triage is the same three branches in every cross-row numeric aggregate, and #6390 exists precisely because
+   * it was copied per function - {@code sum()} was hardened in #5799 and the copies in {@code avg}, {@code variance}
+   * and {@code percentile} drifted away from it. It lives here so the next hardening reaches all of them.
+   *
+   * @param value       the argument to accumulate
+   * @param accumulator where each numeric (or null) value is sent
+   */
+  protected void accumulateNumeric(final Object value, final Consumer<Number> accumulator) {
+    if (value instanceof Number number)
+      accumulator.accept(number);
+    else if (MultiValue.isMultiValue(value))
+      for (final Object item : MultiValue.getMultiValueIterable(value))
+        accumulator.accept(requireNumericOrNull(item));
+    else
+      // A non-numeric, non-null, non-list value is a client-facing type error rather than a silently dropped one,
+      // which used to make an all-invalid input indistinguishable from an all-null one (#5799, #6390).
+      accumulator.accept(requireNumericOrNull(value));
+  }
+
 
   protected SQLAggregatedFunction(final String name) {
     super(name);

--- a/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
@@ -87,6 +87,93 @@ public abstract class SQLFunctionAbstract implements SQLFunction {
   }
 
   /**
+   * Validates a value a numeric function is about to accumulate: {@code null} passes through (nulls are skipped,
+   * matching the documented aggregation behavior), a {@link Number} passes through unchanged, and anything else
+   * (STRING, BOOLEAN, a collection, a record, ...) is a client-facing type error naming the function and the type
+   * it got.
+   * <p>
+   * Issue #5799 introduced this for {@code sum()} so a non-numeric element stopped being silently dropped - which
+   * left the accumulator unchanged and made an all-invalid input indistinguishable from an all-null one. Issue
+   * #6390 pulled it up here because every sibling still did a raw {@code (Number)} cast and answered a
+   * ClassCastException (HTTP 500) where {@code sum()} answered a typed error (HTTP 400).
+   *
+   * @param value the value to validate
+   *
+   * @return the value as a {@link Number}, or {@code null}
+   *
+   * @throws IllegalArgumentException if the value is neither null nor a number
+   */
+  protected Number requireNumericOrNull(final Object value) {
+    if (value == null || value instanceof Number)
+      return (Number) value;
+    throw new IllegalArgumentException(
+        getName() + "() requires numeric input, but received a value of type " + value.getClass().getSimpleName());
+  }
+
+  /**
+   * Orders two values the way {@code max()} / {@code min()} need them ordered, answering a typed argument error when
+   * they are not mutually comparable instead of the ClassCastException the raw {@code ((Comparable) a).compareTo(b)}
+   * threw for something as ordinary as {@code max([1, 'a'])} (issue #6389). Numeric widening is the caller's job -
+   * both functions run {@code Type.castComparableNumber} first, so this only ever sees values already brought to a
+   * common numeric class, or values of genuinely different kinds.
+   *
+   * @param left  the value to place
+   * @param right the value to place it against
+   *
+   * @return the sign of the comparison, as {@link Comparable#compareTo}
+   *
+   * @throws IllegalArgumentException if the two values cannot be compared with each other
+   */
+  @SuppressWarnings("unchecked")
+  protected int compareValues(final Object left, final Object right) {
+    try {
+      return ((Comparable<Object>) left).compareTo(right);
+    } catch (final ClassCastException e) {
+      throw new IllegalArgumentException(
+          getName() + "() cannot compare a value of type " + left.getClass().getSimpleName() + " with a value of type "
+              + right.getClass().getSimpleName(), e);
+    }
+  }
+
+  /**
+   * The boolean analogue of {@link #requireNumericOrNull(Object)}: {@code null} passes through, a {@link Boolean}
+   * passes through, anything else is a client-facing type error rather than a ClassCastException - or, worse, a
+   * silently unchanged accumulator that returns a confident answer for input it never looked at (issue #6389).
+   *
+   * @param value the value to validate
+   *
+   * @return the value as a {@link Boolean}, or {@code null}
+   *
+   * @throws IllegalArgumentException if the value is neither null nor a boolean
+   */
+  protected Boolean requireBooleanOrNull(final Object value) {
+    if (value == null || value instanceof Boolean)
+      return (Boolean) value;
+    throw new IllegalArgumentException(
+        getName() + "() requires boolean input, but received a value of type " + value.getClass().getSimpleName());
+  }
+
+  /**
+   * The strict counterpart of {@link #requireNumericOrNull(Object)} for a scalar CONFIGURATION argument - a window
+   * size, a percentile, an offset - where {@code null} is not a value to skip but a missing setting.
+   *
+   * @param value        the argument value
+   * @param argumentName the argument's name, for the error message
+   *
+   * @return the value as a {@link Number}
+   *
+   * @throws IllegalArgumentException if the value is null or not a number
+   */
+  protected Number requireNumeric(final Object value, final String argumentName) {
+    if (value instanceof Number number)
+      return number;
+    throw new IllegalArgumentException(
+        getName() + "() requires a numeric <" + argumentName + ">, but received " + (value == null ?
+            "null" :
+            "a value of type " + value.getClass().getSimpleName()));
+  }
+
+  /**
    * Converts various input types (float[], double[], Object[], List) to a float array.
    * Delegates to {@link com.arcadedb.index.vector.VectorUtils#toFloatArray(Object)}.
    *

--- a/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
@@ -188,7 +188,13 @@ public abstract class SQLFunctionAbstract implements SQLFunction {
    * @throws IllegalArgumentException if the value is null or not a number
    */
   protected int requireIntArgument(final Object value, final String argumentName) {
-    return NumberUtils.saturateToInt(requireNumeric(value, argumentName));
+    final Integer number = NumberUtils.saturateToIntOrNull(value);
+    if (number != null)
+      return number;
+
+    throw new IllegalArgumentException(
+        getName() + "() requires a numeric <" + argumentName + ">, but received " + NumberUtils.describeRejectedNumber(
+            value));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.sql;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.index.vector.VectorUtils;
 import com.arcadedb.query.sql.executor.SQLFunction;
+import com.arcadedb.utility.NumberUtils;
 
 /**
  * Abstract class to extend to build Custom SQL Functions.
@@ -171,6 +172,23 @@ public abstract class SQLFunctionAbstract implements SQLFunction {
         getName() + "() requires a numeric <" + argumentName + ">, but received " + (value == null ?
             "null" :
             "a value of type " + value.getClass().getSimpleName()));
+  }
+
+  /**
+   * Reads a scalar CONFIGURATION argument as an int, saturating rather than wrapping: {@code Number.intValue()} on a
+   * value outside the int range silently returns an unrelated number, which for an offset or a window size drives a
+   * degenerate computation that still looks plausible. The {@link com.arcadedb.query.sql.method.AbstractSQLMethod}
+   * side of the same batch takes the same care with character indexes.
+   *
+   * @param value        the argument value
+   * @param argumentName the argument's name, for the error message
+   *
+   * @return the value as an int, saturated to the int range
+   *
+   * @throws IllegalArgumentException if the value is null or not a number
+   */
+  protected int requireIntArgument(final Object value, final String argumentName) {
+    return NumberUtils.saturateToInt(requireNumeric(value, argumentName));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionMap.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionMap.java
@@ -62,6 +62,13 @@ public class SQLFunctionMap extends SQLAggregatedCollectionFunction<Map<String, 
       throw new IllegalArgumentException("Map function: expected a map or pairs of parameters as key, value");
     else
       for (int i = 0; i < params.length; i += 2) {
+        // A MAP KEY IS A STRING; ANYTHING ELSE USED TO REACH THIS CAST AND THROW ClassCastException (ISSUE #6389).
+        if (!(params[i] instanceof String))
+          throw new IllegalArgumentException(
+              "Map function: expected a STRING key, but received " + (params[i] == null ?
+                  "null" :
+                  "a value of type " + params[i].getClass().getSimpleName()));
+
         final String key = (String) params[i];
         final Object value = params[i + 1];
 

--- a/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionMap.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/coll/SQLFunctionMap.java
@@ -27,6 +27,12 @@ import java.util.Map;
 
 /**
  * This operator add an entry in a map. The entry is composed by a key and a value.
+ * <p>
+ * A key must be a STRING and anything else is refused, which is deliberately stricter than the
+ * {@code [...].asMap()} method: this function takes key/value pairs the caller wrote out one by one, so a
+ * non-string among them is a mistake in the query worth reporting, whereas {@code asMap()} is documented as
+ * turning an arbitrary list INTO a map and converts what it is handed. Both used to answer a ClassCastException
+ * instead (issue #6389).
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -450,7 +450,9 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
         if (s != null)
           sList.put(paramVertexAxisNames[i], s);
         if (c != null)
-          cList.put(paramVertexAxisNames[i], s);
+          // THE CURRENT NODE'S OWN COORDINATE, NOT THE SOURCE'S: cList IS THE POSITION EVERY HEURISTIC BELOW MEASURES
+          // FROM, AND FILLING IT WITH s MADE h(n) CONSTANT OVER THE WHOLE SEARCH (ISSUE #6385).
+          cList.put(paramVertexAxisNames[i], c);
         if (g != null)
           gList.put(paramVertexAxisNames[i], g);
         if (p != null)

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionHeuristicPathFinderAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionHeuristicPathFinderAbstract.java
@@ -238,7 +238,9 @@ public abstract class SQLFunctionHeuristicPathFinderAbstract extends SQLFunction
       res += Math.pow(Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ?
           glist.get(str) : 0.0)), 2);
     }
-    heuristic = Math.sqrt(res);
+    // dFactor scales every other heuristic, including the two-axis EUCLIDEAN next to it; this was the one of the
+    // five N-axis formulas that dropped it. Invisible until #6385, because h(n) was the same number everywhere.
+    heuristic = dFactor * Math.sqrt(res);
     return heuristic;
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAverage.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAverage.java
@@ -56,7 +56,10 @@ public class SQLFunctionAverage extends SQLAggregatedFunction {
         sum(number);
       else if (MultiValue.isMultiValue(params[0]))
         for (final Object n : MultiValue.getMultiValueIterable(params[0]))
-          sum((Number) n);
+          sum(requireNumericOrNull(n));
+      else
+        // A NON-NUMERIC, NON-NULL, NON-LIST VALUE IS A CLIENT-FACING TYPE ERROR, NOT A ClassCastException (#6390).
+        sum(requireNumericOrNull(params[0]));
 
       return getResult();
     }
@@ -66,7 +69,7 @@ public class SQLFunctionAverage extends SQLAggregatedFunction {
     Number rowSum = null;
     int rowTotal = 0;
     for (int i = 0; i < params.length; ++i) {
-      final Number value = (Number) params[i];
+      final Number value = requireNumericOrNull(params[i]);
       if (value != null) {
         rowTotal++;
         rowSum = rowSum == null ? value : Type.increment(rowSum, value);

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAverage.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAverage.java
@@ -52,15 +52,7 @@ public class SQLFunctionAverage extends SQLAggregatedFunction {
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (params.length == 1) {
-      if (params[0] instanceof Number number)
-        sum(number);
-      else if (MultiValue.isMultiValue(params[0]))
-        for (final Object n : MultiValue.getMultiValueIterable(params[0]))
-          sum(requireNumericOrNull(n));
-      else
-        // A NON-NUMERIC, NON-NULL, NON-LIST VALUE IS A CLIENT-FACING TYPE ERROR, NOT A ClassCastException (#6390).
-        sum(requireNumericOrNull(params[0]));
-
+      accumulateNumeric(params[0], this::sum);
       return getResult();
     }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMax.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMax.java
@@ -55,7 +55,7 @@ public class SQLFunctionMax extends SQLAggregatedFunction {
             subitem = converted[0];
             max = converted[1];
           }
-          if (max == null || subitem != null && ((Comparable) subitem).compareTo(max) > 0)
+          if (max == null || subitem != null && compareValues(subitem, max) > 0)
             max = subitem;
         }
       } else {
@@ -65,7 +65,7 @@ public class SQLFunctionMax extends SQLAggregatedFunction {
           item = converted[0];
           max = converted[1];
         }
-        if (max == null || item != null && ((Comparable) item).compareTo(max) > 0)
+        if (max == null || item != null && compareValues(item, max) > 0)
           max = item;
       }
     }
@@ -82,7 +82,7 @@ public class SQLFunctionMax extends SQLAggregatedFunction {
           context = casted[0];
           max = casted[1];
         }
-        if (((Comparable<Object>) context).compareTo(max) < 0)
+        if (compareValues(context, max) < 0)
           // BIGGER
           context = max;
       }

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMin.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMin.java
@@ -56,7 +56,7 @@ public class SQLFunctionMin extends SQLAggregatedFunction {
             subitem = converted[0];
             min = converted[1];
           }
-          if (min == null || subitem != null && ((Comparable) subitem).compareTo(min) < 0)
+          if (min == null || subitem != null && compareValues(subitem, min) < 0)
             min = subitem;
         }
       } else {
@@ -66,7 +66,7 @@ public class SQLFunctionMin extends SQLAggregatedFunction {
           item = converted[0];
           min = converted[1];
         }
-        if (min == null || item != null && ((Comparable) item).compareTo(min) < 0)
+        if (min == null || item != null && compareValues(item, min) < 0)
           min = item;
       }
     }
@@ -84,7 +84,7 @@ public class SQLFunctionMin extends SQLAggregatedFunction {
           min = casted[1];
         }
 
-        if (((Comparable<Object>) context).compareTo(min) > 0)
+        if (compareValues(context, min) > 0)
           // MINOR
           context = min;
       }

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
@@ -64,9 +64,11 @@ public class SQLFunctionPercentile extends SQLAggregatedFunction {
       addValue(number);
     } else if (MultiValue.isMultiValue(params[0])) {
       for (final Object n : MultiValue.getMultiValueIterable(params[0])) {
-        addValue((Number) n);
+        addValue(requireNumericOrNull(n));
       }
-    }
+    } else
+      // A NON-NUMERIC, NON-NULL, NON-LIST VALUE IS A CLIENT-FACING TYPE ERROR, NOT A ClassCastException (#6390).
+      addValue(requireNumericOrNull(params[0]));
     return null;
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
@@ -60,15 +60,7 @@ public class SQLFunctionPercentile extends SQLAggregatedFunction {
       }
     }
 
-    if (params[0] instanceof Number number) {
-      addValue(number);
-    } else if (MultiValue.isMultiValue(params[0])) {
-      for (final Object n : MultiValue.getMultiValueIterable(params[0])) {
-        addValue(requireNumericOrNull(n));
-      }
-    } else
-      // A NON-NUMERIC, NON-NULL, NON-LIST VALUE IS A CLIENT-FACING TYPE ERROR, NOT A ClassCastException (#6390).
-      addValue(requireNumericOrNull(params[0]));
+    accumulateNumeric(params[0], this::addValue);
     return null;
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPow.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPow.java
@@ -45,7 +45,7 @@ public class SQLFunctionPow extends SQLFunctionMathAbstract {
       throw new IllegalArgumentException("Syntax error: " + getSyntax());
 
     final Object inputValue = params[0];
-    final int powerValue = ((Number) params[1]).intValue();
+    final int powerValue = requireIntArgument(params[1], "power");
 
     switch (inputValue) {
     case null -> result = null;

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSum.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionSum.java
@@ -91,18 +91,6 @@ public class SQLFunctionSum extends SQLAggregatedFunction {
     }
   }
 
-  /**
-   * Validates a single aggregated value: {@code null} passes through (nulls are skipped, matching the documented
-   * behavior), a {@link Number} passes through unchanged, and anything else (STRING, BOOLEAN, ...) is a client-facing
-   * type error rather than being silently ignored - see issue #5799.
-   */
-  private static Number requireNumericOrNull(final Object value) {
-    if (value == null || value instanceof Number)
-      return (Number) value;
-    throw new IllegalArgumentException(
-        NAME + "() requires numeric input, but received a value of type " + value.getClass().getSimpleName());
-  }
-
   public String getSyntax() {
     return "sum(<field> [,<field>*])";
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionVariance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionVariance.java
@@ -92,8 +92,10 @@ public class SQLFunctionVariance extends SQLAggregatedFunction {
       addValue(number);
     } else if (MultiValue.isMultiValue(params[0])) {
       for (final Object n : MultiValue.getMultiValueIterable(params[0]))
-        addValue((Number) n);
-    }
+        addValue(requireNumericOrNull(n));
+    } else
+      // A NON-NUMERIC, NON-NULL, NON-LIST VALUE IS A CLIENT-FACING TYPE ERROR, NOT A ClassCastException (#6390).
+      addValue(requireNumericOrNull(params[0]));
     return null;
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionVariance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionVariance.java
@@ -88,14 +88,7 @@ public class SQLFunctionVariance extends SQLAggregatedFunction {
   @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
-    if (params[0] instanceof Number number) {
-      addValue(number);
-    } else if (MultiValue.isMultiValue(params[0])) {
-      for (final Object n : MultiValue.getMultiValueIterable(params[0]))
-        addValue(requireNumericOrNull(n));
-    } else
-      // A NON-NUMERIC, NON-NULL, NON-LIST VALUE IS A CLIENT-FACING TYPE ERROR, NOT A ClassCastException (#6390).
-      addValue(requireNumericOrNull(params[0]));
+    accumulateNumeric(params[0], this::addValue);
     return null;
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionBoolAnd.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionBoolAnd.java
@@ -44,16 +44,20 @@ public class SQLFunctionBoolAnd extends SQLAggregatedFunction {
         and(boolean1);
       else if (MultiValue.isMultiValue(params[0]))
         for (final Object n : MultiValue.getMultiValueIterable(params[0])) {
-          and((Boolean) n);
+          and(requireBooleanOrNull(n));
           if (and != null && !and) break; // AND SHORT-CIRCUITS ON FALSE
         }
+      else
+        // A NON-BOOLEAN, NON-NULL, NON-LIST VALUE USED TO FALL THROUGH HERE UNTOUCHED AND RETURN THE ACCUMULATOR,
+        // SO bool_and(5) ANSWERED A CONFIDENT `true` FOR AN INPUT IT NEVER LOOKED AT (ISSUE #6389).
+        and(requireBooleanOrNull(params[0]));
       return and;
     }
 
     // PER-ROW MULTI-ARG: AND THE ARGUMENTS INTO A LOCAL VARIABLE WITHOUT TOUCHING THE CROSS-ROW ACCUMULATOR.
     Boolean rowAnd = null;
     for (int i = 0; i < params.length; ++i) {
-      final Boolean value = (Boolean) params[i];
+      final Boolean value = requireBooleanOrNull(params[i]);
       if (value != null) {
         rowAnd = rowAnd == null ? value : rowAnd && value;
         if (!rowAnd) break; // AND SHORT-CIRCUITS ON FALSE

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionBoolOr.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionBoolOr.java
@@ -44,16 +44,20 @@ public class SQLFunctionBoolOr extends SQLAggregatedFunction {
         or(boolean1);
       else if (MultiValue.isMultiValue(params[0]))
         for (final Object n : MultiValue.getMultiValueIterable(params[0])) {
-          or((Boolean) n);
+          or(requireBooleanOrNull(n));
           if (or != null && or) break; // OR SHORT-CIRCUITS ON TRUE
         }
+      else
+        // A NON-BOOLEAN, NON-NULL, NON-LIST VALUE USED TO FALL THROUGH HERE UNTOUCHED AND RETURN THE ACCUMULATOR,
+        // SO bool_or(5) ANSWERED FOR AN INPUT IT NEVER LOOKED AT (ISSUE #6389).
+        or(requireBooleanOrNull(params[0]));
       return or;
     }
 
     // PER-ROW MULTI-ARG: OR THE ARGUMENTS INTO A LOCAL VARIABLE WITHOUT TOUCHING THE CROSS-ROW ACCUMULATOR.
     Boolean rowOr = null;
     for (int i = 0; i < params.length; ++i) {
-      final Boolean value = (Boolean) params[i];
+      final Boolean value = requireBooleanOrNull(params[i]);
       if (value != null) {
         rowOr = rowOr == null ? value : rowOr || value;
         if (rowOr) break; // OR SHORT-CIRCUITS ON TRUE

--- a/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionDecode.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/misc/SQLFunctionDecode.java
@@ -55,16 +55,26 @@ public class SQLFunctionDecode extends SQLFunctionAbstract {
   public Object execute( final Object self, final Identifiable currentRecord, final Object currentResult,
       final Object[] params, final CommandContext context) {
 
+    // A null value decodes to null, mirroring encode() which returns null for anything it cannot turn into bytes.
+    if (params[0] == null || params[1] == null)
+      return null;
+
     final String candidate = params[0].toString();
     final String format = params[1].toString();
 
-    if (SQLFunctionEncode.FORMAT_BASE64.equalsIgnoreCase(format)) {
-      return Base64.getDecoder().decode(candidate);
-    } else if (SQLFunctionEncode.FORMAT_BASE64URL.equalsIgnoreCase(format)) {
-      final int padding = candidate.length() % 4 == 2 ? 2 : (candidate.length() % 4 == 3 ? 1 : 0);
-      return Base64.getDecoder().decode(candidate.replace('-','+').replace('_','/') + "=".repeat(padding));
-    } else {
-      throw new CommandSQLParsingException("Unknown format :" + format);
+    try {
+      if (SQLFunctionEncode.FORMAT_BASE64.equalsIgnoreCase(format)) {
+        return Base64.getDecoder().decode(candidate);
+      } else if (SQLFunctionEncode.FORMAT_BASE64URL.equalsIgnoreCase(format)) {
+        final int padding = candidate.length() % 4 == 2 ? 2 : (candidate.length() % 4 == 3 ? 1 : 0);
+        return Base64.getDecoder().decode(candidate.replace('-', '+').replace('_', '/') + "=".repeat(padding));
+      } else {
+        throw new CommandSQLParsingException("Unknown format :" + format);
+      }
+    } catch (final IllegalArgumentException e) {
+      // The JDK decoder rejects malformed input with a bare IllegalArgumentException whose message names an offset
+      // and nothing else; say which function and which format refused it (issue #6389).
+      throw new IllegalArgumentException(NAME + "() cannot decode the value as " + format + ": " + e.getMessage(), e);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionFormat.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionFormat.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.sql.text;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
+import com.arcadedb.utility.StringUtils;
 
 /**
  * Formats content.
@@ -41,11 +42,16 @@ public class SQLFunctionFormat extends SQLFunctionAbstract {
 
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
+    if (params[0] == null)
+      return null;
+
     final Object[] args = new Object[params.length - 1];
 
     System.arraycopy(params, 1, args, 0, args.length);
 
-    return String.format((String) params[0], args);
+    // A pattern that does not match its arguments is a mistake in the query, so it answers a typed error rather than
+    // the raw java.util.Formatter exception it used to leak (issue #6389).
+    return StringUtils.format(NAME, params[0].toString(), args);
   }
 
   public String getSyntax() {

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionCorrelate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionCorrelate.java
@@ -58,8 +58,8 @@ public class SQLFunctionCorrelate extends SQLAggregatedFunction {
     if (params[0] == null || params[1] == null)
       return null;
 
-    final double a = ((Number) params[0]).doubleValue();
-    final double b = ((Number) params[1]).doubleValue();
+    final double a = requireNumericOrNull(params[0]).doubleValue();
+    final double b = requireNumericOrNull(params[1]).doubleValue();
 
     n++;
     final double dA = a - meanA;

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDate.java
@@ -24,6 +24,7 @@ import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.utility.DateUtils;
 
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -88,18 +89,44 @@ public class SQLFunctionDate extends SQLFunctionAbstract {
           }
         }
 
-        final DateTimeFormatter formatter = DateUtils.getFormatter(format)
-            .withZone(timezone != null ? ZoneId.of(timezone) : context.getDatabase().getSchema().getZoneId());
+        final DateTimeFormatter formatter = formatterFor(format, timezone, context);
 
         date = LocalDateTime.parse(dateAsString, formatter);
-      } catch (DateTimeParseException e) {
-        // DATE FORMAT NOT CORRECT
+      } catch (final DateTimeParseException e) {
+        // THE VALUE DOES NOT MATCH THE FORMAT: NOT AN ERROR, THE DOCUMENTED ANSWER IS NULL. THE ARGUMENTS THEMSELVES
+        // BEING WRONG IS A DIFFERENT STORY AND IS RAISED BY formatterFor() BELOW.
         return null;
       }
     } else
       return null;
 
     return DateUtils.getDate(date, context.getDatabase().getSerializer().getDateTimeImplementation());
+  }
+
+  /**
+   * Builds the formatter for the requested pattern and zone. A malformed pattern ({@code IllegalArgumentException}
+   * out of {@code appendPattern}) and an unknown zone id ({@code ZoneRulesException}, a {@link DateTimeException} but
+   * NOT a {@link DateTimeParseException}) both escaped the caller's catch and surfaced as raw JDK exceptions - an
+   * HTTP 500 for what is a mistake in the call (issue #6388). They are raised here as a typed client error instead,
+   * deliberately NOT folded into the {@code return null} above: a value that does not match its format is an
+   * ordinary miss, a format that cannot exist is a query to fix.
+   */
+  private static DateTimeFormatter formatterFor(final String format, final String timezone, final CommandContext context) {
+    final DateTimeFormatter formatter;
+    try {
+      formatter = DateUtils.getFormatter(format);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException(NAME + "() received an invalid date format '" + format + "': " + e.getMessage(), e);
+    }
+
+    if (timezone == null)
+      return formatter.withZone(context.getDatabase().getSchema().getZoneId());
+
+    try {
+      return formatter.withZone(ZoneId.of(timezone));
+    } catch (final DateTimeException e) {
+      throw new IllegalArgumentException(NAME + "() received an unknown time zone id '" + timezone + "'", e);
+    }
   }
 
   public String getSyntax() {

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDelta.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDelta.java
@@ -55,7 +55,7 @@ public class SQLFunctionDelta extends SQLAggregatedFunction {
     if (params[0] == null || params[1] == null)
       return null;
 
-    final double value = ((Number) params[0]).doubleValue();
+    final double value = requireNumericOrNull(params[0]).doubleValue();
     final long ts = SQLFunctionRate.toEpochMillis(params[1]);
     count++;
 

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDuration.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDuration.java
@@ -24,6 +24,7 @@ import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.utility.DateUtils;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Returns a java.time.Duration.
@@ -46,16 +47,38 @@ public class SQLFunctionDuration extends SQLFunctionAbstract {
     if (params.length != 2)
       throw new IllegalArgumentException("duration() function expected 2 parameters: amount and time-unit");
 
-    long amount = getAmount(params[0]);
+    if (params[0] == null || params[1] == null)
+      return null;
 
-    return Duration.of(amount, DateUtils.parsePrecision(params[1].toString()));
+    final long amount = getAmount(params[0]);
+    final String unitName = params[1].toString();
+    final ChronoUnit unit = DateUtils.parsePrecision(unitName);
+
+    // A java.time.Duration is an exact amount of time, so it accepts only units with an exact length. Weeks have one
+    // (7 days) and are converted; years and months do not - their length depends on which year or month - and used to
+    // reach Duration.of() as an unsupported estimated unit, which threw UnsupportedTemporalTypeException (issue #6388).
+    if (unit == ChronoUnit.WEEKS)
+      return Duration.ofDays(Math.multiplyExact(amount, 7));
+
+    // DAYS is the one estimated unit Duration.of() accepts (as exactly 24 hours); every other one - YEARS, MONTHS -
+    // it rejects, which is precisely the set to refuse here with an explanation rather than let through.
+    if (unit.isDurationEstimated() && unit != ChronoUnit.DAYS)
+      throw new IllegalArgumentException(
+          NAME + "() cannot build a duration of '" + unitName + "': a duration is an exact amount of time and a "
+              + unitName + " has no fixed length. Use days, hours, minutes, seconds or smaller");
+
+    return Duration.of(amount, unit);
   }
 
-  private static long getAmount(Object param) {
+  private static long getAmount(final Object param) {
     if (param instanceof Number number)
       return number.longValue();
     else if (param instanceof String string)
-      return Long.parseLong(string);
+      try {
+        return Long.parseLong(string.trim());
+      } catch (final NumberFormatException e) {
+        throw new IllegalArgumentException(NAME + "() received an amount '" + string + "' that is not a number", e);
+      }
     else
       throw new IllegalArgumentException("amount '" + param + "' not a number or a string");
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDuration.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDuration.java
@@ -58,7 +58,14 @@ public class SQLFunctionDuration extends SQLFunctionAbstract {
     // (7 days) and are converted; years and months do not - their length depends on which year or month - and used to
     // reach Duration.of() as an unsupported estimated unit, which threw UnsupportedTemporalTypeException (issue #6388).
     if (unit == ChronoUnit.WEEKS)
-      return Duration.ofDays(Math.multiplyExact(amount, 7));
+      try {
+        return Duration.ofDays(Math.multiplyExact(amount, 7));
+      } catch (final ArithmeticException e) {
+        // The conversion is the only place an amount can overflow, and a bare ArithmeticException here would be the
+        // one error path in this family still answering 500 for a mistake in the call.
+        throw new IllegalArgumentException(
+            NAME + "() cannot build a duration of " + amount + " weeks: the amount overflows the range of a duration", e);
+      }
 
     // DAYS is the one estimated unit Duration.of() accepts (as exactly 24 hours); every other one - YEARS, MONTHS -
     // it rejects, which is precisely the set to refuse here with an explanation rather than let through.

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDuration.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionDuration.java
@@ -57,7 +57,7 @@ public class SQLFunctionDuration extends SQLFunctionAbstract {
     // A java.time.Duration is an exact amount of time, so it accepts only units with an exact length. Weeks have one
     // (7 days) and are converted; years and months do not - their length depends on which year or month - and used to
     // reach Duration.of() as an unsupported estimated unit, which threw UnsupportedTemporalTypeException (issue #6388).
-    if (unit == ChronoUnit.WEEKS)
+    if (unit == ChronoUnit.WEEKS) {
       try {
         return Duration.ofDays(Math.multiplyExact(amount, 7));
       } catch (final ArithmeticException e) {
@@ -66,6 +66,7 @@ public class SQLFunctionDuration extends SQLFunctionAbstract {
         throw new IllegalArgumentException(
             NAME + "() cannot build a duration of " + amount + " weeks: the amount overflows the range of a duration", e);
       }
+    }
 
     // DAYS is the one estimated unit Duration.of() accepts (as exactly 24 hours); every other one - YEARS, MONTHS -
     // it rejects, which is precisely the set to refuse here with an explanation rather than let through.
@@ -80,13 +81,13 @@ public class SQLFunctionDuration extends SQLFunctionAbstract {
   private static long getAmount(final Object param) {
     if (param instanceof Number number)
       return number.longValue();
-    else if (param instanceof String string)
+    else if (param instanceof String string) {
       try {
         return Long.parseLong(string.trim());
       } catch (final NumberFormatException e) {
         throw new IllegalArgumentException(NAME + "() received an amount '" + string + "' that is not a number", e);
       }
-    else
+    } else
       throw new IllegalArgumentException("amount '" + param + "' not a number or a string");
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionInterpolate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionInterpolate.java
@@ -144,8 +144,8 @@ public class SQLFunctionInterpolate extends SQLAggregatedFunction {
       }
 
       // Interpolate all nulls between prevIdx and nextIdx
-      final double prevVal = ((Number) result.get(prevIdx)).doubleValue();
-      final double nextVal = ((Number) values.get(nextIdx)).doubleValue();
+      final double prevVal = requireNumericOrNull(result.get(prevIdx)).doubleValue();
+      final double nextVal = requireNumericOrNull(values.get(nextIdx)).doubleValue();
       final long prevTs = timestamps.get(prevIdx);
       final long nextTs = timestamps.get(nextIdx);
       final long tsDelta = nextTs - prevTs;

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLag.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLag.java
@@ -65,7 +65,7 @@ public class SQLFunctionLag extends SQLAggregatedFunction {
       final CommandContext context) {
     if (!paramsRead) {
       if (params.length >= 2 && params[1] != null) {
-        offset = requireNumeric(params[1], "offset").intValue();
+        offset = requireIntArgument(params[1], "offset");
         // A negative offset would read past the other end of the ordered rows and throw
         // IndexOutOfBoundsException; it is a client-facing argument error (issue #6388).
         if (offset < 0)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLag.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLag.java
@@ -39,6 +39,8 @@ import java.util.List;
 public class SQLFunctionLag extends SQLAggregatedFunction {
   public static final String NAME = "ts.lag";
 
+  private static final String OPPOSITE = "ts.lead";
+
   private final List<Object[]> pairs = new ArrayList<>();
   private int    offset       = 1;
   private Object defaultValue = null;
@@ -62,8 +64,15 @@ public class SQLFunctionLag extends SQLAggregatedFunction {
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (!paramsRead) {
-      if (params.length >= 2)
-        offset = ((Number) params[1]).intValue();
+      if (params.length >= 2 && params[1] != null) {
+        offset = requireNumeric(params[1], "offset").intValue();
+        // A negative offset would read past the other end of the ordered rows and throw
+        // IndexOutOfBoundsException; it is a client-facing argument error (issue #6388).
+        if (offset < 0)
+          throw new IllegalArgumentException(
+              NAME + "() requires a non-negative <offset>, but received " + offset + ". Use " + OPPOSITE
+                  + "() to look the other way");
+      }
       if (params.length >= 4)
         defaultValue = params[3];
       paramsRead = true;
@@ -85,7 +94,14 @@ public class SQLFunctionLag extends SQLAggregatedFunction {
     if (pairs.isEmpty())
       return new ArrayList<>();
 
-    pairs.sort(Comparator.comparing(p -> ((Comparable) p[1])));
+    // The timestamp is optional (getMinArgs() == 1), so rows without one must not NPE the comparator: the sort is
+    // stable, so they keep their arrival order at the end, which is the only order they have (issue #6388).
+    try {
+      pairs.sort(Comparator.comparing(p -> (Comparable) p[1], Comparator.nullsLast(Comparator.naturalOrder())));
+    } catch (final ClassCastException e) {
+      throw new IllegalArgumentException(
+          NAME + "() cannot order the rows: the <timestamp> values are not mutually comparable", e);
+    }
 
     final List<Object> result = new ArrayList<>(pairs.size());
     for (int i = 0; i < pairs.size(); i++)

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLead.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLead.java
@@ -65,7 +65,7 @@ public class SQLFunctionLead extends SQLAggregatedFunction {
       final CommandContext context) {
     if (!paramsRead) {
       if (params.length >= 2 && params[1] != null) {
-        offset = requireNumeric(params[1], "offset").intValue();
+        offset = requireIntArgument(params[1], "offset");
         // A negative offset would read past the other end of the ordered rows and throw
         // IndexOutOfBoundsException; it is a client-facing argument error (issue #6388).
         if (offset < 0)
@@ -105,8 +105,13 @@ public class SQLFunctionLead extends SQLAggregatedFunction {
 
     final int size = pairs.size();
     final List<Object> result = new ArrayList<>(size);
-    for (int i = 0; i < size; i++)
-      result.add(i + offset < size ? pairs.get(i + offset)[0] : defaultValue);
+    for (int i = 0; i < size; i++) {
+      // Widened: `i + offset` as an int wraps NEGATIVE for a large offset, which reads as "in range" and then indexes
+      // the list with the wrapped value. The lag() twin cannot hit this - `i - offset` only ever goes further out of
+      // range - so the guard belongs here alone.
+      final long target = (long) i + offset;
+      result.add(target < size ? pairs.get((int) target)[0] : defaultValue);
+    }
 
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLead.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionLead.java
@@ -39,6 +39,8 @@ import java.util.List;
 public class SQLFunctionLead extends SQLAggregatedFunction {
   public static final String NAME = "ts.lead";
 
+  private static final String OPPOSITE = "ts.lag";
+
   private final List<Object[]> pairs = new ArrayList<>();
   private int    offset       = 1;
   private Object defaultValue = null;
@@ -62,8 +64,15 @@ public class SQLFunctionLead extends SQLAggregatedFunction {
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
     if (!paramsRead) {
-      if (params.length >= 2)
-        offset = ((Number) params[1]).intValue();
+      if (params.length >= 2 && params[1] != null) {
+        offset = requireNumeric(params[1], "offset").intValue();
+        // A negative offset would read past the other end of the ordered rows and throw
+        // IndexOutOfBoundsException; it is a client-facing argument error (issue #6388).
+        if (offset < 0)
+          throw new IllegalArgumentException(
+              NAME + "() requires a non-negative <offset>, but received " + offset + ". Use " + OPPOSITE
+                  + "() to look the other way");
+      }
       if (params.length >= 4)
         defaultValue = params[3];
       paramsRead = true;
@@ -85,7 +94,14 @@ public class SQLFunctionLead extends SQLAggregatedFunction {
     if (pairs.isEmpty())
       return new ArrayList<>();
 
-    pairs.sort(Comparator.comparing(p -> ((Comparable) p[1])));
+    // The timestamp is optional (getMinArgs() == 1), so rows without one must not NPE the comparator: the sort is
+    // stable, so they keep their arrival order at the end, which is the only order they have (issue #6388).
+    try {
+      pairs.sort(Comparator.comparing(p -> (Comparable) p[1], Comparator.nullsLast(Comparator.naturalOrder())));
+    } catch (final ClassCastException e) {
+      throw new IllegalArgumentException(
+          NAME + "() cannot order the rows: the <timestamp> values are not mutually comparable", e);
+    }
 
     final int size = pairs.size();
     final List<Object> result = new ArrayList<>(size);

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionMovingAvg.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionMovingAvg.java
@@ -74,7 +74,7 @@ public class SQLFunctionMovingAvg extends SQLAggregatedFunction {
       final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
       return opts.getInt("window", -1);
     }
-    return requireNumeric(arg, "window_size").intValue();
+    return requireIntArgument(arg, "window_size");
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionMovingAvg.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionMovingAvg.java
@@ -61,8 +61,10 @@ public class SQLFunctionMovingAvg extends SQLAggregatedFunction {
     if (windowSize < 0)
       windowSize = parseWindow(params[1]);
 
-    if (params[0] instanceof Number number)
-      values.add(number.doubleValue());
+    // A NON-NUMERIC, NON-NULL VALUE IS A CLIENT-FACING TYPE ERROR, NOT A SILENTLY DROPPED SAMPLE (#6390).
+    final Number value = requireNumericOrNull(params[0]);
+    if (value != null)
+      values.add(value.doubleValue());
 
     return null;
   }
@@ -72,7 +74,7 @@ public class SQLFunctionMovingAvg extends SQLAggregatedFunction {
       final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
       return opts.getInt("window", -1);
     }
-    return ((Number) arg).intValue();
+    return requireNumeric(arg, "window_size").intValue();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRank.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRank.java
@@ -68,7 +68,14 @@ public class SQLFunctionRank extends SQLAggregatedFunction {
     if (pairs.isEmpty())
       return new ArrayList<>();
 
-    pairs.sort(Comparator.comparing(p -> ((Comparable) p[1])));
+    // Same shape as ts.lag/ts.lead: the timestamp is optional, so rows without one keep their arrival order rather
+    // than NPE the comparator, and values that cannot be compared with each other are a typed error (#6389, #6390).
+    try {
+      pairs.sort(Comparator.comparing(p -> (Comparable) p[1], Comparator.nullsLast(Comparator.naturalOrder())));
+    } catch (final ClassCastException e) {
+      throw new IllegalArgumentException(
+          NAME + "() cannot order the rows: the <timestamp> values are not mutually comparable", e);
+    }
 
     final List<Integer> result = new ArrayList<>(pairs.size());
     result.add(1);

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionRate.java
@@ -72,7 +72,7 @@ public class SQLFunctionRate extends SQLAggregatedFunction {
       counterResetDetectionSet = true;
     }
 
-    final double value = ((Number) params[0]).doubleValue();
+    final double value = requireNumericOrNull(params[0]).doubleValue();
     final long ts = toEpochMillis(params[1]);
     samples.add(new long[] { ts, Double.doubleToRawLongBits(value) });
     return null;

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionSysdate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionSysdate.java
@@ -23,6 +23,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.utility.DateUtils;
 
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
@@ -47,12 +48,23 @@ public class SQLFunctionSysdate extends SQLFunctionAbstract {
     final LocalDateTime now = LocalDateTime.now();
     Object result = now;
 
-    if (params.length > 0) {
-      if (params.length > 1)
-        result = now.atZone(ZoneId.of(params[1].toString()));
+    // The zone is the FIRST argument - `sysdate([<zoneid>])`. Reading params[1] meant the one-argument form the
+    // syntax documents silently dropped the zone and answered server-local time (issue #6388).
+    if (params.length > 0 && params[0] != null) {
+      final String zoneId = params[0].toString();
+      try {
+        result = now.atZone(ZoneId.of(zoneId));
+      } catch (final DateTimeException e) {
+        throw new IllegalArgumentException(NAME + "() received an unknown time zone id '" + zoneId + "'", e);
+      }
     }
 
     return DateUtils.getDate(result, context.getDatabase().getSerializer().getDateTimeImplementation());
+  }
+
+  @Override
+  public int getMaxArgs() {
+    return 1;
   }
 
   public String getSyntax() {

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTimeBucket.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTimeBucket.java
@@ -50,8 +50,18 @@ public class SQLFunctionTimeBucket extends SQLFunctionConfigurableAbstract {
     if (params.length < 2)
       throw new IllegalArgumentException("time_bucket() requires 2 parameters: interval and timestamp");
 
+    if (params[0] == null || params[1] == null)
+      return null;
+
     final String interval = params[0].toString();
     final long intervalMs = parseInterval(interval);
+
+    // A zero-width (or negative) bucket has no boundary to truncate to: '0s' used to reach the division below and
+    // throw ArithmeticException: / by zero (issue #6388).
+    if (intervalMs <= 0)
+      throw new IllegalArgumentException(
+          "time_bucket() interval '" + interval + "' must be a positive amount of time, but resolves to " + intervalMs
+              + "ms");
 
     final long timestampMs = toEpochMs(params[1]);
 

--- a/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsPercentile.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/time/SQLFunctionTsPercentile.java
@@ -64,13 +64,13 @@ public class SQLFunctionTsPercentile extends SQLAggregatedFunction {
       return null;
 
     if (!percentileSet && params.length > 1 && params[1] != null) {
-      percentile = ((Number) params[1]).doubleValue();
+      percentile = requireNumeric(params[1], "percentile").doubleValue();
       if (percentile < 0.0 || percentile > 1.0)
         throw new IllegalArgumentException("Percentile must be between 0.0 and 1.0, got: " + percentile);
       percentileSet = true;
     }
 
-    values.add(((Number) params[0]).doubleValue());
+    values.add(requireNumericOrNull(params[0]).doubleValue());
     return null;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -795,9 +795,20 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
   /**
    * Parse query text into terms, identifying field-prefixed terms (field:value).
-   * For example, "title:java programming" returns:
+   * For example, on an index over (title, content), "title:java programming" returns:
    * - QueryTerm(fieldName="title", value="java")
    * - QueryTerm(fieldName=null, value="programming")
+   * <p>
+   * A colon only introduces a qualifier when the text before it NAMES AN INDEXED PROPERTY. Everything else is
+   * literal text handed to the analyzer, which is what the {@code CONTAINSTEXT} operator behind this path documents
+   * its argument to be - a value to find, not a query language. Splitting unconditionally turned an ordinary literal
+   * carrying a colon (a time, a timestamp, a {@code ns:name}) into a lookup for a qualified key that the corpus
+   * never stored, so it matched nothing at all (issue #6382).
+   * <p>
+   * On a single-property index the qualifier is dropped even when it does name the property: that index stores
+   * unprefixed tokens only (see {@link #put}), so {@code label:java} means the same as {@code java} there. This
+   * mirrors {@code FullTextQueryExecutor.isUnqualified}, which the Lucene-backed executor already applied and this
+   * path did not.
    *
    * @param queryText The raw query string.
    * @return A list of parsed QueryTerms.
@@ -807,6 +818,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     if (queryText == null || queryText.isEmpty())
       return terms;
 
+    final List<String> propertyNames = getPropertyNames();
+    final boolean multiProperty = propertyNames != null && propertyNames.size() > 1;
+
     // Split by whitespace to get individual terms
     final String[] parts = queryText.split("\\s+");
     for (final String part : parts) {
@@ -815,13 +829,12 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
       // Check for field:value pattern
       final int colonIdx = part.indexOf(':');
-      if (colonIdx > 0 && colonIdx < part.length() - 1) {
-        // Field-prefixed term
-        final String fieldName = part.substring(0, colonIdx);
-        final String value = part.substring(colonIdx + 1);
-        terms.add(new QueryTerm(fieldName, value));
+      if (colonIdx > 0 && colonIdx < part.length() - 1 && propertyNames != null && propertyNames.contains(
+          part.substring(0, colonIdx))) {
+        // Field-prefixed term: qualified only where qualified keys are stored, i.e. on a multi-property index
+        terms.add(new QueryTerm(multiProperty ? part.substring(0, colonIdx) : null, part.substring(colonIdx + 1)));
       } else {
-        // Unqualified term
+        // Literal text: the analyzer decides how it tokenizes
         terms.add(new QueryTerm(null, part));
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -2647,6 +2647,46 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   }
 
   /**
+   * Null-coalescing expression ({@code ??}).
+   * Grammar: expression NULL_COALESCING expression
+   * <p>
+   * Without this visitor ANTLR's default {@code visitChildren} returned the result of the LAST child, which dropped
+   * the left operand from the tree altogether: {@code 'left' ?? 'right'} both rendered and evaluated as
+   * {@code 'right'} (issue #6393). The node is built as a two-operand {@link MathExpression} carrying
+   * {@link MathExpression.Operator#NULL_COALESCING}, whose {@code apply()} already implemented the semantics.
+   * <p>
+   * Unlike the sibling {@code ||} alternative next door, chains are NOT flattened: nesting {@code a ?? b ?? c} as
+   * {@code (a ?? b) ?? c} is what makes the left-to-right short-circuit in {@link MathExpression#execute} possible,
+   * and the operator is left-associative so the nesting matches how it parses.
+   */
+  @Override
+  public Expression visitNullCoalescing(final SQLParser.NullCoalescingContext ctx) {
+    final MathExpression coalesce = new MathExpression();
+    coalesce.childExpressions.add(asMathExpression((Expression) visit(ctx.expression(0))));
+    coalesce.childExpressions.add(asMathExpression((Expression) visit(ctx.expression(1))));
+    coalesce.operators.add(MathExpression.Operator.NULL_COALESCING);
+
+    final Expression result = new Expression();
+    result.mathExpression = coalesce;
+    return result;
+  }
+
+  /**
+   * Adapts an {@link Expression} to the {@link MathExpression} an operator node takes as a child. An expression that
+   * already IS a math expression is used as-is; anything the grammar parks outside that hierarchy (NULL, TRUE/FALSE,
+   * a RID, a JSON literal, an array concatenation, a parenthesised WHERE block) is wrapped in the
+   * {@link BaseExpression#expression} slot, which both {@code execute()} and {@code toString()} already delegate to.
+   */
+  private static MathExpression asMathExpression(final Expression expr) {
+    if (expr.mathExpression != null)
+      return expr.mathExpression;
+
+    final BaseExpression wrapper = new BaseExpression();
+    wrapper.expression = expr;
+    return wrapper;
+  }
+
+  /**
    * Helper method to copy fields from Expression to ArrayConcatExpressionElement.
    */
   private void copyExpressionFields(final Expression from, final ArrayConcatExpressionElement to) {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
@@ -20,6 +20,9 @@ package com.arcadedb.query.sql.method;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.SQLMethod;
+import com.arcadedb.utility.NumberUtils;
+
+import java.math.BigDecimal;
 
 /**
  * @author Johann Sorel (Geomatys)
@@ -95,6 +98,46 @@ public abstract class AbstractSQLMethod implements SQLMethod {
     sb.append(')');
 
     return sb.toString();
+  }
+
+  /**
+   * Reads a character-index argument (a from/to position, a length, a character count) as an int.
+   * <p>
+   * {@code Integer.parseInt(param.toString())} - what every one of these methods used to do - rejects a decimal
+   * literal, so the perfectly ordinary {@code "abcdef".substring(2.5)} answered a NumberFormatException (HTTP 500)
+   * instead of an index, and the #5885 clamps could never run because the parse threw first (issue #6389). A number
+   * is truncated toward zero and saturated into the int range; a string is parsed the same way; anything else is a
+   * typed argument error.
+   *
+   * @param param        the argument value
+   * @param argumentName the argument's name, for the error message
+   *
+   * @return the argument as an int
+   *
+   * @throws IllegalArgumentException if the value cannot be read as a number
+   */
+  protected int indexArgument(final Object param, final String argumentName) {
+    if (param instanceof Number number)
+      return NumberUtils.saturateToInt(number);
+
+    if (param instanceof CharSequence) {
+      final String text = param.toString().trim();
+      try {
+        return Integer.parseInt(text);
+      } catch (final NumberFormatException ignoreAndTryDecimal) {
+        try {
+          return NumberUtils.saturateToInt(new BigDecimal(text));
+        } catch (final NumberFormatException e) {
+          throw new IllegalArgumentException(
+              getName() + "() requires a numeric <" + argumentName + ">, but received '" + text + "'", e);
+        }
+      }
+    }
+
+    throw new IllegalArgumentException(
+        getName() + "() requires a numeric <" + argumentName + ">, but received " + (param == null ?
+            "null" :
+            "a value of type " + param.getClass().getSimpleName()));
   }
 
   protected Object getParameterValue(final Identifiable iRecord, final String iValue) {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
@@ -28,6 +28,14 @@ import java.math.BigDecimal;
  * @author Johann Sorel (Geomatys)
  */
 public abstract class AbstractSQLMethod implements SQLMethod {
+  /**
+   * Longest numeric literal {@link #indexArgument} will parse as a character index. An int is at most ten digits and
+   * a sign, and the decimal fallback allows a fractional part, so this is generous by a wide margin - it exists only
+   * so a pathological literal out of the query text cannot make BigDecimal parse megabytes to reach a number that
+   * saturates to the same bound either way (issue #6389).
+   */
+  private static final int MAX_INDEX_ARGUMENT_DIGITS = 64;
+
   private final String name;
   private final int    minParams;
   private final int    maxParams;
@@ -125,6 +133,15 @@ public abstract class AbstractSQLMethod implements SQLMethod {
       try {
         return Integer.parseInt(text);
       } catch (final NumberFormatException ignoreAndTryDecimal) {
+        // The decimal fallback is what makes `substring(2.5)` work, but BigDecimal parses whatever length it is
+        // handed, and the cost of parsing then comparing grows with it. A character index is at most ten digits and
+        // a sign, so a literal orders of magnitude longer than that is not a number anyone is indexing a string
+        // with - refuse it by length rather than allocate a BigDecimal to find out.
+        if (text.length() > MAX_INDEX_ARGUMENT_DIGITS)
+          throw new IllegalArgumentException(
+              getName() + "() requires a numeric <" + argumentName + ">, but received a " + text.length()
+                  + "-character literal, over the " + MAX_INDEX_ARGUMENT_DIGITS + " limit");
+
         try {
           return NumberUtils.saturateToInt(new BigDecimal(text));
         } catch (final NumberFormatException e) {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/AbstractSQLMethod.java
@@ -22,20 +22,10 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.SQLMethod;
 import com.arcadedb.utility.NumberUtils;
 
-import java.math.BigDecimal;
-
 /**
  * @author Johann Sorel (Geomatys)
  */
 public abstract class AbstractSQLMethod implements SQLMethod {
-  /**
-   * Longest numeric literal {@link #indexArgument} will parse as a character index. An int is at most ten digits and
-   * a sign, and the decimal fallback allows a fractional part, so this is generous by a wide margin - it exists only
-   * so a pathological literal out of the query text cannot make BigDecimal parse megabytes to reach a number that
-   * saturates to the same bound either way (issue #6389).
-   */
-  private static final int MAX_INDEX_ARGUMENT_DIGITS = 64;
-
   private final String name;
   private final int    minParams;
   private final int    maxParams;
@@ -125,36 +115,13 @@ public abstract class AbstractSQLMethod implements SQLMethod {
    * @throws IllegalArgumentException if the value cannot be read as a number
    */
   protected int indexArgument(final Object param, final String argumentName) {
-    if (param instanceof Number number)
-      return NumberUtils.saturateToInt(number);
-
-    if (param instanceof CharSequence) {
-      final String text = param.toString().trim();
-      try {
-        return Integer.parseInt(text);
-      } catch (final NumberFormatException ignoreAndTryDecimal) {
-        // The decimal fallback is what makes `substring(2.5)` work, but BigDecimal parses whatever length it is
-        // handed, and the cost of parsing then comparing grows with it. A character index is at most ten digits and
-        // a sign, so a literal orders of magnitude longer than that is not a number anyone is indexing a string
-        // with - refuse it by length rather than allocate a BigDecimal to find out.
-        if (text.length() > MAX_INDEX_ARGUMENT_DIGITS)
-          throw new IllegalArgumentException(
-              getName() + "() requires a numeric <" + argumentName + ">, but received a " + text.length()
-                  + "-character literal, over the " + MAX_INDEX_ARGUMENT_DIGITS + " limit");
-
-        try {
-          return NumberUtils.saturateToInt(new BigDecimal(text));
-        } catch (final NumberFormatException e) {
-          throw new IllegalArgumentException(
-              getName() + "() requires a numeric <" + argumentName + ">, but received '" + text + "'", e);
-        }
-      }
-    }
+    final Integer index = NumberUtils.saturateToIntOrNull(param);
+    if (index != null)
+      return index;
 
     throw new IllegalArgumentException(
-        getName() + "() requires a numeric <" + argumentName + ">, but received " + (param == null ?
-            "null" :
-            "a value of type " + param.getClass().getSimpleName()));
+        getName() + "() requires a numeric <" + argumentName + ">, but received " + NumberUtils.describeRejectedNumber(
+            param));
   }
 
   protected Object getParameterValue(final Identifiable iRecord, final String iValue) {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodJoin.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodJoin.java
@@ -55,8 +55,9 @@ public class SQLMethodJoin extends AbstractSQLMethod {
           .map(p -> p[0].toString())
           .orElse(",");
 
+      // String::valueOf, not Object::toString: a null element in the list is rendered, not an NPE (issue #6389).
       return list.stream()
-          .map(Object::toString)
+          .map(String::valueOf)
           .collect(Collectors.joining(separator));
 
     } else

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsMap.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsMap.java
@@ -67,7 +67,9 @@ public class SQLMethodAsMap extends AbstractSQLMethod {
     while (iter.hasNext()) {
       final Object key = iter.next();
       if (iter.hasNext())
-        map.put((String) key, iter.next());
+        // A map key is a STRING: converting a non-string key is what asMap() means by "transform into a Map".
+        // The raw cast threw ClassCastException on the perfectly ordinary [1,2,3,4].asMap() (issue #6389).
+        map.put(key == null ? null : key.toString(), iter.next());
     }
 
     return map;

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodConvert.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodConvert.java
@@ -19,11 +19,13 @@
 package com.arcadedb.query.sql.method.conversion;
 
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 import com.arcadedb.schema.Type;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.logging.Level;
 
@@ -60,10 +62,18 @@ public class SQLMethodConvert extends AbstractSQLMethod {
         LogManager.instance().log(this, Level.SEVERE, "Type for destination type was not found", e);
       }
     } else {
-      final Type arcadeType = Type.valueOf(destType.toUpperCase(Locale.ENGLISH));
-      if (arcadeType != null) {
-        return Type.convert(context.getDatabase(), value, arcadeType.getDefaultJavaType());
+      // Type is an enum: valueOf() throws IllegalArgumentException for an unknown name and NEVER returns null, so the
+      // guard that used to stand here was dead code and an unknown type name escaped as a raw JDK exception. Answer
+      // with a typed parsing error that names the valid types instead (issue #6389).
+      final Type arcadeType;
+      try {
+        arcadeType = Type.valueOf(destType.toUpperCase(Locale.ENGLISH));
+      } catch (final IllegalArgumentException e) {
+        throw new CommandSQLParsingException(
+            "Unknown type '" + destType + "' in convert(): expected one of " + Arrays.toString(Type.values())
+                + " or a fully qualified Java class name");
       }
+      return Type.convert(context.getDatabase(), value, arcadeType.getDefaultJavaType());
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodConvert.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodConvert.java
@@ -71,7 +71,7 @@ public class SQLMethodConvert extends AbstractSQLMethod {
       } catch (final IllegalArgumentException e) {
         throw new CommandSQLParsingException(
             "Unknown type '" + destType + "' in convert(): expected one of " + Arrays.toString(Type.values())
-                + " or a fully qualified Java class name");
+                + " or a fully qualified Java class name", e);
       }
       return Type.convert(context.getDatabase(), value, arcadeType.getDefaultJavaType());
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCharAt.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCharAt.java
@@ -47,7 +47,7 @@ public class SQLMethodCharAt extends AbstractSQLMethod {
       return null;
     }
 
-    final int index = Integer.parseInt(params[0].toString());
+    final int index = indexArgument(params[0], "position");
     final String valueAsString = value.toString();
     // Out of range (including negative) has no character to return: null rather than letting
     // charAt() throw StringIndexOutOfBoundsException (#5885).

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodFormat.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodFormat.java
@@ -23,6 +23,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 import com.arcadedb.utility.DateUtils;
+import com.arcadedb.utility.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -43,14 +44,14 @@ public class SQLMethodFormat extends AbstractSQLMethod {
   @Override
   public Object execute(final Object value, final Identifiable iRecord, final CommandContext context, final Object[] params) {
 
-    // TRY TO RESOLVE AS DYNAMIC VALUE
-    String format = (String) getParameterValue(iRecord, params[0].toString());
-    if (format == null)
-      // USE STATIC ONE
-      format = params[0].toString();
+    if (params[0] == null)
+      return null;
 
-    if (format == null)
-      throw new IllegalArgumentException("Format was null");
+    // TRY TO RESOLVE AS DYNAMIC VALUE. The resolved field may hold anything, so it is rendered rather than cast:
+    // a non-STRING field used to answer a ClassCastException here (issue #6389).
+    final Object resolved = getParameterValue(iRecord, params[0].toString());
+    // USE STATIC ONE WHEN THE FIELD DOES NOT RESOLVE
+    final String format = resolved != null ? resolved.toString() : params[0].toString();
 
     if (isCollectionOfDates(value)) {
       final List<String> result = new ArrayList<String>();
@@ -64,7 +65,7 @@ public class SQLMethodFormat extends AbstractSQLMethod {
     } else if (DateUtils.isDate(value)) {
       return DateUtils.format(value, format, params.length > 1 ? (String) params[1] : null);
     }
-    return value != null ? format.formatted(value) : null;
+    return value != null ? StringUtils.format(NAME, format, value) : null;
   }
 
   private boolean isCollectionOfDates(final Object value) {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodIndexOf.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodIndexOf.java
@@ -37,9 +37,12 @@ public class SQLMethodIndexOf extends AbstractSQLMethod {
 
   @Override
   public Object execute( final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
-    final String toFind = FileUtils.getStringContent(params[0].toString());
-    final int startIndex = params.length > 1 ? Integer.parseInt(params[1].toString()) : 0;
+    if (value == null || params[0] == null)
+      return null;
 
-    return value != null ? value.toString().indexOf(toFind, startIndex) : null;
+    final String toFind = FileUtils.getStringContent(params[0].toString());
+    final int startIndex = params.length > 1 ? indexArgument(params[1], "from-index") : 0;
+
+    return value.toString().indexOf(toFind, startIndex);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodLastIndexOf.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodLastIndexOf.java
@@ -36,7 +36,13 @@ public class SQLMethodLastIndexOf extends AbstractSQLMethod {
 
   @Override
   public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context, final Object[] params) {
+    // Same guards as the sibling indexOf(), which had them and this one did not (issue #6389).
+    if (value == null || params[0] == null)
+      return null;
+
     final String toFind = FileUtils.getStringContent(params[0].toString());
-    return params.length > 1 ? value.toString().lastIndexOf(toFind, Integer.parseInt(params[1].toString())) : value.toString().lastIndexOf(toFind);
+    return params.length > 1 ?
+        value.toString().lastIndexOf(toFind, indexArgument(params[1], "from-index")) :
+        value.toString().lastIndexOf(toFind);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodLeft.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodLeft.java
@@ -50,7 +50,7 @@ public class SQLMethodLeft extends AbstractSQLMethod {
 
     // A negative length has no characters to return, same as MySQL's LEFT(): clamp rather than let
     // substring() throw StringIndexOutOfBoundsException (#5885).
-    final int len = Math.max(0, Integer.parseInt(params[0].toString()));
+    final int len = Math.max(0, indexArgument(params[0], "characters"));
     return valueAsString.substring(0, len <= valueAsString.length() ? len : valueAsString.length());
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodRight.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodRight.java
@@ -52,7 +52,7 @@ public class SQLMethodRight extends AbstractSQLMethod {
 
     // A negative offset has no characters to return, same as MySQL's RIGHT(): clamp rather than let
     // substring() throw StringIndexOutOfBoundsException (#5885).
-    final int offset = Math.max(0, Integer.parseInt(params[0].toString()));
+    final int offset = Math.max(0, indexArgument(params[0], "characters"));
     return valueAsString.substring(offset < valueAsString.length() ? valueAsString.length() - offset : 0);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodSubString.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodSubString.java
@@ -48,8 +48,8 @@ public class SQLMethodSubString extends AbstractSQLMethod {
     }
 
     if (params.length > 1) {
-      int from = Integer.parseInt(params[0].toString());
-      int to = Integer.parseInt(params[1].toString());
+      int from = indexArgument(params[0], "from-index");
+      int to = indexArgument(params[1], "to-index");
       final String thisString = value.toString();
       if (from < 0) {
         from = 0;
@@ -66,7 +66,7 @@ public class SQLMethodSubString extends AbstractSQLMethod {
 
       return thisString.substring(from, to);
     } else {
-      int from = Integer.parseInt(params[0].toString());
+      int from = indexArgument(params[0], "from-index");
       final String thisString = value.toString();
       if (from < 0) {
         from = 0;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -787,6 +787,10 @@ public class MathExpression extends SimpleNode {
     if (childExpressions.size() == 2) {
       // Extract scalar values from ResultSets for arithmetic operations (issue #1723)
       final Object leftValue = extractScalarFromResultSet(childExpressions.getFirst().execute(currentRecord, context));
+      // `??` is the one operator whose result can be decided by the left operand alone, so the right one - which may
+      // be a function call or a sub-query - is not evaluated when the fallback is not taken (issue #6393).
+      if (operators.getFirst() == Operator.NULL_COALESCING && leftValue != null)
+        return leftValue;
       final Object rightValue = extractScalarFromResultSet(childExpressions.get(1).execute(currentRecord, context));
       return operators.getFirst().apply(leftValue, rightValue);
     }
@@ -804,6 +808,10 @@ public class MathExpression extends SimpleNode {
     if (childExpressions.size() == 2) {
       // Extract scalar values from ResultSets for arithmetic operations (issue #1723)
       final Object leftValue = extractScalarFromResultSet(childExpressions.getFirst().execute(currentRecord, context));
+      // `??` is the one operator whose result can be decided by the left operand alone, so the right one - which may
+      // be a function call or a sub-query - is not evaluated when the fallback is not taken (issue #6393).
+      if (operators.getFirst() == Operator.NULL_COALESCING && leftValue != null)
+        return leftValue;
       final Object rightValue = extractScalarFromResultSet(childExpressions.get(1).execute(currentRecord, context));
       return operators.getFirst().apply(leftValue, rightValue);
     }
@@ -976,6 +984,9 @@ public class MathExpression extends SimpleNode {
           break;
         case XOR:
           builder.append("^");
+          break;
+        case NULL_COALESCING:
+          builder.append("??");
           break;
         }
         builder.append(" ");

--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -46,7 +46,14 @@ public class DateUtils {
   public static final  String                                       DATE_TIME_ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
   public static final  long                                         MS_IN_A_DAY               = 24 * 60 * 60 * 1000L; // 86_400_000
   private static final ZoneId                                       UTC_ZONE_ID               = ZoneId.of("UTC");
-  private static       ConcurrentHashMap<String, DateTimeFormatter> CACHED_FORMATTERS         = new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, DateTimeFormatter> CACHED_FORMATTERS         = new ConcurrentHashMap<>();
+  /**
+   * Ceiling on {@link #CACHED_FORMATTERS}. The cache exists for the handful of patterns a schema and the built-in
+   * formats produce, which is why an unbounded map was fine while every key came from inside. The SQL {@code date()}
+   * function passes the CALLER's format straight through, so a client sending distinct patterns could grow it without
+   * bound (issue #6388). Past the ceiling a formatter is still built and returned - it is simply not remembered.
+   */
+  private static final int                                          MAX_CACHED_FORMATTERS     = 1_000;
 
   public static Object dateTime(final Database database, final long timestamp, final ChronoUnit sourcePrecision,
       final Class dateTimeImplementation, final ChronoUnit destinationPrecision) {
@@ -544,9 +551,29 @@ public class DateUtils {
   }
 
   public static DateTimeFormatter getFormatter(final String format) {
-    return CACHED_FORMATTERS.computeIfAbsent(format,
-        f -> new DateTimeFormatterBuilder().appendPattern(f).parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0).parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter());
+    final DateTimeFormatter cached = CACHED_FORMATTERS.get(format);
+    if (cached != null)
+      return cached;
+
+    final DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format)
+        .parseDefaulting(ChronoField.HOUR_OF_DAY, 0).parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+        .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).toFormatter();
+
+    // Bounded rather than evicting: the working set is a handful of schema formats that all fit, so an LRU would only
+    // add a lock on a hot path to reorder entries nothing ever evicts. A slight overshoot when several threads race
+    // past the check is harmless - the map is capped by intent, not by contract.
+    if (CACHED_FORMATTERS.size() < MAX_CACHED_FORMATTERS)
+      CACHED_FORMATTERS.putIfAbsent(format, formatter);
+
+    return formatter;
+  }
+
+  /**
+   * Number of patterns currently remembered by {@link #getFormatter(String)}. Test-only visibility into the bound
+   * introduced by issue #6388.
+   */
+  public static int getCachedFormatterCount() {
+    return CACHED_FORMATTERS.size();
   }
 
   public static Object getDate(final Object date, final Class dateImplementation) {

--- a/engine/src/main/java/com/arcadedb/utility/NumberUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/NumberUtils.java
@@ -77,6 +77,61 @@ public class NumberUtils {
   }
 
   /**
+   * Longest numeric literal {@link #saturateToIntOrNull(Object)} will parse. An int is at most ten digits and a
+   * sign, and a decimal fraction is allowed on top, so this is generous by a wide margin - it exists only so a
+   * pathological literal out of query text cannot make BigDecimal parse megabytes to reach a number that saturates
+   * to the same bound either way (issue #6389).
+   */
+  public static final int MAX_NUMERIC_LITERAL_LENGTH = 64;
+
+  /**
+   * Reads an argument that has to be a whole number - a character index, an offset, a window size - as an int,
+   * saturating rather than wrapping, or answers {@code null} when the value is not a number at all.
+   * <p>
+   * A {@link Number} is truncated toward zero; a string is parsed the same way, including a decimal literal, since
+   * {@code Integer.parseInt} rejecting {@code "2.5"} is what made {@code "abcdef".substring(2.5)} throw
+   * (issue #6389). Returning {@code null} rather than throwing lets each caller name itself and its own argument in
+   * the error, which is the only part of this that differed between the SQL function and SQL method sides.
+   *
+   * @param value the argument value
+   *
+   * @return the value as an int, saturated to the int range, or {@code null} if it is not a number
+   */
+  /**
+   * Renders a rejected argument for an error message without echoing an arbitrarily long literal back into a log or
+   * an HTTP response: past {@link #MAX_NUMERIC_LITERAL_LENGTH} the value is summarised by its length instead.
+   */
+  public static String describeRejectedNumber(final Object value) {
+    if (value == null)
+      return "null";
+    final String text = value.toString();
+    return text.length() <= MAX_NUMERIC_LITERAL_LENGTH ?
+        "'" + text + "'" :
+        "a " + text.length() + "-character literal, over the " + MAX_NUMERIC_LITERAL_LENGTH + " limit";
+  }
+
+  public static Integer saturateToIntOrNull(final Object value) {
+    if (value instanceof Number number)
+      return saturateToInt(number);
+
+    if (!(value instanceof CharSequence))
+      return null;
+
+    final String text = value.toString().trim();
+    try {
+      return Integer.parseInt(text);
+    } catch (final NumberFormatException ignoreAndTryDecimal) {
+      if (text.length() > MAX_NUMERIC_LITERAL_LENGTH)
+        return null;
+      try {
+        return saturateToInt(new BigDecimal(text));
+      } catch (final NumberFormatException notANumber) {
+        return null;
+      }
+    }
+  }
+
+  /**
    * Narrows a numeric value to an int, throwing {@link ArithmeticException} if it does not fit -
    * the strict counterpart to {@link #saturateToInt(Number)}. Use this for parameters where an
    * out-of-range value should fail loudly rather than saturate or wrap, because a saturated/wrapped

--- a/engine/src/main/java/com/arcadedb/utility/StringUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/StringUtils.java
@@ -96,17 +96,24 @@ public class StringUtils {
   /**
    * Rejects a conversion whose width or precision exceeds {@link #MAX_FORMAT_WIDTH}. Scans the pattern once rather
    * than compiling a regex: this runs per formatted value.
+   * <p>
+   * A specifier is {@code %[argument_index$][flags][width][.precision]conversion}, and BOTH the width and the
+   * precision size an allocation, so the largest number the specifier names is what is measured. Checking only the
+   * last one read let {@code %2000000.1s} through - the argument is truncated to one character and then padded back
+   * out to a two-million-character field.
    */
   private static void checkFormatWidth(final String caller, final String format) {
     for (int i = 0; i < format.length(); i++) {
       if (format.charAt(i) != '%')
         continue;
 
-      // Skip the argument index, the flags, then read the width - and, past a '.', the precision - as plain digits.
-      // A number too long to be an int is over the ceiling by definition, so digits are counted rather than parsed.
+      // Skip the argument index and the flags, then read the width - and, past a '.', the precision - as plain
+      // digits. A number too long to be an int is over the ceiling by definition, so digits are counted rather than
+      // parsed.
       int j = i + 1;
       long number = 0;
       int digits = 0;
+      long widest = 0;
       while (j < format.length()) {
         final char c = format.charAt(j);
         if (c >= '0' && c <= '9') {
@@ -114,24 +121,39 @@ public class StringUtils {
             number = number * 10 + (c - '0');
           else
             number = Long.MAX_VALUE;
-        } else if (c == '$' || c == '.') {
-          // '$' closed an argument index and '.' opens the precision: either way the digits read so far were not a
-          // width, so start counting again.
+        } else if (c == '$') {
+          // The digits just read were an argument index, which allocates nothing: discard them.
           number = 0;
           digits = 0;
-        } else if (c != '-' && c != '#' && c != '+' && c != ' ' && c != '0' && c != ',' && c != '(') {
+        } else if (c == '.') {
+          // The digits just read were the width, and the precision starts now. The width still has to be measured -
+          // it is what the truncated argument is padded out to.
+          widest = Math.max(widest, number);
+          number = 0;
+          digits = 0;
+        } else if (!isFormatFlag(c)) {
           // Not a flag either: the conversion character, so the specifier ends here.
           break;
         }
         j++;
       }
+      widest = Math.max(widest, number);
 
-      if (number > MAX_FORMAT_WIDTH)
+      if (widest > MAX_FORMAT_WIDTH)
         throw new IllegalArgumentException(
-            caller + "() format '" + format + "' asks for a field of " + number + " characters, over the " + MAX_FORMAT_WIDTH
+            caller + "() format '" + format + "' asks for a field of " + widest + " characters, over the " + MAX_FORMAT_WIDTH
                 + " limit");
 
       i = j;
     }
+  }
+
+  /**
+   * The {@link java.util.Formatter} flag set, {@code '<'} (reuse the previous argument) included. Leaving that one
+   * out made the scanner above mistake it for the conversion character and stop before it ever reached the width, so
+   * {@code %s%<2000000s} bypassed the ceiling entirely.
+   */
+  private static boolean isFormatFlag(final char c) {
+    return c == '-' || c == '#' || c == '+' || c == ' ' || c == '0' || c == ',' || c == '(' || c == '<';
   }
 }

--- a/engine/src/main/java/com/arcadedb/utility/StringUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/StringUtils.java
@@ -26,6 +26,13 @@ import java.util.IllegalFormatException;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class StringUtils {
+  /**
+   * Widest field a {@code %<width>s}-style conversion may ask for in a user-supplied format. Deliberately generous -
+   * a padded report column is nowhere near it - and the point is only that {@code format('%99999999s', 'x')} must not
+   * turn eight characters of query text into a 100MB string (issue #6389).
+   */
+  public static final int MAX_FORMAT_WIDTH = 1_000_000;
+
   protected StringUtils() {
   }
 
@@ -53,13 +60,6 @@ public class StringUtils {
 
     return false;
   }
-
-  /**
-   * Widest field a {@code %<width>s`-style} conversion may ask for in a user-supplied format. Deliberately generous -
-   * a padded report column is nowhere near it - and the point is only that {@code format('%99999999s', 'x')} must not
-   * turn eight characters of query text into a 100MB string (issue #6389).
-   */
-  public static final int MAX_FORMAT_WIDTH = 1_000_000;
 
   /**
    * Applies a user-supplied {@link java.util.Formatter} pattern, answering a typed argument error for everything the

--- a/engine/src/main/java/com/arcadedb/utility/StringUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/StringUtils.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.utility;
 
+import java.util.IllegalFormatException;
+
 /**
  * String helpers that the engine needs on paths where the obvious form allocates.
  *
@@ -50,5 +52,86 @@ public class StringUtils {
         return true;
 
     return false;
+  }
+
+  /**
+   * Widest field a {@code %<width>s`-style} conversion may ask for in a user-supplied format. Deliberately generous -
+   * a padded report column is nowhere near it - and the point is only that {@code format('%99999999s', 'x')} must not
+   * turn eight characters of query text into a 100MB string (issue #6389).
+   */
+  public static final int MAX_FORMAT_WIDTH = 1_000_000;
+
+  /**
+   * Applies a user-supplied {@link java.util.Formatter} pattern, answering a typed argument error for everything the
+   * JDK reports by throwing.
+   * <p>
+   * {@code String.format} raises a family of unchecked exceptions for input that is simply wrong - a conversion that
+   * does not match its argument ({@code format('%d','x')}), a conversion that does not exist ({@code format('%y')}),
+   * a null pattern - and every one of them used to escape the SQL {@code format()} function and its method twin as a
+   * raw JDK exception, i.e. an HTTP 500 for a mistake in the query (issue #6389). The width ceiling is checked BEFORE
+   * formatting, because that one is not an error the JDK reports at all: it allocates.
+   *
+   * @param caller the function or method name, for the error message
+   * @param format the caller-supplied format pattern
+   * @param args   the format arguments
+   *
+   * @return the formatted string
+   *
+   * @throws IllegalArgumentException if the pattern is null, malformed, mismatched or asks for an excessive width
+   */
+  public static String format(final String caller, final String format, final Object... args) {
+    if (format == null)
+      throw new IllegalArgumentException(caller + "() requires a non-null format");
+
+    checkFormatWidth(caller, format);
+
+    try {
+      return String.format(format, args);
+    } catch (final IllegalFormatException e) {
+      throw new IllegalArgumentException(
+          caller + "() cannot apply the format '" + format + "': " + e.getClass().getSimpleName() + " - " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Rejects a conversion whose width or precision exceeds {@link #MAX_FORMAT_WIDTH}. Scans the pattern once rather
+   * than compiling a regex: this runs per formatted value.
+   */
+  private static void checkFormatWidth(final String caller, final String format) {
+    for (int i = 0; i < format.length(); i++) {
+      if (format.charAt(i) != '%')
+        continue;
+
+      // Skip the argument index, the flags, then read the width - and, past a '.', the precision - as plain digits.
+      // A number too long to be an int is over the ceiling by definition, so digits are counted rather than parsed.
+      int j = i + 1;
+      long number = 0;
+      int digits = 0;
+      while (j < format.length()) {
+        final char c = format.charAt(j);
+        if (c >= '0' && c <= '9') {
+          if (++digits <= 10)
+            number = number * 10 + (c - '0');
+          else
+            number = Long.MAX_VALUE;
+        } else if (c == '$' || c == '.') {
+          // '$' closed an argument index and '.' opens the precision: either way the digits read so far were not a
+          // width, so start counting again.
+          number = 0;
+          digits = 0;
+        } else if (c != '-' && c != '#' && c != '+' && c != ' ' && c != '0' && c != ',' && c != '(') {
+          // Not a flag either: the conversion character, so the specifier ends here.
+          break;
+        }
+        j++;
+      }
+
+      if (number > MAX_FORMAT_WIDTH)
+        throw new IllegalArgumentException(
+            caller + "() format '" + format + "' asks for a field of " + number + " characters, over the " + MAX_FORMAT_WIDTH
+                + " limit");
+
+      i = j;
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
@@ -245,7 +245,9 @@ class Issue6389FunctionArgumentTest extends TestHelper {
     final String huge = "9".repeat(100_000);
     assertThatThrownBy(() -> database.query("sql", "SELECT 'abcdef'.substring('" + huge + "') AS a").next())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("limit");
+        .hasMessageContaining("limit")
+        // The message summarises the literal by length rather than echoing 100,000 characters into a log.
+        .hasMessageNotContaining(huge);
     // A long-but-plausible literal still saturates rather than being refused.
     try (final ResultSet rs = database.query("sql", "SELECT 'abcdef'.substring('00000000000000000002.5') AS a")) {
       assertThat(rs.next().<String>getProperty("a")).isEqualTo("cdef");

--- a/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
@@ -125,14 +125,38 @@ class Issue6389FunctionArgumentTest extends TestHelper {
         .hasMessageContaining("limit");
   }
 
+  /**
+   * Both halves of a `%<width>.<precision>s` allocate, and `<` is a Formatter flag - reuse the previous argument -
+   * not a conversion character. Measuring only the last number read, and stopping the scan at `<`, each let a field
+   * far over the ceiling through the check the ceiling exists for.
+   */
+  @Test
+  void formatWidthCeilingHasNoBypass() {
+    // Width behind a precision: the argument is truncated to one character, then padded back out to two million.
+    assertThatThrownBy(() -> database.query("sql", "SELECT format('%2000000.1s','x') AS f").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("limit");
+    // '<' reuses the previous argument; the width follows it.
+    assertThatThrownBy(() -> database.query("sql", "SELECT format('%s%<2000000s','x') AS f").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("limit");
+    // And an argument index still is not a field size, so an ordinary reference is not mistaken for one.
+    try (final ResultSet rs = database.query("sql", "SELECT format('%2000000$s','x','y') AS f")) {
+      assertThatThrownBy(rs::next).isInstanceOf(IllegalArgumentException.class).hasMessageNotContaining("limit");
+    }
+  }
+
   @Test
   void formatStillFormats() {
     try (final ResultSet rs = database.query("sql",
-        "SELECT format('%s-%05d','a',7) AS f, format('%1$s%1$s','z') AS g, format('100%%') AS h")) {
+        "SELECT format('%s-%05d','a',7) AS f, format('%1$s%1$s','z') AS g, format('100%%') AS h, "
+            + "format('%10.3s|','abcdef') AS i, format('%s%<s','q') AS j")) {
       final var row = rs.next();
       assertThat(row.<String>getProperty("f")).isEqualTo("a-00007");
       assertThat(row.<String>getProperty("g")).isEqualTo("zz");
       assertThat(row.<String>getProperty("h")).isEqualTo("100%");
+      assertThat(row.<String>getProperty("i")).isEqualTo("       abc|");
+      assertThat(row.<String>getProperty("j")).isEqualTo("qq");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
@@ -62,6 +62,17 @@ class Issue6389FunctionArgumentTest extends TestHelper {
         .hasMessageContaining("STRING key");
   }
 
+  /**
+   * A null key is rejected rather than turned into a null entry. The raw cast used to produce {@code (String) null}
+   * and store it silently, so a mistyped call built a map with a key nobody can name.
+   */
+  @Test
+  void mapRejectsANullKey() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT map(null,'a') AS m").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("STRING key");
+  }
+
   @Test
   void asMapConvertsANonStringKey() {
     try (final ResultSet rs = database.query("sql", "SELECT [1,2,3,4].asMap() AS m")) {
@@ -134,6 +145,10 @@ class Issue6389FunctionArgumentTest extends TestHelper {
   void formatWidthCeilingHasNoBypass() {
     // Width behind a precision: the argument is truncated to one character, then padded back out to two million.
     assertThatThrownBy(() -> database.query("sql", "SELECT format('%2000000.1s','x') AS f").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("limit");
+    // The same shape on a numeric conversion, where the width is large enough to be an OutOfMemoryError.
+    assertThatThrownBy(() -> database.query("sql", "SELECT format('%2000000000.1f', 3.14) AS f").next())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("limit");
     // '<' reuses the previous argument; the width follows it.

--- a/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A batch of SQL collection/string/misc methods and functions threw a raw runtime exception - an HTTP 500 - for
+ * ordinary valid input, or returned a confident answer for input they never looked at (issue #6389). Each is now
+ * either the natural answer or a typed argument error, which the HTTP layer maps to 400.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6389FunctionArgumentTest extends TestHelper {
+
+  @Test
+  void lastIndexOfGuardsNullsLikeItsIndexOfSibling() {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT nothing.lastindexof('a') AS a, nothing.indexof('a') AS b, 'abcabc'.lastindexof('a') AS c")) {
+      final var row = rs.next();
+      assertThat(row.<Object>getProperty("a")).isNull();
+      assertThat(row.<Object>getProperty("b")).isNull();
+      assertThat(row.<Number>getProperty("c").intValue()).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void joinRendersANullElementInsteadOfThrowing() {
+    try (final ResultSet rs = database.query("sql", "SELECT [1,null,3].join('-') AS j")) {
+      assertThat(rs.next().<String>getProperty("j")).isEqualTo("1-null-3");
+    }
+  }
+
+  @Test
+  void mapRejectsANonStringKey() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT map(1,'a') AS m").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("STRING key");
+  }
+
+  @Test
+  void asMapConvertsANonStringKey() {
+    try (final ResultSet rs = database.query("sql", "SELECT [1,2,3,4].asMap() AS m")) {
+      assertThat(rs.next().<Map<String, Object>>getProperty("m")).containsEntry("1", 2).containsEntry("3", 4);
+    }
+  }
+
+  @Test
+  void convertRejectsAnUnknownTypeName() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT 'x'.convert('nope') AS c").next())
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("nope");
+  }
+
+  @Test
+  void convertStillWorksForAKnownType() {
+    try (final ResultSet rs = database.query("sql", "SELECT '42'.convert('integer') AS c")) {
+      assertThat(rs.next().<Object>getProperty("c")).isEqualTo(42);
+    }
+  }
+
+  @Test
+  void decodeReportsMalformedInputAndPassesNullThrough() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT decode('!!!','base64') AS d").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("base64");
+
+    try (final ResultSet rs = database.query("sql", "SELECT decode(null,'base64') AS d")) {
+      assertThat(rs.next().<Object>getProperty("d")).isNull();
+    }
+  }
+
+  @Test
+  void decodeStillRoundTripsWithEncode() {
+    try (final ResultSet rs = database.query("sql", "SELECT decode(encode('hello','base64'),'base64').asString() AS d")) {
+      assertThat(rs.next().<String>getProperty("d")).contains("hello");
+    }
+  }
+
+  @Test
+  void formatReportsAMismatchedConversion() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT format('%d','x') AS f").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("%d");
+  }
+
+  @Test
+  void formatReportsAnUnknownConversion() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT format('%y') AS f").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("%y");
+  }
+
+  @Test
+  void formatRefusesAnExcessiveFieldWidth() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT format('%99999999s','x') AS f").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("limit");
+    assertThatThrownBy(() -> database.query("sql", "SELECT 'x'.format('%99999999s') AS f").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("limit");
+  }
+
+  @Test
+  void formatStillFormats() {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT format('%s-%05d','a',7) AS f, format('%1$s%1$s','z') AS g, format('100%%') AS h")) {
+      final var row = rs.next();
+      assertThat(row.<String>getProperty("f")).isEqualTo("a-00007");
+      assertThat(row.<String>getProperty("g")).isEqualTo("zz");
+      assertThat(row.<String>getProperty("h")).isEqualTo("100%");
+    }
+  }
+
+  @Test
+  void maxAndMinRejectMutuallyIncomparableValues() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT max([1,'a']) AS m").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cannot compare");
+    assertThatThrownBy(() -> database.query("sql", "SELECT min([1,'a']) AS m").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cannot compare");
+  }
+
+  @Test
+  void maxAndMinStillWorkOnHomogeneousInput() {
+    try (final ResultSet rs = database.query("sql", "SELECT max([3,1,2]) AS a, min([3,1,2]) AS b, max(['a','c','b']) AS c")) {
+      final var row = rs.next();
+      assertThat(row.<Number>getProperty("a").intValue()).isEqualTo(3);
+      assertThat(row.<Number>getProperty("b").intValue()).isEqualTo(1);
+      assertThat(row.<String>getProperty("c")).isEqualTo("c");
+    }
+  }
+
+  @Test
+  void boolAndOrRejectNonBooleanInput() {
+    for (final String query : new String[] { "SELECT bool_and([1,2,3]) AS b", "SELECT bool_and(1,2) AS b",
+        "SELECT bool_and(5) AS b", "SELECT bool_or([1,2,3]) AS b", "SELECT bool_or(5) AS b" })
+      assertThatThrownBy(() -> database.query("sql", query).next())
+          .as(query)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("boolean input");
+  }
+
+  @Test
+  void boolAndOrStillWorkOnBooleans() {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT bool_and([true,true]) AS a, bool_and([true,false]) AS b, bool_or([false,true]) AS c")) {
+      final var row = rs.next();
+      assertThat(row.<Boolean>getProperty("a")).isTrue();
+      assertThat(row.<Boolean>getProperty("b")).isFalse();
+      assertThat(row.<Boolean>getProperty("c")).isTrue();
+    }
+  }
+
+  @Test
+  void stringIndexMethodsAcceptADecimalIndex() {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT 'abcdef'.substring(2.5) AS a, 'abcdef'.left(2.9) AS b, 'abcdef'.right(2.1) AS c, 'abcdef'.charAt(1.7) AS d")) {
+      final var row = rs.next();
+      // Truncated toward zero, then the #5885 clamps apply as they always did.
+      assertThat(row.<String>getProperty("a")).isEqualTo("cdef");
+      assertThat(row.<String>getProperty("b")).isEqualTo("ab");
+      assertThat(row.<String>getProperty("c")).isEqualTo("ef");
+      assertThat(row.<String>getProperty("d")).isEqualTo("b");
+    }
+  }
+
+  @Test
+  void stringIndexMethodsRejectNonNumericIndexes() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT 'abcdef'.substring('x') AS a").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("numeric");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/Issue6389FunctionArgumentTest.java
@@ -235,4 +235,20 @@ class Issue6389FunctionArgumentTest extends TestHelper {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("numeric");
   }
+
+  /**
+   * The decimal fallback must not hand an unbounded literal to BigDecimal: a character index is ten digits and a
+   * sign, so a literal orders of magnitude longer is refused by length rather than parsed to find out.
+   */
+  @Test
+  void stringIndexMethodsRefuseAnAbsurdlyLongLiteral() {
+    final String huge = "9".repeat(100_000);
+    assertThatThrownBy(() -> database.query("sql", "SELECT 'abcdef'.substring('" + huge + "') AS a").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("limit");
+    // A long-but-plausible literal still saturates rather than being refused.
+    try (final ResultSet rs = database.query("sql", "SELECT 'abcdef'.substring('00000000000000000002.5') AS a")) {
+      assertThat(rs.next().<String>getProperty("a")).isEqualTo("cdef");
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/SQLFunctionAdditionalCoverageTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/SQLFunctionAdditionalCoverageTest.java
@@ -295,9 +295,15 @@ class SQLFunctionAdditionalCoverageTest extends TestHelper {
     rs.close();
   }
 
+  /**
+   * sysdate()'s only argument is a ZONE ID, per its documented syntax {@code sysdate([<zoneid>])} - formatting is
+   * .format()'s job. This used to pass 'yyyy-MM-dd' and assert only that the answer was at least ten characters
+   * long, which the default ISO rendering satisfies: the argument was read as params[1] and silently dropped, so the
+   * assertion held whatever was passed (issue #6388).
+   */
   @Test
-  void sysdateWithFormat() {
-    final ResultSet rs = database.query("sql", "SELECT sysdate('yyyy-MM-dd').asString() as now");
+  void sysdateWithZone() {
+    final ResultSet rs = database.query("sql", "SELECT sysdate('Europe/Rome').asString() as now");
     assertThat(rs.hasNext()).isTrue();
     final String now = rs.next().getProperty("now");
     assertThat(now).isNotNull();

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6385AstarHeuristicPositionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6385AstarHeuristicPositionTest.java
@@ -84,14 +84,20 @@ class Issue6385AstarHeuristicPositionTest {
         points[2] = newPoint(db, 10, 8, 0); // goal
       });
 
-      for (final SQLHeuristicFormula formula : SQLHeuristicFormula.values()) {
-        final SQLFunctionAstar threeAxis = axisHeuristic(db, points[0], formula);
-        final SQLFunctionAstar twoAxis = axisHeuristic(db, points[0], formula);
-        twoAxis.paramVertexAxisNames = new String[] { "x", "y" };
+      // A non-default dFactor as well as the default: it scales every heuristic, and running only at 1.0 cannot
+      // see a branch that drops it - which is how the N-axis EUCLIDEAN came to be the one of five that did.
+      for (final double dFactor : new double[] { 1.0, 3.0 })
+        for (final SQLHeuristicFormula formula : SQLHeuristicFormula.values()) {
+          final SQLFunctionAstar threeAxis = axisHeuristic(db, points[0], formula);
+          final SQLFunctionAstar twoAxis = axisHeuristic(db, points[0], formula);
+          twoAxis.paramVertexAxisNames = new String[] { "x", "y" };
+          threeAxis.paramDFactor = dFactor;
+          twoAxis.paramDFactor = dFactor;
 
-        assertThat(threeAxis.getHeuristicCost(points[1], null, points[2], threeAxis.context)).as("%s", formula)
-            .isEqualTo(twoAxis.getHeuristicCost(points[1], null, points[2], twoAxis.context));
-      }
+          assertThat(threeAxis.getHeuristicCost(points[1], null, points[2], threeAxis.context))
+              .as("%s at dFactor %s", formula, dFactor)
+              .isEqualTo(twoAxis.getHeuristicCost(points[1], null, points[2], twoAxis.context));
+        }
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6385AstarHeuristicPositionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6385AstarHeuristicPositionTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The N-axis branch of the A* heuristic stored the SOURCE vertex's coordinate in the map that stands for the CURRENT
+ * node's position, so every {@code h(n)} was computed as if {@code n} were the start: constant over the whole search,
+ * and no longer an estimate of the remaining distance (issue #6385). The two-axis branch was already correct, which is
+ * why the tests below use three axes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6385AstarHeuristicPositionTest {
+
+  @Test
+  void heuristicMeasuresFromTheCurrentNodeNotFromTheSource() throws Exception {
+    TestHelper.executeInNewDatabase("Issue6385AstarHeuristic", db -> {
+      final Vertex[] points = new Vertex[4];
+      db.transaction(() -> {
+        db.getSchema().createVertexType("Point6385");
+        points[0] = newPoint(db, 0, 0, 0);   // source
+        points[1] = newPoint(db, 5, 0, 0);   // halfway
+        points[2] = newPoint(db, 9, 0, 0);   // near the goal
+        points[3] = newPoint(db, 10, 0, 0);  // goal
+      });
+
+      final Vertex source = points[0];
+      final Vertex goal = points[3];
+
+      for (final SQLHeuristicFormula formula : SQLHeuristicFormula.values()) {
+        final SQLFunctionAstar astar = axisHeuristic(db, source, formula);
+
+        final double atSource = astar.getHeuristicCost(source, null, goal, astar.context);
+        final double atHalfway = astar.getHeuristicCost(points[1], null, goal, astar.context);
+        final double atNearGoal = astar.getHeuristicCost(points[2], null, goal, astar.context);
+        final double atGoal = astar.getHeuristicCost(goal, null, goal, astar.context);
+
+        // A node closer to the target must have a strictly smaller estimated remaining cost. With the source
+        // coordinate standing in for the node's own, all four were the same number.
+        assertThat(atSource).as("%s: h(source) > h(halfway)", formula).isGreaterThan(atHalfway);
+        assertThat(atHalfway).as("%s: h(halfway) > h(nearGoal)", formula).isGreaterThan(atNearGoal);
+        assertThat(atGoal).as("%s: h(goal) is zero", formula).isZero();
+      }
+    });
+  }
+
+  /**
+   * The heuristic has to agree with the two-axis branch, which never had the defect: the same points, measured over
+   * the first two of three axes (the third held at zero everywhere), must produce the same estimate whichever branch
+   * computes it.
+   */
+  @Test
+  void nAxisBranchAgreesWithTheTwoAxisBranch() throws Exception {
+    TestHelper.executeInNewDatabase("Issue6385AstarAxisAgreement", db -> {
+      final Vertex[] points = new Vertex[3];
+      db.transaction(() -> {
+        db.getSchema().createVertexType("Point6385");
+        points[0] = newPoint(db, 1, 2, 0);  // source
+        points[1] = newPoint(db, 7, 3, 0);  // node
+        points[2] = newPoint(db, 10, 8, 0); // goal
+      });
+
+      for (final SQLHeuristicFormula formula : SQLHeuristicFormula.values()) {
+        final SQLFunctionAstar threeAxis = axisHeuristic(db, points[0], formula);
+        final SQLFunctionAstar twoAxis = axisHeuristic(db, points[0], formula);
+        twoAxis.paramVertexAxisNames = new String[] { "x", "y" };
+
+        assertThat(threeAxis.getHeuristicCost(points[1], null, points[2], threeAxis.context)).as("%s", formula)
+            .isEqualTo(twoAxis.getHeuristicCost(points[1], null, points[2], twoAxis.context));
+      }
+    });
+  }
+
+  private SQLFunctionAstar axisHeuristic(final Database db, final Vertex source, final SQLHeuristicFormula formula) {
+    final SQLFunctionAstar astar = new SQLFunctionAstar();
+    final BasicCommandContext ctx = new BasicCommandContext();
+    ctx.setDatabase(db);
+    astar.context = ctx;
+    astar.paramSourceVertex = source;
+    astar.paramVertexAxisNames = new String[] { "x", "y", "z" };
+    astar.paramHeuristicFormula = formula;
+    // The tie breaker perturbs the estimate with the parent/source cross product: off, so the assertions are about
+    // the heuristic itself.
+    astar.paramTieBreaker = false;
+    return astar;
+  }
+
+  private Vertex newPoint(final Database db, final double x, final double y, final double z) {
+    return db.newVertex("Point6385").set("x", x).set("y", y).set("z", z).save();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/math/Issue6390AggregateNumericInputTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/math/Issue6390AggregateNumericInputTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.math;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@code sum()} was hardened to reject non-numeric input with a typed error (issue #5799); its aggregate and window
+ * siblings kept the raw {@code (Number)} cast and answered a ClassCastException - an HTTP 500 - for the same input
+ * (issue #6390). They all share {@code SQLFunctionAbstract.requireNumericOrNull} now.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6390AggregateNumericInputTest extends TestHelper {
+
+  @Test
+  void everySumSiblingRejectsANonNumericElement() {
+    for (final String query : new String[] { "SELECT sum(['a', 1]) AS r", "SELECT avg(['a', 1]) AS r",
+        "SELECT variance(['a']) AS r", "SELECT stddev(['a']) AS r", "SELECT variancep(['a']) AS r",
+        "SELECT stddevp(['a']) AS r", "SELECT percentile(['a'], 0.5) AS r", "SELECT median(['a']) AS r" })
+      assertThatThrownBy(() -> database.query("sql", query).next())
+          .as(query)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("requires numeric input");
+  }
+
+  @Test
+  void everySumSiblingRejectsANonNumericScalar() {
+    for (final String query : new String[] { "SELECT sum('a') AS r", "SELECT avg('a') AS r", "SELECT variance('a') AS r",
+        "SELECT percentile('a', 0.5) AS r" })
+      assertThatThrownBy(() -> database.query("sql", query).next())
+          .as(query)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("requires numeric input");
+  }
+
+  @Test
+  void timeSeriesAggregatesRejectNonNumericInput() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Series6390");
+      database.command("sql", "INSERT INTO Series6390 SET a = 'x', b = 'y', ts = 1000, v = 'z'");
+      database.command("sql", "INSERT INTO Series6390 SET a = 'x', b = 'y', ts = 2000, v = 'z'");
+    });
+
+    database.transaction(() -> {
+      for (final String query : new String[] { "SELECT ts.correlate(a, b) AS r FROM Series6390",
+          "SELECT ts.rate(v, ts) AS r FROM Series6390", "SELECT ts.delta(v, ts) AS r FROM Series6390",
+          "SELECT ts.percentile(v, 0.5) AS r FROM Series6390", "SELECT ts.movingAvg(v, 2) AS r FROM Series6390" })
+        assertThatThrownBy(() -> database.query("sql", query).next())
+            .as(query)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("requires numeric input");
+    });
+  }
+
+  @Test
+  void windowConfigurationArgumentsAreCheckedToo() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Window6390");
+      database.command("sql", "INSERT INTO Window6390 SET v = 1");
+      database.command("sql", "INSERT INTO Window6390 SET v = 3");
+    });
+
+    database.transaction(() -> {
+      assertThatThrownBy(() -> database.query("sql", "SELECT ts.movingAvg(v, 'wide') AS r FROM Window6390").next())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("window_size");
+      assertThatThrownBy(() -> database.query("sql", "SELECT ts.percentile(v, 'half') AS r FROM Window6390").next())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("percentile");
+    });
+  }
+
+  @Test
+  void numericInputStillAggregatesNormally() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Ok6390");
+      database.command("sql", "INSERT INTO Ok6390 SET v = 2, ts = 1000");
+      database.command("sql", "INSERT INTO Ok6390 SET v = 4, ts = 2000");
+      database.command("sql", "INSERT INTO Ok6390 SET v = 6, ts = 3000");
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT sum(v) AS s, avg(v) AS a, variance(v) AS va, ts.delta(v, ts) AS d FROM Ok6390")) {
+        final var row = rs.next();
+        assertThat(row.<Number>getProperty("s").intValue()).isEqualTo(12);
+        assertThat(row.<Number>getProperty("a").doubleValue()).isEqualTo(4.0);
+        assertThat(row.<Number>getProperty("va").doubleValue()).isEqualTo(4.0);
+        assertThat(row.<Number>getProperty("d").doubleValue()).isEqualTo(4.0);
+      }
+      try (final ResultSet rs = database.query("sql", "SELECT ts.movingAvg(v, 2) AS m FROM Ok6390")) {
+        assertThat(rs.next().<List<Double>>getProperty("m")).containsExactly(2.0, 3.0, 5.0);
+      }
+      // A null is skipped, not rejected: that is the documented aggregation behaviour and it must survive the guard.
+      try (final ResultSet rs = database.query("sql", "SELECT avg([1, null, 3]) AS a, variance([2, null, 4]) AS v")) {
+        final var row = rs.next();
+        assertThat(row.<Number>getProperty("a").doubleValue()).isEqualTo(2.0);
+        assertThat(row.<Number>getProperty("v").doubleValue()).isEqualTo(2.0);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/math/Issue6390AggregateNumericInputTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/math/Issue6390AggregateNumericInputTest.java
@@ -94,6 +94,50 @@ class Issue6390AggregateNumericInputTest extends TestHelper {
     });
   }
 
+  /**
+   * The same bug class in three functions the first sweep missed: a raw {@code (Number)} on {@code pow()}'s
+   * exponent, a raw {@code Comparable} sort in {@code ts.rank} (the {@code ts.lag}/{@code ts.lead} shape), and raw
+   * casts in {@code ts.interpolate}'s linear branch, unlike the siblings around it.
+   */
+  @Test
+  void theRemainingRawCastSiblingsAnswerTypedErrorsToo() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT pow(2, 'x') AS r").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("numeric");
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Sweep6390");
+      // A gap in the middle, so the linear branch actually has something to interpolate across.
+      database.command("sql", "INSERT INTO Sweep6390 SET v = 'a', ts = 1000");
+      database.command("sql", "INSERT INTO Sweep6390 SET ts = 2000");
+      database.command("sql", "INSERT INTO Sweep6390 SET v = 'b', ts = 3000");
+    });
+
+    database.transaction(() -> {
+      assertThatThrownBy(() -> database.query("sql", "SELECT ts.interpolate(v, 'linear', ts) AS r FROM Sweep6390").next())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("requires numeric input");
+      // ts.rank orders by the timestamp, and a row whose timestamp is null keeps its arrival order at the end
+      // rather than NPE the comparator - the ts.lag/ts.lead treatment, which rank had not had either.
+      try (final ResultSet rs = database.query("sql", "SELECT ts.rank(v, ts) AS r FROM Sweep6390")) {
+        assertThat(rs.next().<List<Object>>getProperty("r")).hasSize(3);
+      }
+      database.command("sql", "INSERT INTO Sweep6390 SET v = 'c'");
+      try (final ResultSet rs = database.query("sql", "SELECT ts.rank(v, ts) AS r FROM Sweep6390")) {
+        assertThat(rs.next().<List<Object>>getProperty("r")).hasSize(4);
+      }
+    });
+  }
+
+  @Test
+  void powStillRaisesNumbers() {
+    try (final ResultSet rs = database.query("sql", "SELECT pow(2, 10) AS a, pow(2, '10') AS b")) {
+      final var row = rs.next();
+      assertThat(row.<Number>getProperty("a").intValue()).isEqualTo(1024);
+      assertThat(row.<Number>getProperty("b").intValue()).isEqualTo(1024);
+    }
+  }
+
   @Test
   void numericInputStillAggregatesNormally() {
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/function/sql/time/Issue6388TimeFunctionArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/time/Issue6388TimeFunctionArgumentTest.java
@@ -82,6 +82,40 @@ class Issue6388TimeFunctionArgumentTest extends TestHelper {
           .hasMessageContaining("no fixed length");
   }
 
+  /**
+   * The weeks conversion is the one place an amount can overflow, and it must answer the same typed error as every
+   * other bad argument in this family rather than a bare ArithmeticException.
+   */
+  @Test
+  void durationRejectsAnAmountThatOverflows() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT duration(1000000000000000000, 'week') AS d").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("overflows");
+  }
+
+  /**
+   * An offset outside the int range must saturate rather than wrap: Number.intValue() on a huge long returns an
+   * unrelated - possibly small and positive - number that would sail past the non-negative check.
+   */
+  @Test
+  void lagAndLeadSaturateAnOutOfRangeOffset() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Huge6388");
+      for (int i = 0; i < 3; i++)
+        database.command("sql", "INSERT INTO Huge6388 SET v = ?, ts = ?", i, i);
+    });
+
+    database.transaction(() -> {
+      // 2^32 wraps to 0 under intValue(); saturated it stays past the end of the rows, so every row takes the default.
+      try (final ResultSet rs = database.query("sql", "SELECT ts.lag(v, 4294967296, ts) AS r FROM Huge6388")) {
+        assertThat(rs.next().<List<Object>>getProperty("r")).containsExactly(null, null, null);
+      }
+      try (final ResultSet rs = database.query("sql", "SELECT ts.lead(v, 4294967296, ts) AS r FROM Huge6388")) {
+        assertThat(rs.next().<List<Object>>getProperty("r")).containsExactly(null, null, null);
+      }
+    });
+  }
+
   @Test
   void timeBucketRejectsANonPositiveInterval() {
     assertThatThrownBy(() -> database.query("sql", "SELECT ts.timeBucket('0s', 1700000000000) AS b").next())

--- a/engine/src/test/java/com/arcadedb/function/sql/time/Issue6388TimeFunctionArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/time/Issue6388TimeFunctionArgumentTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.time;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.DateUtils;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Several SQL time/date functions threw a raw JDK exception - an HTTP 500 - for ordinary valid input, and
+ * {@code sysdate()} silently ignored the argument it documents (issue #6388). Each of these is now either the right
+ * answer or a typed argument error, which the HTTP layer maps to 400.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6388TimeFunctionArgumentTest extends TestHelper {
+
+  @Test
+  void sysdateAppliesTheZoneGivenAsItsOnlyArgument() throws Exception {
+    ((DatabaseInternal) database).getSerializer().setDateTimeImplementation(ZonedDateTime.class);
+    try (final ResultSet rs = database.query("sql",
+        "SELECT sysdate('America/New_York') AS ny, sysdate('Europe/Rome') AS rome")) {
+      final var row = rs.next();
+      final ZonedDateTime ny = row.getProperty("ny");
+      final ZonedDateTime rome = row.getProperty("rome");
+      // The argument used to be read as params[1] and therefore dropped: both answers were the same server-local
+      // LocalDateTime with no zone at all.
+      assertThat(ny.getZone().getId()).isEqualTo("America/New_York");
+      assertThat(rome.getZone().getId()).isEqualTo("Europe/Rome");
+    }
+  }
+
+  @Test
+  void sysdateRejectsAnUnknownZone() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT sysdate('Bogus/Zone') AS d").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Bogus/Zone");
+  }
+
+  @Test
+  void durationSupportsWeeksAsAnExactAmountOfTime() {
+    try (final ResultSet rs = database.query("sql", "SELECT duration(2, 'week') AS d")) {
+      assertThat(rs.next().<Duration>getProperty("d")).isEqualTo(Duration.ofDays(14));
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT duration(3, 'days') AS d")) {
+      assertThat(rs.next().<Duration>getProperty("d")).isEqualTo(Duration.ofDays(3));
+    }
+  }
+
+  @Test
+  void durationRejectsCalendarUnitsWithAReadableMessage() {
+    for (final String unit : new String[] { "year", "month", "years", "months" })
+      assertThatThrownBy(() -> database.query("sql", "SELECT duration(1, '" + unit + "') AS d").next())
+          .as(unit)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("no fixed length");
+  }
+
+  @Test
+  void timeBucketRejectsANonPositiveInterval() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT ts.timeBucket('0s', 1700000000000) AS b").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("positive");
+  }
+
+  @Test
+  void timeBucketWithANullArgumentIsNullNotAnNpe() {
+    try (final ResultSet rs = database.query("sql", "SELECT ts.timeBucket(null, 1700000000000) AS b")) {
+      assertThat(rs.next().<Object>getProperty("b")).isNull();
+    }
+  }
+
+  @Test
+  void timeBucketStillTruncatesToTheBucketStart() {
+    try (final ResultSet rs = database.query("sql", "SELECT ts.timeBucket('1h', 3900000) AS b")) {
+      assertThat(rs.next().<Date>getProperty("b")).isEqualTo(new Date(3_600_000L));
+    }
+  }
+
+  @Test
+  void lagAndLeadRejectANegativeOffset() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Sample6388");
+      for (int i = 0; i < 3; i++)
+        database.command("sql", "INSERT INTO Sample6388 SET v = ?, ts = ?", i, i);
+    });
+
+    database.transaction(() -> {
+      for (final String fn : new String[] { "ts.lag", "ts.lead" })
+        assertThatThrownBy(() -> database.query("sql", "SELECT " + fn + "(v, -1, ts) AS r FROM Sample6388").next())
+            .as(fn)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("non-negative");
+    });
+  }
+
+  @Test
+  void lagWithoutATimestampKeepsArrivalOrderInsteadOfThrowing() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Arrival6388");
+      for (final String v : new String[] { "a", "b", "c" })
+        database.command("sql", "INSERT INTO Arrival6388 SET v = ?", v);
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT ts.lag(v) AS r FROM Arrival6388")) {
+        assertThat(rs.next().<List<Object>>getProperty("r")).containsExactly(null, "a", "b");
+      }
+      try (final ResultSet rs = database.query("sql", "SELECT ts.lead(v) AS r FROM Arrival6388")) {
+        assertThat(rs.next().<List<Object>>getProperty("r")).containsExactly("b", "c", null);
+      }
+    });
+  }
+
+  @Test
+  void lagStillOrdersByTheTimestampWhenGivenOne() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Ordered6388");
+      database.command("sql", "INSERT INTO Ordered6388 SET v = 'c', ts = 3");
+      database.command("sql", "INSERT INTO Ordered6388 SET v = 'a', ts = 1");
+      database.command("sql", "INSERT INTO Ordered6388 SET v = 'b', ts = 2");
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT ts.lag(v, 1, ts) AS r FROM Ordered6388")) {
+        assertThat(rs.next().<List<Object>>getProperty("r")).containsExactly(null, "a", "b");
+      }
+    });
+  }
+
+  @Test
+  void dateRejectsAMalformedPatternInsteadOfLeakingTheJdkException() {
+    // An unterminated literal quote: DateTimeFormatterBuilder.appendPattern() rejects it with an
+    // IllegalArgumentException, which is NOT a DateTimeParseException and so escaped the catch untouched.
+    assertThatThrownBy(() -> database.query("sql", "SELECT date('2020-01-01', \"yyyy-'\") AS d").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("invalid date format");
+  }
+
+  @Test
+  void dateRejectsAnUnknownZoneInsteadOfLeakingTheJdkException() {
+    assertThatThrownBy(() -> database.query("sql", "SELECT date('2020-01-01', 'yyyy-MM-dd', 'Bogus/Zone') AS d").next())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Bogus/Zone");
+  }
+
+  @Test
+  void dateStillAnswersNullWhenTheValueDoesNotMatchTheFormat() {
+    try (final ResultSet rs = database.query("sql", "SELECT date('not-a-date', 'yyyy-MM-dd') AS d")) {
+      assertThat(rs.next().<Object>getProperty("d")).isNull();
+    }
+  }
+
+  @Test
+  void theFormatterCacheIsBounded() {
+    final int before = DateUtils.getCachedFormatterCount();
+    // Distinct caller-supplied patterns used to be remembered forever, one entry each.
+    for (int i = 0; i < 5_000; i++)
+      DateUtils.getFormatter("yyyy-MM-dd'" + ("x".repeat(i % 40 + 1)) + i + "'");
+
+    assertThat(DateUtils.getCachedFormatterCount()).isGreaterThanOrEqualTo(before).isLessThanOrEqualTo(1_000 + 64);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6382ContainsTextColonTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6382ContainsTextColonTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.RangeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code CONTAINSTEXT} is literal text to find, not a query language, but the direct full-text lookup split every
+ * whitespace-separated part on the first {@code ':'} and looked the remainder up as a field-qualified key. A
+ * single-property index never stores a qualified key, so any literal carrying a colon - a time, a timestamp, a
+ * {@code ns:name} - matched nothing at all (issue #6382).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6382ContainsTextColonTest extends TestHelper {
+
+  @Test
+  void singlePropertyIndexMatchesALiteralContainingAColon() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Note6382");
+      database.command("sql", "CREATE PROPERTY Note6382.label STRING");
+      database.command("sql", "CREATE INDEX ON Note6382 (label) FULL_TEXT");
+
+      database.command("sql", "INSERT INTO Note6382 SET id = 'a', label = 'foo:bar happens here'");
+      database.command("sql", "INSERT INTO Note6382 SET id = 'b', label = 'unrelated text'");
+      database.command("sql", "INSERT INTO Note6382 SET id = 'c', label = 'meeting at 3:30 today'");
+    });
+
+    database.transaction(() -> {
+      assertThat(idsMatching("foo:bar")).containsExactly("a");
+      assertThat(idsMatching("3:30")).containsExactly("c");
+    });
+  }
+
+  /**
+   * The Lucene-backed executor treats the sole indexed property named as a qualifier as no qualifier at all
+   * ({@code FullTextQueryExecutor.isUnqualified}); the direct path has to agree.
+   */
+  @Test
+  void singlePropertyIndexAcceptsItsOwnPropertyAsAQualifier() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Qualified6382");
+      database.command("sql", "CREATE PROPERTY Qualified6382.label STRING");
+      database.command("sql", "CREATE INDEX ON Qualified6382 (label) FULL_TEXT");
+
+      database.command("sql", "INSERT INTO Qualified6382 SET id = 'a', label = 'java programming'");
+      database.command("sql", "INSERT INTO Qualified6382 SET id = 'b', label = 'python scripting'");
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT id FROM Qualified6382 WHERE label CONTAINSTEXT 'label:java'")) {
+        assertThat(collect(rs)).containsExactly("a");
+      }
+    });
+  }
+
+  /**
+   * A real field qualifier on a multi-property index keeps working, and a prefix that is NOT an indexed property is
+   * literal text: it matches the document that really carries it, not nothing at all. Exercised through the index
+   * lookup directly, because the planner does not push a single-property {@code CONTAINSTEXT} down onto a
+   * multi-property full-text index.
+   */
+  @Test
+  void multiPropertyIndexKeepsFieldQualifiersAndTreatsUnknownOnesAsLiterals() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Article6382");
+      database.command("sql", "CREATE PROPERTY Article6382.title STRING");
+      database.command("sql", "CREATE PROPERTY Article6382.content STRING");
+      database.command("sql", "CREATE INDEX ON Article6382 (title, content) FULL_TEXT");
+
+      database.command("sql", "INSERT INTO Article6382 SET id = 'a', title = 'java', content = 'databases'");
+      database.command("sql", "INSERT INTO Article6382 SET id = 'b', title = 'python', content = 'java bindings'");
+      database.command("sql", "INSERT INTO Article6382 SET id = 'c', title = 'release notes', content = 'see jira:1234 for details'");
+    });
+
+    database.transaction(() -> {
+      // A real qualifier still narrows to the property it names.
+      assertThat(idsFromIndex("Article6382", "title:java")).containsExactly("a");
+      assertThat(idsFromIndex("Article6382", "content:java")).containsExactly("b");
+      // 'jira' is not an indexed property, so the whole part stays literal text and finds the document that
+      // actually contains it. Before the fix it was looked up as a qualified key nothing ever stored.
+      assertThat(idsFromIndex("Article6382", "jira:1234")).containsExactly("c");
+    });
+  }
+
+  private Set<String> idsFromIndex(final String typeName, final String literal) {
+    final Set<String> ids = new HashSet<>();
+    for (final Index index : database.getSchema().getType(typeName).getAllIndexes(true)) {
+      final IndexCursor cursor = ((RangeIndex) index).get(new Object[] { literal });
+      while (cursor.hasNext())
+        ids.add(cursor.next().asDocument().getString("id"));
+    }
+    return ids;
+  }
+
+  private Set<String> idsMatching(final String literal) {
+    try (final ResultSet rs = database.query("sql", "SELECT id FROM Note6382 WHERE label CONTAINSTEXT ?", literal)) {
+      return collect(rs);
+    }
+  }
+
+  private static Set<String> collect(final ResultSet rs) {
+    final Set<String> ids = new HashSet<>();
+    while (rs.hasNext())
+      ids.add(rs.next().getProperty("id"));
+    return ids;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6393NullCoalescingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6393NullCoalescingTest.java
@@ -28,6 +28,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The SQL null-coalescing operator {@code ??} used to return its RIGHT operand whatever the left one was, because the
@@ -99,6 +100,21 @@ class Issue6393NullCoalescingTest extends TestHelper {
         assertThat(rs.hasNext()).isFalse();
       }
     });
+  }
+
+  /**
+   * The short-circuit is a behaviour, not just an optimisation: the right operand may be a function call or a
+   * sub-query, and it must not run when the fallback is not taken. Observed with an argument that throws when it IS
+   * evaluated, so the two directions are told apart by whether the error escapes.
+   */
+  @Test
+  void rightOperandIsNotEvaluatedWhenTheLeftIsNotNull() {
+    try (final ResultSet rs = database.query("sql", "SELECT 1 ?? 'abcdef'.substring('boom') AS n")) {
+      assertThat(rs.next().<Number>getProperty("n").intValue()).isEqualTo(1);
+    }
+    // ...and IS evaluated when the fallback is taken, so the test above cannot pass by the operand being dead.
+    assertThatThrownBy(() -> database.query("sql", "SELECT null ?? 'abcdef'.substring('boom') AS n").next())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6393NullCoalescingTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6393NullCoalescingTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.antlr.SQLASTBuilder;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.grammar.SQLLexer;
+import com.arcadedb.query.sql.grammar.SQLParser;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The SQL null-coalescing operator {@code ??} used to return its RIGHT operand whatever the left one was, because the
+ * ANTLR AST builder had no visitor for the {@code nullCoalescing} alternative: the default {@code visitChildren}
+ * returned the last child it visited, so the left operand never reached the tree - issue #6393.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6393NullCoalescingTest extends TestHelper {
+
+  @Test
+  void leftOperandWinsWhenNotNull() {
+    try (final ResultSet rs = database.query("sql", "SELECT 'left' ?? 'right' AS n")) {
+      assertThat(rs.next().<String>getProperty("n")).isEqualTo("left");
+    }
+    try (final ResultSet rs = database.query("sql", "SELECT 1 ?? 2 AS n")) {
+      assertThat(rs.next().<Number>getProperty("n").intValue()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void rightOperandWinsWhenLeftIsNull() {
+    try (final ResultSet rs = database.query("sql", "SELECT null ?? 'right' AS n")) {
+      assertThat(rs.next().<String>getProperty("n")).isEqualTo("right");
+    }
+  }
+
+  @Test
+  void bothOperandsNullYieldsNull() {
+    try (final ResultSet rs = database.query("sql", "SELECT null ?? null AS n")) {
+      assertThat(rs.next().<Object>getProperty("n")).isNull();
+    }
+  }
+
+  @Test
+  void missingPropertyFallsBackToTheDefault() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc6393");
+      database.command("sql", "INSERT INTO Doc6393 SET name = 'Jay'");
+      database.command("sql", "INSERT INTO Doc6393 SET other = 'x'");
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT name ?? 'unknown' AS n FROM Doc6393 ORDER BY n")) {
+        assertThat(rs.next().<String>getProperty("n")).isEqualTo("Jay");
+        assertThat(rs.next().<String>getProperty("n")).isEqualTo("unknown");
+      }
+    });
+  }
+
+  @Test
+  void chainedCoalescingTakesTheFirstNonNull() {
+    try (final ResultSet rs = database.query("sql", "SELECT null ?? 'b' ?? 'c' AS n")) {
+      assertThat(rs.next().<String>getProperty("n")).isEqualTo("b");
+    }
+  }
+
+  @Test
+  void usableInAWhereClause() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Where6393");
+      database.command("sql", "INSERT INTO Where6393 SET id = 1, name = 'Jay'");
+      database.command("sql", "INSERT INTO Where6393 SET id = 2");
+    });
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("sql", "SELECT id FROM Where6393 WHERE (name ?? 'unknown') = 'unknown'")) {
+        assertThat(rs.next().<Number>getProperty("id").intValue()).isEqualTo(2);
+        assertThat(rs.hasNext()).isFalse();
+      }
+    });
+  }
+
+  @Test
+  void renderingKeepsTheLeftOperand() {
+    assertThat(renderProjection("SELECT a ?? b AS n FROM V")).contains("a ?? b");
+    // `||` binds tighter than `??`, so the right operand is the whole concatenation.
+    assertThat(renderProjection("SELECT a ?? b || c AS n FROM V")).contains("a ?? b || c");
+  }
+
+  @Test
+  void renderedFormReparsesToTheSameTree() {
+    for (final String query : new String[] { "SELECT a ?? b AS n FROM V", "SELECT a ?? b || c AS n FROM V",
+        "SELECT a || b ?? c AS n FROM V", "SELECT (a ?? b) AS n FROM V", "SELECT a ?? b ?? c AS n FROM V",
+        "SELECT a + 1 ?? b AS n FROM V", "SELECT (a ?? b) + 1 AS n FROM V" }) {
+      final String rendered = render(query);
+      final String reRendered = render(rendered);
+      assertThat(reRendered).as("round trip of '%s'", query).isEqualTo(rendered);
+    }
+  }
+
+  private String renderProjection(final String query) {
+    return render(query);
+  }
+
+  private static String render(final String query) {
+    final SQLLexer lexer = new SQLLexer(CharStreams.fromString(query));
+    final SQLParser parser = new SQLParser(new CommonTokenStream(lexer));
+    return new SQLASTBuilder().visitParse(parser.parse()).toString();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
@@ -203,7 +203,9 @@ class DocumentValidationTest extends TestHelper {
 
     database.command("sql", "create property Validation.long LONG (default 1)");
     database.command("sql", "create property Validation.string STRING (default \"1\")");
-    database.command("sql", "create property Validation.dat DATETIME (default sysdate('YYYY-MM-DD HH:MM:SS'))");
+    // sysdate()'s only argument is a zone id, not a format (issue #6388): the string passed here was never a valid
+    // java.time pattern either, it was simply ignored.
+    database.command("sql", "create property Validation.dat DATETIME (default sysdate())");
 
     assertThat(clazz.getProperty("long").getDefaultValue()).isEqualTo(1L);
     assertThat(clazz.getProperty("string").getDefaultValue()).isEqualTo("1");


### PR DESCRIPTION
Six independent defects that share one shape: valid input answered with something that was not an answer.

Closes #6382, closes #6385, closes #6388, closes #6389, closes #6390, closes #6393.

## #6393 - `??` always returned its right operand

The grammar declares the alternative, `MathExpression.Operator` carries a `NULL_COALESCING` with a working `apply()`, and nothing in between built the node: with no `visitNullCoalescing`, ANTLR's default `visitChildren` returns the LAST child it visited, so the left operand was gone from the tree before anything could evaluate it.

```
SELECT 'left' ?? 'right'   ->  right     (wrong)
SELECT null   ?? 'right'   ->  right     (right, but only by coincidence)
SELECT a ?? b || c         renders as    SELECT b || c
```

The node is now built two-operand and left-nested, which is also what lets `??` short-circuit: the right operand - possibly a function call or a sub-query - is not evaluated when the fallback is not taken. `MathExpression.toString()` had no case for the operator either, so the rendering lost it too; the regression test round-trips `??` against `||` and arithmetic at the neighbouring precedence levels.

## #6385 - the A* heuristic measured from the source

The N-axis branch filled the "current position" map with the **source** vertex's coordinate; the dead local holding the node's own coordinate was the tell. `h(n)` was therefore constant over the whole search - an admissible heuristic that guides nothing - and `dijkstra`, which delegates to A*, degraded the same way. The two-axis branch was already correct, so the test asserts the two agree on the same points, and that `h` decreases as a node approaches the goal.

## #6382 - CONTAINSTEXT split its literal on `:`

The direct full-text lookup split every whitespace-separated part on the first `':'` and looked the remainder up as a field-qualified key. A single-property index stores unprefixed tokens only, so an ordinary literal carrying a colon - a time, a timestamp, a `ns:name` - asked for a key the corpus never had and matched nothing.

A colon now introduces a qualifier only when the text before it **names an indexed property**, and on a single-property index it is dropped even then, mirroring the `FullTextQueryExecutor.isUnqualified` normalization the Lucene-backed executor already had and this path did not. Everything else is literal text handed to the analyzer, which is what `CONTAINSTEXT` documents its argument to be.

## #6388 - time/date functions

| | before | now |
|---|---|---|
| `sysdate('America/New_York')` | zone read from `params[1]`, so the documented one-argument form dropped it and answered server-local time | applies the zone; an unknown zone is a typed error |
| `duration(1,'week')` | `UnsupportedTemporalTypeException` | weeks have an exact length (7 days) and convert; years/months do not and are refused with the reason |
| `ts.timeBucket('0s', ts)` | `ArithmeticException: / by zero` | typed error; a null argument is null |
| `ts.lag(v,-1,ts)` / `ts.lead` | `IndexOutOfBoundsException` | offset must be non-negative |
| `ts.lag(value)` | NPE sorting on the optional timestamp | rows without one keep their arrival order (stable sort) |
| `date(v,'<bad pattern>')` / bad zone | raw `IllegalArgumentException` / `ZoneRulesException` escaped the `DateTimeParseException` catch | typed errors, deliberately **not** folded into the documented `null`: a value that does not match its format is a miss, a format that cannot exist is a query to fix |
| `DateUtils` formatter cache | unbounded, and reachable from `date()` with a caller-supplied pattern | bounded; past the ceiling a formatter is still built, just not remembered |

## #6389 - collection/string/misc functions

Same shape throughout: `lastIndexOf` lacked the null guard its `indexOf` sibling has; `join` mapped with `Object::toString` over a list that may hold null; `map`/`asMap` cast the key; `convert` guarded a `Type.valueOf` that throws rather than returning null; `decode` and both `format`s let `java.util.Formatter`/Base64 exceptions through (and `format` would allocate whatever width was asked for, so there is now a ceiling); `max`/`min` compared mutually incomparable values; `bool_and`/`bool_or` answered a confident `true` for a scalar they never looked at; and the substring family parsed a decimal index with `Integer.parseInt`, so the #5885 clamps could never run - the parse threw first.

## #6390 - the aggregate siblings of `sum()`

`sum()` was hardened to reject non-numeric input in #5799; every aggregate and window sibling kept the raw `(Number)` cast, so `avg`, `variance`/`stddev`/`stddevp`/`variancep`/`median`, `percentile` and the time-series aggregates (`ts.correlate`, `ts.rate`, `ts.delta`, `ts.percentile`, `ts.movingAvg`) answered a ClassCastException where `sum` answered a typed error. The guard moved up to `SQLFunctionAbstract` - along with the boolean and comparability guards the two issues above needed - and `sum` now uses the shared one rather than its own copy. A null is still skipped, which is the documented aggregation behaviour.

## Two existing tests that were passing for the wrong reason

`SQLFunctionAdditionalCoverageTest.sysdateWithFormat` and `DocumentValidationTest.defaultValueIsSetWithSQL` passed `sysdate('yyyy-MM-dd')` and `sysdate('YYYY-MM-DD HH:MM:SS')` as if the argument were a format. Neither was - the argument was ignored, and both assertions held whatever was passed. They now say what they check.

## Verification

Six new regression test classes (49 tests), each verified to fail against the unfixed sources before the change:

- `Issue6393NullCoalescingTest`, `Issue6385AstarHeuristicPositionTest`, `Issue6382ContainsTextColonTest`
- `Issue6388TimeFunctionArgumentTest`, `Issue6389FunctionArgumentTest`, `Issue6390AggregateNumericInputTest`

`mvn -o -pl server -am test -DexcludedGroups=benchmark,slow,vector`: BUILD SUCCESS - engine 12,803, network 450, ha 150, server 794, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3AwhHPosUEUVdSZwEEBef