### PR TITLE
fix(#6403, #6402, #6400, #6395, #6375, #6370, #6362, #6317): eight small fixes across coll.*, LOAD CSV, planner, labels, algo budgets, comprehensions and subqueries

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/coll/AbstractCollFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/AbstractCollFunction.java
@@ -18,11 +18,11 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
+import com.arcadedb.utility.LongRangeList;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -45,16 +45,35 @@ public abstract class AbstractCollFunction implements StatelessFunction {
   }
 
   /**
-   * Safely converts an argument to a List.
+   * Resolves a {@code coll.*} argument declared as a LIST to a List, exactly as the Cypher list builtins
+   * ({@code head()}, {@code tail()}, {@code reverse()}, {@code size()}) resolve theirs.
+   * <p>
+   * This delegates rather than deciding, because the two families answer the same question and had drifted apart on
+   * every part of the answer (issue #6403). {@link CypherFunctionHelper#requireListArgument} accepts a Java array -
+   * a numeric-array parameter is a Cypher LIST, which is what issue #4284 established and what this family never
+   * got - and an {@code Iterable}/{@code Iterator}, and it raises a {@link CommandSemanticException} on a type
+   * mismatch, which the HTTP layer reports as 400 Bad Request. The {@code CommandExecutionException} this used to
+   * raise was reported as 500, so the same client mistake read as a server fault through {@code coll.sort(42)} and
+   * as the caller's through {@code tail(42)} (issues #5476/#5477/#5222).
+   *
+   * @return the argument as a List, or {@code null} when the argument itself is {@code null}
+   *
+   * @throws CommandSemanticException when the argument is neither {@code null} nor a list
    */
-  @SuppressWarnings("unchecked")
   protected List<Object> asList(final Object arg) {
-    if (arg == null)
-      return null;
-    if (arg instanceof List)
-      return (List<Object>) arg;
-    if (arg instanceof Collection)
-      return new ArrayList<>((Collection<Object>) arg);
-    throw new CommandExecutionException(getName() + "() requires a list argument, got: " + arg.getClass().getSimpleName());
+    return CypherFunctionHelper.requireListArgument(arg, getName());
+  }
+
+  /**
+   * The argument as a lazily evaluated range, or {@code null} when it is anything else.
+   * <p>
+   * A range is an arithmetic progression that occupies constant heap however long it is, so the operations that can
+   * answer from its shape alone must not walk it: materialising one reinstates the heap exhaustion the lazy range
+   * removed (issue #6353, advisory GHSA-xmjm-8q85-g778). Asked here rather than at each call site so that the answer
+   * to "is this a range?" is given once - {@link #asList} hands back the very same instance for a range, since a
+   * {@code LongRangeList} is already a {@code List}.
+   */
+  protected static LongRangeList asRange(final Object arg) {
+    return arg instanceof LongRangeList range ? range : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/coll/CollAvg.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollAvg.java
@@ -20,11 +20,15 @@ package com.arcadedb.function.coll;
 
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.List;
 
 /**
  * coll.avg(list) - Returns the average of a list of numbers, or null if the list is empty.
+ * <p>
+ * The mean of an arithmetic progression is the midpoint of its endpoints, so a range is answered without walking it
+ * (issue #6403).
  */
 public class CollAvg extends AbstractCollFunction {
   @Override
@@ -53,6 +57,10 @@ public class CollAvg extends AbstractCollFunction {
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
+
+    final LongRangeList range = asRange(list);
+    if (range != null)
+      return range.isEmpty() ? null : CollSum.rangeSum(range) / range.size();
 
     double sum = 0.0;
     int count = 0;

--- a/engine/src/main/java/com/arcadedb/function/coll/CollDistinct.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollDistinct.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.utility.LongRangeList;
 
@@ -55,12 +54,12 @@ public class CollDistinct extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length != 1)
-      throw new CommandExecutionException("coll.distinct() requires exactly 1 argument");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
-    if (args[0] instanceof LongRangeList range)
+    final LongRangeList range = asRange(list);
+    if (range != null)
       // The step of a range is never zero, so no element repeats: the distinct list IS the range (issue #6353).
       return range;
     return new ArrayList<>(new LinkedHashSet<>(list));

--- a/engine/src/main/java/com/arcadedb/function/coll/CollFlatten.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollFlatten.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.coll;
 
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.utility.LongRangeList;
 
@@ -63,10 +64,13 @@ public class CollFlatten extends AbstractCollFunction {
     if (args.length > 1) {
       if (args[1] == null)
         return null;
-      if (args[1] instanceof Number)
-        maxDepth = ((Number) args[1]).intValue();
-      else if (args[1] instanceof Boolean)
+      if (args[1] instanceof Boolean)
         maxDepth = (Boolean) args[1] ? 1 : -1;
+      else
+        // A caller mistake here is a client error, exactly like every other argument in the family (issue
+        // #6403) - args[1] used to fall through every branch silently and leave maxDepth at its default instead
+        // of raising, so coll.flatten([[1]], 'x') answered as though depth had been omitted (code review).
+        maxDepth = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     }
 
     if (asRange(list) != null)

--- a/engine/src/main/java/com/arcadedb/function/coll/CollFlatten.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollFlatten.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.utility.LongRangeList;
 
@@ -55,8 +54,7 @@ public class CollFlatten extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length < 1)
-      throw new CommandExecutionException("coll.flatten() requires at least 1 argument");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
@@ -71,7 +69,7 @@ public class CollFlatten extends AbstractCollFunction {
         maxDepth = (Boolean) args[1] ? 1 : -1;
     }
 
-    if (args[0] instanceof LongRangeList)
+    if (asRange(list) != null)
       // A range holds longs and nothing else, so it is already flat at every depth - including depth 0, where the
       // answer is the input. Copying it materialised a range that costs no heap while it stays lazy (issue #6353).
       return list;

--- a/engine/src/main/java/com/arcadedb/function/coll/CollIndexOf.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollIndexOf.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.List;
@@ -51,8 +50,7 @@ public class CollIndexOf extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length != 2)
-      throw new CommandExecutionException("coll.indexOf() requires exactly 2 arguments");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null || args[1] == null)
       return null;

--- a/engine/src/main/java/com/arcadedb/function/coll/CollInsert.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollInsert.java
@@ -18,7 +18,8 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
@@ -52,18 +53,18 @@ public class CollInsert extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length != 3)
-      throw new CommandExecutionException("coll.insert() requires exactly 3 arguments (list, index, value)");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
-    if (args[1] == null)
+    final Number indexArg = CypherFunctionHelper.requireNumberArgument(args[1], getName());
+    if (indexArg == null)
       return null;
-    final int index = ((Number) args[1]).intValue();
+    final int index = indexArg.intValue();
     if (index < 0)
-      throw new CommandExecutionException("coll.insert() does not support negative index: " + index);
+      throw new CommandSemanticException(getName() + "() does not support negative index: " + index);
     if (index > list.size())
-      throw new CommandExecutionException("coll.insert() index " + index + " is out of range for list of size " + list.size());
+      throw new CommandSemanticException(getName() + "() index " + index + " is out of range for list of size " + list.size());
     final List<Object> result = new ArrayList<>(list);
     result.add(index, args[2]);
     return result;

