### PR TITLE
fix(#6396): a write that describes bytes it did not write is now caught by the commit that measures them

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -189,6 +189,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   private static final   int                       MAX_PAGES_GATHER_STATS           = 100;
   private static final   long                      MAX_TIMEOUT_GATHER_STATS         = 5000L;
   private static final   int                       GATHER_STATS_MIN_SPACE_PERC      = 10;
+  /**
+   * Whether the free-space claims the write paths make are held against the commit-time measurement (#6396). On
+   * exactly when assertions are - surefire's default, never a production run - because the check IS an assertion:
+   * it costs two field stores per write, and a comparison against a page walk the compression was doing anyway.
+   */
+  private static final   boolean                   CHECK_FREE_SPACE_CLAIMS          = LocalBucket.class.desiredAssertionStatus();
   private static final   int                       SPARE_SPACE_FOR_GROWTH           = 32;
   protected final        int                       contentHeaderSize;
   private final          int                       maxRecordsInPage;
@@ -1793,6 +1799,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     final MutablePage page = database.getTransaction()
             .getPageToModify(new PageId(database, file.getFileId(), pageId), pageSize, false);
     page.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE, 0L);
+    freedWithoutClaiming(page);
 
     database.getTransaction().addDeletedRecord(rid);
   }
@@ -2146,7 +2153,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                   isPlaceHolder ? (-1L * bufferSize) : bufferSize);
           selectedPage.writeByteArray(newRecordPositionInPage + byteWritten, buffer.getContent(), buffer.getContentBeginOffset(),
                   bufferSize);
-          updatePageStatistics(selectedPage.pageId.getPageNumber(), spaceAvailableInCurrentPage, -spaceNeeded);
+          updatePageStatistics(selectedPage, spaceAvailableInCurrentPage, -spaceNeeded);
         }
       } finally {
         selectedPage.endCoveredWrite(previousCoverage);
@@ -2257,7 +2264,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         } else {
           final int byteWritten = selectedPage.writeNumber(newRecordPositionInPage, bufferSize);
           selectedPage.writeByteArray(newRecordPositionInPage + byteWritten, buffer.getContent(), buffer.getContentBeginOffset(), bufferSize);
-          updatePageStatistics(selectedPage.pageId.getPageNumber(), spaceAvailableInCurrentPage, -spaceNeeded);
+          updatePageStatistics(selectedPage, spaceAvailableInCurrentPage, -spaceNeeded);
         }
       } finally {
         selectedPage.endCoveredWrite(previousCoverage);
@@ -2649,7 +2656,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // it against a page this one has moved on from. It is an absolute value, not an increment, so re-stating it
         // corrects the earlier one rather than doubling it.
         if (chunkRegionEnd == page.getMaxContentSize() && body.length != committedChunk.length)
-          updatePageStatistics(pageNumber, chunkRegionEnd - (chunkHeaderPos + committedChunk.length),
+          updatePageStatistics(page, chunkRegionEnd - (chunkHeaderPos + committedChunk.length),
                   committedChunk.length - body.length);
 
         page.writeByteArray(chunkHeaderPos, body, 0, body.length);
@@ -2691,7 +2698,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // #6154: same accounting the write makes, re-derived here against the committed page rather than trusted.
         if (chunkRegionEnd == page.getMaxContentSize()) {
           final int committedChunkEnd = chunkHeaderPos + committedChunk.length;
-          updatePageStatistics(pageNumber, chunkRegionEnd - committedChunkEnd,
+          updatePageStatistics(page, chunkRegionEnd - committedChunkEnd,
                   committedChunkEnd - (existingPos + sizeLen + body.length));
         }
 
@@ -2736,7 +2743,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         if (enlargement > 0) {
           shiftFollowingRecordsRight(page, recordCountInPage, existingPos + slotFootprint, pageOccupiedInBytes,
                   enlargement);
-          updatePageStatistics(pageNumber, freeTailInPage, -enlargement);
+          updatePageStatistics(page, freeTailInPage, -enlargement);
         }
 
         // The check above budgeted the marker at getNumberSpace(); the write below is the only other place that
@@ -2774,7 +2781,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         // and only its own content changes: the records that follow simply move, and their offsets are recomputed
         // from THIS page, so the result is the same page a serial execution would have produced. Refuses (false) when
         // the page cannot host the extra bytes anymore, which sends the transaction to a normal retry.
-        return growRecordInPage(page, pageNumber, recordCountInPage, existingPos,
+        return growRecordInPage(page, recordCountInPage, existingPos,
                 getLastRecordPositionInPage(page, recordCountInPage), rs, isPlaceHolder, body, 0, body.length);
 
       final int sizeLen = page.writeNumber(existingPos, isPlaceHolder ? -1L * body.length : body.length);
@@ -2844,7 +2851,6 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    */
   public boolean rebaseRecordDeleteOnPage(final MutablePage page, final int positionInPage, final byte[] baseBody) {
     try {
-      final int pageNumber = page.getPageId().getPageNumber();
       final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
       final int existingPos = positionInPage < recordCountInPage ? getRecordPositionInPage(page, positionInPage) : 0;
 
@@ -2887,7 +2893,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         final PageAnalysis pageAnalysis = new PageAnalysis(page);
         pageAnalysis.totalRecordsInPage = recordCountInPage;
         getFreeSpaceInPage(pageAnalysis);
-        updatePageStatistics(pageNumber, pageAnalysis.spaceAvailableInCurrentPage, 0);
+        updatePageStatistics(page, pageAnalysis.spaceAvailableInCurrentPage, 0);
       } else
         changesFromLastStats.incrementAndGet();
 
@@ -2923,7 +2929,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
     final int sizeLen = page.writeNumber(contentPos, body.length);
     page.writeByteArray(contentPos + sizeLen, body, 0, body.length);
-    updatePageStatistics(pageNumber, page.getMaxContentSize() - contentPos, -spaceNeeded);
+    updatePageStatistics(page, page.getMaxContentSize() - contentPos, -spaceNeeded);
     return true;
   }
 
@@ -3256,7 +3262,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
                 (edgeAppendReplayable ? MutablePage.COVERAGE_EDGE_APPEND_MERGE : 0));
         final boolean grown;
         try {
-          grown = growRecordInPage(page, pageId, recordCountInPage, recordPositionInPage, lastRecordPositionInPage, recordSize,
+          grown = growRecordInPage(page, recordCountInPage, recordPositionInPage, lastRecordPositionInPage, recordSize,
                   isPlaceHolder, buffer.getContent(), buffer.getContentBeginOffset(), bufferSize);
         } finally {
           page.endCoveredWrite(growCoverage);
@@ -3356,7 +3362,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
               } finally {
                 page.endCoveredWrite(shiftCoverage);
               }
-              updatePageStatistics(pageId, freeTailInPage, -slotEnlargement);
+              updatePageStatistics(page, freeTailInPage, -slotEnlargement);
             }
 
             // #6154: the slot's own footprint and the bytes the shift just claimed are already accounted for; the
@@ -3424,6 +3430,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         final int previousCoverage = page.beginCoveredWrite(slotTracked ?
                 MutablePage.COVERAGE_SLOT_MERGE :
                 (edgeAppendReplayable ? MutablePage.COVERAGE_EDGE_APPEND_MERGE : 0));
+        final long footprintBefore = recordSize[0] + recordSize[1];
         try {
           recordSize[1] = page.writeNumber(recordPositionInPage, isPlaceHolder ? -1L * bufferSize : bufferSize);
           final int recordContentPositionInPage = (int) (recordPositionInPage + recordSize[1]);
@@ -3431,6 +3438,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         } finally {
           page.endCoveredWrite(previousCoverage);
         }
+
+        // #6396: an overwrite that is SHORTER than what the slot held gives those bytes back, and - like the delete,
+        // and for the same reason (#6339) - says nothing about them: telling the statistics would cost the
+        // slot-table scan this branch exists to avoid, since only the LAST record of a page moves its free tail and
+        // nothing here knows whether this is it. The compression the commit runs measures the packed page anyway. A
+        // same-size overwrite (the edge-append rewrite, a property changed in place) moves nothing and leaves the
+        // claim exactly as it was.
+        if (bufferSize + recordSize[1] < footprintBefore)
+          freedWithoutClaiming(page);
 
         LogManager.instance()
                 .log(this, Level.FINE, "Updated record %s with the same size or less as before (%s threadId=%d)", null, rid, page,
@@ -3787,6 +3803,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         } finally {
           page.endCoveredWrite(previousCoverage);
         }
+        freedWithoutClaiming(page);
 
         // Track deleted RID to prevent reuse within the same transaction
         database.getTransaction().addDeletedRecord(rid);
@@ -3807,6 +3824,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           slotTx.poisonSlotRebasePage(fileId, pageId);
 
         page.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE, 0L);
+        freedWithoutClaiming(page);
       }
 
       LogManager.instance()
@@ -3833,6 +3851,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
         // POINTER = 0 MEANS DELETED
         page.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + positionInPage * INT_SERIALIZED_SIZE, 0);
