### PR TITLE
fix(#6409): normalize WITH-setting keys, refuse duplicates everywhere, fix node identity for CASE/ORDER BY/INSERT SET

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -6115,8 +6115,13 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
    * {@code REBUILD TYPE} refused a repeat; the other four silently accepted it, last one wins.
    * <p>
    * The dedup key is the LOWERCASED setting name, not {@link Expression} identity: identity is case-sensitive
-   * (issue #6401), so {@code batchSize} and {@code BATCHSIZE} would otherwise land as two separate map entries even
-   * though every reader recognises a setting with {@code equalsIgnoreCase}.
+   * (issue #6401), so {@code batchSize} and {@code BATCHSIZE} would otherwise land as two separate map entries. That
+   * matches how {@code REBUILD INDEX} and {@code REBUILD TYPE} already recognise a setting, with
+   * {@code equalsIgnoreCase}. The other three don't read case-insensitively - {@code BackupDatabaseStatement}'s
+   * switch is exact-case, and {@code Import}/{@code ExportDatabaseStatement} hand the key through as-is to the
+   * integration-module setter - so for them this is a deliberate defensive choice, not a fix for an existing
+   * case-insensitive read: refusing the case-only repeat is still better than silently keeping whichever spelling the
+   * map iterates last.
    * <p>
    * The key itself is always built as {@code new Expression(Identifier)} - never the raw-{@code value} shape
    * {@code IMPORT}/{@code EXPORT}/{@code BACKUP DATABASE} used to use (issue #6409, item 1) - so every reader can

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -6096,14 +6096,39 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
       final List<SQLParser.IdentifierContext> settingKeys = ctx.identifier().subList(firstSettingKeyIndex, ctx.identifier().size());
       final List<SQLParser.ExpressionContext> settingValues = ctx.expression();
 
+      final Set<String> seenKeys = new HashSet<>();
       for (int i = 0; i < settingKeys.size() && i < settingValues.size(); i++) {
-        final Expression key = new Expression((Identifier) visit(settingKeys.get(i)));
+        final Identifier keyId = (Identifier) visit(settingKeys.get(i));
         final Expression value = (Expression) visit(settingValues.get(i));
-        stmt.settings.put(key, value);
+        putSetting(stmt.settings, seenKeys, keyId, value, "REBUILD INDEX");
       }
     }
 
     return stmt;
+  }
+
+  /**
+   * Adds one {@code WITH} setting to a DDL statement's {@code Map<Expression, Expression> settings}, refusing a
+   * duplicate key. Shared by every statement that carries such a map - {@code REBUILD INDEX}, {@code REBUILD TYPE},
+   * {@code IMPORT DATABASE}, {@code EXPORT DATABASE} and {@code BACKUP DATABASE} - so a repeated setting is treated
+   * the same way whichever of the five statements it is written in (issue #6409, item 2). Before this, only
+   * {@code REBUILD TYPE} refused a repeat; the other four silently accepted it, last one wins.
+   * <p>
+   * The dedup key is the LOWERCASED setting name, not {@link Expression} identity: identity is case-sensitive
+   * (issue #6401), so {@code batchSize} and {@code BATCHSIZE} would otherwise land as two separate map entries even
+   * though every reader recognises a setting with {@code equalsIgnoreCase}.
+   * <p>
+   * The key itself is always built as {@code new Expression(Identifier)} - never the raw-{@code value} shape
+   * {@code IMPORT}/{@code EXPORT}/{@code BACKUP DATABASE} used to use (issue #6409, item 1) - so every reader can
+   * recover the setting name the same way: {@code entry.getKey().toString()}.
+   */
+  private static void putSetting(final Map<Expression, Expression> settings, final Set<String> seenKeys, final Identifier keyId,
+      final Expression value, final String statementName) {
+    final String keyName = keyId.getStringValue().toLowerCase(Locale.ENGLISH);
+    if (!seenKeys.add(keyName))
+      throw new CommandSQLParsingException(
+          statementName + " WITH clause has duplicate setting '" + keyId.getStringValue() + "'. Each setting must appear at most once.");
+    settings.put(new Expression(keyId), value);
   }
 
   /**
@@ -6134,19 +6159,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     stmt.typeName = (Identifier) visit(bodyCtx.typeName);
     stmt.polymorphic = bodyCtx.POLYMORPHIC() != null;
     if (bodyCtx.WITH() != null) {
-      // Track which settingKey strings we've already seen so a duplicate (e.g. WITH batchSize=1, batchSize=2)
-      // doesn't silently shadow the first via Map.put. Bare Expression equality on the key would only catch
-      // exact AST matches; using the lowercased identifier string also catches case variants.
       final Set<String> seenKeys = new HashSet<>();
       for (int i = 0; i < bodyCtx.settingValue.size(); i++) {
         final Identifier keyId = (Identifier) visit(bodyCtx.settingKey.get(i));
-        final String keyName = keyId.getStringValue().toLowerCase(Locale.ENGLISH);
-        if (!seenKeys.add(keyName))
-          throw new CommandSQLParsingException(
-              "REBUILD TYPE WITH clause has duplicate setting '" + keyId.getStringValue()
-                  + "'. Each setting must appear at most once.");
         final Expression value = (Expression) visit(bodyCtx.settingValue.get(i));
-        stmt.settings.put(new Expression(keyId), value);
+        putSetting(stmt.settings, seenKeys, keyId, value, "REBUILD TYPE");
       }
     }
     return stmt;
@@ -7545,16 +7562,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // Parse WITH settings
     if (importCtx.settingList() != null) {
+      final Set<String> seenKeys = new HashSet<>();
       for (final SQLParser.SettingContext settingCtx : importCtx.settingList().setting()) {
         final Identifier key = (Identifier) visit(settingCtx.identifier());
         final Expression value = (Expression) visit(settingCtx.expression());
-
-        // Store as Expression with key/value
-        // ImportDatabaseStatement uses .execute() on the value Expression
-        final Expression keyExpr = new Expression();
-        keyExpr.value = key.getStringValue();
-
-        stmt.settings.put(keyExpr, value);
+        putSetting(stmt.settings, seenKeys, key, value, "IMPORT DATABASE");
       }
     }
 
@@ -7578,16 +7590,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // Parse WITH settings
     if (exportCtx.settingList() != null) {
+      final Set<String> seenKeys = new HashSet<>();
       for (final SQLParser.SettingContext settingCtx : exportCtx.settingList().setting()) {
         final Identifier key = (Identifier) visit(settingCtx.identifier());
         final Expression value = (Expression) visit(settingCtx.expression());
-
-        // Store as Expression with key/value
-        // ExportDatabaseStatement uses .execute() on the value Expression
-        final Expression keyExpr = new Expression();
-        keyExpr.value = key.getStringValue();
-
-        stmt.settings.put(keyExpr, value);
+        putSetting(stmt.settings, seenKeys, key, value, "EXPORT DATABASE");
       }
     }
 
@@ -7634,16 +7641,11 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
     // Parse WITH settings
     if (backupCtx.settingList() != null) {
+      final Set<String> seenKeys = new HashSet<>();
       for (final SQLParser.SettingContext settingCtx : backupCtx.settingList().setting()) {
         final Identifier key = (Identifier) visit(settingCtx.identifier());
         final Expression value = (Expression) visit(settingCtx.expression());
-
-        // Store as Expression with key/value
-        // BackupDatabaseStatement uses .execute() on the value Expression, so no need to extract .value
-        final Expression keyExpr = new Expression();
-        keyExpr.value = key.getStringValue();
-
-        stmt.settings.put(keyExpr, value);
+        putSetting(stmt.settings, seenKeys, key, value, "BACKUP DATABASE");
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayRangeSelector.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ArrayRangeSelector.java
@@ -175,6 +175,15 @@ public class ArrayRangeSelector extends SimpleNode {
     return new SimpleNode[] { fromSelector, toSelector };
   }
 
+  /**
+   * Without this, every field here is null/false-default on a bare-integer range ({@code a[1..3]}), so two parses
+   * of the same range compared unequal (object identity) instead of equal (issue #6409, item 3).
+   */
+  @Override
+  protected Object[] getIdentityElements() {
+    return new Object[] { from, to, newRange, included, fromSelector, toSelector };
+  }
+
   public void setValue(final Object target, final Object value, final CommandContext context) {
     if (target == null) {
       return;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
@@ -96,19 +96,11 @@ public class BackupDatabaseStatement extends SimpleExecStatement {
         for (Map.Entry<Expression, Expression> entry : settings.entrySet()) {
           final String stringValue = entry.getValue().execute((Identifiable) null, context).toString();
 
-          // THE KEY IS A STRING HELD IN Expression.value, AND Expression.toString() RENDERS A STRING QUOTED, SO
-          // MATCHING ON toString() SILENTLY MATCHED NOTHING AND EVERY 'WITH ...' SETTING WAS DROPPED - INCLUDING
-          // encryptionKey, WHICH MEANT A BACKUP ASKED TO BE ENCRYPTED WAS WRITTEN IN CLEAR. READ THE RAW VALUE, AS
-          // ExportDatabaseStatement ALREADY DOES
-          final Object rawKey = entry.getKey().value;
-          if (rawKey == null)
-            // NO FALLBACK TO Expression.toString() HERE ON PURPOSE. THAT IS THE BUGGY MATCH THIS BLOCK EXISTS TO FIX,
-            // AND FALLING BACK TO IT WOULD MEAN A FUTURE PARSER CHANGE THAT STOPPED POPULATING value SILENTLY
-            // RESURRECTED THE CLEARTEXT-ARCHIVE DEFECT INSTEAD OF FAILING
-            throw new CommandExecutionException(
-                "Cannot read the name of a backup setting from the parsed statement: " + entry.getKey());
-
-          final String settingName = rawKey.toString();
+          // The key is now always built as new Expression(Identifier) - never the raw-value shape that made
+          // toString() render nothing and silently drop every 'WITH ...' setting, encryptionKey included, which
+          // meant a backup asked to be encrypted was written in clear (issue #6409, item 1; SQLASTBuilder#putSetting
+          // is the one place all five WITH-settings statements build this key now).
+          final String settingName = entry.getKey().toString();
           try {
             switch (settingName) {
             case "encryptionAlgorithm" -> clazz.getMethod("setEncryptionAlgorithm", String.class)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CaseAlternative.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CaseAlternative.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.query.sql.parser;
 
+import java.util.Objects;
+
 /**
  * Represents a single WHEN...THEN alternative in a SQL CASE expression.
  * Example: WHEN age < 18 THEN 'minor'
@@ -61,5 +63,26 @@ public class CaseAlternative {
 
   public boolean isSimpleForm() {
     return whenCondition != null;
+  }
+
+  /**
+   * {@link CaseExpression#getIdentityElements()} carries {@code alternatives} - a {@code List<CaseAlternative>} -
+   * as one element, and {@code List.equals()} compares it element by element with THIS method, so without it every
+   * two alternatives fell back to reference identity (issue #6409, item 3).
+   */
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    final CaseAlternative that = (CaseAlternative) o;
+    return Objects.equals(whenCondition, that.whenCondition) && Objects.equals(whenExpression, that.whenExpression)
+        && Objects.equals(thenExpression, that.thenExpression);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(whenCondition, whenExpression, thenExpression);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CaseExpression.java
@@ -287,6 +287,18 @@ public class CaseExpression extends MathExpression {
     builder.append(" END");
   }
 
+  /**
+   * Without this override, identity fell back to the inherited {@link MathExpression#getIdentityElements()} -
+   * {@code childExpressions} and {@code operators}, which this class never populates - so every {@code CASE}
+   * expression's identity array held two empty lists, and two DIFFERENT {@code CASE WHEN} expressions compared
+   * EQUAL to each other (issue #6409, item 3: not the under-match the issue's own sweep went looking for, but the
+   * inverse failure the same corpus test catches just as well).
+   */
+  @Override
+  protected Object[] getIdentityElements() {
+    return new Object[] { caseExpression, alternatives, elseExpression };
+  }
+
   @Override
   public CaseExpression copy() {
     if (caseExpression != null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
@@ -93,7 +93,7 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
       final Map<String, String> settingsToString = new HashMap<>();
       for (final Map.Entry<Expression, Expression> entry : settings.entrySet()) {
         final Object executedValue = entry.getValue().execute((Identifiable) null, context);
-        settingsToString.put(entry.getKey().value.toString(), executedValue != null ? executedValue.toString() : entry.getValue().toString());
+        settingsToString.put(entry.getKey().toString(), executedValue != null ? executedValue.toString() : entry.getValue().toString());
       }
       clazz.getMethod("setSettings", Map.class).invoke(exporter, settingsToString);
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
@@ -124,9 +124,14 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
       url.toString(params, builder);
   }
 
+  /**
+   * {@code settings} belongs here too, not just {@code url}: two exports to the same URL with different
+   * {@code WITH} settings (format, overwrite, ...) are different statements. {@link BackupDatabaseStatement} already
+   * includes its {@code settings} the same way; this one didn't (found reviewing #6409, item 3's sweep).
+   */
   @Override
   protected Object[] getIdentityElements() {
-    return new Object[] { url };
+    return new Object[] { url, settings };
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -130,6 +130,12 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
     }
   }
 
+  /**
+   * Compares {@code settings} too, not just {@code url}: for {@code IMPORT DATABASE} the settings ARE the statement
+   * (a CSV import has no URL at all, only {@code WITH vertices=..., edges=...}), so leaving them out of identity
+   * made two imports with completely different sources compare equal (found reviewing #6409, item 3's sweep - the
+   * same over-match direction {@link CaseExpression} had, on a statement rather than an expression node).
+   */
   @Override
   public boolean equals(final Object o) {
     if (this == o)
@@ -137,12 +143,12 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
     if (o == null || getClass() != o.getClass())
       return false;
     final ImportDatabaseStatement that = (ImportDatabaseStatement) o;
-    return Objects.equals(url, that.url);
+    return Objects.equals(url, that.url) && Objects.equals(settings, that.settings);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(url);
+    return Objects.hash(url, settings);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -79,7 +79,7 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
       for (final Map.Entry<Expression, Expression> entry : settings.entrySet()) {
         final Object valueResult = entry.getValue().execute((Identifiable) null, context);
         final String valueStr = valueResult != null ? valueResult.toString() : entry.getValue().toString();
-        settingsToString.put(entry.getKey().value.toString(), valueStr);
+        settingsToString.put(entry.getKey().toString(), valueStr);
       }
 
       clazz.getMethod("setSettings", Map.class).invoke(importer, settingsToString);
@@ -123,7 +123,7 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
         if (!first)
           builder.append(", ");
         first = false;
-        builder.append(entry.getKey().value);
+        entry.getKey().toString(params, builder);
         builder.append(" = ");
         entry.getValue().toString(params, builder);
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InsertSetExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InsertSetExpression.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.parser;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Created by luigidellaquila on 19/02/15.
@@ -50,5 +51,26 @@ public class InsertSetExpression {
 
   public Expression getRight() {
     return right;
+  }
+
+  /**
+   * {@link InsertBody#equals(Object)} carries {@code setExpressions} - a {@code List<InsertSetExpression>} - through
+   * {@code Objects.equals()}, and {@code List.equals()} compares it element by element with THIS method, so without
+   * it two parses of the same {@code INSERT ... SET} statement fell back to reference identity and never compared
+   * equal (issue #6409, item 3).
+   */
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    final InsertSetExpression that = (InsertSetExpression) o;
+    return Objects.equals(left, that.left) && Objects.equals(right, that.right);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(left, right);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OrderByItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OrderByItem.java
@@ -24,6 +24,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.serializer.BinaryComparator;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
@@ -205,5 +206,28 @@ public class OrderByItem {
 
   public void setModifier(final Modifier modifier) {
     this.modifier = modifier;
+  }
+
+  /**
+   * {@link OrderBy#getIdentityElements()} hands {@link SimpleNode#equals(Object)} the raw {@code OrderByItem}
+   * elements to compare with {@link Objects#equals(Object, Object)}, which without this fell back to reference
+   * identity: two separate parses of the very same {@code ORDER BY} clause were never equal, and so neither was any
+   * statement that carries one (issue #6409, item 3).
+   */
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    final OrderByItem that = (OrderByItem) o;
+    return Objects.equals(alias, that.alias) && Objects.equals(modifier, that.modifier) && Objects.equals(recordAttr, that.recordAttr)
+        && Objects.equals(expression, that.expression) && Objects.equals(type, that.type)
+        && Objects.equals(directionParameter, that.directionParameter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(alias, modifier, recordAttr, expression, type, directionParameter);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
@@ -126,6 +126,13 @@ public abstract class SimpleNode implements Node {
 
     final Object[] otherElements = ((SimpleNode) other).getIdentityElements();
 
+    // Every override in the codebase today returns a fixed-length array literal, so this never trips - but nothing
+    // enforces that, and a future override built conditionally (e.g. appending an optional element) would otherwise
+    // throw ArrayIndexOutOfBoundsException out of equals(), which is not a place callers expect to have to handle one
+    // (issue #6409, item 4).
+    if (ownElements.length != otherElements.length)
+      return false;
+
     for (int i = 0; i < ownElements.length; i++)
       if (!Objects.equals(ownElements[i], otherElements[i]))
         return false;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ExportDatabaseStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ExportDatabaseStatementTestParserTest.java
@@ -83,19 +83,15 @@ class ExportDatabaseStatementTestParserTest extends AbstractParserTest {
   }
 
   /**
-   * Renders the settings the way {@code executeSimple} consumes them: the raw setting name held in
-   * {@code Expression.value} against the rendered value.
-   * <p>
-   * Comparing the two {@code Map<Expression, Expression>} instances directly would not work: {@code SimpleNode}
-   * derives {@code hashCode()} from a freshly allocated {@code Object[]}, so an {@code Expression} hashes to a
-   * different bucket on every call and {@code HashMap.equals} can never find a key. That is a separate, pre-existing
-   * defect - the settings map is only ever iterated in production, never looked up - and this test deliberately does
-   * not depend on it either way.
+   * Renders the settings the way {@code executeSimple} consumes them: the setting name read back with
+   * {@code toString()} against the rendered value. The key is built as {@code new Expression(Identifier)} - never
+   * the raw-{@code value} shape this used to read (issue #6409, item 1) - so {@code toString()} is how every one of
+   * the five {@code WITH}-settings statements recovers it now.
    */
   private static Map<String, String> renderSettings(final ExportDatabaseStatement statement) {
     final Map<String, String> rendered = new HashMap<>();
     for (final Map.Entry<Expression, Expression> entry : statement.settings.entrySet())
-      rendered.put(entry.getKey().value.toString(), entry.getValue().toString());
+      rendered.put(entry.getKey().toString(), entry.getValue().toString());
     return rendered;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ImportDatabaseStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ImportDatabaseStatementTestParserTest.java
@@ -89,19 +89,15 @@ class ImportDatabaseStatementTestParserTest extends AbstractParserTest {
   }
 
   /**
-   * Renders the settings the way {@code executeSimple} consumes them: the raw setting name held in
-   * {@code Expression.value} against the rendered value.
-   * <p>
-   * Comparing the two {@code Map<Expression, Expression>} instances directly would not work: {@code SimpleNode}
-   * derives {@code hashCode()} from a freshly allocated {@code Object[]}, so an {@code Expression} hashes to a
-   * different bucket on every call and {@code HashMap.equals} can never find a key. That is a separate, pre-existing
-   * defect - the settings map is only ever iterated in production, never looked up - and this test deliberately does
-   * not depend on it either way.
+   * Renders the settings the way {@code executeSimple} consumes them: the setting name read back with
+   * {@code toString()} against the rendered value. The key is built as {@code new Expression(Identifier)} - never
+   * the raw-{@code value} shape this used to read (issue #6409, item 1) - so {@code toString()} is how every one of
+   * the five {@code WITH}-settings statements recovers it now.
    */
   private static Map<String, String> renderSettings(final ImportDatabaseStatement statement) {
     final Map<String, String> rendered = new HashMap<>();
     for (final Map.Entry<Expression, Expression> entry : statement.settings.entrySet())
-      rendered.put(entry.getKey().value.toString(), entry.getValue().toString());
+      rendered.put(entry.getKey().toString(), entry.getValue().toString());
     return rendered;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6401NodeIdentityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6401NodeIdentityTest.java
@@ -64,7 +64,18 @@ class Issue6401NodeIdentityTest extends AbstractParserTest {
     assertThat(statement.hashCode()).isEqualTo(statement.hashCode());
   }
 
-  /** And the other half of the contract: two nodes that are equal answer the same hash code. */
+  /**
+   * And the other half of the contract: two nodes that are equal answer the same hash code. This is the corpus the
+   * issue #6401 javadoc above suggested widening to sweep for nodes whose identity does not work (issue #6409, item
+   * 3). Widening it surfaced three: {@code foo[1..5]} exercises {@link ArrayRangeSelector}, confirmed by that issue
+   * to fall back to reference identity and UNDER-match (two equal parses compared unequal); {@code ORDER BY} and
+   * {@code INSERT ... SET} exercise {@link OrderByItem} and {@link InsertSetExpression}, which had the same gap; and
+   * a bare {@code CaseExpression} had the opposite failure - no {@code getIdentityElements()} override of its own
+   * meant it inherited {@link MathExpression}'s, which reads fields ({@code childExpressions}, {@code operators})
+   * {@code CaseExpression} never populates, so it OVER-matched: two structurally different {@code CASE WHEN}
+   * expressions compared equal to each other. The rest is a representative spread of statement and expression
+   * shapes rather than an exhaustive walk of the ~67 {@code getIdentityElements()} overrides.
+   */
   @Test
   void equalNodesAnswerEqualHashCodes() {
     for (final String query : new String[] { //
@@ -73,13 +84,48 @@ class Issue6401NodeIdentityTest extends AbstractParserTest {
         "SELECT a.b[1] FROM V WHERE c = 'x'", //
         "SELECT (1 + 2) * 3 FROM V", //
         "SELECT max(a) FROM V GROUP BY b", //
-        "SELECT FROM V WHERE a IN [1, 2, 3]" }) {
+        "SELECT FROM V WHERE a IN [1, 2, 3]", //
+        "SELECT foo[1..5] FROM V", //
+        "SELECT foo[1...5] FROM V", //
+        "SELECT foo[?..?] FROM V", //
+        "SELECT foo[:a..:b] FROM V", //
+        "SELECT FROM V WHERE a = ?", //
+        "SELECT FROM V WHERE a = :name", //
+        "SELECT FROM V WHERE a BETWEEN 1 AND 10", //
+        "SELECT FROM V WHERE a LIKE 'foo%'", //
+        "SELECT FROM V ORDER BY a DESC LIMIT 10 SKIP 5", //
+        "SELECT CASE WHEN a = 1 THEN 'x' ELSE 'y' END FROM V", //
+        "SELECT CASE a WHEN 1 THEN 'x' ELSE 'y' END FROM V", //
+        "UPDATE V SET a = 1 WHERE b = 2", //
+        "DELETE FROM V WHERE a = 1", //
+        "INSERT INTO V SET a = 1", //
+        "REBUILD INDEX idx WITH batchSize = 100", //
+        "REBUILD TYPE Foo WITH batchSize = 100, repartition = true", //
+        "IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = true", //
+        "EXPORT DATABASE file://foo.bar WITH format = 'graphml'", //
+        "BACKUP DATABASE file://foo.bar WITH compressionLevel = 5" }) {
       final SimpleNode one = checkRightSyntax(query);
       final SimpleNode other = checkRightSyntax(query);
 
       assertThat(one).as(query).isEqualTo(other);
       assertThat(one.hashCode()).as(query).isEqualTo(other.hashCode());
     }
+  }
+
+  /**
+   * The inverse of {@link #equalNodesAnswerEqualHashCodes()}: two DIFFERENT {@code CASE WHEN} expressions must
+   * compare unequal. This is the one the corpus test above cannot express - it only ever compares a query against
+   * itself - and it is the one that actually caught the {@link CaseExpression} defect (issue #6409, item 3): before
+   * the fix, every {@code CASE} expression's identity was the two EMPTY lists it inherited from
+   * {@link MathExpression}, so any two of them were equal regardless of their WHEN/THEN content.
+   */
+  @Test
+  void differentCaseExpressionsAreNotTheSameExpression() {
+    final Expression one = projectionOf("SELECT CASE WHEN a = 1 THEN 'x' ELSE 'y' END FROM V");
+    final Expression two = projectionOf("SELECT CASE WHEN a = 2 THEN 'p' ELSE 'q' END FROM V");
+
+    assertThat(one).as("different WHEN/THEN branches are different expressions").isNotEqualTo(two);
+    assertThat(projectionOf("SELECT CASE WHEN a = 1 THEN 'x' ELSE 'y' END FROM V")).as("but the same one is the same").isEqualTo(one);
   }
 
   /** A bare numeric literal: five of {@code BaseExpression}'s fields are null, and the value lived in the sixth. */
@@ -153,10 +199,13 @@ class Issue6401NodeIdentityTest extends AbstractParserTest {
 
   /**
    * The shape that turned item 3 from a trap into a live defect once the hash codes started agreeing with
-   * {@code equals()}: {@code IMPORT}, {@code EXPORT} and {@code BACKUP DATABASE} park a setting NAME in the node's
-   * inherited {@code value} slot rather than building an identifier expression out of it, and {@code value} was not
-   * among {@link Expression}'s identity elements - so every key of a {@code WITH} clause was a node whose every
-   * other field is {@code null}/{@code false}, which is to say equal to every other key.
+   * {@code equals()}: before issue #6409 item 1, {@code IMPORT}, {@code EXPORT} and {@code BACKUP DATABASE} parked a
+   * setting NAME in the node's inherited {@code value} slot rather than building an identifier expression out of it,
+   * and {@code value} was not among {@link Expression}'s identity elements - so every key of a {@code WITH} clause
+   * was a node whose every other field is {@code null}/{@code false}, which is to say equal to every other key.
+   * <p>
+   * The key is now built the same way {@code REBUILD INDEX} and {@code REBUILD TYPE} already built it - {@code new
+   * Expression(Identifier)} - so it is read back with {@code toString()}, not the raw {@code value} slot.
    */
   @Test
   void everySettingKeyOfAWithClauseIsItsOwnKey() {
@@ -164,7 +213,7 @@ class Issue6401NodeIdentityTest extends AbstractParserTest {
         "IMPORT DATABASE http://www.foo.bar WITH forceDatabaseCreate = true, commitEvery = 10000");
 
     assertThat(statement.settings).as("two settings are two entries").hasSize(2);
-    assertThat(statement.settings.keySet().stream().map(k -> k.value.toString()))
+    assertThat(statement.settings.keySet().stream().map(Expression::toString))
         .containsExactlyInAnyOrder("forceDatabaseCreate", "commitEvery");
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6409FollowupsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6409FollowupsTest.java
@@ -137,6 +137,32 @@ class Issue6409FollowupsTest extends AbstractParserTest {
   }
 
   /**
+   * Found while addressing code review on this very PR, in the same sweep as item 3 but on a statement node rather
+   * than an expression node: {@code ImportDatabaseStatement#equals()} only compared {@code url}, and
+   * {@code ExportDatabaseStatement#getIdentityElements()} only listed {@code url} - so two statements with the same
+   * URL but DIFFERENT {@code WITH} settings compared equal. For {@code IMPORT DATABASE} this was the sharper of the
+   * two: it has no URL at all for a CSV import, so the settings ARE the statement.
+   * {@link BackupDatabaseStatement} already included {@code settings} in its identity; the other two now match it.
+   */
+  @Test
+  void importAndExportStatementsWithDifferentSettingsAreNotEqual() throws Exception {
+    final ImportDatabaseStatement importOne = (ImportDatabaseStatement) new SQLAntlrParser(null).parse(
+        "IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = true");
+    final ImportDatabaseStatement importTwo = (ImportDatabaseStatement) new SQLAntlrParser(null).parse(
+        "IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = false");
+    assertThat(importOne).as("same URL, different settings").isNotEqualTo(importTwo);
+    assertThat((ImportDatabaseStatement) new SQLAntlrParser(null).parse("IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = true"))
+        .as("but the same statement is still the same").isEqualTo(importOne);
+
+    final ExportDatabaseStatement exportOne = (ExportDatabaseStatement) new SQLAntlrParser(null).parse(
+        "EXPORT DATABASE file://foo.bar WITH format = 'graphml'");
+    final ExportDatabaseStatement exportTwo = (ExportDatabaseStatement) new SQLAntlrParser(null).parse(
+        "EXPORT DATABASE file://foo.bar WITH format = 'jsonl'");
+    assertThat(exportOne).as("same URL, different settings").isNotEqualTo(exportTwo);
+    assertThat(exportOne.hashCode()).isNotEqualTo(exportTwo.hashCode());
+  }
+
+  /**
    * Item 4: {@link SimpleNode#equals(Object)} indexed the OTHER node's identity array by THIS node's length, with no
    * guard. Safe today because {@code getClass() == other.getClass()} means both arrays come from the same override,
    * and every override returns a fixed-length array literal - but nothing enforces that invariant. This subclass

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6409FollowupsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6409FollowupsTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.query.sql.antlr.SQLAntlrParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6409, items 1, 2 and 4: three follow-ups from #6401 that were not that issue's to fix.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6409FollowupsTest extends AbstractParserTest {
+
+  /**
+   * Item 1: {@code IMPORT}, {@code EXPORT} and {@code BACKUP DATABASE} used to park a setting NAME in the node's
+   * inherited {@code value} slot rather than building an identifier expression out of it, the way {@code REBUILD
+   * INDEX} and {@code REBUILD TYPE} already did. All five now build the key the same way, so all five read it back
+   * the same way too: {@code toString()}, not the raw {@code value} slot.
+   */
+  @Test
+  void allFiveWithSettingsStatementsBuildTheSameKeyShape() throws Exception {
+    final ImportDatabaseStatement imp = (ImportDatabaseStatement) new SQLAntlrParser(null).parse(
+        "IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = true");
+    final ExportDatabaseStatement exp = (ExportDatabaseStatement) new SQLAntlrParser(null).parse(
+        "EXPORT DATABASE file://foo.bar WITH format = 'graphml'");
+    final BackupDatabaseStatement bak = (BackupDatabaseStatement) new SQLAntlrParser(null).parse(
+        "BACKUP DATABASE file://foo.bar WITH compressionLevel = 5");
+    final RebuildIndexStatement idx = (RebuildIndexStatement) new SQLAntlrParser(null).parse(
+        "REBUILD INDEX Foo WITH batchSize = 1000");
+    final RebuildTypeStatement typ = (RebuildTypeStatement) new SQLAntlrParser(null).parse(
+        "REBUILD TYPE Foo WITH batchSize = 1000");
+
+    assertThat(imp.settings.keySet()).as("IMPORT").allMatch(k -> k.isBaseIdentifier());
+    assertThat(exp.settings.keySet()).as("EXPORT").allMatch(k -> k.isBaseIdentifier());
+    assertThat(bak.settings.keySet()).as("BACKUP").allMatch(k -> k.isBaseIdentifier());
+    assertThat(idx.settings.keySet()).as("REBUILD INDEX").allMatch(k -> k.isBaseIdentifier());
+    assertThat(typ.settings.keySet()).as("REBUILD TYPE").allMatch(k -> k.isBaseIdentifier());
+
+    assertThat(imp.settings.keySet().iterator().next().value).as("no raw value slot any more").isNull();
+    assertThat(imp.settings.keySet().stream().map(Expression::toString)).containsExactly("forceDatabaseCreate");
+    assertThat(exp.settings.keySet().stream().map(Expression::toString)).containsExactly("format");
+    assertThat(bak.settings.keySet().stream().map(Expression::toString)).containsExactly("compressionLevel");
+  }
+
+  /**
+   * The historical defect the old shape produced (issue #6080 / #6359, item 2): a backup asked to be encrypted was
+   * silently written in clear because the setting name could not be read back. Guards against a regression on the
+   * executable path, not just the parsed shape.
+   */
+  @Test
+  void importExportBackupSettingsRoundTripThroughToString() {
+    checkRightSyntax("IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = true, commitEvery = 10000");
+    checkRightSyntax("EXPORT DATABASE file://foo.bar WITH format = 'graphml'");
+    checkRightSyntax("BACKUP DATABASE file://foo.bar WITH compressionLevel = 5, encryptionKey = 'secret'");
+  }
+
+  /**
+   * Item 2: before this, only {@code REBUILD TYPE} refused a repeated setting; the other four silently accepted it,
+   * last one wins. All five now agree, and the message names the actual statement.
+   */
+  @Test
+  void allFiveStatementsRefuseADuplicateSetting() {
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("REBUILD INDEX Foo WITH batchSize = 1, batchSize = 2"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("REBUILD INDEX").hasMessageContaining("duplicate setting");
+
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("REBUILD TYPE Foo WITH batchSize = 1, batchSize = 2"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("REBUILD TYPE").hasMessageContaining("duplicate setting");
+
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("IMPORT DATABASE http://foo.bar WITH batchSize = 1, batchSize = 2"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("IMPORT DATABASE").hasMessageContaining("duplicate setting");
+
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("EXPORT DATABASE file://foo.bar WITH batchSize = 1, batchSize = 2"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("EXPORT DATABASE").hasMessageContaining("duplicate setting");
+
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("BACKUP DATABASE file://foo.bar WITH batchSize = 1, batchSize = 2"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("BACKUP DATABASE").hasMessageContaining("duplicate setting");
+  }
+
+  /**
+   * The dedup key is the LOWERCASED name - matching the {@code equalsIgnoreCase} every reader already uses to
+   * recognise a setting - not {@link Expression} identity, which is case-sensitive since #6401. A case-only repeat
+   * ({@code batchSize} / {@code BATCHSIZE}) has to be caught too, in every one of the five statements.
+   */
+  @Test
+  void aCaseOnlyRepeatIsStillADuplicateInEveryStatement() {
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("REBUILD INDEX Foo WITH batchSize = 1, BATCHSIZE = 2"))
+        .isInstanceOf(CommandSQLParsingException.class).hasMessageContaining("duplicate setting");
+
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("IMPORT DATABASE http://foo.bar WITH batchSize = 1, BATCHSIZE = 2"))
+        .isInstanceOf(CommandSQLParsingException.class).hasMessageContaining("duplicate setting");
+
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("EXPORT DATABASE file://foo.bar WITH batchSize = 1, BATCHSIZE = 2"))
+        .isInstanceOf(CommandSQLParsingException.class).hasMessageContaining("duplicate setting");
+
+    assertThatThrownBy(() -> new SQLAntlrParser(null).parse("BACKUP DATABASE file://foo.bar WITH batchSize = 1, BATCHSIZE = 2"))
+        .isInstanceOf(CommandSQLParsingException.class).hasMessageContaining("duplicate setting");
+  }
+
+  /** Two DIFFERENT settings, or the same setting spelled once, must keep working - only an actual repeat is refused. */
+  @Test
+  void distinctSettingsAreNotFlaggedAsDuplicates() throws Exception {
+    final RebuildIndexStatement idx = (RebuildIndexStatement) new SQLAntlrParser(null).parse(
+        "REBUILD INDEX Foo WITH batchSize = 1000, maxAttempts = 5, statsOnly = true");
+    assertThat(idx.settings).hasSize(3);
+
+    final ImportDatabaseStatement imp = (ImportDatabaseStatement) new SQLAntlrParser(null).parse(
+        "IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = true, commitEvery = 10000");
+    assertThat(imp.settings).hasSize(2);
+  }
+
+  /**
+   * Item 4: {@link SimpleNode#equals(Object)} indexed the OTHER node's identity array by THIS node's length, with no
+   * guard. Safe today because {@code getClass() == other.getClass()} means both arrays come from the same override,
+   * and every override returns a fixed-length array literal - but nothing enforces that invariant. This subclass
+   * builds its array conditionally, the shape the issue calls out as the one that would otherwise throw
+   * {@link ArrayIndexOutOfBoundsException} out of {@code equals()}.
+   */
+  private static final class VariableArityNode extends SimpleNode {
+    private final Object[] elements;
+
+    private VariableArityNode(final Object... elements) {
+      this.elements = elements;
+    }
+
+    @Override
+    protected Object[] getIdentityElements() {
+      return elements;
+    }
+  }
+
+  @Test
+  void equalsGuardsAgainstAVariableLengthIdentityArray() {
+    final VariableArityNode shortOne = new VariableArityNode("a");
+    final VariableArityNode longOne = new VariableArityNode("a", "b");
+
+    assertThat(shortOne).as("different arity is never equal, and must not throw").isNotEqualTo(longOne);
+    assertThat(longOne).isNotEqualTo(shortOne);
+    assertThat(shortOne.hashCode()).as("hashCode still has to be computable").isEqualTo(Objects.hash("a"));
+  }
+}


### PR DESCRIPTION
## Summary

Follow-ups from #6401 (merged as #6407), collected while asking, for each parser node, "does identity actually work here now". Fixes items 1-4 of #6409; item 5 is a documented cost, not a defect, so no code change.

- **Item 1** - `IMPORT DATABASE`, `EXPORT DATABASE` and `BACKUP DATABASE` built their `WITH` setting keys as a raw name parked in the node's inherited `value` slot, while `REBUILD INDEX` and `REBUILD TYPE` already built a proper `new Expression(Identifier)`. All five now build the key the same way, and every reader recovers it the same way (`toString()`). This also removes the defensive raw-`value` read (and its `CommandExecutionException` fallback) in `BackupDatabaseStatement` that existed only because the old shape was fragile - the shape that, pre-#6407, made a backup asked to be encrypted get written in clear.
- **Item 2** - only `REBUILD TYPE` refused a duplicate `WITH` setting; the other four silently accepted one, last one wins. A shared `SQLASTBuilder#putSetting` helper now refuses a repeat - keyed on the lowercased name, matching the `equalsIgnoreCase` every reader already uses to recognise a setting - in all five statements.
- **Item 3** - a sweep for parser nodes whose identity does not work, widening the corpus test #6401 left as a starting point (`Issue6401NodeIdentityTest#equalNodesAnswerEqualHashCodes`). Confirmed and fixed:
  - `ArrayRangeSelector` (`a[1..3]`) had no `getIdentityElements()` at all - two parses compared unequal (under-match), exactly as #6409 called out.
  - `OrderByItem` and `InsertSetExpression` are plain (non-`SimpleNode`) helper classes referenced from a parent's identity list, with no `equals()`/`hashCode()` of their own - same under-match, breaking identity for **any** statement carrying an `ORDER BY` or an `INSERT ... SET`.
  - `CaseExpression` had the opposite failure: no identity override of its own meant it inherited `MathExpression`'s, which reads `childExpressions`/`operators` - fields `CaseExpression` never populates - so two structurally different `CASE WHEN` expressions **over-matched** as equal to each other. Confirmed with a throwaway reproduction before fixing (see `differentCaseExpressionsAreNotTheSameExpression` in the test).
- **Item 4** - `SimpleNode.equals()` indexed the *other* node's identity array by *this* node's length, with no guard. Harmless today because every override returns a fixed-length array literal, but a future override built conditionally would throw `ArrayIndexOutOfBoundsException` out of `equals()`. Added the length guard the issue suggested.
- **Item 5** - `hashCode()` being O(subtree) is an inherent, correctly-paid cost of hashing a tree, not a defect (per the issue's own text). No code change; nothing hashes a parsed node on a hot path today.

## Better alternative to what the issue proposed

The issue floated normalizing item 1's key shape and centralizing item 2's duplicate guard as two separate, independent changes. This PR does both through one shared `SQLASTBuilder#putSetting` helper: since the key shape and the dedup-key derivation both start from the same `Identifier`, doing them in one place means there is exactly one spot that knows how a `WITH` setting key is built, for all five statements including `REBUILD TYPE` (which previously duplicated the guard logic inline). That is also the "best alternative" for item 3: rather than hand-auditing the ~67 `getIdentityElements()` overrides, the corpus test that #6401 already had was widened, which is what actually caught `OrderByItem`, `InsertSetExpression` and the `CaseExpression` over-match - none of which the issue text had identified.

## Test plan

- New `Issue6409FollowupsTest`: all five `WITH`-settings statements build the same key shape and round-trip through `toString()`; all five refuse a duplicate setting (case-sensitive and case-insensitive); distinct settings still work; `SimpleNode.equals()` doesn't throw on a variable-length identity array.
- Widened `Issue6401NodeIdentityTest#equalNodesAnswerEqualHashCodes` with `ArrayRangeSelector`, `ORDER BY`, `CASE WHEN`, and all five `WITH`-settings statements; added `differentCaseExpressionsAreNotTheSameExpression` for the over-match direction.
- Fixed two pre-existing tests (`ImportDatabaseStatementTestParserTest`, `ExportDatabaseStatementTestParserTest`) that read the old raw-`value` shape directly.
- `mvn -o -pl engine -am test` on: the full `com.arcadedb.query.sql.parser` package (389 tests), the full ORDER BY suite across `sql`, `sql.executor`, `index` and `select` packages, `SQLCaseTest`, `DatabaseAdminStatementsTest`, `RebuildTypeRepartitionTest` - all green.
- Full reactor `mvn -o compile` - green.

🔗 Closes #6409