### PR TITLE
fix(#6428): EXPORT/BACKUP DATABASE and REBUILD INDEX drop their WITH settings when re-rendered to text

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
@@ -180,6 +180,7 @@ public class BackupDatabaseStatement extends SimpleExecStatement {
       builder.append(' ');
       url.toString(params, builder);
     }
+    appendWithSettings(settings, params, builder);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
@@ -122,6 +122,7 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
     builder.append("EXPORT DATABASE ");
     if (url != null)
       url.toString(params, builder);
+    appendWithSettings(settings, params, builder);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -116,18 +116,7 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
     builder.append("IMPORT DATABASE ");
     if (url != null)
       url.toString(params, builder);
-    if (!settings.isEmpty()) {
-      builder.append(" WITH ");
-      boolean first = true;
-      for (final Map.Entry<Expression, Expression> entry : settings.entrySet()) {
-        if (!first)
-          builder.append(", ");
-        first = false;
-        entry.getKey().toString(params, builder);
-        builder.append(" = ");
-        entry.getValue().toString(params, builder);
-      }
-    }
+    appendWithSettings(settings, params, builder);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -499,6 +499,7 @@ public class RebuildIndexStatement extends DDLStatement {
     } else {
       name.toString(params, builder);
     }
+    appendWithSettings(settings, params, builder);
   }
 
   @Override
@@ -506,6 +507,9 @@ public class RebuildIndexStatement extends DDLStatement {
     final RebuildIndexStatement result = new RebuildIndexStatement();
     result.all = all;
     result.name = name == null ? null : name.copy();
+    // WITHOUT THIS, A COPY SILENTLY DROPS EVERY 'WITH ...' SETTING (batchSize, maxAttempts, statsOnly) - THE SAME
+    // DEFECT Export/Backup/ImportDatabaseStatement HAD (#6080, #6409)
+    result.settings.putAll(settings);
     return result;
   }
 
