### PR TITLE
fix(#6406): TimeSeries check parallelism, CHECK DATABASE docs sync guard, compaction-race test coverage

### DIFF
--- a/.github/scripts/check-database-docs-sync.py
+++ b/.github/scripts/check-database-docs-sync.py
@@ -85,10 +85,12 @@ def top_level_optional_groups(rule_body):
 
 
 def leading_keywords(text):
-    """The leading run of ALL-CAPS tokens in `text`, joined with spaces - the clause's own keyword
-    phrase, stopping at the first token that is not a bare keyword (a rule reference, a literal, a
-    nested group, ...).
-    <p>
+    """
+    Return the leading run of ALL-CAPS tokens in `text`, joined with spaces.
+
+    This is the clause's own keyword phrase, stopping at the first token that is not a bare
+    keyword (a rule reference, a literal, a nested group, ...).
+
     `(`/`)` and `[`/`]` are split off as their own tokens rather than left glued to a neighbour,
     for both callers: a grammar clause can nest a `( ... )` alternation right after its keywords
     (`(identifier | INTEGER_LITERAL)`), and a docs clause can nest a `[,]*`-style placeholder
@@ -136,11 +138,12 @@ def extract_syntax_block(doc_text, anchor):
 
 
 def top_level_bracket_groups(text):
-    """Yields the inner text of every top-level `[ ... ]` group in `text`, in order.
+    r"""
+    Yield the inner text of every top-level `[ ... ]` group in `text`, in order.
 
-    Depth-tracked rather than a `[^\\]]*` regex: a clause's own placeholder can carry a NESTED
+    Depth-tracked rather than a `[^\]]*` regex: a clause's own placeholder can carry a NESTED
     bracket - `[ TYPE <type-name>[,]* ]` has one inside the type-name repetition - and a
-    non-greedy `\\[([^\\]]+?)\\]` stops at that INNER `]`, not the clause's real closing one. That
+    non-greedy `\[([^\]]+?)\]` stops at that INNER `]`, not the clause's real closing one. That
     happened to still resolve to the right clause name here only because `leading_keywords`
     truncates at the first non-keyword token anyway, so the truncated match and the full one
     produce the same phrase by coincidence of today's doc wording - not by construction. A syntax
@@ -209,16 +212,16 @@ def main():
               "does not mention:")
         for clause in missing_from_docs:
             print(f"   - {clause}")
-        print(f"   Update the [[sql-check-database]] syntax block in sql-database-admin.adoc "
-              f"(arcadedb-docs).")
+        print("   Update the [[sql-check-database]] syntax block in sql-database-admin.adoc "
+              "(arcadedb-docs).")
 
     if missing_from_grammar:
         print("❌ The docs' syntax block mentions clause(s) the grammar's checkDatabaseStatement "
               "rule no longer has:")
         for clause in missing_from_grammar:
             print(f"   - {clause}")
-        print(f"   Either the grammar dropped a clause the docs still advertise, or the docs "
-              f"phrase a clause the check does not recognise as one of the grammar's own keywords.")
+        print("   Either the grammar dropped a clause the docs still advertise, or the docs "
+              "phrase a clause the check does not recognise as one of the grammar's own keywords.")
 
     return 1
 

