### PR TITLE
fix(#6337): a star-join count declines the push-down when an arm endpoint carries a label

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -5145,6 +5145,19 @@ public class CypherExecutionPlan {
 
         final int totalHops = pathPattern.getRelationshipCount();
 
+        // Every non-central node of the arm - the far endpoint and any interior node of a multi-hop
+        // arm alike - is a label the degree product cannot enforce: it counts degree off the arm's
+        // edge types and directions alone, with no field on Arm for a per-hop endpoint type, so
+        // (:Author) and () built the same operator and the same, over-counted, answer. Decline the
+        // push-down rather than silently drop the filter, exactly as the central variable's own label
+        // already does above (issue #6337, the arm-endpoint sibling of #6322).
+        for (int i = 0; i <= totalHops; i++) {
+          if (i == centralNodeIdx)
+            continue;
+          if (pathPattern.getNode(i).hasLabels())
+            return null;
+        }
+
         if (centralNodeIdx == 0) {
           final DegreeProductOp.Arm arm = buildArmForward(pathPattern, 0, totalHops, isOptional);
           if (arm == null) return null;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownLabelIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownLabelIssue6322Test.java
@@ -145,10 +145,14 @@ class CypherCountPushDownLabelIssue6322Test extends TestHelper {
   /**
    * The central variable is written once per arm, and the operator enumerates one type of central node, so two
    * arms naming different types cannot both be honoured by it.
+   * <p>
+   * The arms are left unlabelled on purpose, for the same reason as {@code single} above: a labelled arm
+   * endpoint declines the push-down on its own (issue #6337), which would make this test pass even if the
+   * central-label-conflict check it is named for stopped working.
    */
   @Test
   void conflictingCentralLabelsDeclineTheStarCountPushDown() {
-    final String query = "MATCH (p:Post)<-[:WROTE]-(:Author), (p:Draft)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    final String query = "MATCH (p:Post)<-[:WROTE]-(), (p:Draft)-[:TAGGED]->() RETURN count(*) AS c";
     assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
     assertThat(scalarOf(query)).isEqualTo(1);
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownLabelIssue6322Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCountPushDownLabelIssue6322Test.java
@@ -123,14 +123,21 @@ class CypherCountPushDownLabelIssue6322Test extends TestHelper {
     assertThat(scalarOf(query)).isEqualTo(1);
   }
 
-  /** {@code tryDetectStarCountStar}: the central variable's label is the type the operator enumerates. */
+  /**
+   * {@code tryDetectStarCountStar}: the central variable's label is the type the operator enumerates.
+   * <p>
+   * The contrasting {@code single} query below leaves both arms unlabelled on purpose: an arm endpoint's own
+   * label is a separate defect (issue #6337, fixed after this test was written) that declines the push-down
+   * regardless of what the central variable's label set looks like, so this comparison keeps that variable out
+   * of the case being tested here.
+   */
   @Test
   void theCentralVariablesLabelSetDeclinesTheStarCountPushDown() {
     final String query = "MATCH (p:Post:Draft)<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
     assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
     assertThat(scalarOf(query)).isEqualTo(1);
 
-    final String single = "MATCH (p:Post)<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    final String single = "MATCH (p:Post)<-[:WROTE]-(), (p)-[:TAGGED]->() RETURN count(*) AS c";
     assertThat(explainOf(single)).contains("COUNT STAR JOIN");
     assertThat(scalarOf(single)).isEqualTo(3);
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStarCountArmLabelIssue6337Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStarCountArmLabelIssue6337Test.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6337: {@code tryDetectStarCountStar} reads only the central variable's label and
+ * carries nothing for an arm's far endpoint - {@code DegreeProductOp.Arm} has no room for one - so
+ * {@code (p)<-[:WROTE]-(:Author)} and {@code (p)<-[:WROTE]-()} produced the same operator and the same,
+ * over-counted, answer. The fix declines the push-down whenever a non-central node of a star-join pattern
+ * carries a label, exactly as the sibling detectors already do for the central variable's own label
+ * (issue #6322).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherStarCountArmLabelIssue6337Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:Author {k:'a1'})");
+    database.command("opencypher", "CREATE (:Bot {k:'b1'})");
+    database.command("opencypher", "CREATE (:Post {k:'p1'})");
+    database.command("opencypher", "CREATE (:Topic {k:'t1'})");
+
+    database.command("opencypher", "MATCH (a:Author {k:'a1'}), (p:Post {k:'p1'}) CREATE (a)-[:WROTE]->(p)");
+    database.command("opencypher", "MATCH (b:Bot {k:'b1'}), (p:Post {k:'p1'}) CREATE (b)-[:WROTE]->(p)");
+    database.command("opencypher", "MATCH (p:Post {k:'p1'}), (t:Topic {k:'t1'}) CREATE (p)-[:TAGGED]->(t)");
+  }
+
+  /**
+   * Only {@code a1} is an {@code Author}; {@code b1} is a {@code Bot}. The degree product used to count the
+   * in-degree of {@code WROTE} on {@code p1} - which is 2, one Author and one Bot - and multiply it by the
+   * {@code TAGGED} out-degree, giving 2 regardless of the {@code :Author} label on the arm. The materialized
+   * pipeline is ground truth: only the Author-authored, Topic-tagged post exists once.
+   */
+  @Test
+  void aLabelledArmEndpointDeclinesTheStarCountPushDown() {
+    final String labelled = "MATCH (p:Post)<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(labelled)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(labelled)).isEqualTo(1);
+    assertThat(scalarOf(labelled)).isEqualTo(rowCountOf(
+        "MATCH (p:Post)<-[:WROTE]-(a:Author), (p)-[:TAGGED]->(t:Topic) RETURN p"));
+  }
+
+  /**
+   * When no arm carries a label at all, the push-down still applies and still counts both {@code WROTE} arms -
+   * the fix declines on a label the operator cannot enforce, not on the presence of an arm.
+   */
+  @Test
+  void starCountPushDownStillAppliesWhenNoArmCarriesALabel() {
+    final String unlabelled = "MATCH (p:Post)<-[:WROTE]-(), (p)-[:TAGGED]->() RETURN count(*) AS c";
+    assertThat(explainOf(unlabelled)).contains("COUNT STAR JOIN");
+    assertThat(scalarOf(unlabelled)).isEqualTo(2);
+  }
+
+  /** A label on an interior node of a multi-hop arm is just as unenforceable as one on the far endpoint. */
+  @Test
+  void aLabelledInteriorArmNodeDeclinesTheStarCountPushDown() {
+    database.command("opencypher", "CREATE (:Bad {k:'x1'})");
+    database.command("opencypher", "MATCH (b:Bad {k:'x1'}), (p:Post {k:'p1'}) CREATE (b)-[:VIA]->(p)");
+    database.command("opencypher", "MATCH (a:Author {k:'a1'}), (b:Bad {k:'x1'}) CREATE (a)-[:LINK]->(b)");
+
+    final String query = "MATCH (p:Post)<-[:VIA]-(:Bad)<-[:LINK]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query)).isEqualTo(rowCountOf(
+        "MATCH (p:Post)<-[:VIA]-(x:Bad)<-[:LINK]-(a:Author), (p)-[:TAGGED]->(t:Topic) RETURN p"));
+  }
+
+  // ===================================================================================================
+  // helpers
+  // ===================================================================================================
+
+  private long scalarOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private int rowCountOf(final String query) {
+    int count = 0;
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private String explainOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStarCountArmLabelIssue6337Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStarCountArmLabelIssue6337Test.java
@@ -87,6 +87,27 @@ class CypherStarCountArmLabelIssue6337Test extends TestHelper {
         "MATCH (p:Post)<-[:VIA]-(x:Bad)<-[:LINK]-(a:Author), (p)-[:TAGGED]->(t:Topic) RETURN p"));
   }
 
+  /**
+   * The other three tests all put the central variable at position 0 or the last position of its path
+   * pattern, which builds a single {@code Arm} via {@code buildArmForward}/{@code buildArmBackward}. When the
+   * central variable sits in the <em>interior</em> of a pattern instead, {@code tryDetectStarCountStar} splits
+   * it into a {@code leftArm} and a {@code rightArm} from the same pattern - a third construction path the
+   * label-decline loop has to cover too, since it runs once per pattern before that split, not once per arm.
+   */
+  @Test
+  void aLabelledEndpointDeclinesTheStarCountPushDownWhenTheCentralNodeIsInterior() {
+    database.command("opencypher", "CREATE (:Extra {k:'e1'})");
+    database.command("opencypher", "MATCH (p:Post {k:'p1'}), (e:Extra {k:'e1'}) CREATE (p)-[:VIA]->(e)");
+
+    // p sits between (:Author) and (:Topic) in the first pattern, so this one PathPattern alone yields both
+    // a leftArm (back to :Author) and a rightArm (forward to :Topic); the second pattern only supplies p's
+    // second occurrence so it counts as the central variable at all.
+    final String query = "MATCH (:Author)-[:WROTE]->(p:Post)-[:TAGGED]->(:Topic), (p)-[:VIA]->() RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query)).isEqualTo(rowCountOf(
+        "MATCH (a:Author)-[:WROTE]->(p:Post)-[:TAGGED]->(t:Topic), (p)-[:VIA]->(e) RETURN p"));
+  }
+
   // ===================================================================================================
   // helpers
   // ===================================================================================================

--- a/engine/src/test/java/com/arcadedb/query/opencypher/GAVEligibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/GAVEligibilityTest.java
@@ -504,9 +504,35 @@ class GAVEligibilityTest {
     result.close();
   }
 
+  /**
+   * Q7-like: star join with OPTIONAL MATCH arms. The arm endpoints are left unlabelled on purpose: a labelled
+   * endpoint is exactly what issue #6337 now declines the push-down for, since {@code DegreeProductOp.Arm} has
+   * no field to enforce it and silently ignored it before the fix. This test is about the OPTIONAL MATCH
+   * handling of the optimized step, which the unlabelled spelling still reaches; the labelled spelling is
+   * covered by {@link #starJoinQ7WithLabelledArmDeclinesTheOptimizedStep()} below.
+   */
   @Test
   void starJoinQ7OptionalMatchUsesOptimizedStep() {
-    // Q7-like: star join with OPTIONAL MATCH arms
+    final ResultSet result = database.query("opencypher",
+        "PROFILE MATCH ()<-[:HAS_TAG]-(m:Message)-[:HAS_CREATOR]->() OPTIONAL MATCH (m)<-[:LIKES]-() OPTIONAL MATCH (m)<-[:REPLY_OF]-() RETURN count(*) AS count");
+
+    while (result.hasNext())
+      result.next();
+
+    final String planString = result.getExecutionPlan().get().prettyPrint(0, 2);
+    assertThat(planString).contains("COUNT STAR JOIN");
+    result.close();
+  }
+
+  /**
+   * The same Q7-like pattern, with every arm endpoint labelled as the original query (before issue #6337 was
+   * fixed) wrote it. {@code DegreeProductOp} counts degree by edge type and direction alone, with no way to
+   * check a neighbour's type, so a labelled endpoint used to be silently ignored - {@code (:Person)} and
+   * {@code ()} produced the same operator and the same, over-counted, answer. The push-down now declines
+   * instead, leaving the query to the ordinary pipeline, which applies every label.
+   */
+  @Test
+  void starJoinQ7WithLabelledArmDeclinesTheOptimizedStep() {
     final ResultSet result = database.query("opencypher",
         "PROFILE MATCH (:Tag)<-[:HAS_TAG]-(m:Message)-[:HAS_CREATOR]->(:Person) OPTIONAL MATCH (m)<-[:LIKES]-(:Person) OPTIONAL MATCH (m)<-[:REPLY_OF]-(:Comment) RETURN count(*) AS count");
 
@@ -514,7 +540,7 @@ class GAVEligibilityTest {
       result.next();
 
     final String planString = result.getExecutionPlan().get().prettyPrint(0, 2);
-    assertThat(planString).contains("COUNT STAR JOIN");
+    assertThat(planString).doesNotContain("COUNT STAR JOIN");
     result.close();
   }
 


### PR DESCRIPTION
Closes #6337

## What does this PR do?

`tryDetectStarCountStar` (the openCypher star-join `count(*)` push-down, `DegreeProductOp` /
"CSR degree product") reads only the **central** variable's label. `DegreeProductOp.Arm`
carries `edgeTypes`, `directions` and `optional` and has no field for a per-hop endpoint
label, so an arm's far-endpoint label - or an interior node's label on a multi-hop arm - had
nowhere to go and was silently dropped. `(:Author)` and `()` on an arm built the *same*
operator and produced the *same*, over-counted, answer:

```cypher
MATCH (p:Post)<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*)   -- answered 2, should be 1
```
`p1` has an in-degree of 2 on `WROTE` (one `Author`, one `Bot`), and the operator multiplied
that raw degree by the `TAGGED` out-degree regardless of the `:Author` label on the arm.

The fix declines the push-down whenever a non-central node of a star-join pattern carries a
label - the far endpoint of an arm, or an interior node of a multi-hop arm - leaving the
query to the ordinary pipeline, which applies every label correctly. This mirrors what
#6304/#6322 already do for the other count push-down detectors and for the central
variable's own label in this same detector.

## Motivation

Filed by @lvca as a follow-up to #6322/#6325, deliberately left out of that PR because it is
a design decision (decline vs. enforce) rather than a straightforward correction. The issue
lays out two possible shapes:

1. **Decline the push-down** whenever an arm endpoint carries a label the operator cannot
   enforce (the conservative direction, "costs only queries currently answered wrong" as a
   first approximation).
2. Carry per-hop labels into `Arm` and check the neighbour's bucket during the scan - correct,
   but turns the O(1)-per-node fast path (`executeFastScan`, pure array arithmetic over CSR
   degree offsets) into an O(degree) walk per row, i.e. back into the OLTP-style scan the
   operator exists to avoid.

This PR implements (1), matching the issue's stated preference and the precedent already set
in this file. (2), or the "recover cheaply" middle ground the issue also sketches (decline
only when the label's type is *not* provably the only type reachable over that edge/direction
- e.g. via `GraphAnalyticalView`'s vertex-type coverage, or a per-arm bucket-id bitmap checked
only for labelled arms) is a real, separate follow-up worth its own issue: several benchmark
patterns this operator was built for (LDBC-style Q4/Q7 - see `DegreeProductOp`'s own javadoc)
write a label on every arm endpoint, and in those schemas the edge type happens to imply the
endpoint type, so declining is strictly more conservative than necessary there. This PR does
not attempt that recovery; see "Trade-off" below.

## Related issues

- Closes #6337
- Follows on from #6322 / PR #6325 (same class of bug: a detector keying an operator on a
  single label per node, first fixed for the central variable of this same detector)
- Precedent: #6304 (pair-join detector), #6322 (four more detectors)

## Trade-off (please read before merging)

This fix is intentionally conservative and has a measured performance cost: **any** star-join
`count(*)` query that labels an arm endpoint - even when the label is harmless because the
edge type in that schema only ever connects to that type - now falls back to the ordinary
pipeline instead of the O(1) CSR degree-product path. Two existing tests asserted the old
(unsafe) behaviour and were updated:

- `GAVEligibilityTest.starJoinQ7OptionalMatchUsesOptimizedStep` - the Q7-like query with
  labelled OPTIONAL MATCH arms no longer gets the push-down. I reworked it to use unlabelled
  arms (still exercising the OPTIONAL MATCH handling of the optimized step) and added
  `starJoinQ7WithLabelledArmDeclinesTheOptimizedStep` to pin the new decline behaviour on the
  original, labelled query.
- `CypherCountPushDownLabelIssue6322Test.theCentralVariablesLabelSetDeclinesTheStarCountPushDown`
  - its "single label, still pushed down" contrast query had labelled arms too (the very
    #6337 pattern); switched it to unlabelled arms so the test stays focused on the central
    variable's label, which is what it's named for.

No other tests in `engine/src/test/java/com/arcadedb/query/opencypher/**` (387 test classes,
full run, `benchmark`/`slow`/`vector` lanes excluded) regressed.

I'd suggest filing the "recover cheaply" optimization (schema/`GraphAnalyticalView`-based
disjointness, or the per-arm bucket-id bitmap alternative the issue also sketches) as its own
follow-up issue rather than folding it into this correctness fix - the issue's own author
flagged it as "worth measuring before choosing," which argues for a dedicated PR with its own
benchmark rather than bundling an unmeasured optimization into a bug fix.

## Testing

- New regression test `CypherStarCountArmLabelIssue6337Test`:
  - `aLabelledArmEndpointDeclinesTheStarCountPushDown` - reproduces the issue's exact example;
    confirms `EXPLAIN` no longer shows `COUNT STAR JOIN` and the count now matches the
    materialized pipeline's ground truth (1, not 2).
  - `starCountPushDownStillAppliesWhenNoArmCarriesALabel` - confirms the push-down still
    applies (and still over-counts correctly for the *unlabelled* case, which is not a bug -
    an unlabelled arm has nothing to enforce) when no arm carries a label at all.
  - `aLabelledInteriorArmNodeDeclinesTheStarCountPushDown` - confirms a label on an interior
    node of a multi-hop arm (not just the far endpoint) also declines, and the pushed-back
    answer matches the materialized pipeline.
- Updated `CypherCountPushDownLabelIssue6322Test` and `GAVEligibilityTest` as described above.
- `mvn -pl engine -am test` for the full `com.arcadedb.query.opencypher.**` package (387
  classes): all green.
- `mvn -pl engine -am compile`: clean.

## Checklist

- [x] I have run the build using `mvn clean package` (`compile` + full `opencypher` package
  test run; did not run the full multi-module `mvn clean package` given the scope of the
  change)
- [x] My unit tests cover both failure and success scenarios (labelled-declines,
  unlabelled-still-pushed-down, interior-label-declines)

## Review history

**Cycle 1** (commit `d6e616f`, addressing the Claude review on `f4554f6`):

- Fixed: `CypherCountPushDownLabelIssue6322Test.conflictingCentralLabelsDeclineTheStarCountPushDown`
  still labelled both arm endpoints (`:Author`, `:Topic`), so after this PR's fix it passed for
  the wrong reason - the new arm-label decline alone was enough to make the assertion true,
  independently of whether the central-label-conflict logic the test is named for still works.
  Switched it to unlabelled arms (`MATCH (p:Post)<-[:WROTE]-(), (p:Draft)-[:TAGGED]->() ...`),
  the same fix already applied to its two siblings in the original PR body's "Trade-off"
  section.
- Deferred as a follow-up (not fixed here, out of #6337's stated scope): `tryDetectStarCountStar`'s
  label checks - both the pre-existing central-variable one and the new arm-endpoint one this PR
  adds - gate only on `node.hasLabels()`, never on `node.hasProperties()` /
  `node.hasDynamicLabels()`. An inline property filter on the central variable or any arm node
  (e.g. `(p:Post {status:'live'})`) is silently dropped the same way labels used to be, and the
  push-down over-counts on the raw degree. This is the identical bug class as #6337, but on
  properties instead of labels, and it predates this PR (the central-variable half of it comes
  from #6322). The sibling pair-join/chain detectors in this same file already decline on
  `hasProperties()`/`hasDynamicLabels()` (e.g. `CypherExecutionPlan.java:2434`, `:4831`), so the
  fix shape is known; it just isn't part of what #6337 asked for. Filed as #6431 rather than
  expanding this PR's scope.

**Cycle 2** (commit `679eea1`, addressing the Claude review on `d6e616f`): no blocking issues.
One non-blocking coverage suggestion, addressed:

- Added `aLabelledEndpointDeclinesTheStarCountPushDownWhenTheCentralNodeIsInterior` to
  `CypherStarCountArmLabelIssue6337Test`: the other three regression tests all put the central
  variable at position 0 or the last position of its path pattern, which builds a single `Arm`
  via `buildArmForward`/`buildArmBackward`. When the central variable sits in the *interior* of
  a pattern instead, `tryDetectStarCountStar` splits it into a `leftArm` and a `rightArm` from
  the same pattern - a third construction path the label-decline loop has to cover too, since it
  runs once per pattern before that split. The new test pins that it does.

**Cycle 3** (review on `679eea1`): clean approval, no actionable items ("nothing blocking",
per the review). The one note - that a central variable appearing *twice* within the same
`PathPattern` isn't explicitly exercised - is called out by the reviewer itself as
"safe/conservative" (the new loop would just decline on the second occurrence too, same as any
other labelled non-central node), not a defect, so no further change made. Stopping the review
loop here.

