### PR TITLE
fix(#6410, #6411, #6412): an idle connection waits on its socket, a blob is a bytea, and the catalog answers the shape of the question rather than the name of the asker

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -58,6 +58,7 @@ import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.network.PreAuthConnectionGate;
 import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -123,6 +124,11 @@ public class BoltNetworkExecutor extends Thread {
   private final ArcadeDBServer      server;
   private volatile Socket           socket; // Reassigned to the SSLSocket once TLS negotiation completes
   private final BoltSslHelper       sslHelper;
+  /**
+   * The listener's permit for a connection that has not authenticated yet, handed back the moment it does -
+   * or when it goes away without ever doing so (issue #6412).
+   */
+  private final PreAuthConnectionGate.Ticket preAuthTicket;
   private       BoltChunkedInput    input;
   private       BoltChunkedOutput   output;
   private final boolean             debug;
@@ -164,11 +170,17 @@ public class BoltNetworkExecutor extends Thread {
 
   public BoltNetworkExecutor(final ArcadeDBServer server, final Socket socket, final BoltNetworkListener listener,
       final BoltSslHelper sslHelper) {
+    this(server, socket, listener, sslHelper, null);
+  }
+
+  public BoltNetworkExecutor(final ArcadeDBServer server, final Socket socket, final BoltNetworkListener listener,
+      final BoltSslHelper sslHelper, final PreAuthConnectionGate.Ticket preAuthTicket) {
     super("BOLT-" + socket.getRemoteSocketAddress());
     this.server = server;
     this.socket = socket;
     this.listener = listener;
     this.sslHelper = sslHelper;
+    this.preAuthTicket = preAuthTicket;
     this.debug = GlobalConfiguration.BOLT_DEBUG.getValueAsBoolean();
     // NOTE: transport (TLS) negotiation and the socket I/O streams are intentionally set up in run(), on this
     // per-connection thread, so a slow/failed/hostile TLS handshake can never block the shared accept thread.
@@ -254,8 +266,20 @@ public class BoltNetworkExecutor extends Thread {
       LogManager.instance().log(this, Level.SEVERE, "BOLT connection error", e);
     } finally {
       ProtocolContext.clear();
+      // Whatever ended the loop, the listener's permit must go back: a connection that dies without ever
+      // authenticating would otherwise keep its slot for the life of the server (issue #6412).
+      releasePreAuthTicket();
       cleanup();
     }
+  }
+
+  /**
+   * Hands the listener's pre-authentication permit back. Idempotent, so authenticating and then terminating -
+   * the normal life of a connection - releases exactly one permit.
+   */
+  private void releasePreAuthTicket() {
+    if (preAuthTicket != null)
+      preAuthTicket.release();
   }
 
   /**
@@ -1716,6 +1740,7 @@ public class BoltNetworkExecutor extends Thread {
    * keep applying past a successful HELLO/LOGON.
    */
   private void markAuthenticated() {
+    releasePreAuthTicket();
     try {
       socket.setSoTimeout(0);
     } catch (final SocketException e) {

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkListener.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkListener.java
@@ -23,6 +23,7 @@ import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerException;
+import com.arcadedb.server.network.PreAuthConnectionGate;
 import com.arcadedb.server.network.ServerSocketFactory;
 
 import java.io.IOException;
@@ -50,6 +51,8 @@ public class BoltNetworkListener extends Thread {
   private volatile boolean                             active = true;
   private final    Set<BoltNetworkExecutor>            activeConnections = ConcurrentHashMap.newKeySet();
   private final    int                                 maxConnections;
+  /** Bounds how many accepted connections can sit un-authenticated at once (issue #6412). */
+  private final    PreAuthConnectionGate               preAuthGate = new PreAuthConnectionGate("BOLT");
 
   public BoltNetworkListener(final ArcadeDBServer server,
       final ServerSocketFactory socketFactory,
@@ -87,6 +90,21 @@ public class BoltNetworkListener extends Thread {
             continue;
           }
 
+          // One thread and one file descriptor are committed here, before the client has proved anything: past
+          // the cap the socket is closed straight away rather than being given either (issue #6412). This is
+          // narrower than the BOLT_MAX_CONNECTIONS cap above, which counts every connection including the
+          // authenticated ones a healthy client pool holds open.
+          final PreAuthConnectionGate.Ticket ticket = preAuthGate.accept();
+          if (ticket == null) {
+            preAuthGate.logRefusal(this, socket.getRemoteSocketAddress());
+            try {
+              socket.close();
+            } catch (final IOException e) {
+              // Ignore
+            }
+            continue;
+          }
+
           socket.setPerformancePreferences(0, 2, 1);
           socket.setTcpNoDelay(true);
 
@@ -94,9 +112,15 @@ public class BoltNetworkListener extends Thread {
           // blocking TLS handshake are performed on that thread, never here on the accept path, so a slow,
           // aborted or untrusted handshake can only affect its own connection and never wedges the shared
           // listener for other clients (issue #5106).
-          final BoltNetworkExecutor connection = new BoltNetworkExecutor(server, socket, this, sslHelper);
-          activeConnections.add(connection);
-          connection.start();
+          try {
+            final BoltNetworkExecutor connection = new BoltNetworkExecutor(server, socket, this, sslHelper, ticket);
+            activeConnections.add(connection);
+            connection.start();
+          } catch (final Exception e) {
+            // The executor never started, so nothing will hand the permit back for it.
+            ticket.release();
+            throw e;
+          }
 
         } catch (final Exception e) {
           if (active)

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1137,6 +1137,14 @@ public enum GlobalConfiguration {
 
   NETWORK_SOCKET_TIMEOUT("arcadedb.network.socketTimeout", SCOPE.SERVER, "TCP/IP Socket timeout (in ms)", Integer.class, 30000),
 
+  NETWORK_MAX_PREAUTH_CONNECTIONS("arcadedb.network.maxPreAuthConnections", SCOPE.SERVER, """
+      Maximum number of connections a binary wire-protocol listener (Postgres, Redis, BOLT) may hold in the phase
+      before authentication. Each accepted socket costs one thread and one file descriptor before the client has
+      proved who it is, and the handshake timeout (arcadedb.network.socketTimeout) only bounds how long each one
+      may stay there, not how many there can be. Past this cap the listener closes further connections
+      immediately and goes back to accepting. The cap is per listener, so a flood against one protocol cannot use
+      up the budget that lets clients of another log in. 0 means unlimited.""", Integer.class, 500),
+
   NETWORK_USE_SSL("arcadedb.ssl.enabled", SCOPE.SERVER, "Use SSL for client connections", Boolean.class, false),
 
   NETWORK_SSL_KEYSTORE("arcadedb.ssl.keyStore", SCOPE.SERVER, "Path where the SSL certificates are stored", String.class, null),

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -1,0 +1,1294 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Property;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Answers the {@code pg_catalog} and {@code information_schema} queries a PostgreSQL client sends to find out
+ * what is in the database it just connected to (issue #6412).
+ * <p>
+ * These used to be answered by string equality against the exact spelling one tool sends, several of them
+ * gated on {@code application_name} being literally {@code "dbvis"} - so the same question from DBeaver,
+ * pgAdmin, DataGrip or psql fell through and got nothing, and the tool showed an empty database. The gating
+ * was never about the tool: the queries are written by the JDBC driver those tools share, and what differs
+ * between them is spelling, not meaning.
+ * <p>
+ * So recognition here is by <b>shape</b>, and the answer is computed rather than canned:
+ * <ol>
+ * <li>the FROM clause says which emulated relations the query is about, and therefore which family of rows
+ * it is asking for - the schema list, the table list, the columns of a table;</li>
+ * <li>the rows of that family are built from ArcadeDB's own schema;</li>
+ * <li>the client's own projection is evaluated against each row, so the columns come back under the names
+ * the client asked for, in the order it asked for them, with its own {@code CASE} expressions applied - which
+ * is how one implementation answers {@code TABLE_TYPE} correctly for every driver that spells that CASE
+ * differently.</li>
+ * </ol>
+ * A shape outside this - an unmodelled catalog relation, a projection with a construct the expression
+ * evaluator does not implement - is <b>declined</b>, and the caller answers the empty result set that the
+ * rest of {@code pg_catalog} has always answered. Declining is deliberate: a made-up row in a system catalog
+ * is worse than no row, because the client believes it.
+ * <p>
+ * <b>The WHERE clause is the one place that is permissive</b>: a predicate the evaluator cannot read does not
+ * get to remove rows. Everything in this catalog is the user's own types in the one database this connection
+ * is bound to; there are no system schemas, no toast tables and no other databases' rows in it for an
+ * unreadable predicate to be excluding. So the predicates that survive unread ({@code nspname !~ '^pg_temp_'}
+ * and its kin) are ones whose whole purpose is to remove rows this catalog never produced, and reading them
+ * as "keeps everything" is not a guess - it is what they mean here. The predicates that do the work a client
+ * depends on, the name filters of {@code getTables} and {@code getColumns}, are read and applied.
+ * <p>
+ * <b>The schema model.</b> A PostgreSQL connection is bound to one database and sees the schemas inside it;
+ * an ArcadeDB connection is bound to one database whose types are its tables. So the emulated schema list is
+ * exactly one schema, named after the connected database - which is what {@code current_schema()} already
+ * answered - and every type is a table in it. The previous answers disagreed with each other and with that
+ * function: one arm reported every <i>type</i> as a schema, another reported every <i>database on the server</i>
+ * as one, which also told any authenticated user the names of databases they have no access to.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PostgresCatalog {
+  /** The OID PostgreSQL gives the {@code public} schema, reused for the one schema this catalog emulates. */
+  private static final int SCHEMA_OID = 2200;
+  /** PostgreSQL's own first user OID: everything below it is a system object. */
+  private static final int FIRST_USER_OID = 16384;
+  private static final int OID_SPACE      = 1_000_000;
+  /** The OID of the bootstrap superuser in a stock PostgreSQL, used for every "owner" column. */
+  private static final int OWNER_OID      = 10;
+
+  /**
+   * The answer to a catalog query: the columns to announce, in the order the client projected them, and the
+   * rows to send. {@link #DECLINED} is the third possible outcome, distinct from both "not a catalog query"
+   * (null) and "a catalog query with no matching rows" (an answer with an empty row list).
+   */
+  public static class Answer {
+    public final LinkedHashMap<String, PostgresType> columns;
+    public final List<Map<String, Object>>           rows;
+
+    private Answer(final LinkedHashMap<String, PostgresType> columns, final List<Map<String, Object>> rows) {
+      this.columns = columns;
+      this.rows = rows;
+    }
+  }
+
+  /** A catalog query whose shape this class will not answer. The caller sends an empty result set. */
+  public static final Answer DECLINED = new Answer(new LinkedHashMap<>(), null);
+
+  /** The families of rows a catalog query can be about. */
+  private enum Family {
+    SCHEMAS, TABLES, COLUMNS, DATABASES, ROLES, PRIVILEGES, CHARACTER_SETS, COLLATIONS, VIEWS
+  }
+
+  /**
+   * The emulated relations and the columns each one has. A column outside its relation's set makes the query
+   * unanswerable; a column inside it that this catalog does not model answers NULL, which is what PostgreSQL
+   * answers for most of them anyway.
+   */
+  private static final Map<String, Set<String>> RELATIONS = new HashMap<>();
+  /** Which family a relation puts the query in. Relations that only decorate a row are absent. */
+  private static final Map<String, Family>      FAMILIES  = new HashMap<>();
+
+  private static void relation(final String name, final Family family, final String... columns) {
+    RELATIONS.put(name, new LinkedHashSet<>(List.of(columns)));
+    if (family != null)
+      FAMILIES.put(name, family);
+  }
+
+  static {
+    relation("pg_namespace", Family.SCHEMAS, "oid", "nspname", "nspowner", "nspacl");
+    relation("information_schema.schemata", Family.SCHEMAS, "catalog_name", "schema_name", "schema_owner",
+        "default_character_set_catalog", "default_character_set_schema", "default_character_set_name", "sql_path");
+
+    relation("pg_class", Family.TABLES, "oid", "relname", "relnamespace", "reltype", "reloftype", "relowner", "relam",
+        "relfilenode", "reltablespace", "relpages", "reltuples", "relallvisible", "reltoastrelid", "relhasindex",
+        "relisshared", "relpersistence", "relkind", "relnatts", "relchecks", "relhasrules", "relhastriggers",
+        "relhassubclass", "relrowsecurity", "relforcerowsecurity", "relispopulated", "relreplident", "relispartition",
+        "relacl", "reloptions", "relhasoids");
+    relation("pg_tables", Family.TABLES, "schemaname", "tablename", "tableowner", "tablespace", "hasindexes",
+        "hasrules", "hastriggers", "rowsecurity");
+    relation("information_schema.tables", Family.TABLES, "table_catalog", "table_schema", "table_name", "table_type",
+        "self_referencing_column_name", "reference_generation", "user_defined_type_catalog", "user_defined_type_schema",
+        "user_defined_type_name", "is_insertable_into", "is_typed", "commit_action");
+
+    relation("pg_attribute", Family.COLUMNS, "attrelid", "attname", "atttypid", "attstattarget", "attlen", "attnum",
+        "attndims", "attcacheoff", "atttypmod", "attbyval", "attstorage", "attalign", "attnotnull", "atthasdef",
+        "atthasmissing", "attidentity", "attgenerated", "attisdropped", "attislocal", "attinhcount", "attcollation",
+        "attacl", "attoptions", "attfdwoptions");
+    relation("information_schema.columns", Family.COLUMNS, "table_catalog", "table_schema", "table_name", "column_name",
+        "ordinal_position", "column_default", "is_nullable", "data_type", "character_maximum_length",
+        "character_octet_length", "numeric_precision", "numeric_precision_radix", "numeric_scale", "datetime_precision",
+        "udt_catalog", "udt_schema", "udt_name", "is_identity", "identity_generation", "is_generated",
+        "generation_expression", "is_updatable");
+
+    relation("pg_database", Family.DATABASES, "oid", "datname", "datdba", "encoding", "datcollate", "datctype",
+        "datistemplate", "datallowconn", "datconnlimit", "dattablespace", "datacl");
+
+    relation("pg_roles", Family.ROLES, "oid", "rolname", "rolsuper", "rolinherit", "rolcreaterole", "rolcreatedb",
+        "rolcanlogin", "rolreplication", "rolconnlimit", "rolpassword", "rolvaliduntil", "rolbypassrls", "rolconfig");
+    relation("pg_user", Family.ROLES, "usename", "usesysid", "usecreatedb", "usesuper", "userepl", "usebypassrls",
+        "passwd", "valuntil", "useconfig");
+
+    relation("information_schema.usage_privileges", Family.PRIVILEGES, "grantor", "grantee", "object_catalog",
+        "object_schema", "object_name", "object_type", "privilege_type", "is_grantable");
+    relation("information_schema.character_sets", Family.CHARACTER_SETS, "character_set_catalog",
+        "character_set_schema", "character_set_name", "character_repertoire", "form_of_use",
+        "default_collate_catalog", "default_collate_schema", "default_collate_name");
+    relation("information_schema.collations", Family.COLLATIONS, "collation_catalog", "collation_schema",
+        "collation_name", "pad_attribute");
+    relation("pg_views", Family.VIEWS, "schemaname", "viewname", "viewowner", "definition");
+    relation("information_schema.views", Family.VIEWS, "table_catalog", "table_schema", "table_name", "view_definition",
+        "check_option", "is_updatable", "is_insertable_into");
+
+    // Decorating relations: they never decide the family, they only contribute columns to a row. Every one of
+    // them is something ArcadeDB has no equivalent of, so their columns are all NULL - which is exactly what a
+    // LEFT JOIN against them yields in PostgreSQL when there is no comment, no default and no inheritance.
+    relation("pg_description", null, "objoid", "classoid", "objsubid", "description");
+    relation("pg_attrdef", null, "oid", "adrelid", "adnum", "adbin", "adsrc");
+    relation("pg_type", null, "oid", "typname", "typnamespace", "typowner", "typlen", "typbyval", "typtype",
+        "typcategory", "typispreferred", "typisdefined", "typdelim", "typrelid", "typelem", "typarray", "typinput",
+        "typoutput", "typbasetype", "typtypmod", "typnotnull", "typndims", "typcollation", "typdefault");
+    relation("pg_collation", null, "oid", "collname", "collnamespace", "collowner", "collprovider", "collcollate",
+        "collctype");
+  }
+
+  private PostgresCatalog() {
+  }
+
+  /**
+   * A cheap pre-filter, so that an ordinary query pays a substring scan rather than a tokenizer pass. Every
+   * emulated relation is either under {@code information_schema} or named {@code pg_something}.
+   */
+  public static boolean mightBeCatalogQuery(final String query) {
+    return containsIgnoreCase(query, "pg_") || containsIgnoreCase(query, "information_schema");
+  }
+
+  static boolean containsIgnoreCase(final String text, final String search) {
+    final int limit = text.length() - search.length();
+    for (int i = 0; i <= limit; i++)
+      if (text.regionMatches(true, i, search, 0, search.length()))
+        return true;
+    return false;
+  }
+
+  /**
+   * Answers a catalog query.
+   *
+   * @param parameters the values bound to the query's {@code $n} placeholders, which the JDBC driver uses for
+   *                   every name pattern it filters by, so the filter cannot be applied without them
+   *
+   * @return null when the query is not about an emulated catalog relation and the caller must go on with its
+   * normal dispatch; {@link #DECLINED} when it is one but its shape cannot be answered honestly; otherwise
+   * the columns and rows to send.
+   */
+  public static Answer resolve(final String query, final Database database, final String userName,
+      final Object... parameters) {
+    if (query == null || database == null || !mightBeCatalogQuery(query))
+      return null;
+
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize(query);
+    if (tokens == null || tokens.isEmpty())
+      return null;
+
+    // A trailing statement terminator is not part of the statement.
+    while (!tokens.isEmpty() && tokens.get(tokens.size() - 1).isSymbol(";"))
+      tokens.remove(tokens.size() - 1);
+
+    substituteParameters(tokens, parameters);
+
+    return resolveStatement(tokens, new Context(database, userName));
+  }
+
+  /**
+   * Replaces every {@code $n} placeholder with the literal the client bound to it. The catalog is answered
+   * with the parameter values in hand rather than at Parse time, because the driver's table and column lists
+   * put their name filters in parameters: without this, {@code getColumns("Article")} would be answered with
+   * every column of every type.
+   */
+  private static void substituteParameters(final List<PostgresCatalogToken> tokens, final Object[] parameters) {
+    if (parameters == null || parameters.length == 0)
+      return;
+
+    for (int i = 0; i < tokens.size(); i++) {
+      final PostgresCatalogToken token = tokens.get(i);
+      if (token.type != PostgresCatalogToken.Type.SYMBOL || token.text.length() < 2 || token.text.charAt(0) != '$')
+        continue;
+
+      final int index;
+      try {
+        index = Integer.parseInt(token.text.substring(1));
+      } catch (final NumberFormatException e) {
+        continue;
+      }
+
+      if (index < 1 || index > parameters.length)
+        continue;
+
+      final PostgresCatalogToken literal = PostgresCatalogToken.literal(parameters[index - 1]);
+      if (literal != null)
+        tokens.set(i, literal);
+    }
+  }
+
+  private static Answer resolveStatement(final List<PostgresCatalogToken> tokens, final Context context) {
+    if (tokens.isEmpty() || !tokens.get(0).isKeyword("SELECT"))
+      // Not a SELECT at all: a WITH, an INSERT, something else entirely. If it names an emulated relation it
+      // is still a catalog query, and answering it is not this class's job either way.
+      return namesAnEmulatedRelation(tokens) ? DECLINED : null;
+
+    final Statement statement = Statement.split(tokens);
+    if (statement == null)
+      return namesAnEmulatedRelation(tokens) ? DECLINED : null;
+
+    final List<FromEntry> from = parseFrom(statement.from);
+    if (from == null || from.isEmpty())
+      return namesAnEmulatedRelation(tokens) ? DECLINED : null;
+
+    final Map<String, Collection<String>> columnsByRelation = new LinkedHashMap<>();
+    final List<Row> rows;
+
+    if (from.size() == 1 && from.get(0).derived != null) {
+      // A derived table: the inner SELECT is the catalog query and this one is a filter over its output. The
+      // JDBC driver's column list is written this way, so answering it means answering both levels.
+      final Answer inner = resolveStatement(from.get(0).derived, context);
+      if (inner == null || inner.rows == null)
+        return inner == null ? null : DECLINED;
+
+      final String name = from.get(0).alias == null ? "" : from.get(0).alias;
+      rows = new ArrayList<>(inner.rows.size());
+      for (final Map<String, Object> innerRow : inner.rows)
+        rows.add(new Row().withAll(name, innerRow));
+      columnsByRelation.put(name, inner.columns.keySet());
+      from.set(0, new FromEntry(name, null, from.get(0).alias, null));
+    } else {
+      Family family = null;
+      for (final FromEntry entry : from) {
+        if (entry.derived != null)
+          // A derived table joined to something else: more than one level of query planning, which is past
+          // what a catalog emulation should be pretending to do.
+          return DECLINED;
+
+        if (!RELATIONS.containsKey(entry.relation)) {
+          // A relation this catalog does not model. A type the user created is not one - even when its name
+          // starts with pg_ - so the query belongs to the SQL engine; a genuine PostgreSQL catalog relation
+          // is a catalog query that cannot be answered.
+          if (context.database().getSchema().existsType(entry.relation)
+              || (entry.writtenAs != null && context.database().getSchema().existsType(entry.writtenAs)))
+            return null;
+          return isCatalogRelationName(entry.relation) ? DECLINED : null;
+        }
+
+        // COLUMNS wins over TABLES wins over SCHEMAS: a query joining pg_class to pg_attribute is asking about
+        // the columns, and the rows it wants are one per column rather than one per table.
+        final Family entryFamily = FAMILIES.get(entry.relation);
+        if (entryFamily != null)
+          family = mostSpecific(family, entryFamily);
+
+        columnsByRelation.put(entry.relation, RELATIONS.get(entry.relation));
+      }
+
+      if (family == null)
+        return DECLINED;
+
+      rows = buildRows(family, context);
+    }
+
+    return project(statement, from, rows, context, columnsByRelation);
+  }
+
+  private static Family mostSpecific(final Family current, final Family candidate) {
+    if (current == null)
+      return candidate;
+    if (current == candidate)
+      return current;
+    // The families that can legitimately appear together in one query are the three that describe the same
+    // hierarchy; the most detailed one is what the query is about.
+    if (rank(candidate) > rank(current))
+      return candidate;
+    return current;
+  }
+
+  private static int rank(final Family family) {
+    return switch (family) {
+      case SCHEMAS -> 1;
+      case TABLES, VIEWS -> 2;
+      case COLUMNS -> 3;
+      default -> 0;
+    };
+  }
+
+  private static boolean isCatalogRelationName(final String relation) {
+    return relation.startsWith("pg_") || relation.startsWith("information_schema.");
+  }
+
+  /**
+   * Whether the statement names one of the relations this catalog models, which is what makes a statement it
+   * cannot otherwise read a catalog query rather than an ordinary one. The test is against the modelled names
+   * exactly: a type the user called {@code pg_notes} is their table, and swallowing statements about it -
+   * which a "starts with pg_" test would do, to the DDL that creates it as much as to the queries that read
+   * it - would make part of the user's own schema unusable.
+   */
+  private static boolean namesAnEmulatedRelation(final List<PostgresCatalogToken> tokens) {
+    for (int i = 0; i < tokens.size(); i++) {
+      final PostgresCatalogToken token = tokens.get(i);
+      if (token.type != PostgresCatalogToken.Type.IDENTIFIER)
+        continue;
+
+      String name = token.text.toLowerCase(Locale.ENGLISH);
+      if (i + 2 < tokens.size() && tokens.get(i + 1).isSymbol(".")
+          && tokens.get(i + 2).type == PostgresCatalogToken.Type.IDENTIFIER) {
+        final String qualified = name + "." + tokens.get(i + 2).text.toLowerCase(Locale.ENGLISH);
+        if (qualified.startsWith("pg_catalog."))
+          name = qualified.substring("pg_catalog.".length());
+        else
+          name = qualified;
+      }
+
+      if (RELATIONS.containsKey(name))
+        return true;
+    }
+    return false;
+  }
+
+  // ---------------------------------------------------------------- statement structure
+
+  /** The clauses of a SELECT, as token ranges. */
+  private static class Statement {
+    boolean                    distinct;
+    List<PostgresCatalogToken> projection;
+    List<PostgresCatalogToken> from;
+    List<PostgresCatalogToken> where;
+    List<PostgresCatalogToken> orderBy;
+    Integer                    limit;
+
+    /**
+     * Splits a token list at the top-level clause keywords. Returns null for anything with a shape this class
+     * does not read: a set operation, a GROUP BY, a sub-select in place of a FROM item.
+     */
+    static Statement split(final List<PostgresCatalogToken> tokens) {
+      final Statement statement = new Statement();
+      int i = 1; // past SELECT
+
+      if (i < tokens.size() && tokens.get(i).isKeyword("DISTINCT")) {
+        ++i;
+        if (i < tokens.size() && tokens.get(i).isKeyword("ON"))
+          return null;
+        statement.distinct = true;
+      } else if (i < tokens.size() && tokens.get(i).isKeyword("ALL"))
+        ++i;
+
+      final int projectionStart = i;
+      int depth = 0;
+      int fromStart = -1;
+
+      for (; i < tokens.size(); i++) {
+        final PostgresCatalogToken token = tokens.get(i);
+        if (token.isSymbol("(") || token.isSymbol("["))
+          ++depth;
+        else if (token.isSymbol(")") || token.isSymbol("]"))
+          --depth;
+        else if (depth == 0 && token.isKeyword("FROM")) {
+          fromStart = i + 1;
+          break;
+        }
+      }
+
+      if (fromStart < 0)
+        return null;
+
+      statement.projection = new ArrayList<>(tokens.subList(projectionStart, fromStart - 1));
+      if (statement.projection.isEmpty())
+        return null;
+
+      int end = tokens.size();
+      int whereStart = -1;
+      int orderStart = -1;
+      int limitStart = -1;
+      depth = 0;
+
+      for (i = fromStart; i < tokens.size(); i++) {
+        final PostgresCatalogToken token = tokens.get(i);
+        if (token.isSymbol("(") || token.isSymbol("["))
+          ++depth;
+        else if (token.isSymbol(")") || token.isSymbol("]"))
+          --depth;
+        else if (depth == 0) {
+          if (token.isKeyword("UNION") || token.isKeyword("INTERSECT") || token.isKeyword("EXCEPT")
+              || token.isKeyword("HAVING") || token.isKeyword("GROUP") || token.isKeyword("WINDOW")
+              || token.isKeyword("FETCH") || token.isKeyword("OFFSET"))
+            return null;
+          if (token.isKeyword("WHERE") && whereStart < 0 && orderStart < 0)
+            whereStart = i + 1;
+          else if (token.isKeyword("ORDER") && orderStart < 0) {
+            if (i + 1 >= tokens.size() || !tokens.get(i + 1).isKeyword("BY"))
+              return null;
+            orderStart = i + 2;
+          } else if (token.isKeyword("LIMIT") && limitStart < 0)
+            limitStart = i + 1;
+        }
+      }
+
+      if (limitStart > 0) {
+        if (limitStart >= tokens.size())
+          return null;
+        final PostgresCatalogToken limitToken = tokens.get(limitStart);
+        if (limitToken.type != PostgresCatalogToken.Type.NUMBER)
+          return null;
+        try {
+          statement.limit = Integer.valueOf(limitToken.text);
+        } catch (final NumberFormatException e) {
+          return null;
+        }
+        end = Math.min(end, limitStart - 1);
+      }
+
+      if (orderStart > 0) {
+        statement.orderBy = new ArrayList<>(tokens.subList(orderStart, end));
+        end = Math.min(end, orderStart - 2);
+      }
+
+      if (whereStart > 0) {
+        statement.where = new ArrayList<>(tokens.subList(whereStart, end));
+        end = Math.min(end, whereStart - 1);
+      }
+
+      statement.from = new ArrayList<>(tokens.subList(fromStart, end));
+      return statement.from.isEmpty() ? null : statement;
+    }
+  }
+
+  /** One item of the FROM clause: an emulated relation, or a derived table with the tokens of its SELECT. */
+  private static class FromEntry {
+    final String                     relation;
+    /** The name as the client wrote it, which is what a case-sensitive type lookup has to be given. */
+    final String                     writtenAs;
+    final String                     alias;
+    final List<PostgresCatalogToken> derived;
+
+    FromEntry(final String relation, final String writtenAs, final String alias,
+        final List<PostgresCatalogToken> derived) {
+      this.relation = relation;
+      this.writtenAs = writtenAs;
+      this.alias = alias;
+      this.derived = derived;
+    }
+  }
+
+  /**
+   * Reads the relations out of a FROM clause: comma-separated items and explicit JOINs alike. The join
+   * conditions themselves are skipped rather than evaluated - every emulated row already carries the columns
+   * of every relation it can be joined to, so the join is satisfied by construction.
+   */
+  private static List<FromEntry> parseFrom(final List<PostgresCatalogToken> tokens) {
+    final List<FromEntry> entries = new ArrayList<>();
+    int i = 0;
+
+    while (i < tokens.size()) {
+      // Join decorations before the relation name.
+      while (i < tokens.size() && isJoinWord(tokens.get(i)))
+        ++i;
+
+      if (i >= tokens.size())
+        return entries.isEmpty() ? null : entries;
+
+      final PostgresCatalogToken token = tokens.get(i);
+
+      if (token.isSymbol("(")) {
+        // A derived table: read the parenthesised SELECT whole and hand it back for its own resolution.
+        int depth = 0;
+        final int start = i + 1;
+        while (i < tokens.size()) {
+          if (tokens.get(i).isSymbol("("))
+            ++depth;
+          else if (tokens.get(i).isSymbol(")")) {
+            --depth;
+            if (depth == 0)
+              break;
+          }
+          ++i;
+        }
+        if (depth != 0 || i >= tokens.size())
+          return null;
+
+        final List<PostgresCatalogToken> derived = new ArrayList<>(tokens.subList(start, i));
+        ++i; // past ")"
+
+        String derivedAlias = null;
+        if (i < tokens.size() && tokens.get(i).isKeyword("AS"))
+          ++i;
+        if (i < tokens.size() && (tokens.get(i).type == PostgresCatalogToken.Type.IDENTIFIER
+            || tokens.get(i).type == PostgresCatalogToken.Type.QUOTED_IDENTIFIER) && !isStructuralWord(tokens.get(i))) {
+          derivedAlias = tokens.get(i).text.toLowerCase(Locale.ENGLISH);
+          ++i;
+        }
+
+        entries.add(new FromEntry(derivedAlias == null ? "" : derivedAlias, null, derivedAlias, derived));
+
+        if (i < tokens.size() && tokens.get(i).isSymbol(","))
+          ++i;
+        continue;
+      }
+
+      if (token.type != PostgresCatalogToken.Type.IDENTIFIER && token.type != PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
+        // A function call, a VALUES list: not a shape this catalog reads.
+        return null;
+
+      final StringBuilder relation = new StringBuilder(token.text.toLowerCase(Locale.ENGLISH));
+      final StringBuilder written = new StringBuilder(token.text);
+      ++i;
+      while (i + 1 < tokens.size() && tokens.get(i).isSymbol(".")) {
+        final PostgresCatalogToken part = tokens.get(i + 1);
+        if (part.type != PostgresCatalogToken.Type.IDENTIFIER && part.type != PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
+          return null;
+        relation.append('.').append(part.text.toLowerCase(Locale.ENGLISH));
+        written.setLength(0);
+        written.append(part.text);
+        i += 2;
+      }
+
+      String name = relation.toString();
+      // pg_catalog is the schema every pg_ relation lives in, and naming it changes nothing.
+      if (name.startsWith("pg_catalog."))
+        name = name.substring("pg_catalog.".length());
+
+      String alias = null;
+      if (i < tokens.size() && tokens.get(i).isKeyword("AS")) {
+        ++i;
+        if (i >= tokens.size())
+          return null;
+        alias = tokens.get(i).text.toLowerCase(Locale.ENGLISH);
+        ++i;
+      } else if (i < tokens.size() && (tokens.get(i).type == PostgresCatalogToken.Type.IDENTIFIER
+          || tokens.get(i).type == PostgresCatalogToken.Type.QUOTED_IDENTIFIER) && !isStructuralWord(tokens.get(i))) {
+        alias = tokens.get(i).text.toLowerCase(Locale.ENGLISH);
+        ++i;
+      }
+
+      entries.add(new FromEntry(name, written.toString(), alias, null));
+
+      // Skip an ON or USING condition, up to the next comma or join at this level.
+      if (i < tokens.size() && (tokens.get(i).isKeyword("ON") || tokens.get(i).isKeyword("USING"))) {
+        int depth = 0;
+        ++i;
+        while (i < tokens.size()) {
+          final PostgresCatalogToken t = tokens.get(i);
+          if (t.isSymbol("(") || t.isSymbol("["))
+            ++depth;
+          else if (t.isSymbol(")") || t.isSymbol("]"))
+            --depth;
+          else if (depth == 0 && (t.isSymbol(",") || isJoinWord(t)))
+            break;
+          ++i;
+        }
+      }
+
+      if (i < tokens.size() && tokens.get(i).isSymbol(","))
+        ++i;
+    }
+
+    return entries.isEmpty() ? null : entries;
+  }
+
+  private static boolean isJoinWord(final PostgresCatalogToken token) {
+    return token.isKeyword("JOIN") || token.isKeyword("LEFT") || token.isKeyword("RIGHT") || token.isKeyword("FULL")
+        || token.isKeyword("INNER") || token.isKeyword("OUTER") || token.isKeyword("CROSS") || token.isKeyword("NATURAL");
+  }
+
+  private static boolean isStructuralWord(final PostgresCatalogToken token) {
+    return isJoinWord(token) || token.isKeyword("ON") || token.isKeyword("USING") || token.isKeyword("WHERE")
+        || token.isKeyword("ORDER") || token.isKeyword("GROUP") || token.isKeyword("LIMIT") || token.isKeyword("AS");
+  }
+
+  // ---------------------------------------------------------------- rows
+
+  /** What the emulated catalog is a view of: one database, seen by one authenticated user. */
+  private record Context(Database database, String userName) {
+    String schema() {
+      return database.getName();
+    }
+  }
+
+  /** One emulated catalog row, holding the columns of every relation the query could have joined. */
+  private static class Row {
+    final Map<String, Map<String, Object>> relations = new HashMap<>();
+
+    Map<String, Object> of(final String relation) {
+      return relations.computeIfAbsent(relation, name -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+    }
+
+    Row with(final String relation, final Object... namesAndValues) {
+      final Map<String, Object> columns = of(relation);
+      for (int i = 0; i < namesAndValues.length; i += 2)
+        columns.put((String) namesAndValues[i], namesAndValues[i + 1]);
+      return this;
+    }
+
+    /** Adopts an already-projected row of a derived table as this row's only relation. */
+    Row withAll(final String relation, final Map<String, Object> values) {
+      of(relation).putAll(values);
+      return this;
+    }
+
+    /**
+     * Every column of every emulated relation that this row does not explicitly set answers NULL rather than
+     * "no such column", so a query joining a relation whose content ArcadeDB has no equivalent of - comments,
+     * defaults, collations - gets the empty answer PostgreSQL's own LEFT JOIN would give it.
+     */
+    Row complete() {
+      for (final Map.Entry<String, Set<String>> relation : RELATIONS.entrySet()) {
+        final Map<String, Object> columns = of(relation.getKey());
+        for (final String column : relation.getValue())
+          columns.putIfAbsent(column, null);
+      }
+      return this;
+    }
+  }
+
+  private static List<Row> buildRows(final Family family, final Context context) {
+    return switch (family) {
+      case SCHEMAS -> List.of(schemaRow(context).complete());
+      case TABLES -> tableRows(context);
+      case COLUMNS -> columnRows(context);
+      case DATABASES -> List.of(databaseRow(context).complete());
+      case ROLES -> List.of(roleRow(context).complete());
+      case PRIVILEGES -> List.of(privilegeRow(context).complete());
+      case CHARACTER_SETS -> List.of(characterSetRow(context).complete());
+      case COLLATIONS -> List.of(collationRow(context).complete());
+      // ArcadeDB has no relation that a PostgreSQL client would render as a view.
+      case VIEWS -> List.of();
+    };
+  }
+
+  private static Row schemaRow(final Context context) {
+    final String schema = context.schema();
+    return new Row()//
+        .with("pg_namespace", "oid", SCHEMA_OID, "nspname", schema, "nspowner", OWNER_OID)//
+        .with("information_schema.schemata", "catalog_name", schema, "schema_name", schema, "schema_owner",
+            context.userName());
+  }
+
+  private static List<Row> tableRows(final Context context) {
+    final List<DocumentType> types = sortedTypes(context);
+    final List<Row> rows = new ArrayList<>(types.size());
+
+    for (final DocumentType type : types)
+      rows.add(tableRow(context, type).complete());
+
+    return rows;
+  }
+
+  private static Row tableRow(final Context context, final DocumentType type) {
+    final String schema = context.schema();
+    final int oid = oidOf(type.getName());
+
+    return schemaRow(context)//
+        .with("pg_class", "oid", oid, "relname", type.getName(), "relnamespace", SCHEMA_OID, "relowner", OWNER_OID,//
+            "relkind", "r", "relpersistence", "p", "relnatts", type.getPropertyNames().size(),//
+            "relhasindex", !type.getAllIndexes(false).isEmpty(), "relhasrules", Boolean.FALSE,//
+            "relhastriggers", Boolean.FALSE, "relhassubclass", !type.getSubTypes().isEmpty(),//
+            "relispartition", Boolean.FALSE, "relisshared", Boolean.FALSE, "relispopulated", Boolean.TRUE,//
+            "relrowsecurity", Boolean.FALSE, "relforcerowsecurity", Boolean.FALSE, "relchecks", 0,//
+            // -1 is PostgreSQL's own "never analysed, count unknown", which is honest here: counting the
+            // records of every type to answer a table list would turn a metadata query into a full scan.
+            "reltuples", -1, "relpages", 0, "relam", 0, "reltype", 0, "relfilenode", oid, "reltablespace", 0)//
+        .with("pg_tables", "schemaname", schema, "tablename", type.getName(), "tableowner", context.userName(),//
+            "hasindexes", !type.getAllIndexes(false).isEmpty(), "hasrules", Boolean.FALSE, "hastriggers", Boolean.FALSE,//
+            "rowsecurity", Boolean.FALSE)//
+        .with("information_schema.tables", "table_catalog", schema, "table_schema", schema, "table_name",
+            type.getName(), "table_type", "BASE TABLE", "is_insertable_into", "YES", "is_typed", "NO");
+  }
+
+  private static List<Row> columnRows(final Context context) {
+    final String schema = context.schema();
+    final List<Row> rows = new ArrayList<>();
+
+    for (final DocumentType type : sortedTypes(context)) {
+      int ordinal = 0;
+      for (final Property property : sortedProperties(type)) {
+        ++ordinal;
+        final PostgresType pgType = PostgresType.getTypeFromArcade(property.getType(), property.getOfType());
+        final Object defaultValue = property.getDefaultValueDefinition();
+        final boolean notNull = property.isNotNull() || property.isMandatory();
+
+        final Row row = tableRow(context, type)//
+            .with("pg_attribute", "attrelid", oidOf(type.getName()), "attname", property.getName(), "attnum", ordinal,//
+                "atttypid", pgType.code, "attlen", pgType.size, "atttypmod", -1, "attnotnull", notNull,//
+                "atthasdef", defaultValue != null, "attisdropped", Boolean.FALSE, "attislocal", Boolean.TRUE,//
+                "attinhcount", 0, "attndims", pgType.isArrayType() ? 1 : 0, "attcollation", 0, "attstattarget", -1,//
+                "attidentity", "", "attgenerated", "", "atthasmissing", Boolean.FALSE, "attbyval",
+                pgType.size > 0 && pgType.size <= 8, "attstorage", "p", "attalign", "i")//
+            .with("information_schema.columns", "table_catalog", schema, "table_schema", schema, "table_name",
+                type.getName(), "column_name", property.getName(), "ordinal_position", ordinal,//
+                "column_default", defaultValue == null ? null : defaultValue.toString(),//
+                "is_nullable", notNull ? "NO" : "YES", "data_type", pgType.typeName, "udt_catalog", schema,//
+                "udt_schema", "pg_catalog", "udt_name", pgType.typeName, "is_identity", "NO", "is_generated", "NEVER",//
+                "is_updatable", "YES", "numeric_precision_radix", pgType.isNativeScalarType() ? 2 : null);
+
+        // The type row a client joins pg_attribute to in order to name the column's type. It describes the
+        // column's own type, which is the only reading of that join that makes sense.
+        final Map<String, Object> typeColumns = row.of("pg_type");
+        for (final String column : PostgresTypeCatalog.COLUMNS)
+          typeColumns.put(column, PostgresTypeCatalog.columnValue(pgType, column));
+        typeColumns.put("typnamespace", 11);
+
+        rows.add(row.complete());
+      }
+    }
+
+    return rows;
+  }
+
+  private static Row databaseRow(final Context context) {
+    return new Row().with("pg_database", "oid", FIRST_USER_OID, "datname", context.schema(), "datdba", OWNER_OID,//
+        // 6 is UTF8 in PostgreSQL's pg_encoding table, which is the only encoding this protocol speaks.
+        "encoding", 6, "datcollate", "C", "datctype", "C", "datistemplate", Boolean.FALSE, "datallowconn", Boolean.TRUE,//
+        "datconnlimit", -1, "dattablespace", 0);
+  }
+
+  private static Row roleRow(final Context context) {
+    // Only the connected user: enumerating the server's accounts is not something an emulated catalog should
+    // hand out, and no client needs it to browse the database it is connected to.
+    return new Row()//
+        .with("pg_roles", "oid", OWNER_OID, "rolname", context.userName(), "rolsuper", Boolean.FALSE, "rolinherit",
+            Boolean.TRUE, "rolcreaterole", Boolean.FALSE, "rolcreatedb", Boolean.FALSE, "rolcanlogin", Boolean.TRUE,//
+            "rolreplication", Boolean.FALSE, "rolconnlimit", -1, "rolbypassrls", Boolean.FALSE)//
+        .with("pg_user", "usename", context.userName(), "usesysid", OWNER_OID, "usecreatedb", Boolean.FALSE,//
+            "usesuper", Boolean.FALSE, "userepl", Boolean.FALSE, "usebypassrls", Boolean.FALSE);
+  }
+
+  private static Row privilegeRow(final Context context) {
+    final String schema = context.schema();
+    return new Row().with("information_schema.usage_privileges", "grantor", context.userName(), "grantee",
+        context.userName(), "object_catalog", schema, "object_schema", schema, "object_name", schema, "object_type",
+        "SCHEMA", "privilege_type", "USAGE", "is_grantable", "NO");
+  }
+
+  private static Row characterSetRow(final Context context) {
+    return new Row().with("information_schema.character_sets", "character_set_catalog", null, "character_set_schema",
+        null, "character_set_name", "UTF8", "character_repertoire", "UCS", "form_of_use", "UTF8",
+        "default_collate_catalog", context.schema(), "default_collate_schema", "pg_catalog", "default_collate_name",
+        "default");
+  }
+
+  private static Row collationRow(final Context context) {
+    return new Row().with("information_schema.collations", "collation_catalog", context.schema(), "collation_schema",
+        "pg_catalog", "collation_name", "default", "pad_attribute", "NO PAD");
+  }
+
+  private static List<DocumentType> sortedTypes(final Context context) {
+    final List<DocumentType> types = new ArrayList<>(context.database().getSchema().getTypes());
+    types.sort(Comparator.comparing(DocumentType::getName));
+    return types;
+  }
+
+  /**
+   * The properties of a type, super-type properties included and in a stable order, so that a column's
+   * ordinal position does not depend on the order a hash set happens to iterate in.
+   */
+  private static List<Property> sortedProperties(final DocumentType type) {
+    final List<Property> properties = new ArrayList<>();
+    for (final Property property : type.getPolymorphicProperties())
+      if (!property.isHidden())
+        properties.add(property);
+    properties.sort(Comparator.comparing(Property::getName));
+    return properties;
+  }
+
+  /**
+   * A stable OID for a type. PostgreSQL hands a client an OID and expects to be asked about it again - the
+   * table list gives {@code pg_class.oid}, the column list asks for {@code attrelid = <that oid>} - so what
+   * matters is that the same name yields the same number for the life of the schema, not which number.
+   * Deriving it from the name rather than from a position keeps it stable when another type is created.
+   */
+  private static int oidOf(final String typeName) {
+    return FIRST_USER_OID + Math.floorMod(typeName.hashCode(), OID_SPACE);
+  }
+
+  // ---------------------------------------------------------------- projection
+
+  private static Answer project(final Statement statement, final List<FromEntry> from, final List<Row> rows,
+      final Context context, final Map<String, Collection<String>> columnsByRelation) {
+    final List<ProjectionItem> projection = parseProjection(statement.projection, from, columnsByRelation);
+    if (projection == null)
+      return DECLINED;
+
+    // A predicate that will not parse as a whole leaves the rows as they are - see the class comment on why
+    // an unreadable filter does not get to empty an answer whose every row is one of the user's own types.
+    final PostgresCatalogExpression where = statement.where == null ? null :
+        PostgresCatalogExpression.parse(statement.where);
+
+    final List<Row> surviving = new ArrayList<>(rows.size());
+    for (final Row row : rows)
+      if (where == null || PostgresCatalogExpression.isTrue(where.evaluate(new RowResolver(row, from, context, null, 0))))
+        surviving.add(row);
+
+    // Window functions are the one thing that cannot be computed a row at a time: row_number() is defined by
+    // the other rows of its partition. They are computed here, over the rows that survived the filter.
+    final Map<PostgresCatalogExpression.WindowCall, Object[]> windows = computeWindows(projection, surviving, from,
+        context);
+    if (windows == null)
+      return DECLINED;
+
+    final List<Map<String, Object>> answered = new ArrayList<>(surviving.size());
+    for (int i = 0; i < surviving.size(); i++) {
+      final RowResolver resolver = new RowResolver(surviving.get(i), from, context, windows, i);
+
+      final Map<String, Object> projected = new LinkedHashMap<>(projection.size());
+      for (final ProjectionItem item : projection) {
+        final Object value = item.expression.evaluate(resolver);
+        if (value == PostgresCatalogExpression.UNKNOWN)
+          // A projected column this catalog cannot compute: answering the rest of the row would be answering
+          // a different question from the one asked.
+          return DECLINED;
+        projected.put(item.alias, value);
+      }
+
+      answered.add(projected);
+    }
+
+    // With no rows to project - an empty database, or a filter that matched nothing - the projection was
+    // never evaluated, so a column this catalog cannot produce would go unnoticed and the client would be
+    // told the query succeeded. Evaluate it once against an all-null row of the same shape to find out.
+    if (answered.isEmpty()) {
+      final RowResolver probe = new RowResolver(probeRow(from, columnsByRelation), from, context, windows, 0);
+      for (final ProjectionItem item : projection)
+        if (item.expression.evaluate(probe) == PostgresCatalogExpression.UNKNOWN)
+          return DECLINED;
+    }
+
+    List<Map<String, Object>> result = answered;
+
+    if (statement.distinct) {
+      final List<Map<String, Object>> distinct = new ArrayList<>(result.size());
+      final Set<List<Object>> seen = new LinkedHashSet<>();
+      for (final Map<String, Object> row : result)
+        if (seen.add(new ArrayList<>(row.values())))
+          distinct.add(row);
+      result = distinct;
+    }
+
+    if (statement.orderBy != null)
+      result = sort(statement.orderBy, result);
+
+    if (statement.limit != null && result.size() > statement.limit)
+      result = new ArrayList<>(result.subList(0, statement.limit));
+
+    return new Answer(columnsOf(projection, result), result);
+  }
+
+  /** An all-null row carrying every column the query's relations have, used to validate a projection. */
+  private static Row probeRow(final List<FromEntry> from, final Map<String, Collection<String>> columnsByRelation) {
+    final Row row = new Row();
+    for (final FromEntry entry : from) {
+      final Map<String, Object> columns = row.of(entry.relation);
+      final Collection<String> known = columnsByRelation.get(entry.relation);
+      if (known != null)
+        for (final String column : known)
+          columns.put(column, null);
+    }
+    return row.complete();
+  }
+
+  /**
+   * Computes each window function's value for every row, before any row is projected.
+   *
+   * @return the values per window call, or null when one of them is a function whose meaning this catalog
+   * does not know - in which case the query is declined rather than answered with a number that looks right
+   */
+  private static Map<PostgresCatalogExpression.WindowCall, Object[]> computeWindows(
+      final List<ProjectionItem> projection, final List<Row> rows, final List<FromEntry> from,
+      final Context context) {
+    Map<PostgresCatalogExpression.WindowCall, Object[]> windows = null;
+
+    for (final ProjectionItem item : projection) {
+      if (!(item.expression instanceof PostgresCatalogExpression.WindowCall call))
+        continue;
+
+      if (!"row_number".equals(call.name))
+        return null;
+
+      final Object[] values = new Object[rows.size()];
+      final Map<List<Object>, List<Integer>> partitions = new LinkedHashMap<>();
+
+      for (int i = 0; i < rows.size(); i++) {
+        final RowResolver resolver = new RowResolver(rows.get(i), from, context, null, i);
+        final List<Object> key = new ArrayList<>(call.partitionBy.size());
+        for (final PostgresCatalogExpression expression : call.partitionBy) {
+          final Object value = expression.evaluate(resolver);
+          if (value == PostgresCatalogExpression.UNKNOWN)
+            return null;
+          key.add(value);
+        }
+        partitions.computeIfAbsent(key, k -> new ArrayList<>()).add(i);
+      }
+
+      for (final List<Integer> partition : partitions.values()) {
+        if (!call.orderBy.isEmpty()) {
+          final Map<Integer, List<Object>> keys = new LinkedHashMap<>();
+          for (final Integer index : partition) {
+            final RowResolver resolver = new RowResolver(rows.get(index), from, context, null, index);
+            final List<Object> key = new ArrayList<>(call.orderBy.size());
+            for (final PostgresCatalogExpression expression : call.orderBy)
+              key.add(expression.evaluate(resolver));
+            keys.put(index, key);
+          }
+          partition.sort((left, right) -> {
+            final List<Object> l = keys.get(left);
+            final List<Object> r = keys.get(right);
+            for (int i = 0; i < l.size(); i++) {
+              final int comparison = compareValues(l.get(i), r.get(i));
+              if (comparison != 0)
+                return comparison;
+            }
+            return 0;
+          });
+        }
+
+        long number = 0;
+        for (final Integer index : partition)
+          values[index] = ++number;
+      }
+
+      if (windows == null)
+        windows = new LinkedHashMap<>();
+      windows.put(call, values);
+    }
+
+    return windows == null ? Map.of() : windows;
+  }
+
+  /**
+   * The columns to announce. The type comes from the first value that is not null, exactly as the executor
+   * types a column from a sample row; a column that is null in every row is a varchar, which is what an
+   * all-null column has always been announced as.
+   */
+  private static LinkedHashMap<String, PostgresType> columnsOf(final List<ProjectionItem> projection,
+      final List<Map<String, Object>> rows) {
+    final LinkedHashMap<String, PostgresType> columns = new LinkedHashMap<>(projection.size());
+    for (final ProjectionItem item : projection) {
+      PostgresType type = PostgresType.VARCHAR;
+      for (final Map<String, Object> row : rows) {
+        final Object value = row.get(item.alias);
+        if (value != null) {
+          final PostgresType sampled = PostgresType.getTypeForValue(value);
+          type = sampled.isArrayType() || sampled.isNativeScalarType() ? sampled : PostgresType.VARCHAR;
+          break;
+        }
+      }
+      columns.put(item.alias, type);
+    }
+    return columns;
+  }
+
+  /**
+   * Sorts the projected rows. ORDER BY items may name a projected alias, an ordinal position or a source
+   * column; an item that resolves to none of those leaves the rows in the order the catalog built them,
+   * which is by name, rather than declining a query whose data is perfectly answerable.
+   */
+  private static List<Map<String, Object>> sort(final List<PostgresCatalogToken> orderBy,
+      final List<Map<String, Object>> projected) {
+    final List<List<PostgresCatalogToken>> items = splitTopLevel(orderBy);
+    if (items == null || items.isEmpty())
+      return projected;
+
+    final List<Integer> keys = new ArrayList<>(items.size());
+    final List<Boolean> descending = new ArrayList<>(items.size());
+    final List<String> aliases = new ArrayList<>(projected.isEmpty() ? List.of() : projected.get(0).keySet());
+
+    for (final List<PostgresCatalogToken> item : items) {
+      if (item.isEmpty())
+        return projected;
+
+      final List<PostgresCatalogToken> key = new ArrayList<>(item);
+      boolean desc = false;
+      while (!key.isEmpty()) {
+        final PostgresCatalogToken last = key.get(key.size() - 1);
+        if (last.isKeyword("ASC") || last.isKeyword("DESC") || last.isKeyword("NULLS") || last.isKeyword("FIRST")
+            || last.isKeyword("LAST")) {
+          desc |= last.isKeyword("DESC");
+          key.remove(key.size() - 1);
+        } else
+          break;
+      }
+
+      if (key.size() != 1)
+        return projected;
+
+      final PostgresCatalogToken token = key.get(0);
+      int index = -1;
+      if (token.type == PostgresCatalogToken.Type.NUMBER) {
+        try {
+          index = Integer.parseInt(token.text) - 1;
+        } catch (final NumberFormatException e) {
+          return projected;
+        }
+      } else {
+        for (int i = 0; i < aliases.size(); i++)
+          if (aliases.get(i).equalsIgnoreCase(token.text)) {
+            index = i;
+            break;
+          }
+      }
+
+      if (index < 0 || index >= aliases.size())
+        return projected;
+
+      keys.add(index);
+      descending.add(desc);
+    }
+
+    final List<Map<String, Object>> sorted = new ArrayList<>(projected);
+    sorted.sort((left, right) -> {
+      for (int i = 0; i < keys.size(); i++) {
+        final String alias = aliases.get(keys.get(i));
+        final int comparison = compareValues(left.get(alias), right.get(alias));
+        if (comparison != 0)
+          return descending.get(i) ? -comparison : comparison;
+      }
+      return 0;
+    });
+    return sorted;
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static int compareValues(final Object left, final Object right) {
+    if (left == null && right == null)
+      return 0;
+    // PostgreSQL sorts nulls last by default in ascending order.
+    if (left == null)
+      return 1;
+    if (right == null)
+      return -1;
+    if (left instanceof Number l && right instanceof Number r)
+      return Double.compare(l.doubleValue(), r.doubleValue());
+    if (left instanceof Comparable && left.getClass() == right.getClass())
+      return ((Comparable) left).compareTo(right);
+    return String.valueOf(left).compareTo(String.valueOf(right));
+  }
+
+  /** One projected expression and the name its column must be announced under. */
+  private static class ProjectionItem {
+    final PostgresCatalogExpression expression;
+    final String                    alias;
+
+    ProjectionItem(final PostgresCatalogExpression expression, final String alias) {
+      this.expression = expression;
+      this.alias = alias;
+    }
+  }
+
+  private static List<ProjectionItem> parseProjection(final List<PostgresCatalogToken> tokens,
+      final List<FromEntry> from, final Map<String, Collection<String>> columnsByRelation) {
+    final List<List<PostgresCatalogToken>> items = splitTopLevel(tokens);
+    if (items == null || items.isEmpty())
+      return null;
+
+    final List<ProjectionItem> projection = new ArrayList<>(items.size());
+
+    for (final List<PostgresCatalogToken> item : items) {
+      if (item.isEmpty())
+        return null;
+
+      // "*" and "alias.*" expand to the columns of the relations they name.
+      if (item.size() == 1 && item.get(0).isSymbol("*")) {
+        for (final FromEntry entry : from)
+          for (final String column : columnsByRelation.getOrDefault(entry.relation, List.of()))
+            projection.add(new ProjectionItem(new PostgresCatalogExpression.ColumnReference(entry.alias, column), column));
+        continue;
+      }
+      if (item.size() == 3 && item.get(1).isSymbol(".") && item.get(2).isSymbol("*")) {
+        final String qualifier = item.get(0).text.toLowerCase(Locale.ENGLISH);
+        final FromEntry entry = entryFor(from, qualifier);
+        if (entry == null)
+          return null;
+        for (final String column : columnsByRelation.getOrDefault(entry.relation, List.of()))
+          projection.add(new ProjectionItem(new PostgresCatalogExpression.ColumnReference(qualifier, column), column));
+        continue;
+      }
+
+      final PostgresCatalogExpression.Parser parser = PostgresCatalogExpression.parser(item);
+      final PostgresCatalogExpression expression = parser.parseExpression();
+      if (expression == null)
+        return null;
+
+      String alias = null;
+      if (!parser.atEnd()) {
+        parser.skipKeyword("AS");
+        final PostgresCatalogToken token = parser.peek();
+        if (token == null)
+          return null;
+        if (token.type == PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
+          alias = token.text;
+        else if (token.type == PostgresCatalogToken.Type.IDENTIFIER)
+          // PostgreSQL folds every unquoted identifier to lower case.
+          alias = token.text.toLowerCase(Locale.ENGLISH);
+        else
+          return null;
+
+        // Nothing may follow the alias: if something does, this was not an aliased expression but a shape
+        // that has not been read correctly.
+        final List<PostgresCatalogToken> rest = item.subList(parser.getPosition(), item.size());
+        if (rest.size() != 1)
+          return null;
+      }
+
+      if (alias == null)
+        alias = defaultAlias(expression);
+
+      projection.add(new ProjectionItem(expression, alias));
+    }
+
+    return projection;
+  }
+
+  private static String defaultAlias(final PostgresCatalogExpression expression) {
+    if (expression instanceof PostgresCatalogExpression.ColumnReference reference)
+      return reference.name;
+    if (expression instanceof PostgresCatalogExpression.FunctionCall call)
+      return call.name;
+    // PostgreSQL's own name for a column it cannot name from the expression.
+    return "?column?";
+  }
+
+  private static FromEntry entryFor(final List<FromEntry> from, final String qualifier) {
+    for (final FromEntry entry : from)
+      if (qualifier.equals(entry.alias) || qualifier.equals(entry.relation)
+          || entry.relation.endsWith("." + qualifier) || (entry.alias == null && entry.relation.equals(qualifier)))
+        return entry;
+    return null;
+  }
+
+  /** Splits a token list at the commas that are not inside parentheses or brackets. */
+  private static List<List<PostgresCatalogToken>> splitTopLevel(final List<PostgresCatalogToken> tokens) {
+    final List<List<PostgresCatalogToken>> items = new ArrayList<>();
+    List<PostgresCatalogToken> current = new ArrayList<>();
+    int depth = 0;
+
+    for (final PostgresCatalogToken token : tokens) {
+      if (token.isSymbol("(") || token.isSymbol("["))
+        ++depth;
+      else if (token.isSymbol(")") || token.isSymbol("]"))
+        --depth;
+      else if (depth == 0 && token.isSymbol(",")) {
+        items.add(current);
+        current = new ArrayList<>();
+        continue;
+      }
+      current.add(token);
+    }
+
+    if (depth != 0)
+      return null;
+
+    items.add(current);
+    return items;
+  }
+
+  // ---------------------------------------------------------------- evaluation context
+
+  /** Resolves a query's column references and session functions against one emulated row. */
+  private static class RowResolver implements PostgresCatalogExpression.Resolver {
+    private final Row                                                     row;
+    private final List<FromEntry>                                         from;
+    private final Context                                                 context;
+    private final Map<PostgresCatalogExpression.WindowCall, Object[]>     windows;
+    private final int                                                     rowIndex;
+
+    RowResolver(final Row row, final List<FromEntry> from, final Context context,
+        final Map<PostgresCatalogExpression.WindowCall, Object[]> windows, final int rowIndex) {
+      this.row = row;
+      this.from = from;
+      this.context = context;
+      this.windows = windows;
+      this.rowIndex = rowIndex;
+    }
+
+    @Override
+    public Object window(final PostgresCatalogExpression.WindowCall call) {
+      if (windows == null)
+        return PostgresCatalogExpression.UNKNOWN;
+      final Object[] values = windows.get(call);
+      if (values == null || rowIndex >= values.length)
+        return PostgresCatalogExpression.UNKNOWN;
+      return values[rowIndex];
+    }
+
+    @Override
+    public Object column(final String qualifier, final String name) {
+      if (qualifier != null) {
+        final FromEntry entry = entryFor(from, qualifier);
+        if (entry == null)
+          return PostgresCatalogExpression.UNKNOWN;
+        final Map<String, Object> columns = row.relations.get(entry.relation);
+        if (columns == null || !columns.containsKey(name))
+          return PostgresCatalogExpression.UNKNOWN;
+        return columns.get(name);
+      }
+
+      // Unqualified: the first relation in the FROM clause that has such a column, which is how PostgreSQL
+      // resolves it too when only one of them does.
+      for (final FromEntry entry : from) {
+        final Map<String, Object> columns = row.relations.get(entry.relation);
+        if (columns != null && columns.containsKey(name))
+          return columns.get(name);
+      }
+      return PostgresCatalogExpression.UNKNOWN;
+    }
+
+    @Override
+    public Object function(final String name, final List<Object> arguments) {
+      return switch (name) {
+        case "current_schema", "current_database", "current_catalog" -> context.schema();
+        case "current_user", "session_user", "user", "current_role" -> context.userName();
+        case "current_schemas" -> List.of(context.schema());
+        case "version" -> "PostgreSQL " + PostgresNetworkExecutor.PG_SERVER_VERSION;
+        case "pg_get_userbyid" -> context.userName();
+        // Everything this catalog produces is visible to the connection that asked: there is one schema and
+        // it is on the search path by definition.
+        case "pg_table_is_visible", "pg_type_is_visible", "pg_function_is_visible" -> Boolean.TRUE;
+        case "pg_encoding_to_char" -> "UTF8";
+        case "format_type" -> formatType(arguments);
+        // Comments, defaults and ACLs have no ArcadeDB equivalent, and NULL is what PostgreSQL answers for an
+        // object that has none.
+        case "obj_description", "col_description", "shobj_description", "pg_get_expr", "pg_get_indexdef",
+            "pg_get_viewdef", "pg_get_constraintdef", "array_to_string" -> null;
+        default -> PostgresCatalogExpression.UNKNOWN;
+      };
+    }
+
+    private static Object formatType(final List<Object> arguments) {
+      if (arguments.isEmpty() || !(arguments.get(0) instanceof Number oid))
+        return PostgresCatalogExpression.UNKNOWN;
+      final PostgresType type = PostgresType.byCode(oid.intValue());
+      return type == null ? null : type.typeName;
+    }
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -966,7 +966,8 @@ public class PostgresCatalog {
             for (int i = 0; i < l.size(); i++) {
               final int comparison = compareValues(l.get(i), r.get(i));
               if (comparison != 0)
-                return comparison;
+                // DESC numbers the partition the other way round, which is the whole point of writing it.
+                return call.orderByDescending.get(i) ? -comparison : comparison;
             }
             return 0;
           });
@@ -1173,6 +1174,9 @@ public class PostgresCatalog {
     if (expression instanceof PostgresCatalogExpression.ColumnReference reference)
       return reference.name;
     if (expression instanceof PostgresCatalogExpression.FunctionCall call)
+      return call.name;
+    if (expression instanceof PostgresCatalogExpression.WindowCall call)
+      // PostgreSQL names an un-aliased window column after its function, exactly as it does a plain call.
       return call.name;
     // PostgreSQL's own name for a column it cannot name from the expression.
     return "?column?";

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -85,6 +85,18 @@ public class PostgresCatalog {
   /** The OID of the bootstrap superuser in a stock PostgreSQL, used for every "owner" column. */
   private static final int OWNER_OID      = 10;
 
+  /** A catalog query whose shape this class will not answer. The caller sends an empty result set. */
+  public static final Answer DECLINED = new Answer(new LinkedHashMap<>(), null);
+
+  /**
+   * The emulated relations and the columns each one has. A column outside its relation's set makes the query
+   * unanswerable; a column inside it that this catalog does not model answers NULL, which is what PostgreSQL
+   * answers for most of them anyway.
+   */
+  private static final Map<String, Set<String>> RELATIONS = new HashMap<>();
+  /** Which family a relation puts the query in. Relations that only decorate a row are absent. */
+  private static final Map<String, Family>      FAMILIES  = new HashMap<>();
+
   /**
    * The answer to a catalog query: the columns to announce, in the order the client projected them, and the
    * rows to send. {@link #DECLINED} is the third possible outcome, distinct from both "not a catalog query"
@@ -100,22 +112,10 @@ public class PostgresCatalog {
     }
   }
 
-  /** A catalog query whose shape this class will not answer. The caller sends an empty result set. */
-  public static final Answer DECLINED = new Answer(new LinkedHashMap<>(), null);
-
   /** The families of rows a catalog query can be about. */
   private enum Family {
     SCHEMAS, TABLES, COLUMNS, DATABASES, ROLES, PRIVILEGES, CHARACTER_SETS, COLLATIONS, VIEWS
   }
-
-  /**
-   * The emulated relations and the columns each one has. A column outside its relation's set makes the query
-   * unanswerable; a column inside it that this catalog does not model answers NULL, which is what PostgreSQL
-   * answers for most of them anyway.
-   */
-  private static final Map<String, Set<String>> RELATIONS = new HashMap<>();
-  /** Which family a relation puts the query in. Relations that only decorate a row are absent. */
-  private static final Map<String, Family>      FAMILIES  = new HashMap<>();
 
   private static void relation(final String name, final Family family, final String... columns) {
     RELATIONS.put(name, new LinkedHashSet<>(List.of(columns)));

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
@@ -55,6 +55,9 @@ abstract class PostgresCatalogExpression {
     }
   };
 
+  /** Distinguishes "this is not one of the scalar functions" from a scalar function that answered UNKNOWN. */
+  private static final Object NOT_A_SCALAR_FUNCTION = new Object();
+
   /** Supplies the column values of the row being evaluated, and the session values around it. */
   interface Resolver {
     /**
@@ -227,9 +230,6 @@ abstract class PostgresCatalogExpression {
       return resolver.window(this);
     }
   }
-
-  /** Distinguishes "this is not one of the scalar functions" from a scalar function that answered UNKNOWN. */
-  private static final Object NOT_A_SCALAR_FUNCTION = new Object();
 
   private static Object scalarFunction(final String name, final List<Object> values) {
     switch (name) {
@@ -653,64 +653,57 @@ abstract class PostgresCatalogExpression {
         if (token.isKeyword("IS")) {
           ++position;
           final boolean negated = skipKeyword("NOT");
-          if (!skipKeyword("NULL")) {
+          if (!skipKeyword("NULL"))
             // IS TRUE / IS DISTINCT FROM and friends are outside the slice.
             return null;
-          }
           left = new IsNull(left, negated);
-          continue;
-        }
+        } else {
+          final boolean negated = token.isKeyword("NOT") && lookaheadIsKeyword(1, "IN", "LIKE", "ILIKE");
+          if (negated)
+            ++position;
 
-        final boolean negated = token.isKeyword("NOT") && lookaheadIsKeyword(1, "IN", "LIKE", "ILIKE");
-        if (negated)
-          ++position;
+          final PostgresCatalogToken next = peek();
+          if (next == null)
+            return negated ? null : left;
 
-        final PostgresCatalogToken next = peek();
-        if (next == null)
-          return negated ? null : left;
-
-        if (next.isKeyword("IN")) {
-          ++position;
-          if (!skipSymbol("("))
-            return null;
-          final List<PostgresCatalogExpression> candidates = new ArrayList<>();
-          do {
-            final PostgresCatalogExpression candidate = parseExpression();
-            if (candidate == null)
+          if (next.isKeyword("IN")) {
+            ++position;
+            if (!skipSymbol("("))
               return null;
-            candidates.add(candidate);
-          } while (skipSymbol(","));
-          if (!skipSymbol(")"))
+            final List<PostgresCatalogExpression> candidates = new ArrayList<>();
+            do {
+              final PostgresCatalogExpression candidate = parseExpression();
+              if (candidate == null)
+                return null;
+              candidates.add(candidate);
+            } while (skipSymbol(","));
+            if (!skipSymbol(")"))
+              return null;
+            left = new In(left, candidates, negated);
+          } else if (next.isKeyword("LIKE") || next.isKeyword("ILIKE")) {
+            ++position;
+            final PostgresCatalogExpression right = parseConcat();
+            if (right == null)
+              return null;
+            left = new Binary((negated ? "NOT " : "") + next.text.toUpperCase(Locale.ENGLISH), left, right);
+          } else if (negated)
             return null;
-          left = new In(left, candidates, negated);
-          continue;
+          else if (isComparisonOperator(next)) {
+            ++position;
+            final PostgresCatalogExpression right = parseConcat();
+            if (right == null)
+              return null;
+            left = new Binary(next.text, left, right);
+          } else
+            return left;
         }
-
-        if (next.isKeyword("LIKE") || next.isKeyword("ILIKE")) {
-          ++position;
-          final PostgresCatalogExpression right = parseConcat();
-          if (right == null)
-            return null;
-          left = new Binary((negated ? "NOT " : "") + next.text.toUpperCase(Locale.ENGLISH), left, right);
-          continue;
-        }
-
-        if (negated)
-          return null;
-
-        if (next.isSymbol("=") || next.isSymbol("<>") || next.isSymbol("!=") || next.isSymbol("<") || next.isSymbol(">")
-            || next.isSymbol("<=") || next.isSymbol(">=") || next.isSymbol("~") || next.isSymbol("!~")
-            || next.isSymbol("~*") || next.isSymbol("!~*")) {
-          ++position;
-          final PostgresCatalogExpression right = parseConcat();
-          if (right == null)
-            return null;
-          left = new Binary(next.text, left, right);
-          continue;
-        }
-
-        return left;
       }
+    }
+
+    private static boolean isComparisonOperator(final PostgresCatalogToken token) {
+      return token.isSymbol("=") || token.isSymbol("<>") || token.isSymbol("!=") || token.isSymbol("<")
+          || token.isSymbol(">") || token.isSymbol("<=") || token.isSymbol(">=") || token.isSymbol("~")
+          || token.isSymbol("!~") || token.isSymbol("~*") || token.isSymbol("!~*");
     }
 
     private boolean lookaheadIsKeyword(final int offset, final String... keywords) {
@@ -790,25 +783,22 @@ abstract class PostgresCatalogExpression {
         return null;
 
       while (true) {
-        if (peek() != null && peek().isSymbol("::")) {
+        final PostgresCatalogToken token = peek();
+
+        if (token != null && token.isSymbol("::")) {
           // A cast never changes what a catalog query means here: 'pg_class'::regclass is the name, and
           // int4/text casts are there for PostgreSQL's type resolution, which this evaluator does not have.
           ++position;
           if (!skipCastType())
             return null;
-          continue;
-        }
-
-        if (peek() != null && peek().isSymbol("[")) {
+        } else if (token != null && token.isSymbol("[")) {
           ++position;
           final PostgresCatalogExpression index = parseExpression();
           if (index == null || !skipSymbol("]"))
             return null;
           operand = new Subscript(operand, index);
-          continue;
-        }
-
-        return operand;
+        } else
+          return operand;
       }
     }
 

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
@@ -21,6 +21,7 @@ package com.arcadedb.postgres;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -618,12 +619,22 @@ abstract class PostgresCatalogExpression {
     }
 
     PostgresCatalogExpression parseExpression() {
+      return guardDepth(this::parseOr);
+    }
+
+    /**
+     * Runs a production under the depth guard {@link #parseExpression} enforces, for the productions that
+     * recurse on themselves directly - {@code parseNot} over a chain of {@code NOT}, {@code parseUnary} over
+     * a chain of unary {@code -}/{@code +} - and so reach the stack the same way nested parentheses do
+     * without ever calling back through {@link #parseExpression}.
+     */
+    private PostgresCatalogExpression guardDepth(final Supplier<PostgresCatalogExpression> production) {
       if (++depth > MAX_DEPTH) {
         --depth;
         return null;
       }
       try {
-        return parseOr();
+        return production.get();
       } finally {
         --depth;
       }
@@ -659,7 +670,7 @@ abstract class PostgresCatalogExpression {
 
     private PostgresCatalogExpression parseNot() {
       if (skipKeyword("NOT")) {
-        final PostgresCatalogExpression operand = parseNot();
+        final PostgresCatalogExpression operand = guardDepth(this::parseNot);
         return operand == null ? null : new Not(operand);
       }
       return parseComparison();
@@ -791,12 +802,12 @@ abstract class PostgresCatalogExpression {
     private PostgresCatalogExpression parseUnary() {
       if (peek() != null && peek().isSymbol("-")) {
         ++position;
-        final PostgresCatalogExpression operand = parseUnary();
+        final PostgresCatalogExpression operand = guardDepth(this::parseUnary);
         return operand == null ? null : new Negate(operand);
       }
       if (peek() != null && peek().isSymbol("+")) {
         ++position;
-        return parseUnary();
+        return guardDepth(this::parseUnary);
       }
       return parsePostfix();
     }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
@@ -217,12 +217,15 @@ abstract class PostgresCatalogExpression {
     final String                          name;
     final List<PostgresCatalogExpression> partitionBy;
     final List<PostgresCatalogExpression> orderBy;
+    /** One flag per ORDER BY key: the direction it was written with, which decides the numbering. */
+    final List<Boolean>                   orderByDescending;
 
     WindowCall(final String name, final List<PostgresCatalogExpression> partitionBy,
-        final List<PostgresCatalogExpression> orderBy) {
+        final List<PostgresCatalogExpression> orderBy, final List<Boolean> orderByDescending) {
       this.name = name;
       this.partitionBy = partitionBy;
       this.orderBy = orderBy;
+      this.orderByDescending = orderByDescending;
     }
 
     @Override
@@ -563,8 +566,22 @@ abstract class PostgresCatalogExpression {
    * rather than answering part of it.
    */
   static class Parser {
+    /**
+     * How deeply an expression may nest before the query is declined. Every level of parentheses, CASE arm,
+     * function argument or subscript costs one, and a catalog query written by a real client nests a handful
+     * deep - the JDBC driver's table list, the deepest this catalog has to read, reaches four.
+     * <p>
+     * The bound is what keeps "a shape outside the slice is declined" true for <i>every</i> shape: without it
+     * a query with tens of thousands of nested parentheses - well inside the wire protocol's message budget,
+     * and reachable by any authenticated client - would recurse until the stack gave out, and a
+     * StackOverflowError is an Error rather than an Exception, so it would kill the connection thread instead
+     * of being answered with an empty result.
+     */
+    private static final int MAX_DEPTH = 100;
+
     private final List<PostgresCatalogToken> tokens;
     private       int                        position;
+    private       int                        depth;
 
     Parser(final List<PostgresCatalogToken> tokens) {
       this.tokens = tokens;
@@ -601,7 +618,15 @@ abstract class PostgresCatalogExpression {
     }
 
     PostgresCatalogExpression parseExpression() {
-      return parseOr();
+      if (++depth > MAX_DEPTH) {
+        --depth;
+        return null;
+      }
+      try {
+        return parseOr();
+      } finally {
+        --depth;
+      }
     }
 
     private PostgresCatalogExpression parseOr() {
@@ -871,8 +896,13 @@ abstract class PostgresCatalogExpression {
         return new Literal(token.text);
       }
       case NUMBER -> {
+        final Object number = parseNumber(token.text);
+        if (number == null)
+          // Something the lexer read as one numeric token but that is not a number - "1.2.3". Reading it as
+          // SQL NULL would answer the query with a value the client never wrote.
+          return null;
         ++position;
-        return new Literal(parseNumber(token.text));
+        return new Literal(number);
       }
       case QUOTED_IDENTIFIER -> {
         ++position;
@@ -968,6 +998,7 @@ abstract class PostgresCatalogExpression {
 
       final List<PostgresCatalogExpression> partitionBy = new ArrayList<>();
       final List<PostgresCatalogExpression> orderBy = new ArrayList<>();
+      final List<Boolean>                   orderByDescending = new ArrayList<>();
 
       if (skipKeyword("PARTITION")) {
         if (!skipKeyword("BY"))
@@ -988,17 +1019,27 @@ abstract class PostgresCatalogExpression {
           if (key == null)
             return null;
           orderBy.add(key);
-          // A per-key direction would have to be carried into the numbering; nothing this catalog answers
-          // uses one, so it is declined rather than silently ignored.
-          if (peek() != null && (peek().isKeyword("ASC") || peek().isKeyword("DESC")))
+
+          // The direction decides the numbering, so it is carried rather than consumed and forgotten: a key
+          // read as ascending when the client wrote DESC numbers the partition backwards, and a wrong number
+          // in a system catalog is worse than no answer.
+          boolean descending = false;
+          if (peek() != null && (peek().isKeyword("ASC") || peek().isKeyword("DESC"))) {
+            descending = peek().isKeyword("DESC");
             ++position;
+          }
+          // NULLS FIRST/LAST would reorder the ties this numbering breaks by position, so a window that asks
+          // for it is declined rather than numbered by a rule it did not ask for.
+          if (peek() != null && peek().isKeyword("NULLS"))
+            return null;
+          orderByDescending.add(descending);
         } while (skipSymbol(","));
       }
 
       if (!skipSymbol(")"))
         return null;
 
-      return new WindowCall(functionName, partitionBy, orderBy);
+      return new WindowCall(functionName, partitionBy, orderBy, orderByDescending);
     }
 
     private PostgresCatalogExpression parseCase() {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogExpression.java
@@ -1,0 +1,1067 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * The slice of PostgreSQL expression syntax that a client's catalog query is written in, parsed once and
+ * then evaluated against one emulated catalog row at a time (issue #6412).
+ * <p>
+ * A tool does not ask "list the tables"; it sends the query its own driver writes, and that query carries the
+ * answer's shape inside itself. The JDBC driver's table list, for instance, projects the literal
+ * {@code CASE c.relkind WHEN 'r' THEN 'TABLE' ... END} - so a catalog that evaluates the client's own
+ * expressions against a row saying {@code relkind = 'r'} produces exactly the string that client expects,
+ * without this code having to know which tool asked or what it calls a table. That is what replaces the
+ * {@code application_name}-keyed answers: the shape of the query, not the name of the sender, decides.
+ * <p>
+ * Deliberately partial. Anything outside this slice evaluates to {@link #UNKNOWN} rather than to a guess, and
+ * the caller decides what that means: in a projection it means the query cannot be answered honestly and is
+ * declined whole; in a WHERE clause it means that one predicate does not get to remove rows (see
+ * {@link PostgresCatalog} for why that is the safe direction for a catalog whose entire content is the user's
+ * own types).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+abstract class PostgresCatalogExpression {
+  /**
+   * The value of an expression this class cannot evaluate - an unknown function, a column no emulated
+   * relation has, a construct outside the supported slice. Distinct from SQL NULL, which is a value.
+   */
+  static final Object UNKNOWN = new Object() {
+    @Override
+    public String toString() {
+      return "UNKNOWN";
+    }
+  };
+
+  /** Supplies the column values of the row being evaluated, and the session values around it. */
+  interface Resolver {
+    /**
+     * @param qualifier the table alias the reference carried, or null when it was unqualified
+     *
+     * @return the column's value, or {@link #UNKNOWN} when no relation in this query has such a column
+     */
+    Object column(String qualifier, String name);
+
+    /**
+     * @return the value of a niladic session function ({@code current_schema}, {@code current_user}, ...),
+     * or {@link #UNKNOWN}
+     */
+    Object function(String name, List<Object> arguments);
+
+    /**
+     * @return the value a window function takes on the row being evaluated, computed by the caller over the
+     * whole row set before any row is projected, or {@link #UNKNOWN} when it was not computed
+     */
+    default Object window(final WindowCall call) {
+      return UNKNOWN;
+    }
+  }
+
+  abstract Object evaluate(Resolver resolver);
+
+  /**
+   * Parses one expression and returns it, or null when it is not written in the supported slice. The whole
+   * token range must be consumed: a trailing token means the text was something more than one expression.
+   */
+  static PostgresCatalogExpression parse(final List<PostgresCatalogToken> tokens) {
+    final Parser parser = new Parser(tokens);
+    final PostgresCatalogExpression expression = parser.parseExpression();
+    if (expression == null || !parser.atEnd())
+      return null;
+    return expression;
+  }
+
+  /**
+   * Parses the longest expression the token list starts with, leaving the parser positioned after it. Used
+   * where an expression is followed by something else the caller reads itself - a column alias, ORDER BY's
+   * ASC/DESC.
+   */
+  static Parser parser(final List<PostgresCatalogToken> tokens) {
+    return new Parser(tokens);
+  }
+
+  // ---------------------------------------------------------------- value helpers
+
+  /**
+   * How a WHERE predicate that could not be evaluated is read: as "does not exclude this row". A catalog
+   * whose entire content is the user's own types has no system rows for an unrecognised predicate to be
+   * filtering out, so the permissive direction cannot hide a row the client asked for - while the strict
+   * direction would hide every row over one construct nobody parsed.
+   */
+  static boolean isTrue(final Object value) {
+    if (value == UNKNOWN)
+      return true;
+    if (value == null)
+      return false;
+    if (value instanceof Boolean b)
+      return b;
+    if (value instanceof Number n)
+      return n.doubleValue() != 0;
+    return false;
+  }
+
+  static String asString(final Object value) {
+    if (value == null || value == UNKNOWN)
+      return null;
+    if (value instanceof Boolean b)
+      return b ? "t" : "f";
+    return value.toString();
+  }
+
+  // ---------------------------------------------------------------- nodes
+
+  private static class Literal extends PostgresCatalogExpression {
+    private final Object value;
+
+    Literal(final Object value) {
+      this.value = value;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      return value;
+    }
+  }
+
+  static class ColumnReference extends PostgresCatalogExpression {
+    final String qualifier;
+    final String name;
+
+    ColumnReference(final String qualifier, final String name) {
+      this.qualifier = qualifier;
+      this.name = name;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      return resolver.column(qualifier, name);
+    }
+  }
+
+  static class FunctionCall extends PostgresCatalogExpression {
+    final String                              name;
+    final List<PostgresCatalogExpression> arguments;
+
+    FunctionCall(final String name, final List<PostgresCatalogExpression> arguments) {
+      this.name = name;
+      this.arguments = arguments;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final List<Object> values = new ArrayList<>(arguments.size());
+      for (final PostgresCatalogExpression argument : arguments)
+        values.add(argument.evaluate(resolver));
+
+      // NULLIF and COALESCE are evaluated here rather than delegated to the resolver, because they are the
+      // functions whose answer is about their own arguments rather than about the session or the row.
+      if ("nullif".equals(name)) {
+        if (values.size() != 2)
+          return UNKNOWN;
+        final Object first = values.get(0);
+        final Object second = values.get(1);
+        if (first == UNKNOWN || second == UNKNOWN)
+          return UNKNOWN;
+        return first != null && first.equals(second) ? null : first;
+      }
+
+      if ("coalesce".equals(name)) {
+        for (final Object value : values)
+          if (value != null && value != UNKNOWN)
+            return value;
+        return values.isEmpty() ? null : values.get(values.size() - 1);
+      }
+
+      // The plain scalar functions a catalog query wraps a column in - most often lower() on a name it is
+      // about to compare. They are about their arguments alone, so they are evaluated here too.
+      final Object scalar = scalarFunction(name, values);
+      if (scalar != NOT_A_SCALAR_FUNCTION)
+        return scalar;
+
+      return resolver.function(name, values);
+    }
+  }
+
+  /**
+   * A window function: {@code row_number() OVER (PARTITION BY ... ORDER BY ...)}. Its value depends on the
+   * other rows, not only on this one, so it is computed by the caller over the whole row set and read back
+   * here - see {@link Resolver#window}. The JDBC driver's column list is written with one of these, to number
+   * a table's columns from 1 without counting the dropped ones, which is why it is worth having.
+   */
+  static class WindowCall extends PostgresCatalogExpression {
+    final String                          name;
+    final List<PostgresCatalogExpression> partitionBy;
+    final List<PostgresCatalogExpression> orderBy;
+
+    WindowCall(final String name, final List<PostgresCatalogExpression> partitionBy,
+        final List<PostgresCatalogExpression> orderBy) {
+      this.name = name;
+      this.partitionBy = partitionBy;
+      this.orderBy = orderBy;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      return resolver.window(this);
+    }
+  }
+
+  /** Distinguishes "this is not one of the scalar functions" from a scalar function that answered UNKNOWN. */
+  private static final Object NOT_A_SCALAR_FUNCTION = new Object();
+
+  private static Object scalarFunction(final String name, final List<Object> values) {
+    switch (name) {
+    case "lower", "upper", "length", "abs", "trim", "btrim", "ltrim", "rtrim", "replace", "concat" -> {
+      for (final Object value : values)
+        if (value == UNKNOWN)
+          return UNKNOWN;
+    }
+    default -> {
+      return NOT_A_SCALAR_FUNCTION;
+    }
+    }
+
+    if ("concat".equals(name)) {
+      final StringBuilder buffer = new StringBuilder();
+      for (final Object value : values)
+        if (value != null)
+          buffer.append(asString(value));
+      return buffer.toString();
+    }
+
+    if (values.isEmpty() || values.get(0) == null)
+      return values.isEmpty() ? UNKNOWN : null;
+
+    final String first = asString(values.get(0));
+    return switch (name) {
+      case "lower" -> first.toLowerCase(Locale.ENGLISH);
+      case "upper" -> first.toUpperCase(Locale.ENGLISH);
+      case "length" -> (long) first.length();
+      case "trim", "btrim" -> first.trim();
+      case "ltrim" -> first.stripLeading();
+      case "rtrim" -> first.stripTrailing();
+      case "abs" -> values.get(0) instanceof Number n ? (Object) Math.abs(n.doubleValue()) : UNKNOWN;
+      case "replace" -> values.size() == 3 && values.get(1) != null && values.get(2) != null ?
+          first.replace(asString(values.get(1)), asString(values.get(2))) : (values.size() == 3 ? null : UNKNOWN);
+      default -> UNKNOWN;
+    };
+  }
+
+  private static class Not extends PostgresCatalogExpression {
+    private final PostgresCatalogExpression operand;
+
+    Not(final PostgresCatalogExpression operand) {
+      this.operand = operand;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final Object value = operand.evaluate(resolver);
+      if (value == UNKNOWN)
+        return UNKNOWN;
+      if (value == null)
+        return null;
+      return !isTrue(value);
+    }
+  }
+
+  private static class Negate extends PostgresCatalogExpression {
+    private final PostgresCatalogExpression operand;
+
+    Negate(final PostgresCatalogExpression operand) {
+      this.operand = operand;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final Object value = operand.evaluate(resolver);
+      if (value == UNKNOWN)
+        return UNKNOWN;
+      if (value instanceof Number n)
+        return n instanceof Double || n instanceof Float ? (Object) (-n.doubleValue()) : (Object) (-n.longValue());
+      return UNKNOWN;
+    }
+  }
+
+  private static class Binary extends PostgresCatalogExpression {
+    private final String                    operator;
+    private final PostgresCatalogExpression left;
+    private final PostgresCatalogExpression right;
+
+    Binary(final String operator, final PostgresCatalogExpression left, final PostgresCatalogExpression right) {
+      this.operator = operator;
+      this.left = left;
+      this.right = right;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final Object l = left.evaluate(resolver);
+
+      // AND and OR keep their short-circuit behaviour over the three values, so that a predicate whose other
+      // half is unevaluable still decides the row when this half is enough: FALSE AND anything is FALSE.
+      if ("AND".equals(operator)) {
+        if (l != UNKNOWN && l != null && !isTrue(l))
+          return Boolean.FALSE;
+        final Object r = right.evaluate(resolver);
+        if (l == UNKNOWN || r == UNKNOWN)
+          return r != UNKNOWN && r != null && !isTrue(r) ? Boolean.FALSE : UNKNOWN;
+        if (l == null || r == null)
+          return isTrue(l) && isTrue(r) ? null : Boolean.FALSE;
+        return isTrue(l) && isTrue(r);
+      }
+
+      if ("OR".equals(operator)) {
+        if (l != UNKNOWN && l != null && isTrue(l))
+          return Boolean.TRUE;
+        final Object r = right.evaluate(resolver);
+        if (l == UNKNOWN || r == UNKNOWN)
+          return r != UNKNOWN && r != null && isTrue(r) ? Boolean.TRUE : UNKNOWN;
+        if (l == null || r == null)
+          return isTrue(l) || isTrue(r) ? Boolean.TRUE : null;
+        return isTrue(l) || isTrue(r);
+      }
+
+      final Object r = right.evaluate(resolver);
+      if (l == UNKNOWN || r == UNKNOWN)
+        return UNKNOWN;
+
+      return switch (operator) {
+        case "||" -> l == null || r == null ? null : asString(l) + asString(r);
+        case "+", "-", "*", "/" -> arithmetic(operator, l, r);
+        case "~", "!~", "~*", "!~*" -> regex(operator, l, r);
+        case "LIKE", "NOT LIKE", "ILIKE", "NOT ILIKE" -> like(operator, l, r);
+        default -> compare(operator, l, r);
+      };
+    }
+
+    private static Object arithmetic(final String operator, final Object l, final Object r) {
+      if (l == null || r == null)
+        return null;
+      if (!(l instanceof Number ln) || !(r instanceof Number rn))
+        return UNKNOWN;
+      final double result = switch (operator) {
+        case "+" -> ln.doubleValue() + rn.doubleValue();
+        case "-" -> ln.doubleValue() - rn.doubleValue();
+        case "*" -> ln.doubleValue() * rn.doubleValue();
+        default -> rn.doubleValue() == 0 ? Double.NaN : ln.doubleValue() / rn.doubleValue();
+      };
+      if (Double.isNaN(result))
+        return null;
+      return result == Math.rint(result) ? (Object) (long) result : (Object) result;
+    }
+
+    private static Object regex(final String operator, final Object l, final Object r) {
+      if (l == null || r == null)
+        return null;
+      final String value = asString(l);
+      final String pattern = asString(r);
+      try {
+        final boolean matches = Pattern.compile(pattern, operator.endsWith("*") ? Pattern.CASE_INSENSITIVE : 0)
+            .matcher(value).find();
+        return operator.startsWith("!") != matches;
+      } catch (final PatternSyntaxException e) {
+        // A POSIX regex Java cannot compile: not something to guess the answer of.
+        return UNKNOWN;
+      }
+    }
+
+    private static Object like(final String operator, final Object l, final Object r) {
+      if (l == null || r == null)
+        return null;
+      final boolean matches = Pattern.compile(likeToRegex(asString(r)),
+              operator.contains("ILIKE") ? Pattern.CASE_INSENSITIVE : 0)
+          .matcher(asString(l)).matches();
+      return operator.startsWith("NOT") != matches;
+    }
+
+    private static Object compare(final String operator, final Object l, final Object r) {
+      if (l == null || r == null)
+        return null;
+
+      final int comparison;
+      if (l instanceof Number ln && r instanceof Number rn)
+        comparison = Double.compare(ln.doubleValue(), rn.doubleValue());
+      else if (l instanceof Boolean || r instanceof Boolean)
+        comparison = Boolean.compare(isTrue(l), isTrue(r));
+      else
+        comparison = asString(l).compareTo(asString(r));
+
+      return switch (operator) {
+        case "=" -> comparison == 0;
+        case "<>", "!=" -> comparison != 0;
+        case "<" -> comparison < 0;
+        case "<=" -> comparison <= 0;
+        case ">" -> comparison > 0;
+        case ">=" -> comparison >= 0;
+        default -> UNKNOWN;
+      };
+    }
+  }
+
+  /** Translates a SQL LIKE pattern into the equivalent regular expression. */
+  static String likeToRegex(final String pattern) {
+    final StringBuilder regex = new StringBuilder(pattern.length() * 2);
+    for (int i = 0; i < pattern.length(); i++) {
+      final char c = pattern.charAt(i);
+      switch (c) {
+      case '%' -> regex.append(".*");
+      case '_' -> regex.append('.');
+      case '\\' -> {
+        if (i + 1 < pattern.length())
+          regex.append(Pattern.quote(String.valueOf(pattern.charAt(++i))));
+      }
+      default -> regex.append(Pattern.quote(String.valueOf(c)));
+      }
+    }
+    return regex.toString();
+  }
+
+  private static class In extends PostgresCatalogExpression {
+    private final PostgresCatalogExpression       operand;
+    private final List<PostgresCatalogExpression> candidates;
+    private final boolean                         negated;
+
+    In(final PostgresCatalogExpression operand, final List<PostgresCatalogExpression> candidates, final boolean negated) {
+      this.operand = operand;
+      this.candidates = candidates;
+      this.negated = negated;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final Object value = operand.evaluate(resolver);
+      if (value == UNKNOWN)
+        return UNKNOWN;
+      if (value == null)
+        return null;
+
+      boolean found = false;
+      for (final PostgresCatalogExpression candidate : candidates) {
+        final Object other = candidate.evaluate(resolver);
+        if (other == UNKNOWN)
+          return UNKNOWN;
+        if (other == null)
+          continue;
+        if (Boolean.TRUE.equals(Binary.compare("=", value, other))) {
+          found = true;
+          break;
+        }
+      }
+      return negated != found;
+    }
+  }
+
+  private static class IsNull extends PostgresCatalogExpression {
+    private final PostgresCatalogExpression operand;
+    private final boolean                   negated;
+
+    IsNull(final PostgresCatalogExpression operand, final boolean negated) {
+      this.operand = operand;
+      this.negated = negated;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final Object value = operand.evaluate(resolver);
+      if (value == UNKNOWN)
+        return UNKNOWN;
+      return negated != (value == null);
+    }
+  }
+
+  private static class Case extends PostgresCatalogExpression {
+    private final PostgresCatalogExpression       operand;
+    private final List<PostgresCatalogExpression> conditions;
+    private final List<PostgresCatalogExpression> results;
+    private final PostgresCatalogExpression       fallback;
+
+    Case(final PostgresCatalogExpression operand, final List<PostgresCatalogExpression> conditions,
+        final List<PostgresCatalogExpression> results, final PostgresCatalogExpression fallback) {
+      this.operand = operand;
+      this.conditions = conditions;
+      this.results = results;
+      this.fallback = fallback;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final Object subject = operand == null ? null : operand.evaluate(resolver);
+      if (operand != null && subject == UNKNOWN)
+        return UNKNOWN;
+
+      for (int i = 0; i < conditions.size(); i++) {
+        final Object condition = conditions.get(i).evaluate(resolver);
+        if (condition == UNKNOWN)
+          return UNKNOWN;
+
+        final boolean matched;
+        if (operand == null)
+          matched = condition != null && isTrue(condition);
+        else
+          matched = Boolean.TRUE.equals(Binary.compare("=", subject, condition));
+
+        if (matched)
+          return results.get(i).evaluate(resolver);
+      }
+
+      return fallback == null ? null : fallback.evaluate(resolver);
+    }
+  }
+
+  private static class Subscript extends PostgresCatalogExpression {
+    private final PostgresCatalogExpression operand;
+    private final PostgresCatalogExpression index;
+
+    Subscript(final PostgresCatalogExpression operand, final PostgresCatalogExpression index) {
+      this.operand = operand;
+      this.index = index;
+    }
+
+    @Override
+    Object evaluate(final Resolver resolver) {
+      final Object value = operand.evaluate(resolver);
+      final Object position = index.evaluate(resolver);
+      if (value == UNKNOWN || position == UNKNOWN)
+        return UNKNOWN;
+      if (!(value instanceof List<?> list) || !(position instanceof Number n))
+        return UNKNOWN;
+
+      // PostgreSQL arrays are 1-based by default, which is the only base a catalog query ever uses.
+      final int i = n.intValue() - 1;
+      return i < 0 || i >= list.size() ? null : list.get(i);
+    }
+  }
+
+  // ---------------------------------------------------------------- parser
+
+  /**
+   * A recursive-descent parser over the token list. Every method returns null on a construct outside the
+   * supported slice, which propagates up and makes the whole parse fail - the caller then declines the query
+   * rather than answering part of it.
+   */
+  static class Parser {
+    private final List<PostgresCatalogToken> tokens;
+    private       int                        position;
+
+    Parser(final List<PostgresCatalogToken> tokens) {
+      this.tokens = tokens;
+    }
+
+    boolean atEnd() {
+      return position >= tokens.size();
+    }
+
+    int getPosition() {
+      return position;
+    }
+
+    PostgresCatalogToken peek() {
+      return position < tokens.size() ? tokens.get(position) : null;
+    }
+
+    boolean skipKeyword(final String keyword) {
+      final PostgresCatalogToken token = peek();
+      if (token != null && token.isKeyword(keyword)) {
+        ++position;
+        return true;
+      }
+      return false;
+    }
+
+    private boolean skipSymbol(final String symbol) {
+      final PostgresCatalogToken token = peek();
+      if (token != null && token.isSymbol(symbol)) {
+        ++position;
+        return true;
+      }
+      return false;
+    }
+
+    PostgresCatalogExpression parseExpression() {
+      return parseOr();
+    }
+
+    private PostgresCatalogExpression parseOr() {
+      PostgresCatalogExpression left = parseAnd();
+      if (left == null)
+        return null;
+
+      while (skipKeyword("OR")) {
+        final PostgresCatalogExpression right = parseAnd();
+        if (right == null)
+          return null;
+        left = new Binary("OR", left, right);
+      }
+      return left;
+    }
+
+    private PostgresCatalogExpression parseAnd() {
+      PostgresCatalogExpression left = parseNot();
+      if (left == null)
+        return null;
+
+      while (skipKeyword("AND")) {
+        final PostgresCatalogExpression right = parseNot();
+        if (right == null)
+          return null;
+        left = new Binary("AND", left, right);
+      }
+      return left;
+    }
+
+    private PostgresCatalogExpression parseNot() {
+      if (skipKeyword("NOT")) {
+        final PostgresCatalogExpression operand = parseNot();
+        return operand == null ? null : new Not(operand);
+      }
+      return parseComparison();
+    }
+
+    private PostgresCatalogExpression parseComparison() {
+      PostgresCatalogExpression left = parseConcat();
+      if (left == null)
+        return null;
+
+      while (true) {
+        final PostgresCatalogToken token = peek();
+        if (token == null)
+          return left;
+
+        if (token.isKeyword("IS")) {
+          ++position;
+          final boolean negated = skipKeyword("NOT");
+          if (!skipKeyword("NULL")) {
+            // IS TRUE / IS DISTINCT FROM and friends are outside the slice.
+            return null;
+          }
+          left = new IsNull(left, negated);
+          continue;
+        }
+
+        final boolean negated = token.isKeyword("NOT") && lookaheadIsKeyword(1, "IN", "LIKE", "ILIKE");
+        if (negated)
+          ++position;
+
+        final PostgresCatalogToken next = peek();
+        if (next == null)
+          return negated ? null : left;
+
+        if (next.isKeyword("IN")) {
+          ++position;
+          if (!skipSymbol("("))
+            return null;
+          final List<PostgresCatalogExpression> candidates = new ArrayList<>();
+          do {
+            final PostgresCatalogExpression candidate = parseExpression();
+            if (candidate == null)
+              return null;
+            candidates.add(candidate);
+          } while (skipSymbol(","));
+          if (!skipSymbol(")"))
+            return null;
+          left = new In(left, candidates, negated);
+          continue;
+        }
+
+        if (next.isKeyword("LIKE") || next.isKeyword("ILIKE")) {
+          ++position;
+          final PostgresCatalogExpression right = parseConcat();
+          if (right == null)
+            return null;
+          left = new Binary((negated ? "NOT " : "") + next.text.toUpperCase(Locale.ENGLISH), left, right);
+          continue;
+        }
+
+        if (negated)
+          return null;
+
+        if (next.isSymbol("=") || next.isSymbol("<>") || next.isSymbol("!=") || next.isSymbol("<") || next.isSymbol(">")
+            || next.isSymbol("<=") || next.isSymbol(">=") || next.isSymbol("~") || next.isSymbol("!~")
+            || next.isSymbol("~*") || next.isSymbol("!~*")) {
+          ++position;
+          final PostgresCatalogExpression right = parseConcat();
+          if (right == null)
+            return null;
+          left = new Binary(next.text, left, right);
+          continue;
+        }
+
+        return left;
+      }
+    }
+
+    private boolean lookaheadIsKeyword(final int offset, final String... keywords) {
+      final int index = position + offset;
+      if (index >= tokens.size())
+        return false;
+      for (final String keyword : keywords)
+        if (tokens.get(index).isKeyword(keyword))
+          return true;
+      return false;
+    }
+
+    private PostgresCatalogExpression parseConcat() {
+      PostgresCatalogExpression left = parseAdditive();
+      if (left == null)
+        return null;
+
+      while (peek() != null && peek().isSymbol("||")) {
+        ++position;
+        final PostgresCatalogExpression right = parseAdditive();
+        if (right == null)
+          return null;
+        left = new Binary("||", left, right);
+      }
+      return left;
+    }
+
+    private PostgresCatalogExpression parseAdditive() {
+      PostgresCatalogExpression left = parseMultiplicative();
+      if (left == null)
+        return null;
+
+      while (peek() != null && (peek().isSymbol("+") || peek().isSymbol("-"))) {
+        final String operator = peek().text;
+        ++position;
+        final PostgresCatalogExpression right = parseMultiplicative();
+        if (right == null)
+          return null;
+        left = new Binary(operator, left, right);
+      }
+      return left;
+    }
+
+    private PostgresCatalogExpression parseMultiplicative() {
+      PostgresCatalogExpression left = parseUnary();
+      if (left == null)
+        return null;
+
+      while (peek() != null && (peek().isSymbol("*") || peek().isSymbol("/"))) {
+        final String operator = peek().text;
+        ++position;
+        final PostgresCatalogExpression right = parseUnary();
+        if (right == null)
+          return null;
+        left = new Binary(operator, left, right);
+      }
+      return left;
+    }
+
+    private PostgresCatalogExpression parseUnary() {
+      if (peek() != null && peek().isSymbol("-")) {
+        ++position;
+        final PostgresCatalogExpression operand = parseUnary();
+        return operand == null ? null : new Negate(operand);
+      }
+      if (peek() != null && peek().isSymbol("+")) {
+        ++position;
+        return parseUnary();
+      }
+      return parsePostfix();
+    }
+
+    /** Applies the suffixes that bind tightest: a cast and an array subscript. */
+    private PostgresCatalogExpression parsePostfix() {
+      PostgresCatalogExpression operand = parsePrimary();
+      if (operand == null)
+        return null;
+
+      while (true) {
+        if (peek() != null && peek().isSymbol("::")) {
+          // A cast never changes what a catalog query means here: 'pg_class'::regclass is the name, and
+          // int4/text casts are there for PostgreSQL's type resolution, which this evaluator does not have.
+          ++position;
+          if (!skipCastType())
+            return null;
+          continue;
+        }
+
+        if (peek() != null && peek().isSymbol("[")) {
+          ++position;
+          final PostgresCatalogExpression index = parseExpression();
+          if (index == null || !skipSymbol("]"))
+            return null;
+          operand = new Subscript(operand, index);
+          continue;
+        }
+
+        return operand;
+      }
+    }
+
+    /** Consumes a type name after {@code ::}, including {@code varchar(10)} and {@code text[]}. */
+    private boolean skipCastType() {
+      final PostgresCatalogToken token = peek();
+      if (token == null || token.type != PostgresCatalogToken.Type.IDENTIFIER)
+        return false;
+      ++position;
+
+      while (peek() != null && peek().isSymbol(".")) {
+        ++position;
+        if (peek() == null || peek().type != PostgresCatalogToken.Type.IDENTIFIER)
+          return false;
+        ++position;
+      }
+
+      // Some type names are several words: "double precision", "character varying", "timestamp with time zone".
+      while (peek() != null && peek().type == PostgresCatalogToken.Type.IDENTIFIER && isTypeNameWord(peek().text))
+        ++position;
+
+      if (peek() != null && peek().isSymbol("(")) {
+        int depth = 0;
+        while (peek() != null) {
+          if (peek().isSymbol("("))
+            ++depth;
+          else if (peek().isSymbol(")"))
+            --depth;
+          ++position;
+          if (depth == 0)
+            break;
+        }
+      }
+
+      while (peek() != null && peek().isSymbol("[")) {
+        ++position;
+        if (!skipSymbol("]"))
+          return false;
+      }
+
+      return true;
+    }
+
+    private static boolean isTypeNameWord(final String text) {
+      return switch (text.toLowerCase(Locale.ENGLISH)) {
+        case "precision", "varying", "with", "without", "time", "zone" -> true;
+        default -> false;
+      };
+    }
+
+    private PostgresCatalogExpression parsePrimary() {
+      final PostgresCatalogToken token = peek();
+      if (token == null)
+        return null;
+
+      if (token.isSymbol("(")) {
+        ++position;
+        final PostgresCatalogExpression inner = parseExpression();
+        if (inner == null || !skipSymbol(")"))
+          return null;
+        return inner;
+      }
+
+      if (token.isKeyword("CASE"))
+        return parseCase();
+
+      switch (token.type) {
+      case STRING -> {
+        ++position;
+        return new Literal(token.text);
+      }
+      case NUMBER -> {
+        ++position;
+        return new Literal(parseNumber(token.text));
+      }
+      case QUOTED_IDENTIFIER -> {
+        ++position;
+        return parseQualifiedReference(null, token.text);
+      }
+      case IDENTIFIER -> {
+        if (token.isKeyword("NULL")) {
+          ++position;
+          return new Literal(null);
+        }
+        if (token.isKeyword("TRUE")) {
+          ++position;
+          return new Literal(Boolean.TRUE);
+        }
+        if (token.isKeyword("FALSE")) {
+          ++position;
+          return new Literal(Boolean.FALSE);
+        }
+        if (token.isKeyword("SELECT") || token.isKeyword("FROM") || token.isKeyword("WHERE"))
+          // A sub-select, or the end of the expression where the caller expected more.
+          return null;
+
+        ++position;
+        return parseQualifiedReference(null, token.text);
+      }
+      default -> {
+        return null;
+      }
+      }
+    }
+
+    /**
+     * Reads what follows an identifier: further dotted parts, and then either an argument list (a function
+     * call) or nothing (a column reference). {@code pg_catalog.} is dropped, being the schema every one of
+     * these lives in.
+     */
+    private PostgresCatalogExpression parseQualifiedReference(final String qualifier, final String first) {
+      String currentQualifier = qualifier;
+      String name = first;
+
+      while (peek() != null && peek().isSymbol(".")) {
+        ++position;
+        final PostgresCatalogToken next = peek();
+        if (next == null)
+          return null;
+        if (next.isSymbol("*")) {
+          // "t.*" is only meaningful in a projection, which parses star items before reaching this.
+          return null;
+        }
+        if (next.type != PostgresCatalogToken.Type.IDENTIFIER && next.type != PostgresCatalogToken.Type.QUOTED_IDENTIFIER)
+          return null;
+        ++position;
+        currentQualifier = name;
+        name = next.text;
+      }
+
+      if ("pg_catalog".equalsIgnoreCase(currentQualifier) || "information_schema".equalsIgnoreCase(currentQualifier))
+        currentQualifier = null;
+
+      if (peek() != null && peek().isSymbol("(")) {
+        ++position;
+        final List<PostgresCatalogExpression> arguments = new ArrayList<>();
+        if (!skipSymbol(")")) {
+          do {
+            final PostgresCatalogExpression argument = parseExpression();
+            if (argument == null)
+              return null;
+            arguments.add(argument);
+          } while (skipSymbol(","));
+          if (!skipSymbol(")"))
+            return null;
+        }
+        final String functionName = name.toLowerCase(Locale.ENGLISH);
+        if (peek() != null && peek().isKeyword("OVER"))
+          return parseWindow(functionName);
+
+        return new FunctionCall(functionName, arguments);
+      }
+
+      return new ColumnReference(currentQualifier == null ? null : currentQualifier.toLowerCase(Locale.ENGLISH),
+          name.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Reads the {@code OVER (PARTITION BY ... ORDER BY ...)} that follows a window function. Only the two
+     * clauses are read: a frame specification changes what the function means, so a query carrying one is
+     * declined rather than answered as if it were absent.
+     */
+    private PostgresCatalogExpression parseWindow(final String functionName) {
+      ++position; // OVER
+      if (!skipSymbol("("))
+        return null;
+
+      final List<PostgresCatalogExpression> partitionBy = new ArrayList<>();
+      final List<PostgresCatalogExpression> orderBy = new ArrayList<>();
+
+      if (skipKeyword("PARTITION")) {
+        if (!skipKeyword("BY"))
+          return null;
+        do {
+          final PostgresCatalogExpression key = parseExpression();
+          if (key == null)
+            return null;
+          partitionBy.add(key);
+        } while (skipSymbol(","));
+      }
+
+      if (skipKeyword("ORDER")) {
+        if (!skipKeyword("BY"))
+          return null;
+        do {
+          final PostgresCatalogExpression key = parseExpression();
+          if (key == null)
+            return null;
+          orderBy.add(key);
+          // A per-key direction would have to be carried into the numbering; nothing this catalog answers
+          // uses one, so it is declined rather than silently ignored.
+          if (peek() != null && (peek().isKeyword("ASC") || peek().isKeyword("DESC")))
+            ++position;
+        } while (skipSymbol(","));
+      }
+
+      if (!skipSymbol(")"))
+        return null;
+
+      return new WindowCall(functionName, partitionBy, orderBy);
+    }
+
+    private PostgresCatalogExpression parseCase() {
+      ++position; // CASE
+
+      PostgresCatalogExpression operand = null;
+      if (peek() != null && !peek().isKeyword("WHEN")) {
+        operand = parseExpression();
+        if (operand == null)
+          return null;
+      }
+
+      final List<PostgresCatalogExpression> conditions = new ArrayList<>();
+      final List<PostgresCatalogExpression> results = new ArrayList<>();
+      while (skipKeyword("WHEN")) {
+        final PostgresCatalogExpression condition = parseExpression();
+        if (condition == null || !skipKeyword("THEN"))
+          return null;
+        final PostgresCatalogExpression result = parseExpression();
+        if (result == null)
+          return null;
+        conditions.add(condition);
+        results.add(result);
+      }
+
+      if (conditions.isEmpty())
+        return null;
+
+      PostgresCatalogExpression fallback = null;
+      if (skipKeyword("ELSE")) {
+        fallback = parseExpression();
+        if (fallback == null)
+          return null;
+      }
+
+      if (!skipKeyword("END"))
+        return null;
+
+      return new Case(operand, conditions, results, fallback);
+    }
+
+    private static Object parseNumber(final String text) {
+      try {
+        if (text.indexOf('.') < 0 && text.indexOf('e') < 0 && text.indexOf('E') < 0)
+          return Long.parseLong(text);
+      } catch (final NumberFormatException e) {
+        // Falls through to the floating-point reading, which is what an out-of-range integer literal is.
+      }
+      try {
+        return Double.parseDouble(text);
+      } catch (final NumberFormatException e) {
+        return null;
+      }
+    }
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogToken.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalogToken.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One lexical token of a PostgreSQL catalog query (issue #6412).
+ * <p>
+ * Tokenising first is what lets the rest of the catalog emulation work on the <i>structure</i> of a client's
+ * query rather than on its exact text: a comma inside {@code CASE ... END} or inside a quoted string is not a
+ * projection separator, and no amount of splitting the raw string can tell the difference reliably. The
+ * string-equality matching this replaces got that wrong by construction - it could only recognise the one
+ * spelling of the one tool it was written for.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresCatalogToken {
+  enum Type {
+    /** A bare word: a keyword, a relation, a column, a function name. */
+    IDENTIFIER,
+    /** A {@code "double quoted"} identifier, which keeps its case and is never a keyword. */
+    QUOTED_IDENTIFIER,
+    /** A {@code 'single quoted'} string literal, already unescaped. */
+    STRING,
+    NUMBER,
+    /** An operator or punctuation character. */
+    SYMBOL
+  }
+
+  final Type   type;
+  final String text;
+
+  private PostgresCatalogToken(final Type type, final String text) {
+    this.type = type;
+    this.text = text;
+  }
+
+  boolean isKeyword(final String keyword) {
+    return type == Type.IDENTIFIER && text.equalsIgnoreCase(keyword);
+  }
+
+  boolean isSymbol(final String symbol) {
+    return type == Type.SYMBOL && text.equals(symbol);
+  }
+
+  @Override
+  public String toString() {
+    return type + "(" + text + ")";
+  }
+
+  /**
+   * Splits a statement into tokens, or returns null when it contains something this lexer will not read -
+   * an unterminated string, a dollar-quoted body, a comment that never closes. Returning null makes the
+   * caller decline the query, which is the same thing it does for a shape it cannot answer.
+   */
+  static List<PostgresCatalogToken> tokenize(final String query) {
+    final List<PostgresCatalogToken> tokens = new ArrayList<>();
+    final int length = query.length();
+    int i = 0;
+
+    while (i < length) {
+      final char c = query.charAt(i);
+
+      if (Character.isWhitespace(c)) {
+        ++i;
+        continue;
+      }
+
+      // -- line comment
+      if (c == '-' && i + 1 < length && query.charAt(i + 1) == '-') {
+        while (i < length && query.charAt(i) != '\n')
+          ++i;
+        continue;
+      }
+
+      // /* block comment */, which PostgreSQL allows to nest
+      if (c == '/' && i + 1 < length && query.charAt(i + 1) == '*') {
+        int depth = 0;
+        while (i < length) {
+          if (query.charAt(i) == '/' && i + 1 < length && query.charAt(i + 1) == '*') {
+            ++depth;
+            i += 2;
+          } else if (query.charAt(i) == '*' && i + 1 < length && query.charAt(i + 1) == '/') {
+            --depth;
+            i += 2;
+            if (depth == 0)
+              break;
+          } else
+            ++i;
+        }
+        if (depth != 0)
+          return null;
+        continue;
+      }
+
+      // 'string literal', with '' as the embedded quote
+      if (c == '\'') {
+        final StringBuilder value = new StringBuilder();
+        ++i;
+        boolean closed = false;
+        while (i < length) {
+          final char ch = query.charAt(i);
+          if (ch == '\'') {
+            if (i + 1 < length && query.charAt(i + 1) == '\'') {
+              value.append('\'');
+              i += 2;
+              continue;
+            }
+            ++i;
+            closed = true;
+            break;
+          }
+          value.append(ch);
+          ++i;
+        }
+        if (!closed)
+          return null;
+        tokens.add(new PostgresCatalogToken(Type.STRING, value.toString()));
+        continue;
+      }
+
+      // E'escape string', whose backslash escapes matter: pgjdbc writes E'%' and E'\\_' in LIKE patterns
+      if ((c == 'E' || c == 'e') && i + 1 < length && query.charAt(i + 1) == '\'') {
+        final StringBuilder value = new StringBuilder();
+        i += 2;
+        boolean closed = false;
+        while (i < length) {
+          final char ch = query.charAt(i);
+          if (ch == '\\' && i + 1 < length) {
+            value.append(unescape(query.charAt(i + 1)));
+            i += 2;
+            continue;
+          }
+          if (ch == '\'') {
+            if (i + 1 < length && query.charAt(i + 1) == '\'') {
+              value.append('\'');
+              i += 2;
+              continue;
+            }
+            ++i;
+            closed = true;
+            break;
+          }
+          value.append(ch);
+          ++i;
+        }
+        if (!closed)
+          return null;
+        tokens.add(new PostgresCatalogToken(Type.STRING, value.toString()));
+        continue;
+      }
+
+      // `backtick quoted identifier`. PostgreSQL does not have these, but ArcadeDB does, and the executor
+      // rewrites a client's "double quoted" identifiers into them before dispatching (see
+      // PostgresQuotedIdentifierRewriter), so this is the form a catalog query actually arrives in.
+      if (c == '`') {
+        final int end = query.indexOf('`', i + 1);
+        if (end < 0)
+          return null;
+        tokens.add(new PostgresCatalogToken(Type.QUOTED_IDENTIFIER, query.substring(i + 1, end)));
+        i = end + 1;
+        continue;
+      }
+
+      // "quoted identifier", with "" as the embedded quote
+      if (c == '"') {
+        final StringBuilder value = new StringBuilder();
+        ++i;
+        boolean closed = false;
+        while (i < length) {
+          final char ch = query.charAt(i);
+          if (ch == '"') {
+            if (i + 1 < length && query.charAt(i + 1) == '"') {
+              value.append('"');
+              i += 2;
+              continue;
+            }
+            ++i;
+            closed = true;
+            break;
+          }
+          value.append(ch);
+          ++i;
+        }
+        if (!closed)
+          return null;
+        tokens.add(new PostgresCatalogToken(Type.QUOTED_IDENTIFIER, value.toString()));
+        continue;
+      }
+
+      // $1 and friends: a parameter placeholder, which no emulated catalog query can be answered without
+      // the parameter itself, so it is left as a symbol the parser will refuse.
+      if (c == '$') {
+        int j = i + 1;
+        while (j < length && Character.isDigit(query.charAt(j)))
+          ++j;
+        tokens.add(new PostgresCatalogToken(Type.SYMBOL, query.substring(i, j)));
+        i = j;
+        continue;
+      }
+
+      if (Character.isDigit(c)) {
+        int j = i;
+        while (j < length && (Character.isDigit(query.charAt(j)) || query.charAt(j) == '.'))
+          ++j;
+        if (j < length && (query.charAt(j) == 'e' || query.charAt(j) == 'E')) {
+          int k = j + 1;
+          if (k < length && (query.charAt(k) == '+' || query.charAt(k) == '-'))
+            ++k;
+          if (k < length && Character.isDigit(query.charAt(k))) {
+            j = k;
+            while (j < length && Character.isDigit(query.charAt(j)))
+              ++j;
+          }
+        }
+        tokens.add(new PostgresCatalogToken(Type.NUMBER, query.substring(i, j)));
+        i = j;
+        continue;
+      }
+
+      if (Character.isLetter(c) || c == '_') {
+        int j = i;
+        while (j < length && (Character.isLetterOrDigit(query.charAt(j)) || query.charAt(j) == '_' || query.charAt(j) == '$'))
+          ++j;
+        tokens.add(new PostgresCatalogToken(Type.IDENTIFIER, query.substring(i, j)));
+        i = j;
+        continue;
+      }
+
+      // Multi-character operators first, so that "<=" is one token and not two.
+      final String twoOrThree = threeCharOperator(query, i);
+      if (twoOrThree != null) {
+        tokens.add(new PostgresCatalogToken(Type.SYMBOL, twoOrThree));
+        i += twoOrThree.length();
+        continue;
+      }
+
+      tokens.add(new PostgresCatalogToken(Type.SYMBOL, String.valueOf(c)));
+      ++i;
+    }
+
+    return tokens;
+  }
+
+  private static String threeCharOperator(final String query, final int i) {
+    final int length = query.length();
+    if (i + 2 < length) {
+      final String three = query.substring(i, i + 3);
+      if ("!~*".equals(three))
+        return three;
+    }
+    if (i + 1 < length) {
+      final String two = query.substring(i, i + 2);
+      switch (two) {
+      case "<=", ">=", "<>", "!=", "||", "::", "~*", "!~" -> {
+        return two;
+      }
+      default -> {
+        return null;
+      }
+      }
+    }
+    return null;
+  }
+
+  private static char unescape(final char c) {
+    return switch (c) {
+      case 'n' -> '\n';
+      case 't' -> '\t';
+      case 'r' -> '\r';
+      case 'b' -> '\b';
+      case 'f' -> '\f';
+      default -> c;
+    };
+  }
+
+  /**
+   * The token a bound parameter value stands for, so that a query carrying {@code $1} can be answered as if
+   * the client had written the value inline. Returns null for a value with no literal form - a NULL, or an
+   * array - which leaves the placeholder in place and the predicate around it unread.
+   */
+  static PostgresCatalogToken literal(final Object value) {
+    if (value == null)
+      return null;
+    if (value instanceof Number)
+      return new PostgresCatalogToken(Type.NUMBER, value.toString());
+    if (value instanceof CharSequence || value instanceof Character)
+      return new PostgresCatalogToken(Type.STRING, value.toString());
+    if (value instanceof Boolean b)
+      return new PostgresCatalogToken(Type.IDENTIFIER, b ? "TRUE" : "FALSE");
+    return null;
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -61,10 +61,10 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.monitor.QueryProfile;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
+import com.arcadedb.server.network.PreAuthConnectionGate;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
-import com.arcadedb.utility.CodeUtils;
 import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.Pair;
@@ -78,7 +78,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -113,8 +112,6 @@ public class PostgresNetworkExecutor extends Thread {
    * The cap PostgreSQL itself puts on a startup packet ({@code PQ_STARTUP_MSG_LIMIT} in {@code pqcomm.c}).
    */
   private static final int                                            MAX_STARTUP_MESSAGE_LENGTH = 10000;
-  /** How often {@link #waitForAMessage} looks for the client's next pre-authentication message. */
-  private static final int                                            WAIT_FOR_MESSAGE_POLL_MS   = 100;
   private static final Map<Long, Pair<Long, PostgresNetworkExecutor>> ACTIVE_SESSIONS  = new ConcurrentHashMap<>();
   /** Bind-message parameter length denoting a NULL value (wire value -1, read unsigned). */
   private static final long                                           NULL_PARAM_LENGTH = 0xFFFFFFFFL;
@@ -127,15 +124,17 @@ public class PostgresNetworkExecutor extends Thread {
   private final boolean                     DEBUG                 = GlobalConfiguration.POSTGRES_DEBUG.getValueAsBoolean();
   private final boolean                     QUOTED_IDENTIFIERS    = GlobalConfiguration.POSTGRES_QUOTED_IDENTIFIERS.getValueAsBoolean();
   private final Map<String, Object>         connectionProperties  = new HashMap<>();
-  private final Set<String>                 ignoreQueriesAppNames = new HashSet<>(//
-      List.of("dbvis", "Database Navigator - Pool"));
-  // "SELECT oid, typname FROM pg_type" used to sit here too, so a client that builds its OID-to-name map up
-  // front got an empty one (issue #5290). PostgresTypeCatalog answers it now.
-  private final Set<String>                 ignoreQueries         = new HashSet<>(//
-      List.of(//
-          "select distinct PRIVILEGE_TYPE as PRIVILEGE_NAME from INFORMATION_SCHEMA.USAGE_PRIVILEGES order by PRIVILEGE_TYPE asc"));
+  // The exact query spellings to answer with nothing, and the application_name values that gated them, used
+  // to be listed here: see PostgresCatalog, which answers those questions by shape for every client (#6412).
 
   private volatile boolean shutdown = false;
+
+  /**
+   * The listener's permit for a connection that has not authenticated yet, handed back the moment it does -
+   * or when it goes away without ever doing so (issue #6412). Null when the connection was not created by a
+   * listener that caps them.
+   */
+  private final PreAuthConnectionGate.Ticket preAuthTicket;
 
   private Database database;
   private int      nextByte                   = 0;
@@ -157,10 +156,16 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   public PostgresNetworkExecutor(final ArcadeDBServer server, final Socket socket, final Database database) throws IOException {
+    this(server, socket, database, null);
+  }
+
+  public PostgresNetworkExecutor(final ArcadeDBServer server, final Socket socket, final Database database,
+      final PreAuthConnectionGate.Ticket preAuthTicket) throws IOException {
     setName(Constants.PRODUCT + "-postgres/" + socket.getInetAddress());
     this.server = server;
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
     this.database = database;
+    this.preAuthTicket = preAuthTicket;
 
     // Bound the pre-authentication window (issue #6377). One thread and one file descriptor are committed
     // per accepted connection, before anyone has proved who they are, and the listener caps neither; without
@@ -178,6 +183,7 @@ public class PostgresNetworkExecutor extends Thread {
    * Lifts the pre-authentication read timeout armed in the constructor (issue #6377).
    */
   private void markAuthenticated() {
+    releasePreAuthTicket();
     try {
       channel.socket.setSoTimeout(0);
     } catch (final SocketException e) {
@@ -190,8 +196,18 @@ public class PostgresNetworkExecutor extends Thread {
 
   public void close() {
     shutdown = true;
+    releasePreAuthTicket();
     if (channel != null)
       channel.close();
+  }
+
+  /**
+   * Hands the listener's pre-authentication permit back. Idempotent, so authenticating and then closing -
+   * the normal life of a connection - releases exactly one permit.
+   */
+  private void releasePreAuthTicket() {
+    if (preAuthTicket != null)
+      preAuthTicket.release();
   }
 
   @Override
@@ -204,8 +220,10 @@ public class PostgresNetworkExecutor extends Thread {
 
         writeMessage("request for password", () -> channel.writeUnsignedInt(3), 'R', 8);
 
-        waitForAMessage();
-
+        // The password read blocks on the socket, under the handshake timeout armed in the constructor: a
+        // client that connects, receives the password request and then goes silent is closed by that timeout
+        // (issue #6377). It used to need a deadline of its own here, because readMessage could not block
+        // (issue #6410).
         if (!readMessage("password", (type, length) -> userPassword = readString(), 'p'))
           return;
 
@@ -243,7 +261,10 @@ public class PostgresNetworkExecutor extends Thread {
         while (!shutdown) {
           try {
 
-            readMessage("any", (type, length) -> {
+            // False means the connection is finished - the client closed it, or it was closed under this
+            // thread's blocked read. There is nothing left to read from it, so the loop must not go round
+            // again (issue #6410): before the read blocked, false only meant "no byte yet".
+            if (!readMessage("any", (type, length) -> {
               consecutiveErrors = 0;
 
               switch (type) {
@@ -263,7 +284,8 @@ public class PostgresNetworkExecutor extends Thread {
               default -> throw new PostgresProtocolException("Message '" + type + "' not managed");
               }
 
-            }, 'P', 'B', 'E', 'Q', 'S', 'D', 'C', 'H', 'X');
+            }, 'P', 'B', 'E', 'Q', 'S', 'D', 'C', 'H', 'X'))
+              return;
 
           } catch (final Exception e) {
             setErrorInTx();
@@ -387,7 +409,7 @@ public class PostgresNetworkExecutor extends Thread {
 
       // Now send RowDescription or NoData
       // For SELECT queries, we need to determine the columns from the type schema
-      if (portal.isExpectingResult && portal.columns == null) {
+      if (portal.isExpectingResult && portal.columns == null && !portal.catalogQuery) {
         portal.columns = getColumnsFromQuerySchema(portal.query, portal.sqlStatement);
       }
 
@@ -434,7 +456,14 @@ public class PostgresNetworkExecutor extends Thread {
         if (!portal.executed) {
           final long engineStart = System.nanoTime();
           ResultSet resultSet;
-          if (portal.sqlStatement != null) {
+          if (portal.catalogQuery) {
+            // Deferred from parseCommand because the query's filters are bound parameters (issue #6412).
+            final CatalogAnswer catalogAnswer = handleCatalogQuery(portal.query, getParams(portal));
+            resultSet = new IteratorResultSet(
+                (catalogAnswer != null ? catalogAnswer.rows() : Collections.<Result>emptyList()).iterator());
+            if (catalogAnswer != null)
+              portal.columns = catalogAnswer.columns();
+          } else if (portal.sqlStatement != null) {
             final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
             final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
             try {
@@ -453,7 +482,9 @@ public class PostgresNetworkExecutor extends Thread {
             // But always use columns from actual result for DataRows consistency
             if (!portal.rowDescriptionSent) {
               final long serStart = System.nanoTime();
-              portal.columns = getColumns(portal.cachedResultSet);
+              // A catalog answer already carries the columns it must be announced under.
+              if (!portal.catalogQuery || portal.columns == null)
+                portal.columns = getColumns(portal.cachedResultSet);
               if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
                 final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                     getParams(portal), portal.sqlStatement);
@@ -541,6 +572,7 @@ public class PostgresNetworkExecutor extends Thread {
     QueryProfile.pushCurrent(profile);
     Query query = null;
     String queryText = null;
+    CatalogAnswer catalogAnswer = null;
     try {
       final long deserStart = System.nanoTime();
       queryText = readString().trim();
@@ -588,13 +620,12 @@ public class PostgresNetworkExecutor extends Thread {
         explicitTransactionStarted = true;
         database.begin();
         resultSet = new IteratorResultSet(Collections.emptyIterator());
-      } else if (ignoreQueries.contains(query.query))
-        resultSet = new IteratorResultSet(Collections.emptyIterator());
-      else {
-        // Check for pg_type/pg_catalog queries from JDBC drivers
-        final List<Result> pgTypeResult = handlePgTypeQuery(query.query);
-        if (pgTypeResult != null) {
-          resultSet = new IteratorResultSet(pgTypeResult.iterator());
+      } else {
+        // A query about the emulated system catalog, which every client sends and which ArcadeDB's own SQL
+        // engine has no tables for (issue #6412).
+        catalogAnswer = handleCatalogQuery(query.query);
+        if (catalogAnswer != null) {
+          resultSet = new IteratorResultSet(catalogAnswer.rows().iterator());
         } else {
           resultSet = database.command(query.language, query.query, server.getConfiguration());
         }
@@ -603,7 +634,7 @@ public class PostgresNetworkExecutor extends Thread {
       profile.addEngineNanos(System.nanoTime() - engineStart);
 
       final long serStart = System.nanoTime();
-      Map<String, PostgresType> columns = getColumns(cachedResultSet);
+      Map<String, PostgresType> columns = catalogAnswer != null ? catalogAnswer.columns() : getColumns(cachedResultSet);
       if (columns.isEmpty() && cachedResultSet.isEmpty()) {
         final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(query.query, query.language, NO_PARAMETERS, null);
         if (schemaColumns != null)
@@ -712,31 +743,50 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   /**
-   * Handles PostgreSQL system catalog queries (pg_type, pg_catalog) from JDBC drivers.
-   * These queries are used by JDBC drivers to introspect types, especially for arrays.
-   *
-   * @param query The SQL query to check
-   * @return A list of results if this is a pg_type query we handle, null otherwise
+   * The answer to a catalog query: the rows to send, and the columns to announce them under. The columns are
+   * carried rather than inferred from the rows so that an answer with no rows in it still describes itself,
+   * and in the order the client projected - a DataRow is read positionally.
    */
-  private List<Result> handlePgTypeQuery(final String query) {
-    final String upperQuery = query.toUpperCase(Locale.ENGLISH);
+  private record CatalogAnswer(List<Result> rows, Map<String, PostgresType> columns) {
+  }
 
-    // Check if this is a pg_type/pg_catalog query
-    if (!upperQuery.contains("PG_TYPE") && !upperQuery.contains("PG_CATALOG")) {
+  /**
+   * Answers a query about the emulated PostgreSQL system catalog, which is how every client - not only the
+   * ones that were named in an application_name allow-list (issue #6412) - finds out what is in the database
+   * it just connected to.
+   * <p>
+   * Two recognisers share the work: {@link PostgresTypeCatalog} for {@code pg_type}, whose element-type
+   * self-join is a shape no plain projection can express, and {@link PostgresCatalog} for the rest. A shape
+   * neither of them will answer gets the empty result set that a pg_catalog query it did not understand has
+   * always been given, rather than being handed to ArcadeDB's SQL engine, which has no such tables and would
+   * answer with a syntax error.
+   *
+   * @param parameters the values bound to the query's placeholders, empty at Parse time and supplied at
+   *                   Execute time, when the client has sent them
+   *
+   * @return the answer, or null when the query is not about the catalog at all and must be executed normally
+   */
+  private CatalogAnswer handleCatalogQuery(final String query, final Object... parameters) {
+    if (!PostgresCatalog.mightBeCatalogQuery(query))
       return null;
-    }
 
     if (DEBUG)
-      LogManager.instance().log(this, Level.INFO, "PSQL: handling pg_type query: %s (thread=%s)",
-          query, Thread.currentThread().threadId());
+      LogManager.instance().log(this, Level.INFO, "PSQL: handling catalog query: %s (thread=%s)", query,
+          Thread.currentThread().threadId());
 
-    final List<Result> rows = toResults(PostgresTypeCatalog.resolve(query));
-    if (rows != null)
-      return rows;
+    final List<Result> types = toResults(PostgresTypeCatalog.resolve(query));
+    if (types != null)
+      return new CatalogAnswer(types, getColumns(types));
 
-    // For other pg_type queries we don't specifically handle, return empty result
-    // This prevents errors from trying to query non-existent tables
-    return Collections.emptyList();
+    final PostgresCatalog.Answer answer = PostgresCatalog.resolve(query, database, userName, parameters);
+    if (answer != null && answer.rows != null)
+      return new CatalogAnswer(toResults(answer.rows), answer.columns);
+
+    if (answer == PostgresCatalog.DECLINED || PostgresCatalog.containsIgnoreCase(query, "pg_catalog")
+        || PostgresCatalog.containsIgnoreCase(query, "pg_type"))
+      return new CatalogAnswer(Collections.emptyList(), Map.of());
+
+    return null;
   }
 
   private static List<Result> toResults(final List<Map<String, Object>> rows) {
@@ -1680,13 +1730,7 @@ public class PostgresNetworkExecutor extends Thread {
       final String upperCaseText = portal.query.toUpperCase(Locale.ENGLISH);
       final PostgresSystemQuery systemQuery = PostgresSystemQuery.parse(portal.query);
 
-      if (portal.query.isEmpty() ||//
-          (ignoreQueriesAppNames.contains(connectionProperties.get("application_name")) &&//
-              ignoreQueries.contains(portal.query))) {
-        // RETURN EMPTY RESULT
-        portal.executed = true;
-        portal.cachedResultSet = new ArrayList<>();
-      } else if (upperCaseText.startsWith("SAVEPOINT ") ||
+      if (upperCaseText.startsWith("SAVEPOINT ") ||
           upperCaseText.startsWith("RELEASE ") ||
           upperCaseText.startsWith("ROLLBACK TO ")) {
         portal.ignoreExecution = true;
@@ -1705,131 +1749,23 @@ public class PostgresNetworkExecutor extends Thread {
         final String varName = portal.query.substring(5).trim().toLowerCase(Locale.ENGLISH);
         createResultSet(portal, varName, getShowConfigValue(varName));
 
-      } else if ("dbvis".equals(connectionProperties.get("application_name"))) {
-        // SPECIAL CASES
-        if ("SELECT nspname AS TABLE_SCHEM, NULL AS TABLE_CATALOG FROM pg_catalog.pg_namespace  WHERE nspname <> 'pg_toast' AND (nspname !~ '^pg_temp_'  OR nspname = (pg_catalog.current_schemas(true))[1]) AND (nspname !~ '^pg_toast_temp_'  OR nspname = replace((pg_catalog.current_schemas(true))[1], 'pg_temp_', 'pg_toast_temp_'))  ORDER BY TABLE_SCHEM".equals(portal.query)
-            || "SELECT     COLLATION_SCHEMA,     COLLATION_NAME FROM     INFORMATION_SCHEMA.COLLATIONS".equals(portal.query)) {
-          // SPECIAL CASE DB VISUALIZER
-
-          portal.executed = true;
-          portal.cachedResultSet = new ArrayList<>();
-
-          final Map<String, Object> map = new HashMap<>();
-          map.put("TABLE_CATALOG", null);
-          map.put("TABLE_SCHEM", "");
-
-          final Result result = new ResultInternal(map);
-          portal.cachedResultSet.add(result);
-
-          portal.columns = new HashMap<>();
-          portal.columns.put("TABLE_CATALOG", PostgresType.VARCHAR);
-          portal.columns.put("TABLE_SCHEM", PostgresType.VARCHAR);
-
-        } else if (portal.query.contains("ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME ")) {
-          portal.executed = true;
-          portal.cachedResultSet = new ArrayList<>();
-          for (final DocumentType t : database.getSchema().getTypes()) {
-            final Map<String, Object> map = new HashMap<>();
-            map.put("TABLE_CAT", "");
-            map.put("TABLE_SCHEM", "");
-            map.put("TABLE_TYPE", "TABLE");
-            map.put("TABLE_NAME", t.getName());
-            map.put("REMARKS", "");
-            map.put("TYPE_CAT", "");
-            map.put("TYPE_SCHEM", "");
-            map.put("TYPE_NAME", "");
-            map.put("SELF_REFERENCING_COL_NAME", "");
-            map.put("REF_GENERATION", "");
-
-            final Result result = new ResultInternal(map);
-            portal.cachedResultSet.add(result);
-
-            portal.columns = new HashMap<>();
-            portal.columns.put("TABLE_CAT", PostgresType.VARCHAR);
-            portal.columns.put("TABLE_SCHEM", PostgresType.VARCHAR);
-            portal.columns.put("TABLE_TYPE", PostgresType.VARCHAR);
-            portal.columns.put("TABLE_NAME", PostgresType.VARCHAR);
-            portal.columns.put("REMARKS", PostgresType.VARCHAR);
-            portal.columns.put("TYPE_CAT", PostgresType.VARCHAR);
-            portal.columns.put("TYPE_SCHEM", PostgresType.VARCHAR);
-            portal.columns.put("TYPE_NAME", PostgresType.VARCHAR);
-            portal.columns.put("SELF_REFERENCING_COL_NAME", PostgresType.VARCHAR);
-            portal.columns.put("REF_GENERATION", PostgresType.VARCHAR);
-          }
-        }
-      } else if ("select distinct GRANTEE as USER_NAME, 'N' as IS_EXPIRED, 'N' as IS_LOCKED from INFORMATION_SCHEMA.USAGE_PRIVILEGES order by GRANTEE asc".equals(portal.query)) {
-        portal.executed = true;
-        portal.cachedResultSet = new ArrayList<>();
-        final Map<String, Object> map = new HashMap<>();
-        map.put("USER_NAME", "root");
-        map.put("IS_EXPIRED", 'N');
-        map.put("IS_LOCKED", 'N');
-        final Result result = new ResultInternal(map);
-        portal.cachedResultSet.add(result);
-
-        portal.columns = new HashMap<>();
-        portal.columns.put("USER_NAME", PostgresType.VARCHAR);
-        portal.columns.put("IS_EXPIRED", PostgresType.CHAR);
-        portal.columns.put("IS_LOCKED", PostgresType.CHAR);
-
-      } else if ("select CHARACTER_SET_NAME as CHARSET_NAME, -1 as MAX_LENGTH from INFORMATION_SCHEMA.CHARACTER_SETS order by CHARACTER_SET_NAME asc".equals(portal.query)) {
-        portal.executed = true;
-        portal.cachedResultSet = new ArrayList<>();
-        final Map<String, Object> map = new HashMap<>();
-        map.put("CHARSET_NAME", "UTF-8");
-        map.put("MAX_LENGTH", -1);
-        final Result result = new ResultInternal(map);
-        portal.cachedResultSet.add(result);
-
-        portal.columns = new HashMap<>();
-        portal.columns.put("CHARSET_NAME", PostgresType.VARCHAR);
-        portal.columns.put("MAX_LENGTH", PostgresType.INTEGER);
-      } else if (//
-          "select NSPNAME as SCHEMA_NAME, case when lower(NSPNAME)='pg_catalog' then 'Y' else 'N' end as IS_PUBLIC, case when lower(NSPNAME)='information_schema' then 'Y' else 'N' end as IS_SYSTEM, 'N' as IS_EMPTY from PG_CATALOG.PG_NAMESPACE order by NSPNAME asc".equals(portal.query)
-              || "select SCHEMA_NAME, case when lower(SCHEMA_NAME)='pg_catalog' then 'Y' else 'N' end as IS_PUBLIC, case when lower(SCHEMA_NAME)='information_schema' then 'Y' else 'N' end as IS_SYSTEM, 'N' as IS_EMPTY from INFORMATION_SCHEMA.SCHEMATA order by SCHEMA_NAME asc".equals(portal.query)) {
-
-        portal.executed = true;
-        portal.cachedResultSet = new ArrayList<>();
-
-        for (final String dbName : server.getDatabaseNames()) {
-          final Map<String, Object> map = new HashMap<>();
-          map.put("SCHEMA_NAME", dbName);
-          map.put("IS_PUBLIC", "Y");
-          map.put("IS_SYSTEM", "N");
-          map.put("IS_EMPTY", "N");
-          final Result result = new ResultInternal(map);
-          portal.cachedResultSet.add(result);
-        }
-
-        portal.columns = new HashMap<>();
-        portal.columns.put("SCHEMA_NAME", PostgresType.VARCHAR);
-        portal.columns.put("IS_PUBLIC", PostgresType.CHAR);
-        portal.columns.put("IS_SYSTEM", PostgresType.CHAR);
-        portal.columns.put("IS_EMPTY", PostgresType.CHAR);
-      } else if ("SELECT nspname AS TABLE_SCHEM, NULL AS TABLE_CATALOG FROM pg_catalog.pg_namespace  WHERE nspname <> 'pg_toast' AND (nspname !~ '^pg_temp_'  OR nspname = (pg_catalog.current_schemas(true))[1]) AND (nspname !~ '^pg_toast_temp_'  OR nspname = replace((pg_catalog.current_schemas(true))[1], 'pg_temp_', 'pg_toast_temp_'))  AND nspname LIKE E'%' ORDER BY TABLE_SCHEM".equals(portal.query)) {
-
-        portal.executed = true;
-        portal.cachedResultSet = new ArrayList<>();
-
-        for (final DocumentType t : database.getSchema().getTypes()) {
-          final Map<String, Object> map = new HashMap<>();
-          map.put("TABLE_SCHEM", t.getName());
-          map.put("TABLE_CATALOG", database.getName());
-          final Result result = new ResultInternal(map);
-          portal.cachedResultSet.add(result);
-        }
-
-        portal.columns = new HashMap<>();
-        portal.columns.put("TABLE_SCHEM", PostgresType.VARCHAR);
-        portal.columns.put("TABLE_CATALOG", PostgresType.VARCHAR);
       } else {
-        // Check for pg_type/pg_catalog queries from JDBC drivers (extended query protocol)
-        final List<Result> pgTypeResult = handlePgTypeQuery(portal.query);
-        if (pgTypeResult != null) {
-          // pg_type query handled - set up the portal with results
+        // A query about the emulated system catalog. Every family of these used to be matched by string
+        // equality here, several of them only when application_name was literally "dbvis", so the same
+        // question asked by any other client fell through to ArcadeDB's SQL engine and failed (issue #6412).
+        //
+        // One that carries parameters cannot be answered yet: the JDBC driver puts the name patterns of its
+        // table and column lists in them, and their values only arrive with the Bind message. It is marked
+        // here and answered in executeCommand, with the values in hand.
+        final CatalogAnswer catalogAnswer = handleCatalogQuery(portal.query);
+        if (catalogAnswer != null && actualParamCount > 0) {
+          // Recognised, but its filters are bound parameters whose values only arrive with Bind: the answer
+          // computed here would ignore them, so it is thrown away and recomputed in executeCommand.
+          portal.catalogQuery = true;
+        } else if (catalogAnswer != null) {
           portal.executed = true;
-          portal.cachedResultSet = pgTypeResult;
-          portal.columns = getColumns(pgTypeResult);
+          portal.cachedResultSet = catalogAnswer.rows();
+          portal.columns = catalogAnswer.columns();
         } else {
           switch (portal.language) {
           case "sql":
@@ -2166,13 +2102,27 @@ public class PostgresNetworkExecutor extends Thread {
     }
   }
 
+  /**
+   * Reads the client's next message, blocking on the socket until its first byte arrives (issue #6410).
+   * <p>
+   * This used to open with {@code if (!channel.inputHasData()) { sleep(100); return false; }}, which made
+   * every idle connection wake its thread ten times a second to ask an empty socket whether anything had
+   * turned up - and a Postgres client pool is expected to hold long-lived, mostly-idle connections, so the
+   * cost was 10 wakeups per second per pooled connection, for no work. It also meant the end of the stream
+   * was never read: a client that went away left its thread polling a socket that would never produce
+   * another byte, because {@code available()} answers 0 for a closed peer exactly as it does for an idle one.
+   * <p>
+   * Blocking is safe on both of the paths that have to keep working. A server-side {@link #close()} - the
+   * cancel-request path uses it on another connection's executor - closes the socket, and closing a socket
+   * breaks a thread blocked reading it. A client that closes cleanly produces the EOF the arm below already
+   * handled. Before authentication the socket carries the handshake timeout armed in the constructor, so a
+   * silent client is bounded by it rather than by a poll loop of this method's own (issue #6377).
+   *
+   * @return false when the connection is finished - end of stream, or a socket closed under it - in which
+   * case the caller must stop reading from it. True when a message was read and dispatched.
+   */
   private boolean readMessage(final String messageName, final ReadMessageCallback callback, final char... expectedMessageCodes) {
     try {
-      if (!channel.inputHasData()) {
-        CodeUtils.sleep(100);
-        return false;
-      }
-
       final char type = (char) readNextByte();
       final long length = channel.readUnsignedInt();
 
@@ -2205,6 +2155,11 @@ public class PostgresNetworkExecutor extends Thread {
       return false;
     } catch (final IOException e) {
       setErrorInTx();
+      if (shutdown)
+        // The socket was closed under the blocked read, by this executor's own close() - the cancel-request
+        // path calls it from another connection's thread. That is a shutdown, not a protocol error, and it
+        // must not be logged as one.
+        return false;
       throw new PostgresProtocolException("Error on reading " + messageName + " message: " + e.getMessage(), e);
     }
   }
@@ -2217,33 +2172,6 @@ public class PostgresNetworkExecutor extends Thread {
     }
 
     return nextByte = channel.readUnsignedByte();
-  }
-
-  /**
-   * Waits for the client's next pre-authentication message to show up, bounded by the same handshake timeout
-   * as the socket reads around it (issue #6377). {@link #readMessage} deliberately does not block - it
-   * returns false when no byte is available yet - so the pre-auth sequence has to see input arrive before it
-   * reads. Unbounded, this loop was the hole the socket timeout could not close: a client that connected,
-   * sent a startup message and then went silent pinned this thread here forever, and no read was ever
-   * outstanding on the socket for a timeout to interrupt.
-   */
-  private void waitForAMessage() {
-    final int handshakeTimeout = GlobalConfiguration.NETWORK_SOCKET_TIMEOUT.getValueAsInteger();
-    final long deadline = handshakeTimeout > 0 ? System.currentTimeMillis() + handshakeTimeout : Long.MAX_VALUE;
-
-    while (!channel.inputHasData()) {
-      if (shutdown)
-        throw new PostgresProtocolException("Connection closed while waiting for the authentication handshake");
-      if (System.currentTimeMillis() > deadline)
-        throw new PostgresProtocolException("Timeout waiting for the client to complete the authentication handshake");
-
-      try {
-        Thread.sleep(WAIT_FOR_MESSAGE_POLL_MS);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new PostgresProtocolException("Error on reading from the channel");
-      }
-    }
   }
 
   private void reuseLastByte() {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
@@ -22,6 +22,7 @@ import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerException;
+import com.arcadedb.server.network.PreAuthConnectionGate;
 import com.arcadedb.server.network.ServerSocketFactory;
 
 import java.io.IOException;
@@ -29,8 +30,10 @@ import java.net.*;
 import java.util.logging.Level;
 
 public class PostgresNetworkListener extends Thread {
-  private final    ArcadeDBServer      server;
-  private final    ServerSocketFactory socketFactory;
+  private final    ArcadeDBServer         server;
+  private final    ServerSocketFactory    socketFactory;
+  /** Bounds how many accepted connections can sit un-authenticated at once (issue #6412). */
+  private final    PreAuthConnectionGate  preAuthGate     = new PreAuthConnectionGate("PSQL");
   private          ServerSocket        serverSocket;
   private volatile boolean             active          = true;
   private final    int                 protocolVersion = -1;
@@ -55,12 +58,33 @@ public class PostgresNetworkListener extends Thread {
         try {
           final Socket socket = serverSocket.accept();
 
+          // One thread and one file descriptor are committed here, before the client has proved anything: past
+          // the cap the socket is closed straight away rather than being given either (issue #6412). The refusal
+          // is a close and not an ErrorResponse because writing one would be an I/O the refused peer could stall,
+          // on the accept thread, which is the one thing that must never be stallable.
+          final PreAuthConnectionGate.Ticket ticket = preAuthGate.accept();
+          if (ticket == null) {
+            preAuthGate.logRefusal(this, socket.getRemoteSocketAddress());
+            try {
+              socket.close();
+            } catch (final IOException e) {
+              // IGNORE IT: THE CONNECTION IS BEING DROPPED ANYWAY
+            }
+            continue;
+          }
+
           socket.setPerformancePreferences(0, 2, 1);
 
-          // CREATE A NEW PROTOCOL INSTANCE
-          // TODO: OPEN A DATABASE
-          final PostgresNetworkExecutor connection = new PostgresNetworkExecutor(server, socket, null);
-          connection.start();
+          try {
+            // CREATE A NEW PROTOCOL INSTANCE
+            // TODO: OPEN A DATABASE
+            final PostgresNetworkExecutor connection = new PostgresNetworkExecutor(server, socket, null, ticket);
+            connection.start();
+          } catch (final Exception e) {
+            // The executor never started, so nothing will hand the permit back for it.
+            ticket.release();
+            throw e;
+          }
 
         } catch (final Exception e) {
           if (active)

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
@@ -38,6 +38,11 @@ public class PostgresPortal {
   public boolean                   isExpectingResult;
   public boolean                   executed             = false;
   public boolean                   rowDescriptionSent   = false;
+  /**
+   * True when the query is about the emulated system catalog and could not be answered at Parse time because
+   * its filters are bound parameters, whose values only arrive with the Bind message (issue #6412).
+   */
+  public boolean                   catalogQuery         = false;
 
   public PostgresPortal(final String query, String language) {
     this.query = query;

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -69,6 +69,12 @@ public enum PostgresType {
   TEXT(25, "text", 0, 1009, String.class, -1, value -> value),
   BPCHAR(1042, "bpchar", 0, 1014, String.class, -1, value -> value),
   JSON(114, "json", 0, 199, JSONObject.class, -1, PostgresType::parseJsonText),
+  // The type PostgreSQL has for a blob, and the only honest answer for a byte[] (issue #6411). A byte[] used
+  // to be typed as "char"[] (OID 1002) by getTypeForValue and as varchar (OID 1043) by getTypeFromArcade, so
+  // a BINARY column's OID depended on whether the result set happened to be empty - and neither answer was
+  // right: an array of one-byte characters makes the client decode arbitrary bytes as text, which for any
+  // non-UTF-8 payload loses data rather than merely looking odd.
+  BYTEA(17, "bytea", 0, 1001, byte[].class, -1, PostgresType::parseByteaText),
   // Adding array types with PostgreSQL array type codes
   ARRAY_INT(1007, "_int4", 23, 0, Collection.class, -1, value -> parseArrayFromString(value, Integer::parseInt)),
   // 1002 is "char"[], the array of the single-byte CHAR (OID 18) this enum pairs it with. It used to be
@@ -105,6 +111,93 @@ public enum PostgresType {
     if (!trimmed.isEmpty() && trimmed.charAt(0) == '[')
       return new JSONArray(trimmed).toList();
     return new JSONObject(value);
+  }
+
+  /**
+   * Parses the text representation of a bytea. PostgreSQL emits the hex format {@code \x<hexdigits>} for any
+   * server version from 9.0 on - which is what this protocol announces - but still accepts the older escape
+   * format on input, and some clients still send it, so both are read here.
+   */
+  private static byte[] parseByteaText(final String value) {
+    if (value == null)
+      throw new PostgresProtocolException("Cannot parse null BYTEA text value");
+
+    if (value.length() >= 2 && value.charAt(0) == '\\' && (value.charAt(1) == 'x' || value.charAt(1) == 'X')) {
+      final int digits = value.length() - 2;
+      if (digits % 2 != 0)
+        throw new PostgresProtocolException("Invalid hex BYTEA text value: odd number of digits");
+
+      final byte[] bytes = new byte[digits / 2];
+      for (int i = 0; i < bytes.length; i++) {
+        final int high = Character.digit(value.charAt(2 + i * 2), 16);
+        final int low = Character.digit(value.charAt(3 + i * 2), 16);
+        if (high < 0 || low < 0)
+          throw new PostgresProtocolException("Invalid hex BYTEA text value: not a hex digit");
+        bytes[i] = (byte) ((high << 4) | low);
+      }
+      return bytes;
+    }
+
+    return parseByteaEscapeText(value);
+  }
+
+  /**
+   * Decodes the pre-9.0 bytea escape format: a backslash introduces either another backslash or a three-digit
+   * octal byte, and everything else stands for itself.
+   */
+  private static byte[] parseByteaEscapeText(final String value) {
+    final byte[] bytes = new byte[value.length()];
+    int len = 0;
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      if (c != '\\') {
+        bytes[len++] = (byte) c;
+        continue;
+      }
+
+      if (i + 1 >= value.length())
+        throw new PostgresProtocolException("Invalid escaped BYTEA text value: trailing backslash");
+
+      final char next = value.charAt(++i);
+      if (next == '\\') {
+        bytes[len++] = (byte) '\\';
+        continue;
+      }
+
+      if (i + 2 >= value.length())
+        throw new PostgresProtocolException("Invalid escaped BYTEA text value: truncated octal escape");
+
+      int octal = 0;
+      for (int digit = 0; digit < 3; digit++) {
+        final int parsed = Character.digit(value.charAt(i + digit), 8);
+        if (parsed < 0)
+          throw new PostgresProtocolException("Invalid escaped BYTEA text value: not an octal digit");
+        octal = octal * 8 + parsed;
+      }
+      i += 2;
+      bytes[len++] = (byte) octal;
+    }
+    return Arrays.copyOf(bytes, len);
+  }
+
+  /** Renders bytes in the {@code \x<hexdigits>} form PostgreSQL 9.0 and later emit. */
+  private static String toByteaText(final byte[] bytes) {
+    final StringBuilder buffer = new StringBuilder(2 + bytes.length * 2);
+    buffer.append("\\x");
+    for (final byte b : bytes) {
+      buffer.append(Character.forDigit((b >> 4) & 0xF, 16));
+      buffer.append(Character.forDigit(b & 0xF, 16));
+    }
+    return buffer.toString();
+  }
+
+  /** The bytes behind a value announced as bytea, or null when the value is not one. */
+  private static byte[] byteaValueOf(final Object value) {
+    if (value instanceof byte[] bytes)
+      return bytes;
+    if (value instanceof Binary binary)
+      return binary.toByteArray();
+    return null;
   }
 
   private static Boolean parseBooleanText(final String value) {
@@ -307,8 +400,8 @@ public enum PostgresType {
         }
       }
       return PostgresType.ARRAY_TEXT;
-    } else if (val instanceof byte[]) {
-      return PostgresType.ARRAY_CHAR;
+    } else if (val instanceof byte[] || val instanceof Binary) {
+      return PostgresType.BYTEA;
     } else if (val.getClass().isArray()) {
       // Handle Java arrays
       return switch (val) {
@@ -415,7 +508,7 @@ public enum PostgresType {
       case STRING -> PostgresType.VARCHAR;
       case DATETIME, DATETIME_MICROS, DATETIME_NANOS, DATETIME_SECOND -> PostgresType.TIMESTAMP;
       case DATE -> PostgresType.DATE;
-      case BINARY -> PostgresType.VARCHAR; // No direct binary type, use VARCHAR
+      case BINARY -> PostgresType.BYTEA;
       case LIST -> PostgresType.ARRAY_TEXT;
       case ARRAY_OF_SHORTS, ARRAY_OF_INTEGERS -> PostgresType.ARRAY_INT;
       case ARRAY_OF_LONGS -> PostgresType.ARRAY_LONG;
@@ -438,6 +531,7 @@ public enum PostgresType {
   @SuppressWarnings("unchecked")
   public void serializeAsText(final PostgresType pgType, final Binary typeBuffer, final Object value) {
     String serializedValue = null;
+    final byte[] byteaValue = pgType == BYTEA ? byteaValueOf(value) : null;
     if (value == null && pgType.code == BOOLEAN.code) {
       serializedValue = "0";
     } else if (pgType == JSON && value != null && (value instanceof Collection<?> || value.getClass().isArray())) {
@@ -445,6 +539,10 @@ public enum PostgresType {
       // instead of a Postgres array literal, so the payload matches the announced OID.
       serializedValue = serializeCollectionAsJson(
           value instanceof Collection<?> collection ? collection : convertPrimitiveArrayToCollection(value));
+    } else if (byteaValue != null) {
+      // A blob announced as bytea travels as \x<hex> (issue #6411), not as the {1,2,3} array literal the
+      // generic byte[] handling below would produce for it.
+      serializedValue = toByteaText(byteaValue);
     } else if (value instanceof Collection<?> collection) {
       // Handle array serialization
       serializedValue = serializeArrayToString(collection, pgType);
@@ -511,6 +609,16 @@ public enum PostgresType {
     case BOOLEAN -> {
       typeBuffer.putInt(1);
       typeBuffer.putByte((byte) (toBooleanValue(value) ? 1 : 0));
+    }
+    case BYTEA -> {
+      // bytea binary format is the raw bytes, with no framing of its own beyond the length prefix.
+      final byte[] bytes = byteaValueOf(value);
+      if (bytes == null) {
+        serializeAsText(pgType, typeBuffer, value);
+        return;
+      }
+      typeBuffer.putInt(bytes.length);
+      typeBuffer.putByteArray(bytes);
     }
     case CHAR -> {
       // Postgres "char" (OID 18) is a single byte on the wire.
@@ -827,6 +935,7 @@ public enum PostgresType {
         }
         yield LocalDateTime.ofEpochSecond(secs, nanos, ZoneOffset.UTC);
       }
+      case BYTEA -> valueAsBytes.clone();
       case CHAR -> (char) buffer.get();
       case BOOLEAN -> buffer.get() == 1;
       case JSON -> {
@@ -923,7 +1032,8 @@ public enum PostgresType {
    * strings and breaks typed parameter comparisons.
    */
   public boolean isNativeScalarType() {
-    return this == SMALLINT ||
+    return this == BYTEA ||
+        this == SMALLINT ||
         this == INTEGER ||
         this == LONG ||
         this == REAL ||

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -61,7 +61,7 @@ public class PostgresTypeCatalog {
    * pg_type columns this catalog can produce. A projection naming anything outside this set is declined
    * whole rather than answered with holes in it.
    */
-  private static final List<String> COLUMNS = List.of(//
+  static final List<String> COLUMNS = List.of(//
       "oid", "typname", "typelem", "typarray", "typdelim", "typtype", "typcategory", "typlen", "typinput",//
       "typnotnull", "typbasetype", "typnamespace", "typrelid");
 
@@ -274,7 +274,7 @@ public class PostgresTypeCatalog {
     return null;
   }
 
-  private static Object columnValue(final PostgresType type, final String column) {
+  static Object columnValue(final PostgresType type, final String column) {
     return switch (column) {
       case "oid" -> type.code;
       case "typname" -> type.typeName;

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6410IdleConnectionIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6410IdleConnectionIT.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6410: an idle authenticated Postgres connection used to wake its thread ten
+ * times a second to ask {@code in.available()} whether anything had arrived, because
+ * {@code PostgresNetworkExecutor.readMessage()} never blocked. A Postgres client pool is expected to hold
+ * long-lived, mostly-idle connections, so N pooled connections cost 10N timer wakeups per second doing no
+ * work at all.
+ * <p>
+ * The same non-blocking read had a second consequence: a client that simply went away left its connection
+ * thread polling a socket that would never produce another byte, for the lifetime of the server, because
+ * {@code available()} on a closed peer returns 0 exactly as it does on an idle one - the end of the stream
+ * was never actually read.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6410IdleConnectionIT extends PostgresWireProtocolTestBase {
+
+  private static final int    POSTGRES_PORT     = 5432;
+  private static final String EXECUTOR_THREAD   = "ArcadeDB-postgres/";
+  /** How long a thread is given to notice that its connection is gone. Generous: it should be immediate. */
+  private static final long   RETIREMENT_TIMEOUT_MS = 10_000;
+
+  @Test
+  void anIdleConnectionBlocksOnItsSocketInsteadOfPollingIt() throws Exception {
+    final Set<Thread> before = executorThreads();
+
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      assertThat(readSingleInt(statement)).isEqualTo(1);
+
+      final Thread executor = newExecutorThread(before);
+
+      // Sample the connection thread while nothing is being asked of it. A polling loop spends most of its
+      // life in Thread.sleep(), so it is caught in TIMED_WAITING within a handful of samples; a blocking
+      // read never is.
+      for (int i = 0; i < 40; i++) {
+        assertThat(executor.getState())
+            .as("an idle connection thread must be blocked on its socket, not sleeping between polls")
+            .isNotEqualTo(Thread.State.TIMED_WAITING);
+        assertThat(stackOf(executor))
+            .as("an idle connection thread must not be inside a sleep")
+            .doesNotContain("java.lang.Thread.sleep");
+        Thread.sleep(25);
+      }
+    }
+  }
+
+  @Test
+  void aClientDisconnectRetiresTheConnectionThread() throws Exception {
+    final Set<Thread> before = executorThreads();
+
+    final Thread executor;
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      assertThat(readSingleInt(statement)).isEqualTo(1);
+      executor = newExecutorThread(before);
+    }
+
+    assertRetires(executor);
+  }
+
+  @Test
+  void aClientThatVanishesWithoutSayingGoodbyeRetiresTheConnectionThread() throws Exception {
+    final Set<Thread> before = executorThreads();
+
+    final Thread executor;
+    final Socket socket = openSocket();
+    try {
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessageOfType(in, 'R');
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+      readMessageOfType(in, 'Z');
+
+      executor = newExecutorThread(before);
+    } finally {
+      // No Terminate message: the client simply goes away, which is what a killed process or a dropped
+      // network does. The JDBC driver's polite 'X' used to be the only thing that ended the command loop -
+      // without it the thread polled a socket that could never produce another byte, for the lifetime of
+      // the server, because available() answers 0 on a closed peer exactly as it does on an idle one.
+      socket.close();
+    }
+
+    assertRetires(executor);
+  }
+
+  @Test
+  void aServerSideCloseRetiresTheConnectionThread() throws Exception {
+    final Set<Thread> before = executorThreads();
+
+    try (final Socket socket = openSocket()) {
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+      sendStartupMessage(out, "root", getDatabaseName());
+      readMessageOfType(in, 'R');
+      sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+
+      // BackendKeyData carries the process id and the secret a CancelRequest has to quote.
+      final long[] key = readBackendKeyData(in);
+
+      final Thread executor = newExecutorThread(before);
+
+      // The cancel request arrives on a second connection and closes the executor of the session it names -
+      // this is the server closing a connection from underneath a client that is not talking to it at that
+      // moment, and the only thing that has to break a blocked read.
+      try (final Socket cancelSocket = openSocket()) {
+        final DataOutputStream cancel = new DataOutputStream(cancelSocket.getOutputStream());
+        cancel.writeInt(16);
+        cancel.writeInt(80877102); // CancelRequest
+        cancel.writeInt((int) key[0]);
+        cancel.writeInt((int) key[1]);
+        cancel.flush();
+      }
+
+      assertRetires(executor);
+    }
+  }
+
+  /**
+   * Reads messages until BackendKeyData ('K') and returns its process id and secret.
+   */
+  private static long[] readBackendKeyData(final DataInputStream in) throws Exception {
+    while (true) {
+      final int type = in.readUnsignedByte();
+      final int length = in.readInt();
+      if (type == 'K') {
+        final long pid = in.readInt() & 0xFFFFFFFFL;
+        final long secret = in.readInt() & 0xFFFFFFFFL;
+        return new long[] { pid, secret };
+      }
+      in.skipNBytes(length - 4);
+    }
+  }
+
+  private Socket openSocket() throws Exception {
+    final Socket socket = new Socket();
+    socket.connect(new InetSocketAddress("localhost", POSTGRES_PORT), 5_000);
+    socket.setSoTimeout(30_000);
+    return socket;
+  }
+
+  private void assertRetires(final Thread executor) throws Exception {
+    final long deadline = System.currentTimeMillis() + RETIREMENT_TIMEOUT_MS;
+    while (executor.isAlive() && System.currentTimeMillis() < deadline)
+      Thread.sleep(50);
+
+    assertThat(executor.isAlive())
+        .as("the connection thread must notice that its connection is gone and terminate, not keep polling a dead socket")
+        .isFalse();
+  }
+
+  private static String stackOf(final Thread thread) {
+    final StringBuilder buffer = new StringBuilder();
+    for (final StackTraceElement element : thread.getStackTrace())
+      buffer.append(element.toString()).append('\n');
+    return buffer.toString();
+  }
+
+  private static Set<Thread> executorThreads() {
+    final Set<Thread> threads = new HashSet<>();
+    for (final Thread thread : Thread.getAllStackTraces().keySet())
+      if (thread.getName().startsWith(EXECUTOR_THREAD))
+        threads.add(thread);
+    return threads;
+  }
+
+  private static Thread newExecutorThread(final Set<Thread> before) {
+    final Set<Thread> now = executorThreads();
+    now.removeAll(before);
+    assertThat(now).as("the connection must have its own executor thread on the server").hasSize(1);
+    return now.iterator().next();
+  }
+
+  private static int readSingleInt(final Statement statement) throws Exception {
+    try (final ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+      assertThat(resultSet.next()).isTrue();
+      return resultSet.getInt(1);
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    properties.setProperty("preferQueryMode", "simple");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:" + POSTGRES_PORT + "/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6411ByteaIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6411ByteaIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6411: a BINARY property was announced as {@code varchar} when the OID came
+ * from the schema (empty result set) and as {@code "char"[]} when it came from a sampled row, so a client
+ * that prepared against an empty result and then re-executed got two different types for one column. Both
+ * answers were wrong anyway - PostgreSQL's type for a blob is {@code bytea} (OID 17), and decoding arbitrary
+ * bytes as text loses data for any non-UTF-8 payload.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6411ByteaIT extends PostgresWireProtocolTestBase {
+
+  /** Every byte value, so that anything the text encoding mangles shows up. */
+  private static final byte[] PAYLOAD = allByteValues();
+
+  @Test
+  void aBinaryPropertyRoundTripsThroughSetBytesAndGetBytes() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createBlobType(connection);
+
+      try (final PreparedStatement insert = connection.prepareStatement("INSERT INTO Blob6411 SET id = 1, payload = ?")) {
+        insert.setBytes(1, PAYLOAD);
+        insert.execute();
+      }
+
+      try (final PreparedStatement select = connection.prepareStatement("SELECT payload FROM Blob6411 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getBytes("payload")).isEqualTo(PAYLOAD);
+      }
+    }
+  }
+
+  @Test
+  void theColumnIsAnnouncedAsByteaWhetherOrNotARowWasSampled() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createBlobType(connection);
+
+      try (final PreparedStatement insert = connection.prepareStatement("INSERT INTO Blob6411 SET id = 1, payload = ?")) {
+        insert.setBytes(1, PAYLOAD);
+        insert.execute();
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT payload FROM Blob6411 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      final String typeFromSchema;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT payload FROM Blob6411 WHERE id = 2");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isFalse();
+        final ResultSetMetaData metaData = resultSet.getMetaData();
+        typeFromSchema = metaData.getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow).isEqualTo("bytea");
+      assertThat(typeFromSchema)
+          .as("the column's OID must not depend on whether the result set happens to be empty")
+          .isEqualTo(typeFromRow);
+    }
+  }
+
+  @Test
+  void anEmptyBlobRoundTrips() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createBlobType(connection);
+
+      try (final PreparedStatement insert = connection.prepareStatement("INSERT INTO Blob6411 SET id = 3, payload = ?")) {
+        insert.setBytes(1, new byte[0]);
+        insert.execute();
+      }
+
+      try (final PreparedStatement select = connection.prepareStatement("SELECT payload FROM Blob6411 WHERE id = 3");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getBytes("payload")).isEmpty();
+      }
+    }
+  }
+
+  private void createBlobType(final Connection connection) throws Exception {
+    try (final Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DOCUMENT TYPE Blob6411 IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY Blob6411.id IF NOT EXISTS INTEGER");
+      statement.execute("CREATE PROPERTY Blob6411.payload IF NOT EXISTS BINARY");
+    }
+  }
+
+  private static byte[] allByteValues() {
+    final byte[] bytes = new byte[256];
+    for (int i = 0; i < bytes.length; i++)
+      bytes[i] = (byte) i;
+    return bytes;
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6412CatalogIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6412CatalogIT.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the second half of issue #6412: the catalog answers a client needs to render a
+ * database - the schema list, the table list, the columns of a table - were matched by string equality
+ * against one tool's exact spelling, several of them only when {@code application_name} was literally
+ * {@code "dbvis"}. The same questions from any other client fell through and were answered with nothing.
+ * <p>
+ * Every test here goes through the JDBC driver's own {@link DatabaseMetaData} calls, with no
+ * {@code application_name} set at all: the queries are the driver's, not this test's, so what is being
+ * asserted is that the answer follows from the shape of the question rather than from the name of the asker.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6412CatalogIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  void theSchemaListNamesTheConnectedDatabase() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      final List<String> schemas = new ArrayList<>();
+      try (final ResultSet resultSet = connection.getMetaData().getSchemas()) {
+        while (resultSet.next())
+          schemas.add(resultSet.getString("TABLE_SCHEM"));
+      }
+
+      assertThat(schemas).contains(getDatabaseName());
+    }
+  }
+
+  @Test
+  void theTableListNamesEveryType() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      final List<String> tables = new ArrayList<>();
+      final List<String> types = new ArrayList<>();
+      try (final ResultSet resultSet = connection.getMetaData().getTables(null, null, "%", new String[] { "TABLE" })) {
+        while (resultSet.next()) {
+          tables.add(resultSet.getString("TABLE_NAME"));
+          types.add(resultSet.getString("TABLE_TYPE"));
+        }
+      }
+
+      assertThat(tables).contains("Article6412", "Author6412");
+      // The driver's own CASE over relkind produced this string: the catalog never spells it itself.
+      assertThat(types).containsOnly("TABLE");
+    }
+  }
+
+  @Test
+  void theTableListHonoursTheNameTheClientAskedFor() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      final List<String> tables = new ArrayList<>();
+      try (final ResultSet resultSet = connection.getMetaData().getTables(null, null, "Article6412", null)) {
+        while (resultSet.next())
+          tables.add(resultSet.getString("TABLE_NAME"));
+      }
+
+      assertThat(tables).containsExactly("Article6412");
+    }
+  }
+
+  @Test
+  void theColumnListDescribesTheTypesProperties() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createSchema(connection);
+
+      final List<String> columns = new ArrayList<>();
+      final List<String> typeNames = new ArrayList<>();
+      try (final ResultSet resultSet = connection.getMetaData().getColumns(null, null, "Article6412", "%")) {
+        while (resultSet.next()) {
+          columns.add(resultSet.getString("COLUMN_NAME"));
+          typeNames.add(resultSet.getString("TYPE_NAME"));
+        }
+      }
+
+      assertThat(columns).containsExactlyInAnyOrder("id", "published", "title");
+      assertThat(typeNames).contains("int4", "varchar");
+      // Columns of the other type must not leak into the answer: the client asked about one table.
+      assertThat(columns).doesNotContain("name");
+    }
+  }
+
+  @Test
+  void aCatalogQuerySpelledByHandIsAnsweredToo() throws Exception {
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      createSchema(connection);
+
+      // information_schema, in a spelling no tool in the old allow-list ever sent.
+      final List<String> tables = new ArrayList<>();
+      try (final ResultSet resultSet = statement.executeQuery(
+          "SELECT table_name FROM information_schema.tables WHERE table_schema = '" + getDatabaseName()
+              + "' ORDER BY table_name")) {
+        while (resultSet.next())
+          tables.add(resultSet.getString("table_name"));
+      }
+
+      assertThat(tables).contains("Article6412", "Author6412");
+    }
+  }
+
+  @Test
+  void theUserListIsAnsweredForEveryClientNotJustTheAllowListedOne() throws Exception {
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      // This exact query used to be answered only when application_name was "dbvis"; this connection sets none.
+      try (final ResultSet resultSet = statement.executeQuery(
+          "select distinct GRANTEE as USER_NAME, 'N' as IS_EXPIRED, 'N' as IS_LOCKED from INFORMATION_SCHEMA.USAGE_PRIVILEGES order by GRANTEE asc")) {
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getString("USER_NAME")).isEqualTo("root");
+        assertThat(resultSet.getString("IS_EXPIRED")).isEqualTo("N");
+        assertThat(resultSet.next()).isFalse();
+      }
+    }
+  }
+
+  @Test
+  void theCharacterSetListIsAnswered() throws Exception {
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      try (final ResultSet resultSet = statement.executeQuery(
+          "select CHARACTER_SET_NAME as CHARSET_NAME, -1 as MAX_LENGTH from INFORMATION_SCHEMA.CHARACTER_SETS order by CHARACTER_SET_NAME asc")) {
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getString("CHARSET_NAME")).isEqualTo("UTF8");
+        assertThat(resultSet.getInt("MAX_LENGTH")).isEqualTo(-1);
+      }
+    }
+  }
+
+  @Test
+  void theSchemaListSpelledWithCaseExpressionsIsAnswered() throws Exception {
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      // The DbVisualizer spelling, which used to be one of the exact-match arms. Its CASE expressions are
+      // evaluated rather than recognised, so any variation on them works as well.
+      try (final ResultSet resultSet = statement.executeQuery(
+          "select NSPNAME as SCHEMA_NAME, case when lower(NSPNAME)='pg_catalog' then 'Y' else 'N' end as IS_PUBLIC, "
+              + "case when lower(NSPNAME)='information_schema' then 'Y' else 'N' end as IS_SYSTEM, 'N' as IS_EMPTY "
+              + "from PG_CATALOG.PG_NAMESPACE order by NSPNAME asc")) {
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getString("SCHEMA_NAME")).isEqualTo(getDatabaseName());
+        assertThat(resultSet.getString("IS_PUBLIC")).isEqualTo("N");
+        assertThat(resultSet.getString("IS_SYSTEM")).isEqualTo("N");
+        assertThat(resultSet.next()).isFalse();
+      }
+    }
+  }
+
+  @Test
+  void anUnmodelledCatalogRelationIsDeclinedRatherThanGuessedAt() throws Exception {
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      // pg_index has no ArcadeDB equivalent this catalog models. The client gets the empty answer the rest of
+      // pg_catalog has always given, not an error and not an invented row.
+      try (final ResultSet resultSet = statement.executeQuery("SELECT indexrelid FROM pg_catalog.pg_index")) {
+        assertThat(resultSet.next()).isFalse();
+      }
+    }
+  }
+
+  @Test
+  void aUserTypeCalledLikeACatalogRelationIsStillQueryable() throws Exception {
+    try (final Connection connection = openJdbcConnection(); final Statement statement = connection.createStatement()) {
+      // The pre-filter looks for "pg_" anywhere in the query, so a type whose name starts with it has to
+      // survive the catalog recogniser and reach the SQL engine.
+      statement.execute("CREATE DOCUMENT TYPE pg_notes6412 IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY pg_notes6412.note IF NOT EXISTS STRING");
+      statement.execute("INSERT INTO pg_notes6412 SET note = 'mine'");
+
+      try (final ResultSet resultSet = statement.executeQuery("SELECT note FROM pg_notes6412")) {
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getString("note")).isEqualTo("mine");
+      }
+    }
+  }
+
+  private void createSchema(final Connection connection) throws Exception {
+    try (final Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DOCUMENT TYPE Article6412 IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY Article6412.id IF NOT EXISTS INTEGER");
+      statement.execute("CREATE PROPERTY Article6412.title IF NOT EXISTS STRING");
+      statement.execute("CREATE PROPERTY Article6412.published IF NOT EXISTS DATETIME");
+      statement.execute("CREATE DOCUMENT TYPE Author6412 IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY Author6412.name IF NOT EXISTS STRING");
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6412PreAuthCapIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6412PreAuthCapIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the first half of issue #6412: bounding how <i>long</i> a connection may stay
+ * un-authenticated (#6377) does not bound how <i>many</i> may be, and the accept loop committed one thread
+ * and one file descriptor per accepted socket with no ceiling at all. A client opening connections faster
+ * than the handshake timeout reaps them still drove both arbitrarily high.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6412PreAuthCapIT extends PostgresWireProtocolTestBase {
+
+  private static final int POSTGRES_PORT = 5432;
+  private static final int MAX_PREAUTH   = 2;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    // Read by the listener when the plugin starts it, so it has to be in place before the server comes up.
+    GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS.setValue(MAX_PREAUTH);
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS.reset();
+    super.endTest();
+  }
+
+  @Test
+  void connectionsPastTheCapAreClosedWithoutBeingGivenAThread() throws Exception {
+    final List<Socket> sockets = new ArrayList<>();
+    try {
+      // Fill the pre-auth budget with connections that say nothing at all, which is exactly what the flood
+      // this cap exists for looks like.
+      for (int i = 0; i < MAX_PREAUTH; i++)
+        sockets.add(openSocket());
+
+      try (final Socket refused = openSocket()) {
+        // Well under the 30s handshake timeout that would eventually close an *accepted* connection: the
+        // refusal has to happen on the accept path, not by letting the connection in and timing it out. If
+        // this read times out instead of returning EOF, the cap did not apply.
+        refused.setSoTimeout(10_000);
+        assertThat(refused.getInputStream().read())
+            .as("a connection over the pre-authentication cap must be closed straight away")
+            .isEqualTo(-1);
+      }
+
+      // The cap must not be a one-way door: authenticating one of the held connections hands its permit
+      // back, and the next client gets in.
+      authenticate(sockets.get(0));
+
+      try (final Socket admitted = openSocket()) {
+        final DataOutputStream out = new DataOutputStream(admitted.getOutputStream());
+        final DataInputStream in = new DataInputStream(admitted.getInputStream());
+        sendStartupMessage(out, "root", getDatabaseName());
+        assertThat(readMessageType(in))
+            .as("the permit released by an authenticated connection must let the next one in")
+            .isEqualTo('R');
+      }
+    } finally {
+      for (final Socket socket : sockets)
+        socket.close();
+    }
+  }
+
+  @Test
+  void authenticatedConnectionsDoNotHoldPreAuthPermits() throws Exception {
+    final List<Socket> sockets = new ArrayList<>();
+    try {
+      // Three times the cap, all of them authenticated: a permit is held only until the handshake completes,
+      // so a healthy pool of long-lived connections is never refused however small the cap is.
+      for (int i = 0; i < MAX_PREAUTH * 3; i++) {
+        final Socket socket = openSocket();
+        sockets.add(socket);
+        authenticate(socket);
+      }
+    } finally {
+      for (final Socket socket : sockets)
+        socket.close();
+    }
+  }
+
+  private void authenticate(final Socket socket) throws Exception {
+    final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+    final DataInputStream in = new DataInputStream(socket.getInputStream());
+
+    sendStartupMessage(out, "root", getDatabaseName());
+    readMessageOfType(in, 'R');
+    sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+    readMessageOfType(in, 'Z'); // ReadyForQuery: the handshake is over
+  }
+
+  private Socket openSocket() throws Exception {
+    final Socket socket = new Socket();
+    socket.connect(new InetSocketAddress("localhost", POSTGRES_PORT), 5_000);
+    socket.setSoTimeout(30_000);
+    return socket;
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the expression slice a catalog query is written in (issue #6412).
+ * <p>
+ * The three values that flow through it are what these tests are about: a real value, SQL NULL, and
+ * {@link PostgresCatalogExpression#UNKNOWN} - "this evaluator cannot say". Keeping the third distinct from the
+ * second is what lets a projection decline a query it cannot answer honestly while a WHERE clause reads the
+ * same result as "does not exclude this row".
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresCatalogExpressionTest {
+
+  /** A row of made-up catalog columns, plus the session functions the evaluator delegates. */
+  private static class TestResolver implements PostgresCatalogExpression.Resolver {
+    private final Map<String, Object> columns = new HashMap<>();
+
+    TestResolver() {
+      columns.put("relname", "Article");
+      columns.put("relkind", "r");
+      columns.put("nspname", "mydb");
+      columns.put("attnum", 3L);
+      columns.put("attnotnull", Boolean.TRUE);
+      columns.put("description", null);
+    }
+
+    @Override
+    public Object column(final String qualifier, final String name) {
+      return columns.containsKey(name) ? columns.get(name) : PostgresCatalogExpression.UNKNOWN;
+    }
+
+    @Override
+    public Object function(final String name, final List<Object> arguments) {
+      return switch (name) {
+        case "current_schema", "current_database" -> "mydb";
+        case "current_schemas" -> List.of("mydb");
+        default -> PostgresCatalogExpression.UNKNOWN;
+      };
+    }
+  }
+
+  private static Object evaluate(final String expression) {
+    final PostgresCatalogExpression parsed = PostgresCatalogExpression.parse(PostgresCatalogToken.tokenize(expression));
+    assertThat(parsed).as("expression did not parse: %s", expression).isNotNull();
+    return parsed.evaluate(new TestResolver());
+  }
+
+  private static boolean parses(final String expression) {
+    return PostgresCatalogExpression.parse(PostgresCatalogToken.tokenize(expression)) != null;
+  }
+
+  // ---------------------------------------------------------------- values
+
+  @Test
+  void literalsAndColumnsEvaluateToThemselves() {
+    assertThat(evaluate("'abc'")).isEqualTo("abc");
+    assertThat(evaluate("42")).isEqualTo(42L);
+    assertThat(evaluate("1.5")).isEqualTo(1.5d);
+    assertThat(evaluate("NULL")).isNull();
+    assertThat(evaluate("TRUE")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("FALSE")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("relname")).isEqualTo("Article");
+    assertThat(evaluate("c.relname")).isEqualTo("Article");
+  }
+
+  @Test
+  void aColumnNoRelationHasIsUnknownRatherThanNull() {
+    assertThat(evaluate("nosuchcolumn")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+    assertThat(evaluate("description")).isNull();
+  }
+
+  // ---------------------------------------------------------------- comparison
+
+  @Test
+  void comparisonsWorkOnStringsNumbersAndBooleans() {
+    assertThat(evaluate("relname = 'Article'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("relname <> 'Author'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("relname != 'Article'")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("attnum > 2")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("attnum >= 3")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("attnum < 3")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("attnum <= 3")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("attnotnull = TRUE")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void comparingWithNullIsNullAndComparingWithUnknownIsUnknown() {
+    assertThat(evaluate("description = 'anything'")).isNull();
+    assertThat(evaluate("nosuchcolumn = 'anything'")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void isNullAndIsNotNull() {
+    assertThat(evaluate("description IS NULL")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("description IS NOT NULL")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("relname IS NOT NULL")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("nosuchcolumn IS NULL")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+    // IS TRUE and IS DISTINCT FROM are outside the slice, and are declined rather than approximated.
+    assertThat(parses("attnotnull IS TRUE")).isFalse();
+  }
+
+  // ---------------------------------------------------------------- three-valued logic
+
+  @Test
+  void andShortCircuitsOnFalseEvenWhenTheOtherSideIsUnreadable() {
+    // This is what keeps a readable filter working next to one this evaluator cannot parse.
+    assertThat(evaluate("relname = 'Author' AND has_table_privilege(oid, 'SELECT')")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("has_table_privilege(oid, 'SELECT') AND relname = 'Author'")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("has_table_privilege(oid, 'SELECT') AND relname = 'Article'")).isSameAs(
+        PostgresCatalogExpression.UNKNOWN);
+    assertThat(evaluate("relname = 'Article' AND attnum = 3")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void orShortCircuitsOnTrueEvenWhenTheOtherSideIsUnreadable() {
+    assertThat(evaluate("relname = 'Article' OR replace(nspname, 'a', 'b') = 'x'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("nosuchcolumn = 1 OR relname = 'Article'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("nosuchcolumn = 1 OR relname = 'Author'")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void anUnreadablePredicateReadsAsKeepingTheRow() {
+    assertThat(PostgresCatalogExpression.isTrue(PostgresCatalogExpression.UNKNOWN)).isTrue();
+    assertThat(PostgresCatalogExpression.isTrue(null)).isFalse();
+    assertThat(PostgresCatalogExpression.isTrue(Boolean.FALSE)).isFalse();
+    assertThat(PostgresCatalogExpression.isTrue(1L)).isTrue();
+    assertThat(PostgresCatalogExpression.isTrue("text")).isFalse();
+  }
+
+  @Test
+  void not() {
+    assertThat(evaluate("NOT relname = 'Author'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("NOT attnotnull")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("NOT description IS NULL")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("NOT nosuchcolumn")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  // ---------------------------------------------------------------- pattern matching
+
+  @Test
+  void inAndNotIn() {
+    assertThat(evaluate("relkind IN ('r','p','v')")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("relkind IN ('v','m')")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("relkind NOT IN ('v','m')")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("description IN ('a')")).isNull();
+  }
+
+  @Test
+  void likeAndItsVariants() {
+    assertThat(evaluate("relname LIKE 'Art%'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("relname LIKE 'Art'")).isEqualTo(Boolean.FALSE);
+    assertThat(evaluate("relname LIKE 'Articl_'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("relname NOT LIKE 'Aut%'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("relname ILIKE 'article'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("relname NOT ILIKE 'article'")).isEqualTo(Boolean.FALSE);
+    // A percent or underscore escaped with a backslash stands for itself.
+    assertThat(evaluate("relname LIKE 'Article\\%'")).isEqualTo(Boolean.FALSE);
+  }
+
+  @Test
+  void posixRegularExpressions() {
+    assertThat(evaluate("nspname ~ '^my'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("nspname !~ '^pg_'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("nspname ~* '^MY'")).isEqualTo(Boolean.TRUE);
+    assertThat(evaluate("nspname !~* '^MY'")).isEqualTo(Boolean.FALSE);
+    // A pattern Java's regex engine will not compile is not something to guess the answer of.
+    assertThat(evaluate("nspname ~ '['")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  // ---------------------------------------------------------------- arithmetic and text
+
+  @Test
+  void arithmetic() {
+    assertThat(evaluate("2 + 3")).isEqualTo(5L);
+    assertThat(evaluate("2 - 3")).isEqualTo(-1L);
+    assertThat(evaluate("2 * 3")).isEqualTo(6L);
+    assertThat(evaluate("7 / 2")).isEqualTo(3.5d);
+    assertThat(evaluate("-1")).isEqualTo(-1L);
+    assertThat(evaluate("+1")).isEqualTo(1L);
+    // Division by zero is not an answer this evaluator invents.
+    assertThat(evaluate("1 / 0")).isNull();
+    assertThat(evaluate("1 + NULL")).isNull();
+    assertThat(evaluate("1 + relname")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void concatenation() {
+    assertThat(evaluate("nspname || '.' || relname")).isEqualTo("mydb.Article");
+    assertThat(evaluate("nspname || description")).isNull();
+  }
+
+  @Test
+  void scalarFunctions() {
+    assertThat(evaluate("lower(relname)")).isEqualTo("article");
+    assertThat(evaluate("upper(relname)")).isEqualTo("ARTICLE");
+    assertThat(evaluate("length(relname)")).isEqualTo(7L);
+    assertThat(evaluate("trim('  x  ')")).isEqualTo("x");
+    assertThat(evaluate("ltrim('  x')")).isEqualTo("x");
+    assertThat(evaluate("rtrim('x  ')")).isEqualTo("x");
+    assertThat(evaluate("replace(relname, 'Art', 'Ent')")).isEqualTo("Enticle");
+    assertThat(evaluate("concat(nspname, '/', relname)")).isEqualTo("mydb/Article");
+    assertThat(evaluate("abs(-3)")).isEqualTo(3.0d);
+    assertThat(evaluate("lower(description)")).isNull();
+    assertThat(evaluate("lower(nosuchcolumn)")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void coalesceAndNullif() {
+    assertThat(evaluate("coalesce(description, relname)")).isEqualTo("Article");
+    assertThat(evaluate("coalesce(description, NULL)")).isNull();
+    assertThat(evaluate("nullif(relkind, 'r')")).isNull();
+    assertThat(evaluate("nullif(relkind, 'v')")).isEqualTo("r");
+    assertThat(evaluate("nullif(relkind)")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void sessionFunctionsAreDelegatedToTheResolver() {
+    assertThat(evaluate("current_schema()")).isEqualTo("mydb");
+    assertThat(evaluate("pg_catalog.current_database()")).isEqualTo("mydb");
+    assertThat(evaluate("nosuchfunction(1)")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  // ---------------------------------------------------------------- structure
+
+  @Test
+  void caseWithAnOperandIsWhatTheJdbcDriverWritesItsTableTypeWith() {
+    assertThat(evaluate("CASE relkind WHEN 'r' THEN 'TABLE' WHEN 'v' THEN 'VIEW' ELSE NULL END")).isEqualTo("TABLE");
+    assertThat(evaluate("CASE relkind WHEN 'v' THEN 'VIEW' END")).isNull();
+    assertThat(evaluate("CASE nosuchcolumn WHEN 'v' THEN 'VIEW' ELSE 'X' END")).isSameAs(
+        PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void caseWithSearchConditions() {
+    assertThat(evaluate("CASE WHEN lower(nspname) = 'pg_catalog' THEN 'Y' ELSE 'N' END")).isEqualTo("N");
+    assertThat(evaluate("CASE WHEN attnum > 2 THEN 'big' WHEN attnum > 0 THEN 'small' END")).isEqualTo("big");
+    assertThat(evaluate("CASE WHEN description IS NULL THEN 'none' END")).isEqualTo("none");
+  }
+
+  @Test
+  void nestedCaseOverABooleanOperand() {
+    // The exact shape of the JDBC driver's table list: a CASE whose operand is itself a boolean expression.
+    assertThat(evaluate("CASE nspname ~ '^pg_' OR nspname = 'information_schema' "
+        + "WHEN true THEN CASE relkind WHEN 'r' THEN 'SYSTEM TABLE' ELSE NULL END "
+        + "WHEN false THEN CASE relkind WHEN 'r' THEN 'TABLE' ELSE NULL END ELSE NULL END")).isEqualTo("TABLE");
+  }
+
+  @Test
+  void castsAreTransparentAndSubscriptsIndexFromOne() {
+    assertThat(evaluate("'pg_class'::regclass")).isEqualTo("pg_class");
+    assertThat(evaluate("attnum::int4")).isEqualTo(3L);
+    assertThat(evaluate("relname::character varying(10)")).isEqualTo("Article");
+    assertThat(evaluate("relname::text[]")).isEqualTo("Article");
+    assertThat(evaluate("(current_schemas(true))[1]")).isEqualTo("mydb");
+    assertThat(evaluate("(current_schemas(true))[9]")).isNull();
+    assertThat(evaluate("relname[1]")).isSameAs(PostgresCatalogExpression.UNKNOWN);
+  }
+
+  @Test
+  void parenthesesGroup() {
+    assertThat(evaluate("(1 + 2) * 3")).isEqualTo(9L);
+    assertThat(evaluate("(relname = 'Author' OR attnum = 3) AND relkind = 'r'")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void whatIsOutsideTheSliceDoesNotParse() {
+    assertThat(parses("SELECT 1")).isFalse();
+    assertThat(parses("relname =")).isFalse();
+    assertThat(parses("CASE relkind END")).isFalse();
+    assertThat(parses("CASE WHEN relkind = 'r' THEN 'TABLE'")).isFalse();
+    assertThat(parses("relname IN ('a'")).isFalse();
+    assertThat(parses("relname LIKE")).isFalse();
+    assertThat(parses("relname ~")).isFalse();
+    assertThat(parses("(1 + 2")).isFalse();
+    assertThat(parses("relname[1")).isFalse();
+    assertThat(parses("relname::")).isFalse();
+    assertThat(parses("$1")).isFalse();
+    assertThat(parses("relname extra")).isFalse();
+  }
+
+  @Test
+  void aWindowFunctionIsRecognisedAndItsValueComesFromTheCaller() {
+    final PostgresCatalogExpression parsed = PostgresCatalogExpression.parse(
+        PostgresCatalogToken.tokenize("row_number() OVER (PARTITION BY attrelid ORDER BY attnum ASC)"));
+
+    assertThat(parsed).isInstanceOf(PostgresCatalogExpression.WindowCall.class);
+    final PostgresCatalogExpression.WindowCall call = (PostgresCatalogExpression.WindowCall) parsed;
+    assertThat(call.name).isEqualTo("row_number");
+    assertThat(call.partitionBy).hasSize(1);
+    assertThat(call.orderBy).hasSize(1);
+    // Its value is defined by the other rows, so a resolver that was not given one answers UNKNOWN.
+    assertThat(parsed.evaluate(new TestResolver())).isSameAs(PostgresCatalogExpression.UNKNOWN);
+
+    // A frame specification changes what the function means, so it is declined rather than ignored.
+    assertThat(parses("row_number() OVER (ORDER BY attnum ROWS UNBOUNDED PRECEDING)")).isFalse();
+    assertThat(parses("row_number() OVER (PARTITION attrelid)")).isFalse();
+  }
+
+  @Test
+  void valuesRenderAsPostgresWouldWriteThem() {
+    assertThat(PostgresCatalogExpression.asString(Boolean.TRUE)).isEqualTo("t");
+    assertThat(PostgresCatalogExpression.asString(Boolean.FALSE)).isEqualTo("f");
+    assertThat(PostgresCatalogExpression.asString(42L)).isEqualTo("42");
+    assertThat(PostgresCatalogExpression.asString(null)).isNull();
+    assertThat(PostgresCatalogExpression.asString(PostgresCatalogExpression.UNKNOWN)).isNull();
+    assertThat(PostgresCatalogExpression.UNKNOWN.toString()).isEqualTo("UNKNOWN");
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
@@ -361,6 +361,20 @@ class PostgresCatalogExpressionTest {
   }
 
   @Test
+  void aChainOfNotOrUnaryMinusIsBoundedTheSameWayNestedParenthesesAre() {
+    // parseNot() and parseUnary() recurse on themselves directly for a chain of NOT or unary -/+, without
+    // ever calling back through parseExpression() - so the same MAX_DEPTH guard has to be applied at their
+    // own recursion point, not only at parseExpression()'s.
+    assertThat(parses("NOT ".repeat(20) + "relname = 'Article'")).isTrue();
+    assertThat(parses("NOT ".repeat(50_000) + "relname = 'Article'")).isFalse();
+
+    // Space-separated: "--" is a line comment to the lexer, not two unary minuses.
+    assertThat(parses("- ".repeat(20) + "1")).isTrue();
+    assertThat(parses("- ".repeat(50_000) + "1")).isFalse();
+    assertThat(parses("+ ".repeat(50_000) + "1")).isFalse();
+  }
+
+  @Test
   void aNumericLiteralThatIsNotANumberIsDeclinedRatherThanReadAsNull() {
     // The lexer reads "1.2.3" as one numeric token; answering the query with a NULL the client never wrote
     // would be worse than declining it.

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogExpressionTest.java
@@ -315,12 +315,57 @@ class PostgresCatalogExpressionTest {
     assertThat(call.name).isEqualTo("row_number");
     assertThat(call.partitionBy).hasSize(1);
     assertThat(call.orderBy).hasSize(1);
+    assertThat(call.orderByDescending).containsExactly(Boolean.FALSE);
     // Its value is defined by the other rows, so a resolver that was not given one answers UNKNOWN.
     assertThat(parsed.evaluate(new TestResolver())).isSameAs(PostgresCatalogExpression.UNKNOWN);
 
     // A frame specification changes what the function means, so it is declined rather than ignored.
     assertThat(parses("row_number() OVER (ORDER BY attnum ROWS UNBOUNDED PRECEDING)")).isFalse();
     assertThat(parses("row_number() OVER (PARTITION attrelid)")).isFalse();
+  }
+
+  @Test
+  void aWindowOrderByCarriesTheDirectionTheClientWrote() {
+    // The direction decides the numbering, so consuming DESC and forgetting it would number the partition
+    // backwards from what the client asked for - a wrong number rather than no answer.
+    final PostgresCatalogExpression.WindowCall descending = window("row_number() OVER (ORDER BY attnum DESC)");
+    assertThat(descending.orderByDescending).containsExactly(Boolean.TRUE);
+
+    final PostgresCatalogExpression.WindowCall mixed = window(
+        "row_number() OVER (PARTITION BY attrelid ORDER BY attnum DESC, attname ASC)");
+    assertThat(mixed.orderByDescending).containsExactly(Boolean.TRUE, Boolean.FALSE);
+
+    // NULLS FIRST/LAST would reorder the ties this numbering breaks by position, so it is declined.
+    assertThat(parses("row_number() OVER (ORDER BY attnum DESC NULLS LAST)")).isFalse();
+  }
+
+  private static PostgresCatalogExpression.WindowCall window(final String text) {
+    final PostgresCatalogExpression parsed = PostgresCatalogExpression.parse(PostgresCatalogToken.tokenize(text));
+    assertThat(parsed).as("window call did not parse: %s", text).isInstanceOf(
+        PostgresCatalogExpression.WindowCall.class);
+    return (PostgresCatalogExpression.WindowCall) parsed;
+  }
+
+  @Test
+  void aPathologicallyNestedExpressionIsDeclinedRatherThanFatal() {
+    // Any authenticated client can send this, and it is well inside the wire protocol's message budget. An
+    // unbounded parser would recurse until the stack gave out, and a StackOverflowError is an Error, not an
+    // Exception: it would kill the connection thread instead of being answered with an empty result.
+    final int depth = 50_000;
+    final String pathological = "(".repeat(depth) + "1" + ")".repeat(depth);
+
+    assertThat(parses(pathological)).isFalse();
+
+    // The bound is far above anything a real catalog query nests: the JDBC driver's table list reaches four.
+    assertThat(parses("(".repeat(20) + "relname" + ")".repeat(20))).isTrue();
+  }
+
+  @Test
+  void aNumericLiteralThatIsNotANumberIsDeclinedRatherThanReadAsNull() {
+    // The lexer reads "1.2.3" as one numeric token; answering the query with a NULL the client never wrote
+    // would be worse than declining it.
+    assertThat(parses("1.2.3")).isFalse();
+    assertThat(parses("attnum = 1.2.3")).isFalse();
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the shape-based catalog emulation of issue #6412, over the queries the PostgreSQL JDBC
+ * driver actually sends (which is what every JDBC-based tool sends) plus the hand-written spellings that
+ * used to be matched by string equality.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresCatalogTest {
+  private static final String DATABASE_PATH = "./target/databases/PostgresCatalogTest";
+  private static final String USER          = "root";
+
+  private Database database;
+
+  @BeforeEach
+  void createDatabase() {
+    final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    database = factory.create();
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Article").createProperty("id", Type.INTEGER);
+      database.getSchema().getType("Article").createProperty("title", Type.STRING).setMandatory(true);
+      database.getSchema().createDocumentType("Author").createProperty("name", Type.STRING);
+    });
+  }
+
+  @AfterEach
+  void dropDatabase() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  // ---------------------------------------------------------------- the driver's own queries
+
+  /** {@code DatabaseMetaData.getSchemas()} as pgjdbc writes it. */
+  private static final String JDBC_GET_SCHEMAS =
+      "SELECT nspname AS \"TABLE_SCHEM\", current_database() AS \"TABLE_CATALOG\" FROM pg_catalog.pg_namespace "
+          + " WHERE nspname <> 'pg_toast' AND (nspname !~ '^pg_temp_' "
+          + " OR nspname = (pg_catalog.current_schemas(true))[1]) AND (nspname !~ '^pg_toast_temp_' "
+          + " OR nspname = replace((pg_catalog.current_schemas(true))[1], 'pg_temp_', 'pg_toast_temp_')) "
+          + " ORDER BY \"TABLE_SCHEM\"";
+
+  /** {@code DatabaseMetaData.getTables()} as pgjdbc writes it, trimmed of the parts it only adds on demand. */
+  private static final String JDBC_GET_TABLES =
+      "SELECT current_database() AS \"TABLE_CAT\", n.nspname AS \"TABLE_SCHEM\", c.relname AS \"TABLE_NAME\", "
+          + " CASE n.nspname ~ '^pg_' OR n.nspname = 'information_schema' "
+          + " WHEN true THEN CASE "
+          + " WHEN n.nspname = 'pg_catalog' OR n.nspname = 'information_schema' THEN CASE c.relkind "
+          + "  WHEN 'r' THEN 'SYSTEM TABLE' "
+          + "  WHEN 'v' THEN 'SYSTEM VIEW' "
+          + "  WHEN 'i' THEN 'SYSTEM INDEX' "
+          + "  ELSE NULL "
+          + "  END "
+          + " WHEN n.nspname = 'pg_toast' THEN CASE c.relkind "
+          + "  WHEN 'r' THEN 'SYSTEM TOAST TABLE' "
+          + "  WHEN 'i' THEN 'SYSTEM TOAST INDEX' "
+          + "  ELSE NULL "
+          + "  END "
+          + " ELSE CASE c.relkind "
+          + "  WHEN 'r' THEN 'TEMPORARY TABLE' "
+          + "  WHEN 'p' THEN 'TEMPORARY TABLE' "
+          + "  WHEN 'i' THEN 'TEMPORARY INDEX' "
+          + "  WHEN 'S' THEN 'TEMPORARY SEQUENCE' "
+          + "  WHEN 'v' THEN 'TEMPORARY VIEW' "
+          + "  ELSE NULL "
+          + "  END "
+          + " END "
+          + " WHEN false THEN CASE c.relkind "
+          + " WHEN 'r' THEN 'TABLE' "
+          + " WHEN 'p' THEN 'PARTITIONED TABLE' "
+          + " WHEN 'i' THEN 'INDEX' "
+          + " WHEN 'P' then 'PARTITIONED INDEX' "
+          + " WHEN 'S' THEN 'SEQUENCE' "
+          + " WHEN 'v' THEN 'VIEW' "
+          + " WHEN 'c' THEN 'TYPE' "
+          + " WHEN 'f' THEN 'FOREIGN TABLE' "
+          + " WHEN 'm' THEN 'MATERIALIZED VIEW' "
+          + " ELSE NULL "
+          + " END "
+          + " ELSE NULL "
+          + " END "
+          + " AS \"TABLE_TYPE\", d.description AS \"REMARKS\", "
+          + " '' as \"TYPE_CAT\", '' as \"TYPE_SCHEM\", '' as \"TYPE_NAME\", "
+          + "'' AS \"SELF_REFERENCING_COL_NAME\", '' AS \"REF_GENERATION\" "
+          + " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c "
+          + " LEFT JOIN pg_catalog.pg_description d ON (c.oid = d.objoid AND d.objsubid = 0  and d.classoid = 'pg_class'::regclass) "
+          + " WHERE c.relnamespace = n.oid  AND c.relname LIKE $1 AND (false  OR ( c.relkind = 'r' AND n.nspname !~ '^pg_' AND n.nspname <> 'information_schema' ) ) "
+          + " ORDER BY \"TABLE_TYPE\",\"TABLE_SCHEM\",\"TABLE_NAME\" ";
+
+  /** {@code DatabaseMetaData.getColumns()} as pgjdbc writes it: a derived table with a window function in it. */
+  private static final String JDBC_GET_COLUMNS =
+      "SELECT * FROM (SELECT current_database() AS current_database, n.nspname,c.relname,a.attname,a.atttypid,a.attnotnull"
+          + " OR (t.typtype = 'd' AND t.typnotnull) AS attnotnull,a.atttypmod,a.attlen,t.typtypmod,"
+          + "row_number() OVER (PARTITION BY a.attrelid ORDER BY a.attnum) AS attnum, "
+          + "nullif(a.attidentity, '') as attidentity,nullif(a.attgenerated, '') as attgenerated,"
+          + "pg_catalog.pg_get_expr(def.adbin, def.adrelid) AS adsrc,dsc.description,t.typbasetype,t.typtype "
+          + " FROM pg_catalog.pg_namespace n "
+          + " JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid) "
+          + " JOIN pg_catalog.pg_attribute a ON (a.attrelid=c.oid) "
+          + " JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid) "
+          + " LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid=def.adrelid AND a.attnum = def.adnum) "
+          + " LEFT JOIN pg_catalog.pg_description dsc ON (c.oid=dsc.objoid AND a.attnum = dsc.objsubid) "
+          + " LEFT JOIN pg_catalog.pg_class dc ON (dc.oid=dsc.classoid AND dc.relname='pg_class') "
+          + " LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace=dn.oid AND dn.nspname='pg_catalog') "
+          + " WHERE c.relkind in ('r','p','v','f','m') and a.attnum > 0 AND NOT a.attisdropped  AND c.relname LIKE $1) c "
+          + " WHERE true  AND attname LIKE $2 ORDER BY nspname,c.relname,attnum ";
+
+  @Test
+  void theDriversSchemaListNamesTheConnectedDatabase() {
+    final PostgresCatalog.Answer answer = resolve(JDBC_GET_SCHEMAS);
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0)).containsEntry("TABLE_SCHEM", database.getName());
+    assertThat(answer.rows.get(0)).containsEntry("TABLE_CATALOG", database.getName());
+    // The projection order is the client's, because a DataRow is read positionally.
+    assertThat(answer.columns.keySet()).containsExactly("TABLE_SCHEM", "TABLE_CATALOG");
+  }
+
+  @Test
+  void theDriversTableListNamesEveryType() {
+    final PostgresCatalog.Answer answer = resolve(JDBC_GET_TABLES, "%");
+
+    assertThat(names(answer.rows, "TABLE_NAME")).containsExactly("Article", "Author");
+    // Produced by the driver's own CASE over relkind, not by this catalog naming it.
+    assertThat(answer.rows.get(0)).containsEntry("TABLE_TYPE", "TABLE");
+    assertThat(answer.rows.get(0)).containsEntry("TABLE_SCHEM", database.getName());
+    assertThat(answer.rows.get(0)).containsEntry("REMARKS", null);
+  }
+
+  @Test
+  void theDriversTableListAppliesTheNamePatternItBoundAsAParameter() {
+    assertThat(names(resolve(JDBC_GET_TABLES, "Article").rows, "TABLE_NAME")).containsExactly("Article");
+    assertThat(names(resolve(JDBC_GET_TABLES, "A%").rows, "TABLE_NAME")).containsExactly("Article", "Author");
+    assertThat(resolve(JDBC_GET_TABLES, "Missing").rows).isEmpty();
+  }
+
+  @Test
+  void theDriversColumnListDescribesOneTypesProperties() {
+    final PostgresCatalog.Answer answer = resolve(JDBC_GET_COLUMNS, "Article", "%");
+
+    assertThat(names(answer.rows, "attname")).containsExactly("id", "title");
+    assertThat(answer.rows.get(0)).containsEntry("relname", "Article");
+    assertThat(answer.rows.get(0)).containsEntry("atttypid", PostgresType.INTEGER.code);
+    // row_number() over the partition: the ordinal position within its own table, counted from 1.
+    assertThat(answer.rows.get(0)).containsEntry("attnum", 1L);
+    assertThat(answer.rows.get(1)).containsEntry("attnum", 2L);
+    // "title" is mandatory, which is the closest thing ArcadeDB has to NOT NULL.
+    assertThat(answer.rows.get(1)).containsEntry("attnotnull", Boolean.TRUE);
+    assertThat(answer.rows.get(0)).containsEntry("attnotnull", Boolean.FALSE);
+  }
+
+  @Test
+  void theDriversColumnListAppliesTheColumnPattern() {
+    final PostgresCatalog.Answer answer = resolve(JDBC_GET_COLUMNS, "%", "id");
+    assertThat(names(answer.rows, "attname")).containsExactly("id");
+  }
+
+  // ---------------------------------------------------------------- hand-written spellings
+
+  @Test
+  void theSchemaListWithCaseExpressionsIsAnswered() {
+    final PostgresCatalog.Answer answer = resolve(
+        "select NSPNAME as SCHEMA_NAME, case when lower(NSPNAME)='pg_catalog' then 'Y' else 'N' end as IS_PUBLIC, "
+            + "case when lower(NSPNAME)='information_schema' then 'Y' else 'N' end as IS_SYSTEM, 'N' as IS_EMPTY "
+            + "from PG_CATALOG.PG_NAMESPACE order by NSPNAME asc");
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0)).containsEntry("schema_name", database.getName());
+    assertThat(answer.rows.get(0)).containsEntry("is_public", "N");
+    assertThat(answer.rows.get(0)).containsEntry("is_system", "N");
+  }
+
+  @Test
+  void theUserListIsAnswered() {
+    final PostgresCatalog.Answer answer = resolve(
+        "select distinct GRANTEE as USER_NAME, 'N' as IS_EXPIRED, 'N' as IS_LOCKED "
+            + "from INFORMATION_SCHEMA.USAGE_PRIVILEGES order by GRANTEE asc");
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0)).containsEntry("user_name", USER);
+  }
+
+  @Test
+  void theDistinctPrivilegeListIsAnswered() {
+    // This one used to be on an ignore-list, so it came back with no rows at all for every client.
+    final PostgresCatalog.Answer answer = resolve(
+        "select distinct PRIVILEGE_TYPE as PRIVILEGE_NAME from INFORMATION_SCHEMA.USAGE_PRIVILEGES order by PRIVILEGE_TYPE asc");
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0)).containsEntry("privilege_name", "USAGE");
+  }
+
+  @Test
+  void theCharacterSetListIsAnswered() {
+    final PostgresCatalog.Answer answer = resolve(
+        "select CHARACTER_SET_NAME as CHARSET_NAME, -1 as MAX_LENGTH from INFORMATION_SCHEMA.CHARACTER_SETS order by CHARACTER_SET_NAME asc");
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0)).containsEntry("charset_name", "UTF8");
+    assertThat(answer.rows.get(0)).containsEntry("max_length", -1L);
+  }
+
+  @Test
+  void theInformationSchemaTableListIsAnswered() {
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT table_name, table_type FROM information_schema.tables WHERE table_schema = '" + database.getName()
+            + "' ORDER BY table_name");
+
+    assertThat(names(answer.rows, "table_name")).containsExactly("Article", "Author");
+    assertThat(answer.rows.get(0)).containsEntry("table_type", "BASE TABLE");
+  }
+
+  @Test
+  void theInformationSchemaColumnListIsAnswered() {
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT column_name, data_type, is_nullable FROM information_schema.columns "
+            + "WHERE table_name = 'Article' ORDER BY ordinal_position");
+
+    assertThat(names(answer.rows, "column_name")).containsExactly("id", "title");
+    assertThat(answer.rows.get(0)).containsEntry("data_type", "int4");
+    assertThat(answer.rows.get(0)).containsEntry("is_nullable", "YES");
+    assertThat(answer.rows.get(1)).containsEntry("is_nullable", "NO");
+  }
+
+  @Test
+  void aStarProjectionExpandsToTheRelationsColumns() {
+    final PostgresCatalog.Answer answer = resolve("SELECT * FROM pg_catalog.pg_namespace");
+
+    assertThat(answer.columns.keySet()).contains("oid", "nspname", "nspowner", "nspacl");
+    assertThat(answer.rows.get(0)).containsEntry("nspname", database.getName());
+  }
+
+  // ---------------------------------------------------------------- what is not answered
+
+  @Test
+  void aQueryAboutARelationThisCatalogDoesNotModelIsDeclined() {
+    assertThat(resolveRaw("SELECT indexrelid FROM pg_catalog.pg_index")).isSameAs(PostgresCatalog.DECLINED);
+  }
+
+  @Test
+  void aProjectionThisCatalogCannotComputeIsDeclinedRatherThanAnsweredWithHoles() {
+    // A row for every table with a made-up size in it would be worse than no answer, because the client
+    // believes what a system catalog tells it.
+    assertThat(resolveRaw("SELECT relname, pg_total_relation_size(c.oid) FROM pg_class c")).isSameAs(
+        PostgresCatalog.DECLINED);
+  }
+
+  @Test
+  void anOrdinaryQueryIsNotACatalogQuery() {
+    assertThat(resolveRaw("SELECT name FROM Author")).isNull();
+    assertThat(resolveRaw("SELECT 1")).isNull();
+  }
+
+  @Test
+  void aUserTypeNamedLikeACatalogRelationIsNotACatalogQuery() {
+    database.transaction(() -> database.getSchema().createDocumentType("pg_notes"));
+    assertThat(resolveRaw("SELECT note FROM pg_notes")).isNull();
+  }
+
+  @Test
+  void anUnreadablePredicateDoesNotEmptyTheAnswer() {
+    // has_table_privilege() is not modelled. Read strictly, the whole table list would come back empty; the
+    // rows it could exclude are ones this catalog never produces.
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT relname FROM pg_class c WHERE has_table_privilege(c.oid, 'SELECT') AND relname LIKE 'A%'");
+
+    assertThat(names(answer.rows, "relname")).containsExactly("Article", "Author");
+  }
+
+  @Test
+  void aReadablePredicateStillFiltersWhenAnUnreadableOneIsBesideIt() {
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT relname FROM pg_class c WHERE has_table_privilege(c.oid, 'SELECT') AND relname = 'Author'");
+
+    assertThat(names(answer.rows, "relname")).containsExactly("Author");
+  }
+
+  // ---------------------------------------------------------------- helpers
+
+  private PostgresCatalog.Answer resolve(final String query, final Object... parameters) {
+    final PostgresCatalog.Answer answer = resolveRaw(query, parameters);
+    assertThat(answer).as("query was not recognised as a catalog query: %s", query).isNotNull();
+    assertThat(answer).as("query was declined: %s", query).isNotSameAs(PostgresCatalog.DECLINED);
+    return answer;
+  }
+
+  private PostgresCatalog.Answer resolveRaw(final String query, final Object... parameters) {
+    return PostgresCatalog.resolve(query, database, USER, parameters);
+  }
+
+  private static List<Object> names(final List<Map<String, Object>> rows, final String column) {
+    return rows.stream().map(row -> row.get(column)).toList();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -308,6 +308,118 @@ class PostgresCatalogTest {
     assertThat(names(answer.rows, "relname")).containsExactly("Author");
   }
 
+  // ---------------------------------------------------------------- the remaining families and clauses
+
+  @Test
+  void theDatabaseListNamesOnlyTheConnectedDatabase() {
+    // Enumerating the server's databases is not something an emulated catalog should hand out, and a
+    // PostgreSQL connection is bound to one database anyway.
+    final PostgresCatalog.Answer answer = resolve("SELECT datname, encoding FROM pg_database");
+
+    assertThat(names(answer.rows, "datname")).containsExactly(database.getName());
+    assertThat(answer.rows.get(0)).containsEntry("encoding", 6);
+  }
+
+  @Test
+  void theRoleListNamesOnlyTheConnectedUser() {
+    assertThat(names(resolve("SELECT rolname FROM pg_roles").rows, "rolname")).containsExactly(USER);
+    assertThat(names(resolve("SELECT usename FROM pg_user").rows, "usename")).containsExactly(USER);
+  }
+
+  @Test
+  void theCollationListIsAnswered() {
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT COLLATION_SCHEMA, COLLATION_NAME FROM INFORMATION_SCHEMA.COLLATIONS");
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0)).containsEntry("collation_name", "default");
+  }
+
+  @Test
+  void theViewListIsEmptyBecauseThereAreNoViewsToReport() {
+    // An empty answer is a real answer, and it still describes its own columns.
+    final PostgresCatalog.Answer answer = resolve("SELECT viewname FROM pg_views");
+
+    assertThat(answer.rows).isEmpty();
+    assertThat(answer.columns.keySet()).containsExactly("viewname");
+  }
+
+  @Test
+  void aQualifiedStarExpandsToThatRelationsColumns() {
+    final PostgresCatalog.Answer answer = resolve("SELECT n.* FROM pg_catalog.pg_namespace n");
+
+    assertThat(answer.columns.keySet()).containsExactly("oid", "nspname", "nspowner", "nspacl");
+  }
+
+  @Test
+  void orderByFollowsTheClientsDirectionAndOrdinal() {
+    assertThat(names(resolve("SELECT relname FROM pg_class ORDER BY relname DESC").rows, "relname"))
+        .containsExactly("Author", "Article");
+    assertThat(names(resolve("SELECT relname FROM pg_class ORDER BY 1 DESC").rows, "relname"))
+        .containsExactly("Author", "Article");
+    // An ORDER BY this catalog cannot resolve leaves the rows in the order it built them, by name, rather
+    // than declining a query whose data is perfectly answerable.
+    assertThat(names(resolve("SELECT relname FROM pg_class ORDER BY pg_relation_size(oid)").rows, "relname"))
+        .containsExactly("Article", "Author");
+  }
+
+  @Test
+  void limitTruncatesTheAnswer() {
+    assertThat(resolve("SELECT relname FROM pg_class ORDER BY relname LIMIT 1").rows).hasSize(1);
+  }
+
+  @Test
+  void distinctCollapsesRowsThatProjectTheSameValues() {
+    // One row per type, but the projection keeps only the schema they share.
+    final PostgresCatalog.Answer answer = resolve("SELECT DISTINCT nspname FROM pg_namespace n, pg_class c");
+
+    assertThat(answer.rows).hasSize(1);
+  }
+
+  @Test
+  void aSetOperationOrAGroupByIsDeclined() {
+    // Both change what the rows are, and answering the half this catalog understands would be answering a
+    // different question.
+    assertThat(resolveRaw("SELECT relname FROM pg_class UNION SELECT nspname FROM pg_namespace")).isSameAs(
+        PostgresCatalog.DECLINED);
+    assertThat(resolveRaw("SELECT relkind FROM pg_class GROUP BY relkind")).isSameAs(PostgresCatalog.DECLINED);
+    assertThat(resolveRaw("SELECT relname FROM pg_class LIMIT ALL")).isSameAs(PostgresCatalog.DECLINED);
+  }
+
+  @Test
+  void aStatementThatIsNotASelectIsNotAnsweredButIsNotSwallowedEither() {
+    // A DDL statement naming an emulated relation is still not this class's business, but one naming a user
+    // type - even a type called pg_something - must reach the SQL engine untouched.
+    assertThat(resolveRaw("INSERT INTO pg_class SET relname = 'x'")).isSameAs(PostgresCatalog.DECLINED);
+    assertThat(resolveRaw("CREATE DOCUMENT TYPE pg_notes")).isNull();
+  }
+
+  @Test
+  void aBoundParameterWithNoLiteralFormLeavesItsPredicateUnread() {
+    // A null parameter cannot be written inline, so the predicate around it is not read - and an unreadable
+    // predicate does not remove rows.
+    final PostgresCatalog.Answer answer = resolveRaw("SELECT relname FROM pg_class WHERE relname LIKE $1",
+        (Object) null);
+
+    assertThat(names(answer.rows, "relname")).containsExactly("Article", "Author");
+  }
+
+  @Test
+  void theColumnsOfAnAnswerAreTypedFromItsValues() {
+    final PostgresCatalog.Answer answer = resolve("SELECT relname, oid, relhasindex FROM pg_class");
+
+    assertThat(answer.columns.get("relname")).isEqualTo(PostgresType.VARCHAR);
+    assertThat(answer.columns.get("oid")).isEqualTo(PostgresType.INTEGER);
+    assertThat(answer.columns.get("relhasindex")).isEqualTo(PostgresType.BOOLEAN);
+  }
+
+  @Test
+  void anExpressionWithNoAliasIsAnnouncedTheWayPostgresWouldNameIt() {
+    final PostgresCatalog.Answer answer = resolve("SELECT relname, current_database(), 1 + 1 FROM pg_class");
+
+    assertThat(answer.columns.keySet()).containsExactly("relname", "current_database", "?column?");
+  }
+
   // ---------------------------------------------------------------- helpers
 
   private PostgresCatalog.Answer resolve(final String query, final Object... parameters) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -308,6 +308,31 @@ class PostgresCatalogTest {
     assertThat(names(answer.rows, "relname")).containsExactly("Author");
   }
 
+  @Test
+  void aWindowNumbersItsPartitionInTheDirectionTheClientAskedFor() {
+    // The same shape the JDBC driver's column list uses, but ordered the other way round: the numbering has
+    // to follow, or the client is handed numbers that contradict its own ORDER BY.
+    final PostgresCatalog.Answer ascending = resolve(
+        "SELECT a.attname, row_number() OVER (PARTITION BY a.attrelid ORDER BY a.attnum) AS n "
+            + "FROM pg_class c, pg_attribute a WHERE c.relname = 'Article'");
+    assertThat(names(ascending.rows, "attname")).containsExactly("id", "title");
+    assertThat(names(ascending.rows, "n")).containsExactly(1L, 2L);
+
+    final PostgresCatalog.Answer descending = resolve(
+        "SELECT a.attname, row_number() OVER (PARTITION BY a.attrelid ORDER BY a.attnum DESC) AS n "
+            + "FROM pg_class c, pg_attribute a WHERE c.relname = 'Article'");
+    assertThat(names(descending.rows, "attname")).containsExactly("id", "title");
+    assertThat(names(descending.rows, "n")).containsExactly(2L, 1L);
+  }
+
+  @Test
+  void anUnAliasedWindowColumnIsNamedAfterItsFunction() {
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT row_number() OVER (ORDER BY relname) FROM pg_class");
+
+    assertThat(answer.columns.keySet()).containsExactly("row_number");
+  }
+
   // ---------------------------------------------------------------- the remaining families and clauses
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTokenTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTokenTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the catalog query lexer of issue #6412. Tokenising is what lets the catalog work on the
+ * structure of a client's query rather than on its exact text, so the cases that matter here are the ones
+ * where a character means something other than itself: quotes, escapes, comments and multi-character
+ * operators.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PostgresCatalogTokenTest {
+
+  @Test
+  void wordsNumbersAndSymbolsAreSeparated() {
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("SELECT oid, 42 FROM pg_type");
+
+    assertThat(texts(tokens)).containsExactly("SELECT", "oid", ",", "42", "FROM", "pg_type");
+    assertThat(tokens.get(0).type).isEqualTo(PostgresCatalogToken.Type.IDENTIFIER);
+    assertThat(tokens.get(3).type).isEqualTo(PostgresCatalogToken.Type.NUMBER);
+    assertThat(tokens.get(2).type).isEqualTo(PostgresCatalogToken.Type.SYMBOL);
+  }
+
+  @Test
+  void aStringLiteralKeepsItsContentAndDoublesAsItsOwnEscape() {
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("WHERE relname = 'it''s here'");
+
+    final PostgresCatalogToken literal = tokens.get(tokens.size() - 1);
+    assertThat(literal.type).isEqualTo(PostgresCatalogToken.Type.STRING);
+    assertThat(literal.text).isEqualTo("it's here");
+  }
+
+  @Test
+  void anEscapeStringLiteralUnescapesBackslashes() {
+    // pgjdbc writes E'%' and E'\\_' in the LIKE patterns of its metadata queries.
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("nspname LIKE E'a\\\\_b\\nc'");
+
+    final PostgresCatalogToken literal = tokens.get(tokens.size() - 1);
+    assertThat(literal.type).isEqualTo(PostgresCatalogToken.Type.STRING);
+    assertThat(literal.text).isEqualTo("a\\_b\nc");
+  }
+
+  @Test
+  void aQuotedIdentifierKeepsItsCase() {
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("SELECT nspname AS \"TABLE_SCHEM\"");
+
+    final PostgresCatalogToken alias = tokens.get(tokens.size() - 1);
+    assertThat(alias.type).isEqualTo(PostgresCatalogToken.Type.QUOTED_IDENTIFIER);
+    assertThat(alias.text).isEqualTo("TABLE_SCHEM");
+  }
+
+  @Test
+  void aBacktickQuotedIdentifierIsReadTheSameWay() {
+    // The executor rewrites a client's "double quoted" identifiers into backticks before dispatching, so this
+    // is the form a catalog query actually arrives in.
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("SELECT nspname AS `TABLE_SCHEM`");
+
+    final PostgresCatalogToken alias = tokens.get(tokens.size() - 1);
+    assertThat(alias.type).isEqualTo(PostgresCatalogToken.Type.QUOTED_IDENTIFIER);
+    assertThat(alias.text).isEqualTo("TABLE_SCHEM");
+  }
+
+  @Test
+  void multiCharacterOperatorsAreOneTokenEach() {
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("a <= b >= c <> d != e || f :: g ~* h !~ i !~* j");
+
+    assertThat(texts(tokens)).contains("<=", ">=", "<>", "!=", "||", "::", "~*", "!~", "!~*");
+  }
+
+  @Test
+  void placeholdersSurviveAsTheirOwnToken() {
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("relname LIKE $12");
+
+    final PostgresCatalogToken placeholder = tokens.get(tokens.size() - 1);
+    assertThat(placeholder.type).isEqualTo(PostgresCatalogToken.Type.SYMBOL);
+    assertThat(placeholder.text).isEqualTo("$12");
+  }
+
+  @Test
+  void commentsAreSkipped() {
+    assertThat(texts(PostgresCatalogToken.tokenize("SELECT oid -- the type's id\nFROM pg_type"))).containsExactly("SELECT",
+        "oid", "FROM", "pg_type");
+    assertThat(texts(PostgresCatalogToken.tokenize("SELECT /* a /* nested */ comment */ oid"))).containsExactly("SELECT",
+        "oid");
+  }
+
+  @Test
+  void exponentNotationIsOneNumber() {
+    final List<PostgresCatalogToken> tokens = PostgresCatalogToken.tokenize("1.5e-3");
+
+    assertThat(tokens).hasSize(1);
+    assertThat(tokens.get(0).type).isEqualTo(PostgresCatalogToken.Type.NUMBER);
+    assertThat(tokens.get(0).text).isEqualTo("1.5e-3");
+  }
+
+  @Test
+  void anUnterminatedQuoteOrCommentIsRefusedRatherThanGuessedAt() {
+    assertThat(PostgresCatalogToken.tokenize("SELECT 'unterminated")).isNull();
+    assertThat(PostgresCatalogToken.tokenize("SELECT \"unterminated")).isNull();
+    assertThat(PostgresCatalogToken.tokenize("SELECT `unterminated")).isNull();
+    assertThat(PostgresCatalogToken.tokenize("SELECT E'unterminated")).isNull();
+    assertThat(PostgresCatalogToken.tokenize("SELECT /* unterminated")).isNull();
+  }
+
+  @Test
+  void aBoundParameterBecomesTheLiteralTheClientSent() {
+    assertThat(PostgresCatalogToken.literal("Article").type).isEqualTo(PostgresCatalogToken.Type.STRING);
+    assertThat(PostgresCatalogToken.literal("Article").text).isEqualTo("Article");
+    assertThat(PostgresCatalogToken.literal(42).type).isEqualTo(PostgresCatalogToken.Type.NUMBER);
+    assertThat(PostgresCatalogToken.literal(Boolean.TRUE).text).isEqualTo("TRUE");
+    assertThat(PostgresCatalogToken.literal('x').type).isEqualTo(PostgresCatalogToken.Type.STRING);
+    // A value with no literal form leaves the placeholder in place, and the predicate around it unread.
+    assertThat(PostgresCatalogToken.literal(null)).isNull();
+    assertThat(PostgresCatalogToken.literal(new byte[] { 1 })).isNull();
+  }
+
+  @Test
+  void tokensDescribeThemselves() {
+    // toString() is only ever read by a human debugging a declined query, but a broken one is worse than none.
+    assertThat(PostgresCatalogToken.tokenize("oid").get(0).toString()).isEqualTo("IDENTIFIER(oid)");
+  }
+
+  private static List<String> texts(final List<PostgresCatalogToken> tokens) {
+    return tokens.stream().map(token -> token.text).toList();
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
@@ -84,7 +84,6 @@ class PostgresTypeResolutionPathTest {
    *       tell them apart and answers DATE for either.
    *   <li>DECIMAL: neither DOUBLE (lossy) nor VARCHAR is right; the fix is a NUMERIC (OID 1700) entry with a
    *       binary encoder.
-   *   <li>BINARY: neither VARCHAR nor _char is right; the fix is a BYTEA (OID 17) entry.
    * </ul>
    * Removing an entry here is the intended way to land one of those fixes.
    */
@@ -95,7 +94,6 @@ class PostgresTypeResolutionPathTest {
     KNOWN_DISAGREEMENTS.put(Type.BYTE, new PathDisagreement(PostgresType.SMALLINT, PostgresType.INTEGER));
     KNOWN_DISAGREEMENTS.put(Type.DATETIME, new PathDisagreement(PostgresType.TIMESTAMP, PostgresType.DATE));
     KNOWN_DISAGREEMENTS.put(Type.DECIMAL, new PathDisagreement(PostgresType.DOUBLE, PostgresType.VARCHAR));
-    KNOWN_DISAGREEMENTS.put(Type.BINARY, new PathDisagreement(PostgresType.VARCHAR, PostgresType.ARRAY_CHAR));
   }
 
   private record PathDisagreement(PostgresType schemaPath, PostgresType valuePath) {
@@ -147,7 +145,7 @@ class PostgresTypeResolutionPathTest {
     // Only the primitive byte[] carries Type.BINARY's blob meaning; a Byte[] is an array of small integers, and
     // Byte elements already resolve to int4 everywhere else (getTypeForValue, getArrayTypeForElementType).
     assertThat(PostgresType.getTypeForValue(new Byte[] { 1, 2 })).isEqualTo(PostgresType.ARRAY_INT);
-    assertThat(PostgresType.getTypeForValue(new byte[] { 1, 2 })).isEqualTo(PostgresType.ARRAY_CHAR);
+    assertThat(PostgresType.getTypeForValue(new byte[] { 1, 2 })).isEqualTo(PostgresType.BYTEA);
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -272,7 +272,8 @@ class PostgresTypeTest {
 
   @Test
   void getTypeForValueByteArray() {
-    assertThat(PostgresType.getTypeForValue(new byte[]{1, 2, 3})).isEqualTo(PostgresType.ARRAY_CHAR);
+    // A byte[] is a blob, not an array of one-byte characters (issue #6411).
+    assertThat(PostgresType.getTypeForValue(new byte[]{1, 2, 3})).isEqualTo(PostgresType.BYTEA);
   }
 
   @Test
@@ -369,7 +370,7 @@ class PostgresTypeTest {
 
   @Test
   void getTypeFromArcadeBinary() {
-    assertThat(PostgresType.getTypeFromArcade(Type.BINARY)).isEqualTo(PostgresType.VARCHAR);
+    assertThat(PostgresType.getTypeFromArcade(Type.BINARY)).isEqualTo(PostgresType.BYTEA);
   }
 
   @Test
@@ -2014,5 +2015,116 @@ class PostgresTypeTest {
     assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.DATE.code, 0,
         "1716138311000".getBytes()))
         .isInstanceOf(DateTimeParseException.class);
+  }
+
+  // ==================== BYTEA Tests (issue #6411) ====================
+
+  @Test
+  void byteaCarriesPostgresOwnCatalogIdentity() {
+    // The OID, name and array type PostgreSQL itself uses: a client resolves the OID it was handed in
+    // RowDescription against these, so anything else resolves to a different type or to nothing.
+    assertThat(PostgresType.BYTEA.code).isEqualTo(17);
+    assertThat(PostgresType.BYTEA.typeName).isEqualTo("bytea");
+    assertThat(PostgresType.BYTEA.arrayCode).isEqualTo(1001);
+    assertThat(PostgresType.BYTEA.elementCode).isEqualTo(0);
+    assertThat(PostgresType.BYTEA.isArrayType()).isFalse();
+    // Announced with its own OID rather than collapsed to varchar, which is what makes a client call
+    // getBytes() on it instead of decoding arbitrary bytes as text.
+    assertThat(PostgresType.BYTEA.isNativeScalarType()).isTrue();
+    assertThat(PostgresType.BYTEA.hasBinaryEncoding()).isTrue();
+  }
+
+  @Test
+  void serializeAsTextByteArrayUsesTheHexFormat() {
+    Binary buffer = new Binary();
+    PostgresType.BYTEA.serializeAsText(PostgresType.BYTEA, buffer, new byte[] { 0x00, 0x01, (byte) 0xFF, 0x7F });
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("\\x0001ff7f");
+  }
+
+  @Test
+  void serializeAsTextEmptyByteArrayIsTheEmptyHexString() {
+    Binary buffer = new Binary();
+    PostgresType.BYTEA.serializeAsText(PostgresType.BYTEA, buffer, new byte[0]);
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("\\x");
+  }
+
+  @Test
+  void getTypeForValueArcadeBinary() {
+    assertThat(PostgresType.getTypeForValue(new Binary(new byte[] { 1, 2 }))).isEqualTo(PostgresType.BYTEA);
+  }
+
+  @Test
+  void serializeAsTextArcadeBinaryUsesTheHexFormat() {
+    Binary buffer = new Binary();
+    PostgresType.BYTEA.serializeAsText(PostgresType.BYTEA, buffer, new Binary(new byte[] { 0x0A, 0x0B }));
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("\\x0a0b");
+  }
+
+  @Test
+  void serializeAsBinaryByteArrayIsTheRawBytes() {
+    Binary buffer = new Binary();
+    PostgresType.BYTEA.serializeAsBinary(PostgresType.BYTEA, buffer, new byte[] { 1, 2, 3 });
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(3);
+    byte[] data = new byte[3];
+    buffer.getByteBuffer().get(data);
+    assertThat(data).isEqualTo(new byte[] { 1, 2, 3 });
+  }
+
+  @Test
+  void deserializeByteaFromHexText() {
+    Object result = PostgresType.deserialize(PostgresType.BYTEA.code, 0, "\\x0001ff7f".getBytes());
+    assertThat(result).isInstanceOf(byte[].class);
+    assertThat((byte[]) result).isEqualTo(new byte[] { 0x00, 0x01, (byte) 0xFF, 0x7F });
+  }
+
+  @Test
+  void deserializeByteaFromEscapeText() {
+    // The pre-9.0 output format, which PostgreSQL still accepts on input and some clients still send.
+    Object result = PostgresType.deserialize(PostgresType.BYTEA.code, 0, "ab\\000\\\\c".getBytes());
+    assertThat((byte[]) result).isEqualTo(new byte[] { 'a', 'b', 0, '\\', 'c' });
+  }
+
+  @Test
+  void deserializeByteaFromBinary() {
+    final byte[] payload = new byte[] { 5, 6, 7 };
+    Object result = PostgresType.deserialize(PostgresType.BYTEA.code, 1, payload);
+    assertThat((byte[]) result).isEqualTo(payload);
+  }
+
+  @Test
+  void deserializeByteaRejectsMalformedHex() {
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.BYTEA.code, 0, "\\x0".getBytes()))
+        .isInstanceOf(PostgresProtocolException.class);
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.BYTEA.code, 0, "\\xzz".getBytes()))
+        .isInstanceOf(PostgresProtocolException.class);
+  }
+
+  @Test
+  void byteaRoundTripsThroughItsOwnTextFormat() {
+    final byte[] payload = new byte[256];
+    for (int i = 0; i < payload.length; i++)
+      payload[i] = (byte) i;
+
+    Binary buffer = new Binary();
+    PostgresType.BYTEA.serializeAsText(PostgresType.BYTEA, buffer, payload);
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+
+    assertThat((byte[]) PostgresType.deserialize(PostgresType.BYTEA.code, 0, data)).isEqualTo(payload);
   }
 }

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -35,6 +35,7 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.network.PreAuthConnectionGate;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.NumberUtils;
@@ -63,6 +64,11 @@ public class RedisNetworkExecutor extends Thread {
   private final    Map<String, Object> defaultBucket    = new ConcurrentHashMap<>();
   private          String              selectedDatabaseName = null;
   private          ServerSecurityUser  authenticatedUser    = null;
+  /**
+   * The listener's permit for a connection that has not authenticated yet, handed back the moment it does -
+   * or when it goes away without ever doing so (issue #6412).
+   */
+  private final    PreAuthConnectionGate.Ticket preAuthTicket;
   private final    int                 maxMultiBulkDepth;
   private final    int                 maxMultiBulkLength;
   private final    int                 maxBulkLength;
@@ -86,6 +92,12 @@ public class RedisNetworkExecutor extends Thread {
   }
 
   public RedisNetworkExecutor(final ArcadeDBServer server, final Socket socket) throws IOException {
+    this(server, socket, null);
+  }
+
+  public RedisNetworkExecutor(final ArcadeDBServer server, final Socket socket,
+      final PreAuthConnectionGate.Ticket preAuthTicket) throws IOException {
+    this.preAuthTicket = preAuthTicket;
     setName(Constants.PRODUCT + "-redis/" + socket.getInetAddress());
     this.server = server;
     this.channel = new ChannelBinaryServer(socket, server.getConfiguration());
@@ -183,6 +195,9 @@ public class RedisNetworkExecutor extends Thread {
       }
     } finally {
       ProtocolContext.clear();
+      // Whatever ended the loop, the listener's permit must go back: a connection that dies without ever
+      // authenticating would otherwise keep its slot for the life of the server (issue #6412).
+      releasePreAuthTicket();
     }
   }
 
@@ -199,8 +214,18 @@ public class RedisNetworkExecutor extends Thread {
 
   public void close() {
     shutdown = true;
+    releasePreAuthTicket();
     if (channel != null)
       channel.close();
+  }
+
+  /**
+   * Hands the listener's pre-authentication permit back. Idempotent, so authenticating and then closing -
+   * the normal life of a connection - releases exactly one permit.
+   */
+  private void releasePreAuthTicket() {
+    if (preAuthTicket != null)
+      preAuthTicket.release();
   }
 
   private void executeCommand(final Object command) {
@@ -685,6 +710,7 @@ public class RedisNetworkExecutor extends Thread {
    */
   private void markAuthenticated(final ServerSecurityUser user) {
     this.authenticatedUser = user;
+    releasePreAuthTicket();
     try {
       channel.socket.setSoTimeout(0);
     } catch (final SocketException e) {

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkListener.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkListener.java
@@ -22,6 +22,7 @@ import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerException;
+import com.arcadedb.server.network.PreAuthConnectionGate;
 import com.arcadedb.server.network.ServerSocketFactory;
 
 import java.io.IOException;
@@ -35,6 +36,8 @@ public class RedisNetworkListener extends Thread {
   private volatile     boolean             active          = true;
   private static final int                 protocolVersion = -1;
   private              ClientConnected     callback;
+  /** Bounds how many accepted connections can sit un-authenticated at once (issue #6412). */
+  private final        PreAuthConnectionGate preAuthGate = new PreAuthConnectionGate("Redis wrapper");
 
   public interface ClientConnected {
     void connected();
@@ -58,11 +61,30 @@ public class RedisNetworkListener extends Thread {
         try {
           final Socket socket = serverSocket.accept();
 
+          // One thread and one file descriptor are committed here, before the client has proved anything: past
+          // the cap the socket is closed straight away rather than being given either (issue #6412).
+          final PreAuthConnectionGate.Ticket ticket = preAuthGate.accept();
+          if (ticket == null) {
+            preAuthGate.logRefusal(this, socket.getRemoteSocketAddress());
+            try {
+              socket.close();
+            } catch (final IOException e) {
+              // IGNORE IT: THE CONNECTION IS BEING DROPPED ANYWAY
+            }
+            continue;
+          }
+
           socket.setPerformancePreferences(0, 2, 1);
 
-          // CREATE A NEW PROTOCOL INSTANCE
-          final RedisNetworkExecutor connection = new RedisNetworkExecutor(server, socket);
-          connection.start();
+          try {
+            // CREATE A NEW PROTOCOL INSTANCE
+            final RedisNetworkExecutor connection = new RedisNetworkExecutor(server, socket, ticket);
+            connection.start();
+          } catch (final Exception e) {
+            // The executor never started, so nothing will hand the permit back for it.
+            ticket.release();
+            throw e;
+          }
 
           if (callback != null)
             callback.connected();

--- a/server/src/main/java/com/arcadedb/server/network/PreAuthConnectionGate.java
+++ b/server/src/main/java/com/arcadedb/server/network/PreAuthConnectionGate.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.network;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+
+import io.micrometer.core.instrument.Metrics;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+/**
+ * Caps how many connections a wire-protocol listener may hold in the phase before authentication (issue
+ * #6412).
+ * <p>
+ * Each of the three binary protocol listeners (Postgres, Redis, BOLT) commits one operating-system thread
+ * and one file descriptor per accepted socket, before anyone has proved who they are. Bounding how <i>long</i>
+ * a connection may stay in that phase - the handshake read timeout of #6377, #5912 and #5978 - only sets the
+ * rate at which those are reclaimed; it does not bound how <i>many</i> exist at once, so a client that opens
+ * connections faster than the timeout reaps them still drives thread and descriptor count arbitrarily high.
+ * This is the other half: past the cap, the socket is closed immediately and the accept loop moves on.
+ * <p>
+ * Two deliberate properties:
+ * <ul>
+ * <li><b>The refusal is a close, not a message.</b> Writing a protocol-level "too many connections" error
+ * would be friendlier, but it would be a write performed on the accept thread, and a peer that never reads
+ * its socket can stall that write - which would hand an attacker the whole listener rather than one
+ * connection. Nothing that a remote peer can slow down belongs on the accept path.</li>
+ * <li><b>A permit is released once, when the connection first authenticates</b> (or when it dies before
+ * doing so). Protocols that can return to an unauthenticated state - BOLT's LOGOFF, Redis re-AUTH - do not
+ * take a permit again: the cap exists to bound connections that have not yet proved anything, and a
+ * connection that has authenticated once is no longer one of those.</li>
+ * </ul>
+ * Each listener owns its own gate rather than sharing one server-wide, so a flood against one protocol
+ * cannot use up the budget that lets clients of another protocol log in.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class PreAuthConnectionGate {
+  /** How often a listener that is refusing connections says so, so that a flood cannot flood the log too. */
+  private static final long LOG_INTERVAL_MS = 10_000;
+
+  private final String       protocol;
+  private final int          maxConnections;
+  private final Semaphore    permits;
+  private final AtomicLong   refused         = new AtomicLong();
+  private final AtomicLong   lastLogTime     = new AtomicLong();
+
+  /**
+   * A held permit. Releasing it is idempotent, so the connection can hand it back at the point it
+   * authenticates and again when it terminates without the count going wrong.
+   */
+  public static class Ticket {
+    private final PreAuthConnectionGate gate;
+    private final AtomicBoolean         released = new AtomicBoolean();
+
+    private Ticket(final PreAuthConnectionGate gate) {
+      this.gate = gate;
+    }
+
+    public void release() {
+      if (released.compareAndSet(false, true) && gate.permits != null)
+        gate.permits.release();
+    }
+  }
+
+  public PreAuthConnectionGate(final String protocol) {
+    this(protocol, GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS.getValueAsInteger());
+  }
+
+  public PreAuthConnectionGate(final String protocol, final int maxConnections) {
+    this.protocol = protocol;
+    this.maxConnections = maxConnections;
+    this.permits = maxConnections > 0 ? new Semaphore(maxConnections) : null;
+  }
+
+  /**
+   * Takes a permit for a freshly accepted connection, or returns null when the listener is already holding
+   * as many unauthenticated connections as it is allowed to. A null answer means the caller must close the
+   * socket and carry on accepting.
+   */
+  public Ticket accept() {
+    if (permits == null)
+      return new Ticket(this);
+
+    if (!permits.tryAcquire()) {
+      refused.incrementAndGet();
+      Metrics.counter(protocol.toLowerCase() + ".connection.refused").increment();
+      return null;
+    }
+
+    return new Ticket(this);
+  }
+
+  /**
+   * Logs a refusal, at most once per {@link #LOG_INTERVAL_MS}: the message is worth having, but under the
+   * flood it describes it would otherwise be written thousands of times a second.
+   */
+  public void logRefusal(final Object source, final Object remoteAddress) {
+    final long now = System.currentTimeMillis();
+    final long last = lastLogTime.get();
+    if (now - last < LOG_INTERVAL_MS && last != 0)
+      return;
+    if (!lastLogTime.compareAndSet(last, now))
+      return;
+
+    LogManager.instance().log(source, Level.WARNING,
+        "%s: refused connection from %s, already holding the maximum of %d connections that have not authenticated "
+            + "(%d refused so far; raise %s to allow more)", protocol, remoteAddress, maxConnections, refused.get(),
+        GlobalConfiguration.NETWORK_MAX_PREAUTH_CONNECTIONS.getKey());
+  }
+
+  /** Connections currently accepted but not yet authenticated. */
+  public int getPending() {
+    return permits == null ? 0 : maxConnections - permits.availablePermits();
+  }
+
+  /** How many connections have been refused because the cap was already reached. */
+  public long getRefused() {
+    return refused.get();
+  }
+
+  public int getMaxConnections() {
+    return maxConnections;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/network/PreAuthConnectionGateTest.java
+++ b/server/src/test/java/com/arcadedb/server/network/PreAuthConnectionGateTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.network;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the pre-authentication connection cap of issue #6412.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PreAuthConnectionGateTest {
+
+  @Test
+  void connectionsPastTheCapAreRefused() {
+    final PreAuthConnectionGate gate = new PreAuthConnectionGate("TEST", 2);
+
+    assertThat(gate.accept()).isNotNull();
+    assertThat(gate.accept()).isNotNull();
+
+    assertThat(gate.accept()).as("the third connection is over the cap").isNull();
+    assertThat(gate.getPending()).isEqualTo(2);
+    assertThat(gate.getRefused()).isEqualTo(1);
+  }
+
+  @Test
+  void aReleasedPermitLetsTheNextConnectionIn() {
+    final PreAuthConnectionGate gate = new PreAuthConnectionGate("TEST", 1);
+
+    final PreAuthConnectionGate.Ticket ticket = gate.accept();
+    assertThat(ticket).isNotNull();
+    assertThat(gate.accept()).isNull();
+
+    ticket.release();
+
+    assertThat(gate.getPending()).isZero();
+    assertThat(gate.accept()).isNotNull();
+  }
+
+  @Test
+  void releasingTwiceGivesBackOnlyOnePermit() {
+    // A connection releases when it authenticates and again when it closes, which is the normal life of
+    // one: a second release must not create a permit out of nothing.
+    final PreAuthConnectionGate gate = new PreAuthConnectionGate("TEST", 1);
+
+    final PreAuthConnectionGate.Ticket ticket = gate.accept();
+    ticket.release();
+    ticket.release();
+
+    assertThat(gate.accept()).isNotNull();
+    assertThat(gate.accept()).as("the cap is still 1, not 2").isNull();
+  }
+
+  @Test
+  void aCapOfZeroMeansUnlimited() {
+    final PreAuthConnectionGate gate = new PreAuthConnectionGate("TEST", 0);
+
+    for (int i = 0; i < 1_000; i++)
+      assertThat(gate.accept()).isNotNull();
+
+    assertThat(gate.getRefused()).isZero();
+    assertThat(gate.getPending()).isZero();
+  }
+
+  @Test
+  void theCapHoldsUnderConcurrentAccepts() throws Exception {
+    final int cap = 8;
+    final int threads = 32;
+    final PreAuthConnectionGate gate = new PreAuthConnectionGate("TEST", cap);
+
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(threads);
+    final AtomicInteger accepted = new AtomicInteger();
+    final List<Thread> workers = new ArrayList<>(threads);
+
+    for (int i = 0; i < threads; i++) {
+      final Thread worker = new Thread(() -> {
+        try {
+          start.await();
+          if (gate.accept() != null)
+            accepted.incrementAndGet();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          done.countDown();
+        }
+      });
+      workers.add(worker);
+      worker.start();
+    }
+
+    start.countDown();
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    for (final Thread worker : workers)
+      worker.join();
+
+    assertThat(accepted.get()).isEqualTo(cap);
+    assertThat(gate.getRefused()).isEqualTo(threads - cap);
+  }
+}


### PR DESCRIPTION
Closes #6410, closes #6411, closes #6412.

## #6410 - an idle connection busy-polled its socket ten times a second

`PostgresNetworkExecutor.readMessage()` opened with
`if (!channel.inputHasData()) { sleep(100); return false; }`, so every **idle authenticated** connection woke
its thread ten times a second to ask an empty socket whether anything had arrived. A Postgres client pool is
expected to hold long-lived, mostly-idle connections, which is the shape this is worst for.

The read now blocks. The two things that had to keep working do:

- **a server-side `close()`** closes the socket, which breaks a thread blocked reading it - the cancel-request
  path already relied on exactly this;
- **EOF** is what a clean client close produces, and `readMessage` already had an arm for it.

The same non-blocking read had a second consequence, fixed with it: a client that vanished *without* sending
Terminate left its connection thread polling a socket that could never produce another byte, for the life of
the server, because `available()` answers 0 on a closed peer exactly as it does on an idle one. Only the JDBC
driver's polite `'X'` ever ended that loop.

`waitForAMessage()`, which existed only because `readMessage` could not block (#6377), is gone; the password
read blocks under the handshake timeout instead.

Checked the sibling protocols as the issue asked: `RedisNetworkExecutor` and `BoltNetworkExecutor` already
block, so there is nothing to change there.

## #6411 - a BINARY column had two different OIDs depending on whether a row was sampled

`getTypeForValue(byte[])` answered `"char"[]` (1002) and `getTypeFromArcade(Type.BINARY)` answered `varchar`
(1043) - the exact disagreement the two comments in that file were written to prevent, so a client that
prepared against an empty result and then re-executed got two different types for one column.

Neither answer was right. `BYTEA` (OID 17, `typcategory` U) is now an entry of its own with the `\x<hex>` text
encoding, the raw-bytes binary encoding, and both PostgreSQL text input formats (hex and the pre-9.0 escape
form) accepted back. Both resolution paths point at it, `PostgresTypeCatalog` picks it up for free, and the
`KNOWN_DISAGREEMENTS` entry that pinned the old behaviour in `PostgresTypeResolutionPathTest` is removed
rather than updated.

## #6412 part one - the pre-authentication connection count is now bounded

#6377 (and #5912, #5978) bounded how *long* a connection may stay unauthenticated; the accept loop still
committed one thread and one file descriptor per accepted socket with no ceiling, so a client opening
connections faster than the timeout reaps them still drove both arbitrarily high.

`PreAuthConnectionGate` (new, in `server`) is one mechanism applied to all three binary protocol listeners,
configured by `arcadedb.network.maxPreAuthConnections` (default 500, 0 = unlimited), per listener so a flood
against one protocol cannot use up the budget that lets clients of another log in.

Two deliberate choices, both documented in the class:

- **the refusal is a close, not a protocol error message.** Writing one would be an I/O performed on the
  accept thread, and a peer that never reads its socket can stall that write - handing an attacker the whole
  listener instead of one connection.
- **a permit is released the first time a connection authenticates** (or when it dies without doing so).
  Protocols that can return to an unauthenticated state - BOLT LOGOFF, Redis re-AUTH - do not take one again.

## #6412 part two - the catalog answers the shape of the question, not the name of the asker

Around 150 lines of exact-string matching, several arms gated on `application_name` being literally `"dbvis"`,
are replaced by `PostgresCatalog`. The gating was never really about the tool: those queries are written by
the JDBC driver that DBeaver, DataGrip, pgAdmin and DbVisualizer all share, and what differs between them is
spelling, not meaning.

Recognition is now by shape and the answer is computed:

1. the FROM clause says which emulated relations the query is about, and so which family of rows it wants;
2. the rows of that family are built from ArcadeDB's own schema;
3. the client's **own projection** is evaluated against each row.

Step 3 is what makes this general: `DatabaseMetaData.getTables()` comes back with `TABLE_TYPE = 'TABLE'`
because the driver's own `CASE c.relkind WHEN 'r' THEN 'TABLE' ...` is evaluated against a row saying
`relkind = 'r'` - this code never spells that string. The evaluator reads the slice of PostgreSQL expression
syntax those queries are written in: CASE in both forms, `~`/`LIKE`/`IN`/`IS NULL`, casts, array subscripts,
`row_number() OVER (PARTITION BY ... ORDER BY ...)` and a one-level derived table (the last two are what
`getColumns()` is written with).

Two rules worth calling out:

- **a shape outside that slice is declined**, and the caller sends the empty result set that pg_catalog has
  always sent for a query it did not understand. A made-up row in a system catalog is worse than no row,
  because the client believes it.
- **the WHERE clause is the one permissive place**: a predicate that cannot be read does not get to remove
  rows. Everything in this catalog is the user's own types in one database - there are no system schemas,
  toast tables or other databases' rows for an unreadable predicate to be excluding, so the ones that survive
  unread (`nspname !~ '^pg_temp_'`, `has_table_privilege(...)`) are exactly the ones that mean "keep
  everything" here. The name filters that a client depends on are read and applied.

Queries whose filters are bound parameters (`getTables`, `getColumns`) are answered at Execute time, when
their values have arrived, rather than at Parse time.

**Behaviour change worth reviewing:** the emulated schema list is now exactly one schema, named after the
connected database - which is what `current_schema()` already answered. The removed arms disagreed with each
other and with that function: one reported every *type* as a schema, another reported every *database on the
server*, which also told any authenticated user the names of databases they cannot open.

## Tests

- `Issue6410IdleConnectionIT` - an idle connection thread is never caught sleeping; it retires on a client
  Terminate, on a client that vanishes without one, and on a server-side close driven by a real
  CancelRequest. The two new behaviours fail on `main` (the second hangs until the 10s bound).
- `Issue6411ByteaIT` - a 256-byte payload round-trips through `setBytes`/`getBytes`, and the column is
  announced as `bytea` whether or not a row was sampled. Plus unit coverage of both text formats, the binary
  format, and the malformed-input rejections.
- `Issue6412PreAuthCapIT` - a connection past the cap is closed promptly (well inside the handshake timeout
  that would otherwise mask the difference), authenticating one frees the slot, and authenticated connections
  never hold permits. `PreAuthConnectionGateTest` covers the gate itself, including concurrent accepts.
- `PostgresCatalogTest` - the driver's *actual* `getSchemas`/`getTables`/`getColumns` SQL, the hand-written
  spellings that used to be exact-matched, what is declined, and that an ordinary query - including one about
  a user type named `pg_notes` - is not treated as a catalog query.
- `Issue6412CatalogIT` - the same through `DatabaseMetaData`, over the wire, with no `application_name` set.

Full `postgresw` suite green (334 unit + 160 IT), and `redisw` + `bolt` green for the gate change.