--- a/engine/src/main/java/com/arcadedb/function/coll/CollMax.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollMax.java
@@ -18,14 +18,17 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.List;
 
 /**
  * coll.max(list) - Returns the maximum value in the list.
+ * <p>
+ * The largest element of an arithmetic progression is one of its two endpoints, so a range is answered without
+ * walking it (issue #6403). See {@link CollMin} for why the constant-space walk left by issue #6353 is not enough.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -52,11 +55,14 @@ public class CollMax extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length != 1)
-      throw new CommandExecutionException("coll.max() requires exactly 1 argument");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null || list.isEmpty())
       return null;
+
+    final LongRangeList range = asRange(list);
+    if (range != null)
+      return range.getStep() > 0 ? range.get(range.size() - 1) : range.get(0);
 
     Object max = null;
     for (final Object item : list) {

--- a/engine/src/main/java/com/arcadedb/function/coll/CollMin.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollMin.java
@@ -18,14 +18,18 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.List;
 
 /**
  * coll.min(list) - Returns the minimum value in the list.
+ * <p>
+ * The smallest element of an arithmetic progression is one of its two endpoints, so a range is answered without
+ * walking it (issue #6403). The walk was already constant space after issue #6353, but with
+ * {@code arcadedb.queryMaxRangeSize} raised it is still a billion iterations for an answer the shape gives away.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -52,11 +56,14 @@ public class CollMin extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length != 1)
-      throw new CommandExecutionException("coll.min() requires exactly 1 argument");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null || list.isEmpty())
       return null;
+
+    final LongRangeList range = asRange(list);
+    if (range != null)
+      return range.getStep() > 0 ? range.get(0) : range.get(range.size() - 1);
 
     Object min = null;
     for (final Object item : list) {

--- a/engine/src/main/java/com/arcadedb/function/coll/CollRemove.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollRemove.java
@@ -18,7 +18,8 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.utility.LongRangeList;
 
@@ -58,23 +59,25 @@ public class CollRemove extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length < 2)
-      throw new CommandExecutionException("coll.remove() requires at least 2 arguments (list, index)");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
-    if (args[1] == null)
+    final Number indexArg = CypherFunctionHelper.requireNumberArgument(args[1], getName());
+    if (indexArg == null)
       return null;
 
-    final int index = ((Number) args[1]).intValue();
+    final int index = indexArg.intValue();
     if (index < 0)
-      throw new CommandExecutionException("coll.remove() does not support negative index: " + index);
+      throw new CommandSemanticException(getName() + "() does not support negative index: " + index);
     if (index >= list.size())
-      throw new CommandExecutionException("coll.remove() index " + index + " is out of range for list of size " + list.size());
-    if (args.length > 2 && args[2] == null)
+      throw new CommandSemanticException(getName() + "() index " + index + " is out of range for list of size " + list.size());
+    final Number countArg = args.length > 2 ? CypherFunctionHelper.requireNumberArgument(args[2], getName()) : null;
+    if (args.length > 2 && countArg == null)
       return null;
-    final int count = args.length > 2 ? ((Number) args[2]).intValue() : 1;
-    if (args[0] instanceof LongRangeList range) {
+    final int count = countArg != null ? countArg.intValue() : 1;
+    final LongRangeList range = asRange(list);
+    if (range != null) {
       // The loop below stops at the end of the list, so it removes min(count, size - index) elements.
       final int removed = Math.min(Math.max(count, 0), range.size() - index);
       if (index == 0)

--- a/engine/src/main/java/com/arcadedb/function/coll/CollSort.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollSort.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.utility.LongRangeList;
@@ -58,12 +57,12 @@ public class CollSort extends AbstractCollFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    if (args.length != 1)
-      throw new CommandExecutionException("coll.sort() requires exactly 1 argument");
+    checkArity(args);
     final List<Object> list = asList(args[0]);
     if (list == null)
       return null;
-    if (args[0] instanceof LongRangeList range)
+    final LongRangeList range = asRange(list);
+    if (range != null)
       return range.getStep() > 0 ? range : range.reversed();
     final List<Object> result = new ArrayList<>(list);
     result.sort(CypherFunctionHelper::cypherCompare);

--- a/engine/src/main/java/com/arcadedb/function/coll/CollSum.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollSum.java
@@ -20,11 +20,15 @@ package com.arcadedb.function.coll;
 
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.LongRangeList;
 
 import java.util.List;
 
 /**
  * coll.sum(list) - Returns the sum of a list of numbers.
+ * <p>
+ * The sum of an arithmetic progression is {@code n * (first + last) / 2}, so a range is answered without walking it
+ * (issue #6403).
  */
 public class CollSum extends AbstractCollFunction {
   @Override
@@ -54,6 +58,10 @@ public class CollSum extends AbstractCollFunction {
     if (list == null)
       return null;
 
+    final LongRangeList range = asRange(list);
+    if (range != null)
+      return rangeSum(range);
+
     double sum = 0.0;
     for (final Object item : list) {
       final Number number = CypherFunctionHelper.requireNumberArgument(item, getName());
@@ -61,5 +69,17 @@ public class CollSum extends AbstractCollFunction {
         sum += number.doubleValue();
     }
     return sum;
+  }
+
+  /**
+   * The closed form {@code n * (first + last) / 2}, evaluated in {@code double} because that is the type this
+   * function answers in anyway. Both endpoints are widened before they are added: their long sum can overflow even
+   * though each is a long, and a wrapped sum would answer a plausible wrong number rather than fail.
+   */
+  static double rangeSum(final LongRangeList range) {
+    final int size = range.size();
+    if (size == 0)
+      return 0.0;
+    return ((double) range.get(0) + (double) range.get(size - 1)) * size / 2.0;
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/coll/CollToSet.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/CollToSet.java
@@ -18,51 +18,27 @@
  */
 package com.arcadedb.function.coll;
 
-import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.utility.LongRangeList;
-
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-
 /**
- * coll.toSet(list) - Returns a unique list backed by a set, i.e. the given list with duplicates removed.
- * Order is not significant to the caller, but the order of first occurrence is preserved so the result is
- * deterministic. Like the rest of the {@code coll.*} namespace, duplicates are recognized by object equality,
- * so {@code coll.toSet([1, 1.0])} keeps both elements.
+ * coll.toSet(list) - the APOC spelling of {@link CollDistinct}, kept because a migrating query catalogue writes it
+ * (issue #6157).
+ * <p>
+ * It is an alias and nothing more: both names answer {@code [1, 2]} for {@code [1, 1, 2]}, both preserve the order
+ * of first occurrence, both recognize duplicates by object equality (so {@code coll.toSet([1, 1.0])} keeps both
+ * elements), and both return a LIST - the name is the only difference. Written as a subclass rather than as a
+ * second copy of the body so there is one implementation to fix: while there were two, every change to one had to
+ * be remembered for the other, and the lazy-range short-circuit of issue #6353 had to be written twice
+ * (issue #6403).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class CollToSet extends AbstractCollFunction {
+public class CollToSet extends CollDistinct {
   @Override
   protected String getSimpleName() {
     return "toSet";
   }
 
   @Override
-  public int getMinArgs() {
-    return 1;
-  }
-
-  @Override
-  public int getMaxArgs() {
-    return 1;
-  }
-
-  @Override
   public String getDescription() {
     return "Returns a unique list from the given list, preserving the order of first occurrence";
-  }
-
-  @Override
-  public Object execute(final Object[] args, final CommandContext context) {
-    checkArity(args);
-    final List<Object> list = asList(args[0]);
-    if (list == null)
-      return null;
-    if (args[0] instanceof LongRangeList range)
-      // The step of a range is never zero, so no element repeats: the set IS the range (issue #6353).
-      return range;
-    return new ArrayList<>(new LinkedHashSet<>(list));
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/cypher/LoadCSVFileFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/LoadCSVFileFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.cypher;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -44,6 +45,6 @@ public class LoadCSVFileFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    return context.getVariable("__loadCSV_file");
+    return context.getVariable(LoadCSVRowContext.FILE);
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/cypher/LoadCSVLineNumberFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/LoadCSVLineNumberFunction.java
@@ -19,6 +19,7 @@
 package com.arcadedb.function.cypher;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -44,6 +45,6 @@ public class LoadCSVLineNumberFunction implements StatelessFunction {
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
     checkArity(args);
-    return context.getVariable("__loadCSV_linenumber");
+    return context.getVariable(LoadCSVRowContext.LINE_NUMBER);
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.LongConsumer;
 import java.util.logging.Level;
 
 /**
@@ -2119,6 +2120,22 @@ public class GraphEngine {
    */
   public static int[][] buildAdjacencyList(final List<Vertex> vertices, final Map<RID, Integer> ridToIdx,
       final Vertex.DIRECTION dir, final String[] relTypes) {
+    return buildAdjacencyList(vertices, ridToIdx, dir, relTypes, null);
+  }
+
+  /**
+   * As {@link #buildAdjacencyList(List, Map, Vertex.DIRECTION, String[])}, with a hook fired between the counting
+   * pass and the allocation.
+   * <p>
+   * The counting pass already establishes the exact number of neighbour entries, and it does so at the one moment
+   * the result is still free: nothing has been allocated yet. That is where a caller bounding its heap wants to
+   * decide, so the total is handed over there rather than after a structure it may refuse has already been built
+   * (issue #6317). A hook that throws aborts the build.
+   *
+   * @param entryCount notified with the total number of neighbour entries about to be allocated; may be null
+   */
+  public static int[][] buildAdjacencyList(final List<Vertex> vertices, final Map<RID, Integer> ridToIdx,
+      final Vertex.DIRECTION dir, final String[] relTypes, final LongConsumer entryCount) {
     final int n = vertices.size();
     final int[] counts = new int[n];
     for (int i = 0; i < n; i++) {
@@ -2139,6 +2156,12 @@ public class GraphEngine {
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }
+    }
+    if (entryCount != null) {
+      long total = 0;
+      for (int i = 0; i < n; i++)
+        total += counts[i];
+      entryCount.accept(total);
     }
     final int[][] adj = new int[n][];
     for (int i = 0; i < n; i++)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
@@ -492,10 +493,21 @@ public final class Labels {
    * <p>
    * Duplicate labels are automatically ignored, matching Neo4j's behavior
    * (GitHub issue #3264).
+   * <p>
+   * A label literally equal to {@link #NO_LABEL_TYPE} is refused rather than created: {@link #LABEL_SEPARATOR}
+   * makes the sentinel unwritable as one label among several (it can never survive {@link #isLabelComposite}'s
+   * name match), but a single-label {@code CREATE (:`~NO_LABEL~`)} bypasses that entirely and would otherwise
+   * land the vertex on the sentinel type itself - the exact {@code V}/{@code Vertex} collision this class exists
+   * to close, reopened under a name a query merely has to spell correctly instead of guess (issue #6395 review).
+   * Every write path that can introduce a new label - {@code CreateStep}, {@code MergeStep}, {@code SetStep}'s
+   * {@code SET n:Label}, and the {@code merge.node} procedure - creates its type through this one method, so the
+   * guard here closes all of them at once.
    *
    * @param schema the database schema
    * @param labels list of labels for the vertex (duplicates are ignored)
    * @return the type name to use (composite type name if multiple unique labels)
+   *
+   * @throws CommandSemanticException when {@code labels} contains {@link #NO_LABEL_TYPE}
    */
   public static String ensureCompositeType(final Schema schema, final List<String> labels) {
     if (labels == null || labels.isEmpty())
@@ -503,6 +515,10 @@ public final class Labels {
 
     // Deduplicate and sort labels using TreeSet
     final Set<String> uniqueLabels = new TreeSet<>(labels);
+
+    if (uniqueLabels.contains(NO_LABEL_TYPE))
+      throw new CommandSemanticException(
+          "'" + NO_LABEL_TYPE + "' is a reserved type name and cannot be used as a label");
 
     // Handle single label case (including after deduplication)
     if (uniqueLabels.size() == 1) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/Labels.java
@@ -63,6 +63,33 @@ public final class Labels {
   public static final String LABEL_SEPARATOR = "~";
 
   /**
+   * The type a vertex created with no labels lands in, and the one type a supertype walk never reports as a label.
+   * <p>
+   * Before this, "no labels" was represented by a type named {@code V} or {@code Vertex} - names drawn from the
+   * same namespace users write labels from, so the two meanings collided. A node whose only label was genuinely
+   * {@code V} matched {@code (n:V)} (the type system does not distinguish "this vertex's type is called V" from
+   * "this vertex was tagged V") and then reported {@code labels(n) = []}, because {@link #getLabels} filtered the
+   * name to answer the other question. Adding a label to such a node rebuilt its composite from the label set
+   * {@link #getOwnLabels} computed, which the same filter had emptied, so {@code SET n:Extra} silently dropped the
+   * original label instead of keeping it alongside the new one (issue #6395, the corner issue #6363 deliberately
+   * left alone).
+   * <p>
+   * Reserved by construction rather than by convention: {@link #LABEL_SEPARATOR} already cannot appear inside a
+   * single label (it is how a composite name is told apart from one), so wrapping the sentinel in it - as opposed
+   * to picking an ordinary-looking word like {@code V} - means no label a query writes can ever equal this name,
+   * and the filter in {@link #isBaseVertexTypeName} needs no exception for a real label happening to share it.
+   * <p>
+   * Also the type the imported-from-Neo4j graph's unlabelled nodes land in, and the common supertype every
+   * imported label type extends (see {@code Neo4jImporter}): a shared root lets one polymorphic query reach
+   * every vertex the import produced regardless of its label, which is worth keeping - the mistake was giving
+   * that root a name ({@code Node}) that a real schema might also want to use as an ordinary label, and that the
+   * label walk did not know to filter away from an ancestor position. Filtering this sentinel at every depth of
+   * the walk, not only at the vertex's own type, is what makes a shared root safe to keep: {@code Person EXTENDS
+   * ~NO_LABEL~} reports {@code ["Person"]}, not {@code ["NO_LABEL", "Person"]}.
+   */
+  public static final String NO_LABEL_TYPE = LABEL_SEPARATOR + "NO_LABEL" + LABEL_SEPARATOR;
+
+  /**
    * Private constructor to prevent instantiation.
    */
   private Labels() {
@@ -86,11 +113,11 @@ public final class Labels {
    * </ul>
    *
    * @param labels list of label names (duplicates are ignored)
-   * @return composite type name, or "V" if labels is null/empty
+   * @return composite type name, or {@link #NO_LABEL_TYPE} if labels is null/empty
    */
   public static String getCompositeTypeName(final List<String> labels) {
     if (labels == null || labels.isEmpty())
-      return "V";
+      return NO_LABEL_TYPE;
     if (labels.size() == 1)
       return labels.get(0);
 
@@ -106,8 +133,8 @@ public final class Labels {
 
   /**
    * Every label a vertex answers to: its own type name and each of its ancestors', sorted alphabetically, with the
-   * synthetic composite names left out. A node whose own type is the base {@code V}/{@code Vertex} carries no label
-   * at all and answers with an empty list.
+   * synthetic composite names and {@link #NO_LABEL_TYPE} left out. A node whose own type is the sentinel carries
+   * no label at all and answers with an empty list.
    * <p>
    * The set this returns is exactly the set {@link #hasLabel} says yes to, which is the invariant Cypher promises and
    * the one this used to break (issue #6363): the rule was "supertypes are the labels, unless there are none", written
@@ -135,8 +162,8 @@ public final class Labels {
   public static List<String> getLabels(final DocumentType type) {
     final String typeName = type.getName();
 
-    // If the vertex was created without labels, it has the base "Vertex" type
-    // In Cypher, unlabeled nodes have an empty label list
+    // A vertex created without labels lands in NO_LABEL_TYPE, and in Cypher an unlabelled node has an empty
+    // label list.
     if (isBaseVertexTypeName(typeName))
       return List.of();
 
@@ -148,19 +175,30 @@ public final class Labels {
 
     final Set<String> labels = new TreeSet<>();
     collectLabels(type, labels);
-    return new ArrayList<>(labels);
+    return List.copyOf(labels);
   }
 
   /**
-   * Adds {@code type}'s label to {@code out} unless the type is a synthetic composite, then recurses into its
-   * supertypes.
+   * Adds {@code type}'s label to {@code out} unless the type is a synthetic composite or the sentinel, then
+   * recurses into its supertypes.
    * <p>
-   * The base vertex name is filtered at the entry point only, never here: {@code V} is a perfectly ordinary label
-   * that a query may write - the openCypher TCK does, in {@code (b:U:V:W:X:Y:Z)} - and a supertype called {@code V}
-   * is one a node genuinely answers to.
+   * Unlike {@code V}/{@code Vertex} before issue #6395, {@link #NO_LABEL_TYPE} is filtered at every depth, not
+   * only at the vertex's own type: it is reserved by construction (its name can never be a real label, see the
+   * field's own javadoc), so there is no ordinary-label reading to preserve for it the way there was for a
+   * genuine supertype named {@code V} - the openCypher TCK writes exactly that in {@code (b:U:V:W:X:Y:Z)}, and
+   * with {@code V} no longer a sentinel it is reported like any other label.
    */
   private static void collectLabels(final DocumentType type, final Set<String> out) {
     final List<DocumentType> superTypes = type.getSuperTypes();
+    if (isBaseVertexTypeName(type.getName())) {
+      // The sentinel is never a label, however deep in the hierarchy it appears - unlike V/Vertex before it, it
+      // is not a name a query can ever have written, so there is no ordinary-label reading to preserve here the
+      // way there is one for a genuine supertype named V (issue #6395). Recurse past it rather than stopping: a
+      // type that extends it may still extend something else worth reporting.
+      for (int i = 0; i < superTypes.size(); i++)
+        collectLabels(superTypes.get(i), out);
+      return;
+    }
     if (!isLabelComposite(type, superTypes))
       out.add(type.getName());
     for (int i = 0; i < superTypes.size(); i++)
@@ -193,7 +231,7 @@ public final class Labels {
 
     final Set<String> labels = new TreeSet<>();
     collectOwnLabels(type, labels);
-    return new ArrayList<>(labels);
+    return List.copyOf(labels);
   }
 
   /**
@@ -202,6 +240,14 @@ public final class Labels {
    */
   private static void collectOwnLabels(final DocumentType type, final Set<String> out) {
     final List<DocumentType> superTypes = type.getSuperTypes();
+    if (isBaseVertexTypeName(type.getName())) {
+      // Symmetric with collectLabels: a composite that happens to inherit the sentinel through one of its own
+      // supertypes (the Neo4j importer's shared root, reached through a label type) must not have it show
+      // through a relabelling's own-label set either.
+      for (int i = 0; i < superTypes.size(); i++)
+        collectOwnLabels(superTypes.get(i), out);
+      return;
+    }
     if (!isLabelComposite(type, superTypes)) {
       out.add(type.getName());
       return;
@@ -236,12 +282,11 @@ public final class Labels {
   }
 
   /**
-   * Whether a type name is the base vertex type a node lands in when it carries no label at all: such a node is a
-   * Cypher node with an empty label list. Asked of the node's own type only - a supertype with the same name is a
-   * label the node was given and answers to, and is reported like any other.
+   * Whether a type name is {@link #NO_LABEL_TYPE}, the type a node lands in when it carries no label at all: such
+   * a node is a Cypher node with an empty label list.
    */
   private static boolean isBaseVertexTypeName(final String typeName) {
-    return "V".equals(typeName) || "Vertex".equals(typeName);
+    return NO_LABEL_TYPE.equals(typeName);
   }
 
   /**
@@ -454,7 +499,7 @@ public final class Labels {
    */
   public static String ensureCompositeType(final Schema schema, final List<String> labels) {
     if (labels == null || labels.isEmpty())
-      return "V";
+      return NO_LABEL_TYPE;
 
     // Deduplicate and sort labels using TreeSet
     final Set<String> uniqueLabels = new TreeSet<>(labels);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
@@ -78,6 +78,15 @@ public final class LoadCSVRowContext {
    * ends at the first {@code WITH} - and, because the functions read a context variable that no later row resets,
    * {@code WITH row RETURN linenumber()} answered every row with the line number of whichever row happened to be
    * evaluated last. Neo4j documents both functions as usable anywhere in the query following {@code LOAD CSV}.
+   * <p>
+   * Deliberately unconditional: this carries the context forward whether or not the {@code WITH} that produced
+   * {@code target} actually projects {@code row} or anything derived from it - {@code WITH 1 AS x} still keeps
+   * {@code file()}/{@code linenumber()} answering for the rest of the query. That reading follows from "usable
+   * anywhere in the query following LOAD CSV": the two functions are a property of the query's position relative
+   * to the LOAD CSV clause, the same way {@code count(*)} needs no variable in scope, not a property of whether
+   * the row variable itself survived the projection. Pinned by
+   * {@code CypherLoadCSVRowContextIssue6402Test.theRowContextSurvivesAProjectionThatDropsRowEntirely}
+   * (issue #6402 code review).
    */
   public static void carryOver(final Result source, final ResultInternal target) {
     if (source == null || target == null || !source.hasProperty(FILE))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/LoadCSVRowContext.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+
+/**
+ * Where the LOAD CSV row context - the file {@code file()} answers and the line {@code linenumber()} answers - is
+ * written, carried and read.
+ * <p>
+ * Both are functions of the <b>row</b>, not of the caller: two rows of the same query have two different line
+ * numbers, and a query reading several files has a different file per row. So the values travel on the row that
+ * {@code LOAD CSV} emitted them with, and the {@link CommandContext} variables the two functions read are set from
+ * that row immediately before the function runs.
+ * <p>
+ * Written here rather than at each consumer because the propagation existed on exactly one of the two expression
+ * evaluation paths: a projection went through {@code ExpressionEvaluator}, which lifted the row values into the
+ * context, and a {@code WHERE} predicate went through the AST node, which did not. {@code file()} was therefore
+ * {@code null} inside a predicate - {@code WHERE file() IS NOT NULL} silently dropped every row of the file - while
+ * the same call in the {@code RETURN} of the same query answered correctly, and two predicate forms disagreed with
+ * each other (issue #6402). One writer, every consumer served: the same arrangement issue #6354 arrived at for
+ * arithmetic.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class LoadCSVRowContext {
+  /**
+   * Row property, and context variable, carrying the URL of the file the row was read from.
+   * <p>
+   * Named with the {@link InternalVariables#PREFIX} marker because it is execution state and not a variable the
+   * query wrote: without it {@code LOAD CSV FROM ... AS row RETURN *} answered with two columns nobody asked for,
+   * which is exactly the leak issue #5444 closed for the executor's other generated bindings.
+   */
+  public static final String FILE = InternalVariables.PREFIX + "loadCSV_file";
+
+  /** Row property, and context variable, carrying the 1-based line the row was read from. */
+  public static final String LINE_NUMBER = InternalVariables.PREFIX + "loadCSV_linenumber";
+
+  private LoadCSVRowContext() {
+    // utility class
+  }
+
+  /**
+   * Stamps a freshly emitted LOAD CSV row with the file and line it came from.
+   * <p>
+   * {@code lineNumber} is {@code int}, matching {@code LoadCSVStep}'s own counter, so {@code linenumber()} keeps
+   * answering an {@code Integer} rather than silently widening to a {@code Long} that a caller comparing against
+   * a literal would no longer equal.
+   */
+  public static void stamp(final ResultInternal row, final String file, final int lineNumber) {
+    row.setProperty(FILE, file);
+    row.setProperty(LINE_NUMBER, lineNumber);
+  }
+
+  /**
+   * Carries the row context of an input row onto a row projected from it, so that a clause after a {@code WITH}
+   * still knows which line it is looking at.
+   * <p>
+   * A projection keeps only what it names, and {@code WITH row} names one variable, so without this the context
+   * ends at the first {@code WITH} - and, because the functions read a context variable that no later row resets,
+   * {@code WITH row RETURN linenumber()} answered every row with the line number of whichever row happened to be
+   * evaluated last. Neo4j documents both functions as usable anywhere in the query following {@code LOAD CSV}.
+   */
+  public static void carryOver(final Result source, final ResultInternal target) {
+    if (source == null || target == null || !source.hasProperty(FILE))
+      return;
+    if (!target.hasProperty(FILE)) {
+      target.setProperty(FILE, source.getProperty(FILE));
+      target.setProperty(LINE_NUMBER, source.getProperty(LINE_NUMBER));
+    }
+  }
+
+  /**
+   * Publishes the row's context on the command context, so {@code file()} and {@code linenumber()} - which, like
+   * every {@code StatelessFunction}, are handed arguments and a context but not the row - read the values of the
+   * row being evaluated. Called from the single place a Cypher function is invoked with a row in hand.
+   * <p>
+   * A row carrying no LOAD CSV context leaves the variables alone rather than clearing them: the row a nested
+   * evaluation is handed is not always the driving row, and clearing on every function call would blank the values
+   * an enclosing LOAD CSV row legitimately set.
+   */
+  public static void bind(final Result row, final CommandContext context) {
+    if (row == null || context == null || !row.hasProperty(FILE))
+      return;
+    context.setVariable(FILE, row.getProperty(FILE));
+    context.setVariable(LINE_NUMBER, row.getProperty(LINE_NUMBER));
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/FunctionCallExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/FunctionCallExpression.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 
@@ -73,11 +74,33 @@ public class FunctionCallExpression implements Expression {
           final Object[] args = new Object[arguments.size()];
           for (int i = 0; i < args.length; i++)
             args[i] = arguments.get(i).evaluate(result, context);
-          return function.execute(args, context);
+          return invoke(function, args, result, context);
         }
       }
     }
     throw new UnsupportedOperationException("Function evaluation requires StatelessFunction: " + functionName);
+  }
+
+  /**
+   * Runs a resolved Cypher function against pre-evaluated arguments, after publishing whatever state the function
+   * is entitled to read off the row it is being evaluated on.
+   * <p>
+   * A {@code StatelessFunction} is handed arguments and a {@link CommandContext}, never the row, so a function whose
+   * answer is a property of the row - {@code file()} and {@code linenumber()} after {@code LOAD CSV} - can only be
+   * served by the caller publishing it first. Both evaluation paths call this rather than each doing it themselves:
+   * only one of them did, so the same call answered differently in a {@code RETURN} and in a {@code WHERE} of the
+   * same query (issue #6402). Same arrangement as {@code ArithmeticExpression.apply} (issue #6354) - the semantics
+   * live in one place and each path only resolves its inputs.
+   *
+   * @param function the resolved executor
+   * @param args     the already-evaluated arguments
+   * @param result   the row being evaluated, {@code null} when there is none
+   * @param context  the command context handed to the function
+   */
+  public static Object invoke(final StatelessFunction function, final Object[] args, final Result result,
+      final CommandContext context) {
+    LoadCSVRowContext.bind(result, context);
+    return function.execute(args, context);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
@@ -152,14 +152,9 @@ public class ExpressionEvaluator {
       args[i] = evaluate(expression.getArguments().get(i), result, context);
     }
 
-    // Propagate LOAD CSV context from current row to context for file()/linenumber()
-    if (result != null && result.hasProperty("__loadCSV_file")) {
-      context.setVariable("__loadCSV_file", result.getProperty("__loadCSV_file"));
-      context.setVariable("__loadCSV_linenumber", result.getProperty("__loadCSV_linenumber"));
-    }
-
-    // Execute function
-    return function.execute(args, context);
+    // Execute function through the shared invocation point, which also publishes the row-scoped state a function
+    // may read off the context - the LOAD CSV file()/linenumber() pair (issue #6402).
+    return FunctionCallExpression.invoke(function, args, result, context);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -371,9 +371,11 @@ public class CreateStep extends AbstractExecutionStep {
   private Vertex createVertex(final NodePattern nodePattern, final Result currentResult) {
     final long startVertex = context.isProfiling() ? System.nanoTime() : 0;
 
+    // No label written: land in the reserved sentinel rather than a name a query could also have written as
+    // a real label (issue #6395).
     final List<String> labels = nodePattern.hasLabels()
         ? nodePattern.getLabels()
-        : List.of("Vertex");
+        : List.of(Labels.NO_LABEL_TYPE);
 
     // Get or create the appropriate type (composite if multiple labels)
     final String typeName = Labels.ensureCompositeType(

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -371,17 +371,18 @@ public class CreateStep extends AbstractExecutionStep {
   private Vertex createVertex(final NodePattern nodePattern, final Result currentResult) {
     final long startVertex = context.isProfiling() ? System.nanoTime() : 0;
 
-    // No label written: land in the reserved sentinel rather than a name a query could also have written as
-    // a real label (issue #6395).
-    final List<String> labels = nodePattern.hasLabels()
-        ? nodePattern.getLabels()
-        : List.of(Labels.NO_LABEL_TYPE);
-
-    // Get or create the appropriate type (composite if multiple labels)
-    final String typeName = Labels.ensureCompositeType(
-        context.getDatabase().getSchema(),
-        labels
-    );
+    // No label written: land in the reserved sentinel directly, bypassing ensureCompositeType - that method's
+    // job is turning USER-WRITTEN labels into a type name, and it refuses one literally equal to the sentinel
+    // (issue #6395 review: CREATE (:`~NO_LABEL~`) must not be able to land a vertex on the same type an
+    // unlabelled CREATE does). Passing the sentinel through it as though it were a written label would collide
+    // with that guard on every unlabelled CREATE.
+    final String typeName;
+    if (nodePattern.hasLabels()) {
+      typeName = Labels.ensureCompositeType(context.getDatabase().getSchema(), nodePattern.getLabels());
+    } else {
+      typeName = Labels.NO_LABEL_TYPE;
+      context.getDatabase().getSchema().getOrCreateVertexType(Labels.NO_LABEL_TYPE);
+    }
 
     final MutableVertex vertex = context.getDatabase().newVertex(typeName);
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/LoadCSVStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/LoadCSVStep.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.LoadCSVClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
@@ -153,8 +154,7 @@ public class LoadCSVStep extends AbstractExecutionStep {
                   rowValue = fields;
                 }
                 final ResultInternal result = createOutputRow(currentInputRow, rowValue);
-                result.setProperty("__loadCSV_file", currentUrl);
-                result.setProperty("__loadCSV_linenumber", currentLineNumber);
+                LoadCSVRowContext.stamp(result, currentUrl, currentLineNumber);
                 buffer.add(result);
                 continue;
               }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1134,15 +1134,15 @@ public class MergeStep extends AbstractExecutionStep {
    * @return created vertex
    */
   private Vertex createVertex(final NodePattern nodePattern, final Result result) {
-    // No label written: land in the reserved sentinel rather than a name a query could also have written as
-    // a real label (issue #6395).
-    final List<String> labels = nodePattern.hasLabels()
-        ? nodePattern.getLabels()
-        : List.of(Labels.NO_LABEL_TYPE);
-
-    // Get or create the appropriate type (composite if multiple labels)
-    final String typeName = Labels.ensureCompositeType(
-        context.getDatabase().getSchema(), labels);
+    // No label written: land in the reserved sentinel directly, bypassing ensureCompositeType - see
+    // CreateStep.createVertex for why (issue #6395 review).
+    final String typeName;
+    if (nodePattern.hasLabels()) {
+      typeName = Labels.ensureCompositeType(context.getDatabase().getSchema(), nodePattern.getLabels());
+    } else {
+      typeName = Labels.NO_LABEL_TYPE;
+      context.getDatabase().getSchema().getOrCreateVertexType(Labels.NO_LABEL_TYPE);
+    }
 
     final MutableVertex vertex = context.getDatabase().newVertex(typeName);
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1134,9 +1134,11 @@ public class MergeStep extends AbstractExecutionStep {
    * @return created vertex
    */
   private Vertex createVertex(final NodePattern nodePattern, final Result result) {
+    // No label written: land in the reserved sentinel rather than a name a query could also have written as
+    // a real label (issue #6395).
     final List<String> labels = nodePattern.hasLabels()
         ? nodePattern.getLabels()
-        : List.of("Vertex");
+        : List.of(Labels.NO_LABEL_TYPE);
 
     // Get or create the appropriate type (composite if multiple labels)
     final String typeName = Labels.ensureCompositeType(

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -298,8 +298,11 @@ public class RemoveStep extends AbstractExecutionStep {
 
     final String newTypeName;
     if (remainingLabels.isEmpty()) {
-      newTypeName = "V";
-      schema.getOrCreateVertexType("V");
+      // The same reserved sentinel CreateStep/MergeStep use for "no labels", rather than a second, differently
+      // named type meaning the same thing (issue #6395: a node stripped of its last label used to land in "V"
+      // while one created unlabelled landed in "Vertex", so the two collided with neither and with each other).
+      newTypeName = Labels.NO_LABEL_TYPE;
+      schema.getOrCreateVertexType(Labels.NO_LABEL_TYPE);
     } else {
       newTypeName = Labels.ensureCompositeType(schema, remainingLabels);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
@@ -77,6 +77,7 @@ public class SubqueryStep extends AbstractExecutionStep {
   private final ExpressionEvaluator expressionEvaluator;
   private final Set<String> importedVariables;
   private final boolean importAllVariables;
+  private final boolean innerMayWrite;
 
   public SubqueryStep(final SubqueryClause subqueryClause, final CommandContext context,
                        final DatabaseInternal database, final Map<String, Object> parameters,
@@ -88,6 +89,7 @@ public class SubqueryStep extends AbstractExecutionStep {
     this.expressionEvaluator = expressionEvaluator;
     this.importedVariables = computeImportedVariables(subqueryClause);
     this.importAllVariables = importedVariables == null;
+    this.innerMayWrite = !subqueryClause.getInnerStatement().isReadOnly();
   }
 
   /**
@@ -438,7 +440,14 @@ public class SubqueryStep extends AbstractExecutionStep {
 
       return results;
     } finally {
-      refreshDocumentBindings(outerRow);
+      // Only a subquery that can write has anything to refresh. A read-only one cannot have invalidated a binding,
+      // and re-reading it is not free of consequence: lookupByRID answers from the transaction cache, so the
+      // snapshot the outer row was carrying is replaced by the live, shared record instance - and a write performed
+      // for a LATER row then shows through the binding of an EARLIER one. That is issue #6362: inserting the
+      // identity subquery CALL (*) { RETURN 0 AS barrier } after MERGE ... ON MATCH SET turned [10, 99] into
+      // [99, 99]. The refresh itself is still required for the writing case it was added for (issue #4182).
+      if (innerMayWrite)
+        refreshDocumentBindings(outerRow);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
@@ -89,6 +89,16 @@ public class SubqueryStep extends AbstractExecutionStep {
     this.expressionEvaluator = expressionEvaluator;
     this.importedVariables = computeImportedVariables(subqueryClause);
     this.importAllVariables = importedVariables == null;
+    // isReadOnly() is exact for every CREATE/SET/MERGE/DELETE/REMOVE/FOREACH shape and for a CALL to a registered
+    // CypherProcedure (SimpleCypherStatement.anyWriteProcedureCall), which is every write path Cypher itself
+    // exposes. It is NOT exact for a call - anywhere in the statement, CALL or expression position - into a
+    // user-defined SQL function (DEFINE FUNCTION): SQLFunctionDefinition.execute runs the definition as a full
+    // "sqlscript" command, which can itself CREATE/UPDATE/DELETE. Such a call reads as read-only here and skips
+    // the refresh below, which can reintroduce #4182/#6362-style staleness for that one narrow shape. Tracked as
+    // a known limitation (issue #6395 review) rather than fixed here: closing it properly needs the same
+    // whole-statement, every-expression-position walk isReadOnly() itself would need, and this flag also backs
+    // HA leader routing (issue #6094) - not a change to make inside an unrelated bug-fix batch under time
+    // pressure.
     this.innerMayWrite = !subqueryClause.getInnerStatement().isReadOnly();
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
@@ -95,7 +95,7 @@ public class SubqueryStep extends AbstractExecutionStep {
     // user-defined SQL function (DEFINE FUNCTION): SQLFunctionDefinition.execute runs the definition as a full
     // "sqlscript" command, which can itself CREATE/UPDATE/DELETE. Such a call reads as read-only here and skips
     // the refresh below, which can reintroduce #4182/#6362-style staleness for that one narrow shape. Tracked as
-    // a known limitation (issue #6395 review) rather than fixed here: closing it properly needs the same
+    // a known limitation (issue #6362 review, filed as #6418) rather than fixed here: closing it properly needs the same
     // whole-statement, every-expression-position walk isReadOnly() itself would need, and this flag also backs
     // HA leader routing (issue #6094) - not a change to make inside an unrelated bug-fix batch under time
     // pressure.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
@@ -18,6 +18,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
 import com.arcadedb.query.opencypher.ast.WithClause;
@@ -242,6 +243,9 @@ public class WithStep extends AbstractExecutionStep {
         result.setProperty(item.getOutputName(), value);
       }
     }
+
+    // The LOAD CSV file()/linenumber() pair describes the row, not the projection, so it survives one (issue #6402).
+    LoadCSVRowContext.carryOver(inputResult, result);
 
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -1845,21 +1845,11 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
         properties = visitProperties(propsCtx);
     }
 
-    // Path length (variable-length relationships)
+    // Path length (variable-length relationships), read through the one place that knows what [*] means.
     if (ctx.pathLength() != null) {
-      final Cypher25Parser.PathLengthContext pathLen = ctx.pathLength();
-      if (pathLen.from != null) {
-        minHops = Integer.parseInt(pathLen.from.getText());
-      }
-      if (pathLen.to != null) {
-        maxHops = Integer.parseInt(pathLen.to.getText());
-      }
-      if (pathLen.single != null) {
-        minHops = maxHops = Integer.parseInt(pathLen.single.getText());
-      }
-      // Bare * with no range: [*] means [*1..] (min=1, max=unbounded)
-      if (minHops == null && maxHops == null)
-        minHops = 1;
+      final ParserUtils.PathLength pathLength = ParserUtils.parsePathLength(ctx.pathLength());
+      minHops = pathLength.minHops();
+      maxHops = pathLength.maxHops();
     }
 
     // Direction

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -2583,7 +2583,7 @@ class CypherExpressionBuilder {
     boolean labelDisjunction = false;
 
     if (ctx.variable() != null) {
-      variable = ctx.variable().getText();
+      variable = ParserUtils.stripBackticks(ctx.variable().getText());
     }
 
     if (ctx.labelExpression() != null) {
@@ -2620,7 +2620,7 @@ class CypherExpressionBuilder {
     Integer maxHops = null;
 
     if (ctx.variable() != null) {
-      variable = ctx.variable().getText();
+      variable = ParserUtils.stripBackticks(ctx.variable().getText());
     }
 
     if (ctx.labelExpression() != null) {
@@ -2635,18 +2635,13 @@ class CypherExpressionBuilder {
         properties = parseMapProperties(ctx.properties().map());
     }
 
-    // Path length (variable-length relationships)
+    // Path length (variable-length relationships), read through the one place that knows what [*] means.
+    // Written as its own copy of the MATCH-side block, this is where [*] lost its normalization to [*1..] and a
+    // pattern comprehension planned it as a single fixed hop (issue #6370).
     if (ctx.pathLength() != null) {
-      final Cypher25Parser.PathLengthContext pathLen = ctx.pathLength();
-      if (pathLen.from != null) {
-        minHops = Integer.parseInt(pathLen.from.getText());
-      }
-      if (pathLen.to != null) {
-        maxHops = Integer.parseInt(pathLen.to.getText());
-      }
-      if (pathLen.single != null) {
-        minHops = maxHops = Integer.parseInt(pathLen.single.getText());
-      }
+      final ParserUtils.PathLength pathLength = ParserUtils.parsePathLength(ctx.pathLength());
+      minHops = pathLength.minHops();
+      maxHops = pathLength.maxHops();
     }
 
     // Direction
@@ -2673,19 +2668,17 @@ class CypherExpressionBuilder {
   }
 
   /**
-   * Extract labels from a labelExpression context.
+   * Extract labels from a labelExpression context, through the same grammar-based walk the MATCH-side builder uses.
+   * <p>
+   * This used to split the raw text on {@code :}, {@code &} and {@code |}, which is a different answer from the one
+   * {@code MATCH} gives for the same pattern: a backtick-quoted label containing a separator was chopped into
+   * pieces, the backticks were kept on every name, and a dynamic {@code $(expression)} label was turned into a
+   * literal label named after its own source text. The two blocks were meant to be copies of each other, and every
+   * way they were not is a way an expression-position pattern answered differently from the identical MATCH
+   * pattern (issues #6370, #6363).
    */
   private List<String> extractLabels(final Cypher25Parser.LabelExpressionContext ctx) {
-    final String text = ctx.getText();
-    final String cleanText = text.replaceAll("^:+", "");
-    final String[] parts = cleanText.split("[:&|]+");
-    final List<String> labels = new ArrayList<>();
-    for (String part : parts) {
-      if (!part.isEmpty()) {
-        labels.add(part);
-      }
-    }
-    return labels;
+    return ParserUtils.extractLabels(ctx);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/ParserUtils.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/ParserUtils.java
@@ -59,6 +59,46 @@ public class ParserUtils {
   }
 
   /**
+   * The hop bounds a relationship pattern's {@code *} suffix declares, as the pair
+   * {@code RelationshipPattern} carries: {@code null} on either side means "unbounded in that direction", and both
+   * {@code null} means the pattern is not variable-length at all.
+   *
+   * @param minHops lower bound, inclusive
+   * @param maxHops upper bound, inclusive, {@code null} when unbounded
+   */
+  public record PathLength(Integer minHops, Integer maxHops) {
+    /** The bounds of a relationship pattern carrying no {@code *} suffix: a single fixed hop. */
+    public static final PathLength FIXED_SINGLE_HOP = new PathLength(null, null);
+  }
+
+  /**
+   * Reads the hop bounds off a {@code pathLength} context, normalizing the bare {@code [*]} spelling.
+   * <p>
+   * {@code [*]} means {@code [*1..]} everywhere in Cypher, and normalizing it is not decoration: with both bounds
+   * left {@code null}, {@code RelationshipPattern.isVariableLength()} answers false and the hop is planned as one
+   * fixed hop, so {@code [(a)-[*]->(b:A) | b.n]} silently answered as though the user had written a single-hop
+   * pattern. That is what happened while the MATCH-side builder normalized it and the expression-side copy of the
+   * same block did not (issue #6370), so the normalization lives here and both builders read it from one place
+   * rather than each carrying its own copy to drift from.
+   *
+   * @param ctx the {@code pathLength} context, which the caller has already established is present
+   *
+   * @return the declared bounds, never {@code null}
+   */
+  public static PathLength parsePathLength(final Cypher25Parser.PathLengthContext ctx) {
+    if (ctx == null)
+      return PathLength.FIXED_SINGLE_HOP;
+    if (ctx.single != null) {
+      final int exact = Integer.parseInt(ctx.single.getText());
+      return new PathLength(exact, exact);
+    }
+    final Integer minHops = ctx.from != null ? Integer.parseInt(ctx.from.getText()) : null;
+    final Integer maxHops = ctx.to != null ? Integer.parseInt(ctx.to.getText()) : null;
+    // Bare * with no range: [*] means [*1..] (min=1, max=unbounded).
+    return minHops == null && maxHops == null ? new PathLength(1, null) : new PathLength(minHops, maxHops);
+  }
+
+  /**
    * Extract labels from a label expression context using grammar-based parsing.
    * Handles multiple labels, alternative labels, and combinations.
    * Examples:

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -274,6 +274,46 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
   /** Heap cost of one {@code double} array element, the entry type of every embedding and distance matrix. */
   protected static final long DOUBLE_BYTES = 8L;
 
+  /** Heap cost of one {@code long} array element, the word type of the {@link java.util.BitSet} neighbour matrices. */
+  protected static final long LONG_BYTES = 8L;
+
+  /**
+   * Estimated heap one OLTP-loaded vertex costs the call, for the structures {@code loadGraph} builds around it:
+   * the {@code List<Vertex>} slot, the {@code HashMap} table slot, the {@code HashMap.Node} and the boxed
+   * {@code Integer} index of the RID index, and the loaded record's own object shell.
+   * <p>
+   * The record's payload is on top of this and is not estimated: it is whatever the user stored. The figure is
+   * therefore a floor, which is the useful direction - it is what the call holds per vertex whatever the data
+   * looks like, and at ten million vertices it is already most of a gigabyte for the index alone (issue #6317).
+   */
+  protected static final long OLTP_VERTEX_BYTES = 96L;
+
+  /**
+   * Heap cost of a {@link java.util.BitSet} object on top of the {@code long[]} of words it wraps: the object
+   * header, the {@code words} reference, the {@code wordsInUse} int, the {@code sizeIsSticky} flag and padding.
+   * <p>
+   * Same order-of-magnitude heuristic as {@link #MATRIX_ROW_OVERHEAD_BYTES}, and it matters for the same reason:
+   * a bit matrix is one BitSet per node, so the wrapper is paid {@code nodeCount} times.
+   */
+  protected static final long BITSET_OVERHEAD_BYTES = 32L;
+
+  /**
+   * Estimated heap footprint of a {@code rows}-long array of {@code new BitSet(bits)}, wrappers and row headers
+   * included, in saturating {@code long} arithmetic.
+   * <p>
+   * {@code new BitSet(bits)} allocates {@code ceil(bits / 64)} longs immediately, whatever the node's real degree
+   * turns out to be, so a {@code BitSet[n]} of {@code new BitSet(n)} is a genuine {@code n²/8}-byte structure -
+   * the {@code nodeCount x nodeCount} shape {@link GlobalConfiguration#CYPHER_ALGO_MAX_WORKING_MEMORY} names in
+   * its own documentation, eight times denser per element than the {@code double[n][n]} matrices and therefore
+   * slipping through to a far larger graph before it exhausts the heap (issue #6375).
+   *
+   * @param rows how many bit sets are allocated, normally the node count
+   * @param bits how many bits each of them is sized for, normally the node count
+   */
+  protected static long bitsetMatrixBytes(final long rows, final long bits) {
+    return saturatingSum(matrixBytes(rows, (bits + 63) / 64, LONG_BYTES), saturatingProduct(rows, BITSET_OVERHEAD_BYTES));
+  }
+
   /**
    * Estimated heap footprint of a {@code new T[rows][columns]} of an element type {@code elementBytes} wide,
    * row headers included, in saturating {@code long} arithmetic.
@@ -480,6 +520,37 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     return GraphEngine.buildRidIndex(vertices);
   }
 
+  /**
+   * Loads every vertex the call will work over, charging each one to the call's budget as it arrives.
+   * <p>
+   * The list, the RID index built beside it and the loaded records are the first allocation of every procedure in
+   * this package and the one no budget priced: a call could be refused for a 64 MB matrix having already
+   * allocated a multi-gigabyte graph to measure it against, and a call that was accepted held that graph for its
+   * whole duration with the budget none the wiser (issue #6317).
+   * <p>
+   * The bound is carried by the walk rather than by a reservation made once the count is known. Both refuse the
+   * same calls, but a check afterwards first pays in full for a traversal it will throw away - the same argument
+   * {@code algo.mst} settled the same way in issue #6300. The refusal itself still goes through
+   * {@link MemoryBudget#reserve}, so there is one place that decides and one shape of message.
+   *
+   * @param db         the database
+   * @param nodeLabels vertex type filter (null = all types)
+   * @param memory     the call's budget
+   */
+  protected List<Vertex> loadVertices(final Database db, final String[] nodeLabels, final MemoryBudget memory) {
+    final long maxVertices = memory.capacityFor(OLTP_VERTEX_BYTES);
+    final List<Vertex> vertices = new ArrayList<>();
+    final Iterator<Vertex> iter = getAllVertices(db, nodeLabels);
+    while (iter.hasNext()) {
+      if (vertices.size() >= maxVertices)
+        memory.reserve(saturatingProduct(vertices.size() + 1L, OLTP_VERTEX_BYTES), "the loaded graph",
+            "at least " + (vertices.size() + 1) + " nodes");
+      vertices.add(iter.next());
+    }
+    memory.reserve(saturatingProduct(vertices.size(), OLTP_VERTEX_BYTES), "the loaded graph", vertices.size() + " nodes");
+    return vertices;
+  }
+
   /** @see GraphEngine#neighborRid(Edge, RID, Vertex.DIRECTION) */
   protected RID neighborRid(final Edge edge, final RID sourceRid, final Vertex.DIRECTION dir) {
     return GraphEngine.neighborRid(edge, sourceRid, dir);
@@ -556,19 +627,19 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
 
   protected GraphData loadGraph(final Database db, final String[] nodeLabels, final String[] relTypes,
       final CommandContext context) {
+    final MemoryBudget memory = newMemoryBudget(db);
     if (nodeLabels == null || nodeLabels.length == 0) {
       final GraphTraversalProvider provider = findProvider(db, relTypes);
       if (provider != null) {
         if (context != null)
           context.setVariable(CommandContext.CSR_ACCELERATED_VAR, true);
-        return new GraphData(provider, provider.getNodeCount());
+        // A Graph Analytical View is shared, pre-built state this call neither allocates nor frees, so its own
+        // footprint is not the call's to price. What is the call's is the copy adjacency() takes out of it, and
+        // that is reserved there.
+        return new GraphData(provider, provider.getNodeCount(), memory);
       }
     }
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> iter = getAllVertices(db, nodeLabels);
-    while (iter.hasNext())
-      vertices.add(iter.next());
-    return new GraphData(vertices, buildRidIndex(vertices));
+    return new GraphData(loadVertices(db, nodeLabels, memory), memory);
   }
 
   /**
@@ -583,19 +654,38 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
     private final GraphTraversalProvider provider;
     private final List<Vertex>           vertices;
     private final Map<RID, Integer>      ridToIdx;
+    private final MemoryBudget           memory;
 
-    private GraphData(final GraphTraversalProvider provider, final int nodeCount) {
+    private GraphData(final GraphTraversalProvider provider, final int nodeCount, final MemoryBudget memory) {
       this.provider = provider;
       this.vertices = null;
       this.ridToIdx = null;
       this.nodeCount = nodeCount;
+      this.memory = memory;
     }
 
-    private GraphData(final List<Vertex> vertices, final Map<RID, Integer> ridToIdx) {
+    private GraphData(final List<Vertex> vertices, final MemoryBudget memory) {
+      this(vertices, GraphEngine.buildRidIndex(vertices), memory);
+    }
+
+    private GraphData(final List<Vertex> vertices, final Map<RID, Integer> ridToIdx, final MemoryBudget memory) {
       this.provider = null;
       this.vertices = vertices;
       this.ridToIdx = ridToIdx;
       this.nodeCount = vertices.size();
+      this.memory = memory;
+    }
+
+    /**
+     * The budget this call is spending, already charged for the graph itself.
+     * <p>
+     * An algorithm that reserves a working set of its own takes it from here rather than opening a second budget:
+     * the unit being bounded is the call, and a call that opened one budget per component could exceed the limit
+     * by however many components it happens to have. The graph is the first and usually the largest of them
+     * (issue #6317).
+     */
+    public MemoryBudget memory() {
+      return memory;
     }
 
     public int[][] adjacency(final Vertex.DIRECTION dir, final String... relTypes) {
@@ -603,6 +693,10 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
         // Try zero-allocation NeighborView first
         final NeighborView nv = provider.getNeighborView(dir, relTypes);
         if (nv != null) {
+          long entries = 0;
+          for (int i = 0; i < nodeCount; i++)
+            entries += nv.offsetEnd(i) - nv.offset(i);
+          reserveAdjacency(nodeCount, entries);
           final int[][] adj = new int[nodeCount][];
           final int[] nbrs = nv.neighbors();
           for (int i = 0; i < nodeCount; i++) {
@@ -612,12 +706,41 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
           }
           return adj;
         }
+        // No view to size the copy from, so the rows are priced as they arrive.
+        reserveAdjacency(nodeCount, 0);
         final int[][] adj = new int[nodeCount][];
-        for (int i = 0; i < nodeCount; i++)
+        long entries = 0;
+        for (int i = 0; i < nodeCount; i++) {
           adj[i] = provider.getNeighborIds(i, dir, relTypes);
+          entries += adj[i].length;
+          if ((i & 1023) == 1023) {
+            reserveAdjacency(0, entries);
+            entries = 0;
+          }
+        }
+        reserveAdjacency(0, entries);
         return adj;
       }
-      return GraphEngine.buildAdjacencyList(vertices, ridToIdx, dir, relTypes);
+      // buildAdjacencyList counts every entry before it allocates a single row, so the exact footprint is known
+      // at the one moment it is still free to refuse: that count is handed here and reserved before the fill.
+      return GraphEngine.buildAdjacencyList(vertices, ridToIdx, dir, relTypes,
+          entries -> reserveAdjacency(nodeCount, entries));
+    }
+
+    /**
+     * Charges {@code rows} neighbour-row headers and {@code entries} neighbour ids to the call's budget.
+     * <p>
+     * The adjacency is the second unpriced allocation issue #6317 names, and the larger one: 4 bytes per edge
+     * plus a row header per node, with {@code Vertex.DIRECTION.BOTH} materialising each edge twice. An algorithm
+     * that asks for it in two directions - {@code algo.cliques} does - pays for both, which is right: it holds
+     * both at once.
+     */
+    private void reserveAdjacency(final long rows, final long entries) {
+      if (rows == 0 && entries == 0)
+        return;
+      memory.reserve(saturatingSum(saturatingProduct(rows, MATRIX_ROW_OVERHEAD_BYTES),
+              saturatingProduct(entries, INT_BYTES)), "the adjacency list",
+          rows > 0 ? rows + " nodes, " + entries + " edge entries" : entries + " edge entries");
     }
 
     /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -706,7 +706,13 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
           }
           return adj;
         }
-        // No view to size the copy from, so the rows are priced as they arrive.
+        // No view to size the copy from, so the rows are priced as they arrive, 1024 nodes at a time. That
+        // interval is a node count, not a byte count: a single supernode's neighbour list is fully materialised
+        // by getNeighborIds() before the next checkpoint has a chance to refuse it, unlike the NeighborView
+        // branch above and the OLTP buildAdjacencyList below, both of which know the exact entry count before
+        // allocating a single row. Narrow in practice - it takes one enormous row rather than many average ones
+        // to matter - and left as a known limitation rather than checkpointed per-row, which would cost a
+        // reservation call per node on every CSR-backed call that lacks a NeighborView (code review, issue #6317).
         reserveAdjacency(nodeCount, 0);
         final int[][] adj = new int[nodeCount][];
         long entries = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -115,7 +115,7 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
     // involved - the graph alone sizes it. Reserved before it is allocated so that a graph too large for
     // Floyd-Warshall is a client error naming the node count and the budget, rather than an OutOfMemoryError
     // that takes the rest of the JVM's work down with it.
-    newMemoryBudget(db).reserve(matrixBytes(n, n, DOUBLE_BYTES), "the distance matrix", n + " x " + n + " nodes");
+    graph.memory().reserve(matrixBytes(n, n, DOUBLE_BYTES), "the distance matrix", n + " x " + n + " nodes");
 
     // Allocate distance matrix: one large contiguous allocation is GC-friendly
     final double[][] dist = new double[n][n];

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
@@ -31,8 +31,6 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -212,10 +210,7 @@ public class AlgoArticleRank extends AbstractAlgoProcedure {
 
   private Stream<Result> executeWithOLTP(final Database db, final double dampingFactor,
       final int maxIterations, final double tolerance, final WorkGuard guard) {
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> iter = getAllVertices(db, null);
-    while (iter.hasNext())
-      vertices.add(iter.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
     if (vertices.isEmpty())
       return Stream.empty();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -32,7 +32,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -101,10 +100,7 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> vertIter = getAllVertices(db, null);
-    while (vertIter.hasNext())
-      vertices.add(vertIter.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
     if (vertices.isEmpty())
       return Stream.empty();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
@@ -58,6 +58,11 @@ import java.util.stream.Stream;
 public class AlgoClique extends AbstractAlgoProcedure {
   public static final String NAME = "algo.clique";
 
+  /**
+   * Heap cost of a {@code StackFrame} object and the deque slot holding it, on top of the bit sets it references.
+   */
+  private static final long STACK_FRAME_OVERHEAD_BYTES = 64L;
+
   @Override
   public String getName() {
     return NAME;
@@ -223,11 +228,6 @@ public class AlgoClique extends AbstractAlgoProcedure {
 
     return results.stream();
   }
-
-  /**
-   * Heap cost of a {@code StackFrame} object and the deque slot holding it, on top of the bit sets it references.
-   */
-  private static final long STACK_FRAME_OVERHEAD_BYTES = 64L;
 
   private static final class StackFrame {
     BitSet R;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoClique.java
@@ -105,8 +105,12 @@ public class AlgoClique extends AbstractAlgoProcedure {
     final int[][] adjOut = graph.adjacency(Vertex.DIRECTION.OUT, relTypes);
     final int[][] adjIn  = graph.adjacency(Vertex.DIRECTION.IN,  relTypes);
 
+    // A nodeCount x nodeCount bit matrix, reserved before the first BitSet is allocated and built under the
+    // checkpoint, because the build is itself O(n²/64) (issue #6375).
+    graph.memory().reserve(bitsetMatrixBytes(n, n), "the neighbour bitsets", n + " x " + n + " nodes");
     final BitSet[] adj = new BitSet[n];
     for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
       adj[i] = new BitSet(n);
       for (final int j : adjOut[i])
         adj[i].set(j);
@@ -129,7 +133,20 @@ public class AlgoClique extends AbstractAlgoProcedure {
 
     stack.push(new StackFrame(initialR, initialP, initialX));
 
+    // A Bron-Kerbosch frame carries five bit sets of n bits, and the stack is as deep as the largest clique the
+    // search has reached, so at its peak the stack is a second nodeCount x nodeCount structure - larger than the
+    // adjacency matrix above it. Priced at the peak rather than per push: a frame is popped, and the budget never
+    // releases, so charging every push would quote a total nobody is holding (issue #6375).
+    final long frameBytes = saturatingSum(bitsetMatrixBytes(5, n), STACK_FRAME_OVERHEAD_BYTES);
+    int deepest = 1;
+    graph.memory().reserve(frameBytes, "the clique search stack", "1 frame of " + n + " nodes");
+
     while (!stack.isEmpty()) {
+      if (stack.size() > deepest) {
+        graph.memory().reserve(saturatingProduct(stack.size() - deepest, frameBytes), "the clique search stack",
+            stack.size() + " frames of " + n + " nodes");
+        deepest = stack.size();
+      }
       // Maximal-clique enumeration is exponential in the graph in the worst case, and neither `minSize` nor
       // anything else bounds the search - minSize only filters what is reported (issue #6302). One frame costs
       // at least a bit-set scan, so the check needs no throttle.
@@ -206,6 +223,11 @@ public class AlgoClique extends AbstractAlgoProcedure {
 
     return results.stream();
   }
+
+  /**
+   * Heap cost of a {@code StackFrame} object and the deque slot holding it, on top of the bit sets it references.
+   */
+  private static final long STACK_FRAME_OVERHEAD_BYTES = 64L;
 
   private static final class StackFrame {
     BitSet R;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDegreeCentrality.java
@@ -24,8 +24,6 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -82,10 +80,7 @@ public class AlgoDegreeCentrality extends AbstractAlgoProcedure {
     final String dirArg = args.length > 1 ? extractString(args[1], "direction") : "BOTH";
 
     final Database db = context.getDatabase();
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> iter = getAllVertices(db, null);
-    while (iter.hasNext())
-      vertices.add(iter.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
 
     final int n = vertices.size();
     if (n == 0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstraSingleSource.java
@@ -32,7 +32,6 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -152,10 +151,7 @@ public class AlgoDijkstraSingleSource extends AbstractAlgoProcedure {
 
   private Stream<Result> executeWithOLTP(final Database db, final Vertex startNode,
       final String[] relTypes, final String weightProperty, final Vertex.DIRECTION dir) {
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> iter = getAllVertices(db, null);
-    while (iter.hasNext())
-      vertices.add(iter.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
 
     final int n = vertices.size();
     if (n == 0)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoFastRP.java
@@ -123,7 +123,7 @@ public class AlgoFastRP extends AbstractAlgoProcedure {
     // matrix - at the default of 128 the pair costs about 2 KB per node, 2 GB at a million nodes. The node count
     // and the knob are all the estimate needs, so the reservation comes before the adjacency lists are
     // materialised: a call that cannot afford its matrices should not first pay the O(edges) build.
-    newMemoryBudget(db).reserve(saturatingProduct(2L, matrixBytes(n, dimensions, DOUBLE_BYTES)),
+    graph.memory().reserve(saturatingProduct(2L, matrixBytes(n, dimensions, DOUBLE_BYTES)),
         "the embedding matrices", "2 matrices of " + n + " nodes x dimensions=" + dimensions);
 
     final int[][] adj = graph.adjacency(dir, relTypes);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGraphSAGE.java
@@ -122,7 +122,7 @@ public class AlgoGraphSAGE extends AbstractAlgoProcedure {
     // of the first layer, whose concatenation is 2 x initDim wide. The node count and the knob are all the
     // estimates need, so they are reserved before the adjacency lists are materialised: a call that cannot
     // afford its matrices should not first pay the O(edges) build.
-    final MemoryBudget memory = newMemoryBudget(db);
+    final MemoryBudget memory = graph.memory();
     memory.reserve(matrixBytes(n, initDim, DOUBLE_BYTES), "the node feature matrix",
         n + " nodes x " + initDim + " initial features");
     // Unconditional since #6264 gave `layers` a minimum of 1: there is no longer a zero-layer call whose layer

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHashGNN.java
@@ -121,7 +121,7 @@ public class AlgoHashGNN extends AbstractAlgoProcedure {
     // row, not a matrix; at the default of 128 the three together cost about 2 KB per node. The node count and
     // the knob are all the estimates need, so they are reserved before the adjacency lists are materialised: a
     // call that cannot afford its matrices should not first pay the O(edges) build.
-    final MemoryBudget memory = newMemoryBudget(db);
+    final MemoryBudget memory = graph.memory();
     memory.reserve(saturatingProduct(2L, matrixBytes(n, numFeatures, BOOLEAN_BYTES)), "the feature matrices",
         "2 matrices of " + n + " nodes x " + numFeatures + " features (embeddingDimension=" + embDim + " x 4)");
     memory.reserve(matrixBytes(n, embDim, DOUBLE_BYTES), "the embedding matrix",

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHierarchicalClustering.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoHierarchicalClustering.java
@@ -97,9 +97,12 @@ public class AlgoHierarchicalClustering extends AbstractAlgoProcedure {
       return Stream.empty();
     final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH, relTypes);
 
-    // Build neighbor BitSets for Jaccard similarity
+    // Build neighbor BitSets for Jaccard similarity: a nodeCount x nodeCount bit matrix, reserved before the
+    // first BitSet is allocated and built under the checkpoint, because the build is itself O(n²/64) (issue #6375).
+    graph.memory().reserve(bitsetMatrixBytes(n, n), "the neighbour bitsets", n + " x " + n + " nodes");
     final BitSet[] neighborSets = new BitSet[n];
     for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
       neighborSets[i] = new BitSet(n);
       neighborSets[i].set(i); // include self for union calculation
       for (final int j : adj[i])

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKNN.java
@@ -110,9 +110,12 @@ public class AlgoKNN extends AbstractAlgoProcedure {
     final int k = Math.min(rawK, n);
     final int[][] adj = graph.adjacency(dir, relTypes);
 
-    // Build BitSets for O(1) intersection
+    // Build BitSets for O(1) intersection: a nodeCount x nodeCount bit matrix, reserved before the first BitSet
+    // is allocated and built under the checkpoint, because the build is itself O(n²/64) (issue #6375).
+    graph.memory().reserve(bitsetMatrixBytes(n, n), "the neighbour bitsets", n + " x " + n + " nodes");
     final BitSet[] neighborSets = new BitSet[n];
     for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
       neighborSets[i] = new BitSet(n);
       for (final int j : adj[i])
         neighborSets[i].set(j);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -32,7 +32,6 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -96,10 +95,8 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> iter = getAllVertices(db, null);
-    while (iter.hasNext())
-      vertices.add(iter.next());
+    final MemoryBudget memory = newMemoryBudget(db);
+    final List<Vertex> vertices = loadVertices(db, null, memory);
 
     final int n = vertices.size();
     if (n == 0)
@@ -117,7 +114,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
     // dense formulation is a client error naming the node count and the budget, rather than an
     // OutOfMemoryError. The two spur masks beside it are nodeCount-sized and allocated once for the whole call
     // (see below), so they are a rounding error next to the matrix and are priced with it rather than apart.
-    newMemoryBudget(db).reserve(saturatingSum(matrixBytes(n, n, DOUBLE_BYTES), matrixBytes(2, n, BOOLEAN_BYTES)),
+    memory.reserve(saturatingSum(matrixBytes(n, n, DOUBLE_BYTES), matrixBytes(2, n, BOOLEAN_BYTES)),
         "the weight matrix and the spur masks",
         "a double matrix of " + n + " x " + n + " nodes and two boolean masks of " + n + " nodes");
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKTruss.java
@@ -97,7 +97,10 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH, relTypes);
 
     // Build neighbor BitSets for O(1) membership test: a nodeCount x nodeCount bit matrix, built before the
-    // peeling loop that carries the checkpoint.
+    // peeling loop that carries the checkpoint. Reserved twice over the call because computeFullTrussDecomposition
+    // builds a second one below while this one is still alive, which is exactly what the running total is for
+    // (issue #6375).
+    graph.memory().reserve(bitsetMatrixBytes(n, n), "the neighbour bitsets", n + " x " + n + " nodes");
     final BitSet[] neighborSets = new BitSet[n];
     for (int i = 0; i < n; i++) {
       guard.checkPeriodically(i);
@@ -191,6 +194,8 @@ public class AlgoKTruss extends AbstractAlgoProcedure {
     // Assign truss numbers: nodes in remaining edges get at least kParam truss number
     // For full decomposition, track max k where each node is still connected
     // Re-run the full decomposition
+    graph.memory().reserve(bitsetMatrixBytes(n, n), "the neighbour bitsets of the truss decomposition",
+        n + " x " + n + " nodes");
     final int[] nodeTruss = computeFullTrussDecomposition(guard, n, adj, neighborSets, edgeMap, edges, edgeCount);
 
     final List<Result> results = new ArrayList<>(n);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLabelPropagation.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLabelPropagation.java
@@ -31,8 +31,6 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 
 import com.arcadedb.utility.IntIntHashMap;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -140,10 +138,7 @@ public class AlgoLabelPropagation extends AbstractAlgoProcedure {
 
   private Stream<Result> executeWithOLTP(final Database db, final int maxIterations,
       final Vertex.DIRECTION direction, final WorkGuard guard) {
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> vertIter = getAllVertices(db, null);
-    while (vertIter.hasNext())
-      vertices.add(vertIter.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
     if (vertices.isEmpty())
       return Stream.empty();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
@@ -30,9 +30,7 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 
 import com.arcadedb.utility.IntIntHashMap;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -106,10 +104,7 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> vertIter = getAllVertices(db, null);
-    while (vertIter.hasNext())
-      vertices.add(vertIter.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
     if (vertices.isEmpty())
       return Stream.empty();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -29,8 +29,6 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -103,10 +101,8 @@ public class AlgoMST extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> iter = getAllVertices(db, null);
-    while (iter.hasNext())
-      vertices.add(iter.next());
+    final MemoryBudget memory = newMemoryBudget(db);
+    final List<Vertex> vertices = loadVertices(db, null, memory);
 
     final int n = vertices.size();
     if (n == 0)
@@ -127,7 +123,6 @@ public class AlgoMST extends AbstractAlgoProcedure {
     // The budget is consulted as pass 1 counts rather than once it is done. Both refuse the same calls, but a
     // check afterwards first pays in full for a traversal it will throw away - the same argument that puts
     // algo.steinerTree's reservation ahead of its adjacency build.
-    final MemoryBudget memory = newMemoryBudget(db);
     final long maxEdges = memory.capacityFor(EDGE_BYTES);
 
     // Collect edges — two passes to allocate primitive arrays without reallocation. Ghost edges are

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
@@ -29,9 +29,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -94,10 +92,8 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> iter = getAllVertices(db, null);
-    while (iter.hasNext())
-      vertices.add(iter.next());
+    final MemoryBudget memory = newMemoryBudget(db);
+    final List<Vertex> vertices = loadVertices(db, null, memory);
 
     final int n = vertices.size();
     if (n == 0)
@@ -114,7 +110,7 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
     // both alive to the end: 1.6 GB at 10 000 nodes, with no knob involved. Reserved before the first is
     // allocated so that a graph too large for the dense formulation is a client error naming the node count and
     // the budget, rather than an OutOfMemoryError.
-    newMemoryBudget(db).reserve(saturatingProduct(2L, matrixBytes(n, n, DOUBLE_BYTES)),
+    memory.reserve(saturatingProduct(2L, matrixBytes(n, n, DOUBLE_BYTES)),
         "the capacity and residual matrices", "2 matrices of " + n + " x " + n + " nodes");
 
     // Build capacity matrix as n×n array

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -31,7 +31,6 @@ import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -97,10 +96,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
 
     final Database db = context.getDatabase();
     final WorkGuard guard = newWorkGuard(context);
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> it = getAllVertices(db, null);
-    while (it.hasNext())
-      vertices.add(it.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
     final int n = vertices.size();
     if (n == 0)
       return Stream.empty();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoNode2Vec.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoNode2Vec.java
@@ -130,7 +130,7 @@ public class AlgoNode2Vec extends AbstractAlgoProcedure {
 
     // Both reservations are made off the node count and the knobs alone, so they come before the adjacency
     // lists are materialised: a call that cannot afford its buffers should not first pay the O(edges) build.
-    final MemoryBudget memory = newMemoryBudget(db);
+    final MemoryBudget memory = graph.memory();
     // Sized in long arithmetic: `n * walksPerNode` wraps int for a large walksPerNode, which used to size the
     // walk matrix with a negative or (for an exact multiple of 2^32) far too small a value.
     final long totalWalksAsLong = saturatingProduct(n, walksPerNode);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -33,7 +33,6 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.WorkGuard;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -150,10 +149,7 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
   private Stream<Result> executeWithOLTP(final Database db, final double dampingFactor,
       final int maxIterations, final double tolerance, final String weightProperty,
       final Vertex.DIRECTION direction, final WorkGuard guard) {
-    final List<Vertex> vertices = new ArrayList<>();
-    final Iterator<Vertex> vertIter = getAllVertices(db, null);
-    while (vertIter.hasNext())
-      vertices.add(vertIter.next());
+    final List<Vertex> vertices = loadVertices(db, null, newMemoryBudget(db));
     if (vertices.isEmpty())
       return Stream.empty();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRandomWalk.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoRandomWalk.java
@@ -118,7 +118,7 @@ public class AlgoRandomWalk extends AbstractAlgoProcedure {
     // `steps + 1` is computed in long: at Integer.MAX_VALUE the int form wraps to Integer.MIN_VALUE and the
     // allocation died with a bare NegativeArraySizeException.
     final long walkCapacity = steps + 1L;
-    newMemoryBudget(db).reserve(walkCapacity * INT_BYTES, "the random walk buffer", "steps=" + steps);
+    graph.memory().reserve(walkCapacity * INT_BYTES, "the random walk buffer", "steps=" + steps);
     if (walkCapacity > Integer.MAX_VALUE)
       throw new IllegalArgumentException(getName() + "(): steps=" + steps + " needs " + walkCapacity
           + " walk entries, more than the " + Integer.MAX_VALUE + " a Java array can hold");

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSLPA.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSLPA.java
@@ -124,7 +124,7 @@ public class AlgoSLPA extends AbstractAlgoProcedure {
     // BEFORE the first row is allocated; `iterations + 1` is computed in long because at
     // Integer.MAX_VALUE the int form wraps to Integer.MIN_VALUE and died as a bare NegativeArraySizeException.
     final long rowCapacity = iterations + 1L;
-    newMemoryBudget(db).reserve(matrixBytes(n, rowCapacity, INT_BYTES), "the label memory",
+    graph.memory().reserve(matrixBytes(n, rowCapacity, INT_BYTES), "the label memory",
         "iterations=" + iterations + " over " + n + " nodes");
     if (rowCapacity > Integer.MAX_VALUE)
       throw new IllegalArgumentException(getName() + "(): iterations=" + iterations + " needs " + rowCapacity

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSimRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSimRank.java
@@ -117,7 +117,7 @@ public class AlgoSimRank extends AbstractAlgoProcedure {
     // no knob involved. The node count is all the estimate needs, so the reservation comes before the adjacency
     // lists are materialised: a graph too large for SimRank is then a client error naming the node count and
     // the budget, rather than an OutOfMemoryError paid for after an O(edges) build.
-    newMemoryBudget(db).reserve(saturatingProduct(2L, matrixBytes(n, n, DOUBLE_BYTES)), "the similarity matrices",
+    graph.memory().reserve(saturatingProduct(2L, matrixBytes(n, n, DOUBLE_BYTES)), "the similarity matrices",
         "2 matrices of " + n + " x " + n + " nodes");
 
     // Build IN adjacency list (who points to whom)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoSteinerTree.java
@@ -129,7 +129,7 @@ public class AlgoSteinerTree extends AbstractAlgoProcedure {
     // by 2 happens after the product, so the wrap is not avoided by the result fitting an int - and a negative
     // pairCount reached `new int[pairCount]` as a bare NegativeArraySizeException naming nothing.
     final long pairCount = (long) t * (t - 1) / 2;
-    final MemoryBudget memory = newMemoryBudget(db);
+    final MemoryBudget memory = graph.memory();
     memory.reserve(saturatingSum(matrixBytes(t, n, DOUBLE_BYTES), matrixBytes(t, n, INT_BYTES)),
         "the per-terminal Dijkstra tables", t + " terminals x " + n + " nodes");
     // Per pair: the endpoints pU/pV, the weight pW, and the two int arrays the index sort works over (the

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoTriangleCount.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoTriangleCount.java
@@ -94,9 +94,12 @@ public class AlgoTriangleCount extends AbstractAlgoProcedure {
     // Always use BOTH for triangle counting (undirected notion)
     final int[][] adj = graph.adjacency(Vertex.DIRECTION.BOTH, relTypes);
 
-    // Build neighbor BitSets for fast intersection
+    // Build neighbor BitSets for fast intersection: a nodeCount x nodeCount bit matrix, reserved before the
+    // first BitSet is allocated and built under the checkpoint, because the build is itself O(n²/64) (issue #6375).
+    graph.memory().reserve(bitsetMatrixBytes(n, n), "the neighbour bitsets", n + " x " + n + " nodes");
     final BitSet[] neighborSets = new BitSet[n];
     for (int i = 0; i < n; i++) {
+      guard.checkPeriodically(i);
       neighborSets[i] = new BitSet(n);
       for (final int j : adj[i])
         neighborSets[i].set(j);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBareStarComprehensionIssue6370Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBareStarComprehensionIssue6370Test.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6370: {@code [*]} means {@code [*1..]} everywhere in Cypher, and a pattern comprehension read it as one
+ * fixed hop.
+ * <p>
+ * The MATCH-side builder normalized the bare star; {@code CypherExpressionBuilder}, which carries its own copy of
+ * the same block for expression-position patterns, did not, leaving both bounds {@code null} - and
+ * {@code RelationshipPattern.isVariableLength()} is {@code minHops != null || maxHops != null}, so the hop was
+ * not variable-length at all. The query did not fail; it answered as though the user had written a one-hop
+ * pattern. Neo4j answers {@code ['a1']} for both spellings.
+ * <p>
+ * The fix is not a second copy of the normalization - the two blocks are already copies of each other, which is
+ * how they drifted - so the two other ways they had drifted are pinned here as well: the expression-side block
+ * split its label expression out of the raw text, which chops a backtick-quoted label containing a separator and
+ * keeps the backticks on every name, and it left backticks on the pattern variables.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherBareStarComprehensionIssue6370Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-bare-star-6370");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:C {n:'c1'})-[:R]->(:E {n:'e1'})-[:R]->(:A {n:'a1'})");
+      database.command("opencypher", "CREATE (:C {n:'c2'})-[:R]->(:A {n:'a2'})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void aBareStarInAComprehensionIsAVariableLengthHop() {
+    // Two hops away, so a fixed single hop reaches nothing and answered [] without any error.
+    assertThat(listOf("MATCH (a:C {n:'c1'}) RETURN [(a)-[*]->(b:A) | b.n] AS l")).containsExactly("a1");
+    // The explicit spelling of the same thing, which already worked - the two must agree.
+    assertThat(listOf("MATCH (a:C {n:'c1'}) RETURN [(a)-[*1..]->(b:A) | b.n] AS l")).containsExactly("a1");
+    // And the MATCH clause, which normalized it all along.
+    assertThat(keys("MATCH (a:C {n:'c1'})-[*]->(b:A) RETURN b.n AS k")).containsExactly("a1");
+  }
+
+  @Test
+  void aBareStarStillReachesAOneHopNeighbour() {
+    // The counterweight: [*1..] includes the single hop, so widening the bound must not lose it.
+    assertThat(listOf("MATCH (a:C {n:'c2'}) RETURN [(a)-[*]->(b:A) | b.n] AS l")).containsExactly("a2");
+  }
+
+  @Test
+  void theOtherBoundedSpellingsAreUnchanged() {
+    assertThat(listOf("MATCH (a:C {n:'c1'}) RETURN [(a)-[*2]->(b:A) | b.n] AS l")).containsExactly("a1");
+    assertThat(listOf("MATCH (a:C {n:'c1'}) RETURN [(a)-[*1..1]->(b:A) | b.n] AS l")).isEmpty();
+    assertThat(listOf("MATCH (a:C {n:'c1'}) RETURN [(a)-[*..2]->(b:A) | b.n] AS l")).containsExactly("a1");
+    assertThat(listOf("MATCH (a:C {n:'c1'}) RETURN [(a)-[:R]->(b:E) | b.n] AS l")).containsExactly("e1");
+  }
+
+  @Test
+  void aBackquotedLabelInAComprehensionIsOneLabel() {
+    // The expression-side builder split the label expression on ':', '&' and '|' in the raw text, so a quoted
+    // name carrying one of those was chopped into pieces and every piece kept its backticks.
+    database.transaction(() -> database.command("opencypher", "CREATE (:C {n:'c3'})-[:R]->(:`A|B` {n:'ab1'})"));
+
+    assertThat(listOf("MATCH (a:C {n:'c3'}) RETURN [(a)-[:R]->(b:`A|B`) | b.n] AS l")).containsExactly("ab1");
+    // The MATCH spelling of the same question, which is the answer the comprehension has to match.
+    assertThat(keys("MATCH (a:C {n:'c3'})-[:R]->(b:`A|B`) RETURN b.n AS k")).containsExactly("ab1");
+  }
+
+  @Test
+  void aBackquotedVariableInAComprehensionBindsTheSameNameAsInAMatch() {
+    assertThat(listOf("MATCH (a:C {n:'c2'}) RETURN [(a)-[:R]->(`my node`:A) | `my node`.n] AS l"))
+        .containsExactly("a2");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private List<Object> listOf(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      return (List<Object>) resultSet.next().getProperty("l");
+    }
+  }
+
+  private List<Object> keys(final String query) {
+    final List<Object> values = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        values.add(resultSet.next().getProperty("k"));
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCollFunctionParityIssue6403Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCollFunctionParityIssue6403Test.java
@@ -140,6 +140,15 @@ class CypherCollFunctionParityIssue6403Test {
   }
 
   @Test
+  void aNonNumericFlattenDepthIsAClientErrorToo() {
+    // Found in code review: depth silently stayed at its default of 1 instead of raising, for any argument that
+    // was neither null, a Number nor a Boolean.
+    assertThatThrownBy(() -> drain("RETURN coll.flatten([[1, 2], [3]], 'x') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("Type mismatch");
+  }
+
+  @Test
   void anOutOfRangeIndexIsAClientErrorToo() {
     assertThatThrownBy(() -> drain("RETURN coll.insert([1, 2], -1, 0) AS r"))
         .isInstanceOf(CommandSemanticException.class)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCollFunctionParityIssue6403Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCollFunctionParityIssue6403Test.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.function.CypherFunctionRegistry;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.LongRangeList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6403: the {@code coll.*} namespace and the Cypher list builtins answer the same question about their
+ * argument and had drifted apart on every part of the answer.
+ * <p>
+ * The cause was one method - {@code AbstractCollFunction.asList} - which accepted only a {@code Collection},
+ * where the builtins go through {@code CypherFunctionHelper.requireListArgument}. Three consequences, all
+ * asserted here against the builtin that is the family's counterpart, so the two are held to the same answer
+ * rather than each to a remembered one:
+ * <ol>
+ *   <li>a numeric-array parameter is a Cypher LIST (issue #4284) and reached {@code reverse()} but not
+ *   {@code coll.sort()};</li>
+ *   <li>a type error is the caller's mistake, so it is a {@link CommandSemanticException} and HTTP 400 - the
+ *   {@code CommandExecutionException} the family raised is mapped to 500, and the same mistake by the same
+ *   client read as a server fault through one name and as their own through the other (issues #5476/#5477/#5222);</li>
+ *   <li>{@code coll.toSet} and {@code coll.distinct} were two copies of one behaviour, which is two places to
+ *   fix - the arrangement issue #6354 exists to remove.</li>
+ * </ol>
+ * Also covered: {@code coll.min}/{@code max}/{@code sum}/{@code avg} answer a lazily evaluated range from its
+ * shape instead of walking it, which is the same "answer exactly where the answer is exact" principle as
+ * issue #6353.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherCollFunctionParityIssue6403Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-coll-parity-6403");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // 1. An array parameter is a LIST for the whole family, not only for the builtins
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aPrimitiveArrayParameterIsAListForCollFunctionsToo() {
+    final Map<String, Object> params = Map.of("arr", new long[] { 3L, 1L, 2L });
+
+    // The builtins already accepted it (issue #4284) - asserted alongside so the two stay the same answer.
+    assertThat(list("RETURN reverse($arr) AS r", params)).containsExactly(2L, 1L, 3L);
+    assertThat(list("RETURN tail($arr) AS r", params)).containsExactly(1L, 2L);
+
+    assertThat(list("RETURN coll.sort($arr) AS r", params)).containsExactly(1L, 2L, 3L);
+    assertThat(list("RETURN coll.distinct($arr) AS r", params)).containsExactly(3L, 1L, 2L);
+    assertThat(list("RETURN coll.union($arr, $arr) AS r", params)).containsExactly(3L, 1L, 2L);
+    assertThat(list("RETURN coll.flatten($arr) AS r", params)).containsExactly(3L, 1L, 2L);
+    assertThat(single("RETURN coll.indexOf($arr, 1) AS r", params)).isEqualTo(1L);
+    assertThat(single("RETURN coll.max($arr) AS r", params)).isEqualTo(3L);
+    assertThat(single("RETURN coll.sum($arr) AS r", params)).isEqualTo(6.0);
+  }
+
+  @Test
+  void anObjectArrayParameterIsAListForCollFunctionsToo() {
+    final Map<String, Object> params = Map.of("arr", new Object[] { "b", "a", "b" });
+
+    assertThat(list("RETURN coll.distinct($arr) AS r", params)).containsExactly("b", "a");
+    assertThat(list("RETURN coll.toSet($arr) AS r", params)).containsExactly("b", "a");
+    assertThat(list("RETURN coll.sort($arr) AS r", params)).containsExactly("a", "b", "b");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // 2. A type error is the caller's mistake, and reads the same way through either family
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aNonListArgumentIsAClientTypeErrorForCollFunctionsToo() {
+    // The builtin, unchanged, as the reference wording.
+    assertThatThrownBy(() -> drain("RETURN tail(42) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("Type mismatch: tail() expects a LIST<ANY> argument but got INTEGER");
+
+    for (final String call : new String[] { "coll.sort(42)", "coll.distinct(42)", "coll.toSet(42)",
+        "coll.flatten(42)", "coll.pairsMin(42)", "coll.min(42)", "coll.max(42)", "coll.sum(42)", "coll.avg(42)",
+        "coll.indexOf(42, 1)", "coll.insert(42, 0, 1)", "coll.remove(42, 0)", "coll.union(42, [1])",
+        "coll.unionAll(42, [1])" })
+      assertThatThrownBy(() -> drain("RETURN " + call + " AS r"))
+          .as("%s must report a client type error, not a server fault", call)
+          .isInstanceOf(CommandSemanticException.class)
+          .hasMessageContaining("Type mismatch")
+          .hasMessageContaining("but got INTEGER");
+  }
+
+  @Test
+  void aWrongArgumentCountIsAClientErrorForCollFunctionsToo() {
+    // The hand-rolled "requires exactly N arguments" checks were CommandExecutionException, i.e. HTTP 500,
+    // where checkArity - which every other function uses - raises CommandSemanticException.
+    for (final String call : new String[] { "coll.sort([1], [2])", "coll.distinct([1], [2])", "coll.min([1], [2])",
+        "coll.max([1], [2])", "coll.flatten()", "coll.indexOf([1])", "coll.insert([1], 0)", "coll.remove([1])" })
+      assertThatThrownBy(() -> drain("RETURN " + call + " AS r"))
+          .as("%s must report a client error", call)
+          .isInstanceOf(CommandSemanticException.class);
+  }
+
+  @Test
+  void anOutOfRangeIndexIsAClientErrorToo() {
+    assertThatThrownBy(() -> drain("RETURN coll.insert([1, 2], -1, 0) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("negative");
+    assertThatThrownBy(() -> drain("RETURN coll.remove([1, 2], 10) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("out of range");
+    // A non-numeric index used to reach ((Number) args[1]) and surface as a bare ClassCastException.
+    assertThatThrownBy(() -> drain("RETURN coll.remove([1, 2], 'x') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("Type mismatch");
+  }
+
+  @Test
+  void nullStillPropagatesRatherThanRaising() {
+    // The one exception to the type rule, and the same one the builtins make: null in, null out.
+    assertThat(single("RETURN coll.sort(null) AS r", Map.of())).isNull();
+    assertThat(single("RETURN coll.distinct(null) AS r", Map.of())).isNull();
+    assertThat(single("RETURN tail(null) AS r", Map.of())).isNull();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // 3. coll.toSet is coll.distinct
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void toSetAndDistinctAreOneImplementation() {
+    assertThat(CypherFunctionRegistry.get("coll.toSet")).isInstanceOf(CypherFunctionRegistry.get("coll.distinct")
+        .getClass());
+    assertThat(list("RETURN coll.toSet([1, 1, 2]) AS r", Map.of()))
+        .isEqualTo(list("RETURN coll.distinct([1, 1, 2]) AS r", Map.of()));
+    // Both names keep answering, including through the apoc. prefix a migrating catalogue writes (issue #6157).
+    assertThat(CypherFunctionRegistry.get("apoc.coll.toSet")).isSameAs(CypherFunctionRegistry.get("coll.toSet"));
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The range short-circuits, which must survive the routing change and gain the aggregates
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aRangeIsStillAnsweredWithoutBeingCopied() {
+    assertThat(single("RETURN coll.sort(range(1, 5)) AS r", Map.of())).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.distinct(range(1, 5)) AS r", Map.of())).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.toSet(range(1, 5)) AS r", Map.of())).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.flatten(range(1, 5)) AS r", Map.of())).isInstanceOf(LongRangeList.class);
+    assertThat(single("RETURN coll.remove(range(1, 5), 0, 2) AS r", Map.of())).isInstanceOf(LongRangeList.class);
+  }
+
+  @Test
+  void theAggregatesAnswerARangeFromItsShape() {
+    // The endpoints and the closed form, not a walk: with arcadedb.queryMaxRangeSize raised these are the
+    // difference between an answer and a billion iterations.
+    assertThat(single("RETURN coll.min(range(1, 10)) AS r", Map.of())).isEqualTo(1L);
+    assertThat(single("RETURN coll.max(range(1, 10)) AS r", Map.of())).isEqualTo(10L);
+    assertThat(single("RETURN coll.min(range(10, 1, -1)) AS r", Map.of())).isEqualTo(1L);
+    assertThat(single("RETURN coll.max(range(10, 1, -1)) AS r", Map.of())).isEqualTo(10L);
+    assertThat(single("RETURN coll.sum(range(1, 10)) AS r", Map.of())).isEqualTo(55.0);
+    assertThat(single("RETURN coll.avg(range(1, 10)) AS r", Map.of())).isEqualTo(5.5);
+    assertThat(single("RETURN coll.sum(range(1, 10, 3)) AS r", Map.of())).isEqualTo(22.0);
+    assertThat(single("RETURN coll.avg(range(1, 10, 3)) AS r", Map.of())).isEqualTo(5.5);
+
+    // The counterweight: the closed form has to give the same answer the walk gave.
+    assertThat(single("RETURN coll.sum([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) AS r", Map.of())).isEqualTo(55.0);
+    assertThat(single("RETURN coll.avg([1, 4, 7, 10]) AS r", Map.of())).isEqualTo(5.5);
+    assertThat(single("RETURN coll.min([]) AS r", Map.of())).isNull();
+    assertThat(single("RETURN coll.avg(range(1, 0)) AS r", Map.of())).isNull();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  private Object single(final String query, final Map<String, Object> params) {
+    try (final ResultSet resultSet = database.query("opencypher", query, params)) {
+      return resultSet.next().getProperty("r");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object> list(final String query, final Map<String, Object> params) {
+    return (List<Object>) single(query, params);
+  }
+
+  private void drain(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        resultSet.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue6402Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue6402Test.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6402: {@code file()} and {@code linenumber()} answered correctly in a projection and {@code null} in a
+ * {@code WHERE} predicate, because the LOAD CSV row context was lifted onto the {@link
+ * com.arcadedb.query.sql.executor.CommandContext} by {@code ExpressionEvaluator} - the path a projection takes -
+ * and by nothing on the AST path a predicate takes.
+ * <p>
+ * The shape of the test is the one {@code CypherArithmeticEvaluatorParityTest} uses: the same expression in a
+ * projection and in a predicate, asserted to answer identically. What made it worth a test rather than a fix is
+ * that two predicate forms disagreed with <i>each other</i> in the same clause position - {@code linenumber()}
+ * was null enough for {@code IS NOT NULL} to reject every row and non-null enough for {@code > 1} to keep two -
+ * so no reading of Cypher makes both answers right, and asserting one form would not have caught the other.
+ * <p>
+ * Neo4j, the openCypher reference implementation, documents both functions as usable anywhere in the query
+ * following {@code LOAD CSV}, predicates included.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherLoadCSVRowContextIssue6402Test {
+  private Database database;
+  private String   url;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    final File csv = new File("./target/databases/cypher-loadcsv-6402/people.csv");
+    csv.getParentFile().mkdirs();
+    try (final PrintWriter writer = new PrintWriter(csv, "UTF-8")) {
+      writer.println("name,age");
+      writer.println("alice,30");
+      writer.println("bob,40");
+    }
+    url = csv.getAbsolutePath();
+
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-loadcsv-6402/db");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The matrix: the same call, in a projection and in each predicate form
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void fileAnswersTheSameInAProjectionAndInEveryPredicateForm() {
+    assertThat(rows("RETURN file() AS r")).hasSize(3).allMatch(url::equals);
+
+    // Every row of the file has a file(), so every predicate form must keep all three.
+    assertThat(rows("WITH row WHERE file() IS NOT NULL RETURN 1 AS r")).hasSize(3);
+    assertThat(rows("WITH row WHERE file() = '" + url + "' RETURN 1 AS r")).hasSize(3);
+    assertThat(rows("WITH row WHERE file() IS NOT NULL AND linenumber() > 0 RETURN 1 AS r")).hasSize(3);
+    assertThat(rows("WITH row WHERE NOT file() IS NULL RETURN 1 AS r")).hasSize(3);
+    assertThat(rows("WITH row WHERE file() IS NULL RETURN 1 AS r")).isEmpty();
+  }
+
+  @Test
+  void lineNumberAnswersTheSameInAProjectionAndInEveryPredicateForm() {
+    assertThat(rows("RETURN linenumber() AS r")).containsExactly(1, 2, 3);
+
+    assertThat(rows("WITH row WHERE linenumber() IS NOT NULL RETURN linenumber() AS r")).containsExactly(1, 2, 3);
+    // Skipping the header this way is the single most common LOAD CSV idiom.
+    assertThat(rows("WITH row WHERE linenumber() > 1 RETURN linenumber() AS r")).containsExactly(2, 3);
+    assertThat(rows("WITH row WHERE linenumber() > 1 AND linenumber() IS NOT NULL RETURN linenumber() AS r"))
+        .containsExactly(2, 3);
+    assertThat(rows("WITH row WHERE linenumber() >= 1 RETURN linenumber() AS r")).containsExactly(1, 2, 3);
+    assertThat(rows("WITH row WHERE linenumber() > 5 RETURN linenumber() AS r")).isEmpty();
+  }
+
+  @Test
+  void theRowContextSurvivesAProjectionThatDoesNotNameIt() {
+    // A projection keeps only what it names, so after `WITH row` the context used to be gone - and, because the
+    // two functions read a context variable no later row reset, every row answered with the line number of
+    // whichever row happened to be evaluated last.
+    assertThat(rows("WITH row RETURN linenumber() AS r")).containsExactly(1, 2, 3);
+    assertThat(rows("WITH row AS renamed RETURN linenumber() AS r")).containsExactly(1, 2, 3);
+    assertThat(rows("WITH row RETURN file() AS r")).hasSize(3).allMatch(url::equals);
+    assertThat(rows("WITH row, linenumber() AS ln WITH ln RETURN ln AS r")).containsExactly(1, 2, 3);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The context is execution state, so it does not become a column of its own
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theRowContextIsNotProjectedByReturnStar() {
+    for (final String query : new String[] { "RETURN *", "WITH * RETURN *", "WITH row RETURN *" })
+      try (final ResultSet resultSet = database.query("opencypher", load(query))) {
+        while (resultSet.hasNext()) {
+          final Result result = resultSet.next();
+          assertThat(result.getPropertyNames())
+              .as("%s must project the query's own variables and nothing else", query)
+              .containsExactly("row");
+        }
+      }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  private String load(final String tail) {
+    return "LOAD CSV FROM '" + url + "' AS row " + tail;
+  }
+
+  private List<Object> rows(final String tail) {
+    final List<Object> values = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", load(tail))) {
+      while (resultSet.hasNext())
+        values.add(resultSet.next().getProperty("r"));
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue6402Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLoadCSVRowContextIssue6402Test.java
@@ -120,6 +120,15 @@ class CypherLoadCSVRowContextIssue6402Test {
     assertThat(rows("WITH row, linenumber() AS ln WITH ln RETURN ln AS r")).containsExactly(1, 2, 3);
   }
 
+  @Test
+  void theRowContextSurvivesAProjectionThatDropsRowEntirely() {
+    // The deliberate reading, pinned per code review: file()/linenumber() are a property of the query's
+    // position relative to LOAD CSV, not of row still being in scope - the same way count(*) needs no variable
+    // bound. "WITH 1 AS x" drops row from scope entirely and must not turn the functions off.
+    assertThat(rows("WITH 1 AS x RETURN linenumber() AS r")).containsExactly(1, 2, 3);
+    assertThat(rows("WITH 1 AS x RETURN file() AS r")).hasSize(3).allMatch(url::equals);
+  }
+
   // ---------------------------------------------------------------------------------------------------------
   // The context is execution state, so it does not become a column of its own
   // ---------------------------------------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMissingFunctionsTest.java
@@ -436,9 +436,12 @@ class CypherMissingFunctionsTest {
 
   @Test
   void collToSetNonListArgument() {
+    // A non-list argument is the caller's mistake, so since issue #6403 coll.* raises the same
+    // CommandSemanticException (HTTP 400) the Cypher list builtins do, with their "Type mismatch" wording,
+    // rather than the CommandExecutionException (HTTP 500) it used to raise with its own wording.
     assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.toSet('not a list') AS result").hasNext())
-        .isInstanceOf(CommandExecutionException.class)
-        .hasMessageContaining("coll.toSet() requires a list argument");
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("Type mismatch: coll.toSet() expects a LIST<ANY> argument but got STRING");
   }
 
   @Test
@@ -536,9 +539,10 @@ class CypherMissingFunctionsTest {
 
   @Test
   void collPairsMinNonListArgument() {
+    // Same reclassification as coll.toSet above (issue #6403).
     assertThatThrownBy(() -> database.query("opencypher", "RETURN coll.pairsMin('not a list') AS result").hasNext())
-        .isInstanceOf(CommandExecutionException.class)
-        .hasMessageContaining("coll.pairsMin() requires a list argument");
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("Type mismatch: coll.pairsMin() expects a LIST<ANY> argument but got STRING");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlannerDifferentialIssue6400Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlannerDifferentialIssue6400Test.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6400: the native Cypher engine plans a MATCH clause with two independent implementations - the
+ * cost-based physical plan built by {@code CypherOptimizer} and the traditional plan built by
+ * {@code CypherExecutionPlan.buildMatchStep} - and which one runs a given clause is decided by syntax that has
+ * nothing to do with the clause's meaning. Wrapping a query in {@code CALL { ... }}, writing {@code OPTIONAL}
+ * in front of it, or binding a named path on one of its parts all route it to the traditional plan; the same
+ * clause on its own goes to the cost-based one.
+ * <p>
+ * That arrangement is only safe while the two agree, and nothing checked that they did. Issue #6310 was exactly
+ * this: relationship uniqueness across a comma was implemented in one planner and not the other, so the same
+ * clause answered 0 rows as written and 4 rows inside a {@code CALL} subquery. The 3897-scenario openCypher TCK
+ * does not catch this class of defect either - each scenario exercises whichever planner its own spelling
+ * happens to route to, so a divergence only shows up if some scenario is written in the shape that lands on the
+ * broken side.
+ * <p>
+ * This harness closes that gap generically. It generates a corpus of MATCH clauses combinatorially - the #6310
+ * defect needed three properties to line up at once (two parts, a shared variable, and one part unable to
+ * collide with itself), which is the kind of conjunction a hand-written list misses - runs each clause down both
+ * planners against one fixture, and asserts the two answers are equal as multisets.
+ * <h2>How the routing is forced, and why it is verified rather than assumed</h2>
+ * The routing is forcible from the query text, so no engine hook is needed: the clause as written goes to the
+ * cost-based planner and the same clause wrapped in {@code CALL { ... }} goes to the traditional one. But the
+ * cost-based planner declines far more than variable-length hops - two comma-separated parts that share no
+ * variable are a Cartesian product it also declines - so a corpus entry cannot be assumed to have exercised
+ * both. {@code EXPLAIN} reports which planner ran, and every pair is classified by it before being compared:
+ * a pair that lands on the traditional plan twice is counted as non-differential and
+ * {@link #theCorpusActuallyExercisesBothPlanners()} holds the differential count to a floor, so the harness
+ * cannot quietly become an expensive way of comparing one planner against itself.
+ * <p>
+ * On disagreement the cost-based answer is not automatically the authority. For #6310 it happened to be right,
+ * but nothing guarantees that direction, so a failure here is a question to answer rather than a side to
+ * believe: {@link CypherMatchClauseUniquenessIssue6310Test} is where the expected values for the shapes settled
+ * so far are pinned.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherPlannerDifferentialIssue6400Test {
+  /** What {@code EXPLAIN} prints when the cost-based optimizer declined the statement. */
+  private static final String TRADITIONAL_MARKER = "Traditional Execution (Non-Optimized)";
+
+  private Database database;
+
+  /** Which planner {@code EXPLAIN} says ran a statement. */
+  private enum Planner {
+    COST_BASED, TRADITIONAL
+  }
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-planner-differential-6400");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.transaction(() -> {
+      // Sub-typing on both sides, so a pattern written against a super-type also selects the sub-type's records
+      // and the two planners have to agree about that too.
+      database.command("sql", "CREATE VERTEX TYPE A");
+      database.command("sql", "CREATE VERTEX TYPE B");
+      database.command("sql", "CREATE VERTEX TYPE C");
+      database.command("sql", "CREATE VERTEX TYPE E");
+      database.command("sql", "CREATE VERTEX TYPE SUBA EXTENDS A");
+      database.command("sql", "CREATE EDGE TYPE R");
+      database.command("sql", "CREATE EDGE TYPE S");
+      database.command("sql", "CREATE EDGE TYPE SUBR EXTENDS R");
+
+      // Three C -> E -> A chains, an extra C feeding the first E (so a clause that ignores relationship
+      // uniqueness has a strictly larger answer than one that honours it), a multi-labelled node, a sub-typed
+      // node and a sub-typed edge, and one undirected-only pair reachable solely by walking an edge backwards.
+      database.command("opencypher", "CREATE (a1:A {n:'a1', v:1})<-[:R]-(e1:E {n:'e1', v:2})<-[:R]-(c1:C {n:'c1', v:3})");
+      database.command("opencypher", "CREATE (a2:A {n:'a2', v:1})<-[:R]-(e2:E {n:'e2', v:2})<-[:R]-(c2:C {n:'c2', v:4})");
+      database.command("opencypher", "CREATE (a3:A {n:'a3', v:5})<-[:R]-(e3:E {n:'e3', v:2})<-[:R]-(c3:C {n:'c3', v:3})");
+      database.command("opencypher", "MATCH (e:E {n:'e1'}), (c:C {n:'c2'}) CREATE (c)-[:R]->(e)");
+      database.command("opencypher", "CREATE (:A:B {n:'ab1', v:1})<-[:S]-(:E {n:'e4', v:2})");
+      database.command("opencypher", "CREATE (:SUBA {n:'sa1', v:1})<-[:SUBR]-(:C {n:'c4', v:3})");
+      database.command("opencypher", "MATCH (a:A {n:'a1'}), (c:C {n:'c3'}) CREATE (a)-[:S]->(c)");
+
+      // Then one hop of every (start label x relationship type x far label) combination the corpus writes, so a
+      // comparison of two empty result sets is the exception rather than the rule. Two empty answers are equal,
+      // and a sparse fixture would therefore pass every comparison in the harness without comparing anything -
+      // which is what the row-count floor in theTwoPlannersAnswerEveryCorpusClauseIdentically refuses.
+      int id = 0;
+      for (final String startLabel : new String[] { "A", "C", "E", "SUBA", "A:B" })
+        for (final String relType : new String[] { "R", "S", "SUBR" })
+          for (final String farLabel : new String[] { "E", "A" }) {
+            final String tag = "g" + (id++);
+            database.command("opencypher", "CREATE (:" + startLabel + " {n:'" + tag + "s', v:1})-[:" + relType
+                + "]->(:" + farLabel + " {n:'" + tag + "t', v:2})");
+          }
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The corpus
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * Label expressions written on an endpoint. Every endpoint carries one: the cost-based planner declines a node
+   * pattern with no label at all, so a corpus that left endpoints bare would route entirely to the traditional
+   * plan and compare it against itself - which is the vacuity {@link #theCorpusActuallyExercisesBothPlanners()}
+   * exists to refuse.
+   * <p>
+   * The conjunction and disjunction forms are declined by the cost-based planner today and are kept in the
+   * corpus deliberately: they cost one {@code EXPLAIN} each and start being compared for free on the day the
+   * optimizer learns them, which is exactly when a divergence would otherwise go unnoticed.
+   */
+  private static final String[] LABELS = { ":A", ":C", ":E", ":SUBA", ":A:B", ":A|C" };
+
+  /** Labels for the far endpoint of a hop, kept short because the near endpoint already varies over all six. */
+  private static final String[] FAR_LABELS = { ":E", ":A" };
+
+  /** Relationship type expressions: untyped, typed, disjunction, sub-type, and an unrelated type. */
+  private static final String[] REL_TYPES = { "", ":R", ":S", ":R|S", ":SUBR" };
+
+  /** The three hop directions. Uniqueness proofs read the ends of a hop, and an undirected hop has none. */
+  private static final String[] DIRECTIONS = { "->", "<-", "--" };
+
+  /** Inline property filters, which the cost-based planner may push into the scan and the other may not. */
+  private static final String[] INLINE_FILTERS = { "", " {v: 1}" };
+
+  /**
+   * One corpus entry: the MATCH clause and the projection that reads its bindings back.
+   *
+   * @param match      the whole {@code MATCH ...} clause
+   * @param projection the {@code RETURN} item list, written so it is valid both on its own and inside a
+   *                   {@code CALL} subquery
+   */
+  private record Query(String match, String projection) {
+    String costBased() {
+      return match + " RETURN " + projection;
+    }
+
+    String traditional() {
+      // A CALL subquery routes the clause inside it to the traditional plan whatever the clause is, and the
+      // outer statement only forwards the columns, so the two spellings ask exactly the same question.
+      return "CALL { " + match + " RETURN " + projection + " } RETURN " + outerProjection();
+    }
+
+    private String outerProjection() {
+      final StringBuilder outer = new StringBuilder();
+      for (final String item : projection.split(",")) {
+        if (!outer.isEmpty())
+          outer.append(", ");
+        outer.append(item.substring(item.lastIndexOf(" AS ") + 4).trim());
+      }
+      return outer.toString();
+    }
+  }
+
+  /**
+   * Every MATCH clause the harness compares, built as the cross product of the dimensions above rather than
+   * written out: the defect this exists for needed three properties to hold at once, and picking the triples by
+   * hand is picking the ones somebody already thought of.
+   */
+  private static List<Query> corpus() {
+    final List<Query> queries = new ArrayList<>();
+
+    // Single-part patterns: one hop, every direction x relationship type x endpoint labels x inline filter.
+    for (final String direction : DIRECTIONS)
+      for (final String relType : REL_TYPES)
+        for (final String label : LABELS)
+          for (final String farLabel : FAR_LABELS)
+            for (final String filter : INLINE_FILTERS)
+              queries.add(new Query("MATCH " + hop("x" + label + filter, "r1" + relType, "y" + farLabel, direction),
+                  "x.n AS xn, y.n AS yn"));
+
+    // Two-part patterns sharing a variable, which is where relationship uniqueness across the comma bites
+    // (issue #6310) and also the shape the cost-based planner is willing to join.
+    for (final String direction : DIRECTIONS)
+      for (final String relType : REL_TYPES)
+        for (final String label : LABELS)
+          queries.add(new Query("MATCH " + hop("x" + label, "r1" + relType, "y:E", direction) + ", "
+              + hop("y:E", "r2", "z:A", "->"), "x.n AS xn, y.n AS yn, z.n AS zn"));
+
+    // Two-part patterns sharing no variable: a Cartesian product, where uniqueness across the comma still
+    // applies and the row count is the product of the two parts less the pairings that are the same edge.
+    for (final String relType : REL_TYPES)
+      for (final String label : LABELS)
+        queries.add(new Query("MATCH " + hop("x" + label, "r1" + relType, "y:E", "->") + ", "
+            + hop("p:E", "r2", "q:A", "->"), "x.n AS xn, p.n AS pn"));
+
+    // Anonymous hops, which the plan has to bind itself to be able to compare them at all.
+    for (final String direction : DIRECTIONS)
+      for (final String label : LABELS)
+        queries.add(new Query("MATCH " + hop("x" + label, "", "y:E", direction) + ", " + hop("y:E", "", "z:A", "->"),
+            "x.n AS xn, z.n AS zn"));
+
+    // A WHERE predicate beside the pattern: what the cost-based planner may push into the scan.
+    for (final String label : LABELS)
+      queries.add(new Query("MATCH " + hop("x" + label, "r1:R", "y:E", "->") + " WHERE y.v = 2 AND x.n <> 'c2'",
+          "x.n AS xn, y.n AS yn"));
+
+    return queries;
+  }
+
+  /** Renders one hop with the given endpoints, relationship spec and direction. */
+  private static String hop(final String start, final String rel, final String end, final String direction) {
+    final String relPart = rel.isEmpty() ? "[]" : "[" + rel + "]";
+    return switch (direction) {
+      case "->" -> "(" + start + ")-" + relPart + "->(" + end + ")";
+      case "<-" -> "(" + start + ")<-" + relPart + "-(" + end + ")";
+      default -> "(" + start + ")-" + relPart + "-(" + end + ")";
+    };
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The assertions
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void theTwoPlannersAnswerEveryCorpusClauseIdentically() {
+    final List<String> divergent = new ArrayList<>();
+    int comparedWithRows = 0;
+
+    for (final Query query : corpus()) {
+      if (planner(query.costBased()) != Planner.COST_BASED)
+        // The cost-based planner declined this clause, so both spellings would run the traditional plan and
+        // there is nothing to compare. Counted, and held to a floor, by theCorpusActuallyExercisesBothPlanners.
+        continue;
+
+      final List<String> optimized = rows(query.costBased());
+      final List<String> traditional = rows(query.traditional());
+      if (!optimized.equals(traditional))
+        divergent.add(query.match() + "\n    cost-based : " + optimized + "\n    traditional: " + traditional);
+      else if (!optimized.isEmpty())
+        comparedWithRows++;
+    }
+
+    assertThat(divergent)
+        .as("the same MATCH clause must answer the same rows whichever planner ran it - see issue #6400")
+        .isEmpty();
+
+    // Two empty result sets are equal, so a fixture that matched nothing would pass every comparison above
+    // while comparing nothing at all. This is the second vacuity guard, on the data rather than the routing.
+    assertThat(comparedWithRows)
+        .as("the fixture must make most corpus clauses actually match something")
+        .isGreaterThan(100);
+  }
+
+  @Test
+  void theCorpusActuallyExercisesBothPlanners() {
+    int differential = 0;
+    for (final Query query : corpus())
+      if (planner(query.costBased()) == Planner.COST_BASED)
+        differential++;
+
+    // The failure mode that would make the whole harness vacuous is every corpus entry routing to the
+    // traditional plan twice over, which comparing them would then "pass" without having compared anything.
+    // The floor is well under the count observed so the assertion tracks the harness, not the optimizer's
+    // current appetite; if the optimizer ever declines this much of the corpus, that is itself the finding.
+    assertThat(differential)
+        .as("the corpus must contain clauses the cost-based planner actually accepts")
+        .isGreaterThan(100);
+  }
+
+  @Test
+  void theComparisonItselfDiscriminates() {
+    // The third vacuity guard, on the comparison rather than on the routing or the data: a rows() that flattened
+    // everything to the same string would make the harness pass whatever the two planners answered.
+    assertThat(rows("MATCH (x:C)-[:R]->(y:E) RETURN x.n AS xn, y.n AS yn"))
+        .isNotEqualTo(rows("MATCH (x:C)-[:R]->(y:E) RETURN y.n AS xn, x.n AS yn"));
+  }
+
+  @Test
+  void everyCallWrappedSpellingReallyRunsTheTraditionalPlan() {
+    // The other half of the routing claim: the CALL wrapper is what forces the traditional plan, and if that
+    // ever stopped being true the comparison above would be running the same planner twice.
+    for (final Query query : corpus())
+      assertThat(planner(query.traditional()))
+          .as("CALL { ... } must route its body to the traditional plan: %s", query.traditional())
+          .isEqualTo(Planner.TRADITIONAL);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------------------------------------
+
+  private Planner planner(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", "EXPLAIN " + query)) {
+      final String plan = resultSet.next().getProperty("executionPlanAsString");
+      return plan.contains(TRADITIONAL_MARKER) ? Planner.TRADITIONAL : Planner.COST_BASED;
+    }
+  }
+
+  /** The result rows as a sorted list of flattened strings, so the comparison is a multiset comparison. */
+  private List<String> rows(final String query) {
+    final List<String> rows = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext()) {
+        final Result row = resultSet.next();
+        final StringBuilder flattened = new StringBuilder();
+        for (final String property : row.getPropertyNames())
+          flattened.append(property).append('=').append(String.valueOf((Object) row.getProperty(property))).append('|');
+        rows.add(flattened.toString());
+      }
+    }
+    Collections.sort(rows);
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherReservedNoLabelSentinelIssue6395Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherReservedNoLabelSentinelIssue6395Test.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Issue #6395: a node whose only label is literally {@code V} or {@code Vertex} used to report no labels, and a
@@ -152,14 +154,47 @@ class CypherReservedNoLabelSentinelIssue6395Test {
   }
 
   @Test
-  void theSentinelItselfIsNotWritableAsALabel() {
-    // ~NO_LABEL~ contains the composite separator, so it can never survive as a single label name - the same
-    // guard that already refuses it inside any other label.
-    command("CREATE (n {k:'x'}) SET n:`~NO_LABEL~`");
+  void theSentinelItselfIsNotWritableAsALabelViaCreate() {
+    // Found in code review: CREATE (:`~NO_LABEL~`) bypasses the composite-name protection entirely, because a
+    // single label is never run through isLabelComposite - it lands directly on the sentinel type, which
+    // isBaseVertexTypeName then filters, reopening the exact V/Vertex collision this class exists to close under
+    // a name a query merely has to spell correctly instead of guess.
+    assertThatThrownBy(() -> command("CREATE (:`~NO_LABEL~` {k:'x'})"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining(Labels.NO_LABEL_TYPE);
 
-    // Whatever the engine did with a label containing the separator, it must not have become the sentinel: the
-    // node still answers to no genuine label, or to a label distinguishable from the reserved one.
-    assertThat(labelsOf("k", "x")).doesNotContain(Labels.NO_LABEL_TYPE);
+    assertThat(rows("MATCH (n {k:'x'}) RETURN n.k AS r"))
+        .as("the rejected CREATE must not have left a node behind")
+        .isEmpty();
+  }
+
+  @Test
+  void theSentinelItselfIsNotWritableAsALabelViaSet() {
+    // A vertex already typed as the sentinel: SET-ing the same label it already carries is Cypher's ordinary
+    // no-op (SET n:Existing on a vertex that already answers to Existing changes nothing), and instanceOf
+    // correctly says an unlabelled vertex's own type already IS the sentinel - so this path never reaches
+    // ensureCompositeType with a label list at all, and is the counterweight asserting that.
+    command("CREATE (n {k:'already-unlabelled'})");
+    command("MATCH (n {k:'already-unlabelled'}) SET n:`~NO_LABEL~`");
+    assertThat(labelsOf("k", "already-unlabelled")).isEmpty();
+
+    // A vertex that genuinely gains a new label: this is the path that must be rejected, since it is the one
+    // that would otherwise build a composite naming the sentinel.
+    command("CREATE (n:Foo {k:'x'})");
+
+    assertThatThrownBy(() -> command("MATCH (n:Foo {k:'x'}) SET n:`~NO_LABEL~`"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining(Labels.NO_LABEL_TYPE);
+
+    // The rejected SET must not have relabelled the node either.
+    assertThat(labelsOf("k", "x")).containsExactly("Foo");
+  }
+
+  @Test
+  void theSentinelItselfIsNotWritableAsALabelViaMerge() {
+    assertThatThrownBy(() -> command("MERGE (n:`~NO_LABEL~` {k:'x'})"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining(Labels.NO_LABEL_TYPE);
   }
 
   // ---------------------------------------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherReservedNoLabelSentinelIssue6395Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherReservedNoLabelSentinelIssue6395Test.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6395: a node whose only label is literally {@code V} or {@code Vertex} used to report no labels, and a
+ * label write on it dropped the label instead of keeping it.
+ * <p>
+ * The engine used those two names for two different things at once - the type a node lands in when it has no
+ * labels at all, and an ordinary user label a query is free to write - and {@code Labels.getLabels} could only
+ * tell them apart by name, so it filtered the name and the genuine label disappeared with it. Two directions were
+ * weighed in the issue: narrow the special case (make {@code RemoveStep} strip to whatever {@code CreateStep}
+ * uses, so there is at least only one unlabelled type), or delete it by reserving an internal name no user type
+ * can collide with. This test pins the second: {@link Labels#NO_LABEL_TYPE} - {@code ~NO_LABEL~} - is not a name
+ * any Cypher label can ever equal, because {@link Labels#LABEL_SEPARATOR} already cannot appear inside a single
+ * label, so {@code V} and {@code Vertex} become ordinary labels and the special-casing in
+ * {@code Labels.getLabels}/{@code getOwnLabels} is unconditional rather than narrowed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherReservedNoLabelSentinelIssue6395Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-no-label-sentinel-6395");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // 1. The label is no longer lost on read
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aNodeWhoseOnlyLabelIsVReportsIt() {
+    command("CREATE (:V {k:'onlyV'})");
+
+    assertThat(labelsOf("k", "onlyV")).containsExactly("V");
+    assertThat(scalar("MATCH (n:V) RETURN n.k AS r")).isEqualTo("onlyV");
+    assertThat(scalar("MATCH (n) WHERE n:V RETURN n.k AS r")).isEqualTo("onlyV");
+  }
+
+  @Test
+  void aNodeWhoseOnlyLabelIsVertexReportsIt() {
+    command("CREATE (:Vertex {k:'onlyVertex'})");
+
+    assertThat(labelsOf("k", "onlyVertex")).containsExactly("Vertex");
+    assertThat(scalar("MATCH (n:Vertex) RETURN n.k AS r")).isEqualTo("onlyVertex");
+  }
+
+  @Test
+  void aCompositeCarryingVStillReportsAllThreeLabels() {
+    // The exact shape the openCypher TCK writes (CREATE (b:U:V:W:X:Y:Z)) and the case the issue explicitly says
+    // must keep behaving exactly as it does today: V is not the WHOLE label set here, so this passed before the
+    // fix and must go on passing after it.
+    command("CREATE (:U:V:W {k:'composite'})");
+
+    assertThat(labelsOf("k", "composite")).containsExactlyInAnyOrder("U", "V", "W");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // 2. Adding a label no longer removes one
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void addingALabelToAVOnlyNodeKeepsV() {
+    command("CREATE (:V {k:'onlyV'})");
+
+    command("MATCH (n {k:'onlyV'}) SET n:Extra");
+
+    assertThat(labelsOf("k", "onlyV")).containsExactlyInAnyOrder("Extra", "V");
+    assertThat(scalar("MATCH (n:V) RETURN count(n) AS r")).isEqualTo(1L);
+    assertThat(scalar("MATCH (n:Extra) RETURN n.k AS r")).isEqualTo("onlyV");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // 3. There is one unlabelled type, not two - stripped-to-zero and created-unlabelled behave identically
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aNodeStrippedOfItsLastLabelAndOneCreatedUnlabelledAnswerTheSamePredicates() {
+    command("CREATE (:Foo {k:'stripped'}), ({k:'born-plain'})");
+    command("MATCH (n:Foo) REMOVE n:Foo");
+
+    assertThat(labelsOf("k", "stripped")).isEmpty();
+    assertThat(labelsOf("k", "born-plain")).isEmpty();
+
+    // Neither answers to :V or :Vertex - those are ordinary labels now, and nobody wrote them.
+    assertThat(rows("MATCH (n:V) RETURN n.k AS r")).isEmpty();
+    assertThat(rows("MATCH (n:Vertex) RETURN n.k AS r")).isEmpty();
+
+    // Both are reached by the same unlabelled-node query, and nothing else is.
+    assertThat(rows("MATCH (n) WHERE size(labels(n)) = 0 RETURN n.k AS r"))
+        .containsExactlyInAnyOrder("stripped", "born-plain");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The counterweight: a real label named V or Vertex is written and read like any other, on every path
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void vAndVertexBehaveAsOrdinaryLabelsOnEveryPath() {
+    command("CREATE (:V {k:'v1'}), (:Vertex {k:'vx1'}), (:Other {k:'o1'})");
+
+    assertThat(rows("MATCH (n:V) RETURN n.k AS r")).containsExactly("v1");
+    assertThat(rows("MATCH (n:Vertex) RETURN n.k AS r")).containsExactly("vx1");
+    assertThat(rows("MATCH (n:V|Vertex) RETURN n.k AS r")).containsExactlyInAnyOrder("v1", "vx1");
+    assertThat(rows("MATCH (n) WHERE n:Other RETURN n.k AS r")).containsExactly("o1");
+
+    command("MATCH (n:V {k:'v1'}) REMOVE n:V");
+    assertThat(labelsOf("k", "v1")).isEmpty();
+    assertThat(rows("MATCH (n:V) RETURN n.k AS r")).isEmpty();
+  }
+
+  @Test
+  void theSentinelItselfIsNotWritableAsALabel() {
+    // ~NO_LABEL~ contains the composite separator, so it can never survive as a single label name - the same
+    // guard that already refuses it inside any other label.
+    command("CREATE (n {k:'x'}) SET n:`~NO_LABEL~`");
+
+    // Whatever the engine did with a label containing the separator, it must not have become the sentinel: the
+    // node still answers to no genuine label, or to a label distinguishable from the reserved one.
+    assertThat(labelsOf("k", "x")).doesNotContain(Labels.NO_LABEL_TYPE);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  private void command(final String query) {
+    database.transaction(() -> {
+      try (final ResultSet resultSet = database.command("opencypher", query)) {
+        while (resultSet.hasNext())
+          resultSet.next();
+      }
+    });
+  }
+
+  private Object scalar(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      return resultSet.next().getProperty("r");
+    }
+  }
+
+  private List<Object> rows(final String query) {
+    final List<Object> values = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        values.add(resultSet.next().getProperty("r"));
+    }
+    return values;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object> labelsOf(final String matchProperty, final Object value) {
+    try (final ResultSet resultSet = database.query("opencypher",
+        "MATCH (n {" + matchProperty + ": $v}) RETURN labels(n) AS l", java.util.Map.of("v", value))) {
+      final Result result = resultSet.next();
+      return (List<Object>) result.getProperty("l");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryRowBindingIssue6362Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherSubqueryRowBindingIssue6362Test.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6362: inserting an identity {@code CALL (*) { RETURN 0 AS barrier }} after a
+ * {@code MERGE ... ON MATCH SET} changed the rows the query returned - {@code [{i:1, k4:10}, {i:2, k4:99}]}
+ * became {@code [{i:1, k4:99}, {i:2, k4:99}]}, so a write performed for the second input row showed through the
+ * binding the first row was carrying.
+ * <p>
+ * The cause is {@code SubqueryStep.refreshDocumentBindings}, added for issue #4182 so that a {@code SET} inside
+ * the subquery is visible to the clauses after it. It re-reads every {@code Document} binding on the outer row
+ * through {@code lookupByRID}, which answers from the transaction cache - so the snapshot the row was carrying
+ * is replaced by the live, shared record instance, and every later mutation of that record is then visible
+ * through a row that had already passed the subquery.
+ * <p>
+ * A read-only subquery cannot have invalidated any binding, so for it the refresh is pure damage and is now
+ * skipped. The writing case it was added for keeps it, which is what
+ * {@link #aWritingSubqueryStillRefreshesTheOuterBinding()} holds it to.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherSubqueryRowBindingIssue6362Test {
+  private Database database;
+
+  /**
+   * The reporter's query up to the {@code MERGE}: two input rows over one {@code n0}, whose {@code k4} the
+   * {@code MERGE} sets on the second row only - the first row creates the pattern, so {@code ON MATCH} does not
+   * fire for it.
+   */
+  private static final String HEAD = """
+      UNWIND [1, 2] AS i \
+      MATCH (n0 {id: 1})<-[:rt4]-(m {id: 114}), (n1 {id: 126})-[:rt2]->(x)-[:rt5]->(n0) \
+      MERGE (n0)-[:rt1 {id: 42}]->(n2 {id: 2})<-[:rt11 {id: 43}]-(n0) \
+      ON MATCH SET n0.k4 = 99\s""";
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-subquery-row-binding-6362");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    buildFixture();
+  }
+
+  /**
+   * Rebuilds the reported four-node, three-relationship graph from nothing.
+   * <p>
+   * Called before every query rather than once per test: the {@code MERGE} under test is what creates the
+   * pattern {@code ON MATCH} then fires on, so a second run over the same database would find it already there
+   * and set {@code k4} on the very first input row - which is the answer this test exists to distinguish from.
+   */
+  private void buildFixture() {
+    database.transaction(() -> {
+      database.command("opencypher", "MATCH (n) DETACH DELETE n");
+      database.command("opencypher", "CREATE (n0 {id: 1, k4: 10}), (m {id: 114}), (n1 {id: 126}), (x {id: 115})");
+      database.command("opencypher", """
+          MATCH (m {id: 114}), (n0 {id: 1}), (n1 {id: 126}), (x {id: 115}) \
+          CREATE (m)-[:rt4]->(n0), (n1)-[:rt2]->(x)-[:rt5]->(n0)""");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void anIdentitySubqueryDoesNotChangeTheRows() {
+    final List<String> withoutSubquery = onFreshFixture(HEAD + "RETURN i, n0.k4 AS k4");
+    final List<String> withSubquery = onFreshFixture(HEAD + """
+        WITH i, n0, n2 \
+        CALL (*) { RETURN 0 AS barrier } \
+        WITH i, n0, n2 \
+        RETURN i, n0.k4 AS k4""");
+
+    assertThat(withoutSubquery).containsExactly("1|10", "2|99");
+    assertThat(withSubquery)
+        .as("an identity CALL (*) subquery must not change what the query returns")
+        .isEqualTo(withoutSubquery);
+  }
+
+  @Test
+  void theImplicitScopeSpellingBehavesTheSameWay() {
+    assertThat(onFreshFixture(HEAD + """
+        WITH i, n0, n2 \
+        CALL { RETURN 0 AS barrier } \
+        WITH i, n0, n2 \
+        RETURN i, n0.k4 AS k4""")).containsExactly("1|10", "2|99");
+  }
+
+  @Test
+  void thePlainControlsAreUnchanged() {
+    // A plain WITH, and an UNWIND barrier, both already preserved the streaming answer; they are the reference
+    // the subquery spelling has to match.
+    assertThat(onFreshFixture(HEAD + "WITH i, n0, n2 RETURN i, n0.k4 AS k4")).containsExactly("1|10", "2|99");
+    assertThat(onFreshFixture(HEAD + "WITH i, n0, n2 UNWIND [0] AS b WITH i, n0, n2 RETURN i, n0.k4 AS k4"))
+        .containsExactly("1|10", "2|99");
+  }
+
+  @Test
+  void theWriteItselfStillLands() {
+    // The difference under test is a row-binding one, not a persistence one: after the query the record holds 99
+    // either way.
+    onFreshFixture(HEAD + "WITH i, n0, n2 CALL (*) { RETURN 0 AS barrier } WITH i, n0, n2 RETURN i, n0.k4 AS k4");
+    assertThat(command("MATCH (n {id: 1}) RETURN n.id AS i, n.k4 AS k4")).containsExactly("1|99");
+  }
+
+  @Test
+  void aWritingSubqueryStillRefreshesTheOuterBinding() {
+    // Issue #4182, which is why the refresh exists: a SET performed inside the subquery must be visible to the
+    // clauses after it through the imported variable.
+    assertThat(command("""
+        MATCH (n {id: 1}) \
+        CALL (*) { WITH n SET n.k4 = 777 RETURN 0 AS ignored } \
+        RETURN n.id AS i, n.k4 AS k4""")).containsExactly("1|777");
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+
+  /** Rebuilds the fixture, then runs the query and flattens its rows. */
+  private List<String> onFreshFixture(final String query) {
+    buildFixture();
+    return command(query);
+  }
+
+  private List<String> command(final String query) {
+    final List<String> rows = new ArrayList<>();
+    database.transaction(() -> {
+      try (final ResultSet resultSet = database.command("opencypher", query)) {
+        while (resultSet.hasNext()) {
+          final Result row = resultSet.next();
+          final StringBuilder flattened = new StringBuilder();
+          for (final String property : row.getPropertyNames()) {
+            if (!flattened.isEmpty())
+              flattened.append('|');
+            flattened.append(String.valueOf((Object) row.getProperty(property)));
+          }
+          rows.add(flattened.toString());
+        }
+      }
+    });
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/LabelsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/LabelsTest.java
@@ -38,12 +38,13 @@ class LabelsTest extends TestHelper {
 
   @Test
   void getCompositeTypeNameWithNull() {
-    assertThat(Labels.getCompositeTypeName(null)).isEqualTo("V");
+    // Issue #6395: the fallback is the reserved sentinel, not a name a real label could also be.
+    assertThat(Labels.getCompositeTypeName(null)).isEqualTo(Labels.NO_LABEL_TYPE);
   }
 
   @Test
   void getCompositeTypeNameWithEmptyList() {
-    assertThat(Labels.getCompositeTypeName(Collections.emptyList())).isEqualTo("V");
+    assertThat(Labels.getCompositeTypeName(Collections.emptyList())).isEqualTo(Labels.NO_LABEL_TYPE);
   }
 
   @Test
@@ -97,7 +98,7 @@ class LabelsTest extends TestHelper {
   void ensureCompositeTypeWithEmptyList() {
     database.transaction(() -> {
       String typeName = Labels.ensureCompositeType(database.getSchema(), Collections.emptyList());
-      assertThat(typeName).isEqualTo("V");
+      assertThat(typeName).isEqualTo(Labels.NO_LABEL_TYPE);
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherBugFixesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherBugFixesTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -68,21 +69,24 @@ class OpenCypherBugFixesTest extends TestHelper {
 
   @Test
   void collRemoveOutOfBoundsThrows() {
-    // Issue #3446: coll.remove([1, 2], 10) should throw an error
+    // Issue #3446: coll.remove([1, 2], 10) should throw an error. An out-of-range index is the caller's mistake,
+    // so since issue #6403 it is a CommandSemanticException (HTTP 400) rather than the CommandExecutionException
+    // (HTTP 500) the family used to raise for every error, arity included.
     assertThatThrownBy(() -> {
       try (final ResultSet rs = database.command("opencypher", "RETURN coll.remove([1, 2], 10) AS result")) {
         rs.next();
       }
-    }).isInstanceOf(CommandExecutionException.class);
+    }).isInstanceOf(CommandSemanticException.class);
   }
 
   @Test
   void collRemoveNegativeIndexThrows() {
+    // Same client-error reclassification as the out-of-bounds case above (issue #6403).
     assertThatThrownBy(() -> {
       try (final ResultSet rs = database.command("opencypher", "RETURN coll.remove([1, 2], -1) AS result")) {
         rs.next();
       }
-    }).isInstanceOf(CommandExecutionException.class);
+    }).isInstanceOf(CommandSemanticException.class);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCreateTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCreateTest.java
@@ -4,6 +4,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -191,10 +193,9 @@ class OpenCypherCreateTest {
 
   @Test
   void createWithoutLabel() {
-    database.getSchema().createVertexType("Vertex");
-
     database.transaction(() -> {
-      // Create vertex without label (should default to "Vertex")
+      // Create vertex without label: lands in the reserved sentinel rather than a name a query could also
+      // have written as a real label (issue #6395), so labels(n) correctly answers [] for it too.
       final ResultSet result = database.command("opencypher", "CREATE (n {name: 'Test'}) RETURN n");
 
       assertThat((Object) result).isNotNull();
@@ -202,8 +203,12 @@ class OpenCypherCreateTest {
 
       final Result r = result.next();
       final Vertex v = (Vertex) r.toElement();
-      assertThat(v.getTypeName()).isEqualTo("Vertex");
+      assertThat(v.getTypeName()).isEqualTo(Labels.NO_LABEL_TYPE);
       assertThat((String) v.get("name")).isEqualTo("Test");
+
+      final ResultSet labels = database.query("opencypher",
+          "MATCH (n {name: 'Test'}) RETURN labels(n) AS l");
+      assertThat((List<Object>) labels.next().getProperty("l")).isEmpty();
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6263AlgoWorkingMemoryBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6263AlgoWorkingMemoryBudgetTest.java
@@ -132,7 +132,8 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
         .as("the working set of the call is the sum of its components, not its largest one")
         .hasStackTraceContaining(
             "the embedding matrices would need 8448 bytes (2 matrices of 4 nodes x embeddingDimension=128)")
-        .hasStackTraceContaining("on top of the 14240 bytes this call already reserved")
+        // 14624 rather than 14240: since #6317 the graph itself is priced, and the 4-node fixture costs 384 bytes.
+        .hasStackTraceContaining("on top of the 14624 bytes this call already reserved")
         .hasStackTraceContaining("more than the 20000 bytes allowed");
   }
 
@@ -169,7 +170,8 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
 
     assertThatThrownBy(() -> drain("CALL algo.hashgnn({seed: 42}) YIELD node RETURN node"))
         .hasStackTraceContaining("the embedding matrix would need 4224 bytes (4 nodes x embeddingDimension=128)")
-        .hasStackTraceContaining("on top of the 4352 bytes this call already reserved");
+        // 4736 rather than 4352: the 384 bytes of the loaded graph, priced since #6317.
+        .hasStackTraceContaining("on top of the 4736 bytes this call already reserved");
   }
 
   @Test
@@ -191,7 +193,8 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
     assertThatThrownBy(() -> drain("CALL algo.graphsage({layers: 2, seed: 42}) YIELD node RETURN node"))
         .hasStackTraceContaining("the layer matrices would need 69760 bytes "
             + "(4 nodes x embeddingDimension=64 plus a projection of 64 x 128)")
-        .hasStackTraceContaining("on top of the 2176 bytes this call already reserved");
+        // 2560 rather than 2176: the 384 bytes of the loaded graph, priced since #6317.
+        .hasStackTraceContaining("on top of the 2560 bytes this call already reserved");
   }
 
   // ── The square matrices, which no knob sizes at all ──────────────────────
@@ -201,7 +204,9 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
     // Floyd-Warshall's matrix is nodeCount x nodeCount with no parameter involved: 800 MB at 10 000 nodes. The
     // procedure documents itself as suitable "up to a few thousand vertices", which until now was advice
     // rather than a bound.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    // 500 rather than 100: since #6317 the graph is the first thing reserved, and the 4-node fixture costs 384
+    // bytes, so a budget below that refuses the load and never reaches the matrix this test is about.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500L);
 
     assertThatThrownBy(() -> drain("CALL algo.apsp() YIELD source, target, distance RETURN distance"))
         .hasStackTraceContaining("the distance matrix would need 256 bytes (4 x 4 nodes)")
@@ -212,7 +217,7 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
   void simRankRejectsSimilarityMatricesLargerThanTheBudget() {
     // A question about two nodes that allocates two full nodeCount x nodeCount matrices, because the
     // similarity of one pair is defined recursively over every pair.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500L);
 
     assertThatThrownBy(() -> drain("""
         MATCH (a:Node {name: 'A'}), (c:Node {name: 'C'}) \
@@ -224,7 +229,7 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
 
   @Test
   void maxFlowRejectsCapacityMatricesLargerThanTheBudget() {
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500L);
 
     assertThatThrownBy(() -> drain("""
         MATCH (a:Node {name: 'A'}), (c:Node {name: 'C'}) \
@@ -236,7 +241,7 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
 
   @Test
   void kShortestPathsRejectsTheWeightMatrixLargerThanTheBudget() {
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500L);
 
     assertThatThrownBy(() -> drain("""
         MATCH (a:Node {name: 'A'}), (c:Node {name: 'C'}) \
@@ -257,7 +262,7 @@ class Issue6263AlgoWorkingMemoryBudgetTest {
     // `terminalNodes` is a list, so unlike every other knob in the package it has no numeric form to validate:
     // its length sizes a terminals x nodeCount pair of tables, and nothing bounds it - not even the node count,
     // since repeating the same vertex is accepted. Two terminals over 4 nodes are 128 + 96 bytes.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500L);
 
     assertThatThrownBy(() -> drain("""
         MATCH (a:Node {name: 'A'}), (c:Node {name: 'C'}) \

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6289AlgoAllocationChurnTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6289AlgoAllocationChurnTest.java
@@ -153,8 +153,9 @@ class Issue6289AlgoAllocationChurnTest {
   void kShortestPathsPricesTwoNodeSizedMasksRatherThanASquareOne() {
     // The reservation follows the allocation: what is held beside the weight matrix is two boolean[nodeCount]
     // masks for the whole call, not a nodeCount x nodeCount matrix per spur node. On this graph that is
-    // 501 x 501 doubles plus two 501-entry masks.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    // 501 x 501 doubles plus two 501-entry masks. The budget has to admit the loaded graph, priced since #6317
+    // at 501 x OLTP_VERTEX_BYTES, and still refuse the ~2 MB matrix, which 100 KB does.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100_000L);
 
     final int n = CHAIN_HOPS * 2 + 1 + PADDING_NODES;
     assertThatThrownBy(() -> drain("""

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6300AlgoMSTEdgeBudgetTest.java
@@ -90,8 +90,10 @@ class Issue6300AlgoMSTEdgeBudgetTest {
 
   @Test
   void theEdgeArraysAreRefusedWhenTheyDoNotFitTheBudget() {
-    // 24 bytes per edge, so 100 bytes buys four of them and the fifth is over.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    // The graph is priced first since #6317 - 11 nodes at OLTP_VERTEX_BYTES is 1056 bytes - and what is left
+    // over is what buys edges: 24 bytes each, so the 100 bytes above the graph buy four of them and the fifth
+    // is over.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1156L);
 
     assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source, target RETURN source, target"))
         .as("the edge arrays are the dense working set of an algo.mst call and must be priced like any other")
@@ -104,7 +106,7 @@ class Issue6300AlgoMSTEdgeBudgetTest {
     // The message quotes the count reached, not the graph's total: the walk stops when the budget runs out, so
     // there is no total to quote yet. That is the observable difference between reserving during the counting
     // pass and reserving after it - and it is the whole point of the placement.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1156L);
 
     assertThatThrownBy(() -> drain("CALL algo.mst('w') YIELD source RETURN source"))
         .hasStackTraceContaining("more than 4 edges");
@@ -112,9 +114,10 @@ class Issue6300AlgoMSTEdgeBudgetTest {
 
   @Test
   void aBudgetThatFitsLetsTheCallThrough() {
-    // The counterweight: the reservation must not refuse a graph it can serve. 10 edges at 24 bytes is 240, so
-    // 1 KB is comfortable, and the MST of a path is the path itself - every edge, at its own weight.
-    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1024L);
+    // The counterweight: the reservation must not refuse a graph it can serve. 11 nodes cost 1056 bytes and
+    // 10 edges at 24 bytes is 240, so 4 KB is comfortable, and the MST of a path is the path itself - every
+    // edge, at its own weight.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 4096L);
 
     final List<Object> rows = drain("CALL algo.mst('w') YIELD source, weight, totalWeight RETURN source, weight, totalWeight");
     assertThat(rows).hasSize(EDGE_COUNT);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6317AlgoGraphLoadBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6317AlgoGraphLoadBudgetTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6317: the graph an {@code algo.*} call loads is the first allocation of every procedure in the package
+ * and was priced by no budget - so a call could be refused for a 64 MB matrix having already allocated a
+ * multi-gigabyte graph to measure it against, and a call that was accepted held that graph for its whole
+ * duration with {@code arcadedb.cypher.algoMaxWorkingMemory} none the wiser.
+ * <p>
+ * Three allocations, now all reserved: the {@code List<Vertex>} of loaded records, the {@code Map<RID, Integer>}
+ * index built beside it (a boxed {@code Integer} and a {@code HashMap.Node} per vertex), and the {@code int[][]}
+ * adjacency, which is the larger of the two - 4 bytes per edge plus a row header per node, with
+ * {@code Vertex.DIRECTION.BOTH} materialising each edge twice.
+ * <p>
+ * Both are bounded where the count becomes known rather than after the structure exists: the vertex walk carries
+ * its own stopping rule through {@code MemoryBudget.capacityFor}, and the adjacency build already counts every
+ * entry before it allocates a single row, so the total is handed to the budget at the one moment the result is
+ * still free to refuse. That placement is the difference between refusing a call and paying in full for a
+ * traversal before refusing it - the same argument {@code algo.mst} settled in issue #6300.
+ * <p>
+ * The budget is also now one budget per call rather than one per component: the graph is charged first and every
+ * later reservation accumulates on top of it, which is what {@link #theWorkingSetAccumulatesOnTopOfTheGraph()}
+ * holds it to.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6317AlgoGraphLoadBudgetTest {
+  /** Eleven nodes, so the loaded graph is a figure the assertions below can name exactly. */
+  private static final int NODE_COUNT = 11;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6317-graph-load-budget");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // A path, so the graph is connected and every procedure below has something to traverse.
+    database.transaction(() -> {
+      final List<MutableVertex> nodes = new ArrayList<>(NODE_COUNT);
+      for (int i = 0; i < NODE_COUNT; i++)
+        nodes.add(database.newVertex("Node").set("idx", i).set("name", "N" + i).save());
+      for (int i = 0; i < NODE_COUNT - 1; i++)
+        nodes.get(i).newEdge("LINK", nodes.get(i + 1), true, new Object[] { "w", (double) (i + 1) }).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ── The graph itself ─────────────────────────────────────────────────────
+
+  @Test
+  void theLoadedGraphIsRefusedWhenItDoesNotFitTheBudget() {
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+
+    assertThatThrownBy(() -> drain("CALL algo.pageRank() YIELD node RETURN node"))
+        .as("the graph is the largest thing the working set holds and must be priced like any other component")
+        .hasStackTraceContaining("algo.pagerank(): the loaded graph would need")
+        .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+  }
+
+  @Test
+  void theRefusalNamesTheNodeCountItStoppedAt() {
+    // The walk stops when the budget runs out, so the message quotes the count reached rather than the graph's
+    // total - there is no total to quote yet. That is the observable difference between bounding the walk and
+    // reserving after it, and it is the whole point of the placement.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+
+    assertThatThrownBy(() -> drain("CALL algo.pageRank() YIELD node RETURN node"))
+        .hasStackTraceContaining("at least 2 nodes");
+  }
+
+  @Test
+  void theProceduresThatLoadTheirOwnVertexListArePricedToo() {
+    // algo.maxFlow, algo.kShortestPaths and algo.mst build the list and the RID index by hand rather than
+    // through loadGraph, and went on bypassing the budget when loadGraph stopped doing so.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 100L);
+
+    for (final String[] call : new String[][] {
+        { "algo.maxFlow", "MATCH (a:Node {idx: 0}), (z:Node {idx: 10}) CALL algo.maxFlow(a, z) YIELD maxFlow RETURN maxFlow" },
+        { "algo.kShortestPaths",
+            "MATCH (a:Node {idx: 0}), (z:Node {idx: 10}) CALL algo.kShortestPaths(a, z, 2) YIELD weight RETURN weight" },
+        { "algo.mst", "CALL algo.mst('w') YIELD source RETURN source" } })
+      assertThatThrownBy(() -> drain(call[1]))
+          .as("%s loads the same graph and must price it", call[0])
+          .hasStackTraceContaining(call[0] + "(): the loaded graph would need");
+  }
+
+  // ── The adjacency ────────────────────────────────────────────────────────
+
+  @Test
+  void theAdjacencyListIsRefusedWhenItDoesNotFitTheBudget() {
+    // 11 nodes cost 1056 bytes, so a budget just above that admits the graph and leaves nothing for the
+    // adjacency - which is the larger of the two on any real graph. algo.wcc rather than algo.pagerank here
+    // because it takes its neighbour lists through GraphData.adjacency, which is where the copy is priced.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1100L);
+
+    assertThatThrownBy(() -> drain("CALL algo.wcc() YIELD node RETURN node"))
+        .hasStackTraceContaining("the adjacency list would need")
+        .hasStackTraceContaining(NODE_COUNT + " nodes, ")
+        .hasStackTraceContaining("edge entries");
+  }
+
+  @Test
+  void theWorkingSetAccumulatesOnTopOfTheGraph() {
+    // One budget per call, not one per component: the distance matrix is charged on top of the graph and the
+    // adjacency, so the message names what was already reserved.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1500L);
+
+    assertThatThrownBy(() -> drain("CALL algo.apsp() YIELD distance RETURN distance"))
+        .hasStackTraceContaining("bytes this call already reserved");
+  }
+
+  // ── The counterweights ───────────────────────────────────────────────────
+
+  @Test
+  void aBudgetThatFitsLetsTheCallThrough() {
+    // The reservation must not refuse a graph it can serve: at the default budget this one is trivial.
+    assertThat(drain("CALL algo.pageRank() YIELD node RETURN node")).hasSize(NODE_COUNT);
+    assertThat(drain("CALL algo.wcc() YIELD node RETURN node")).hasSize(NODE_COUNT);
+  }
+
+  @Test
+  void aDisabledBudgetPricesNothing() {
+    // Negative means no limit, and that has to reach the graph load and the adjacency too.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, -1L);
+
+    assertThat(drain("CALL algo.pageRank() YIELD node RETURN node")).hasSize(NODE_COUNT);
+    assertThat(drain("CALL algo.mst('w') YIELD source RETURN source")).hasSize(NODE_COUNT - 1);
+  }
+
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        rows.add(resultSet.next());
+    }
+    return rows;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6375AlgoBitsetMatrixBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6375AlgoBitsetMatrixBudgetTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6375: five algorithms built a {@code nodeCount x nodeCount} {@code BitSet} matrix up front,
+ * unconditionally, without reserving against {@code arcadedb.cypher.algoMaxWorkingMemory} - the budget whose own
+ * documentation names the {@code nodeCount x nodeCount} matrices as exactly what it exists to cap.
+ * <p>
+ * {@code new BitSet(n)} allocates {@code ceil(n/64)} longs whatever the node's real degree turns out to be, so a
+ * {@code BitSet[n]} of them is a genuine {@code n²/8}-byte structure. Eight times denser per element than the
+ * {@code double[n][n]} matrices the budget already refused, it slipped through to a far larger graph and then
+ * exhausted the heap - the {@code OutOfMemoryError} the budget exists to replace with a client error naming the
+ * component and the setting.
+ * <p>
+ * The build loops were also the unguarded phase of an otherwise abortable call, the same blind spot issue #6295
+ * closed for the SLPA/GraphSAGE/HashGNN initialisation loops: the consumption loops carried the checkpoint and
+ * the {@code O(n²/64)} build ahead of them did not.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6375AlgoBitsetMatrixBudgetTest {
+  /**
+   * A budget that admits the four-node graph and its adjacency and refuses the bit matrix on top of them. The
+   * matrix itself is 288 bytes at this size; what matters to the assertions below is only that it is the
+   * component the refusal names.
+   */
+  private static final long BUDGET_ABOVE_THE_GRAPH_BELOW_THE_MATRIX = 700L;
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6375-bitset-budget");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    // A directed cycle over four nodes: every node has a neighbour in both directions, so each of the five
+    // procedures has a matrix to build and something to find in it.
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      final MutableVertex d = database.newVertex("Node").set("name", "D").save();
+      a.newEdge("LINK", b, true, (Object[]) null).save();
+      b.newEdge("LINK", c, true, (Object[]) null).save();
+      c.newEdge("LINK", d, true, (Object[]) null).save();
+      d.newEdge("LINK", a, true, (Object[]) null).save();
+      a.newEdge("LINK", c, true, (Object[]) null).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      database.drop();
+      database = null;
+    }
+  }
+
+  /** The five procedures, each with a call that reaches its bit matrix. */
+  private static final String[][] CALLS = {
+      { "algo.triangleCount", "CALL algo.triangleCount() YIELD node RETURN node" },
+      { "algo.knn", "CALL algo.knn(2) YIELD node RETURN node" },
+      { "algo.kTruss", "CALL algo.kTruss() YIELD node RETURN node" },
+      { "algo.clique", "CALL algo.clique() YIELD clique RETURN clique" },
+      { "algo.hierarchicalClustering", "CALL algo.hierarchicalClustering(2) YIELD node RETURN node" } };
+
+  @Test
+  void everyBitsetMatrixIsRefusedWhenItDoesNotFitTheBudget() {
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+        BUDGET_ABOVE_THE_GRAPH_BELOW_THE_MATRIX);
+
+    for (final String[] call : CALLS)
+      assertThatThrownBy(() -> drain(call[1]))
+          .as("%s builds a nodeCount x nodeCount bit matrix and must price it", call[0])
+          .hasStackTraceContaining(call[0] + "(): the neighbour bitsets")
+          .hasStackTraceContaining("(4 x 4 nodes)")
+          .hasStackTraceContaining(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getKey());
+  }
+
+  @Test
+  void kTrussPricesItsSecondMatrixSeparately() {
+    // computeFullTrussDecomposition builds a second bit matrix while the first is still alive, so the peak is
+    // twice the shape - which is what a running total is for.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1000L);
+
+    assertThatThrownBy(() -> drain("CALL algo.kTruss() YIELD node RETURN node"))
+        .hasStackTraceContaining("the neighbour bitsets of the truss decomposition")
+        .hasStackTraceContaining("(4 x 4 nodes)");
+  }
+
+  @Test
+  void cliquePricesItsSearchStackAtThePeakDepth() {
+    // The Bron-Kerbosch frames are five bit sets each and the stack is as deep as the largest clique reached,
+    // so at its peak the stack is a second nodeCount x nodeCount structure.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 1000L);
+
+    assertThatThrownBy(() -> drain("CALL algo.clique() YIELD clique RETURN clique"))
+        .hasStackTraceContaining("the clique search stack")
+        .hasStackTraceContaining("frame");
+  }
+
+  @Test
+  void aBudgetThatFitsLetsEveryCallThrough() {
+    // The counterweight: the reservation must not refuse a graph it can serve. At the default budget none of
+    // these five is anywhere near the limit.
+    for (final String[] call : CALLS)
+      assertThat(drain(call[1])).as("%s must still run at the default budget", call[0]).isNotNull();
+  }
+
+  @Test
+  void aDisabledBudgetPricesNothing() {
+    // Negative means no limit, and that has to keep meaning no limit for the newly priced component too.
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, -1L);
+
+    for (final String[] call : CALLS)
+      assertThat(drain(call[1])).as("%s must be unbounded when the budget is disabled", call[0]).isNotNull();
+  }
+
+  private List<Object> drain(final String query) {
+    final List<Object> rows = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        rows.add(resultSet.next());
+    }
+    return rows;
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -112,8 +112,17 @@ public class Neo4jImporter {
       .optionalStart().appendLiteral('[').appendZoneRegionId().appendLiteral(']').optionalEnd()
       .optionalEnd()
       .toFormatter();
-  // Vertex type holding the nodes that carry no label, and the super type of every label-derived type.
-  private final static String                         ROOT_NODE_TYPE           = "Node";
+  // Vertex type holding the nodes that carry no label, and the super type of every label-derived type. The
+  // reserved sentinel Cypher's own "no labels" bookkeeping uses (Labels.NO_LABEL_TYPE), not a literal "Node" -
+  // found while fixing issue #6395: "Node" is exactly the kind of ordinary-looking name a real schema might
+  // also want as a genuine label, and Labels.getLabels/getOwnLabels only ever filtered a supertype's name by
+  // exact match against the two names that used to mean "no labels" (V, Vertex) - "Node" was never one of
+  // them, so it leaked as a phantom label onto every node this importer produced (labels(n) reported
+  // ["Node", "Person"] rather than ["Person"]) independently of, and before, that issue. Reusing the sentinel -
+  // now filtered at every depth by construction - keeps the "one query reaches every imported vertex" property
+  // this root exists for while making it invisible to labels() the same way it already is for Cypher's own
+  // unlabelled nodes.
+  private final static String                         ROOT_NODE_TYPE           = Labels.NO_LABEL_TYPE;
 
   // Neo4j ID -> packed ArcadeDB RID mapping, populated during vertex pass.
   // Uses primitive LongLongMap for numeric IDs (common case), falls back to HashMap for non-numeric IDs.

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterLabelCharactersIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterLabelCharactersIT.java
@@ -21,12 +21,14 @@ package com.arcadedb.integration.importer;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.integration.TestHelper;
+import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -69,7 +71,11 @@ class Neo4jImporterLabelCharactersIT {
 
   /**
    * A node with no labels used to throw NullPointerException out of the schema pass, before the vertex pass could
-   * reach its "skip it" branch. Such nodes now land in the root {@code Node} type rather than being lost.
+   * reach its "skip it" branch. Such nodes now land in the reserved root type rather than being lost - the same
+   * sentinel Cypher's own unlabelled nodes use ({@link Labels#NO_LABEL_TYPE}), not a literal {@code Node}: that
+   * name is exactly the kind of ordinary label a real graph might also want to write, and leaked as a phantom
+   * label onto every imported node - {@code labels(n)} answered {@code ["Node", "Person"]} rather than
+   * {@code ["Person"]} - independently of, and before, issue #6395.
    */
   @Test
   void importNodesWithoutLabels() throws Exception {
@@ -84,8 +90,12 @@ class Neo4jImporterLabelCharactersIT {
     try (final Database db = new DatabaseFactory(DATABASE_PATH).open()) {
       assertThat(db.getSchema().existsType("Person")).isTrue();
       assertThat(db.countType("Person", false)).isEqualTo(1L);
-      // The three unlabelled nodes are kept on the root type instead of being dropped.
-      assertThat(db.countType("Node", false)).isEqualTo(3L);
+      // The three unlabelled nodes are kept on the reserved root type instead of being dropped, and are
+      // invisible to labels() - unlike a literal "Node" type, this name can never collide with a real label.
+      assertThat(db.countType(Labels.NO_LABEL_TYPE, false)).isEqualTo(3L);
+      final List<Object> labels = db.query("opencypher", "MATCH (n {name: 'NoLabel'}) RETURN labels(n) AS l")
+          .next().getProperty("l");
+      assertThat(labels).isEmpty();
     }
   }
 


### PR DESCRIPTION
## Summary

Eight small, independent bugs that came out of earlier analysis, fixed together:

- **#6403** - `coll.*` never got the argument-coercion/error-classification pass the Cypher list builtins got. `AbstractCollFunction.asList` now delegates to `CypherFunctionHelper.requireListArgument`, so the family accepts arrays/`Iterable`s like `tail()`/`reverse()` do, and raises `CommandSemanticException` (HTTP 400) instead of `CommandExecutionException` (HTTP 500) for a caller mistake. `coll.toSet` is now a one-line subclass of `coll.distinct` rather than a second copy of its body. `coll.min`/`max`/`sum`/`avg` answer a range from its two endpoints instead of walking it.
- **#6402** - `file()`/`linenumber()` after `LOAD CSV` answered correctly in a `RETURN` and `null` in a `WHERE`, because the row context was lifted onto the `CommandContext` by `ExpressionEvaluator` only, not by the AST path a predicate takes. Both now go through one shared invocation point (`FunctionCallExpression.invoke`), and the context now survives a `WITH row` that doesn't re-name it.
- **#6400** - added a differential harness (`CypherPlannerDifferentialIssue6400Test`) that runs a combinatorial MATCH corpus through both the cost-based and the traditional planner and asserts they agree, with three vacuity guards (routing actually differs, rows actually match something, the comparison itself discriminates) so the harness can't silently stop testing anything.
- **#6395** - "no labels" was represented by the ordinary label names `V`/`Vertex`, which a query could also write, so `Labels.getLabels` filtered them and a genuine `:V` label vanished. Reserved a sentinel (`~NO_LABEL~`, unwritable as a label because it contains `LABEL_SEPARATOR`) and filter it at every depth of the supertype walk rather than only at a vertex's own type. Found while investigating: the Neo4j importer's shared root type was literally named `"Node"`, which leaked as a phantom label onto every imported node independently of this issue - fixed by reusing the same reserved sentinel as that root, keeping the "one query reaches every imported vertex" property while making it invisible to `labels()`.
- **#6375** - five algorithms (`triangleCount`, `knn`, `kTruss`, `clique`, `hierarchicalClustering`) built `nodeCount x nodeCount` `BitSet` matrices without reserving against `arcadedb.cypher.algoMaxWorkingMemory`, even though the setting's own docs name exactly that shape. Now reserved before allocation, with the build loops made abortable.
- **#6370** - a bare `[*]` inside a pattern comprehension parsed as one fixed hop, because `CypherExpressionBuilder`'s copy of the path-length normalization never got the `[*] == [*1..]` fix `CypherASTBuilder`'s copy did. Lifted into one shared `ParserUtils.parsePathLength` helper both builders call.
- **#6362** - inserting an identity `CALL (*) { RETURN 0 AS barrier }` after `MERGE ... ON MATCH SET` changed the query's answer, because `SubqueryStep`'s post-#4182 binding refresh re-reads every `Document` binding from the transaction cache even for a read-only subquery, letting a later row's write show through an earlier row's binding. Now skipped when the inner statement is read-only.
- **#6317** - the graph an `algo.*` call loads (vertex list, RID index, adjacency) was the one allocation no budget priced. `loadGraph`/`loadVertices` now bound the vertex walk via `MemoryBudget.capacityFor`, and `adjacency()` prices the CSR/OLTP neighbour-list copy before it's built.

## Test plan

- [x] New regression test per issue (`CypherCollFunctionParityIssue6403Test`, `CypherLoadCSVRowContextIssue6402Test`, `CypherPlannerDifferentialIssue6400Test`, `CypherReservedNoLabelSentinelIssue6395Test`, `Issue6375AlgoBitsetMatrixBudgetTest`, `CypherBareStarComprehensionIssue6370Test`, `CypherSubqueryRowBindingIssue6362Test`, `Issue6317AlgoGraphLoadBudgetTest`)
- [x] Updated pre-existing tests whose expectations changed with the fix (exception type for `coll.remove`/`coll.toSet`/`coll.pairsMin`, the `V`/`Vertex` sentinel rename in `LabelsTest`/`OpenCypherCreateTest`, the algo working-memory-budget figures now that the graph itself is priced)
- [x] Full `engine` module suite green: 12,799 tests, 0 failures, 0 errors (excluding benchmark/vector/slow lanes)
- [x] `integration` module Neo4j importer tests green (15 tests, including the renamed root-type assertion)
- [x] Manually verified against the reproduction table in each issue