+        freedWithoutClaiming(page);
       }
     }
   }
@@ -3864,6 +3883,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
 
     final List<int[]> orderedRecordContentInPage = getOrderedRecordsInPage(page, recordCountInPage, false);
+
+    // #6396: the one moment both descriptions of this page's free tail exist at once - what the writes SAID it would
+    // be, and what the page HAS. See verifyFreeSpaceClaim; the derivation has to happen BEFORE the defrag below moves
+    // the records.
+    if (CHECK_FREE_SPACE_CLAIMS)
+      verifyFreeSpaceClaim(page, orderedRecordContentInPage);
 
     if (orderedRecordContentInPage.isEmpty()) {
       if (recordCountInPage > 0) {
@@ -3920,6 +3945,70 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   }
 
   /**
+   * The caller is about to give bytes back on this page - free a slot, overwrite a record with a shorter one - and,
+   * deliberately, will not tell the free-space statistics: the compression the commit runs measures the packed page
+   * anyway, and accounting at the free itself was measured to be worth less than the slot-table scan per freed slot
+   * it costs (#6339). So whatever a previous write claimed about the page's free tail stops being that tail and stays
+   * a floor under it (#6396): the check that follows can no longer demand equality, but it still catches the writer
+   * that claims MORE free space than the page has.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private static void freedWithoutClaiming(final MutablePage page) {
+    if (CHECK_FREE_SPACE_CLAIMS)
+      page.relaxFreeSpaceClaim();
+  }
+
+  /**
+   * Holds what a transaction's writes SAID this page's free tail would be against what the page, read here, actually
+   * has (#6396).
+   * <p>
+   * Everything the free-space statistics are told by a write is a delta that write computes about its own bytes,
+   * and nothing observable after a commit depends on it being right: every page a transaction touches is compressed
+   * at commit, {@link #compressPageInternal} MEASURES its free tail there and {@link #accountCompressedPage}
+   * overwrites whatever the deltas had accumulated. So a writer could be - and, until #6154, #6339 and #6358 were
+   * each opened for one, repeatedly was - thousands of bytes wrong without a single red test. Two independent
+   * descriptions of one quantity, and no mechanism keeping them honest.
+   * <p>
+   * This is that mechanism, and it needs no fixture: every commit in every test becomes a check of the write-path
+   * arithmetic. The comparison is an EQUALITY, against the tail the page has BEFORE the defrag - which is exactly
+   * what a write reports, holes and all - rather than against the packed tail {@code accountCompressedPage} goes on
+   * to record, because that one is larger by every hole the compression is about to close and a claim short by the
+   * same amount would slip through it.
+   * <p>
+   * A write that GIVES BYTES BACK and deliberately does not report them - a delete (#6339), an in-place update that
+   * shrank - demotes the claim to a lower bound ({@link #freedWithoutClaiming}) instead of dropping it, so the
+   * equality relaxes to {@code <=} on that page and the over-reporting direction stays checked everywhere. A page no
+   * write has spoken about carries {@link MutablePage#FREE_SPACE_CLAIM_UNKNOWN} and is skipped. If this fires on a
+   * NEW write path, the answer is a corrected delta or that one call, never a widening of the comparison.
+   *
+   * @param orderedRecordContentInPage the page's live records in position order, as the compression read them and
+   *                                   before it moved any of them.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private void verifyFreeSpaceClaim(final MutablePage page, final List<int[]> orderedRecordContentInPage) {
+    final int claimed = page.getFreeSpaceClaim();
+    if (claimed == MutablePage.FREE_SPACE_CLAIM_UNKNOWN)
+      return;
+
+    // The tail the page has right now: everything past the last record it holds. Same derivation, and the same
+    // getMaxContentSize() base, gatherPageStatistics measures a page it has not written with (#4958, #5067).
+    int freeTailInPage = page.getMaxContentSize() - contentHeaderSize;
+    if (!orderedRecordContentInPage.isEmpty()) {
+      final int[] lastRecord = orderedRecordContentInPage.getLast();
+      freeTailInPage = page.getMaxContentSize() - (lastRecord[0] + lastRecord[1]);
+    }
+
+    final boolean exact = page.isFreeSpaceClaimExact();
+    assert exact ? claimed == freeTailInPage : claimed <= freeTailInPage :
+        "page " + page.getPageId() + " of bucket '" + componentName + "' was reported to the free-space statistics with "
+            + claimed + (exact ? " free bytes" : " free bytes or more") + ", but holds " + freeTailInPage + " ("
+            + orderedRecordContentInPage.size() + " records). A write described bytes it did not write: correct its "
+            + "delta, or call freedWithoutClaiming() if it gives bytes back without reporting them";
+  }
+
+  /**
    * Records, in the free-space statistics, the free tail a page has once {@link #compressPageInternal} has packed it
    * (#6339). The delta convention of {@link #updatePageStatistics} carries an absolute value as
    * {@code (theSpaceThereIs, 0)}, which is what this is: a measurement, not a change - and a page packed to its
@@ -3940,7 +4029,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * @author Luca Garulli (l.garulli@arcadedata.com)
    */
   private void accountCompressedPage(final MutablePage page, final int contentEndInPage) {
-    updatePageStatistics(page.getPageId().getPageNumber(), page.getMaxContentSize() - contentEndInPage, 0);
+    updatePageStatistics(page, page.getMaxContentSize() - contentEndInPage, 0);
   }
 
   private void wipeOutFreeSpace(final MutablePage page, final short recordCountInPage) throws IOException {
@@ -4583,7 +4672,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // takes ALL of it whenever it takes any, so this lands the page's free space on exactly 0 and drops its entry.
     final int freeTailTakenByHeadChunk = availableSpaceForFirstChunk - slotBytesAlreadyOwned;
     if (freeTailTakenByHeadChunk > 0)
-      updatePageStatistics(firstPage.pageId.getPageNumber(), freeTailTakenByHeadChunk, -freeTailTakenByHeadChunk);
+      updatePageStatistics(firstPage, freeTailTakenByHeadChunk, -freeTailTakenByHeadChunk);
 
     newPosition += INT_SERIALIZED_SIZE;
 
@@ -4685,8 +4774,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       nextPage.writeByteArray(newPosition, content, contentOffset, chunkSize);
 
-      updatePageStatistics(nextPage.pageId.getPageNumber(), freeSpaceBeforeChunk,
-              -chunkFootprint(chunkMarkerSize, chunkSize));
+      updatePageStatistics(nextPage, freeSpaceBeforeChunk, -chunkFootprint(chunkMarkerSize, chunkSize));
 
       bufferSize -= chunkSize;
       contentOffset += chunkSize;
@@ -4829,8 +4917,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // LAST record, which is exactly when its region runs to the maximum content size. In every other case the region
     // is bounded by the neighbour that follows and the tail does not move, so there is nothing to account.
     if (headChunkRegionEnd == currentPage.getMaxContentSize() && chunkSize != previousChunkSize)
-      updatePageStatistics(currentPage.pageId.getPageNumber(), headChunkRoom - previousChunkSize,
-              previousChunkSize - chunkSize);
+      updatePageStatistics(currentPage, headChunkRoom - previousChunkSize, previousChunkSize - chunkSize);
 
     newPosition += INT_SERIALIZED_SIZE;
 
@@ -4858,6 +4945,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // (#6358) - before this, the two allocating branches each guessed at it from what they knew before the write.
       int freeSpaceBeforeChunk = -1;
       int chunkMarkerSize = 0;
+      // #6396: what the reused chunk declared before this iteration rewrote it, so a chunk that comes out SHORTER
+      // can say so. -1 while there is no reused chunk.
+      int chunkSizeBefore = -1;
 
       if (nextChunkPointer > 0) {
         final int chunkPageId = (int) (nextChunkPointer / maxRecordsInPage);
@@ -4879,6 +4969,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
         newPosition = (int) (recordPositionInPage + recordSize[1]);
         chunkSize = nextPage.readInt(newPosition);
+        chunkSizeBefore = chunkSize;
         nextChunkPointer = nextPage.readLong(newPosition + INT_SERIALIZED_SIZE);
 
       } else {
@@ -4976,8 +5067,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // it is one derivation shared with the spill and with the page walk, rather than a subtraction each writer
       // improvised.
       if (freeSpaceBeforeChunk > -1)
-        updatePageStatistics(nextPage.pageId.getPageNumber(), freeSpaceBeforeChunk,
-                -chunkFootprint(chunkMarkerSize, chunkSize));
+        updatePageStatistics(nextPage, freeSpaceBeforeChunk, -chunkFootprint(chunkMarkerSize, chunkSize));
+      else if (chunkSize < chunkSizeBefore)
+        // #6396: the LAST chunk of a record that shrank is rewritten shorter inside the footprint the chain already
+        // owns. It takes nothing, so there is no delta to report - but when that chunk is the last record of its
+        // page it hands bytes back to the free tail, which is the compression's to measure and no longer anything a
+        // previous claim on this page describes.
+        freedWithoutClaiming(nextPage);
 
       // SAVE THE POSITION OF THE POINTER TO THE NEXT CHUNK
       newPosition += INT_SERIALIZED_SIZE;
@@ -5083,7 +5179,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // whose region runs to the page's maximum content size moves the free tail; anywhere else the region is bounded
     // by the neighbour that follows and nothing moves.
     if (chunkRegionEnd == page.getMaxContentSize())
-      updatePageStatistics(pageId, chunkRegionEnd - previousChunkEnd,
+      updatePageStatistics(page, chunkRegionEnd - previousChunkEnd,
               previousChunkEnd - (recordPositionInPage + sizeBytes + bufferSize));
 
     freeChunkChain(rid, chainToFree);
@@ -5131,6 +5227,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       // DELETE THE CHUNK AS RECORD IN THE PAGE
       nextPage.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET + chunkPositionInPage * INT_SERIALIZED_SIZE, 0L);
+      freedWithoutClaiming(nextPage);
 
       if (recordPositionInPage == 0) {
         LogManager.instance()
@@ -5245,7 +5342,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * @return true when the page could host the extra bytes and the record was written; false when the caller has to
    * spill the record out of the page (placeholder or chunk chain) - in that case nothing has been written.
    */
-  private boolean growRecordInPage(final MutablePage page, final int pageNumber, final short recordCountInPage,
+  private boolean growRecordInPage(final MutablePage page, final short recordCountInPage,
                                    final int recordPositionInPage, final int lastRecordPositionInPage, final long[] recordSize,
                                    final boolean isPlaceHolder, final byte[] content, final int contentOffset,
                                    final int contentSize) throws IOException {
@@ -5267,7 +5364,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     recordSize[1] = page.writeNumber(recordPositionInPage, isPlaceHolder ? -1L * contentSize : contentSize);
     page.writeByteArray((int) (recordPositionInPage + recordSize[1]), content, contentOffset, contentSize);
 
-    updatePageStatistics(pageNumber, spaceAvailableInCurrentPage, -additionalSpaceNeeded);
+    updatePageStatistics(page, spaceAvailableInCurrentPage, -additionalSpaceNeeded);
     return true;
   }
 
@@ -5661,6 +5758,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * The overload is gone rather than given a sentinel of its own, because a sentinel nobody passes is a second
    * meaning waiting for the next caller to find by accident.
    *
+   * @param page           the page image this write landed on. Takes the page rather than its number so the two
+   *                       cannot disagree, and so the claim of #6396 can be kept on the very object the commit
+   *                       measures.
    * @param availableSpace free space the page had before this write, measured against
    *                       {@link BasePage#getMaxContentSize()} - never {@code getAvailableContentSize()}, which
    *                       still counts the page header.
@@ -5668,11 +5768,13 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    *                       and 0 when {@code availableSpace} is a measurement of the settled page rather than a
    *                       change to it (see {@link #accountCompressedPage}).
    */
-  private void updatePageStatistics(final int pageId, final int availableSpace, final int delta) {
+  private void updatePageStatistics(final MutablePage page, final int availableSpace, final int delta) {
     changesFromLastStats.incrementAndGet();
 
     if (reuseSpaceMode.ordinal() < REUSE_SPACE_MODE.HIGH.ordinal())
       return;
+
+    final int pageId = page.getPageId().getPageNumber();
 
     // A page cannot have less than no free space. Under -ea (surefire's default) this is the tripwire that says a
     // write path and the commit-time measurement have stopped describing the same bytes; in production the branches
@@ -5680,6 +5782,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     assert availableSpace >= 0 && availableSpace + delta >= 0 :
         "page " + pageId + " of bucket '" + componentName + "' is reported with " + availableSpace + " free bytes and a delta of "
             + delta;
+
+    // #6396: what this write says the page's free tail is, kept on the page image itself so the commit can hold it
+    // against the measurement it makes on the very same object. Deliberately NOT the entry in freeSpaceInPages: that
+    // map is bucket-wide (a concurrent transaction's write to the same page would be compared against ours), it is
+    // thresholded and evicted (most pages carry no entry at all), and it is also written from outside by
+    // setPageStatistics and gatherPageStatistics, neither of which is a claim any writer made.
+    if (CHECK_FREE_SPACE_CLAIMS)
+      page.claimFreeSpace(availableSpace + delta);
 
     synchronized (freeSpaceInPages) {
       if (availableSpace + delta == 0)

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -193,6 +193,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * Whether the free-space claims the write paths make are held against the commit-time measurement (#6396). On
    * exactly when assertions are - surefire's default, never a production run - because the check IS an assertion:
    * it costs two field stores per write, and a comparison against a page walk the compression was doing anyway.
+   * <p>
+   * It is gated a second time, by {@code reuseSpaceMode}: {@link #updatePageStatistics} returns before stating a
+   * claim below {@link REUSE_SPACE_MODE#HIGH}, so under a non-default {@code arcadedb.bucketReuseSpaceMode} every
+   * page stays at {@link MutablePage#FREE_SPACE_CLAIM_UNKNOWN} and the check goes quiet. That is right rather than
+   * an oversight - there are no deltas to keep honest when nothing is tracking free space - but it is worth knowing
+   * before wondering why the assertion never fires.
    */
   private static final   boolean                   CHECK_FREE_SPACE_CLAIMS          = LocalBucket.class.desiredAssertionStatus();
   private static final   int                       SPARE_SPACE_FOR_GROWTH           = 32;
@@ -2755,6 +2761,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             "the chunk marker took " + markerSizeWritten + " bytes where " + markerSize + " were budgeted";
 
         page.writeByteArray(existingPos + markerSizeWritten, body, 0, body.length);
+
+        // #6396: a slot that spilled as the LAST record of its page eats into the free tail directly, and
+        // slotEnlargementForChunkHead counts that tail as room the slot already has - so the enlargement above is 0
+        // by construction there and reports nothing. How much of the tail the head chunk really took depends on the
+        // COMMITTED page this replay landed on, not on the one the write measured, so it is measured here: the head
+        // chunk ends where it ends, and everything past it is what the page has left.
+        if (lastRecordPositionInPage == existingPos)
+          updatePageStatistics(page, page.getMaxContentSize() - (existingPos + markerSizeWritten + body.length), 0);
+
         return true;
       }
 
@@ -2786,6 +2801,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       final int sizeLen = page.writeNumber(existingPos, isPlaceHolder ? -1L * body.length : body.length);
       page.writeByteArray((int) (existingPos + sizeLen), body, 0, body.length);
+
+      // #6396: the mirror of updateRecordInternal's same-or-shorter branch, and it gives bytes back the same way -
+      // silently, because only the page's LAST record moves the free tail and nothing here knows whether this is it.
+      // Saying so matters MORE on this path than on the live one: rebaseSlots replays every buffered slot onto ONE
+      // page image and compresses it once at the end, so a shrink that stayed quiet would leave the exact claim
+      // ANOTHER slot's replay made (a growth re-flowing the same page) standing over a page it no longer describes.
+      if (sizeLen + body.length < rs[1] + committedSize)
+        freedWithoutClaiming(page);
+
       return true;
 
     } catch (final IOException e) {

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -3960,6 +3960,27 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   }
 
   /**
+   * The free TAIL of a page: everything past the last record it holds, measured against
+   * {@link BasePage#getMaxContentSize()} - the usable content region, never {@code getAvailableContentSize()}, which
+   * still counts the page header (#4958, #5067). The quantity every write path reports to the free-space statistics,
+   * derived in ONE place so the scan that reads a page it did not write ({@link #gatherPageStatistics}) and the check
+   * that holds the writers to it ({@link #verifyFreeSpaceClaim}) cannot come to describe it differently - which is
+   * the very failure #6396 exists to make loud.
+   *
+   * @param orderedRecordsInPage the page's live records in position order, as {@link #getOrderedRecordsInPage}
+   *                             returns them.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  private int freeTailInPage(final BasePage page, final List<int[]> orderedRecordsInPage) {
+    if (orderedRecordsInPage.isEmpty())
+      return page.getMaxContentSize() - contentHeaderSize;
+
+    final int[] lastRecord = orderedRecordsInPage.getLast();
+    return page.getMaxContentSize() - (lastRecord[0] + lastRecord[1]);
+  }
+
+  /**
    * Holds what a transaction's writes SAID this page's free tail would be against what the page, read here, actually
    * has (#6396).
    * <p>
@@ -3992,13 +4013,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     if (claimed == MutablePage.FREE_SPACE_CLAIM_UNKNOWN)
       return;
 
-    // The tail the page has right now: everything past the last record it holds. Same derivation, and the same
-    // getMaxContentSize() base, gatherPageStatistics measures a page it has not written with (#4958, #5067).
-    int freeTailInPage = page.getMaxContentSize() - contentHeaderSize;
-    if (!orderedRecordContentInPage.isEmpty()) {
-      final int[] lastRecord = orderedRecordContentInPage.getLast();
-      freeTailInPage = page.getMaxContentSize() - (lastRecord[0] + lastRecord[1]);
-    }
+    // The tail the page has right now, through the same derivation gatherPageStatistics measures an unwritten page
+    // with: comparing a claim against a second opinion of the quantity would be the defect this check is for.
+    final int freeTailInPage = freeTailInPage(page, orderedRecordContentInPage);
 
     final boolean exact = page.isFreeSpaceClaimExact();
     assert exact ? claimed == freeTailInPage : claimed <= freeTailInPage :
@@ -5718,11 +5735,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
             // #4958: measure against the usable content region (getMaxContentSize), not the physical
             // page size: the latter overstated the free space of every page by the page header size.
-            int freeSpaceInPage = page.getMaxContentSize() - contentHeaderSize;
-            if (!orderedRecordContentInPage.isEmpty()) {
-              final int[] lastRecord = orderedRecordContentInPage.getLast();
-              freeSpaceInPage = page.getMaxContentSize() - (lastRecord[0] + lastRecord[1]);
-            }
+            final int freeSpaceInPage = freeTailInPage(page, orderedRecordContentInPage);
 
             final int freeSpacePerc = freeSpaceInPage * 100 / (page.getMaxContentSize() - contentHeaderSize);
 

--- a/engine/src/main/java/com/arcadedb/engine/MutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/MutablePage.java
@@ -57,6 +57,11 @@ public class MutablePage extends BasePage implements TrackableContent {
    * this class had before issue #5470.
    */
   private static final int     MAX_MODIFIED_RANGES        = 8;
+  /**
+   * No write has stated what free tail this page has: {@link #getFreeSpaceClaim()} has nothing to confront the
+   * commit-time measurement with. Not the same as zero, which is a page a write has sealed.
+   */
+  static final         int     FREE_SPACE_CLAIM_UNKNOWN   = -1;
   private static final byte[]  ZERO_BYTES_ARRAY;
   // Sorted, disjoint and non-adjacent intervals as [from0,to0, from1,to1, ...]. One extra slot is kept free so an
   // insertion can happen before the merge that puts the count back within budget.
@@ -72,6 +77,16 @@ public class MutablePage extends BasePage implements TrackableContent {
   // one could hide a dirtied byte from the coverage proof, which is the very hazard #5596 exists to remove.
   private              int     declaredCoverage           = 0;
   private              int     uncoveredMechanisms        = 0;
+  // Free-space bookkeeping (issue #6396). The free tail this transaction's writes SAY the page has, or
+  // FREE_SPACE_CLAIM_UNKNOWN when no write has said anything about it, plus whether that number is still EXACT: a
+  // write that gives bytes back without reporting them (a delete, an in-place shrink) turns the claim into a lower
+  // bound rather than throwing it away, which keeps the over-reporting direction - the one that hands the allocator
+  // a page with nothing left - checked on every page. Written only by LocalBucket's write paths and only while
+  // assertions are on, and read only by the compression the commit runs on this page, which measures the same
+  // quantity from the page itself and so is the one place able to confront what a writer claimed with what it did.
+  // Plain fields for the same reason the two above are: this image belongs to one transaction and one thread.
+  private              int     freeSpaceClaim             = FREE_SPACE_CLAIM_UNKNOWN;
+  private              boolean freeSpaceClaimIsExact      = false;
   // AtomicReference so the WAL ack can be taken EXACTLY ONCE (#4928 review): the success path, the
   // file-dropped flush branch and the dropped-file batch purge can race on the same page (the flush loop
   // does not remove pages from the batch list), and a double notifyPageFlushed would steal another page's
@@ -105,6 +120,53 @@ public class MutablePage extends BasePage implements TrackableContent {
   @Override
   public MutablePage modify() {
     return this;
+  }
+
+  /**
+   * States, for the free-space check of issue #6396, the free tail this page has once the write in progress has
+   * landed - the very number the write reports to the bucket's free-space statistics, and an EXACT one. The commit
+   * compresses every page a transaction touched and MEASURES the same quantity there, so anything said here is
+   * checked a moment later against what the page actually holds.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  void claimFreeSpace(final int freeTailInPage) {
+    this.freeSpaceClaim = freeTailInPage;
+    this.freeSpaceClaimIsExact = true;
+  }
+
+  /**
+   * Demotes the claim to a LOWER BOUND: the write in progress gives bytes back - a delete (#6339), an in-place
+   * update that shrank - and deliberately does not report them, because the compression the commit runs measures the
+   * packed page anyway. Such a write can only move the free tail outwards, so what a previous write said stops being
+   * the page's tail and stays a floor under it. Kept rather than dropped, because the floor is exactly what rules
+   * out the dangerous direction: a writer claiming MORE free space than the page has.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  void relaxFreeSpaceClaim() {
+    this.freeSpaceClaimIsExact = false;
+  }
+
+  /**
+   * The free tail this transaction's writes claim the page has, or {@link #FREE_SPACE_CLAIM_UNKNOWN} when none of
+   * them stated one. Read together with {@link #isFreeSpaceClaimExact()}, which says whether it is the tail itself
+   * or a floor under it.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  int getFreeSpaceClaim() {
+    return freeSpaceClaim;
+  }
+
+  /**
+   * Whether {@link #getFreeSpaceClaim()} is still the page's free tail rather than a lower bound on it - see
+   * {@link #relaxFreeSpaceClaim()}.
+   *
+   * @author Luca Garulli (l.garulli@arcadedata.com)
+   */
+  boolean isFreeSpaceClaimExact() {
+    return freeSpaceClaimIsExact;
   }
 
   public TrackableBinary getTrackable() {

--- a/engine/src/test/java/com/arcadedb/engine/Issue6396FreeSpaceClaimTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6396FreeSpaceClaimTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.BucketPageLayoutTestSupport;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Issue #6396: nothing kept the free-space deltas honest.
+ * <p>
+ * Every write path in {@code LocalBucket} tells the free-space statistics how much free tail the page it just wrote
+ * has left. Since #6339/#6349 the commit compresses every page a transaction touched, MEASURES that same quantity
+ * there and overwrites whatever the deltas had accumulated - so nothing observable after a commit depends on a delta
+ * being right, and a writer could be (and, in #6154, #6339 and #6358, repeatedly was) thousands of bytes wrong
+ * without a single red test. #6358's regression test had to reach for {@code updateRecordNoLock} to pull a bucket
+ * write out of the commit just to read the hint before the measurement replaced it.
+ * <p>
+ * The tripwire this pins closes that gap: the write's claim is kept on the page image itself and confronted, by the
+ * compression, with the tail the page actually has. It is an assertion, so it costs nothing in production and fires
+ * on every commit of every test under {@code -ea}.
+ * <p>
+ * What the tests below have to establish, in this order, is that the check is ENGAGED (a real insert leaves a claim,
+ * and it is the tail the page really has - not an unknown that would make every other assertion here vacuous), that
+ * it catches BOTH directions of a wrong writer, that a write which legitimately gives bytes back demotes the claim to
+ * a lower bound instead of breaking it - and that the lower bound still catches an over-claim - and that a page no
+ * write spoke about is skipped rather than failed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6396FreeSpaceClaimTest extends BucketPageLayoutTestSupport {
+  private static final String TYPE = "Claimed";
+
+  private LocalBucket bucket;
+
+  @BeforeEach
+  void createType() {
+    assumeThat(LocalBucket.class.desiredAssertionStatus())
+        .as("the free-space claim check IS an assertion: it can only be tested with -ea")
+        .isTrue();
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1).createProperty("v", Type.STRING));
+    bucket = bucketOf(TYPE);
+  }
+
+  /**
+   * The check is engaged. An ordinary insert leaves a claim on the page it wrote, and that claim is the free tail the
+   * page has - derived here from the record table, independently of the walk {@code compressPageInternal} makes.
+   * <p>
+   * Without this, every other test in this class could pass on a page carrying no claim at all.
+   */
+  @Test
+  void anInsertClaimsTheTailThePageReallyHas() {
+    final List<RID> rids = new ArrayList<>();
+    database.transaction(() -> {
+      for (int i = 0; i < 8; i++)
+        rids.add(database.newDocument(TYPE).set("v", "v".repeat(512)).save().getIdentity());
+
+      final MutablePage page = pageOf(rids.getFirst());
+      assertThat(page.getFreeSpaceClaim())
+          .as("an insert must state what free tail it leaves; without a claim the commit has nothing to check")
+          .isNotEqualTo(MutablePage.FREE_SPACE_CLAIM_UNKNOWN);
+      assertThat(page.getFreeSpaceClaim()).isEqualTo(freeTailOf(page, rids.getLast()));
+    });
+
+    // And it survives the commit that measures the same page: the two descriptions agree end to end.
+    assertThat(bucket.getFreeSpaceHintForPage(0)).isEqualTo(freeTailAfterCommit(rids.getLast()));
+    checkDatabase();
+  }
+
+  /**
+   * Over-reporting: the direction that hands the allocator a page with nothing left on it, and the shape of the
+   * {@code getAvailableContentSize()} base #6358 removed - a writer measuring against a base that still counted the
+   * page header, and so claiming bytes the page does not have.
+   */
+  @Test
+  void aWriterClaimingMoreTailThanThePageHasIsCaughtByTheCommit() {
+    final RID rid = insertOne();
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      database.newDocument(TYPE).set("v", "v".repeat(512)).save();
+      pageOf(rid).claimFreeSpace(bucket.getPageSize());
+    }))
+        .as("a page cannot have a whole page's worth of free tail once records are on it")
+        .rootCause().isInstanceOf(AssertionError.class)
+        .hasMessageContaining("was reported to the free-space statistics with");
+  }
+
+  /**
+   * Under-reporting: harmless to the allocator (it only loses a placement it could have made), but it is the shape of
+   * #6358's {@code rebaseRecordDeleteOnPage} - a measured tail with the freed record's footprint subtracted from it
+   * a second time - and the ONE of the four that no tripwire caught until it was found by reading. A check in the
+   * over-reporting direction alone would let it through, which is why the comparison is an equality against the tail
+   * BEFORE the defrag rather than an upper bound against the packed one.
+   */
+  @Test
+  void aWriterClaimingLessTailThanThePageHasIsCaughtToo() {
+    final RID rid = insertOne();
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      database.newDocument(TYPE).set("v", "v".repeat(512)).save();
+      pageOf(rid).claimFreeSpace(pageOf(rid).getFreeSpaceClaim() - 1);
+    }))
+        .as("one byte short is still a writer describing bytes it did not write")
+        .rootCause().isInstanceOf(AssertionError.class)
+        .hasMessageContaining("was reported to the free-space statistics with");
+  }
+
+  /**
+   * A delete frees its bytes and deliberately tells the statistics nothing - the compression measures the packed page
+   * anyway, and accounting at the free itself costs a slot-table scan per freed slot for four pages out of 239
+   * (#6339). So does an in-place update that shrinks the record. Both demote the claim to a LOWER BOUND rather than
+   * dropping it: they can only move the free tail outwards, so what the insert said stays a floor under it and the
+   * over-reporting direction goes on being checked on the page.
+   * <p>
+   * Both delete shapes matter: a record deleted in the MIDDLE of the page leaves a hole the defrag closes, and the
+   * LAST record of the page hands its tail straight back. The second is the one that breaks the equality, and the
+   * reason the demotion has to exist at all.
+   */
+  @Test
+  void aSilentFreeDemotesTheClaimToALowerBound() {
+    final List<RID> rids = new ArrayList<>();
+    database.transaction(() -> {
+      for (int i = 0; i < 8; i++)
+        rids.add(database.newDocument(TYPE).set("v", "v".repeat(512)).save().getIdentity());
+    });
+
+    database.transaction(() -> {
+      database.newDocument(TYPE).set("v", "v".repeat(512)).save();
+      rids.get(3).asDocument(true).delete();
+      assertLowerBoundOn(pageOf(rids.getFirst()));
+    });
+
+    database.transaction(() -> {
+      database.newDocument(TYPE).set("v", "v".repeat(512)).save();
+      rids.getLast().asDocument(true).delete();
+      assertLowerBoundOn(pageOf(rids.getFirst()));
+    });
+
+    // The last record of the page, shrunk in place: the tail moves outwards and nothing reports it.
+    database.transaction(() -> {
+      final RID last = database.newDocument(TYPE).set("v", "v".repeat(512)).save().getIdentity();
+      assertThat(pageOf(last).isFreeSpaceClaimExact()).as("the insert that created it stated an exact tail").isTrue();
+      writeNow(last.asDocument(true).modify().set("v", "v"));
+      assertLowerBoundOn(pageOf(last));
+    });
+
+    assertThat(countRecords(TYPE)).isEqualTo(9);
+    checkDatabase();
+  }
+
+  /**
+   * The demotion is not an exemption. A page that saw a silent free is checked with {@code <=} instead of {@code ==},
+   * and the floor is exactly what a writer claiming bytes the page does not have still trips over - which is the
+   * whole reason the claim is demoted rather than dropped.
+   */
+  @Test
+  void theLowerBoundStillCatchesAnOverClaim() {
+    final RID rid = insertOne();
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      database.newDocument(TYPE).set("v", "v".repeat(512)).save();
+      final MutablePage page = pageOf(rid);
+      page.claimFreeSpace(bucket.getPageSize());
+      page.relaxFreeSpaceClaim();
+    }))
+        .as("a floor above the page's real tail is still a writer describing bytes it did not write")
+        .rootCause().isInstanceOf(AssertionError.class)
+        .hasMessageContaining("free bytes or more");
+  }
+
+  /**
+   * A page a transaction modified without any write speaking about its free space carries no claim, and the commit's
+   * measurement has nothing to be held against. Skipped, never failed: a tripwire that fires on pages nobody made a
+   * statement about is a tripwire that gets widened until it says nothing.
+   * <p>
+   * It also pins that the claim is per TRANSACTION: the page below is the same page the insert of the previous
+   * transaction claimed an exact tail on, and this one starts over with nothing stated.
+   */
+  @Test
+  void aPageNoWriteSpokeAboutIsNotChecked() {
+    final RID rid = insertOne();
+
+    database.transaction(() -> {
+      final MutablePage page = pageOf(rid);
+      assertThat(page.getFreeSpaceClaim()).isEqualTo(MutablePage.FREE_SPACE_CLAIM_UNKNOWN);
+      // Dirty the page without changing it, so the commit really does compress it.
+      page.writeShort(LocalBucket.PAGE_RECORD_COUNT_IN_PAGE_OFFSET, page.readShort(LocalBucket.PAGE_RECORD_COUNT_IN_PAGE_OFFSET));
+    });
+
+    assertThat(countRecords(TYPE)).isEqualTo(1);
+    checkDatabase();
+  }
+
+  /**
+   * The whole point of keeping the claim on the page image rather than in the bucket's {@code freeSpaceInPages} map:
+   * that map is bucket-wide, so a concurrent transaction's delta for the same page would be what our commit measures
+   * itself against - and the two transactions describe two different futures of that page, only one of which is going
+   * to commit. Threads inserting into the same bucket at once must not make each other fail.
+   */
+  @Test
+  void concurrentWritersToTheSameBucketDoNotCheckEachOther() throws Exception {
+    final int writers = 4;
+    final int perWriter = 60;
+    final CountDownLatch start = new CountDownLatch(1);
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    final List<Thread> threads = new ArrayList<>();
+
+    for (int w = 0; w < writers; w++) {
+      final int id = w;
+      final Thread thread = new Thread(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < perWriter; i++) {
+            final int seq = i;
+            database.transaction(() -> database.newDocument(TYPE).set("v", "w" + id + "-" + seq).save(), true, 50);
+          }
+        } catch (final Throwable e) {
+          errors.add(e);
+        }
+      }, "issue6396-writer-" + w);
+      threads.add(thread);
+      thread.start();
+    }
+
+    start.countDown();
+    for (final Thread thread : threads)
+      thread.join();
+
+    assertThat(errors).as("a claim is one transaction's own; no writer may be checked against another's")
+        .isEmpty();
+    assertThat(countRecords(TYPE)).isEqualTo((long) writers * perWriter);
+    checkDatabase();
+  }
+
+  /** The claim survives a silent free as a floor: still stated, no longer exact. */
+  private void assertLowerBoundOn(final MutablePage page) {
+    assertThat(page.getFreeSpaceClaim())
+        .as("a silent free demotes the claim, it does not drop it - the floor is what keeps over-reporting checked")
+        .isNotEqualTo(MutablePage.FREE_SPACE_CLAIM_UNKNOWN);
+    assertThat(page.isFreeSpaceClaimExact()).isFalse();
+  }
+
+  /**
+   * Runs the update the COMMIT would run, one line earlier: {@code save()} only queues a record and the bucket write
+   * happens inside the commit, a line before the compression whose measurement is what these tests compare against.
+   * The same call the commit makes on every queued record ({@code TransactionContext.commit1stPhase} ->
+   * {@code updateRecordNoLock}); pulling it forward changes when the write happens, never what it writes.
+   */
+  private void writeNow(final MutableDocument record) {
+    ((DatabaseInternal) database).updateRecordNoLock(record, false);
+  }
+
+  private RID insertOne() {
+    final RID[] rid = new RID[1];
+    database.transaction(() -> rid[0] = database.newDocument(TYPE).set("v", "v".repeat(512)).save().getIdentity());
+    return rid[0];
+  }
+
+  /** The page image the running transaction holds for {@code rid}'s page - the very object its writes claimed on. */
+  private MutablePage pageOf(final RID rid) {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    try {
+      return db.getTransaction().getPageToModify(
+          new PageId(db, rid.getBucketId(), (int) (rid.getPosition() / bucket.getMaxRecordsInPage())),
+          bucket.getPageSize(), false);
+    } catch (final Exception e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  /**
+   * Free tail of {@code page} read from the record table alone, given {@code last} is the record physically last on
+   * it (true of the pages built here: plain records appended one after the other into a fresh page).
+   */
+  private int freeTailOf(final MutablePage page, final RID last) {
+    final int offset = recordOffsetOf(page, last);
+    final long[] size = page.readNumberAndSize(offset);
+    final int tail = page.getMaxContentSize() - (int) (offset + size[1] + size[0]);
+    assertThat(tail).as("the fixture must leave a tail to talk about").isPositive();
+    return tail;
+  }
+
+  /** The same derivation, run in a transaction of its own once the commit has settled the page. */
+  private int freeTailAfterCommit(final RID last) {
+    final int[] tail = new int[1];
+    database.transaction(() -> tail[0] = freeTailOf(pageOf(last), last));
+    return tail[0];
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6396FreeSpaceClaimTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6396FreeSpaceClaimTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.BucketPageLayoutTestSupport;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.MutableDocument;
@@ -195,6 +196,59 @@ class Issue6396FreeSpaceClaimTest extends BucketPageLayoutTestSupport {
         .as("a floor above the page's real tail is still a writer describing bytes it did not write")
         .rootCause().isInstanceOf(AssertionError.class)
         .hasMessageContaining("free bytes or more");
+  }
+
+  /**
+   * The disjoint-slot merge replays SEVERAL slot writes onto ONE page image and compresses it once, at the end
+   * (#5381, {@code TransactionContext.rebaseSlots}) - so a replay branch that says nothing about the free tail does
+   * not merely fail to update a hint, it leaves the claim ANOTHER slot's replay made standing over a page that has
+   * moved on. Found in review of this change.
+   * <p>
+   * The shape: one record GROWS (its replay states an exact tail) and the page's LAST record SHRINKS in the same
+   * transaction, while a concurrent commit to the same page forces the replay. The shrink's replay branch is the
+   * mirror of {@code updateRecordInternal}'s same-or-shorter overwrite and gives the tail back exactly as that one
+   * does, so it demotes the claim exactly as that one does.
+   * <p>
+   * Deterministic rather than racing: the concurrent commit happens on another thread which is joined before this
+   * transaction commits, so the page version has certainly moved by the time the merge is asked for.
+   */
+  @Test
+  void aSlotMergeReplayGivingBytesBackDoesNotLeaveAnotherSlotsClaimStanding() {
+    final boolean slotMerge = GlobalConfiguration.TX_PAGE_SLOT_MERGE.getValueAsBoolean();
+    GlobalConfiguration.TX_PAGE_SLOT_MERGE.setValue(true);
+    try {
+      final List<RID> rids = new ArrayList<>();
+      database.transaction(() -> {
+        for (int i = 0; i < 8; i++)
+          rids.add(database.newDocument(TYPE).set("v", "v".repeat(400)).save().getIdentity());
+      });
+
+      final RID first = rids.getFirst();
+      final RID last = rids.getLast();
+      final RID bystander = rids.get(4);
+
+      database.transaction(() -> {
+        // A growth, whose replay states an exact free tail for the whole page...
+        first.asDocument(true).modify().set("v", "g".repeat(700)).save();
+        // ...and a shrink of the record that ENDS the page, whose replay hands bytes back to that same tail.
+        last.asDocument(true).modify().set("v", "s").save();
+
+        // A committed change to the same page, from another transaction: this is what makes our commit reload the
+        // page and replay our two slots onto it instead of writing our own image.
+        inAnotherThread(() -> database.transaction(
+            () -> bystander.asDocument(true).modify().set("v", "b".repeat(400)).save()));
+      });
+
+      database.transaction(() -> {
+        assertThat(first.asDocument(true).getString("v")).isEqualTo("g".repeat(700));
+        assertThat(last.asDocument(true).getString("v")).isEqualTo("s");
+        assertThat(bystander.asDocument(true).getString("v")).isEqualTo("b".repeat(400));
+      });
+      assertThat(countRecords(TYPE)).isEqualTo(8);
+      checkDatabase();
+    } finally {
+      GlobalConfiguration.TX_PAGE_SLOT_MERGE.setValue(slotMerge);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #6396.

## The gap

Every write path in `LocalBucket` tells the free-space statistics how much free tail the page it just wrote has left. Since #6339/#6349 the commit compresses **every** page a transaction touched, MEASURES that same quantity in `compressPageInternal` and overwrites whatever the deltas accumulated. So nothing observable after a commit depends on a delta being right, and a writer could be thousands of bytes wrong without a single red test. #6154, #6339 and #6358 were each opened for one such writer, and #6358's regression test had to reach for `updateRecordNoLock` to pull a bucket write out of the commit just to read the hint before the measurement replaced it.

## Where the claim lives - and why not where the issue proposed

The issue proposed comparing inside `accountCompressedPage`, against the entry the deltas left in `freeSpaceInPages`. That map is the wrong side of the comparison on three counts:

- it is **bucket-wide**, so a concurrent transaction's delta for the same page is what our commit would measure itself against - two transactions describing two different futures of one page, only one of which will commit;
- it is **thresholded and evicted** (`MINIMUM_SPACE_LEFT_IN_PAGE`, `GATHER_STATS_MIN_SPACE_PERC`, `MAX_PAGES_GATHER_STATS`), so most pages carry no entry to check at all;
- it is **written from outside** by `setPageStatistics` (HA/backup, tests) and `gatherPageStatistics` (its own scan), neither of which is a claim any writer made - the issue lists both as caveats to work around.

The claim instead lives on the `MutablePage` the transaction is building, next to the #5596 coverage fields and under the same guarantee the class already states: one transaction's private image, one thread. That makes the check race-free, independent of every threshold, and live on **every page of every commit** rather than on the ones the map happens to hold.

## The comparison

An **equality**, against the free tail as it stands BEFORE the defrag - which is exactly what a write reports, holes and all - and not an upper bound against the packed tail `accountCompressedPage` records. An upper bound would have let through #6358's `rebaseRecordDeleteOnPage`, the one of the four that no tripwire caught until it was found by reading.

A write that gives bytes back and deliberately does not report them - a delete (#6339), an in-place update that shrank, the last chunk of a record that shrank into the footprint its chain already owns - **demotes** the claim to a lower bound rather than dropping it, so `<=` still catches the over-reporting direction on those pages too.

It is an `assert`: on under `-ea` (surefire's default), absent from a production run.

## Fallout

`updatePageStatistics` now takes the `MutablePage` rather than its page number, so the two cannot disagree. That made the page number redundant in `growRecordInPage` and `rebaseRecordDeleteOnPage`; it is gone from both.

## Verification

- New `Issue6396FreeSpaceClaimTest` (7 tests): the check is **engaged** (an insert leaves a claim, and it is the tail derived independently from the record table - without this every other assertion would be vacuous); an over-claim and an under-claim are both caught at commit; a silent free demotes rather than breaks, and the demoted floor still catches an over-claim; a page no write spoke about is skipped; four threads writing the same bucket concurrently do not check each other.
- Full engine suite: **12851 tests, 0 failures, 0 errors**. The `slow` lane: **238, 0 failures**.
- The first full run under the check found one real silent writer (an in-place update shrinking the last record of its page, off by one byte in `Issue4351Test`), which is now the demotion above - the tripwire earning its keep on its first pass.

The `server` module was not run: port 2480 is occupied by an unrelated process on this machine, and its failures would read as authentication errors rather than as a port conflict. The change is engine-internal and every bucket write path it touches is exercised by the engine suite.