### PR TITLE
fix(#6392): the value of a SET is everything after the first '=', and a brace that closes nothing is just a character

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -185,9 +185,10 @@ public class Console {
       if (value.startsWith("-D")) {
         // SETTING
         final String keyValue = value.substring(2);
-        final int separatorPos = keyValue.indexOf('=');
-        final String key = separatorPos < 0 ? keyValue : keyValue.substring(0, separatorPos);
-        final String propertyValue = separatorPos < 0 ? "" : keyValue.substring(separatorPos + 1);
+        final String[] pair = splitKeyValue(keyValue);
+        // ON THE COMMAND LINE A SETTING WITH NO '=' AT ALL IS THE SAME AS ONE WITH AN EMPTY VALUE
+        final String key = pair == null ? keyValue : pair[0];
+        final String propertyValue = pair == null ? "" : pair[1];
         if (key.isEmpty())
           System.err.println("Ignoring malformed system property argument '" + value + "': missing key");
         else {
@@ -310,12 +311,13 @@ public class Console {
   }
 
   private void executeSet(final String line) {
-    final String[] parts = line.split("=");
-    if (parts.length != 2)
+    // THE VALUE IS EVERYTHING AFTER THE FIRST '=': IT CAN CONTAIN FURTHER SEPARATORS AND IT CAN BE EMPTY (ISSUE #6392)
+    final String[] pair = splitKeyValue(line);
+    if (pair == null || pair[0].isBlank())
       throw new ConsoleException("Invalid syntax for SET, use SET <name> = <value>");
 
-    final String key = parts[0].trim();
-    final String value = parts[1].trim();
+    final String key = pair[0].trim();
+    final String value = pair[1].trim();
 
     switch (key.toLowerCase()) {
     case "limit" -> {
@@ -1171,6 +1173,20 @@ public class Console {
   private String getPrompt() {
     final String databaseName = databaseProxy != null ? databaseProxy.getName() : null;
     return PROMPT.formatted(databaseName != null ? "{" + databaseName + "}" : "");
+  }
+
+  /**
+   * Splits a `&lt;key&gt;=&lt;value&gt;` pair on the FIRST '=' only, so a value that contains further separators (a connection
+   * string, a base64 padding, a date pattern) is kept whole and an empty value is a value, not a missing one. Returns null when
+   * there is no separator at all, leaving to the caller the choice between rejecting the input and reading it as an empty value.
+   * Shared by the `-D&lt;key&gt;=&lt;value&gt;` arguments (issue #5928) and by the SET command (issue #6392), which used to
+   * disagree on the rule.
+   */
+  static String[] splitKeyValue(final String pair) {
+    final int separatorPos = pair.indexOf('=');
+    if (separatorPos < 0)
+      return null;
+    return new String[] { pair.substring(0, separatorPos), pair.substring(separatorPos + 1) };
   }
 
   private static boolean setGlobalConfiguration(final String key, final String value, final boolean printError) {

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -313,13 +313,17 @@ public class Console {
   private void executeSet(final String line) {
     // THE VALUE IS EVERYTHING AFTER THE FIRST '=': IT CAN CONTAIN FURTHER SEPARATORS AND IT CAN BE EMPTY (ISSUE #6392)
     final String[] pair = splitKeyValue(line);
-    if (pair == null || pair[0].isBlank())
+    if (pair == null)
       throw new ConsoleException("Invalid syntax for SET, use SET <name> = <value>");
+    if (pair[0].isBlank())
+      // SAY WHICH HALF IS MISSING, LIKE THE `-D<key>=<value>` PATH ALREADY DOES
+      throw new ConsoleException("Invalid syntax for SET: missing name, use SET <name> = <value>");
 
     final String key = pair[0].trim();
     final String value = pair[1].trim();
 
-    switch (key.toLowerCase()) {
+    // THE SETTING NAMES ARE ASCII, SO THE CASE MUST FOLD IN ENGLISH: WITH A TURKISH DEFAULT LOCALE `LIMIT` WOULD NOT MATCH
+    switch (key.toLowerCase(Locale.ENGLISH)) {
     case "limit" -> {
       limit = Integer.parseInt(value);
       outputLine(3, "Set new limit to %d", limit);

--- a/console/src/main/java/com/arcadedb/console/TerminalParser.java
+++ b/console/src/main/java/com/arcadedb/console/TerminalParser.java
@@ -32,6 +32,10 @@ import java.util.Locale;
  * <p>
  * The line comment marker depends on the language in use: SQL uses `--`, while Cypher, Gremlin and Mongo use `//`. This matters
  * because a double dash is a legal undirected relationship in Cypher (`(a) -- (b)`) and a double slash is a division in SQL.
+ * <p>
+ * A semicolon inside a JSON object literal is not a separator either, so the open braces are counted while scanning. The count
+ * never goes below zero: an unbalanced closing brace is a typo in one command and must not change how the following ones are
+ * split (issue #6392).
  */
 public class TerminalParser extends DefaultParser {
   private static final String SQL_LINE_COMMENT   = "--";
@@ -151,7 +155,10 @@ public class TerminalParser extends DefaultParser {
           current.append(c);
         } else if (c == '}') {
           final int prevDepth = braceDepth;
-          braceDepth--;
+          // A CLOSING BRACE WITH NOTHING OPEN IS JUST TEXT: LETTING THE DEPTH GO NEGATIVE WOULD STOP EVERY FOLLOWING SEMICOLON
+          // FROM SEPARATING THE COMMANDS FOR THE REST OF THE TEXT (ISSUE #6392)
+          if (braceDepth > 0)
+            braceDepth--;
           current.append(c);
 
           // Check if we just closed all braces and there's more content after newlines

--- a/console/src/test/java/com/arcadedb/console/ConsoleSplitKeyValueTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleSplitKeyValueTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.console;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the contract of the `&lt;key&gt;=&lt;value&gt;` rule shared by the `-D` command line arguments (issue #5928) and by the
+ * SET command (issue #6392), which used to disagree on it. The two call sites are covered end to end by {@link ConsoleTest},
+ * but they read the result differently, so the rule itself is worth stating once on its own.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ConsoleSplitKeyValueTest {
+  @Test
+  void theValueIsEverythingAfterTheFirstSeparator() {
+    assertThat(Console.splitKeyValue("a=b")).containsExactly("a", "b");
+    assertThat(Console.splitKeyValue("a=b=c")).containsExactly("a", "b=c");
+    assertThat(Console.splitKeyValue("a===")).containsExactly("a", "==");
+  }
+
+  @Test
+  void anEmptyValueIsAValue() {
+    assertThat(Console.splitKeyValue("a=")).containsExactly("a", "");
+  }
+
+  @Test
+  void anEmptyKeyIsReturnedAsSuchForTheCallerToReject() {
+    assertThat(Console.splitKeyValue("=b")).containsExactly("", "b");
+    assertThat(Console.splitKeyValue("=")).containsExactly("", "");
+  }
+
+  /**
+   * No separator at all is not an empty value: the caller decides, because the command line reads it as one while SET rejects it.
+   */
+  @Test
+  void noSeparatorLeavesTheChoiceToTheCaller() {
+    assertThat(Console.splitKeyValue("a")).isNull();
+    assertThat(Console.splitKeyValue("")).isNull();
+  }
+
+  /**
+   * The blanks around the separator belong to the caller too: SET trims them, the `-D` arguments keep them.
+   */
+  @Test
+  void surroundingBlanksArePreserved() {
+    assertThat(Console.splitKeyValue(" a = b ")).containsExactly(" a ", " b ");
+  }
+}

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -292,6 +292,53 @@ class ConsoleTest {
   }
 
   /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6392: SET used to split the argument on every '=', so a value that
+   * contains one (a connection string, a base64 padding, a date pattern) was rejected as a syntax error. It is the same rule
+   * already fixed for the `-D<key>=<value>` arguments in #5928.
+   */
+  @Test
+  void setKeepsAValueContainingTheSeparator() throws Exception {
+    try {
+      assertThat(console.parse("set " + GlobalConfiguration.SERVER_BACKUP_DIRECTORY.getKey() + " = ./target/backups?a=b")).isTrue();
+      assertThat(GlobalConfiguration.SERVER_BACKUP_DIRECTORY.getValueAsString()).isEqualTo("./target/backups?a=b");
+    } finally {
+      GlobalConfiguration.SERVER_BACKUP_DIRECTORY.reset();
+    }
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6392: an empty value dropped the trailing token, leaving a single part
+   * that was rejected instead of clearing the setting.
+   */
+  @Test
+  void setAcceptsAnEmptyValue() throws Exception {
+    try {
+      assertThat(console.parse("set " + GlobalConfiguration.SERVER_BACKUP_DIRECTORY.getKey() + " =")).isTrue();
+      assertThat(GlobalConfiguration.SERVER_BACKUP_DIRECTORY.getValueAsString()).isEmpty();
+    } finally {
+      GlobalConfiguration.SERVER_BACKUP_DIRECTORY.reset();
+    }
+  }
+
+  @Test
+  void setStillWorksWithAPlainValue() throws Exception {
+    assertThatCode(() -> console.parse("set limit = 7")).doesNotThrowAnyException();
+  }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6392: what is still malformed must stay malformed.
+   */
+  @Test
+  void setWithoutTheSeparatorIsRejected() {
+    assertThatThrownBy(() -> console.parse("set limit")).isInstanceOf(ConsoleException.class);
+  }
+
+  @Test
+  void setWithoutAKeyIsRejected() {
+    assertThatThrownBy(() -> console.parse("set = 7")).isInstanceOf(ConsoleException.class);
+  }
+
+  /**
    * Issue https://github.com/ArcadeData/arcadedb/issues/5927
    */
   @Test

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -44,6 +44,7 @@ import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -326,16 +327,37 @@ class ConsoleTest {
   }
 
   /**
-   * Issue https://github.com/ArcadeData/arcadedb/issues/6392: what is still malformed must stay malformed.
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6392: what is still malformed must stay malformed, and the message says
+   * which half is missing so the user does not have to guess.
    */
   @Test
   void setWithoutTheSeparatorIsRejected() {
-    assertThatThrownBy(() -> console.parse("set limit")).isInstanceOf(ConsoleException.class);
+    assertThatThrownBy(() -> console.parse("set limit")).isInstanceOf(ConsoleException.class)
+        .hasMessageContaining("Invalid syntax for SET, use");
   }
 
   @Test
   void setWithoutAKeyIsRejected() {
-    assertThatThrownBy(() -> console.parse("set = 7")).isInstanceOf(ConsoleException.class);
+    assertThatThrownBy(() -> console.parse("set = 7")).isInstanceOf(ConsoleException.class).hasMessageContaining("missing name");
+    assertThatThrownBy(() -> console.parse("set    = 7")).isInstanceOf(ConsoleException.class).hasMessageContaining("missing name");
+  }
+
+  /**
+   * The setting names are ASCII, so their case must fold in English: with a Turkish default locale the dotless lowercase of 'I'
+   * used to make `LIMIT` miss its own branch and fall through to the global configuration.
+   */
+  @Test
+  void setNameIsFoldedInEnglishWhateverTheDefaultLocale() throws Exception {
+    final Locale defaultLocale = Locale.getDefault();
+    final StringBuilder buffer = new StringBuilder();
+    console.setOutput(output -> buffer.append(output));
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      console.parse("set LIMIT = 7");
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
+    assertThat(buffer.toString()).contains("Set new limit to 7");
   }
 
   /**

--- a/console/src/test/java/com/arcadedb/console/TerminalParserTest.java
+++ b/console/src/test/java/com/arcadedb/console/TerminalParserTest.java
@@ -133,4 +133,36 @@ class TerminalParserTest {
     assertThat(split("INSERT INTO doc CONTENT {\"a\": \"b;c\", \"d\": 1}")).containsExactly(
         "INSERT INTO doc CONTENT {\"a\": \"b;c\", \"d\": 1}");
   }
+
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6392: one closing brace too many used to drive the brace depth below
+   * zero, and from there no semicolon could ever match the `depth == 0` test again, so every following command was appended to
+   * the malformed one instead of being executed on its own.
+   */
+  @Test
+  void unbalancedClosingBraceDoesNotDisableTheSeparator() {
+    assertThat(split("INSERT INTO doc CONTENT {\"a\":{\"b\":1}}}; SELECT 1; SELECT 2")).containsExactly(
+        "INSERT INTO doc CONTENT {\"a\":{\"b\":1}}}", " SELECT 1", " SELECT 2");
+  }
+
+  @Test
+  void closingBraceWithNothingOpenIsJustText() {
+    assertThat(split("SELECT 1 }; SELECT 2")).containsExactly("SELECT 1 }", " SELECT 2");
+  }
+
+  /**
+   * Every stray brace used to dig the depth one level deeper, so the damage survived any number of well formed JSON objects
+   * coming after it.
+   */
+  @Test
+  void strayBracesDoNotAccumulate() {
+    assertThat(split("} ; } ; SELECT 1")).containsExactly("} ", " } ", " SELECT 1");
+    assertThat(split("SELECT 1 }; INSERT INTO doc CONTENT {\"a\": 1}; SELECT 2")).containsExactly("SELECT 1 }",
+        " INSERT INTO doc CONTENT {\"a\": 1}", " SELECT 2");
+  }
+
+  @Test
+  void unbalancedClosingBraceInsideAStringIsNotCounted() {
+    assertThat(split("SELECT '}}}' ; SELECT 1")).containsExactly("SELECT '}}}' ", " SELECT 1");
+  }
 }


### PR DESCRIPTION
Closes #6392.

Both findings in the issue are real, both read at HEAD and both reproduced by a failing test before the fix.

## 1. `SET` rejected any value containing `=`, and any empty value

`executeSet()` split on **every** `=` and demanded exactly two parts:

```java
final String[] parts = line.split("=");
if (parts.length != 2)
  throw new ConsoleException("Invalid syntax for SET, use SET <name> = <value>");
```

* `set somekey = a=b` -> 3 parts -> rejected. Connection strings, base64 padding and date patterns were unsettable.
* `set somekey =` -> `split` drops the trailing empty token -> 1 part -> rejected, so a setting could not be cleared.

The sibling `-D<key>=<value>` handler had already been taught the right rule in #5928, so the two argument paths of the same console disagreed on what a `key=value` pair is.

**What the issue proposed, and what this does instead.** The issue proposed inlining `indexOf('=')` in `executeSet`. That fixes the symptom but leaves the same rule written out twice, one copy per call site, which is how the two paths drifted apart in the first place. Instead the rule now lives in a single `Console.splitKeyValue()`: it cuts on the **first** `=` and returns `null` when there is none, leaving each caller its own policy for a missing separator. The command line keeps reading a bare `-Dkey` as an empty value (unchanged, still covered by the #5928 tests); `SET` still rejects an argument with no `=` at all, and now also rejects an empty key, which used to fall through to `setGlobalConfiguration("")` and merely print `Setting '' is not supported by the console`.

Deliberately **not** done: stripping surrounding quotes from the value. `set x = 'a=b'` still sets the literal `'a=b'`. That is a separate behaviour change with its own back-compat surface, and nothing in the issue asks for it.

## 2. An unbalanced `}` disabled `;` command splitting for the rest of the text

`TerminalParser` counts open braces so a `;` inside a JSON object literal is not a separator, and the delimiter branch requires `braceDepth == 0`. `braceDepth--` had no floor, so one closing brace too many - a typo such as `INSERT ... CONTENT {"a":{"b":1}}} ;` - drove the count to `-1`. From there **no** `;` could ever match `== 0` again: every following command was appended into the current word instead of being executed on its own. Each stray brace dug one level deeper, so no amount of well formed JSON afterwards recovered the count.

A brace that closes nothing is just a character, so the count now stops at zero. The `prevDepth == 1` newline-split heuristic needs no extra guard: with the floor in place `prevDepth` is 0 in exactly the case that used to go negative, so the heuristic already does not fire. A `}` inside quotes was, and remains, handled by the `quoteStart` branch and never counted.

One correction to the issue text: `load <script>` parses the file **line by line** (`executeLoad` resets `pending` after each line unless a block comment is open), so the damage there is bounded to the rest of the offending line rather than the rest of the file. The unbounded case is a multi-statement string handed to `parse()` - which is exactly what batch mode builds, joining every non-flag argument with `"\n;"` - and a multi-statement line typed at the prompt.

## Tests

`TerminalParserTest` (all failed before the fix, except the last, which guards the case that already worked):
* `unbalancedClosingBraceDoesNotDisableTheSeparator` - the issue's own example, three commands out.
* `closingBraceWithNothingOpenIsJustText`
* `strayBracesDoNotAccumulate` - proves a later well formed JSON object is not swallowed.
* `unbalancedClosingBraceInsideAStringIsNotCounted` - regression guard on the quoted path.

`ConsoleTest`:
* `setKeepsAValueContainingTheSeparator`, `setAcceptsAnEmptyValue` - failed before with `Invalid syntax for SET`.
* `setWithoutAKeyIsRejected` - failed before (it silently printed "not supported").
* `setStillWorksWithAPlainValue`, `setWithoutTheSeparatorIsRejected` - guards on what must not change.

Both tests restore `SERVER_BACKUP_DIRECTORY` in a `finally`, and the fixture's `@AfterEach` already drops the database and calls `GlobalConfiguration.resetAll()`.

Verified: `mvn -o -pl console -am test` -> 794 server + 75 console tests, all green.

## Follow-up spotted, not fixed here (filed as #6423)

`PostgresNetworkExecutor.setConfiguration()` splits a Postgres `SET` on `q.split("=")` and takes `parts[1]`, so it truncates a value at the second `=` - the same class of bug in a different module - and `GetDynamicContentHandler` does `pair.split("=")` then reads `kv[1]` without a length check, which throws `ArrayIndexOutOfBoundsException` on an include parameter with no `=`. Out of scope for a console issue; filed as #6423.