--- a/.github/scripts/check-database-docs-sync.py
+++ b/.github/scripts/check-database-docs-sync.py
@@ -87,10 +87,20 @@ def top_level_optional_groups(rule_body):
 def leading_keywords(text):
     """The leading run of ALL-CAPS tokens in `text`, joined with spaces - the clause's own keyword
     phrase, stopping at the first token that is not a bare keyword (a rule reference, a literal, a
-    nested group, ...)."""
-    tokens = text.replace('(', ' ( ').replace(')', ' ) ').split()
+    nested group, ...).
+    <p>
+    `(`/`)` and `[`/`]` are split off as their own tokens rather than left glued to a neighbour,
+    for both callers: a grammar clause can nest a `( ... )` alternation right after its keywords
+    (`(identifier | INTEGER_LITERAL)`), and a docs clause can nest a `[,]*`-style placeholder
+    repetition the same way (`<type-name>[,]*`). Either glued form would fail the bare-keyword
+    regex as one token and silently truncate the phrase one word early - splitting them off first
+    means a token is exactly one keyword or exactly one punctuation mark, never both at once.
+    """
+    tokens = text
+    for bracket in '()[]':
+        tokens = tokens.replace(bracket, f' {bracket} ')
     words = []
-    for tok in tokens:
+    for tok in tokens.split():
         if KEYWORD.match(tok):
             words.append(tok)
         else:
@@ -125,12 +135,43 @@ def extract_syntax_block(doc_text, anchor):
     return doc_text[fence_start + 4:fence_end]
 
 
+def top_level_bracket_groups(text):
+    """Yields the inner text of every top-level `[ ... ]` group in `text`, in order.
+
+    Depth-tracked rather than a `[^\\]]*` regex: a clause's own placeholder can carry a NESTED
+    bracket - `[ TYPE <type-name>[,]* ]` has one inside the type-name repetition - and a
+    non-greedy `\\[([^\\]]+?)\\]` stops at that INNER `]`, not the clause's real closing one. That
+    happened to still resolve to the right clause name here only because `leading_keywords`
+    truncates at the first non-keyword token anyway, so the truncated match and the full one
+    produce the same phrase by coincidence of today's doc wording - not by construction. A syntax
+    block phrased differently (uppercase text inside the nested brackets, or brackets before the
+    clause's own keyword) would have silently misparsed. Depth tracking has no such coincidence to
+    rely on.
+    """
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == '[':
+            depth = 1
+            j = i + 1
+            while j < n and depth > 0:
+                if text[j] == '[':
+                    depth += 1
+                elif text[j] == ']':
+                    depth -= 1
+                j += 1
+            yield text[i + 1:j - 1]
+            i = j
+        else:
+            i += 1
+
+
 def docs_clauses(doc_path, anchor='sql-check-database'):
     with open(doc_path, 'r', encoding='utf-8') as f:
         block = extract_syntax_block(f.read(), anchor)
     clauses = set()
-    for match in re.finditer(r'\[\s*([^\]]+?)\s*\]', block):
-        phrase = leading_keywords(match.group(1))
+    for group in top_level_bracket_groups(block):
+        phrase = leading_keywords(group.strip())
         if phrase:
             clauses.add(phrase)
     return clauses

--- a/.github/scripts/check-database-docs-sync.py
+++ b/.github/scripts/check-database-docs-sync.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+#
+# Fails when the SQL grammar's `CHECK DATABASE` clause list and its documented syntax block have
+# drifted apart (issue #6406 item 2).
+#
+# Context: RECORD (#5680), DELETE ORPHANS (#6090) and RECLAIM UNREFERENCED FILES (#6189) each
+# landed a new clause in `checkDatabaseStatement` (SQLParser.g4) without a matching edit to the
+# `[[sql-check-database]]` syntax block in arcadedb-docs's sql-database-admin.adoc - three separate
+# PRs missing the same line, which is a process gap rather than three oversights: nothing noticed,
+# because nothing looked. The next clause will miss it too unless something automated looks every
+# time.
+#
+# What this checks: every clause in the grammar rule's TOP-LEVEL `(...)?` groups - identified by
+# the leading run of ALL-CAPS keyword tokens in each group, e.g. `TYPE`, `BUCKET`, `RECORD`, `FIX`,
+# `DELETE ORPHANS`, `RECLAIM UNREFERENCED FILES`, `DEEP`, `COMPRESS` - must appear as a `[ ... ]`
+# clause in the docs' `[source,sql]` syntax block. The reverse (a clause the docs mention that the
+# grammar no longer has) is checked too: it is the same drift, just noticed from the other side,
+# and just as easy to leave stale once a clause is removed.
+#
+# What this deliberately does NOT check: clause ORDER, argument syntax (`<type-name>[,]*` vs
+# `<rid>[,]*`), or prose accuracy. Those need a human; this only proves neither side forgot a
+# clause exists.
+#
+# This generalises to any statement whose grammar rule and documented syntax are both one block
+# (the issue names this explicitly), but is scoped to CHECK DATABASE for now - that is the
+# statement with the history of drift, and a generic version needs a registry of which grammar
+# rule maps to which doc anchor, which is more machinery than one statement's guard justifies today.
+#
+# Usage:
+#   check-database-docs-sync.py <path-to-SQLParser.g4> <path-to-sql-database-admin.adoc>
+#
+# @author Luca Garulli (l.garulli@arcadedata.com)
+#
+import re
+import sys
+
+KEYWORD = re.compile(r'^[A-Z][A-Z_]*$')
+
+
+def strip_antlr_comments(text):
+    """Removes ANTLR `//...` and `/* ... */` comments so they cannot be mistaken for grammar tokens."""
+    text = re.sub(r'/\*.*?\*/', ' ', text, flags=re.DOTALL)
+    text = re.sub(r'//[^\n]*', ' ', text)
+    return text
+
+
+def extract_rule_body(grammar_text, rule_name):
+    """Returns the text between a named rule's `:` and its terminating top-level `;`."""
+    start = re.search(r'(?:^|\n)' + re.escape(rule_name) + r'\s*\n?\s*:', grammar_text)
+    if not start:
+        raise ValueError(f"rule '{rule_name}' not found in grammar")
+    pos = start.end()
+    depth = 0
+    for i in range(pos, len(grammar_text)):
+        c = grammar_text[i]
+        if c == '(':
+            depth += 1
+        elif c == ')':
+            depth -= 1
+        elif c == ';' and depth == 0:
+            return grammar_text[pos:i]
+    raise ValueError(f"rule '{rule_name}' has no terminating ';' (unbalanced parentheses?)")
+
+
+def top_level_optional_groups(rule_body):
+    """Yields the inner text of every top-level `( ... )?` group in a rule body, in order."""
+    i = 0
+    n = len(rule_body)
+    while i < n:
+        if rule_body[i] == '(':
+            depth = 1
+            j = i + 1
+            while j < n and depth > 0:
+                if rule_body[j] == '(':
+                    depth += 1
+                elif rule_body[j] == ')':
+                    depth -= 1
+                j += 1
+            # j is now just past the matching ')'
+            if j < n and rule_body[j] == '?':
+                yield rule_body[i + 1:j - 1]
+            i = j
+        else:
+            i += 1
+
+
+def leading_keywords(text):
+    """The leading run of ALL-CAPS tokens in `text`, joined with spaces - the clause's own keyword
+    phrase, stopping at the first token that is not a bare keyword (a rule reference, a literal, a
+    nested group, ...)."""
+    tokens = text.replace('(', ' ( ').replace(')', ' ) ').split()
+    words = []
+    for tok in tokens:
+        if KEYWORD.match(tok):
+            words.append(tok)
+        else:
+            break
+    return ' '.join(words)
+
+
+def grammar_clauses(grammar_path, rule_name='checkDatabaseStatement'):
+    with open(grammar_path, 'r', encoding='utf-8') as f:
+        text = strip_antlr_comments(f.read())
+    body = extract_rule_body(text, rule_name)
+    clauses = set()
+    for group in top_level_optional_groups(body):
+        phrase = leading_keywords(group)
+        if phrase:
+            clauses.add(phrase)
+    return clauses
+
+
+def extract_syntax_block(doc_text, anchor):
+    """The first `[source,sql] ---- ... ----` block after `[[anchor]]`."""
+    anchor_pos = doc_text.find(f'[[{anchor}]]')
+    if anchor_pos < 0:
+        raise ValueError(f"anchor '[[{anchor}]]' not found in docs")
+    block_start = doc_text.find('[source,sql]', anchor_pos)
+    if block_start < 0:
+        raise ValueError(f"no [source,sql] block after '[[{anchor}]]'")
+    fence_start = doc_text.find('----', block_start)
+    fence_end = doc_text.find('----', fence_start + 4)
+    if fence_start < 0 or fence_end < 0:
+        raise ValueError(f"[source,sql] block after '[[{anchor}]]' is not fenced with '----'")
+    return doc_text[fence_start + 4:fence_end]
+
+
+def docs_clauses(doc_path, anchor='sql-check-database'):
+    with open(doc_path, 'r', encoding='utf-8') as f:
+        block = extract_syntax_block(f.read(), anchor)
+    clauses = set()
+    for match in re.finditer(r'\[\s*([^\]]+?)\s*\]', block):
+        phrase = leading_keywords(match.group(1))
+        if phrase:
+            clauses.add(phrase)
+    return clauses
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('Usage: check-database-docs-sync.py <path-to-SQLParser.g4> <path-to-sql-database-admin.adoc>',
+              file=sys.stderr)
+        return 2
+
+    grammar_path, doc_path = sys.argv[1], sys.argv[2]
+
+    try:
+        grammar = grammar_clauses(grammar_path)
+    except ValueError as e:
+        print(f"ERROR: could not read CHECK DATABASE clauses from the grammar: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        docs = docs_clauses(doc_path)
+    except ValueError as e:
+        print(f"ERROR: could not read CHECK DATABASE clauses from the docs: {e}", file=sys.stderr)
+        return 2
+
+    missing_from_docs = sorted(grammar - docs)
+    missing_from_grammar = sorted(docs - grammar)
+
+    if not missing_from_docs and not missing_from_grammar:
+        print(f"✅ CHECK DATABASE: grammar and docs agree on {len(grammar)} clause(s)")
+        return 0
+
+    if missing_from_docs:
+        print("❌ The grammar's checkDatabaseStatement rule has clause(s) the docs' syntax block "
+              "does not mention:")
+        for clause in missing_from_docs:
+            print(f"   - {clause}")
+        print(f"   Update the [[sql-check-database]] syntax block in sql-database-admin.adoc "
+              f"(arcadedb-docs).")
+
+    if missing_from_grammar:
+        print("❌ The docs' syntax block mentions clause(s) the grammar's checkDatabaseStatement "
+              "rule no longer has:")
+        for clause in missing_from_grammar:
+            print(f"   - {clause}")
+        print(f"   Either the grammar dropped a clause the docs still advertise, or the docs "
+              f"phrase a clause the check does not recognise as one of the grammar's own keywords.")
+
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/check-database-docs-sync.py
+++ b/.github/scripts/check-database-docs-sync.py
@@ -85,19 +85,16 @@ def top_level_optional_groups(rule_body):
 
 
 def leading_keywords(text):
-    """
-    Return the leading run of ALL-CAPS tokens in `text`, joined with spaces.
-
-    This is the clause's own keyword phrase, stopping at the first token that is not a bare
-    keyword (a rule reference, a literal, a nested group, ...).
-
-    `(`/`)` and `[`/`]` are split off as their own tokens rather than left glued to a neighbour,
-    for both callers: a grammar clause can nest a `( ... )` alternation right after its keywords
-    (`(identifier | INTEGER_LITERAL)`), and a docs clause can nest a `[,]*`-style placeholder
-    repetition the same way (`<type-name>[,]*`). Either glued form would fail the bare-keyword
-    regex as one token and silently truncate the phrase one word early - splitting them off first
-    means a token is exactly one keyword or exactly one punctuation mark, never both at once.
-    """
+    """Return the leading run of ALL-CAPS tokens in `text`, joined with spaces."""
+    # This is the clause's own keyword phrase, stopping at the first token that is not a bare
+    # keyword (a rule reference, a literal, a nested group, ...).
+    #
+    # `(`/`)` and `[`/`]` are split off as their own tokens rather than left glued to a neighbour,
+    # for both callers: a grammar clause can nest a `( ... )` alternation right after its keywords
+    # (`(identifier | INTEGER_LITERAL)`), and a docs clause can nest a `[,]*`-style placeholder
+    # repetition the same way (`<type-name>[,]*`). Either glued form would fail the bare-keyword
+    # regex as one token and silently truncate the phrase one word early - splitting them off
+    # first means a token is exactly one keyword or exactly one punctuation mark, never both.
     tokens = text
     for bracket in '()[]':
         tokens = tokens.replace(bracket, f' {bracket} ')
@@ -138,19 +135,16 @@ def extract_syntax_block(doc_text, anchor):
 
 
 def top_level_bracket_groups(text):
-    r"""
-    Yield the inner text of every top-level `[ ... ]` group in `text`, in order.
-
-    Depth-tracked rather than a `[^\]]*` regex: a clause's own placeholder can carry a NESTED
-    bracket - `[ TYPE <type-name>[,]* ]` has one inside the type-name repetition - and a
-    non-greedy `\[([^\]]+?)\]` stops at that INNER `]`, not the clause's real closing one. That
-    happened to still resolve to the right clause name here only because `leading_keywords`
-    truncates at the first non-keyword token anyway, so the truncated match and the full one
-    produce the same phrase by coincidence of today's doc wording - not by construction. A syntax
-    block phrased differently (uppercase text inside the nested brackets, or brackets before the
-    clause's own keyword) would have silently misparsed. Depth tracking has no such coincidence to
-    rely on.
-    """
+    r"""Yield the inner text of every top-level `[ ... ]` group in `text`, in order."""
+    # Depth-tracked rather than a `[^\]]*` regex: a clause's own placeholder can carry a NESTED
+    # bracket - `[ TYPE <type-name>[,]* ]` has one inside the type-name repetition - and a
+    # non-greedy `\[([^\]]+?)\]` stops at that INNER `]`, not the clause's real closing one. That
+    # happened to still resolve to the right clause name here only because `leading_keywords`
+    # truncates at the first non-keyword token anyway, so the truncated match and the full one
+    # produce the same phrase by coincidence of today's doc wording - not by construction. A
+    # syntax block phrased differently (uppercase text inside the nested brackets, or brackets
+    # before the clause's own keyword) would have silently misparsed. Depth tracking has no such
+    # coincidence to rely on.
     i = 0
     n = len(text)
     while i < n:

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -25,6 +25,7 @@ COLLECT="$SCRIPTS/collect-coverage-reports.sh"
 RESULTS="$SCRIPTS/check-test-results.py"
 GUARDS="$SCRIPTS/check-test-reporter-guards.py"
 ALLOWLIST="$SCRIPTS/check-license-allowlist.py"
+DBDOCSSYNC="$SCRIPTS/check-database-docs-sync.py"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -956,6 +957,75 @@ expect "rejects a malformed report" 2 "not valid JSON" \
 printf '[]\n' >"$work/array.sarif"
 expect "rejects well-formed JSON that is not an object" 2 "not valid JSON" \
     "$SCRIPTS/filter-meterian-sarif.py" "$work/array.sarif"
+
+echo "check-database-docs-sync.py"
+
+# The #6406 shape: the grammar's checkDatabaseStatement rule and the docs' [[sql-check-database]]
+# syntax block, taken from a real snapshot of both at the time this test was written, agree.
+mkdir -p "$work/dbdocs-clean"
+cat >"$work/dbdocs-clean/SQLParser.g4" <<'EOF'
+checkDatabaseStatement
+    : CHECK DATABASE
+      (TYPE identifier (COMMA identifier)*)?
+      (BUCKET (identifier | INTEGER_LITERAL) (COMMA (identifier | INTEGER_LITERAL))*)?
+      (RECORD rid (COMMA rid)*)?
+      (FIX)?
+      (DELETE ORPHANS)?
+      (RECLAIM UNREFERENCED FILES)?
+      (DEEP)?
+      (COMPRESS)?
+    ;
+EOF
+cat >"$work/dbdocs-clean/sql-database-admin.adoc" <<'EOF'
+[[sql-check-database]]
+===== SQL - `CHECK DATABASE`
+
+[source,sql]
+----
+CHECK DATABASE [ TYPE <type-name>[,]* ] [ BUCKET <bucket-name>[,]* ] [ RECORD <rid>[,]* ]
+              [ FIX ] [ DELETE ORPHANS ] [ RECLAIM UNREFERENCED FILES ] [ DEEP ] [ COMPRESS ]
+----
+EOF
+expect "accepts a grammar and docs block that agree" 0 "agree on 8 clause" \
+    "$DBDOCSSYNC" "$work/dbdocs-clean/SQLParser.g4" "$work/dbdocs-clean/sql-database-admin.adoc"
+
+# The #5680/#6090/#6189 shape itself: a clause lands in the grammar and the docs are never
+# touched. Modeled here as VALIDATE SIGNATURES, a clause neither side has ever had, so this pins
+# detection rather than a coincidence with real history.
+mkdir -p "$work/dbdocs-grammar-ahead"
+cp "$work/dbdocs-clean/sql-database-admin.adoc" "$work/dbdocs-grammar-ahead/"
+sed 's/(COMPRESS)?/(COMPRESS)?\n      (VALIDATE SIGNATURES)?/' \
+    "$work/dbdocs-clean/SQLParser.g4" >"$work/dbdocs-grammar-ahead/SQLParser.g4"
+expect "rejects a grammar clause the docs never mention" 1 "VALIDATE SIGNATURES" \
+    "$DBDOCSSYNC" "$work/dbdocs-grammar-ahead/SQLParser.g4" "$work/dbdocs-grammar-ahead/sql-database-admin.adoc"
+
+# The other direction: the docs still advertise a clause a later grammar change removed. Just as
+# stale, and just as easy to miss without something that reads both sides.
+mkdir -p "$work/dbdocs-docs-ahead"
+cp "$work/dbdocs-clean/sql-database-admin.adoc" "$work/dbdocs-docs-ahead/"
+sed '/(RECLAIM UNREFERENCED FILES)?/d' \
+    "$work/dbdocs-clean/SQLParser.g4" >"$work/dbdocs-docs-ahead/SQLParser.g4"
+expect "rejects a docs clause the grammar no longer has" 1 "RECLAIM UNREFERENCED FILES" \
+    "$DBDOCSSYNC" "$work/dbdocs-docs-ahead/SQLParser.g4" "$work/dbdocs-docs-ahead/sql-database-admin.adoc"
+
+# A multi-keyword clause (DELETE ORPHANS) has to match as ONE phrase, not as two single-keyword
+# clauses that happen to sit next to each other - otherwise a docs block that separately mentions
+# a bare `[ DELETE ]` and a bare `[ ORPHANS ]` would be accepted as if it spelled out the clause
+# the grammar actually has.
+mkdir -p "$work/dbdocs-split-phrase"
+cp "$work/dbdocs-clean/SQLParser.g4" "$work/dbdocs-split-phrase/"
+sed 's/\[ DELETE ORPHANS \]/[ DELETE ] [ ORPHANS ]/' \
+    "$work/dbdocs-clean/sql-database-admin.adoc" >"$work/dbdocs-split-phrase/sql-database-admin.adoc"
+expect "treats a multi-keyword clause as one phrase, not separate keywords" 1 "DELETE ORPHANS" \
+    "$DBDOCSSYNC" "$work/dbdocs-split-phrase/SQLParser.g4" "$work/dbdocs-split-phrase/sql-database-admin.adoc"
+
+# A missing anchor or a missing rule is a script/input problem, not a clause mismatch - it must
+# fail loudly with which one is missing rather than reporting an empty, vacuously-agreeing diff.
+mkdir -p "$work/dbdocs-no-anchor"
+cp "$work/dbdocs-clean/SQLParser.g4" "$work/dbdocs-no-anchor/"
+printf 'No CHECK DATABASE section here.\n' >"$work/dbdocs-no-anchor/sql-database-admin.adoc"
+expect "fails loudly when the docs anchor is missing" 2 "anchor" \
+    "$DBDOCSSYNC" "$work/dbdocs-no-anchor/SQLParser.g4" "$work/dbdocs-no-anchor/sql-database-admin.adoc"
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -1027,6 +1027,35 @@ printf 'No CHECK DATABASE section here.\n' >"$work/dbdocs-no-anchor/sql-database
 expect "fails loudly when the docs anchor is missing" 2 "anchor" \
     "$DBDOCSSYNC" "$work/dbdocs-no-anchor/SQLParser.g4" "$work/dbdocs-no-anchor/sql-database-admin.adoc"
 
+# A clause whose placeholder repetition sits directly against the clause's OWN last keyword, no
+# space in between (RECLAIM UNREFERENCED FILES[,]*) - code review on #6406 flagged that a
+# non-greedy `\[([^\]]+?)\]` extracting the docs' bracket groups stops at the FIRST `]` it meets,
+# which here is the placeholder's own inner one, truncating the captured text to "...FILES[," and
+# silently dropping FILES from the recovered phrase. That used to be a false-positive drift alarm
+# (grammar and docs agreeing in reality, reported as disagreeing) rather than a crash, which is
+# exactly the failure mode a docs-sync guard must not have: it would tell a PR author to "fix" a
+# doc line that was already correct. Depth-tracked bracket matching plus splitting `[`/`]` off as
+# their own tokens in leading_keywords (matching how `(`/`)` were already split) fixes it.
+mkdir -p "$work/dbdocs-adjacent-bracket"
+cat >"$work/dbdocs-adjacent-bracket/SQLParser.g4" <<'EOF'
+checkDatabaseStatement
+    : CHECK DATABASE
+      (TYPE identifier (COMMA identifier)*)?
+      (RECLAIM UNREFERENCED FILES)?
+    ;
+EOF
+cat >"$work/dbdocs-adjacent-bracket/sql-database-admin.adoc" <<'EOF'
+[[sql-check-database]]
+===== SQL - `CHECK DATABASE`
+
+[source,sql]
+----
+CHECK DATABASE [ TYPE <type-name>[,]* ] [ RECLAIM UNREFERENCED FILES[,]* ]
+----
+EOF
+expect "recovers a full keyword phrase when a placeholder touches the last keyword" 0 "agree on 2 clause" \
+    "$DBDOCSSYNC" "$work/dbdocs-adjacent-bracket/SQLParser.g4" "$work/dbdocs-adjacent-bracket/sql-database-admin.adoc"
+
 echo
 if [[ $failures -gt 0 ]]; then
     echo "$failures of $checks checks failed"

--- a/.github/workflows/check-database-docs-sync.yml
+++ b/.github/workflows/check-database-docs-sync.yml
@@ -21,6 +21,13 @@
 # (#6189) each added a clause to CHECK DATABASE's grammar without a matching edit to its
 # documented syntax in arcadedb-docs - three separate PRs missing the same line, because nothing
 # checked. This job is what checks, every time the grammar rule that can drift changes.
+#
+# It always diffs against arcadedb-docs' CURRENT default branch, so if a grammar change and its
+# doc update are sequenced as two separate PRs (grammar landing first), the grammar PR's run of
+# this job is red until the docs PR merges - that is the check doing its job, not a bug: the two
+# really are out of sync at that point, and this job exists to say so rather than let it pass
+# silently. Land the doc update first, or accept the red job until it does; workflow_dispatch
+# below re-runs the check on demand once arcadedb-docs catches up.
 name: CHECK DATABASE docs sync
 
 on:

--- a/.github/workflows/check-database-docs-sync.yml
+++ b/.github/workflows/check-database-docs-sync.yml
@@ -1,0 +1,66 @@
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Issue #6406 item 2: RECORD (#5680), DELETE ORPHANS (#6090) and RECLAIM UNREFERENCED FILES
+# (#6189) each added a clause to CHECK DATABASE's grammar without a matching edit to its
+# documented syntax in arcadedb-docs - three separate PRs missing the same line, because nothing
+# checked. This job is what checks, every time the grammar rule that can drift changes.
+name: CHECK DATABASE docs sync
+
+on:
+  pull_request:
+    paths:
+      - 'engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4'
+      - '.github/scripts/check-database-docs-sync.py'
+      - '.github/workflows/check-database-docs-sync.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4'
+  workflow_dispatch:
+    # Allow manual trigger, e.g. to re-check after an arcadedb-docs-only edit.
+
+permissions:
+  contents: read
+
+jobs:
+  check-sync:
+    name: Check CHECK DATABASE grammar/docs sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout arcadedb
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: arcadedb
+
+      # Read-only, public repo, no credentials needed - this job only ever reads
+      # sql-database-admin.adoc from arcadedb-docs' default branch, it never writes to it.
+      - name: Checkout arcadedb-docs
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ArcadeData/arcadedb-docs
+          path: arcadedb-docs
+
+      - name: Compare the grammar's CHECK DATABASE clauses against the documented syntax
+        run: |
+          arcadedb/.github/scripts/check-database-docs-sync.py \
+            arcadedb/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4 \
+            arcadedb-docs/src/main/asciidoc/reference/sql/sql-database-admin.adoc

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -734,8 +734,11 @@ public class DatabaseChecker {
 
       try {
         // ONE walk over the type's shards, not three: the report carries the totals this pass publishes alongside
-        // the findings, with each shard measuring itself inside the same lock window it checks itself in - so the
-        // numbers and the verdict describe one instant rather than three.
+        // the findings, and the totals are read inside the SAME lock window each shard's mutable-half check
+        // already runs in - so the numbers describe one instant, not a second and third walk over the same
+        // shards. The sealed-half findings do not share that window (issue #6406 item 1: they are fanned out
+        // across the type's own pool, after every shard's mutable half has already run) - see
+        // TimeSeriesEngine.checkIntegrity's own javadoc for what that trades away and why it is still safe.
         final TimeSeriesEngine.IntegrityReport report = engine.checkIntegrity(options);
 
         totalShards += report.shards();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -759,6 +759,15 @@ public class TimeSeriesEngine implements AutoCloseable {
    * can happen between the two checks", it was "each half's own findings and totals describe one self-consistent
    * instant of THAT half" - and a wider gap does not weaken that, it only makes a compaction landing in it more
    * likely, which was already an accepted, documented outcome before this issue.
+   * <p>
+   * <b>{@code shardExecutor} has a new kind of consumer</b> (code review of #6406): this pass never touched that
+   * pool before this issue, and {@code appendBatch}'s parallel dispatch (no enclosing transaction on the calling
+   * thread) and {@link #aggregateMultiBlocks} already share it. A {@code DEEP} check now occupies all
+   * {@code shardCount} of its threads for the length of a full CRC32/decode walk over every shard's sealed file,
+   * so a concurrent append or aggregation that would otherwise run immediately queues behind it instead. Sharing
+   * the pool for this shape of read-only per-shard work is the existing, intentional design (see the
+   * {@code engine-concurrency} skill's pool inventory) - this is a new, and potentially long-running, consumer of
+   * it, not a new pool or a new pattern.
    */
   public IntegrityReport checkIntegrity(final TimeSeriesIntegrity.Options options) throws IOException {
     final List<String> problems = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -727,9 +727,9 @@ public class TimeSeriesEngine implements AutoCloseable {
    * storage component in the engine was covered; these three formats, each with its own magic, header and (for the
    * sealed store) CRCs, were not.
    * <p>
-   * Every shard is visited ONCE, and the totals come back with the verdict rather than being gathered by a second
-   * and third walk over the same shards: each shard measures itself inside the same lock window it checks itself
-   * in, so the numbers and the findings describe one instant instead of three.
+   * Every shard is visited ONCE for each half, and the totals come back with the verdict rather than being
+   * gathered by a second and third walk over the same shards: each shard measures itself inside the same lock
+   * window it checks itself in, so the numbers and the findings describe one instant instead of three.
    * <p>
    * Each line names the shard it came from, since a type has as many of each file as it has shards and an operator
    * acting on a finding needs to know which one to act on.
@@ -737,6 +737,16 @@ public class TimeSeriesEngine implements AutoCloseable {
    * The two knobs in {@link TimeSeriesIntegrity.Options} are {@code DEEP}, which decodes every sealed block rather
    * than only verifying its CRC, and {@code FIX}, which repairs derived bookkeeping and never a sample. Both are
    * documented where they are decided: {@code DatabaseChecker.setDeep} and {@code DatabaseChecker.checkTimeSeries}.
+   * <p>
+   * <b>Sequential mutable half, fanned-out sealed half (issue #6406 item 1).</b> {@link TimeSeriesShard#checkMutableIntegrity}
+   * opens a transaction bound to the calling thread, so shards are walked for it one at a time, exactly as before
+   * this issue. {@link TimeSeriesShard#checkSealedIntegrity} opens none and does {@code DEEP}'s per-block decoding -
+   * by a distance the heaviest work this pass does - so it is fanned out across {@code shardExecutor} instead: the
+   * same pool {@link #aggregateMultiBlocks} already uses for the same shape of read-only per-shard work, and a
+   * pool this class owns for exactly its own lifetime, so nothing here reaches for shared or engine-global
+   * parallelism. A type with one shard sees no fan-out (a single future, resolved on the pool with the same cost as
+   * calling it directly); the benefit scales with shard count, which is also where the sequential form's wall-clock
+   * used to scale.
    */
   public IntegrityReport checkIntegrity(final TimeSeriesIntegrity.Options options) throws IOException {
     final List<String> problems = new ArrayList<>();
@@ -744,14 +754,54 @@ public class TimeSeriesEngine implements AutoCloseable {
     long samples = 0;
     long sealedBlocks = 0;
 
-    for (final TimeSeriesShard shard : shards) {
-      final TimeSeriesShard.IntegrityReport report = shard.checkIntegrity(options);
-      for (final String problem : report.problems())
-        problems.add("shard " + shard.getShardIndex() + " " + problem);
-      for (final String repair : report.repairs())
-        repairs.add("shard " + shard.getShardIndex() + " " + repair);
-      samples += report.samples();
-      sealedBlocks += report.sealedBlocks();
+    // PHASE 1: THE MUTABLE HALF, SEQUENTIAL - each shard opens (and, under FIX, commits) its own transaction, and
+    // ArcadeDB transactions are bound to the calling thread, so this cannot be fanned out without putting
+    // concurrent transactions of the same database on different pool threads.
+    final TimeSeriesShard.IntegrityReport[] mutableReports = new TimeSeriesShard.IntegrityReport[shardCount];
+    for (int s = 0; s < shardCount; s++) {
+      mutableReports[s] = shards[s].checkMutableIntegrity(options);
+      samples += mutableReports[s].samples();
+      sealedBlocks += mutableReports[s].sealedBlocks();
+    }
+
+    // PHASE 2: THE SEALED HALF, FANNED OUT - opens no transaction, so every shard's sealed store can be checked on
+    // its own pool thread concurrently. This is where DEEP's per-block decoding lands, which is the expensive part
+    // of the whole pass.
+    @SuppressWarnings("unchecked")
+    final CompletableFuture<TimeSeriesShard.IntegrityReport>[] sealedFutures = new CompletableFuture[shardCount];
+    for (int s = 0; s < shardCount; s++) {
+      final TimeSeriesShard shard = shards[s];
+      sealedFutures[s] = CompletableFuture.supplyAsync(() -> {
+        try {
+          return shard.checkSealedIntegrity(options);
+        } catch (final IOException e) {
+          throw new CompletionException(e);
+        }
+      }, shardExecutor);
+    }
+
+    try {
+      CompletableFuture.allOf(sealedFutures).join();
+    } catch (final CompletionException e) {
+      if (e.getCause() instanceof IOException ioe)
+        throw ioe;
+      throw new IOException("Parallel shard integrity check failed", e.getCause());
+    }
+
+    // Merged in shard order, once both halves of every shard are known, so the report's shard-ordering does not
+    // depend on which pool thread happened to finish first.
+    for (int s = 0; s < shardCount; s++) {
+      final int shardIndex = shards[s].getShardIndex();
+      for (final String problem : mutableReports[s].problems())
+        problems.add("shard " + shardIndex + " " + problem);
+      for (final String repair : mutableReports[s].repairs())
+        repairs.add("shard " + shardIndex + " " + repair);
+
+      final TimeSeriesShard.IntegrityReport sealedReport = sealedFutures[s].join();
+      for (final String problem : sealedReport.problems())
+        problems.add("shard " + shardIndex + " " + problem);
+      for (final String repair : sealedReport.repairs())
+        repairs.add("shard " + shardIndex + " " + repair);
     }
 
     if (tagDictionary != null)

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -747,6 +747,18 @@ public class TimeSeriesEngine implements AutoCloseable {
    * parallelism. A type with one shard sees no fan-out (a single future, resolved on the pool with the same cost as
    * calling it directly); the benefit scales with shard count, which is also where the sequential form's wall-clock
    * used to scale.
+   * <p>
+   * <b>What running all shards' mutable halves before any shard's sealed half actually widens</b> (code review of
+   * #6406, called out here rather than left to be inferred from the two methods' javadoc separately): before this
+   * split, one shard's sealed check ran immediately after that SAME shard's mutable check, so the window between
+   * them was however long the unlock-and-return took - a handful of instructions. Now every shard's sealed check
+   * waits for EVERY shard's mutable check to finish first, so for every shard but the last, that window is however
+   * long the remaining shards' mutable phases take - potentially the bulk of the whole pass's sequential portion.
+   * This is a genuine change in how long a compaction has to land in the gap, not only a documentation one. It is
+   * still safe for the reason {@link TimeSeriesShard#checkSealedIntegrity} gives: the guarantee was never "nothing
+   * can happen between the two checks", it was "each half's own findings and totals describe one self-consistent
+   * instant of THAT half" - and a wider gap does not weaken that, it only makes a compaction landing in it more
+   * likely, which was already an accepted, documented outcome before this issue.
    */
   public IntegrityReport checkIntegrity(final TimeSeriesIntegrity.Options options) throws IOException {
     final List<String> problems = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -100,6 +100,13 @@ public class TimeSeriesShard implements AutoCloseable {
    * {@link ConcurrentModificationException} from the real commit would. Same idiom as
    * {@code RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT} for the equivalent leader-side problem.
    * <p>
+   * One static field for every {@code TimeSeriesShard} in the JVM, not one per instance or per type - same
+   * shape as {@link #TEST_PRE_PHASE4C_HOOK}, and safe today for the same reason: this module runs with a single
+   * Surefire fork and no parallel test execution, so at most one test has it armed at a time. Do not enable
+   * parallel test execution for this module without addressing this hook (and {@link #TEST_PRE_PHASE4C_HOOK}) -
+   * two tests racing to arm/clear the same field would each risk firing the other's fault, or clearing a fault
+   * a still-running test needed.
+   * <p>
    * Tests that set this MUST reset it to {@code null} in an {@code @AfterEach} method, for the same
    * reason as {@link #TEST_PRE_PHASE4C_HOOK} above.
    */

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -1115,10 +1115,14 @@ public class TimeSeriesShard implements AutoCloseable {
    * <p>
    * <b>The consequence of the two halves no longer sharing one window</b>, stated rather than left to be
    * discovered: a compaction may run between {@link #checkMutableIntegrity} and this call, so the sealed store this
-   * checks can hold blocks the other's totals did not count. That was already true of the original, unsplit method -
-   * the two halves never shared a lock even there - and it is the right trade regardless: the totals are a report of
-   * what was there and the findings here are a verdict on what is there, and a compaction moving rows between two
-   * halves that are BOTH being reported cannot invent or lose a sample.
+   * checks can hold blocks the other's totals did not count. That gap already existed in the original, unsplit
+   * method - the two halves never shared a lock even there - but {@link TimeSeriesEngine#checkIntegrity} widened
+   * it (code review of #6406): every shard's mutable half now runs before any shard's sealed half, so for every
+   * shard but the last, this method can start well after its own {@link #checkMutableIntegrity} returned rather
+   * than immediately after, and the compaction has correspondingly longer to land in the gap. It is still the
+   * right trade: the totals are a report of what was there and the findings here are a verdict on what is there,
+   * and a compaction moving rows between two halves that are BOTH being reported cannot invent or lose a sample -
+   * a wider gap changes how OFTEN that trade is exercised, not whether it holds.
    */
   public IntegrityReport checkSealedIntegrity(final TimeSeriesIntegrity.Options options) throws IOException {
     final List<String> problems = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -41,6 +41,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 
 /**
  * Pairs a mutable TimeSeriesBucket with a sealed TimeSeriesSealedStore.
@@ -88,6 +89,21 @@ public class TimeSeriesShard implements AutoCloseable {
    * it leaks into subsequent tests in the same JVM and silently alters their compaction timing.
    */
   public static volatile Runnable TEST_PRE_PHASE4C_HOOK = null;
+
+  /**
+   * Test-only fault-injection hook (issue #6406 item 5). When non-null, fires in
+   * {@link #checkMutableIntegrity} immediately before the {@code FIX} transaction's commit -
+   * but only on the path that actually reaches a commit, a repair with something to write. Set
+   * to a non-null {@link Consumer} (the argument is {@code "<type>_shard_<index>"}) to simulate the
+   * compaction-race arm this method's own javadoc documents but cannot exercise deterministically
+   * without a live concurrent compaction: throw from the consumer, exactly as a losing
+   * {@link ConcurrentModificationException} from the real commit would. Same idiom as
+   * {@code RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT} for the equivalent leader-side problem.
+   * <p>
+   * Tests that set this MUST reset it to {@code null} in an {@code @AfterEach} method, for the same
+   * reason as {@link #TEST_PRE_PHASE4C_HOOK} above.
+   */
+  public static volatile Consumer<String> TEST_FIX_COMMIT_FAULT = null;
 
   public TimeSeriesShard(final DatabaseInternal database, final String baseName, final int shardIndex,
                          final List<ColumnDefinition> columns) throws IOException {
@@ -946,20 +962,31 @@ public class TimeSeriesShard implements AutoCloseable {
   }
 
   /**
-   * Validates both halves of this shard - the mutable bucket's pages and the sealed store's blocks - and returns
-   * one line per problem, empty when there is none, together with what the two halves hold (issue #6340) and, when
+   * Validates the mutable bucket's pages and returns one line per problem, empty when there is none, together with
+   * what BOTH halves of the shard hold at this instant (issue #6340) and, when
    * {@link TimeSeriesIntegrity.Options#fix()} is set, one line per repair applied (issue #6360).
    * <p>
-   * <b>Two windows, and which work goes in which is the whole design here.</b>
+   * This is the SHORT, transaction-bound half of the shard's check; {@link #checkSealedIntegrity} is the other,
+   * expensive one. The split (issue #6406 item 1) is what lets {@link TimeSeriesEngine#checkIntegrity} run this
+   * half sequentially, one shard at a time as before, while fanning {@link #checkSealedIntegrity} out across
+   * {@code shardExecutor} - the same pool {@code aggregateMultiBlocks} already uses for the same shape of
+   * read-only per-shard work. Fanning THIS half out too would put concurrent transactions from the same database
+   * on different pool threads, which ArcadeDB transactions do not support (they are bound to the calling thread);
+   * {@link #checkSealedIntegrity} opens none, so it carries no such restriction.
    * <p>
-   * The SHORT window holds {@link #appendLock} and then the compaction READ lock - the order
+   * <b>The window, and why it covers both totals even though only one half is checked here.</b>
+   * <p>
+   * It holds {@link #appendLock} and then the compaction READ lock - the order
    * {@link #appendSamples(TimeSeriesRowSource)} takes them in, and the one that keeps this free of the inversion
    * the class comment warns about. It covers the mutable bucket's check and BOTH totals. It has to: the mutable
    * header's counters are raised by every append and recomputed by every compaction, so reconciling them against
    * the pages without holding anything would report a healthy shard as damaged whenever a write landed in
    * between, and a total taken outside it would describe neither the state the walk checked nor any other single
    * instant, since a compaction moves rows from one half to the other. That window is bounded by the mutable
-   * bucket's page count and reads page headers only.
+   * bucket's page count and reads page headers only. The sealed store's contribution to the totals
+   * ({@code getTotalSampleCount()}/{@code getBlockCount()}) is a cheap header read, not the CRC walk
+   * {@link #checkSealedIntegrity} does - it is read here, under this window, for the same reason the mutable
+   * count is: so the combined total describes one instant rather than two.
    * <p>
    * <b>The repair of the mutable header rides in that same window</b>, in a transaction this method owns, and it
    * follows {@link #appendSamples(TimeSeriesRowSource)}'s rule to the letter: on a replicated database the
@@ -972,24 +999,12 @@ public class TimeSeriesShard implements AutoCloseable {
    * write numbers that no longer describe the pages. The next {@code CHECK DATABASE FIX} walks again and finds
    * whatever is true then; the operator is told to run it.
    * <p>
-   * The sealed store's check runs OUTSIDE both, under nothing but its own {@code directoryLock}, which it takes
-   * itself. That is the expensive half - it CRC32s the whole {@code .ts.sealed} file - and holding the append lock
-   * across it would stall ingestion on this shard for the length of a sequential read of the largest file the type
-   * owns. It does not need them: a sealed block is immutable once written, and every path that mutates the file
-   * ({@code appendBlock}, {@code commitTempCompactionFile}, {@code truncateBefore}, {@code downsampleBlocks},
-   * {@code truncateToBlockCount}, {@code installSealedFileBytes}) takes that same directory WRITE lock, so its own
-   * read lock already excludes all of them - and a repairing pass takes that write lock itself.
-   * <p>
-   * The consequence, stated rather than left to be discovered: a compaction may run between the two windows, so
-   * the sealed store the second half checks can hold blocks the totals did not count. That is the right trade -
-   * the totals are a report of what was there and the findings are a verdict on what is there, and a compaction
-   * moving rows between two halves that are BOTH being reported cannot invent or lose a sample.
-   * <p>
-   * Each problem is prefixed with which half of the shard it came from, because the two are different files with
-   * different formats and different repairs: the mutable bucket is replicated page-by-page under HA while the
-   * sealed store is derived and rebuilt locally by each node's own compaction.
+   * Each problem is prefixed with {@code "mutable bucket: "}, mirroring {@link #checkSealedIntegrity}'s
+   * {@code "sealed store: "}, because the two are different files with different formats and different repairs:
+   * the mutable bucket is replicated page-by-page under HA while the sealed store is derived and rebuilt locally
+   * by each node's own compaction.
    */
-  public IntegrityReport checkIntegrity(final TimeSeriesIntegrity.Options options) throws IOException {
+  public IntegrityReport checkMutableIntegrity(final TimeSeriesIntegrity.Options options) throws IOException {
     final List<String> problems = new ArrayList<>();
     final List<String> repairs = new ArrayList<>();
     // Not final: the CME arm below re-reads them, because the values taken inside a transaction that then rolled
@@ -1028,8 +1043,19 @@ public class TimeSeriesShard implements AutoCloseable {
           transactionOpen = false;
           if (mutableOutcome.repairs().isEmpty())
             db.rollback();
-          else
+          else {
+            // Test-only fault injection (issue #6406 item 5), fired only on the path a real
+            // concurrent compaction could actually contend: a repair with something to commit,
+            // right where this method's own javadoc says the race would land - after the
+            // replicated branch above has released the compaction lock, immediately before the
+            // commit. Mirrors RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT, the same idiom for
+            // the same problem (forcing a race that needs a live compaction or a live Raft
+            // cluster to occur on its own). Always null in production.
+            final Consumer<String> fixCommitFault = TEST_FIX_COMMIT_FAULT;
+            if (fixCommitFault != null)
+              fixCommitFault.accept(typeName + "_shard_" + shardIndex);
             db.commit();
+          }
         }
 
         // Merged only once the transaction carrying them has committed. A repair the commit lost is not a repair,
@@ -1066,13 +1092,45 @@ public class TimeSeriesShard implements AutoCloseable {
       appendLock.unlock();
     }
 
+    return new IntegrityReport(problems, repairs, samples, sealedBlocks);
+  }
+
+  /**
+   * Validates the sealed store's blocks and returns one line per problem, prefixed {@code "sealed store: "}, empty
+   * when there is none, together with one line per repair applied when {@link TimeSeriesIntegrity.Options#fix()}
+   * is set. The totals in the returned {@link IntegrityReport} are always zero: {@link #checkMutableIntegrity}
+   * already reads both halves' totals under its own window, for the reason given there, so this half reports
+   * findings only.
+   * <p>
+   * This is the EXPENSIVE half - under {@code DEEP} it decodes every block, and even at the cheaper tier it CRC32s
+   * the whole {@code .ts.sealed} file - and the reason it is a separate method from {@link #checkMutableIntegrity}
+   * (issue #6406 item 1): it opens no transaction and takes neither {@link #appendLock} nor the compaction lock, so
+   * it is safe to run on a pool thread while other shards' mutable halves - or this same shard's, sequentially -
+   * run on the caller's. It takes only the sealed store's own {@code directoryLock}, which
+   * {@link TimeSeriesSealedStore#checkIntegrity} acquires itself: a sealed block is immutable once written, and
+   * every path that mutates the file ({@code appendBlock}, {@code commitTempCompactionFile}, {@code truncateBefore},
+   * {@code downsampleBlocks}, {@code truncateToBlockCount}, {@code installSealedFileBytes}) takes that same
+   * directory WRITE lock, so a reporting run's read lock already excludes all of them, and a repairing run takes
+   * the write lock itself.
+   * <p>
+   * <b>The consequence of the two halves no longer sharing one window</b>, stated rather than left to be
+   * discovered: a compaction may run between {@link #checkMutableIntegrity} and this call, so the sealed store this
+   * checks can hold blocks the other's totals did not count. That was already true of the original, unsplit method -
+   * the two halves never shared a lock even there - and it is the right trade regardless: the totals are a report of
+   * what was there and the findings here are a verdict on what is there, and a compaction moving rows between two
+   * halves that are BOTH being reported cannot invent or lose a sample.
+   */
+  public IntegrityReport checkSealedIntegrity(final TimeSeriesIntegrity.Options options) throws IOException {
+    final List<String> problems = new ArrayList<>();
+    final List<String> repairs = new ArrayList<>();
+
     final TimeSeriesIntegrity.Outcome sealedOutcome = sealedStore.checkIntegrity(options);
     for (final String problem : sealedOutcome.problems())
       problems.add("sealed store: " + problem);
     for (final String repair : sealedOutcome.repairs())
       repairs.add("sealed store: " + repair);
 
-    return new IntegrityReport(problems, repairs, samples, sealedBlocks);
+    return new IntegrityReport(problems, repairs, 0, 0);
   }
 
   public TimeSeriesBucket getMutableBucket() {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -1046,11 +1046,17 @@ public class TimeSeriesShard implements AutoCloseable {
           else {
             // Test-only fault injection (issue #6406 item 5), fired only on the path a real
             // concurrent compaction could actually contend: a repair with something to commit,
-            // right where this method's own javadoc says the race would land - after the
-            // replicated branch above has released the compaction lock, immediately before the
-            // commit. Mirrors RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT, the same idiom for
-            // the same problem (forcing a race that needs a live compaction or a live Raft
-            // cluster to occur on its own). Always null in production.
+            // immediately before the commit. On a REPLICATED database (db.isReplicated() above)
+            // this is also after the compaction lock was released, which is where a real
+            // compaction race would land per this method's own javadoc. A test that exercises
+            // this hook against a plain, non-replicated database (as Issue6406CompactionRaceIntegrityTest
+            // does) fires it while that lock is STILL held - the hook forces the same
+            // ConcurrentModificationException the catch block below has to handle either way, so
+            // that difference does not matter to what is being tested, but do not read this
+            // comment as claiming the lock is always released by this point; only the replicated
+            // branch releases it. Mirrors RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT, the
+            // same idiom for the same problem (forcing a race that needs a live compaction or a
+            // live Raft cluster to occur on its own). Always null in production.
             final Consumer<String> fixCommitFault = TEST_FIX_COMMIT_FAULT;
             if (fixCommitFault != null)
               fixCommitFault.accept(typeName + "_shard_" + shardIndex);

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406CompactionRaceIntegrityTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406CompactionRaceIntegrityTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.BasePage;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6406 item 5: the compaction-race arm of {@link TimeSeriesShard#checkMutableIntegrity}
+ * - a {@code FIX} whose commit loses a version race against a concurrent compaction on the mutable bucket's page 0
+ * - had no coverage. Not because it cannot go wrong, but because forcing a real, deterministic
+ * {@link ConcurrentModificationException} on that exact commit needs a live compaction racing a live
+ * {@code CHECK DATABASE FIX} at exactly the right instant, which neither {@code Issue6360SealedStoreIntegrityTest}
+ * nor {@code Issue6360CheckDatabaseTimeSeriesTest} attempts (both run single-threaded, non-replicated).
+ * <p>
+ * This test takes the option the issue itself named as one of the ways to close the gap: a package-private (here,
+ * test-only public) hook - {@link TimeSeriesShard#TEST_FIX_COMMIT_FAULT} - fired exactly where the real commit
+ * would be, on exactly the path that reaches one (a repair with something to write). Same idiom as
+ * {@code RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT} for the equivalent leader-side problem: throw the same
+ * exception class a losing commit would, and let production code's own catch block do the rest.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6406CompactionRaceIntegrityTest extends TestHelper {
+
+  private static final int ROWS = 500;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // Deliberately leaves the mutable header disagreeing with its pages between the two CHECK DATABASE runs.
+    return false;
+  }
+
+  @AfterEach
+  void clearHook() {
+    TimeSeriesShard.TEST_FIX_COMMIT_FAULT = null;
+  }
+
+  private TimeSeriesEngine createType(final String typeName) {
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS 1");
+    return ((LocalTimeSeriesType) database.getSchema().getType(typeName)).getEngine();
+  }
+
+  private void appendRows(final TimeSeriesEngine engine, final int rows) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + i * 1_000L;
+      columns[0][i] = "host_" + (i % 7);
+      columns[1][i] = (double) i;
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+
+  private Result runCheck(final String suffix) {
+    try (final ResultSet resultSet = database.command("sql", "CHECK DATABASE" + suffix)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      return resultSet.next();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<String> warningsOf(final Result row) {
+    return (Collection<String>) row.<Collection<?>>getProperty("warnings");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<String> repairsOf(final Result row) {
+    return (Collection<String>) row.<Collection<?>>getProperty("timeSeriesRepairs");
+  }
+
+  /**
+   * A repair that loses the race is reported as NOT LANDED - told to the operator by name, with the totals
+   * re-read from what actually survived rather than from the rolled-back transaction - and a second,
+   * un-contended run then repairs it cleanly. That second run is the point: it proves the corruption this test
+   * plants is real and repairable, so the first run's "no repair" outcome is because of the injected race, not
+   * because there was nothing to fix in the first place.
+   */
+  @Test
+  void aFixThatLosesTheCommitRaceIsReportedNotAppliedAndRetryable() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    final String bucketPath = engine.getShard(0).getMutableBucket().getComponentFile().getFilePath();
+
+    database.close();
+    try {
+      // Page 0's sample counter, at content offset 7 of the header page (same corruption #6360 uses).
+      try (final RandomAccessFile raf = new RandomAccessFile(new File(bucketPath), "rw")) {
+        raf.seek(BasePage.PAGE_HEADER_SIZE + 7);
+        raf.writeLong(ROWS + 500L);
+      }
+    } finally {
+      database = factory.open();
+    }
+
+    final Result reported = runCheck("");
+    assertThat(warningsOf(reported)).as("the corruption must actually be visible before the race is injected")
+        .anyMatch(w -> w.contains("declares " + (ROWS + 500) + " sample(s)"));
+
+    TimeSeriesShard.TEST_FIX_COMMIT_FAULT = shard ->
+        // The exact exception class and shape the real commit2ndPhase would throw on a losing page-version
+        // check (com.arcadedb.exception.ConcurrentModificationException), so the catch block in
+        // checkMutableIntegrity cannot tell this from the real thing.
+        { throw new ConcurrentModificationException("TEST fault injection: simulated compaction race on shard " + shard); };
+
+    final Result raced = runCheck(" FIX");
+    // Nothing landed - the fault fired instead of a real commit - so this run reports zero repairs...
+    assertThat(raced.<Long>getProperty("repairedTimeSeries")).isZero();
+    final Collection<String> repairs = repairsOf(raced);
+    assertThat(repairs).as("repairs: %s", repairs).noneMatch(r -> r.contains("mutable bucket"));
+    // ...and says so BY NAME, telling the operator to run it again rather than reporting success or silence.
+    final Collection<String> warnings = warningsOf(raced);
+    assertThat(warnings).as("warnings: %s", warnings)
+        .anyMatch(w -> w.contains("mutable bucket") && w.contains("compaction rewrote page 0")
+            && w.contains("run the check again"));
+    // The totals are re-read from what survived the rollback, not from the (never-committed) repaired header.
+    assertThat(raced.<Long>getProperty("totalTimeSeriesSamples")).isEqualTo((long) ROWS + 500L);
+
+    TimeSeriesShard.TEST_FIX_COMMIT_FAULT = null;
+
+    final Result fixed = runCheck(" FIX");
+    assertThat(fixed.<Long>getProperty("repairedTimeSeries")).isEqualTo(1L);
+    assertThat(repairsOf(fixed)).anyMatch(r -> r.contains("mutable bucket") && r.contains("rewrote page 0's counters"));
+
+    final Result after = runCheck("");
+    assertThat(warningsOf(after)).isEmpty();
+    assertThat(after.<Long>getProperty("totalTimeSeriesSamples")).isEqualTo((long) ROWS);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406ShardFanoutIntegrityTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406ShardFanoutIntegrityTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6406 item 1: {@link TimeSeriesEngine#checkIntegrity} now runs the sealed half of
+ * every shard's check ({@link TimeSeriesShard#checkSealedIntegrity}) fanned out across {@code shardExecutor}
+ * instead of one shard at a time, while the mutable half ({@link TimeSeriesShard#checkMutableIntegrity}) stays
+ * sequential.
+ * <p>
+ * What this has to prove that a single-shard test cannot: with several shards in flight on different pool
+ * threads, a finding still comes back attributed to the RIGHT shard, an undamaged shard still reports nothing, and
+ * the totals returned by the sequential mutable phase still add up to what the fanned-out sealed phase actually
+ * found - i.e. the two arrays the implementation zips back together by index ({@code mutableReports[s]} and
+ * {@code sealedFutures[s].join()}) are not silently misaligned by the fan-out.
+ * <p>
+ * The corruption is planted on shard 2 of 4, not shard 0: an off-by-one or a swapped index would have a decent
+ * chance of still passing against shard 0.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6406ShardFanoutIntegrityTest extends TestHelper {
+
+  private static final int SHARDS      = 4;
+  private static final int ROWS        = 2_000;
+  private static final int DAMAGED_SHARD = 2;
+
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    // One test leaves a damaged sealed store behind on purpose.
+    return false;
+  }
+
+  private TimeSeriesEngine createType(final String typeName) {
+    database.command("sql", "CREATE TIMESERIES TYPE " + typeName
+        + " TIMESTAMP ts TAGS (hostname STRING) FIELDS (usage DOUBLE) SHARDS " + SHARDS);
+    return ((LocalTimeSeriesType) database.getSchema().getType(typeName)).getEngine();
+  }
+
+  private void appendRows(final TimeSeriesEngine engine, final int rows) throws IOException {
+    final long[] timestamps = new long[rows];
+    final Object[][] columns = new Object[2][rows];
+    for (int i = 0; i < rows; i++) {
+      timestamps[i] = 1_700_000_000_000L + i * 1_000L;
+      columns[0][i] = "host_" + (i % 7);
+      columns[1][i] = (double) i;
+    }
+    engine.appendBatch(timestamps, columns);
+  }
+
+  private Result runCheck(final String suffix) {
+    try (final ResultSet resultSet = database.command("sql", "CHECK DATABASE" + suffix)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      return resultSet.next();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<String> warningsOf(final Result row) {
+    return (Collection<String>) row.<Collection<?>>getProperty("warnings");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<String> repairsOf(final Result row) {
+    return (Collection<String>) row.<Collection<?>>getProperty("timeSeriesRepairs");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<String> corruptedTypesOf(final Result row) {
+    return (Collection<String>) row.<Collection<?>>getProperty("corruptedTimeSeries");
+  }
+
+  /**
+   * A finding planted on one shard of several comes back attributed to that shard alone, the other shards report
+   * nothing, and the totals the sequential mutable phase already knew still match what the fanned-out sealed
+   * phase found on the healthy shards.
+   */
+  @Test
+  void aSealedCorruptionOnOneShardOfSeveralIsAttributedToThatShardAlone() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+
+    final long samplesBeforeCorruption = engine.countSamples();
+    assertThat(samplesBeforeCorruption).isEqualTo((long) ROWS);
+
+    final File damagedSealedFile = new File(getDatabasePath(), "Cpu_shard_" + DAMAGED_SHARD + ".ts.sealed");
+    assertThat(damagedSealedFile).as("shard %d must have compacted at least one block to have a sealed file", DAMAGED_SHARD)
+        .exists();
+
+    database.close();
+    try (final RandomAccessFile raf = new RandomAccessFile(damagedSealedFile, "rw")) {
+      // magic(4) version(1) colCount(2), then the block count - same offset the sealed-header test of #6360 uses.
+      raf.seek(7);
+      raf.writeInt(4_242);
+    } finally {
+      database = factory.open();
+    }
+
+    final Result reported = runCheck("");
+
+    assertThat(corruptedTypesOf(reported)).containsExactly("Cpu");
+
+    final Collection<String> warnings = warningsOf(reported);
+    // Attributed to the damaged shard, and to no other: a swapped or off-by-one index in the fan-out's merge
+    // would either miss this line or put it under the wrong shard number.
+    assertThat(warnings).as("warnings: %s", warnings)
+        .anyMatch(w -> w.contains("shard " + DAMAGED_SHARD + " sealed store") && w.contains("declares 4242 block(s)"));
+    for (int s = 0; s < SHARDS; s++) {
+      if (s == DAMAGED_SHARD)
+        continue;
+      final int shard = s;
+      assertThat(warnings).as("shard %d must report nothing: warnings=%s", shard, warnings)
+          .noneMatch(w -> w.contains("shard " + shard + " "));
+    }
+
+    // The mutable half (sequential, computed BEFORE the sealed fan-out) already knew the true sample count; the
+    // sealed corruption is a header/directory mismatch, not a lost block, so the total is unaffected by it.
+    assertThat(reported.<Long>getProperty("totalTimeSeriesSamples")).isEqualTo((long) ROWS);
+
+    final Result fixed = runCheck(" FIX");
+    assertThat(fixed.<Long>getProperty("repairedTimeSeries")).isEqualTo(1L);
+    final Collection<String> repairs = repairsOf(fixed);
+    assertThat(repairs).as("repairs: %s", repairs)
+        .anyMatch(r -> r.contains("shard " + DAMAGED_SHARD + " sealed store") && r.contains("rewrote the header from the block directory"));
+    for (int s = 0; s < SHARDS; s++) {
+      if (s == DAMAGED_SHARD)
+        continue;
+      final int shard = s;
+      assertThat(repairs).as("shard %d must have nothing to repair: repairs=%s", shard, repairs)
+          .noneMatch(r -> r.contains("shard " + shard + " "));
+    }
+
+    database.close();
+    database = factory.open();
+    assertThat(warningsOf(runCheck(""))).isEmpty();
+    assertThat(runCheck("").<Long>getProperty("totalTimeSeriesSamples")).isEqualTo((long) ROWS);
+  }
+
+  /**
+   * A healthy multi-shard type reports the same totals under the new split/fanned-out check as it did as one
+   * per-shard call before #6406: the {@code DEEP} tier decodes every sealed block of every shard, on whichever
+   * pool thread it lands on, and the merge still adds up.
+   */
+  @Test
+  void aHealthyMultiShardTypeReportsCleanUnderDeep() throws Exception {
+    final TimeSeriesEngine engine = createType("Cpu");
+    appendRows(engine, ROWS);
+    engine.compactAll();
+    appendRows(engine, 250);
+
+    final Result row = runCheck(" DEEP");
+
+    assertThat(warningsOf(row)).isEmpty();
+    assertThat(corruptedTypesOf(row)).isEmpty();
+    assertThat(row.<Long>getProperty("totalTimeSeriesSamples")).isEqualTo(ROWS + 250L);
+    assertThat(row.<Long>getProperty("totalTimeSeriesSealedBlocks")).isGreaterThan(0L);
+    assertThat(row.<Long>getProperty("repairedTimeSeries")).isZero();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406ShardFanoutIntegrityTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406ShardFanoutIntegrityTest.java
@@ -50,8 +50,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class Issue6406ShardFanoutIntegrityTest extends TestHelper {
 
-  private static final int SHARDS      = 4;
-  private static final int ROWS        = 2_000;
+  private static final int SHARDS        = 4;
+  private static final int ROWS          = 2_000;
   private static final int DAMAGED_SHARD = 2;
 
   @Override


### PR DESCRIPTION
## Summary

Three independent, self-contained follow-ups from #6360 (PR #6366), bundled as issue #6406. Items 3 and 4 of that issue were investigated but are chronic-CI-flake territory rather than something this PR fixes - see the detailed writeup on [#6406](https://github.com/ArcadeData/arcadedb/issues/6406#issuecomment-5332476134) and the item-4 follow-up, #6415.

- **Item 1 - parallel sealed-store checks.** `TimeSeriesShard.checkIntegrity` split into `checkMutableIntegrity` (transaction-bound, stays sequential per shard) and `checkSealedIntegrity` (opens no transaction - where `DEEP`'s per-block decode lives, by a distance the expensive half of the pass). `TimeSeriesEngine.checkIntegrity` now runs the mutable half sequentially as before, then fans the sealed half out across the type's own `shardExecutor` - the same pool `aggregateMultiBlocks` already uses for the same shape of read-only per-shard work.
- **Item 2 - CHECK DATABASE grammar/docs sync, enforced.** The docs content was already correct (fixed separately in arcadedb-docs per the issue). What was missing is a machine check so the *next* clause added to `checkDatabaseStatement` doesn't repeat the RECORD (#5680) / DELETE ORPHANS (#6090) / RECLAIM UNREFERENCED FILES (#6189) pattern of landing without a doc update. Added `.github/scripts/check-database-docs-sync.py` + `.github/workflows/check-database-docs-sync.yml`, triggered on `SQLParser.g4` changes, which checks out arcadedb-docs read-only and diffs the grammar's clauses against the `[[sql-check-database]]` syntax block (both directions - grammar-ahead and docs-ahead).
- **Item 5 - the untested compaction-race arm, now tested.** Added `TimeSeriesShard.TEST_FIX_COMMIT_FAULT`, a test-only fault-injection hook fired immediately before a `FIX` repair's commit - same idiom as `RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT` for the equivalent leader-side problem. `Issue6406CompactionRaceIntegrityTest` throws the same `ConcurrentModificationException` a losing commit would and asserts the whole contract: the repair is reported as not-landed by name, totals are re-read from what survived, and a second uncontended run then repairs cleanly.

## Files changed

- `engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java` - fan out the sealed half of `checkIntegrity` (item 1)
- `engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java` - split `checkIntegrity` into `checkMutableIntegrity`/`checkSealedIntegrity` (item 1); add `TEST_FIX_COMMIT_FAULT` hook (item 5)
- `.github/scripts/check-database-docs-sync.py` - new, the grammar/docs diff check (item 2)
- `.github/workflows/check-database-docs-sync.yml` - new, wires the check into CI (item 2)
- `.github/scripts/tests/test-ci-scripts.sh` - self-tests for the new script (item 2)
- `engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406ShardFanoutIntegrityTest.java` - new, regression test for item 1
- `engine/src/test/java/com/arcadedb/engine/timeseries/Issue6406CompactionRaceIntegrityTest.java` - new, regression test for item 5

## Test plan

- [x] `mvn -o -pl engine,ha-raft -am compile` - clean
- [x] `mvn -o -pl engine test -Dtest='*TimeSeries*,Issue6406*,Issue6360*,Issue6340*,DictionaryMultiPageTest'` - 284/284 passing
- [x] `mvn -o -pl engine test` (full engine module, 2 independent full runs) - 12773/12773 and 12750-ish/all passing, 0 failures both times
- [x] `.github/scripts/tests/test-ci-scripts.sh` - 65/65 checks passing, including 5 new ones for `check-database-docs-sync.py`
- [x] `check-database-docs-sync.py` run against the real `SQLParser.g4` + a fresh clone of arcadedb-docs' `sql-database-admin.adoc` - agrees on all 8 clauses
- [x] Manually verified both directions of drift detection (a clause added to the grammar without a doc update, and a clause removed from the grammar the docs still mention) against synthetic fixtures

Closes #6406 (items 1, 2, 5). Item 3 (`RaftPriorityRejoinIT`/`ha-integration-tests`) turned out to be the already-tracked chronic HA flake (#5668/#5702), not a single-cause bug - documented, not filed separately. Item 4 (`DictionaryMultiPageTest` drain) is real but not reproducible locally after extensive investigation - filed as #6415.