@@ -520,13 +524,14 @@ public class RebuildIndexStatement extends DDLStatement {
 
     if (all != that.all)
       return false;
-    return Objects.equals(name, that.name);
+    return Objects.equals(name, that.name) && Objects.equals(settings, that.settings);
   }
 
   @Override
   public int hashCode() {
     int result = all ? 1 : 0;
     result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + settings.hashCode();
     return result;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
@@ -365,18 +365,7 @@ public class RebuildTypeStatement extends DDLStatement {
     typeName.toString(params, builder);
     if (polymorphic)
       builder.append(" POLYMORPHIC");
-    if (!settings.isEmpty()) {
-      builder.append(" WITH ");
-      boolean first = true;
-      for (final Map.Entry<Expression, Expression> e : settings.entrySet()) {
-        if (!first)
-          builder.append(", ");
-        e.getKey().toString(params, builder);
-        builder.append(" = ");
-        e.getValue().toString(params, builder);
-        first = false;
-      }
-    }
+    appendWithSettings(settings, params, builder);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
@@ -46,6 +46,28 @@ public class Statement extends SimpleNode {
     throw new UnsupportedOperationException("missing implementation in " + getClass().getSimpleName());
   }
 
+  /**
+   * Renders a {@code WITH key = value, ...} clause for the statements that carry a free-form settings map
+   * (REBUILD INDEX, REBUILD TYPE, IMPORT/EXPORT/BACKUP DATABASE). Appends nothing when {@code settings} is empty.
+   * Shared so every one of them stays in sync: before this, {@code EXPORT}/{@code BACKUP DATABASE} and
+   * {@code REBUILD INDEX} silently dropped their {@code WITH} clause when re-rendered to text (issue #6428).
+   */
+  protected static void appendWithSettings(final Map<Expression, Expression> settings, final Map<String, Object> params,
+      final StringBuilder builder) {
+    if (settings.isEmpty())
+      return;
+    builder.append(" WITH ");
+    boolean first = true;
+    for (final Map.Entry<Expression, Expression> entry : settings.entrySet()) {
+      if (!first)
+        builder.append(", ");
+      first = false;
+      entry.getKey().toString(params, builder);
+      builder.append(" = ");
+      entry.getValue().toString(params, builder);
+    }
+  }
+
   public void validate() throws CommandSQLParsingException {
     // NO VALIDATION BY DEFAULT
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/BackupDatabaseStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/BackupDatabaseStatementTestParserTest.java
@@ -20,6 +20,9 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BackupDatabaseStatementTestParserTest extends AbstractParserTest {
@@ -32,6 +35,10 @@ class BackupDatabaseStatementTestParserTest extends AbstractParserTest {
     checkRightSyntax("BACKUP DATABASE file:///foo/bar/");
     checkRightSyntax("backup database "); // USE THE DEFAULT FILE NAME
 
+    // WITH clause settings
+    checkRightSyntax("BACKUP DATABASE WITH compressionLevel = 5");
+    checkRightSyntax("BACKUP DATABASE file:///foo/bar/ WITH compressionLevel = 5, maxMBPerSecond = 10");
+
     checkWrongSyntax("backup database file:///foo/bar/ foo bar");
     checkWrongSyntax("backup database http://www.foo.bar asdf ");
     checkWrongSyntax("BACKUP DATABASE https://www.foo.bar asd ");
@@ -42,5 +49,36 @@ class BackupDatabaseStatementTestParserTest extends AbstractParserTest {
     final SimpleNode parsed = checkRightSyntax("backup database ");
     assertThat(parsed).isInstanceOf(BackupDatabaseStatement.class);
     assertThat(((BackupDatabaseStatement) parsed).isIdempotent()).isTrue();
+  }
+
+  /**
+   * Regression test for issue #6428, item 1: {@code toString()} only rendered {@code url}, never {@code settings},
+   * so any code path that re-serializes the statement (statement caching keyed on text, query logging, an audit
+   * trail) would silently lose the {@code WITH} clause - the same shape as the historical cleartext-encryption bug
+   * (#6080), but on the print path instead of the read path.
+   * <p>
+   * Parsed with {@link #checkSyntax(String, boolean)} rather than {@link #checkRightSyntax(String)} on purpose:
+   * this test asserts the round trip preserves {@code settings}, so it needs the pre-fix {@code toString()} output
+   * to compare against, not just proof that whatever comes out still parses.
+   */
+  @Test
+  void toStringRoundTripsTheWithSettings() {
+    final SimpleNode parsed = checkSyntax("BACKUP DATABASE file:///foo/bar/ WITH compressionLevel = 5, maxMBPerSecond = 10", true);
+    final BackupDatabaseStatement original = (BackupDatabaseStatement) parsed;
+
+    final StringBuilder builder = new StringBuilder();
+    original.toString(null, builder);
+    assertThat(builder.toString()).contains("WITH");
+
+    final BackupDatabaseStatement roundTripped = (BackupDatabaseStatement) checkSyntax(builder.toString(), true);
+    assertThat(renderSettings(roundTripped)).isEqualTo(renderSettings(original));
+    assertThat(roundTripped.url).isEqualTo(original.url);
+  }
+
+  private static Map<String, String> renderSettings(final BackupDatabaseStatement statement) {
+    final Map<String, String> rendered = new HashMap<>();
+    for (final Map.Entry<Expression, Expression> entry : statement.settings.entrySet())
+      rendered.put(entry.getKey().toString(), entry.getValue().toString());
+    return rendered;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ExportDatabaseStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ExportDatabaseStatementTestParserTest.java
@@ -70,6 +70,26 @@ class ExportDatabaseStatementTestParserTest extends AbstractParserTest {
     assertThat(copy.url).isEqualTo(original.url);
   }
 
+  /**
+   * Regression test for issue #6428, item 1: {@code toString()} only rendered {@code url}, never {@code settings},
+   * so any code path that re-serializes the statement (statement caching keyed on text, query logging, an audit
+   * trail) would silently lose the {@code WITH} clause.
+   */
+  @Test
+  void toStringRoundTripsTheWithSettings() {
+    final SimpleNode parsed = checkSyntax("EXPORT DATABASE file://Movies.graphson.tgz WITH format = 'graphson', overwrite = true",
+        true);
+    final ExportDatabaseStatement original = (ExportDatabaseStatement) parsed;
+
+    final StringBuilder builder = new StringBuilder();
+    original.toString(null, builder);
+    assertThat(builder.toString()).contains("WITH");
+
+    final ExportDatabaseStatement roundTripped = (ExportDatabaseStatement) checkSyntax(builder.toString(), true);
+    assertThat(renderSettings(roundTripped)).isEqualTo(renderSettings(original));
+    assertThat(roundTripped.url).isEqualTo(original.url);
+  }
+
   @Test
   void copyOfAStatementWithoutSettingsKeepsAnEmptyMap() {
     final SimpleNode parsed = checkSyntax("EXPORT DATABASE file://Movies.jsonl.tgz", true);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/RebuildIndexStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/RebuildIndexStatementTestParserTest.java
@@ -21,6 +21,9 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.query.sql.antlr.SQLAntlrParser;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RebuildIndexStatementTestParserTest extends AbstractParserTest {
@@ -55,5 +58,58 @@ class RebuildIndexStatementTestParserTest extends AbstractParserTest {
         "REBUILD INDEX `Foo.bar` WITH batchSize = 1000");
     assertThat(named.all).isFalse();
     assertThat(named.settings.keySet()).anyMatch(k -> "batchSize".equals(k.toString()));
+  }
+
+  /**
+   * Regression test for issue #6428, item 1: {@code toString()} rendered the index name/{@code *} only, never
+   * {@code settings}, so any code path that re-serializes the statement (statement caching keyed on text, query
+   * logging, an audit trail) would silently lose the {@code WITH} clause - same defect as
+   * {@code Export}/{@code BackupDatabaseStatement}, found in the same statement family while fixing those two.
+   * <p>
+   * Parsed with {@link #checkSyntax(String, boolean)} rather than {@link #checkRightSyntax(String)} on purpose:
+   * this test asserts the round trip preserves {@code settings}, so it needs the pre-fix {@code toString()} output
+   * to compare against, not just proof that whatever comes out still parses.
+   */
+  @Test
+  void toStringRoundTripsTheWithSettings() {
+    final SimpleNode parsed = checkSyntax("REBUILD INDEX `Foo.bar.baz` WITH batchSize = 1000, maxAttempts = 3", true);
+    final RebuildIndexStatement original = (RebuildIndexStatement) parsed;
+
+    final StringBuilder builder = new StringBuilder();
+    original.toString(null, builder);
+    assertThat(builder.toString()).contains("WITH");
+
+    final RebuildIndexStatement roundTripped = (RebuildIndexStatement) checkSyntax(builder.toString(), true);
+    assertThat(renderSettings(roundTripped)).isEqualTo(renderSettings(original));
+    assertThat(roundTripped.name).isEqualTo(original.name);
+  }
+
+  /**
+   * Regression test for the same statement family's {@code copy()}/{@code equals()} gap found alongside item 1:
+   * {@code copy()} never carried {@code settings} over (silently dropping every {@code WITH} setting, the same
+   * defect {@code Export}/{@code Backup}/{@code ImportDatabaseStatement} had, #6080/#6409) and {@code equals()}/
+   * {@code hashCode()} never compared them (so two rebuilds with different settings compared equal, the same
+   * over-match direction found for {@code ImportDatabaseStatement} in #6409's identity sweep).
+   */
+  @Test
+  void copyAndEqualsKeepTheWithSettings() {
+    final RebuildIndexStatement original = (RebuildIndexStatement) checkSyntax(
+        "REBUILD INDEX `Foo.bar.baz` WITH batchSize = 1000, maxAttempts = 3", true);
+
+    final RebuildIndexStatement copy = (RebuildIndexStatement) original.copy();
+    assertThat(renderSettings(copy)).isEqualTo(renderSettings(original));
+    assertThat(copy).isEqualTo(original);
+    assertThat(copy.hashCode()).isEqualTo(original.hashCode());
+
+    final RebuildIndexStatement differentSettings = (RebuildIndexStatement) checkSyntax(
+        "REBUILD INDEX `Foo.bar.baz` WITH batchSize = 2000", true);
+    assertThat(differentSettings).isNotEqualTo(original);
+  }
+
+  private static Map<String, String> renderSettings(final RebuildIndexStatement statement) {
+    final Map<String, String> rendered = new HashMap<>();
+    for (final Map.Entry<Expression, Expression> entry : statement.settings.entrySet())
+      rendered.put(entry.getKey().toString(), entry.getValue().toString());
+    return rendered;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #6428.

- `ExportDatabaseStatement#toString()` and `BackupDatabaseStatement#toString()` only rendered `url`, never
  `settings` - re-serializing a parsed statement (statement caching keyed on text, query logging, an audit trail)
  silently dropped the `WITH` clause.
- While fixing those two, found `RebuildIndexStatement` (part of the same five-statement `WITH`-settings family:
  `REBUILD INDEX`, `REBUILD TYPE`, `IMPORT`/`EXPORT`/`BACKUP DATABASE`) has the identical `toString()` gap, plus two
  related ones not named in the issue text:
  - `copy()` never carried `settings` over at all - the same silent-drop shape #6080/#6409 already fixed for
    `Export`/`Backup`/`ImportDatabaseStatement`.
  - `equals()`/`hashCode()` never compared `settings` - so two `REBUILD INDEX` statements with different settings
    compared equal, the same over-match direction #6409's identity sweep found for `ImportDatabaseStatement`.
- Introduced `Statement#appendWithSettings()` as one shared renderer for the `WITH key = value, ...` clause and
  pointed all five settings-bearing statements at it, replacing four near-identical copies of the same loop
  (`ImportDatabaseStatement` and `RebuildTypeStatement` already rendered it correctly; refactored onto the shared
  helper for consistency, no behavior change there).

Issue #6428's item 2 (the node-identity sweep from #6409 isn't exhaustive) is explicitly a marker for next time,
not a request for an audit right now - no code change for it in this PR.

## Test plan

- New regression tests, each asserting a `toString()` round trip preserves `settings` (parse -> render -> reparse
  -> compare settings maps), since the existing `checkRightSyntax` helper only proves the rendered text still
  parses, not that content survived:
  - `ExportDatabaseStatementTestParserTest#toStringRoundTripsTheWithSettings`
  - `BackupDatabaseStatementTestParserTest#toStringRoundTripsTheWithSettings`
  - `RebuildIndexStatementTestParserTest#toStringRoundTripsTheWithSettings`
  - `RebuildIndexStatementTestParserTest#copyAndEqualsKeepTheWithSettings`
- All four failed against the pre-fix code, pass after.
- Ran the full `com.arcadedb.query.sql.parser` test package, the broader `RebuildIndex*` executor tests
  (`RebuildIndexOrphanBucketTest`, `RebuildIndexLockExhaustionTest`, `RebuildIndexPreservesNameTest`,
  `RebuildIndexPartitionValidationTest`), and `RebuildTypeRepartitionTest` (covers the `RebuildTypeStatement`
  refactor) - all green.
- `mvn -o -pl engine -am compile` clean.

## Files changed

- `engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java`
- `engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java`
- `engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java`
- `engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java`
- `engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java`
- `engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java`
- `engine/src/test/java/com/arcadedb/query/sql/parser/ExportDatabaseStatementTestParserTest.java`
- `engine/src/test/java/com/arcadedb/query/sql/parser/BackupDatabaseStatementTestParserTest.java`
- `engine/src/test/java/com/arcadedb/query/sql/parser/RebuildIndexStatementTestParserTest.java`