### PR TITLE
fix(#6368): Cypher aggregation pulls upstream at plan batch size, not a fixed 10,000

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/AggregationStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/AggregationStep.java
@@ -44,10 +44,22 @@ public class AggregationStep extends AbstractExecutionStep {
   private final CypherFunctionFactory functionFactory;
   private final ExpressionEvaluator evaluator;
 
-  // Configurable batch size for streaming aggregation (default: 10,000)
-  private static final int DEFAULT_BATCH_SIZE = 10000;
-  private static final int BATCH_SIZE = Integer.parseInt(
-      System.getProperty("arcadedb.aggregation.batchSize", String.valueOf(DEFAULT_BATCH_SIZE)));
+  // Batch size for pulling from upstream while accumulating aggregation input. By default this
+  // step pulls at the SAME granularity the rest of the plan uses (the nRecords it was asked for),
+  // rather than a large fixed size: a mutating clause upstream of the aggregation (SET/CREATE/
+  // MERGE/DELETE) can be interleaved with a variable-length path traversal that freezes node
+  // references into a path at the moment the path is built (TraversalPath / RowAliases -
+  // propagateUpdate only redirects a row's own top-level aliases, not nodes nested inside a path,
+  // list or map). Pulling one huge batch up front makes this step traverse - and freeze - a later
+  // row's path before an earlier row's write to that very same node has run, permanently baking in
+  // a pre-write value that a non-aggregating pull of the same query would not see (issue #6368: a
+  // bare COLLECT()/UNWIND changed which property values a later WHERE/RETURN observed, purely
+  // because it happened to pull upstream in one 10,000-row batch instead of the usual 100). An
+  // explicit override remains available for callers whose upstream has no side effects and want
+  // fewer round trips.
+  private static final String BATCH_SIZE_PROPERTY = "arcadedb.aggregation.batchSize";
+  private static final Integer CONFIGURED_BATCH_SIZE = System.getProperty(BATCH_SIZE_PROPERTY) != null ?
+      Integer.parseInt(System.getProperty(BATCH_SIZE_PROPERTY)) : null;
 
   public AggregationStep(final ReturnClause returnClause, final CommandContext context,
       final CypherFunctionFactory functionFactory) {
@@ -98,7 +110,7 @@ public class AggregationStep extends AbstractExecutionStep {
     }
 
     // Process all rows, feeding data to aggregators
-    final ResultSet prevResults = prev.syncPull(context, BATCH_SIZE);
+    final ResultSet prevResults = prev.syncPull(context, CONFIGURED_BATCH_SIZE != null ? CONFIGURED_BATCH_SIZE : nRecords);
     Result representativeRow = null;
 
     while (prevResults.hasNext()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
@@ -52,10 +52,12 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
   private final CypherFunctionFactory functionFactory;
   private final ExpressionEvaluator evaluator;
 
-  // Configurable batch size for streaming aggregation (default: 10,000)
-  private static final int DEFAULT_BATCH_SIZE = 10000;
-  private static final int BATCH_SIZE = Integer.parseInt(
-      System.getProperty("arcadedb.aggregation.batchSize", String.valueOf(DEFAULT_BATCH_SIZE)));
+  // Batch size for pulling from upstream while accumulating aggregation input. See the identical
+  // comment on AggregationStep.CONFIGURED_BATCH_SIZE (issue #6368) for why this defaults to the
+  // caller's own nRecords rather than a large fixed size.
+  private static final String BATCH_SIZE_PROPERTY = "arcadedb.aggregation.batchSize";
+  private static final Integer CONFIGURED_BATCH_SIZE = System.getProperty(BATCH_SIZE_PROPERTY) != null ?
+      Integer.parseInt(System.getProperty(BATCH_SIZE_PROPERTY)) : null;
 
   public GroupByAggregationStep(final ReturnClause returnClause, final CommandContext context,
       final CypherFunctionFactory functionFactory) {
@@ -109,10 +111,10 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
     final List<Result> results;
 
     if (singleKeyPath) {
-      results = aggregateSingleKey(groupingKeys.get(0), aggExpressions, aggOutputNames, aggCount, context);
+      results = aggregateSingleKey(groupingKeys.get(0), aggExpressions, aggOutputNames, aggCount, context, nRecords);
     } else {
       results = aggregateMultiKey(groupingKeys, aggregationItems, complexAggregationItems,
-          aggExpressions, aggOutputNames, aggCount, context);
+          aggExpressions, aggOutputNames, aggCount, context, nRecords);
     }
 
     return new ResultSet() {
@@ -142,14 +144,14 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
    */
   private List<Result> aggregateSingleKey(final GroupingKey groupingKey,
       final FunctionCallExpression[] aggExpressions, final String[] aggOutputNames, final int aggCount,
-      final CommandContext context) {
+      final CommandContext context, final int nRecords) {
 
     // Map: raw grouping value -> array of aggregation functions (indexed, not HashMap)
     // LinkedHashMap preserves insertion order, needed because ORDER BY in WITH clauses
     // may fail to resolve aggregation expressions and fall back to iteration order
     final Map<Object, StatelessFunction[]> groups = new LinkedHashMap<>();
 
-    final ResultSet prevResults = prev.syncPull(context, BATCH_SIZE);
+    final ResultSet prevResults = prev.syncPull(context, CONFIGURED_BATCH_SIZE != null ? CONFIGURED_BATCH_SIZE : nRecords);
 
     while (prevResults.hasNext()) {
       final Result inputRow = prevResults.next();
@@ -214,11 +216,11 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
   private List<Result> aggregateMultiKey(final List<GroupingKey> groupingKeys,
       final List<AggregationItem> aggregationItems, final List<ComplexAggregationItem> complexAggregationItems,
       final FunctionCallExpression[] aggExpressions, final String[] aggOutputNames, final int aggCount,
-      final CommandContext context) {
+      final CommandContext context, final int nRecords) {
 
     final Map<GroupKeyValues, GroupAggregators> groups = new LinkedHashMap<>();
 
-    final ResultSet prevResults = prev.syncPull(context, BATCH_SIZE);
+    final ResultSet prevResults = prev.syncPull(context, CONFIGURED_BATCH_SIZE != null ? CONFIGURED_BATCH_SIZE : nRecords);
 
     while (prevResults.hasNext()) {
       final Result inputRow = prevResults.next();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
@@ -1356,4 +1356,139 @@ class OpenCypherVariableLengthPathTest {
       db.drop();
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Issue #6368: collect()/UNWIND on a VLP row must not change which upstream SET writes a later
+  // path's nodes observe, compared to the same MATCH+SET returned directly.
+  // ---------------------------------------------------------------------------
+
+  // Issue #6368: a K4 graph where every node is reachable from every other node in 1..4 undirected
+  // hops, so a VLP MATCH from one start node revisits nodes already touched (and SET) while exploring
+  // from an earlier start node. AggregationStep/GroupByAggregationStep used to pull the entire
+  // upstream MATCH+SET in one large fixed batch (10,000 rows), so every VLP path got built - and its
+  // node references frozen - before any SET had run. A plain (non-aggregating) RETURN pulls in much
+  // smaller batches, so by the time a later start node's path revisits an earlier one's node, that
+  // node's own SET has already applied. The two forms must agree.
+  private Database setupIssue6368Graph(final String path) {
+    final Database database = new DatabaseFactory(path).create();
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (n {id: 0, klist: ['v0']})");
+      database.command("opencypher", "CREATE (n {id: 1, klist: ['v1']})");
+      database.command("opencypher", "CREATE (n {id: 2, klist: ['v2']})");
+      database.command("opencypher", "CREATE (n {id: 3, klist: ['v3']})");
+
+      database.command("opencypher", "MATCH (a {id: 0}), (b {id: 1}) CREATE (a)-[:R6368 {id: 101}]->(b)");
+      database.command("opencypher", "MATCH (a {id: 0}), (b {id: 2}) CREATE (a)-[:R6368 {id: 102}]->(b)");
+      database.command("opencypher", "MATCH (a {id: 0}), (b {id: 3}) CREATE (a)-[:R6368 {id: 103}]->(b)");
+      database.command("opencypher", "MATCH (a {id: 1}), (b {id: 2}) CREATE (a)-[:R6368 {id: 106}]->(b)");
+      database.command("opencypher", "MATCH (a {id: 1}), (b {id: 3}) CREATE (a)-[:R6368 {id: 107}]->(b)");
+      database.command("opencypher", "MATCH (a {id: 2}), (b {id: 3}) CREATE (a)-[:R6368 {id: 111}]->(b)");
+    });
+    return database;
+  }
+
+  // Issue #6368: WITH collect(row) AS rows / UNWIND must return the same node properties the same
+  // MATCH+SET returns directly (no collect()/UNWIND in between)
+  @SuppressWarnings("unchecked")
+  @Test
+  void collectUnwindDoesNotChangeVlpNodePropertiesVersusDirectReturn() {
+    final Database direct = setupIssue6368Graph("./target/databases/issue-6368-direct");
+    final Database collectUnwind = setupIssue6368Graph("./target/databases/issue-6368-collect");
+    try {
+      final Result[] directRowHolder = new Result[1];
+      direct.transaction(() -> {
+        final ResultSet rs = direct.command("opencypher", """
+            CALL {
+              MATCH p0 = (n0)-[*1..4]-()
+              SET n0.klist = []
+              RETURN n0, p0
+            }
+            WITH n0, p0
+            WHERE n0.id = 3 AND size(nodes(p0)) = 2 AND nodes(p0)[1].id = 2
+            RETURN n0.id AS n0Id,
+                   [x IN nodes(p0) | {id: x.id, klist: x.klist}] AS pathNodes
+            """);
+        assertThat(rs.hasNext()).as("Direct query must return the filtered row").isTrue();
+        directRowHolder[0] = rs.next();
+      });
+      final Result directRow = directRowHolder[0];
+
+      final Result[] collectRowHolder = new Result[1];
+      collectUnwind.transaction(() -> {
+        final ResultSet rs = collectUnwind.command("opencypher", """
+            CALL {
+              MATCH p0 = (n0)-[*1..4]-()
+              SET n0.klist = []
+              WITH {n0: n0, p0: p0} AS row
+              WITH collect(row) AS rows
+              UNWIND rows AS row
+              RETURN row.n0 AS n0, row.p0 AS p0
+            }
+            WITH n0, p0
+            WHERE n0.id = 3 AND size(nodes(p0)) = 2 AND nodes(p0)[1].id = 2
+            RETURN n0.id AS n0Id,
+                   [x IN nodes(p0) | {id: x.id, klist: x.klist}] AS pathNodes
+            """);
+        assertThat(rs.hasNext()).as("collect()/UNWIND query must return the filtered row").isTrue();
+        collectRowHolder[0] = rs.next();
+      });
+      final Result collectRow = collectRowHolder[0];
+
+      assertThat(((Number) collectRow.getProperty("n0Id")).longValue())
+          .isEqualTo(((Number) directRow.getProperty("n0Id")).longValue());
+
+      final List<Map<String, Object>> directPathNodes = (List<Map<String, Object>>) directRow.getProperty("pathNodes");
+      final List<Map<String, Object>> collectPathNodes = (List<Map<String, Object>>) collectRow.getProperty("pathNodes");
+      assertThat(collectPathNodes)
+          .as("collect()/UNWIND must observe the same node properties as the direct query")
+          .isEqualTo(directPathNodes);
+
+      // Pin down the concrete expected shape too, not just parity between the two forms: node 2's
+      // own SET (as a start node earlier in the traversal) must be visible when node 2 is later
+      // revisited as a path node from a different start node.
+      assertThat(collectPathNodes).hasSize(2);
+      assertThat(((Number) collectPathNodes.get(1).get("id")).longValue()).isEqualTo(2L);
+      assertThat((List<String>) collectPathNodes.get(1).get("klist")).as("node 2's SET must be visible").isEmpty();
+    } finally {
+      direct.drop();
+      collectUnwind.drop();
+    }
+  }
+
+  // Issue #6368: the GROUP BY aggregation path (implicit grouping via a non-aggregated key alongside
+  // collect()) must not change VLP node properties either - GroupByAggregationStep had the same
+  // large-fixed-batch defect as AggregationStep.
+  @SuppressWarnings("unchecked")
+  @Test
+  void groupByCollectDoesNotChangeVlpNodePropertiesVersusDirectReturn() {
+    final Database database = setupIssue6368Graph("./target/databases/issue-6368-groupby");
+    try {
+      final Result[] rowHolder = new Result[1];
+      database.transaction(() -> {
+        final ResultSet rs = database.command("opencypher", """
+            CALL {
+              MATCH p0 = (n0)-[*1..4]-()
+              SET n0.klist = []
+              WITH n0, collect(p0) AS paths
+              UNWIND paths AS p0
+              RETURN n0, p0
+            }
+            WITH n0, p0
+            WHERE n0.id = 3 AND size(nodes(p0)) = 2 AND nodes(p0)[1].id = 2
+            RETURN [x IN nodes(p0) | {id: x.id, klist: x.klist}] AS pathNodes
+            """);
+        assertThat(rs.hasNext()).as("GROUP BY collect() query must return the filtered row").isTrue();
+        rowHolder[0] = rs.next();
+      });
+      final Result row = rowHolder[0];
+
+      final List<Map<String, Object>> pathNodes = (List<Map<String, Object>>) row.getProperty("pathNodes");
+      assertThat(pathNodes).hasSize(2);
+      assertThat(((Number) pathNodes.get(1).get("id")).longValue()).isEqualTo(2L);
+      assertThat((List<String>) pathNodes.get(1).get("klist"))
+          .as("node 2's SET must be visible through the GROUP BY collect() path too").isEmpty();
+    } finally {
+      database.drop();
+    }
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a Cypher correctness bug where inserting a `collect()`/`UNWIND` pass-through into a
`MATCH ... SET ...` pipeline changed which node property values a later `WHERE`/`RETURN`
observed for a variable-length path, compared to the identical query without the
`collect()`/`UNWIND`.

`AggregationStep` and `GroupByAggregationStep` (the executor steps behind any Cypher
aggregation function, including `collect()`) pulled their entire upstream input using a
hardcoded `BATCH_SIZE = 10000`, ignoring the `nRecords` batch size (100 by default) the
rest of the plan was asked to use. A batch that large let `ExpandPathStep` build **every**
candidate variable-length path - across **every** matched start node - in one shot, before
the downstream `SetStep` had applied `SET` to *any* of them.

`TraversalPath` freezes a node's property values into the path at the moment the path is
built, and `RowAliases.propagateUpdate` deliberately only redirects a row's own top-level
variable aliases after a `SET`, not nodes nested inside a path, list, or map (see that
class's doc comment - a documented, accepted trade-off for the common case). So when the
oversized batch let `ExpandPathStep` explore a later start node's path before an earlier
start node's own `SET` had run, the earlier node's *pre-write* property values got
permanently baked into the later node's path.

A plain (non-aggregating) `RETURN` pulls in the plan's normal ~100-row batches, which -
for the reported graph - happened to interleave `SET` and traversal closely enough that
the earlier write had already landed by the time a later start node's path revisited that
node. That was incidental to the batch-size/graph-size ratio, not a guarantee -
`collect()`/`UNWIND` simply made the same underlying non-determinism visible by using a
batch large enough to defeat the interleaving entirely.

Confirmed by instrumenting `ExpandPathStep`/`SetStep` and comparing event order for the
two forms of the reported query: the non-aggregating form interleaves `EXPAND`/`SET` in
~100-row chunks (node 2's `SET` had already run 22 of 39 times by the time node 3's path
revisited it); the `collect()`/`UNWIND` form ran all 156 `EXPAND` events for all 4 start
nodes first, then all 156 `SET` events - so node 2's path reference was frozen well before
its own `SET` ever ran.

### Fix

`AggregationStep.syncPull` and `GroupByAggregationStep.syncPull` (both the single-key and
multi-key grouping paths) now pull from upstream using the caller-supplied `nRecords` by
default, matching the granularity the rest of the plan already uses, instead of a fixed
10,000-row batch. The existing `arcadedb.aggregation.batchSize` system property remains
available as an explicit override for callers who know their upstream pipeline has no
side effects and want fewer round trips.

## Motivation

Issue #6368: a bare `collect()`/`UNWIND` between a variable-length-path `MATCH` and a `SET`
changed the `klist` property value the query reported for a path node, purely because of
which internal batch size the executor happened to use - a query that should be a
value-preserving pass-through was not.

## Related issues

Closes #6368

## Additional Notes

- Both `AggregationStep` and `GroupByAggregationStep` had the identical defect (same
  hardcoded `BATCH_SIZE` pattern); both are fixed the same way, and both have a dedicated
  regression test.
- No new dependency, no public API change. The `arcadedb.aggregation.batchSize` system
  property keeps working exactly as before for anyone who had set it explicitly.

## Checklist

- [x] I have run the build using `mvn clean package` command (`mvn -pl engine -am compile test-compile`, plus targeted test runs below)
- [x] My unit tests cover both failure and success scenarios

### Test plan

- `OpenCypherVariableLengthPathTest#collectUnwindDoesNotChangeVlpNodePropertiesVersusDirectReturn` -
  reproduces the exact issue query pair (direct vs. `collect()`/`UNWIND`, each against its own clean
  database) and asserts the returned `pathNodes` are identical; also pins the concrete expected shape
  (node 2's `klist` must be empty, reflecting its own `SET`).
- `OpenCypherVariableLengthPathTest#groupByCollectDoesNotChangeVlpNodePropertiesVersusDirectReturn` -
  same defect through the `GroupByAggregationStep` path (`WITH n0, collect(p0) AS paths`).
- Both new tests were verified to **fail** against the pre-fix source (via a temporary revert of the
  two source files) with the exact reported mismatch, then verified to **pass** with the fix applied.
- Full `OpenCypherVariableLengthPathTest` class (45 tests): pass.
- Broader aggregation/collect/VLP-adjacent classes (`OpenCypherCollectUnwindTest`, `OpenCypherGroupByTest`,
  `StreamingAggregationTest`, `CollectDistinctTest`, `HeadCollectTest`, `CypherLabelWriteRowFanoutIssue6312Test`,
  `CypherCollectSubqueryCorrelatedTest`, `CypherCountSubqueryCorrelatedTest`, `CypherCountSubqueryTest`): pass.
- Full `com.arcadedb.query.opencypher.**` test package (excluding `benchmark`/`slow`/`vector` lanes): pass,
  0 failures/errors.
- `mvn -pl engine -am compile test-compile`: clean.
