### PR TITLE
fix(#6414): a documented option is applied, and a full-text index answers the same question whatever its arity

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3579,10 +3579,13 @@ of them are a conjunction. Every whitespace-separated word is bound to the prope
 the first. A single-property index builds the same one-element key it always did, and a one-element key keeps its
 historical "text to find in any indexed property" meaning, so nothing that passed a single query string changes.
 
-**Behaviour change.** `CONTAINSTEXT` on a property covered by a multi-property full-text index now matches analyzer
-tokens (case-insensitive, whole-token) rather than substrings, which is what the same operator has always done on a
-single-property index. A query relying on the substring fallback - `title CONTAINSTEXT 'ava'` matching `java` -
-stops matching there. Use a `SEARCH_INDEX(...)` wildcard, or `LIKE '%ava%'`, for substring search.
+> [!IMPORTANT]
+> **Behaviour change.** `CONTAINSTEXT` on a property covered by a multi-property full-text index now matches analyzer
+> tokens (case-insensitive, whole-token) rather than substrings, which is what the same operator has always done on a
+> single-property index. A query relying on the substring fallback - `title CONTAINSTEXT 'ava'` matching `java` -
+> stops matching there. Use a `SEARCH_INDEX(...)` wildcard, or `LIKE '%ava%'`, for substring search. The operator's
+> meaning is now decided by whether a full-text index covers the property, which `EXPLAIN` answers, and no longer by
+> how many properties that index happens to span.
 
 Two smaller items ride along. The "is this qualifier really a field?" rule now lives in one place consulted by both
 full-text query paths, rather than in two copies that drifted apart once already - #6382 existed because the
@@ -3590,6 +3593,7 @@ Lucene-backed executor had the rule and the direct `get()` path did not. And the
 #1814 wrote its dynamic default as `default "sysdate('YYYY-MM-DD')"`, a double-quoted SQL *string literal*: the
 call never happened, the literal text was stored verbatim, and the test asserted only that a constant string is not
 null - so it could not have failed if dynamic-default evaluation regressed. It now uses an expression and asserts
-the value is today's date, before and after `APPLY DEFAULTS`.
+the stored value parses as a date, before and after `APPLY DEFAULTS`, with a sentinel in between that the expression
+cannot produce. Deliberately not an equality against today's date: the two transactions can straddle midnight.
 
 [#6414](https://github.com/ArcadeData/arcadedb/issues/6414)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3540,3 +3540,56 @@ same number. It now scales like its two-axis twin and like the other four.
 [#6389](https://github.com/ArcadeData/arcadedb/issues/6389)
 [#6390](https://github.com/ArcadeData/arcadedb/issues/6390)
 [#6393](https://github.com/ArcadeData/arcadedb/issues/6393)
+
+## A documented A* option is applied, and CONTAINSTEXT answers the same question whatever the index's shape (#6414)
+
+Four follow-ups from #6408, independent of each other.
+
+`astar`'s `customHeuristicFormula` was documented in the function's own syntax string, listed among its accepted
+options, and read from the caller's map into a field that **nothing ever consulted**. There was no `CUSTOM` constant
+to dispatch to either, so a query supplying one silently got `MANHATTAN` - the default - with no error and no
+warning. The option now names a SQL function that computes `h(n)`, called as
+`fn(currentVertex, parentVertex, targetVertex, sourceVertex, depth, dFactor)` and returning a number. It is
+consulted before any vertex-axis test, so a custom formula works with no `vertexAxisNames` declared at all and owns
+`h(n)` outright: no axis is read and no tie-breaker is layered on its answer. Every way of getting it wrong is now an
+error the caller sees - an unknown function name, `heuristicFormula:'CUSTOM'` with no function named, a built-in
+formula named alongside a custom one (a contradiction, not a precedence question), or a function that returns
+something that is not a number. `dijkstra`, which has no heuristic, keeps rejecting the option outright.
+
+`CONTAINSTEXT` on a **multi-property** full-text index was two defects, and both are now fixed.
+
+A condition on one of the index's properties was not pushed down at all: the planner required the *first* index
+property to be constrained and then every following one, so `WHERE title CONTAINSTEXT 'java'` on an index over
+`(title, content)` fell back to a full scan. That is not only slower - the scan evaluates `CONTAINSTEXT` as
+`String.contains`, where the index matches analyzer *tokens*, so the same operator over the same data answered
+differently depending only on how the index had been declared. `label CONTAINSTEXT 'ava'` found a row whose label is
+`java` on a multi-property index and found nothing on a single-property one, and nothing in the query text told the
+user which they were getting.
+
+A condition on **both** properties was worse: it *was* pushed down, but the lookup read only the first key and the
+planner had already removed both conditions from the residual filter, so the second was dropped entirely.
+`WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'zzz'` returned every row of the type - the second
+condition matches nothing - rather than none.
+
+A full-text index key is one query string per indexed property, not a composite key whose used prefix has to be
+contiguous, and a multi-property index already stores every token twice, once qualified as `field:token` and once
+unprefixed. The key is now POSITIONAL: `keys[i]` is the text to find in the i-th indexed property and a `null` slot
+leaves that property unconstrained, so any subset of the properties in any position is an exact lookup, and several
+of them are a conjunction. Every whitespace-separated word is bound to the property its condition names, not just
+the first. A single-property index builds the same one-element key it always did, and a one-element key keeps its
+historical "text to find in any indexed property" meaning, so nothing that passed a single query string changes.
+
+**Behaviour change.** `CONTAINSTEXT` on a property covered by a multi-property full-text index now matches analyzer
+tokens (case-insensitive, whole-token) rather than substrings, which is what the same operator has always done on a
+single-property index. A query relying on the substring fallback - `title CONTAINSTEXT 'ava'` matching `java` -
+stops matching there. Use a `SEARCH_INDEX(...)` wildcard, or `LIKE '%ava%'`, for substring search.
+
+Two smaller items ride along. The "is this qualifier really a field?" rule now lives in one place consulted by both
+full-text query paths, rather than in two copies that drifted apart once already - #6382 existed because the
+Lucene-backed executor had the rule and the direct `get()` path did not. And the designated regression test for
+#1814 wrote its dynamic default as `default "sysdate('YYYY-MM-DD')"`, a double-quoted SQL *string literal*: the
+call never happened, the literal text was stored verbatim, and the test asserted only that a constant string is not
+null - so it could not have failed if dynamic-default evaluation regressed. It now uses an expression and asserts
+the value is today's date, before and after `APPLY DEFAULTS`.
+
+[#6414](https://github.com/ArcadeData/arcadedb/issues/6414)

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GhostEdgeReporter;
@@ -336,11 +337,26 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
         context.paramHeuristicFormula = SQLHeuristicFormula.valueOf(raw.toString().toUpperCase(Locale.ENGLISH));
     }
 
-    context.paramCustomHeuristicFormula = opts.getString(PARAM_CUSTOM_HEURISTIC_FORMULA, context.paramCustomHeuristicFormula);
+    // The option the syntax advertises is now applied instead of being read into a field nothing consulted (issue
+    // #6414). Supplying it selects CUSTOM, so a caller does not have to write the formula name twice; naming a
+    // different formula alongside it is a contradiction rather than a precedence question, and says so.
+    if (opts.containsKey(PARAM_CUSTOM_HEURISTIC_FORMULA)) {
+      if (opts.containsKey(PARAM_HEURISTIC_FORMULA) && context.paramHeuristicFormula != SQLHeuristicFormula.CUSTOM)
+        throw new CommandSQLParsingException(
+            "Options '" + PARAM_HEURISTIC_FORMULA + "' (" + context.paramHeuristicFormula + ") and '"
+                + PARAM_CUSTOM_HEURISTIC_FORMULA + "' conflict for function '" + NAME
+                + "': a custom formula replaces the built-in one, so name only one of them");
+
+      context.bindCustomHeuristicFunction(opts.getString(PARAM_CUSTOM_HEURISTIC_FORMULA, null), this.context);
+    } else if (context.paramHeuristicFormula == SQLHeuristicFormula.CUSTOM)
+      throw new CommandSQLParsingException(
+          "Option '" + PARAM_HEURISTIC_FORMULA + "' of function '" + NAME + "' is CUSTOM but no '"
+              + PARAM_CUSTOM_HEURISTIC_FORMULA + "' was given to name the function to call");
   }
 
   public String getSyntax() {
-    return "astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) \n // options  : {direction:\"OUT\",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , tieBreaker:true,maxDepth:99999,dFactor:1.0,customHeuristicFormula:'custom_Function_Name_here'  }";
+    return "astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) \n // options  : {direction:\"OUT\",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , tieBreaker:true,maxDepth:99999,dFactor:1.0,heuristicFormula:'MANHATTAN',customHeuristicFormula:'custom_Function_Name_here'  }"
+        + "\n // customHeuristicFormula names a SQL function called as fn(currentVertex, parentVertex, targetVertex, sourceVertex, depth, dFactor) and returning h(n) as a number";
   }
 
   @Override
@@ -396,6 +412,11 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
   @Override
   protected double getHeuristicCost(final Vertex node, Vertex parent, final Vertex target, final CommandContext ctx) {
     double hresult = 0.0;
+
+    // Ahead of every axis test on purpose: a custom formula owns h(n) outright, so it applies whether or not the
+    // caller also declared vertex axes, and no tie-breaker is layered on top of its answer.
+    if (paramHeuristicFormula == SQLHeuristicFormula.CUSTOM)
+      return getCustomHeuristicCost(node, parent, target, currentDepth, ctx);
 
     if (paramVertexAxisNames.length == 0) {
       return hresult;

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -91,7 +91,7 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
   public LinkedList<RID> execute(final Object self, final Identifiable currentRecord, final Object currentResult,
       final Object[] params, final CommandContext ctx) {
     context = ctx;
-    final SQLFunctionAstar context = this;
+    final SQLFunctionAstar astar = this;
 
     final Document record = currentRecord != null ? (Document) currentRecord.getRecord() : null;
 
@@ -144,7 +144,7 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     paramWeightFieldName = FileUtils.getStringContent(params[2]);
 
     if (params.length > 3) {
-      bindAdditionalParams(params[3], context);
+      bindAdditionalParams(params[3], astar);
     }
     ctx.setVariable("getNeighbors", 0);
     if (paramSourceVertex == null || paramDestinationVertex == null) {
@@ -296,7 +296,7 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     return result;
   }
 
-  private void bindAdditionalParams(final Object additionalParams, final SQLFunctionAstar context) {
+  private void bindAdditionalParams(final Object additionalParams, final SQLFunctionAstar astar) {
     if (additionalParams == null)
       return;
 
@@ -311,44 +311,44 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
 
     if (opts.containsKey(PARAM_EDGE_TYPE_NAMES))
-      context.paramEdgeTypeNames = stringArray(opts.get(PARAM_EDGE_TYPE_NAMES));
+      astar.paramEdgeTypeNames = stringArray(opts.get(PARAM_EDGE_TYPE_NAMES));
     if (opts.containsKey(PARAM_VERTEX_AXIS_NAMES))
-      context.paramVertexAxisNames = stringArray(opts.get(PARAM_VERTEX_AXIS_NAMES));
+      astar.paramVertexAxisNames = stringArray(opts.get(PARAM_VERTEX_AXIS_NAMES));
 
     if (opts.containsKey(PARAM_DIRECTION)) {
       final Object raw = opts.get(PARAM_DIRECTION);
       if (raw instanceof Vertex.DIRECTION direction)
-        context.paramDirection = direction;
+        astar.paramDirection = direction;
       else
-        context.paramDirection = Vertex.DIRECTION.valueOf(raw.toString().toUpperCase(Locale.ENGLISH));
+        astar.paramDirection = Vertex.DIRECTION.valueOf(raw.toString().toUpperCase(Locale.ENGLISH));
     }
 
-    context.paramParallel = opts.getBoolean(PARAM_PARALLEL, context.paramParallel);
-    context.paramMaxDepth = opts.getLong(PARAM_MAX_DEPTH, context.paramMaxDepth);
-    context.paramEmptyIfMaxDepth = opts.getBoolean(PARAM_EMPTY_IF_MAX_DEPTH, context.paramEmptyIfMaxDepth);
-    context.paramTieBreaker = opts.getBoolean(PARAM_TIE_BREAKER, context.paramTieBreaker);
-    context.paramDFactor = opts.getDouble(PARAM_D_FACTOR, context.paramDFactor);
+    astar.paramParallel = opts.getBoolean(PARAM_PARALLEL, astar.paramParallel);
+    astar.paramMaxDepth = opts.getLong(PARAM_MAX_DEPTH, astar.paramMaxDepth);
+    astar.paramEmptyIfMaxDepth = opts.getBoolean(PARAM_EMPTY_IF_MAX_DEPTH, astar.paramEmptyIfMaxDepth);
+    astar.paramTieBreaker = opts.getBoolean(PARAM_TIE_BREAKER, astar.paramTieBreaker);
+    astar.paramDFactor = opts.getDouble(PARAM_D_FACTOR, astar.paramDFactor);
 
     if (opts.containsKey(PARAM_HEURISTIC_FORMULA)) {
       final Object raw = opts.get(PARAM_HEURISTIC_FORMULA);
       if (raw instanceof SQLHeuristicFormula formula)
-        context.paramHeuristicFormula = formula;
+        astar.paramHeuristicFormula = formula;
       else
-        context.paramHeuristicFormula = SQLHeuristicFormula.valueOf(raw.toString().toUpperCase(Locale.ENGLISH));
+        astar.paramHeuristicFormula = SQLHeuristicFormula.valueOf(raw.toString().toUpperCase(Locale.ENGLISH));
     }
 
     // The option the syntax advertises is now applied instead of being read into a field nothing consulted (issue
     // #6414). Supplying it selects CUSTOM, so a caller does not have to write the formula name twice; naming a
     // different formula alongside it is a contradiction rather than a precedence question, and says so.
     if (opts.containsKey(PARAM_CUSTOM_HEURISTIC_FORMULA)) {
-      if (opts.containsKey(PARAM_HEURISTIC_FORMULA) && context.paramHeuristicFormula != SQLHeuristicFormula.CUSTOM)
+      if (opts.containsKey(PARAM_HEURISTIC_FORMULA) && astar.paramHeuristicFormula != SQLHeuristicFormula.CUSTOM)
         throw new CommandSQLParsingException(
-            "Options '" + PARAM_HEURISTIC_FORMULA + "' (" + context.paramHeuristicFormula + ") and '"
+            "Options '" + PARAM_HEURISTIC_FORMULA + "' (" + astar.paramHeuristicFormula + ") and '"
                 + PARAM_CUSTOM_HEURISTIC_FORMULA + "' conflict for function '" + NAME
                 + "': a custom formula replaces the built-in one, so name only one of them");
 
-      context.bindCustomHeuristicFunction(opts.getString(PARAM_CUSTOM_HEURISTIC_FORMULA, null), this.context);
-    } else if (context.paramHeuristicFormula == SQLHeuristicFormula.CUSTOM)
+      astar.bindCustomHeuristicFunction(opts.getString(PARAM_CUSTOM_HEURISTIC_FORMULA, null), context);
+    } else if (astar.paramHeuristicFormula == SQLHeuristicFormula.CUSTOM)
       throw new CommandSQLParsingException(
           "Option '" + PARAM_HEURISTIC_FORMULA + "' of function '" + NAME + "' is CUSTOM but no '"
               + PARAM_CUSTOM_HEURISTIC_FORMULA + "' was given to name the function to call");

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionHeuristicPathFinderAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionHeuristicPathFinderAbstract.java
@@ -19,8 +19,12 @@
 package com.arcadedb.function.sql.graph;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.SQLQueryEngine;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.SQLFunction;
 import com.arcadedb.function.sql.math.SQLFunctionMathAbstract;
 
 import java.util.HashSet;
@@ -60,6 +64,12 @@ public abstract class SQLFunctionHeuristicPathFinderAbstract extends SQLFunction
   protected double              paramDFactor                = 1.0;
   protected String              paramCustomHeuristicFormula = "";
 
+  /**
+   * The function named by {@link #PARAM_CUSTOM_HEURISTIC_FORMULA}, resolved once when the options are bound rather than
+   * once per visited node. Non-null exactly when {@link #paramHeuristicFormula} is {@link SQLHeuristicFormula#CUSTOM}.
+   */
+  protected SQLFunction         customHeuristicFunction;
+
   protected              CommandContext context;
   protected final        List<Vertex>   route = new LinkedList<>();
   protected static final float          MIN   = 0f;
@@ -89,6 +99,49 @@ public abstract class SQLFunctionHeuristicPathFinderAbstract extends SQLFunction
 
   protected abstract double getHeuristicCost(final Vertex node, final Vertex parent, final Vertex target,
                                              CommandContext context);
+
+  /**
+   * Resolves the SQL function named by the {@code customHeuristicFormula} option and remembers it, so an unknown name is a
+   * failure of the query that supplied it rather than a silently ignored option (issue #6414).
+   *
+   * @param functionName the SQL function name, optionally library-qualified ({@code library.function})
+   * @param ctx          the command context, used to reach the SQL query engine of the current database
+   */
+  protected void bindCustomHeuristicFunction(final String functionName, final CommandContext ctx) {
+    final String trimmed = functionName == null ? "" : functionName.trim();
+    if (trimmed.isEmpty())
+      throw new CommandSQLParsingException(
+          "Option '" + PARAM_CUSTOM_HEURISTIC_FORMULA + "' for function '" + getName() + "' must name a function");
+
+    try {
+      customHeuristicFunction = ((SQLQueryEngine) ctx.getDatabase().getQueryEngine("sql")).getFunction(trimmed);
+    } catch (final CommandExecutionException e) {
+      throw new CommandSQLParsingException(
+          "Option '" + PARAM_CUSTOM_HEURISTIC_FORMULA + "' for function '" + getName() + "' names an unknown function '" + trimmed
+              + "'", e);
+    }
+    paramCustomHeuristicFormula = trimmed;
+    paramHeuristicFormula = SQLHeuristicFormula.CUSTOM;
+  }
+
+  /**
+   * Computes h(n) by invoking the user function bound by {@link #bindCustomHeuristicFunction}. The function receives
+   * {@code (currentVertex, parentVertex, targetVertex, sourceVertex, depth, dFactor)} and must answer a number: unlike the
+   * built-in formulas it owns h(n) entirely, so no axis is read and no tie-breaker is added on top of its answer.
+   */
+  protected double getCustomHeuristicCost(final Vertex node, final Vertex parent, final Vertex target, final long depth,
+                                          final CommandContext ctx) {
+    final Object result = customHeuristicFunction.execute(null, node, null,
+        new Object[] { node, parent, target, paramSourceVertex, depth, paramDFactor }, ctx);
+
+    if (result instanceof Number number)
+      return number.doubleValue();
+
+    throw new CommandExecutionException(
+        "Custom heuristic function '" + paramCustomHeuristicFormula + "' must return a number, returned: " + (result == null ?
+            "null" :
+            result + " (" + result.getClass().getSimpleName() + ")"));
+  }
 
   protected LinkedList<RID> getPath() {
     final LinkedList<RID> result = new LinkedList<>();

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLHeuristicFormula.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLHeuristicFormula.java
@@ -20,9 +20,12 @@ package com.arcadedb.function.sql.graph;
 
 /**
  * Heuristic formula enum.
+ * <p>
+ * {@link #CUSTOM} is not computed here: it delegates h(n) to the SQL function named by the {@code customHeuristicFormula}
+ * option, which is why that option exists at all. It is selected implicitly by supplying that option (issue #6414).
  *
  * @author Saeed Tabrizi (saeed a_t  nowcando.com)
  */
 public enum SQLHeuristicFormula {
-  MANHATTAN, MAXAXIS, DIAGONAL, EUCLIDEAN, EUCLIDEANNOSQR
+  MANHATTAN, MAXAXIS, DIAGONAL, EUCLIDEAN, EUCLIDEANNOSQR, CUSTOM
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAverage.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionAverage.java
@@ -20,7 +20,6 @@ package com.arcadedb.function.sql.math;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.function.sql.SQLAggregatedFunction;
 import com.arcadedb.schema.Type;
 

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionPercentile.java
@@ -20,7 +20,6 @@ package com.arcadedb.function.sql.math;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.function.sql.SQLAggregatedFunction;
 
 import java.util.ArrayList;

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionVariance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionVariance.java
@@ -20,7 +20,6 @@ package com.arcadedb.function.sql.math;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.function.sql.SQLAggregatedFunction;
 
 /**

--- a/engine/src/main/java/com/arcadedb/index/Index.java
+++ b/engine/src/main/java/com/arcadedb/index/Index.java
@@ -82,7 +82,31 @@ public interface Index {
 
   String getTypeName();
 
+  /**
+   * The property names this index is defined on, in index order. A name can carry the modifier that says HOW the property is
+   * indexed - {@code "tags by item"}, {@code "map by key"}, {@code "map by value"} - which is part of the stored name, not of
+   * the document property: use {@link #basePropertyName} to get back the property a query names.
+   */
   List<String> getPropertyNames();
+
+  /**
+   * Strips the {@code by key} / {@code by value} / {@code by item} modifier an index property name can carry, leaving the
+   * document property it indexes. {@code "obj.hd by item"} answers {@code "obj.hd"}; a name with no modifier answers itself.
+   * <p>
+   * The distinction matters wherever an index property name meets a name the user wrote: a query says {@code obj.hd}, the
+   * index calls the same thing {@code obj.hd by item}, and comparing the two spellings directly silently matches nothing.
+   */
+  static String basePropertyName(final String indexProperty) {
+    if (indexProperty == null)
+      return null;
+    if (indexProperty.endsWith(" by key"))
+      return indexProperty.substring(0, indexProperty.length() - 7);
+    if (indexProperty.endsWith(" by value"))
+      return indexProperty.substring(0, indexProperty.length() - 9);
+    if (indexProperty.endsWith(" by item"))
+      return indexProperty.substring(0, indexProperty.length() - 8);
+    return indexProperty;
+  }
 
   String getName();
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -21,6 +21,7 @@ package com.arcadedb.index.fulltext;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.RID;
 import com.arcadedb.function.text.TextLevenshteinDistance;
+import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.IndexException;
@@ -486,7 +487,8 @@ public class FullTextQueryExecutor {
    * A term is unqualified when the parser left it on the {@link #DEFAULT_FIELD} sentinel, or when it is qualified with the
    * sole property of a single-property index: such an index stores only unprefixed postings (see
    * {@link LSMTreeFullTextIndex#put}), so {@code field:term} and {@code term} are equivalent there. This is what lets a
-   * non-colliding sentinel be used without breaking single-property {@code content:term} queries.
+   * non-colliding sentinel be used without breaking single-property {@code content:term} queries. The property is compared
+   * by its BASE name, since {@code obj.hd} is what a query can write for a property the index calls {@code obj.hd by item}.
    * <p>
    * Issue #6382 existed because the two paths had encoded this rule separately and drifted: the executor had it and the
    * direct path did not, so a single-property index answered nothing for any literal containing a colon. Both now call
@@ -498,7 +500,8 @@ public class FullTextQueryExecutor {
   static boolean isUnqualified(final List<String> propertyNames, final String field) {
     if (field == null || field.isEmpty() || DEFAULT_FIELD.equals(field))
       return true;
-    return propertyNames != null && propertyNames.size() == 1 && propertyNames.getFirst().equals(field);
+    return propertyNames != null && propertyNames.size() == 1 && Index.basePropertyName(propertyNames.getFirst())
+        .equals(field);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -472,15 +472,33 @@ public class FullTextQueryExecutor {
   }
 
   /**
-   * Returns true when a parsed query field denotes the "unqualified" target rather than a real, field-qualified clause. A term is
-   * unqualified when the parser left it on the {@link #DEFAULT_FIELD} sentinel, or when it is qualified with the sole property of a
-   * single-property index: such an index stores only unprefixed postings, so {@code field:term} and {@code term} are equivalent
-   * there. This is what lets a non-colliding sentinel be used without breaking single-property {@code content:term} queries.
+   * Returns true when a parsed query field denotes the "unqualified" target rather than a real, field-qualified clause. See
+   * {@link #isUnqualified(List, String)}, which owns the rule for both query paths.
    */
   private boolean isUnqualified(final String field) {
+    return isUnqualified(propertyNames, field);
+  }
+
+  /**
+   * The one place the "is this qualifier really a field?" rule lives, consulted by both full-text query paths: this
+   * Lucene-backed executor and the direct {@code get()} lookup in {@link LSMTreeFullTextIndex#parseQueryTerms}.
+   * <p>
+   * A term is unqualified when the parser left it on the {@link #DEFAULT_FIELD} sentinel, or when it is qualified with the
+   * sole property of a single-property index: such an index stores only unprefixed postings (see
+   * {@link LSMTreeFullTextIndex#put}), so {@code field:term} and {@code term} are equivalent there. This is what lets a
+   * non-colliding sentinel be used without breaking single-property {@code content:term} queries.
+   * <p>
+   * Issue #6382 existed because the two paths had encoded this rule separately and drifted: the executor had it and the
+   * direct path did not, so a single-property index answered nothing for any literal containing a colon. Both now call
+   * here, so there is nothing left to drift (issue #6414, item 4).
+   *
+   * @param propertyNames the indexed property names, in index order
+   * @param field         the field a parsed query term is qualified with, or null/empty for none
+   */
+  static boolean isUnqualified(final List<String> propertyNames, final String field) {
     if (field == null || field.isEmpty() || DEFAULT_FIELD.equals(field))
       return true;
-    return propertyNames.size() == 1 && propertyNames.get(0).equals(field);
+    return propertyNames != null && propertyNames.size() == 1 && propertyNames.getFirst().equals(field);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -25,7 +25,6 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
-import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.index.TypeIndex;
@@ -196,27 +195,10 @@ public class FullTextSearch {
     final int effectiveLimit = limit < 1 ? -1 : limit;
 
     final List<Object[]> perProperty = LSMTreeFullTextIndex.splitPositionalKey(typeIndex.getPropertyNames(), keys);
-    if (perProperty != null) {
-      Map<RID, Float> intersection = null;
-      for (final Object[] key : perProperty) {
-        final Map<RID, Float> matches = new HashMap<>();
-        try (final IndexCursor cursor = searchSimple(typeIndex, key, -1)) {
-          mergeCursor(matches, cursor);
-        }
-
-        if (intersection == null)
-          intersection = matches;
-        else {
-          intersection.keySet().retainAll(matches.keySet());
-          for (final Map.Entry<RID, Float> e : intersection.entrySet())
-            e.setValue(e.getValue() + matches.get(e.getKey()));
-        }
-
-        if (intersection.isEmpty())
-          break;
-      }
-      return rankedCursor(intersection == null ? Map.of() : intersection, keys, effectiveLimit);
-    }
+    if (perProperty != null)
+      return LSMTreeFullTextIndex.rankedCursor(
+          LSMTreeFullTextIndex.intersectPerProperty(perProperty, key -> searchSimple(typeIndex, key, -1)), keys,
+          effectiveLimit);
 
     final Map<String, Float> scoringTokens = bucketIndexes.getFirst().getSimpleQueryTokenBoosts(keys);
     final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes,
@@ -226,7 +208,7 @@ public class FullTextSearch {
       mergeCursor(allResults,
           ftIndex.scoreBM25WithContext(null, scoringTokens, keys, effectiveLimit, scoringContext));
 
-    return rankedCursor(allResults, keys, effectiveLimit);
+    return LSMTreeFullTextIndex.rankedCursor(allResults, keys, effectiveLimit);
   }
 
   /**
@@ -351,20 +333,6 @@ public class FullTextSearch {
     }
   }
 
-  private static IndexCursor rankedCursor(final Map<RID, Float> scores, final Object[] keys, final int limit) {
-    final List<IndexCursorEntry> entries = new ArrayList<>(scores.size());
-    for (final Map.Entry<RID, Float> score : scores.entrySet())
-      entries.add(new IndexCursorEntry(keys, score.getKey(), score.getValue()));
-
-    entries.sort((left, right) -> {
-      final int scoreComparison = Float.compare(right.floatScore, left.floatScore);
-      return scoreComparison != 0 ? scoreComparison :
-          left.record.getIdentity().compareTo(right.record.getIdentity());
-    });
-    if (limit > -1 && entries.size() > limit)
-      return new TempIndexCursor(entries.subList(0, limit));
-    return new TempIndexCursor(entries);
-  }
 
   private static RID canonicalRID(final RID rid) {
     return rid instanceof final FullTextPostingRID posting ?

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -181,6 +181,10 @@ public class FullTextSearch {
   /**
    * Executes the literal-token lookup used by {@link TypeIndex#get(Object[])} while keeping BM25 scores comparable across bucket
    * indexes. Lucene boolean/wildcard syntax is intentionally not interpreted on this path.
+   * <p>
+   * A POSITIONAL key over a multi-property index (see {@link LSMTreeFullTextIndex#splitPositionalKey}) is a conjunction over
+   * the properties it constrains, so it is answered as one type-wide lookup per property, intersected. The corpus statistics
+   * stay type-wide within each of those lookups, which is what keeps the scores comparable (issue #6414).
    */
   public static IndexCursor searchSimple(final TypeIndex typeIndex, final Object[] keys, final int limit) {
     final List<LSMTreeFullTextIndex> bucketIndexes = getBucketIndexes(typeIndex);
@@ -190,6 +194,30 @@ public class FullTextSearch {
       throw new IllegalArgumentException("searchSimple requires a BM25 full-text index");
 
     final int effectiveLimit = limit < 1 ? -1 : limit;
+
+    final List<Object[]> perProperty = LSMTreeFullTextIndex.splitPositionalKey(typeIndex.getPropertyNames(), keys);
+    if (perProperty != null) {
+      Map<RID, Float> intersection = null;
+      for (final Object[] key : perProperty) {
+        final Map<RID, Float> matches = new HashMap<>();
+        try (final IndexCursor cursor = searchSimple(typeIndex, key, -1)) {
+          mergeCursor(matches, cursor);
+        }
+
+        if (intersection == null)
+          intersection = matches;
+        else {
+          intersection.keySet().retainAll(matches.keySet());
+          for (final Map.Entry<RID, Float> e : intersection.entrySet())
+            e.setValue(e.getValue() + matches.get(e.getKey()));
+        }
+
+        if (intersection.isEmpty())
+          break;
+      }
+      return rankedCursor(intersection == null ? Map.of() : intersection, keys, effectiveLimit);
+    }
+
     final Map<String, Float> scoringTokens = bucketIndexes.getFirst().getSimpleQueryTokenBoosts(keys);
     final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes,
         scanDocumentFrequencies(bucketIndexes, scoringTokens));

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -66,6 +66,7 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 /**
@@ -236,6 +237,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * <p>
    * Each whitespace-separated part of the text is qualified individually, because that is the granularity
    * {@link #parseQueryTerms} works at: qualifying only the head would leave every following word matching any property.
+   * The qualifier is the property's BASE name ({@code obj.hd}, not the index's {@code obj.hd by item}): the modified
+   * spelling carries spaces, which the whitespace split would tear apart before anything could recognise it.
    *
    * @param propertyNames the indexed property names, in index order
    * @param keys          the lookup key
@@ -250,9 +253,27 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     for (int i = 0; i < keys.length; i++) {
       if (keys[i] == null)
         continue;
-      result.add(new Object[] { qualifyEveryPart(keys[i].toString(), propertyNames.get(i)) });
+      result.add(new Object[] { qualifyEveryPart(keys[i].toString(), Index.basePropertyName(propertyNames.get(i))) });
     }
     return result;
+  }
+
+  /**
+   * Answers the indexed property a query qualifier names, in the spelling the POSTINGS use, or {@code null} when the
+   * qualifier names no indexed property.
+   * <p>
+   * The two spellings differ for a property indexed with a modifier: {@link #put} prefixes tokens with the index's own
+   * property name ({@code obj.hd by item}) while a query can only write the base name ({@code obj.hd}) - the modified one
+   * carries spaces and would not survive the whitespace split. Matching on the base name and answering with the stored one
+   * is what lets a field-qualified lookup reach those postings at all.
+   */
+  private static String storedFieldFor(final List<String> propertyNames, final String qualifier) {
+    if (propertyNames == null || qualifier == null)
+      return null;
+    for (final String property : propertyNames)
+      if (property.equals(qualifier) || Index.basePropertyName(property).equals(qualifier))
+        return property;
+    return null;
   }
 
   /**
@@ -277,15 +298,24 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * Answers the documents that satisfy EVERY per-property query, scores summed. The conjunction is what makes a positional
    * key a faithful translation of the {@code AND} that produced it; within one property the terms keep the existing
    * disjunctive coordination scoring.
+   * <p>
+   * One implementation, called from here for a bucket-local lookup and from {@link FullTextSearch#searchSimple} for the
+   * type-wide BM25 one. Two copies of a full-text rule is exactly what issue #6382 came from, so this one is shared rather
+   * than written twice (issue #6414).
+   *
+   * @param perProperty one single-element key per constrained property, as {@link #splitPositionalKey} returns
+   * @param lookup      answers one property's key; the caller decides whether that is bucket-local or type-wide
    */
-  private IndexCursor getAllOf(final List<Object[]> perProperty, final Object[] keys, final int limit) {
+  static Map<RID, Float> intersectPerProperty(final List<Object[]> perProperty,
+      final Function<Object[], IndexCursor> lookup) {
     Map<RID, Float> intersection = null;
     for (final Object[] key : perProperty) {
       final Map<RID, Float> matches = new HashMap<>();
-      try (final IndexCursor cursor = get(key, -1)) {
+      try (final IndexCursor cursor = lookup.apply(key)) {
         while (cursor.hasNext()) {
-          final RID rid = cursor.next().getIdentity();
-          matches.merge(rid, cursor.getFloatScore(), Float::sum);
+          // merge, not put: a cursor answers one entry per document today, and summing is the answer that stays right if
+          // one ever answers the same document twice.
+          matches.merge(canonicalRID(cursor.next().getIdentity()), cursor.getFloatScore(), Float::sum);
         }
       }
 
@@ -301,14 +331,14 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         break;
     }
 
-    return rankedCursor(intersection, keys, limit);
+    return intersection == null ? Map.of() : intersection;
   }
 
   /**
    * Builds the most-relevant-first cursor over an already scored document set, RID as a stable tiebreaker so equal-scored
    * documents come back in a deterministic order.
    */
-  private static IndexCursor rankedCursor(final Map<RID, Float> scores, final Object[] keys, final int limit) {
+  static IndexCursor rankedCursor(final Map<RID, Float> scores, final Object[] keys, final int limit) {
     if (scores == null || scores.isEmpty())
       return new TempIndexCursor(List.of());
 
@@ -342,7 +372,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   public IndexCursor get(final Object[] keys, final int limit) {
     final List<Object[]> perProperty = splitPositionalKey(getPropertyNames(), keys);
     if (perProperty != null)
-      return getAllOf(perProperty, keys, limit);
+      return rankedCursor(intersectPerProperty(perProperty, key -> get(key, -1)), keys, limit);
 
     if (underlyingIndex.isStoreTermFrequency())
       return getBM25(keys, limit);
@@ -938,12 +968,14 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
       // Check for field:value pattern
       final int colonIdx = part.indexOf(':');
-      if (colonIdx > 0 && colonIdx < part.length() - 1 && propertyNames != null && propertyNames.contains(
-          part.substring(0, colonIdx))) {
-        final String field = part.substring(0, colonIdx);
+      final String storedField = colonIdx > 0 && colonIdx < part.length() - 1 ?
+          storedFieldFor(propertyNames, part.substring(0, colonIdx)) :
+          null;
+      if (storedField != null) {
         // Field-prefixed term: qualified only where qualified keys are stored, i.e. on a multi-property index
-        terms.add(new QueryTerm(FullTextQueryExecutor.isUnqualified(propertyNames, field) ? null : field,
-            part.substring(colonIdx + 1)));
+        terms.add(new QueryTerm(FullTextQueryExecutor.isUnqualified(propertyNames, part.substring(0, colonIdx)) ?
+            null :
+            storedField, part.substring(colonIdx + 1)));
       } else {
         // Literal text: the analyzer decides how it tokenizes
         terms.add(new QueryTerm(null, part));

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -224,9 +224,115 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
+   * Decomposes a POSITIONAL key over a multi-property index into one field-qualified single-text query per constrained
+   * property, or answers {@code null} when the key is not positional and must keep its historical "text to find anywhere"
+   * meaning.
+   * <p>
+   * A multi-property full-text index stores each token twice - once qualified as {@code field:token} and once unprefixed
+   * (see {@link #put}) - so a per-property lookup is exact rather than a filter over a superset. Before issue #6414 nothing
+   * could ask for one: {@code get()} read {@code keys[0]} and ignored the rest, so
+   * {@code WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'zzz'} was answered by the first condition alone with
+   * the second silently dropped, and a condition on a single property could not use the index at all.
+   * <p>
+   * Each whitespace-separated part of the text is qualified individually, because that is the granularity
+   * {@link #parseQueryTerms} works at: qualifying only the head would leave every following word matching any property.
+   *
+   * @param propertyNames the indexed property names, in index order
+   * @param keys          the lookup key
+   *
+   * @return one single-element key per constrained property, or {@code null} if {@code keys} is not a positional key
+   */
+  static List<Object[]> splitPositionalKey(final List<String> propertyNames, final Object[] keys) {
+    if (propertyNames == null || propertyNames.size() < 2 || keys == null || keys.length != propertyNames.size())
+      return null;
+
+    final List<Object[]> result = new ArrayList<>(keys.length);
+    for (int i = 0; i < keys.length; i++) {
+      if (keys[i] == null)
+        continue;
+      result.add(new Object[] { qualifyEveryPart(keys[i].toString(), propertyNames.get(i)) });
+    }
+    return result;
+  }
+
+  /**
+   * Prefixes every whitespace-separated part of {@code text} with {@code field:}, the form {@link #parseQueryTerms}
+   * recognises as a field qualifier. A part that already carries a colon keeps it as literal text: only the FIRST colon
+   * separates the qualifier, so {@code jira:1234} under field {@code title} becomes {@code title:jira:1234} and is
+   * analyzed as the two tokens the document really stored (issue #6382's rule, unchanged).
+   */
+  private static String qualifyEveryPart(final String text, final String field) {
+    final StringBuilder qualified = new StringBuilder(text.length() + 16);
+    for (final String part : text.split("\\s+")) {
+      if (part.isEmpty())
+        continue;
+      if (!qualified.isEmpty())
+        qualified.append(' ');
+      qualified.append(field).append(':').append(part);
+    }
+    return qualified.toString();
+  }
+
+  /**
+   * Answers the documents that satisfy EVERY per-property query, scores summed. The conjunction is what makes a positional
+   * key a faithful translation of the {@code AND} that produced it; within one property the terms keep the existing
+   * disjunctive coordination scoring.
+   */
+  private IndexCursor getAllOf(final List<Object[]> perProperty, final Object[] keys, final int limit) {
+    Map<RID, Float> intersection = null;
+    for (final Object[] key : perProperty) {
+      final Map<RID, Float> matches = new HashMap<>();
+      try (final IndexCursor cursor = get(key, -1)) {
+        while (cursor.hasNext()) {
+          final RID rid = cursor.next().getIdentity();
+          matches.merge(rid, cursor.getFloatScore(), Float::sum);
+        }
+      }
+
+      if (intersection == null)
+        intersection = matches;
+      else {
+        intersection.keySet().retainAll(matches.keySet());
+        for (final Map.Entry<RID, Float> e : intersection.entrySet())
+          e.setValue(e.getValue() + matches.get(e.getKey()));
+      }
+
+      if (intersection.isEmpty())
+        break;
+    }
+
+    return rankedCursor(intersection, keys, limit);
+  }
+
+  /**
+   * Builds the most-relevant-first cursor over an already scored document set, RID as a stable tiebreaker so equal-scored
+   * documents come back in a deterministic order.
+   */
+  private static IndexCursor rankedCursor(final Map<RID, Float> scores, final Object[] keys, final int limit) {
+    if (scores == null || scores.isEmpty())
+      return new TempIndexCursor(List.of());
+
+    final ArrayList<IndexCursorEntry> list = new ArrayList<>(scores.size());
+    for (final Map.Entry<RID, Float> e : scores.entrySet())
+      list.add(new IndexCursorEntry(keys, e.getKey(), e.getValue()));
+
+    if (list.size() > 1)
+      list.sort((o1, o2) -> {
+        final int cmp = Float.compare(o2.floatScore, o1.floatScore);
+        return cmp != 0 ? cmp : o1.record.getIdentity().compareTo(o2.record.getIdentity());
+      });
+
+    return new TempIndexCursor(limit > -1 && list.size() > limit ? list.subList(0, limit) : list);
+  }
+
+  /**
    * Searches the index for the given query text.
    * The query text is parsed into terms, analyzed, and then matched against the index.
    * Results are scored based on the number of matching terms (coordination factor).
+   * <p>
+   * On a multi-property index the key is POSITIONAL: {@code keys[i]} is the text to find in the i-th indexed property, and a
+   * {@code null} slot leaves that property unconstrained. See {@link #splitPositionalKey}. A one-element key keeps the
+   * historical meaning - text to find in any indexed property - so nothing that passed a single query string changes.
    *
    * @param keys  The query arguments. keys[0] is expected to be the query string.
    * @param limit The maximum number of results to return. -1 for no limit.
@@ -234,6 +340,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   @Override
   public IndexCursor get(final Object[] keys, final int limit) {
+    final List<Object[]> perProperty = splitPositionalKey(getPropertyNames(), keys);
+    if (perProperty != null)
+      return getAllOf(perProperty, keys, limit);
+
     if (underlyingIndex.isStoreTermFrequency())
       return getBM25(keys, limit);
 
@@ -806,9 +916,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * never stored, so it matched nothing at all (issue #6382).
    * <p>
    * On a single-property index the qualifier is dropped even when it does name the property: that index stores
-   * unprefixed tokens only (see {@link #put}), so {@code label:java} means the same as {@code java} there. This
-   * mirrors {@code FullTextQueryExecutor.isUnqualified}, which the Lucene-backed executor already applied and this
-   * path did not.
+   * unprefixed tokens only (see {@link #put}), so {@code label:java} means the same as {@code java} there. That
+   * decision is not made here - both query paths ask {@link FullTextQueryExecutor#isUnqualified(List, String)}, so
+   * they cannot drift apart again the way they did in issue #6382 (issue #6414, item 4).
    *
    * @param queryText The raw query string.
    * @return A list of parsed QueryTerms.
@@ -819,7 +929,6 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       return terms;
 
     final List<String> propertyNames = getPropertyNames();
-    final boolean multiProperty = propertyNames != null && propertyNames.size() > 1;
 
     // Split by whitespace to get individual terms
     final String[] parts = queryText.split("\\s+");
@@ -831,8 +940,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       final int colonIdx = part.indexOf(':');
       if (colonIdx > 0 && colonIdx < part.length() - 1 && propertyNames != null && propertyNames.contains(
           part.substring(0, colonIdx))) {
+        final String field = part.substring(0, colonIdx);
         // Field-prefixed term: qualified only where qualified keys are stored, i.e. on a multi-property index
-        terms.add(new QueryTerm(multiProperty ? part.substring(0, colonIdx) : null, part.substring(colonIdx + 1)));
+        terms.add(new QueryTerm(FullTextQueryExecutor.isUnqualified(propertyNames, field) ? null : field,
+            part.substring(colonIdx + 1)));
       } else {
         // Literal text: the analyzer decides how it tokenizes
         terms.add(new QueryTerm(null, part));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -386,7 +386,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       final String fieldName = textCondition.getLeft().getDefaultAlias().getStringValue();
       int position = -1;
       for (int i = 0; i < properties.size(); i++)
-        if (SelectExecutionPlanner.stripIndexPropertyModifier(properties.get(i)).equals(fieldName)) {
+        if (Index.basePropertyName(properties.get(i)).equals(fieldName)) {
           position = i;
           break;
         }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -365,6 +365,12 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * condition alongside, anything but {@code CONTAINSTEXT}, a property this index does not cover, a multi-value key, or two
    * conditions on the same property. A single-property index takes this path too and produces the same one-element key it
    * always did (issue #6414, item 2).
+   * <p>
+   * A condition whose right side evaluates to {@code null} makes the whole block match NOTHING rather than leaving its
+   * property unconstrained. The two readings share one slot - a {@code null} slot is exactly how the key says "this property
+   * is not constrained" - so folding a null-valued condition into it would silently drop the condition instead of failing
+   * it. That is what {@link ContainsTextCondition#evaluate} does off the index (a non-String value is never a match), what
+   * a single-property index already did (an empty query text finds no term), and now what a multi-property one does too.
    */
   private boolean processFullTextBlock() {
     if (index.getType() != Schema.INDEX_TYPE.FULL_TEXT || additionalRangeCondition != null)
@@ -395,7 +401,13 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
         return false;
 
       final Object value = textCondition.getRight().execute((Result) null, context);
-      if (value != null && !(value instanceof Identifiable) && MultiValue.isMultiValue(value))
+      if (value == null) {
+        // Unsatisfiable, not unconstrained: no cursor at all, which fetchNextEntry() reads as an exhausted scan.
+        cursor = null;
+        fetchNextEntry();
+        return true;
+      }
+      if (!(value instanceof Identifiable) && MultiValue.isMultiValue(value))
         return false;
 
       keys[position] = value;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -366,6 +366,10 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * conditions on the same property. A single-property index takes this path too and produces the same one-element key it
    * always did (issue #6414, item 2).
    * <p>
+   * The already-filled-slot case is reachable only when one document property is indexed twice under different modifiers
+   * ({@code (m by key, m by value)}), since the planner claims at most one condition per index property; two conditions on
+   * one property leave the second in the residual filter instead, with the semantics gap that is issue #6427.
+   * <p>
    * A condition whose right side evaluates to {@code null} makes the whole block match NOTHING rather than leaving its
    * property unconstrained. The two readings share one slot - a {@code null} slot is exactly how the key says "this property
    * is not constrained" - so folding a null-valued condition into it would silently drop the condition instead of failing

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -31,6 +31,7 @@ import com.arcadedb.query.sql.parser.BetweenCondition;
 import com.arcadedb.query.sql.parser.BinaryCompareOperator;
 import com.arcadedb.query.sql.parser.BinaryCondition;
 import com.arcadedb.query.sql.parser.BooleanExpression;
+import com.arcadedb.query.sql.parser.ContainsTextCondition;
 import com.arcadedb.query.sql.parser.EqualsCompareOperator;
 import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.query.sql.parser.GeOperator;
@@ -41,6 +42,7 @@ import com.arcadedb.query.sql.parser.LeOperator;
 import com.arcadedb.query.sql.parser.LtOperator;
 import com.arcadedb.query.sql.parser.PCollection;
 import com.arcadedb.query.sql.parser.ValueExpression;
+import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryTypes;
 import com.arcadedb.utility.MultiIterator;
@@ -343,11 +345,65 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * it's not key = [...] but a real condition on field names, already ordered (field names will be ignored)
    */
   private void processAndBlock() {
+    if (processFullTextBlock())
+      return;
+
     final PCollection fromKey = indexKeyFrom((AndBlock) condition, additionalRangeCondition);
     final PCollection toKey = indexKeyTo((AndBlock) condition, additionalRangeCondition);
     final boolean fromKeyIncluded = indexKeyFromIncluded((AndBlock) condition, additionalRangeCondition);
     final boolean toKeyIncluded = indexKeyToIncluded((AndBlock) condition, additionalRangeCondition);
     init(fromKey, fromKeyIncluded, toKey, toKeyIncluded);
+  }
+
+  /**
+   * Builds the POSITIONAL key a full-text index expects and opens the lookup with it: {@code keys[i]} is the text to find in
+   * the i-th indexed property, {@code null} leaving that property unconstrained. Field names matter here, unlike everywhere
+   * else on this step - a full-text index key is one query string per property rather than a composite ordered key, so a
+   * condition on the second property alone is a perfectly good key and must not be shifted into the first slot.
+   * <p>
+   * Answers false, leaving the generic path to run, whenever the block is not exactly that: another index type, a range
+   * condition alongside, anything but {@code CONTAINSTEXT}, a property this index does not cover, a multi-value key, or two
+   * conditions on the same property. A single-property index takes this path too and produces the same one-element key it
+   * always did (issue #6414, item 2).
+   */
+  private boolean processFullTextBlock() {
+    if (index.getType() != Schema.INDEX_TYPE.FULL_TEXT || additionalRangeCondition != null)
+      return false;
+
+    final List<String> properties = index.getPropertyNames();
+    if (properties == null || properties.isEmpty())
+      return false;
+
+    final List<BooleanExpression> subBlocks = ((AndBlock) condition).getSubBlocks();
+    if (subBlocks.isEmpty())
+      return false;
+
+    final Object[] keys = new Object[properties.size()];
+    for (final BooleanExpression exp : subBlocks) {
+      if (!(exp instanceof ContainsTextCondition textCondition))
+        return false;
+
+      final String fieldName = textCondition.getLeft().getDefaultAlias().getStringValue();
+      int position = -1;
+      for (int i = 0; i < properties.size(); i++)
+        if (SelectExecutionPlanner.stripIndexPropertyModifier(properties.get(i)).equals(fieldName)) {
+          position = i;
+          break;
+        }
+
+      if (position < 0 || keys[position] != null)
+        return false;
+
+      final Object value = textCondition.getRight().execute((Result) null, context);
+      if (value != null && !(value instanceof Identifiable) && MultiValue.isMultiValue(value))
+        return false;
+
+      keys[position] = value;
+    }
+
+    cursor = index.get(keys);
+    fetchNextEntry();
+    return true;
   }
 
   private void processIsNullCondition() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3903,8 +3903,31 @@ public class SelectExecutionPlanner {
   }
 
   /**
+   * Strips the {@code by key} / {@code by value} / {@code by item} modifier an index property name can carry, leaving the
+   * document property it indexes.
+   */
+  static String stripIndexPropertyModifier(final String indexField) {
+    if (indexField.endsWith(" by key"))
+      return indexField.substring(0, indexField.length() - 7);
+    if (indexField.endsWith(" by value"))
+      return indexField.substring(0, indexField.length() - 9);
+    if (indexField.endsWith(" by item"))
+      return indexField.substring(0, indexField.length() - 8);
+    return indexField;
+  }
+
+  /**
    * given a full text index and a flat AND block, returns a descriptor on how to process it with an
    * index (index, index key and additional filters to apply after index fetch
+   * <p>
+   * Every {@code CONTAINSTEXT} the index covers is claimed, whichever properties they are and however few: a full-text index
+   * key is one query string per indexed property, not a composite key whose prefix has to be contiguous, and a multi-property
+   * index stores each token both field-qualified and unprefixed so a per-property lookup is exact. Requiring the FIRST index
+   * property to be constrained, and then every following one, meant a condition on one property of a two-property index fell
+   * back to a full scan - where {@code CONTAINSTEXT} silently changed from analyzer-token matching to
+   * {@code String.contains} - while a condition on BOTH was pushed down and then answered by the first one alone, with the
+   * second dropped from the filter as well (issue #6414, item 2). {@link FetchFromIndexStep} turns the claimed conditions
+   * into the positional key the index expects.
    *
    * @param context
    * @param index
@@ -3916,41 +3939,23 @@ public class SelectExecutionPlanner {
   private IndexSearchDescriptor buildIndexSearchDescriptorForFulltext(final CommandContext context, final Index index,
       final AndBlock block, final DocumentType clazz) {
     final List<String> indexFields = index.getPropertyNames();
-    final BinaryCondition keyCondition = new BinaryCondition();
-    final Identifier key = new Identifier("key");
-    keyCondition.setLeft(new Expression(key));
-    boolean found = false;
 
     final AndBlock blockCopy = block.copy();
-    Iterator<BooleanExpression> blockIterator;
-
     final AndBlock indexKeyValue = new AndBlock();
     final IndexSearchDescriptor result = new IndexSearchDescriptor();
     result.index = (RangeIndex) index;
     result.keyCondition = indexKeyValue;
+
     for (final String indexField : indexFields) {
-      blockIterator = blockCopy.getSubBlocks().iterator();
-      final boolean breakHere = false;
-      boolean indexFieldFound = false;
+      final String baseFieldName = stripIndexPropertyModifier(indexField);
+      final Iterator<BooleanExpression> blockIterator = blockCopy.getSubBlocks().iterator();
       while (blockIterator.hasNext()) {
         final BooleanExpression singleExp = blockIterator.next();
         if (singleExp instanceof ContainsTextCondition textCondition) {
           final Expression left = textCondition.getLeft();
           // Get field name from expression - handle both simple identifiers (e.g. txt) and dotted
           // path expressions (e.g. lst.txt) used with BY ITEM nested property indexes
-          final String fieldName = left.getDefaultAlias().getStringValue();
-          // Strip modifiers to get base field name
-          String baseFieldName = indexField;
-          if (indexField.endsWith(" by key")) {
-            baseFieldName = indexField.substring(0, indexField.length() - 7);
-          } else if (indexField.endsWith(" by value")) {
-            baseFieldName = indexField.substring(0, indexField.length() - 9);
-          } else if (indexField.endsWith(" by item")) {
-            baseFieldName = indexField.substring(0, indexField.length() - 8);
-          }
-          if (baseFieldName.equals(fieldName)) {
-            found = true;
-            indexFieldFound = true;
+          if (baseFieldName.equals(left.getDefaultAlias().getStringValue())) {
             final ContainsTextCondition condition = new ContainsTextCondition();
             condition.setLeft(left);
             condition.setRight(textCondition.getRight().copy());
@@ -3960,20 +3965,13 @@ public class SelectExecutionPlanner {
           }
         }
       }
-      if (breakHere || !indexFieldFound) {
-        break;
-      }
     }
 
-    if (result.getSubBlocks().size() < index.getPropertyNames().size() && !index.supportsOrderedIterations())
-      // hash indexes do not support partial key match
+    if (indexKeyValue.getSubBlocks().isEmpty())
       return null;
 
-    if (found) {
-      result.remainingCondition = blockCopy;
-      return result;
-    }
-    return null;
+    result.remainingCondition = blockCopy;
+    return result;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3987,15 +3987,7 @@ public class SelectExecutionPlanner {
     BinaryCondition additionalRangeCondition = null;
 
     for (String indexField : indexFields) {
-      // Strip modifiers to get base field name
-      String baseFieldName = indexField;
-      if (indexField.endsWith(" by key")) {
-        baseFieldName = indexField.substring(0, indexField.length() - 7);
-      } else if (indexField.endsWith(" by value")) {
-        baseFieldName = indexField.substring(0, indexField.length() - 9);
-      } else if (indexField.endsWith(" by item")) {
-        baseFieldName = indexField.substring(0, indexField.length() - 8);
-      }
+      final String baseFieldName = Index.basePropertyName(indexField);
 
       final boolean supportNull = index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.INDEX;
       final boolean ciCollation = isIndexCaseInsensitive(index, indexFields.indexOf(indexField));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3914,6 +3914,12 @@ public class SelectExecutionPlanner {
    * {@code String.contains} - while a condition on BOTH was pushed down and then answered by the first one alone, with the
    * second dropped from the filter as well (issue #6414, item 2). {@link FetchFromIndexStep} turns the claimed conditions
    * into the positional key the index expects.
+   * <p>
+   * At most ONE condition per index property is claimed - the inner loop breaks after the first match - so a second
+   * condition on the same property stays in the residual filter and is answered by {@code String.contains} rather than by
+   * the index's analyzer. The positional key has one slot per property and cannot express two texts for one: within a
+   * property the terms of a single query text are OR-ed, while the {@code AND} between two conditions wants both. Serving
+   * it means one lookup per CONDITION rather than per property, which is issue #6427.
    *
    * @param context
    * @param index

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3903,20 +3903,6 @@ public class SelectExecutionPlanner {
   }
 
   /**
-   * Strips the {@code by key} / {@code by value} / {@code by item} modifier an index property name can carry, leaving the
-   * document property it indexes.
-   */
-  static String stripIndexPropertyModifier(final String indexField) {
-    if (indexField.endsWith(" by key"))
-      return indexField.substring(0, indexField.length() - 7);
-    if (indexField.endsWith(" by value"))
-      return indexField.substring(0, indexField.length() - 9);
-    if (indexField.endsWith(" by item"))
-      return indexField.substring(0, indexField.length() - 8);
-    return indexField;
-  }
-
-  /**
    * given a full text index and a flat AND block, returns a descriptor on how to process it with an
    * index (index, index key and additional filters to apply after index fetch
    * <p>
@@ -3947,7 +3933,7 @@ public class SelectExecutionPlanner {
     result.keyCondition = indexKeyValue;
 
     for (final String indexField : indexFields) {
-      final String baseFieldName = stripIndexPropertyModifier(indexField);
+      final String baseFieldName = Index.basePropertyName(indexField);
       final Iterator<BooleanExpression> blockIterator = blockCopy.getSubBlocks().iterator();
       while (blockIterator.hasNext()) {
         final BooleanExpression singleExp = blockIterator.next();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
@@ -28,6 +28,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The {@code CONTAINSTEXT} operator.
+ * <p>
+ * When a full-text index covers the property on the left, the planner pushes the whole condition down onto it and the
+ * answer is analyzer-TOKEN matching: case-insensitive, whole tokens, stop words and stemming as the index's analyzer
+ * defines them. That holds however the index is declared - one property or several - since issue #6414 gave the
+ * multi-property index a per-property key.
+ * <p>
+ * The {@link #evaluate} below is the fallback for everything else, and it is a plain case-sensitive
+ * {@code String.contains}: substring matching, no analyzer involved. So the operator's meaning is decided by whether a
+ * full-text index covers the property, which {@code EXPLAIN} answers - {@code FETCH FROM INDEX} versus a scan - and
+ * nothing else. Use {@code SEARCH_INDEX(...)} for the full Lucene query syntax, or {@code LIKE '%..%'} when substring
+ * matching is what is wanted.
+ */
 @SuppressWarnings("ALL")
 public class ContainsTextCondition extends BooleanExpression {
   public Expression left;

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6385AstarHeuristicPositionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6385AstarHeuristicPositionTest.java
@@ -51,7 +51,7 @@ class Issue6385AstarHeuristicPositionTest {
       final Vertex source = points[0];
       final Vertex goal = points[3];
 
-      for (final SQLHeuristicFormula formula : SQLHeuristicFormula.values()) {
+      for (final SQLHeuristicFormula formula : axisFormulas()) {
         final SQLFunctionAstar astar = axisHeuristic(db, source, formula);
 
         final double atSource = astar.getHeuristicCost(source, null, goal, astar.context);
@@ -87,7 +87,7 @@ class Issue6385AstarHeuristicPositionTest {
       // A non-default dFactor as well as the default: it scales every heuristic, and running only at 1.0 cannot
       // see a branch that drops it - which is how the N-axis EUCLIDEAN came to be the one of five that did.
       for (final double dFactor : new double[] { 1.0, 3.0 })
-        for (final SQLHeuristicFormula formula : SQLHeuristicFormula.values()) {
+        for (final SQLHeuristicFormula formula : axisFormulas()) {
           final SQLFunctionAstar threeAxis = axisHeuristic(db, points[0], formula);
           final SQLFunctionAstar twoAxis = axisHeuristic(db, points[0], formula);
           twoAxis.paramVertexAxisNames = new String[] { "x", "y" };
@@ -99,6 +99,15 @@ class Issue6385AstarHeuristicPositionTest {
               .isEqualTo(twoAxis.getHeuristicCost(points[1], null, points[2], twoAxis.context));
         }
     });
+  }
+
+  /**
+   * Every formula that is computed FROM THE AXES. CUSTOM is not one of them: it delegates h(n) wholesale to a
+   * user function and reads no coordinate, so the distance assertions below say nothing about it (issue #6414).
+   */
+  private static SQLHeuristicFormula[] axisFormulas() {
+    return new SQLHeuristicFormula[] { SQLHeuristicFormula.MANHATTAN, SQLHeuristicFormula.MAXAXIS,
+        SQLHeuristicFormula.DIAGONAL, SQLHeuristicFormula.EUCLIDEAN, SQLHeuristicFormula.EUCLIDEANNOSQR };
   }
 
   private SQLFunctionAstar axisHeuristic(final Database db, final Vertex source, final SQLHeuristicFormula formula) {

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6414AstarCustomHeuristicTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/Issue6414AstarCustomHeuristicTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.sql.SQLFunctionAbstract;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.SQLQueryEngine;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@code astar}'s {@code customHeuristicFormula} option was documented, listed among the accepted options and read into
+ * a field that nothing ever consulted: a query supplying one silently got MANHATTAN, with no error and no warning
+ * (issue #6414, item 1). It now names a SQL function that computes h(n), and every way of getting that wrong is an
+ * error the caller sees.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6414AstarCustomHeuristicTest extends TestHelper {
+  private static final String            CUSTOM_FUNCTION = "distanceOnX6414";
+  private static final String            NOT_A_NUMBER    = "notANumber6414";
+  private static final AtomicInteger     CALLS           = new AtomicInteger();
+  private static final List<List<Object>> ARGUMENTS      = new ArrayList<>();
+
+  @BeforeEach
+  void registerFunctionsAndGraph() {
+    CALLS.set(0);
+    ARGUMENTS.clear();
+
+    final SQLQueryEngine engine = (SQLQueryEngine) database.getQueryEngine("sql");
+    engine.getFunctionFactory().register(new SQLFunctionAbstract(CUSTOM_FUNCTION) {
+      @Override
+      public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult,
+          final Object[] params, final CommandContext context) {
+        CALLS.incrementAndGet();
+        ARGUMENTS.add(Arrays.asList(params));
+        final Vertex current = (Vertex) params[0];
+        final Vertex target = (Vertex) params[2];
+        return Math.abs(target.getDouble("x") - current.getDouble("x"));
+      }
+
+      @Override
+      public String getSyntax() {
+        return CUSTOM_FUNCTION + "(current, parent, target, source, depth, dFactor)";
+      }
+    });
+    engine.getFunctionFactory().register(new SQLFunctionAbstract(NOT_A_NUMBER) {
+      @Override
+      public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult,
+          final Object[] params, final CommandContext context) {
+        return "not a number";
+      }
+
+      @Override
+      public String getSyntax() {
+        return NOT_A_NUMBER + "()";
+      }
+    });
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Node6414");
+      database.command("sql", "CREATE PROPERTY Node6414.name STRING");
+      database.command("sql", "CREATE PROPERTY Node6414.x DOUBLE");
+      database.command("sql", "CREATE EDGE TYPE Road6414");
+      database.command("sql", "CREATE PROPERTY Road6414.weight DOUBLE");
+
+      for (int i = 0; i < 4; i++)
+        database.command("sql", "INSERT INTO Node6414 SET name = ?, x = ?", "n" + i, (double) i);
+
+      // A cheap three-hop chain and one expensive shortcut, so the answer is only right if the search really runs.
+      link("n0", "n1", 1);
+      link("n1", "n2", 1);
+      link("n2", "n3", 1);
+      link("n0", "n3", 10);
+    });
+  }
+
+  @AfterEach
+  void unregisterFunctions() {
+    final SQLQueryEngine engine = (SQLQueryEngine) database.getQueryEngine("sql");
+    engine.getFunctionFactory().unregister(CUSTOM_FUNCTION);
+    engine.getFunctionFactory().unregister(NOT_A_NUMBER);
+  }
+
+  @Test
+  void customHeuristicFormulaIsInvokedAndDrivesTheSearch() {
+    final List<String> names = pathNames(
+        "{'direction':'OUT','customHeuristicFormula':'" + CUSTOM_FUNCTION + "'}");
+
+    assertThat(names).containsExactly("n0", "n1", "n2", "n3");
+    // The point of the whole item: the option is applied, not read and dropped.
+    assertThat(CALLS.get()).isGreaterThan(0);
+  }
+
+  /**
+   * A custom formula owns h(n) outright, so it applies with no {@code vertexAxisNames} declared at all - the branch
+   * every built-in formula lives in is never reached. The arguments it receives are the contract the syntax states.
+   */
+  @Test
+  void customHeuristicReceivesTheDocumentedArguments() {
+    pathNames("{'direction':'OUT','dFactor':2.5,'customHeuristicFormula':'" + CUSTOM_FUNCTION + "'}");
+
+    assertThat(ARGUMENTS).isNotEmpty();
+    for (final List<Object> args : ARGUMENTS) {
+      assertThat(args).hasSize(6);
+      assertThat(args.get(0)).isInstanceOf(Vertex.class);   // current
+      assertThat(args.get(2)).isInstanceOf(Vertex.class);   // target
+      assertThat(args.get(3)).isInstanceOf(Vertex.class);   // source
+      assertThat(args.get(4)).isInstanceOf(Long.class);     // depth
+      assertThat(args.get(5)).isEqualTo(2.5);               // dFactor
+    }
+    // The first call is the source's own estimate, taken before any node has a parent.
+    assertThat(ARGUMENTS.getFirst().get(1)).isNull();
+  }
+
+  @Test
+  void heuristicFormulaCustomWithoutAFunctionNameIsRejected() {
+    assertThatThrownBy(() -> pathNames("{'direction':'OUT','heuristicFormula':'CUSTOM'}"))
+        .hasMessageContaining("customHeuristicFormula");
+  }
+
+  @Test
+  void anUnknownFunctionNameIsRejected() {
+    assertThatThrownBy(() -> pathNames("{'direction':'OUT','customHeuristicFormula':'noSuchFunction6414'}"))
+        .hasMessageContaining("noSuchFunction6414");
+  }
+
+  @Test
+  void aBuiltInFormulaAndACustomOneTogetherAreAContradiction() {
+    assertThatThrownBy(() -> pathNames(
+        "{'direction':'OUT','heuristicFormula':'EUCLIDEAN','customHeuristicFormula':'" + CUSTOM_FUNCTION + "'}"))
+        .hasMessageContaining("conflict");
+  }
+
+  @Test
+  void aCustomFormulaThatDoesNotReturnANumberIsRejected() {
+    assertThatThrownBy(() -> pathNames("{'direction':'OUT','customHeuristicFormula':'" + NOT_A_NUMBER + "'}"))
+        .hasMessageContaining("must return a number");
+  }
+
+  /**
+   * {@code dijkstra} does not accept the option at all - it never had a heuristic - and says so rather than ignoring it.
+   */
+  @Test
+  void dijkstraStillRejectsTheOptionOutright() {
+    assertThatThrownBy(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT dijkstra((SELECT FROM Node6414 WHERE name = 'n0'), (SELECT FROM Node6414 WHERE name = 'n3'), 'weight', "
+              + "{'direction':'OUT','customHeuristicFormula':'" + CUSTOM_FUNCTION + "'}) AS path")) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).hasMessageContaining("customHeuristicFormula");
+  }
+
+  private List<String> pathNames(final String options) {
+    final List<String> names = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql",
+        "SELECT expand(astar((SELECT FROM Node6414 WHERE name = 'n0'), (SELECT FROM Node6414 WHERE name = 'n3'), 'weight', "
+            + options + ")) AS path")) {
+      while (rs.hasNext())
+        names.add(rs.next().toElement().getString("name"));
+    }
+    return names;
+  }
+
+  private void link(final String from, final String to, final double weight) {
+    database.command("sql",
+        "CREATE EDGE Road6414 FROM (SELECT FROM Node6414 WHERE name = ?) TO (SELECT FROM Node6414 WHERE name = ?) SET weight = ?",
+        from, to, weight);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6382ContainsTextColonTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6382ContainsTextColonTest.java
@@ -84,8 +84,8 @@ class Issue6382ContainsTextColonTest extends TestHelper {
   /**
    * A real field qualifier on a multi-property index keeps working, and a prefix that is NOT an indexed property is
    * literal text: it matches the document that really carries it, not nothing at all. Exercised through the index
-   * lookup directly, because the planner does not push a single-property {@code CONTAINSTEXT} down onto a
-   * multi-property full-text index.
+   * lookup directly: it is the raw qualifier handling that is under test here, below the positional per-property key
+   * the planner now builds for a multi-property index (issue #6414).
    */
   @Test
   void multiPropertyIndexKeepsFieldQualifiersAndTreatsUnknownOnesAsLiterals() {

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A {@code CONTAINSTEXT} on one property of a MULTI-property full-text index was not pushed down onto the index, and the
+ * scan it fell back to evaluates the operator as {@code String.contains}: the same operator over the same data answered
+ * differently depending only on how the index happened to be declared. Pushed down on BOTH properties it was worse than
+ * that - the lookup read the first condition and the planner dropped the second from the filter as well, so a query
+ * whose second condition matched nothing returned every row (issue #6414, item 2).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6414ContainsTextMultiPropertyIndexTest extends TestHelper {
+
+  @Test
+  void aConditionOnOnePropertyOfAMultiPropertyIndexUsesTheIndex() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
+
+    database.transaction(() -> {
+      assertThat(explain("SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java'"))
+          .contains("FETCH FROM INDEX Article6414[title,content]");
+      // The second property alone is just as good a key: a full-text key is one query string per property, not a
+      // composite key whose used prefix has to start at the first one.
+      assertThat(explain("SELECT id FROM Article6414 WHERE content CONTAINSTEXT 'java'"))
+          .contains("FETCH FROM INDEX Article6414[title,content]");
+    });
+  }
+
+  /**
+   * The heart of the item: the answer must not depend on the index's arity. Every query below is run against the same
+   * rows indexed once as {@code (title, content)} and once as {@code (title)}, and the two must agree.
+   */
+  @Test
+  void multiAndSinglePropertyIndexesAnswerTheSameQuestionTheSameWay() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
+    createArticles("CREATE INDEX ON Single6414 (title) FULL_TEXT", "Single6414");
+
+    database.transaction(() -> {
+      for (final String literal : new String[] { "java", "JAVA", "ava", "rocks", "databases" }) {
+        final Set<String> multi = ids("Article6414", "title", literal);
+        final Set<String> single = ids("Single6414", "title", literal);
+        assertThat(multi).as("literal '%s'", literal).isEqualTo(single);
+      }
+    });
+  }
+
+  /**
+   * The property named in the condition is the property searched: a token that only the OTHER indexed property carries
+   * is not a match, even though the index stores it unprefixed as well.
+   */
+  @Test
+  void aConditionIsRestrictedToThePropertyItNames() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
+
+    database.transaction(() -> {
+      assertThat(ids("Article6414", "title", "databases")).isEmpty();
+      assertThat(ids("Article6414", "content", "databases")).containsExactly("a");
+      // Every whitespace-separated word is bound to the named property, not just the first. Qualifying only the head
+      // would leave 'databases' matching any property and bring row 'a' back through its content.
+      assertThat(ids("Article6414", "title", "zzz databases")).isEmpty();
+      assertThat(ids("Article6414", "title", "zzz java")).containsExactlyInAnyOrder("a", "c");
+    });
+  }
+
+  @Test
+  void twoConditionsOnTheSameIndexAreAConjunction() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
+
+    database.transaction(() -> {
+      // Before the fix this returned every row in the type: the lookup honoured 'java' and the planner had already
+      // removed 'zzz' from the filter it would otherwise have been checked by.
+      assertThat(idsMatching(
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'zzz'")).isEmpty();
+      assertThat(idsMatching(
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'databases'"))
+          .containsExactly("a");
+    });
+  }
+
+  /**
+   * A condition the index cannot serve stays in the filter that runs over the fetched rows: claiming the
+   * {@code CONTAINSTEXT} must not swallow whatever else the {@code AND} carried.
+   */
+  @Test
+  void conditionsTheIndexDoesNotServeStillFilter() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
+
+    database.transaction(() -> {
+      assertThat(idsMatching("SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND id = 'c'"))
+          .containsExactly("c");
+      assertThat(idsMatching("SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND id = 'b'")).isEmpty();
+    });
+  }
+
+  /**
+   * The BM25 similarity reaches the index through a different scoring path (type-wide corpus statistics), which has to
+   * read the same positional key.
+   */
+  @Test
+  void theSameHoldsForABM25Index() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT METADATA {\"similarity\": \"BM25\"}");
+
+    database.transaction(() -> {
+      assertThat(ids("Article6414", "title", "java")).containsExactlyInAnyOrder("a", "c");
+      assertThat(ids("Article6414", "title", "databases")).isEmpty();
+      assertThat(ids("Article6414", "content", "databases")).containsExactly("a");
+      assertThat(idsMatching(
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'zzz'")).isEmpty();
+    });
+  }
+
+  private void createArticles(final String indexCommand) {
+    createArticles(indexCommand, "Article6414");
+  }
+
+  private void createArticles(final String indexCommand, final String typeName) {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE " + typeName);
+      database.command("sql", "CREATE PROPERTY " + typeName + ".title STRING");
+      database.command("sql", "CREATE PROPERTY " + typeName + ".content STRING");
+      database.command("sql", indexCommand);
+
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'a', title = 'java', content = 'databases'");
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'b', title = 'python', content = 'java bindings'");
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'c', title = 'JAVA rocks', content = 'other'");
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'd', title = 'cooking notes', content = 'pasta'");
+    });
+  }
+
+  private Set<String> ids(final String typeName, final String property, final String literal) {
+    return idsMatching("SELECT id FROM " + typeName + " WHERE " + property + " CONTAINSTEXT '" + literal + "'");
+  }
+
+  private Set<String> idsMatching(final String query) {
+    final Set<String> ids = new LinkedHashSet<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        ids.add(rs.next().getProperty("id"));
+    }
+    return ids;
+  }
+
+  private String explain(final String query) {
+    try (final ResultSet rs = database.query("sql", "EXPLAIN " + query)) {
+      return rs.next().toJSON().toString();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
@@ -147,6 +147,33 @@ class Issue6414ContainsTextMultiPropertyIndexTest extends TestHelper {
   }
 
   /**
+   * Pins what a SECOND condition on an already-claimed property does today, which issue #6427 exists to change. The
+   * planner claims one condition per index property, so this one is answered by the index and that one by the residual
+   * {@code String.contains} - the last place where the same operator still means two things in one query. The
+   * assertions are a record of the current answer, not an endorsement of it: the third is the one #6427 will flip.
+   */
+  @Test
+  void aSecondConditionOnTheSamePropertyIsStillAnsweredByTheRowFilter() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
+    database.transaction(() -> database.command("sql",
+        "INSERT INTO Article6414 SET id = 'e', title = 'java concurrency', content = 'threads'"));
+
+    database.transaction(() -> {
+      // The index answers 'java'; the row filter answers 'concurrency' as a substring, and agrees here.
+      assertThat(idsMatching(
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'concurrency'"))
+          .containsExactly("e");
+      // A second condition that matches nothing still empties the result: it is checked, just not by the index.
+      assertThat(idsMatching(
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'zzz'")).isEmpty();
+      // #6427: the index is case-insensitive and the row filter is not, so the two conditions disagree about the same
+      // word. Once a second condition reaches the index this becomes 'e'.
+      assertThat(idsMatching(
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'CONCURRENCY'")).isEmpty();
+    });
+  }
+
+  /**
    * The BM25 similarity reaches the index through a different scoring path (type-wide corpus statistics), which has to
    * read the same positional key.
    */

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
@@ -22,7 +22,9 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,6 +121,32 @@ class Issue6414ContainsTextMultiPropertyIndexTest extends TestHelper {
   }
 
   /**
+   * A {@code null} value cannot match anything - {@link com.arcadedb.query.sql.parser.ContainsTextCondition#evaluate}
+   * answers false for it off the index, and a single-property index answers nothing. On the positional key the two
+   * readings share one slot, since {@code null} is also how the key says "this property is not constrained", so the
+   * condition has to fail the whole block rather than quietly disappear from it.
+   */
+  @Test
+  void aNullValuedConditionMatchesNothingRatherThanBeingDropped() {
+    createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
+    createArticles("CREATE INDEX ON Single6414 (title) FULL_TEXT", "Single6414");
+
+    final Map<String, Object> noValue = new HashMap<>();
+    noValue.put("missing", null);
+
+    database.transaction(() -> {
+      // Was 'a': the unsatisfiable condition landed in the slot that means "unconstrained" and was never checked.
+      assertThat(idsMatching(
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT :missing", noValue))
+          .isEmpty();
+      assertThat(idsMatching("SELECT id FROM Article6414 WHERE content CONTAINSTEXT :missing", noValue)).isEmpty();
+      // The same question of a single-property index, which always answered nothing, and of a property no index covers.
+      assertThat(idsMatching("SELECT id FROM Single6414 WHERE title CONTAINSTEXT :missing", noValue)).isEmpty();
+      assertThat(idsMatching("SELECT id FROM Article6414 WHERE id CONTAINSTEXT :missing", noValue)).isEmpty();
+    });
+  }
+
+  /**
    * The BM25 similarity reaches the index through a different scoring path (type-wide corpus statistics), which has to
    * read the same positional key.
    */
@@ -193,8 +221,12 @@ class Issue6414ContainsTextMultiPropertyIndexTest extends TestHelper {
   }
 
   private Set<String> idsMatching(final String query) {
+    return idsMatching(query, Map.of());
+  }
+
+  private Set<String> idsMatching(final String query, final Map<String, Object> parameters) {
     final Set<String> ids = new LinkedHashSet<>();
-    try (final ResultSet rs = database.query("sql", query)) {
+    try (final ResultSet rs = database.query("sql", query, parameters)) {
       while (rs.hasNext())
         ids.add(rs.next().getProperty("id"));
     }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
@@ -135,6 +135,41 @@ class Issue6414ContainsTextMultiPropertyIndexTest extends TestHelper {
     });
   }
 
+  /**
+   * A property indexed {@code BY ITEM} is named {@code "obj.hd by item"} by the index and {@code obj.hd} by every query
+   * that mentions it, and {@link LSMTreeFullTextIndex#put} prefixes its postings with the FORMER. So the per-property key
+   * only reaches them if the qualifier written as the base name resolves back to the stored spelling: without that, this
+   * shape answered nothing at all, and before the positional key it answered its first condition and dropped the second.
+   */
+  @Test
+  void aNestedByItemPropertyIsSearchedByTheNameTheQueryWrites() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Pair6414");
+      database.command("sql", "CREATE PROPERTY Pair6414.hd STRING");
+      database.command("sql", "CREATE PROPERTY Pair6414.tl STRING");
+      database.command("sql", "CREATE DOCUMENT TYPE Doc6414");
+      database.command("sql", "CREATE PROPERTY Doc6414.obj LIST OF Pair6414");
+      database.command("sql", "CREATE INDEX combo6414 ON Doc6414 (`obj.hd` BY ITEM, `obj.tl` BY ITEM) FULL_TEXT");
+
+      database.command("sql", "INSERT INTO Doc6414 SET id = 'x', obj = "
+          + "[{\"@type\": \"Pair6414\", \"hd\": \"alpha\", \"tl\": \"beta\"}]");
+      database.command("sql", "INSERT INTO Doc6414 SET id = 'y', obj = "
+          + "[{\"@type\": \"Pair6414\", \"hd\": \"gamma\", \"tl\": \"delta\"}]");
+    });
+
+    database.transaction(() -> {
+      assertThat(explain("SELECT id FROM Doc6414 WHERE `obj.hd` CONTAINSTEXT 'alpha'")).contains("FETCH FROM INDEX");
+      assertThat(idsMatching("SELECT id FROM Doc6414 WHERE `obj.hd` CONTAINSTEXT 'alpha'")).containsExactly("x");
+      // The token lives in the OTHER indexed property, so the condition naming this one does not match it.
+      assertThat(idsMatching("SELECT id FROM Doc6414 WHERE `obj.hd` CONTAINSTEXT 'beta'")).isEmpty();
+      assertThat(idsMatching(
+          "SELECT id FROM Doc6414 WHERE `obj.hd` CONTAINSTEXT 'alpha' AND `obj.tl` CONTAINSTEXT 'beta'"))
+          .containsExactly("x");
+      assertThat(idsMatching(
+          "SELECT id FROM Doc6414 WHERE `obj.hd` CONTAINSTEXT 'alpha' AND `obj.tl` CONTAINSTEXT 'zzz'")).isEmpty();
+    });
+  }
+
   private void createArticles(final String indexCommand) {
     createArticles(indexCommand, "Article6414");
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
@@ -33,6 +33,7 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -1082,33 +1083,50 @@ public class UpdateStatementExecutionTest extends TestHelper {
     });
   }
 
-  // Issue #1814: APPLY DEFAULTS evaluates dynamic default expressions (e.g. sysdate) on UPDATE
+  /**
+   * Issue #1814: APPLY DEFAULTS evaluates dynamic default expressions (e.g. sysdate) on UPDATE.
+   * <p>
+   * The default has to be an EXPRESSION. Written as {@code default "sysdate(...)"} - a double-quoted SQL string
+   * literal - the call never happened and the literal text was stored verbatim, so the test asserted only that a
+   * constant string is not null and could not fail if dynamic-default evaluation regressed (issue #6414, item 3).
+   * The assertions below are on the value itself: it has to parse as a date, and after APPLY DEFAULTS it has to have
+   * replaced a sentinel the expression cannot produce.
+   */
   @Test
   void updateWithApplyDefaultsAndDynamicDefault() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE timestamped");
       database.command("sql", "CREATE PROPERTY timestamped.name STRING");
-      database.command("sql", "CREATE PROPERTY timestamped.updated STRING (default \"sysdate('YYYY-MM-DD')\")");
+      database.command("sql", "CREATE PROPERTY timestamped.updated STRING (default sysdate().format('yyyy-MM-dd'))");
     });
 
     database.transaction(() -> {
       database.command("sql", "INSERT INTO timestamped SET name = 'test'");
-
-      ResultSet result = database.query("sql", "SELECT FROM timestamped WHERE name = 'test'");
-      assertThat(result.hasNext()).isTrue();
-      var record = result.next();
-      String initialUpdated = record.getProperty("updated");
-      assertThat((Object) initialUpdated).isNotNull();
+      assertThatIsADate(readUpdated());
     });
 
     database.transaction(() -> {
+      // A sentinel the default cannot produce: after APPLY DEFAULTS re-evaluates the expression it must be gone.
+      database.command("sql", "UPDATE timestamped SET updated = 'stale' WHERE name = 'test'");
       database.command("sql", "UPDATE timestamped SET updated = null APPLY DEFAULTS WHERE name = 'test'");
-
-      ResultSet result = database.query("sql", "SELECT FROM timestamped WHERE name = 'test'");
-      assertThat(result.hasNext()).isTrue();
-      var record = result.next();
-      assertThat((Object) record.getProperty("updated")).isNotNull();
+      assertThatIsADate(readUpdated());
     });
+  }
+
+  private String readUpdated() {
+    try (final ResultSet result = database.query("sql", "SELECT FROM timestamped WHERE name = 'test'")) {
+      assertThat(result.hasNext()).isTrue();
+      return result.next().getProperty("updated");
+    }
+  }
+
+  /**
+   * Deliberately not an equality against today's date: the two transactions above can straddle midnight. Parsing is
+   * enough to prove the expression ran, because the stored literal it replaces - and the 'stale' sentinel - do not.
+   */
+  private static void assertThatIsADate(final String value) {
+    assertThat(value).matches("\\d{4}-\\d{2}-\\d{2}");
+    assertThat(LocalDate.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd"))).isNotNull();
   }
 
 }

--- a/studio/src/main/resources/static/js/function-reference.json
+++ b/studio/src/main/resources/static/js/function-reference.json
@@ -291,8 +291,8 @@
         },
         {
           "name": "astar",
-          "syntax": "astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) \n // options  : {direction:\"OUT\",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , tieBreaker:true,maxDepth:99999,dFactor:1.0,customHeuristicFormula:'custom_Function_Name_here'  }",
-          "description": "astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) \n // options  : {direction:\"OUT\",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , tieBreaker:true,maxDepth:99999,dFactor:1.0,customHeuristicFormula:'custom_Function_Name_here'  }",
+          "syntax": "astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) \n // options  : {direction:\"OUT\",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , tieBreaker:true,maxDepth:99999,dFactor:1.0,heuristicFormula:'MANHATTAN',customHeuristicFormula:'custom_Function_Name_here'  }\n // customHeuristicFormula names a SQL function called as fn(currentVertex, parentVertex, targetVertex, sourceVertex, depth, dFactor) and returning h(n) as a number",
+          "description": "astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) \n // options  : {direction:\"OUT\",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , tieBreaker:true,maxDepth:99999,dFactor:1.0,heuristicFormula:'MANHATTAN',customHeuristicFormula:'custom_Function_Name_here'  }\n // customHeuristicFormula names a SQL function called as fn(currentVertex, parentVertex, targetVertex, sourceVertex, depth, dFactor) and returning h(n) as a number",
           "since": "sql"
         },
         {


### PR DESCRIPTION
Closes #6414.

Four follow-ups from #6408, independent of each other, plus a best-effort answer to the fifth.

## 1. `astar`'s `customHeuristicFormula` is applied instead of ignored

The option was in the function's own syntax string, in its accepted-options set, and read from the caller's map into
a field that nothing ever consulted. There was no `CUSTOM` constant to dispatch to either, so a query supplying one
silently got `MANHATTAN` with no error and no warning.

The issue offered "implement the dispatch, or reject the option". Rejecting it would delete a documented feature, so
the dispatch is implemented: the option names a SQL function called as
`fn(currentVertex, parentVertex, targetVertex, sourceVertex, depth, dFactor)` and returning h(n) as a number. It is
resolved **once** when the options are bound, not once per visited node, and consulted **ahead of every axis test**,
so a custom formula works with no `vertexAxisNames` declared and owns h(n) outright: no axis is read and no
tie-breaker is layered on its answer.

Every way of getting it wrong is now an error the caller sees, which is the other half of the issue's ask:

| input | outcome |
| --- | --- |
| `customHeuristicFormula:'noSuchFn'` | rejected, naming the function |
| `heuristicFormula:'CUSTOM'` with no function named | rejected |
| `heuristicFormula:'EUCLIDEAN'` **and** `customHeuristicFormula:'f'` | rejected as a contradiction, not resolved by precedence |
| a function returning a non-number | rejected |

`dijkstra`, which has no heuristic, already rejected the option outright and still does.

## 2. `CONTAINSTEXT` and the multi-property full-text index

This turned out to be **two** defects, and the second is a wrong-results bug the issue did not know about.

**No push-down, and different semantics.** The planner required the *first* index property to be constrained and
then every following one, so a condition on one property of an index over `(title, content)` was not pushed down at
all. The scan it fell back to evaluates the operator as `String.contains` where the index matches analyzer tokens,
so the same operator over the same data answered differently depending only on how the index had been declared -
exactly as reported.

**A conjunction answered by one of its conditions.** A condition on *both* properties *was* pushed down, but
`get()` read `keys[0]` and ignored the rest, while the planner had already removed both conditions from the residual
filter. Reproduced on `2982f5504`:

```sql
SELECT id FROM Article WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'zzz'
```
returned **every row of the type**. `'zzz'` matches nothing; nothing was left to check it.

**The fix.** A full-text index key is one query string per indexed property, not a composite key whose used prefix
has to be contiguous, and a multi-property index already stores every token twice - once as `field:token` and once
unprefixed - so a per-property lookup is exact rather than a filter over a superset. The key is now **positional**:
`keys[i]` is the text to find in the i-th indexed property and a `null` slot leaves that property unconstrained. Any
subset in any position is an exact lookup, and several of them are a conjunction. Every whitespace-separated word is
bound to the property its condition names, not just the first.

A single-property index builds the same one-element key it always did, and a one-element key keeps its historical
"text to find in any indexed property" meaning, so nothing that passed a single query string changes. Conditions the
index cannot serve stay in the filter that runs over the fetched rows.

> [!IMPORTANT]
> **Behaviour change.** `CONTAINSTEXT` on a property covered by a *multi*-property full-text index now matches
> analyzer tokens (case-insensitive, whole-token) rather than substrings, which is what the same operator has always
> done on a single-property index. `title CONTAINSTEXT 'ava'` no longer matches `java` there. Use
> `SEARCH_INDEX(...)` or `LIKE '%ava%'` for substring search. The operator's meaning is now decided by whether a
> full-text index covers the property - which `EXPLAIN` answers - and not by the index's arity.

## 3. The vacuous regression test for #1814

`UpdateStatementExecutionTest.updateWithApplyDefaultsAndDynamicDefault` wrote its dynamic default as
`default "sysdate('YYYY-MM-DD')"` - a double-quoted SQL **string literal**. The call never happened, the literal text
was stored verbatim, and the test asserted only that a constant string is not null, so it could not have failed if
dynamic-default evaluation regressed. It uses an expression now (`sysdate().format('yyyy-MM-dd')`) and asserts the
value parses as a date, before and after `APPLY DEFAULTS`, with a sentinel in between that the expression cannot
produce. Deliberately not an equality against today's date: the two transactions can straddle midnight.

## 4. One copy of the full-text qualifier rule

`FullTextQueryExecutor.isUnqualified` and `LSMTreeFullTextIndex.parseQueryTerms` encoded the same rule twice. #6382
existed *because* they had drifted; #6408 closed it by writing the equivalent logic in the second place. Both now
call one method, with the semantics unchanged.

## 5. The Codacy CodeStyle finding

Codacy's PR comment on #6408 names neither the rule nor the file, and the check does not run against `main`, so it
cannot be recovered from GitHub - Codacy only reports issues *new to a diff*, so it will not resurface on this PR
either. Best effort instead: scanning that PR's changed production sources found three unused imports it left behind
(`MultiValue` in `SQLFunctionAverage`, `SQLFunctionPercentile` and `SQLFunctionVariance`, whose usage it removed).
That matches "CodeStyle, minor" and is removed here. If the dashboard shows something else, it is still open.

## Verification

- New: `Issue6414AstarCustomHeuristicTest` (7 tests - dispatch, documented arguments, and each rejection path)
- New: `Issue6414ContainsTextMultiPropertyIndexTest` (6 tests - index is used for either property; a multi- and a
  single-property index answer every literal identically; a condition is restricted to the property it names; the
  conjunction; residual filters still run; the same over a BM25 index, which reaches the index by a different
  scoring path)
- `Issue6385AstarHeuristicPositionTest` iterated `SQLHeuristicFormula.values()`; it now names the five axis formulas,
  since `CUSTOM` reads no coordinate and the distance assertions say nothing about it
- Studio's `function-reference.json` updated for `astar`'s new syntax string
- Full engine unit suite: **12854 tests, 0 failures, 0 errors** (`-DexcludedGroups=benchmark,slow,vector`)
