### PR TITLE
fix(#6418, #6404, #6415): Cypher function-call write classification, gRPC lookupByRID category, and a self-diagnosing flake

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/CypherBuiltinFunctions.java
+++ b/engine/src/main/java/com/arcadedb/function/CypherBuiltinFunctions.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function;
+
+/**
+ * The Cypher scalar/aggregate function names that are hardcoded into the engine rather than looked up through
+ * {@link CypherFunctionRegistry} or a database's function library - {@code toUpper}, {@code abs}, {@code coalesce}
+ * and the like. Every one of them is a pure, built-in Java implementation with no path to a schema-registered
+ * {@code DEFINE FUNCTION} body, so a name in this list can never be the write-capable custom function issue #6418
+ * is about.
+ * <p>
+ * The single source of truth for that name list, shared by the executor that resolves a call
+ * ({@code CypherFunctionFactory.isCypherSpecificFunction}) and the parse-time classifier that has to tell a call to
+ * one of these apart from a call into a {@code library.function} custom function ({@code SimpleCypherStatement}'s
+ * read-only analysis) - both need the same answer to "is this name closed and pure", and duplicating the list
+ * between them is exactly how the two would drift.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class CypherBuiltinFunctions {
+
+  private CypherBuiltinFunctions() {
+  }
+
+  /**
+   * Whether {@code functionName} - already lower-cased, matching {@code FunctionCallExpression.getFunctionName()} -
+   * is one of the engine's hardcoded Cypher scalar/aggregate functions.
+   */
+  public static boolean isBuiltin(final String functionName) {
+    return switch (functionName) {
+      // Graph functions
+      case "id", "elementid", "labels", "type", "keys", "properties", "startnode", "endnode" -> true;
+      // Path functions
+      case "nodes", "relationships", "length", "path_length" -> true;
+      // Math functions
+      case "rand", "sign", "ceil", "ceiling", "floor", "abs", "sqrt", "round", "isnan",
+           "cosh", "sinh", "tanh", "cot", "coth", "pi", "e", "randomuuid",
+           "acos", "asin", "atan", "atan2", "cos", "sin", "tan",
+           "degrees", "radians", "haversin", "exp", "log", "ln", "log10" -> true;
+      // General functions
+      case "coalesce" -> true;
+      // Predicate functions
+      case "isempty", "exists" -> true;
+      // List functions
+      case "size", "head", "tail", "last", "range" -> true;
+      // String functions
+      case "left", "right", "reverse", "split", "substring", "tolower", "toupper", "lower", "upper", "ltrim", "rtrim", "btrim" ->
+          true;
+      // String functions (additional)
+      case "trim", "replace", "char.length", "character.length", "char_length", "character_length", "charlength",
+           "normalize", "isnormalized" -> true;
+      // Type conversion functions
+      case "tostring", "tointeger", "tofloat", "toboolean",
+           "tostringornull", "tointegerornull", "tofloatornull", "tobooleanornull",
+           "tobooleanlist", "tofloatlist", "tointegerlist", "tostringlist" -> true;
+      // Scalar functions
+      case "nullif", "valuetype" -> true;
+      // Aggregation functions
+      case "collect", "collect_list", "percentiledisc", "percentile_disc", "percentilecont", "percentile_cont", "min", "max",
+           "avg" -> true;
+      // Temporal functions
+      case "timestamp" -> true;
+      // Temporal constructor functions
+      case "date", "localtime", "local_time", "time", "zoned_time", "localdatetime", "local_datetime", "datetime", "zoned_datetime",
+           "duration", "duration_between" -> true;
+      // Temporal truncation functions
+      case "date.truncate", "localtime.truncate", "time.truncate", "localdatetime.truncate", "datetime.truncate" -> true;
+      // Temporal epoch functions
+      case "datetime.fromepoch", "datetime.fromepochmillis" -> true;
+      // Temporal format function
+      case "format" -> true;
+      // Duration calculation functions
+      case "duration.between", "duration.inmonths", "duration.indays", "duration.inseconds" -> true;
+      // LOAD CSV context functions
+      case "file", "linenumber" -> true;
+      // Vector similarity functions
+      case "vector.similarity.cosine", "vector.similarity.euclidean" -> true;
+      // Vector construction and distance functions (used by Cypher vector(), vector_norm(), vector_distance())
+      // Note: vector_norm and vector_distance with EUCLIDEAN/DOT metrics delegate to SQL functions
+      // (vector.magnitude, vector.l1Norm, vector.l2Distance, vector.dotProduct) via the SQL bridge
+      case "vector.create", "vector.distance.manhattan", "vector.distance.cosine",
+           "vector", "vector.dimension.count", "vector_dimension_count", "vector.distance" -> true;
+      // Vector distance functions
+      case "vector.distance.euclidean" -> true;
+      // Vector norm function
+      case "vector.norm" -> true;
+      // Geo-spatial functions
+      case "point", "distance", "point.withinbbox", "point.distance" -> true;
+      // Temporal clock functions (realtime/statement/transaction are aliases for current instant)
+      case "date.realtime", "date.statement", "date.transaction" -> true;
+      case "localtime.realtime", "localtime.statement", "localtime.transaction" -> true;
+      case "time.realtime", "time.statement", "time.transaction" -> true;
+      case "localdatetime.realtime", "localdatetime.statement", "localdatetime.transaction" -> true;
+      case "datetime.realtime", "datetime.statement", "datetime.transaction" -> true;
+      default -> false;
+    };
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/SimpleCypherStatement.java
@@ -18,11 +18,16 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.function.CypherBuiltinFunctions;
+import com.arcadedb.function.CypherFunctionRegistry;
+import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
+import com.arcadedb.query.opencypher.parser.CypherExpressionWalker;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
 import com.arcadedb.query.opencypher.procedures.CypherProcedureRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Simple implementation of CypherStatement for Phase 1.
@@ -155,8 +160,9 @@ public class SimpleCypherStatement implements CypherStatement {
     final boolean hasForeach = this.clausesInOrder.stream().anyMatch(c -> c.getType() == ClauseEntry.ClauseType.FOREACH);
     final boolean writeSubquery = anyWriteSubquery(this.clausesInOrder);
     final boolean writeProcedureCall = anyWriteProcedureCall(this.callClauses);
+    final boolean unresolvedFunctionCall = anyUnresolvedFunctionCall(this);
     this.readOnly = !hasCreate && !hasMerge && !hasDelete && !hasRemove && !hasForeach
-        && (setClause == null || setClause.isEmpty()) && !writeSubquery && !writeProcedureCall;
+        && (setClause == null || setClause.isEmpty()) && !writeSubquery && !writeProcedureCall && !unresolvedFunctionCall;
 
     // Pre-compute flags used by CypherExecutionPlan.execute() to avoid repeated clause scanning
     this.hasVariableLengthPath = computeHasVariableLengthPath();
@@ -264,10 +270,12 @@ public class SimpleCypherStatement implements CypherStatement {
    * A {@code CALL} nested in a {@code CALL { ... }} subquery is already covered: {@link #anyWriteSubquery}
    * recurses through the inner statement's own {@code isReadOnly()}, which now accounts for this.
    * <p>
-   * A name that resolves to no registered procedure is left alone - it is not this method's business to guess
-   * what a SQL-function fallback or an outright unknown name does. The registry lookup is a static
-   * case-insensitive map read that also strips the {@code apoc.} prefix, so both spellings of one procedure
-   * classify identically, and it costs nothing at execution time: this runs once per parse, and parsed
+   * A name that resolves to no registered procedure falls through {@link #isConfirmedPureFunctionName} - the same
+   * check an expression-position call goes through (issue #6418) - because {@code CallStep} resolves a CALL target
+   * through the identical chain: {@link CypherProcedureRegistry}, then {@link CypherFunctionRegistry}, then a
+   * {@code DEFINE FUNCTION} custom adapter for a dotted name, then the built-in SQL fallback. The registry lookup
+   * is a static case-insensitive map read that also strips the {@code apoc.} prefix, so both spellings of one
+   * procedure classify identically, and it costs nothing at execution time: this runs once per parse, and parsed
    * statements are cached per query text.
    */
   private static boolean anyWriteProcedureCall(final List<CallClause> calls) {
@@ -275,10 +283,13 @@ public class SimpleCypherStatement implements CypherStatement {
       return false;
     for (final CallClause call : calls) {
       final CypherProcedure procedure = CypherProcedureRegistry.get(call.getProcedureName());
-      // A per-call refinement may only narrow, so a procedure that never writes needs no second look.
-      if (procedure == null || !procedure.isWriteProcedure())
+      if (procedure != null) {
+        // A per-call refinement may only narrow, so a procedure that never writes needs no second look.
+        if (procedure.isWriteProcedure() && procedure.isWriteProcedure(literalArguments(call)))
+          return true;
         continue;
-      if (procedure.isWriteProcedure(literalArguments(call)))
+      }
+      if (!isConfirmedPureFunctionName(call.getProcedureName()))
         return true;
     }
     return false;
@@ -298,6 +309,75 @@ public class SimpleCypherStatement implements CypherStatement {
       if (arguments.get(i) instanceof LiteralExpression literal)
         values[i] = literal.getValue();
     return values;
+  }
+
+  /** Explicit access to a built-in SQL function, e.g. {@code RETURN sql.abs(-1)} - always closed and pure. */
+  private static final String SQL_FUNCTION_PREFIX = "sql.";
+
+  /**
+   * Returns {@code true} when {@code rawName} is confirmed, without any database access, to be unable to resolve to
+   * a schema-registered {@code DEFINE FUNCTION} body - the gap issue #6418 is about, reachable both from a CALL
+   * clause target ({@link #anyWriteProcedureCall}) and from a function call in expression position
+   * ({@link #anyUnresolvedFunctionCall}), since {@code CallStep} and {@code FunctionCallExpression}'s resolver
+   * fall through the identical chain: {@link CypherProcedureRegistry} or {@link CypherFunctionRegistry}, then a
+   * {@code DEFINE FUNCTION} custom adapter for a dotted name, then the built-in SQL fallback.
+   * <p>
+   * {@code CustomFunctionAdapter.getOrCreateCustomFunctionAdapter} - the one and only path from either call shape
+   * to a schema-registered function body - refuses outright to build an adapter for a name with no {@code .} in
+   * it. So a BARE name, whichever of a function's several underscored or dotted spellings the caller used
+   * ({@code count}, {@code vector_distance}, ...), can never reach one and needs no lookup at all; only a DOTTED
+   * name needs a further check, since a namespaced built-in ({@code text.*}/{@code map.*}/{@code date.*}/
+   * {@code vector.*}/...) is dotted too - and the parser rewrites the underscored {@code vector_norm}/
+   * {@code vector_distance} spellings into a dotted SQL bridge name of their own ({@code vector.magnitude},
+   * {@code vector.l2Distance}, ...) before a {@link FunctionCallExpression} is ever built, so those two land here
+   * as dotted regardless of how the query spelled them. A dotted name is confirmed pure when it is registered in
+   * {@link CypherFunctionRegistry}, one of the hardcoded names in {@link CypherBuiltinFunctions}
+   * ({@code date.truncate}, {@code point.withinbbox}, ...), explicitly bridged to a built-in SQL function via the
+   * {@code sql.} prefix, or - matching {@code CypherFunctionFactory}'s own last resort - a name
+   * {@link DefaultSQLFunctionFactory} already answers for directly, unprefixed and unmapped (the vector bridge
+   * names above are exactly this case: registered as built-in SQL functions under their dotted names, reached with
+   * no {@code sql.} prefix and no {@link CypherFunctionRegistry} entry either). Every other dotted name - a
+   * {@code library.function} custom function being the shape #6418 is about, but also a plain typo - is
+   * conservatively treated as possibly a write: a false "maybe writes" costs a caller its optimization, a false
+   * "definitely read-only" costs correctness (a follower serving a write locally instead of forwarding it to the
+   * leader, or {@code SubqueryStep} skipping the refresh #6362 needs), the same asymmetry
+   * {@link CypherReferencedVariables} applies to its own "shape not modelled" answer.
+   */
+  private static boolean isConfirmedPureFunctionName(final String rawName) {
+    final String name = rawName.toLowerCase(Locale.ROOT);
+    return !name.contains(".") || CypherFunctionRegistry.hasFunction(name) || CypherBuiltinFunctions.isBuiltin(name)
+        || name.startsWith(SQL_FUNCTION_PREFIX) || DefaultSQLFunctionFactory.getInstance().hasFunction(name);
+  }
+
+  /**
+   * Returns {@code true} when the statement calls a function whose write-or-not status cannot be confirmed at parse
+   * time - a call in expression position ({@code WITH foo() AS x}, {@code RETURN sql.foo()}, nested inside another
+   * expression) that {@link #isConfirmedPureFunctionName} cannot clear. {@code SQLFunctionDefinition.execute} runs
+   * a {@code DEFINE FUNCTION} body as a full {@code sqlscript} command that can itself write, so a call reaching
+   * one here must not be classified read-only. See issue #6418.
+   * <p>
+   * Reuses {@link CypherExpressionWalker} - the traversal {@link CypherReferencedVariables} relies on for the same
+   * kind of "every expression, wherever it appears" question - rather than a partial recursion of its own, so this
+   * reaches {@code WHERE}, {@code SET}, {@code CREATE}/{@code MERGE} inline properties, {@code FOREACH} bodies and
+   * nested {@code CALL { }}/{@code EXISTS}/{@code COUNT}/{@code COLLECT} subqueries alike.
+   */
+  private static boolean anyUnresolvedFunctionCall(final CypherStatement statement) {
+    final UnresolvedFunctionCallDetector detector = new UnresolvedFunctionCallDetector();
+    CypherExpressionWalker.walk(statement, detector);
+    return detector.found;
+  }
+
+  private static final class UnresolvedFunctionCallDetector implements CypherExpressionWalker.Visitor {
+    private boolean found = false;
+
+    @Override
+    public void visit(final Expression expression) {
+      if (found || !(expression instanceof FunctionCallExpression call))
+        return;
+
+      if (!isConfirmedPureFunctionName(call.getFunctionName()))
+        found = true;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherFunctionFactory.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor;
 
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.function.CypherBuiltinFunctions;
 import com.arcadedb.function.CypherFunctionRegistry;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.agg.CollectDistinctFunction;
@@ -298,75 +299,13 @@ public class CypherFunctionFactory {
 
   /**
    * Check if this is a Cypher-specific function (not available in SQL).
+   * <p>
+   * The name list is {@link CypherBuiltinFunctions}, shared with {@code SimpleCypherStatement}'s parse-time
+   * read-only classification (issue #6418), which needs the same "is this name closed and pure" answer without
+   * being able to reach this executor-layer class.
    */
   private boolean isCypherSpecificFunction(final String functionName) {
-    return switch (functionName) {
-      // Graph functions
-      case "id", "elementid", "labels", "type", "keys", "properties", "startnode", "endnode" -> true;
-      // Path functions
-      case "nodes", "relationships", "length", "path_length" -> true;
-      // Math functions
-      case "rand", "sign", "ceil", "ceiling", "floor", "abs", "sqrt", "round", "isnan",
-           "cosh", "sinh", "tanh", "cot", "coth", "pi", "e", "randomuuid",
-           "acos", "asin", "atan", "atan2", "cos", "sin", "tan",
-           "degrees", "radians", "haversin", "exp", "log", "ln", "log10" -> true;
-      // General functions
-      case "coalesce" -> true;
-      // Predicate functions
-      case "isempty", "exists" -> true;
-      // List functions
-      case "size", "head", "tail", "last", "range" -> true;
-      // String functions
-      case "left", "right", "reverse", "split", "substring", "tolower", "toupper", "lower", "upper", "ltrim", "rtrim", "btrim" ->
-          true;
-      // String functions (additional)
-      case "trim", "replace", "char.length", "character.length", "char_length", "character_length", "charlength",
-           "normalize", "isnormalized" -> true;
-      // Type conversion functions
-      case "tostring", "tointeger", "tofloat", "toboolean",
-           "tostringornull", "tointegerornull", "tofloatornull", "tobooleanornull",
-           "tobooleanlist", "tofloatlist", "tointegerlist", "tostringlist" -> true;
-      // Scalar functions
-      case "nullif", "valuetype" -> true;
-      // Aggregation functions
-      case "collect", "collect_list", "percentiledisc", "percentile_disc", "percentilecont", "percentile_cont", "min", "max",
-           "avg" -> true;
-      // Temporal functions
-      case "timestamp" -> true;
-      // Temporal constructor functions
-      case "date", "localtime", "local_time", "time", "zoned_time", "localdatetime", "local_datetime", "datetime", "zoned_datetime",
-           "duration", "duration_between" -> true;
-      // Temporal truncation functions
-      case "date.truncate", "localtime.truncate", "time.truncate", "localdatetime.truncate", "datetime.truncate" -> true;
-      // Temporal epoch functions
-      case "datetime.fromepoch", "datetime.fromepochmillis" -> true;
-      // Temporal format function
-      case "format" -> true;
-      // Duration calculation functions
-      case "duration.between", "duration.inmonths", "duration.indays", "duration.inseconds" -> true;
-      // LOAD CSV context functions
-      case "file", "linenumber" -> true;
-      // Vector similarity functions
-      case "vector.similarity.cosine", "vector.similarity.euclidean" -> true;
-      // Vector construction and distance functions (used by Cypher vector(), vector_norm(), vector_distance())
-      // Note: vector_norm and vector_distance with EUCLIDEAN/DOT metrics delegate to SQL functions
-      // (vector.magnitude, vector.l1Norm, vector.l2Distance, vector.dotProduct) via the SQL bridge
-      case "vector.create", "vector.distance.manhattan", "vector.distance.cosine",
-           "vector", "vector.dimension.count", "vector_dimension_count", "vector.distance" -> true;
-      // Vector distance functions
-      case "vector.distance.euclidean" -> true;
-      // Vector norm function
-      case "vector.norm" -> true;
-      // Geo-spatial functions
-      case "point", "distance", "point.withinbbox", "point.distance" -> true;
-      // Temporal clock functions (realtime/statement/transaction are aliases for current instant)
-      case "date.realtime", "date.statement", "date.transaction" -> true;
-      case "localtime.realtime", "localtime.statement", "localtime.transaction" -> true;
-      case "time.realtime", "time.statement", "time.transaction" -> true;
-      case "localdatetime.realtime", "localdatetime.statement", "localdatetime.transaction" -> true;
-      case "datetime.realtime", "datetime.statement", "datetime.transaction" -> true;
-      default -> false;
-    };
+    return CypherBuiltinFunctions.isBuiltin(functionName);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DictionaryMultiPageTest.java
@@ -479,8 +479,17 @@ class DictionaryMultiPageTest extends TestHelper {
       dictionary.getIdByName("aNameOnPageZero", true);
       assertThat(dictionary.getTotalPages()).isEqualTo(1);
       assertThat(((DatabaseInternal) other).getPageManager().waitAllPagesOfDatabaseAreFlushed(other)).isTrue();
+      // Issue #6415: this premise has failed intermittently on CI's full-suite unit-tests lane (getTotalPages()
+      // 0 instead of 1) right after the drain above reported success, with no local repro found across 3300+
+      // iterations and 2 full engine-module runs. Read the raw OS file length too, bypassing the FileChannel
+      // entirely: if a recurrence shows this ALSO at 0, the write itself never reached disk (a flush-pipeline
+      // bug); if this shows the correct 65536 while the channel disagrees, the two disagree only through
+      // PaginatedComponentFile's own view (a channel visibility/caching bug) - the two hypotheses the original
+      // investigation could not distinguish between without exactly this data point.
+      final long rawOsFileLength = dictionary.getComponentFile().getOSFile().length();
       assertThat(dictionary.getComponentFile().getTotalPages())
-          .as("the premise: the file really holds page 0 and nothing after it")
+          .as("the premise: the file really holds page 0 and nothing after it (raw OS file length observed as %d bytes)",
+              rawOsFileLength)
           .isEqualTo(1L);
 
       // CLAIM TWO PAGES THAT WERE NEVER WRITTEN

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6418UnresolvedFunctionCallClassificationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6418UnresolvedFunctionCallClassificationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.QueryNotIdempotentException;
+import com.arcadedb.query.OperationType;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6418: {@code SimpleCypherStatement.isReadOnly()} only inspected top-level
+ * {@code CALL} clauses resolving to a registered {@code CypherProcedure}. A call into a user-defined
+ * {@code DEFINE FUNCTION} - in {@code CALL} position or, as here, in plain expression position
+ * ({@code WITH library.fn() AS x}, {@code RETURN library.fn()}) - was invisible to it:
+ * {@code SQLFunctionDefinition.execute} runs the function body as a full {@code sqlscript} command, which can
+ * itself {@code CREATE}/{@code UPDATE}/{@code DELETE}, yet the statement was classified read-only.
+ * <p>
+ * Mirrors {@code Issue6094WriteProcedureCallClassificationTest}, the direct precedent for this same flag and the
+ * same three consequences (HA leader routing, {@code Database.query()}'s idempotency gate, and
+ * {@code analyze().getOperationTypes()}), for the shape #6094 already covers - a registered write
+ * {@code CypherProcedure} in {@code CALL} position - but which does not reach a {@code DEFINE FUNCTION} call
+ * outside a {@code CALL} clause at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6418UnresolvedFunctionCallClassificationTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6418");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Issue6418Person");
+    database.command("sql",
+        "DEFINE FUNCTION test6418.createPerson \"INSERT INTO Issue6418Person SET name = :n RETURN @rid\" PARAMETERS [n] LANGUAGE sql");
+    database.command("sql", "DEFINE FUNCTION test6418.echo \"SELECT :a AS result\" PARAMETERS [a] LANGUAGE sql");
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  private boolean isIdempotent(final String query) {
+    return database.getQueryEngine("opencypher").analyze(query).isIdempotent();
+  }
+
+  @Test
+  void writeFunctionCallInWithClauseIsNotIdempotent() {
+    assertThat(isIdempotent("WITH test6418.createPerson('Alice') AS r RETURN r")).isFalse();
+  }
+
+  @Test
+  void writeFunctionCallInReturnClauseIsNotIdempotent() {
+    assertThat(isIdempotent("RETURN test6418.createPerson('Bob')")).isFalse();
+  }
+
+  @Test
+  void writeFunctionCallInsideCallSubqueryIsNotIdempotent() {
+    assertThat(isIdempotent(
+        "CALL { WITH test6418.createPerson('Carol') AS r RETURN r } RETURN r")).isFalse();
+  }
+
+  /**
+   * A read-only user-defined SQL function (a plain projection, no write inside its body) is a name this
+   * classifier cannot confirm pure either - it has no database access at parse time - so it is conservatively
+   * treated the same as a writing one. Costs the caller its idempotent-query fast path, never correctness: the
+   * opposite misclassification is the one #6418 is about.
+   */
+  @Test
+  void readOnlyCustomFunctionIsConservativelyNotIdempotentEither() {
+    assertThat(isIdempotent("RETURN test6418.echo('x')")).isFalse();
+  }
+
+  @Test
+  void builtinFunctionCallsStayIdempotent() {
+    assertThat(isIdempotent("RETURN toUpper('x')")).isTrue();
+    assertThat(isIdempotent("WITH abs(-1) AS a RETURN a")).isTrue();
+    assertThat(isIdempotent("RETURN text.indexOf('abc', 'b')")).isTrue();
+    assertThat(isIdempotent("RETURN sql.abs(-1)")).isTrue();
+    assertThat(isIdempotent("MATCH (n:Issue6418Person) RETURN n")).isTrue();
+  }
+
+  @Test
+  void queryRejectsWriteFunctionCallInExpressionPosition() {
+    assertThatThrownBy(() -> database.query("opencypher", "RETURN test6418.createPerson('Dave')"))
+        .isInstanceOf(QueryNotIdempotentException.class);
+  }
+
+  /**
+   * {@code CallStep} auto-commits around a {@code CALL} to a write procedure (#6073), but a write reached only
+   * through a function evaluated during projection has no step of its own to hang that convenience off - it is
+   * not something {@code isReadOnly()} controls either way, on this path or before this fix. An explicit
+   * transaction is the general contract for an embedded write {@code command()} outside that one convenience, and
+   * is what proves the write behind the function call actually executes.
+   */
+  @Test
+  void commandStillExecutesWriteFunctionCallInExpressionPosition() {
+    database.begin();
+    try (ResultSet rs = database.command("opencypher", "RETURN test6418.createPerson('Eve')")) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+    database.commit();
+    try (ResultSet check = database.query("sql", "SELECT FROM Issue6418Person WHERE name = 'Eve'")) {
+      assertThat(check.hasNext()).isTrue();
+    }
+  }
+
+  @Test
+  void operationTypesOfAWriteFunctionCallInExpressionPositionAreNotReadOnly() {
+    assertThat(database.getQueryEngine("opencypher")
+        .analyze("RETURN test6418.createPerson('Frank')")
+        .getOperationTypes())
+        .doesNotContain(OperationType.READ);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6418UnresolvedFunctionCallClassificationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6418UnresolvedFunctionCallClassificationTest.java
@@ -107,6 +107,25 @@ class Issue6418UnresolvedFunctionCallClassificationTest {
     assertThat(isIdempotent("MATCH (n:Issue6418Person) RETURN n")).isTrue();
   }
 
+  /**
+   * The trickiest branch of {@code isConfirmedPureFunctionName}: the parser rewrites the underscored
+   * {@code vector_norm}/{@code vector_distance} spellings into a dotted SQL bridge name ({@code vector.magnitude},
+   * {@code vector.l2Distance}, ...) before a {@code FunctionCallExpression} is ever built, so these land in the
+   * classifier as dotted names resolved via {@code DefaultSQLFunctionFactory}'s direct (unprefixed, unmapped)
+   * lookup rather than via {@link com.arcadedb.function.CypherFunctionRegistry} or
+   * {@link com.arcadedb.function.CypherBuiltinFunctions}. Pinned here directly rather than only transitively
+   * through execution, since a regression in this branch specifically would misclassify every dotted built-in
+   * that isn't in the other two sources.
+   */
+  @Test
+  void dottedBuiltinsResolvedOnlyThroughTheSqlFunctionFactoryStayIdempotent() {
+    assertThat(isIdempotent(
+        "RETURN vector_norm(vector([1.0, 5.0, 3.0, 6.7], 4, FLOAT32), EUCLIDEAN) AS norm")).isTrue();
+    assertThat(isIdempotent(
+        "RETURN vector_distance(vector([1.0, 5.0, 3.0, 6.7], 4, FLOAT32), vector([5.0, 2.5, 3.1, 9.0], 4, FLOAT32), EUCLIDEAN) AS distance"))
+        .isTrue();
+  }
+
   @Test
   void queryRejectsWriteFunctionCallInExpressionPosition() {
     assertThatThrownBy(() -> database.query("opencypher", "RETURN test6418.createPerson('Dave')"))

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCustomFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherCustomFunctionTest.java
@@ -38,7 +38,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void sqlFunctionInExpression() {
     database.command("sql", "DEFINE FUNCTION math.sum \"SELECT :a + :b\" PARAMETERS [a,b] LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "RETURN math.sum(3, 5) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN math.sum(3, 5) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Number>getProperty("result").longValue()).isEqualTo(8L);
   }
@@ -49,7 +49,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     database.command("opencypher", "CREATE (:Number {value: 10})");
     database.command("opencypher", "CREATE (:Number {value: 3})");
 
-    final ResultSet rs = database.query("opencypher", "MATCH (n:Number) WHERE n.value > math.threshold() RETURN n.value ORDER BY n.value");
+    final ResultSet rs = database.command("opencypher", "MATCH (n:Number) WHERE n.value > math.threshold() RETURN n.value ORDER BY n.value");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Number>getProperty("n.value").longValue()).isEqualTo(10L);
     assertThat(rs.hasNext()).isFalse();
@@ -59,7 +59,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void sqlFunctionWithMultipleArgs() {
     database.command("sql", "DEFINE FUNCTION math.add3 \"SELECT :a + :b + :c\" PARAMETERS [a,b,c] LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "RETURN math.add3(1, 2, 3) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN math.add3(1, 2, 3) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Number>getProperty("result").longValue()).isEqualTo(6L);
   }
@@ -68,15 +68,18 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void sqlFunctionReturningNull() {
     database.command("sql", "DEFINE FUNCTION test.returnNull \"SELECT null\" LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "RETURN test.returnNull() as result");
+    final ResultSet rs = database.command("opencypher", "RETURN test.returnNull() as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat((Object) rs.next().getProperty("result")).isNull();
   }
 
   @Test
   void undefinedFunctionThrowsError() {
+    // command(), not query(): an unresolved dotted name is indistinguishable at parse time from a custom
+    // DEFINE FUNCTION call, so query() now rejects it up front as not idempotent (issue #6418) before ever
+    // trying to resolve it. command() has no such gate and reaches the actual "unknown function" error below.
     assertThatThrownBy(() -> {
-      final ResultSet rs = database.query("opencypher", "RETURN nonexistent.func() as result");
+      final ResultSet rs = database.command("opencypher", "RETURN nonexistent.func() as result");
       rs.hasNext(); // Force query evaluation (queries are lazy)
     })
         .isInstanceOf(CommandExecutionException.class)
@@ -87,7 +90,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void sqlFunctionInListComprehension() {
     database.command("sql", "DEFINE FUNCTION math.double \"SELECT :x * 2\" PARAMETERS [x] LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "RETURN [x IN range(1,3) | math.double(x)] as result");
+    final ResultSet rs = database.command("opencypher", "RETURN [x IN range(1,3) | math.double(x)] as result");
     assertThat(rs.hasNext()).isTrue();
     final Object result = rs.next().getProperty("result");
     assertThat(result).asList().containsExactly(2L, 4L, 6L);
@@ -97,7 +100,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void callClauseStillWorks() {
     database.command("sql", "DEFINE FUNCTION math.multiply \"SELECT :a * :b\" PARAMETERS [a,b] LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "CALL math.multiply(4, 2) YIELD result RETURN result");
+    final ResultSet rs = database.command("opencypher", "CALL math.multiply(4, 2) YIELD result RETURN result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Number>getProperty("result").longValue()).isEqualTo(8L);
   }
@@ -107,7 +110,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     // Define initial function
     database.command("sql", "DEFINE FUNCTION test.value \"SELECT 10\" LANGUAGE sql");
 
-    ResultSet rs = database.query("opencypher", "RETURN test.value() as result");
+    ResultSet rs = database.command("opencypher", "RETURN test.value() as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Number>getProperty("result").longValue()).isEqualTo(10L);
 
@@ -115,7 +118,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     database.getSchema().getFunctionLibrary("test").unregisterFunction("value");
     database.command("sql", "DEFINE FUNCTION test.value \"SELECT 20\" LANGUAGE sql");
 
-    rs = database.query("opencypher", "RETURN test.value() as result");
+    rs = database.command("opencypher", "RETURN test.value() as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Number>getProperty("result").longValue()).isEqualTo(20L);
   }
@@ -126,7 +129,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void javaScriptFunctionInExpression() {
     database.command("sql", "DEFINE FUNCTION js.multiply \"return x * y\" PARAMETERS [x,y] LANGUAGE js");
 
-    final ResultSet rs = database.query("opencypher", "RETURN js.multiply(4, 2) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN js.multiply(4, 2) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Integer>getProperty("result")).isEqualTo(8);
   }
@@ -135,7 +138,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void javaScriptFunctionWithString() {
     database.command("sql", "DEFINE FUNCTION js.greet \"return 'Hello ' + name\" PARAMETERS [name] LANGUAGE js");
 
-    final ResultSet rs = database.query("opencypher", "RETURN js.greet('World') as result");
+    final ResultSet rs = database.command("opencypher", "RETURN js.greet('World') as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<String>getProperty("result")).isEqualTo("Hello World");
   }
@@ -146,7 +149,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void defineCypherFunction() {
     database.command("sql", "DEFINE FUNCTION cypher.double \"RETURN $x * 2\" PARAMETERS [x] LANGUAGE cypher");
 
-    final ResultSet rs = database.query("opencypher", "RETURN cypher.double(5) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN cypher.double(5) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Long>getProperty("result")).isEqualTo(10L);
   }
@@ -155,7 +158,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void defineCypherFunctionWithOpenCypherAlias() {
     database.command("sql", "DEFINE FUNCTION cypher.triple \"RETURN $x * 3\" PARAMETERS [x] LANGUAGE opencypher");
 
-    final ResultSet rs = database.query("opencypher", "RETURN cypher.triple(5) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN cypher.triple(5) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Long>getProperty("result")).isEqualTo(15L);
   }
@@ -175,7 +178,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     final Number nodeId = createResult.next().getProperty("aid");
 
     // Call function that queries graph data
-    final ResultSet rs = database.query("opencypher", "RETURN graph.countNeighbors($nodeId) as neighbors", "nodeId", nodeId);
+    final ResultSet rs = database.command("opencypher", "RETURN graph.countNeighbors($nodeId) as neighbors", "nodeId", nodeId);
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Long>getProperty("neighbors")).isEqualTo(1L);
   }
@@ -199,7 +202,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     database.command("sql", "DEFINE FUNCTION custom.addTen \"SELECT :value + 10\" PARAMETERS [value] LANGUAGE sql");
 
     // Call SQL function from Cypher
-    final ResultSet rs = database.query("opencypher", "RETURN custom.addTen(5) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN custom.addTen(5) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Number>getProperty("result").longValue()).isEqualTo(15L);
   }
@@ -209,7 +212,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     database.command("sql", "DEFINE FUNCTION js.power \"return Math.pow(x, y)\" PARAMETERS [x,y] LANGUAGE js");
 
     // Call JS function from Cypher
-    final ResultSet rs = database.query("opencypher", "RETURN js.power(2, 3) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN js.power(2, 3) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Integer>getProperty("result")).isEqualTo(8);
   }
@@ -220,7 +223,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void functionWithNoParameters() {
     database.command("sql", "DEFINE FUNCTION test.pi \"SELECT 3.14159\" LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "RETURN test.pi() as result");
+    final ResultSet rs = database.command("opencypher", "RETURN test.pi() as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Float>getProperty("result")).isEqualTo(3.14159f);
   }
@@ -229,7 +232,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
   void functionInComplexExpression() {
     database.command("sql", "DEFINE FUNCTION math.square \"SELECT :x * :x\" PARAMETERS [x] LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "RETURN math.square(3) + math.square(4) as result");
+    final ResultSet rs = database.command("opencypher", "RETURN math.square(3) + math.square(4) as result");
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<Long>getProperty("result")).isEqualTo(25L);
   }
@@ -244,7 +247,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     // id() returns a Neo4j-compatible Long-encoded RID since issue #4183.
     final Number nodeId = createResult.next().getProperty("nid");
 
-    final ResultSet rs = database.query("opencypher", "RETURN cypher.getLabel($nodeId) as label", "nodeId", nodeId);
+    final ResultSet rs = database.command("opencypher", "RETURN cypher.getLabel($nodeId) as label", "nodeId", nodeId);
     assertThat(rs.hasNext()).isTrue();
     assertThat(rs.next().<String>getProperty("label")).isEqualTo("TestNode");
   }
@@ -254,7 +257,7 @@ class OpenCypherCustomFunctionTest extends TestHelper {
     database.command("sql", "DEFINE FUNCTION math.add \"SELECT :a + :b\" PARAMETERS [a,b] LANGUAGE sql");
     database.command("sql", "DEFINE FUNCTION math.sub \"SELECT :a - :b\" PARAMETERS [a,b] LANGUAGE sql");
 
-    final ResultSet rs = database.query("opencypher", "RETURN math.add(10, 5) as sum, math.sub(10, 5) as diff");
+    final ResultSet rs = database.command("opencypher", "RETURN math.add(10, 5) as sum, math.sub(10, 5) as diff");
     assertThat(rs.hasNext()).isTrue();
     final var result = rs.next();
     assertThat(result.<Long>getProperty("sum")).isEqualTo(15);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
@@ -297,8 +297,13 @@ class OpenCypherUnionCallProfileTest {
     // Define a custom SQL function
     database.command("sql", "DEFINE FUNCTION math.add \"SELECT :a + :b AS result\" PARAMETERS [a,b] LANGUAGE sql");
 
-    // Test calling the custom function via Cypher CALL
-    final ResultSet result = database.query("opencypher", "CALL math.add(3, 5)");
+    // Test calling the custom function via Cypher CALL. command(), not query(): a CALL target unresolved
+    // against the built-in registries is indistinguishable at parse time from a custom DEFINE FUNCTION call,
+    // so query() now rejects it as not idempotent (issue #6418). Explicit YIELD/RETURN, not a bare CALL: a
+    // write-classified statement with no RETURN clause is CypherExecutionPlan.execute()'s signal that only
+    // side effects matter (CREATE/SET/DELETE with nothing to project), which swallows a bare CALL's own
+    // implicit output the same way once the CALL itself is no longer misclassified read-only.
+    final ResultSet result = database.command("opencypher", "CALL math.add(3, 5) YIELD value RETURN value");
 
     assertThat(result.hasNext()).isTrue();
     final Result row = result.next();
@@ -313,8 +318,9 @@ class OpenCypherUnionCallProfileTest {
     // Define a custom SQL function that returns input
     database.command("sql", "DEFINE FUNCTION my.echo \"SELECT :input AS output\" PARAMETERS [input] LANGUAGE sql");
 
-    // Test calling with string parameter
-    final ResultSet result = database.query("opencypher", "CALL my.echo('Hello World')");
+    // Test calling with string parameter. command(), not query(), and explicit YIELD/RETURN: see
+    // callCustomSQLFunction above.
+    final ResultSet result = database.command("opencypher", "CALL my.echo('Hello World') YIELD value RETURN value");
 
     assertThat(result.hasNext()).isTrue();
     final Result row = result.next();

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -1957,11 +1957,23 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     else
       cat = mapRecordType(grpcRecord);
 
-    if (cat != null)
-      map.put("@cat", cat);
-
     if (cat == null)
       return null;
+
+    // The wire's @cat is trustworthy for the CATEGORY (issue #6404), but constructing a concrete
+    // RemoteImmutableDocument/Vertex/Edge still needs the type resolvable client-side - its constructor looks
+    // the type up eagerly and throws SchemaException if it can't. Unlike @cat, the client's schema cache has no
+    // way to know about a type created after it was last (or never) loaded, and RemoteSchema only reloads a
+    // NEVER-loaded cache, not a stale one: a type created after the first schema access on this connection stays
+    // invisible until something explicitly invalidates the cache. Before @cat was sent on the wire this same
+    // existsType() check was where the category came from in the first place (mapRecordType(), below), so an
+    // unresolvable type was already silently downgraded to the property-only fallback instead of a crash -
+    // trusting the wire for the category must not remove that safety net.
+    final String typeName = grpcRecord.getType();
+    if (typeName.isEmpty() || !getSchema().existsType(typeName))
+      return null;
+
+    map.put("@cat", cat);
 
     return switch (cat) {
       case "d" -> new RemoteImmutableDocument(this, map);

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -1948,18 +1948,6 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     if (!grpcRecord.getType().isEmpty())
       map.put("@type", grpcRecord.getType());
 
-    GrpcValue catFromGrpcRecord = grpcRecord.getPropertiesMap().get("@cat");
-
-    String cat;
-
-    if (catFromGrpcRecord != null)
-      cat = catFromGrpcRecord.getStringValue();
-    else
-      cat = mapRecordType(grpcRecord);
-
-    if (cat == null)
-      return null;
-
     // The wire's @cat is trustworthy for the CATEGORY (issue #6404), but constructing a concrete
     // RemoteImmutableDocument/Vertex/Edge still needs the type resolvable client-side - its constructor looks
     // the type up eagerly and throws SchemaException if it can't. Unlike @cat, the client's schema cache has no
@@ -1968,9 +1956,16 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     // invisible until something explicitly invalidates the cache. Before @cat was sent on the wire this same
     // existsType() check was where the category came from in the first place (mapRecordType(), below), so an
     // unresolvable type was already silently downgraded to the property-only fallback instead of a crash -
-    // trusting the wire for the category must not remove that safety net.
+    // trusting the wire for the category must not remove that safety net. Checked once, up front, so the
+    // @cat-absent fallback below can reuse the confirmed type instead of resolving it a second time.
     final String typeName = grpcRecord.getType();
     if (typeName.isEmpty() || !getSchema().existsType(typeName))
+      return null;
+
+    final GrpcValue catFromGrpcRecord = grpcRecord.getPropertiesMap().get("@cat");
+    final String cat = catFromGrpcRecord != null ? catFromGrpcRecord.getStringValue() : mapRecordType(typeName);
+
+    if (cat == null)
       return null;
 
     map.put("@cat", cat);
@@ -1983,23 +1978,16 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     };
   }
 
-  private String mapRecordType(GrpcRecord grpcRecord) {
-    // Determine record category from type name
-    String typeName = grpcRecord.getType();
-
-    // Check schema to determine actual type
+  /** {@code typeName} must already be confirmed to exist client-side - see the {@code existsType()} check above. */
+  private String mapRecordType(final String typeName) {
     try {
-      if (typeName != null && !typeName.isBlank() && getSchema().existsType(typeName)) {
-        Object type = getSchema().getType(typeName);
-
-        return switch (type) {
-          case VertexType v -> "v";
-          case EdgeType e -> "e";
-          case DocumentType d -> "d";
-          default -> null;
-        };
-      } else
-        return null;
+      final Object type = getSchema().getType(typeName);
+      return switch (type) {
+        case VertexType v -> "v";
+        case EdgeType e -> "e";
+        case DocumentType d -> "d";
+        default -> null;
+      };
 
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6404LookupByRidEndToEndIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6404LookupByRidEndToEndIT.java
@@ -48,10 +48,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * fallback that {@code lookupByRID()}, which must return a concrete {@link Record}, does not have.
  *
  * <p>The fix sends {@code @cat} on the wire, matching HTTP, so the client never needs the schema fallback at all.
+ * This is the end-to-end reproduction through the high-level client; {@code Issue6404LookupByRidMissingCatIT} in
+ * {@code grpcw} pins the same fix directly against the wire response.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class Issue6404LookupByRidMissingCatIT extends BaseGraphServerTest {
+public class Issue6404LookupByRidEndToEndIT extends BaseGraphServerTest {
 
   private static final int    GRPC_PORT   = 50051;
   private static final int    HTTP_PORT   = 2480;
@@ -62,7 +64,7 @@ public class Issue6404LookupByRidMissingCatIT extends BaseGraphServerTest {
   @Override
   public void setTestConfiguration() {
     super.setTestConfiguration();
-    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
   }
 
   @BeforeEach

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6404LookupByRidMissingCatIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue6404LookupByRidMissingCatIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6404: {@link RemoteGrpcDatabase#lookupByRID(RID)} threw {@link
+ * com.arcadedb.exception.RecordNotFoundException} for an existing, previously persisted vertex, even though the
+ * same RID was returned by a SQL query on the same connection and was loadable through the HTTP client.
+ *
+ * <p>Root cause: {@code ArcadeDbGrpcService.convertToGrpcRecord()} / {@code convertResultToGrpcRecord()} never sent
+ * the {@code @cat} metadata property that {@code JsonSerializer} always sends over HTTP. The client's
+ * {@code grpcRecordToDBRecord()} falls back to resolving the category through the remote schema
+ * ({@code RemoteSchema.existsType()}) when {@code @cat} is absent, and a freshly opened connection - one that has
+ * never otherwise touched the schema - resolves that lookup against a type the client has not (yet, or ever)
+ * cached, so the fallback returns {@code null} and the "found" response is turned into a spurious
+ * "not found" exception. SQL queries do not notice because {@code grpcRecordToResult()} has a property-only
+ * fallback that {@code lookupByRID()}, which must return a concrete {@link Record}, does not have.
+ *
+ * <p>The fix sends {@code @cat} on the wire, matching HTTP, so the client never needs the schema fallback at all.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6404LookupByRidMissingCatIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT   = 50051;
+  private static final int    HTTP_PORT   = 2480;
+  private static final String VERTEX_TYPE = "Issue6404Vertex";
+
+  private RemoteGrpcServer grpcServer;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void createServerHandle() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    if (grpcServer != null)
+      grpcServer.close();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  /**
+   * Mirrors the issue's reproducer: the type and the vertex are created and persisted on one connection (standing
+   * in for "a previous session"), then a BRAND NEW {@link RemoteGrpcDatabase} - whose {@code RemoteSchema} has never
+   * been touched - looks the vertex up by RID found through a plain SQL query, never through the schema.
+   */
+  @Test
+  void lookupByRidFindsAnExistingVertexOnAFreshConnectionThatNeverLoadedTheSchema() {
+    final RID rid;
+    try (RemoteGrpcDatabase setup = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, HTTP_PORT, getDatabaseName(), "root",
+        DEFAULT_PASSWORD_FOR_TESTS)) {
+      setup.command("sql", "CREATE VERTEX TYPE `" + VERTEX_TYPE + "` IF NOT EXISTS");
+      setup.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.ldapId IF NOT EXISTS STRING");
+      setup.command("sql", "DELETE FROM `" + VERTEX_TYPE + "`");
+      try (ResultSet rs = setup.command("sql", "INSERT INTO `" + VERTEX_TYPE + "` SET ldapId = 'heimdall'")) {
+        rid = rs.next().getIdentity().orElseThrow();
+      }
+    }
+
+    try (RemoteGrpcDatabase fresh = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, HTTP_PORT, getDatabaseName(), "root",
+        DEFAULT_PASSWORD_FOR_TESTS)) {
+
+      try (ResultSet rs = fresh.query("sql", "SELECT FROM `" + VERTEX_TYPE + "` WHERE ldapId = 'heimdall'")) {
+        assertThat(rs.hasNext()).isTrue();
+        final Result queried = rs.next();
+        assertThat(queried.getIdentity().orElseThrow()).isEqualTo(rid);
+      }
+
+      // Before the fix: RecordNotFoundException, even though the row above was found through the same connection.
+      final Record record = fresh.lookupByRID(rid);
+
+      assertThat(record).isInstanceOf(Vertex.class);
+      assertThat(record.asVertex().getTypeName()).isEqualTo(VERTEX_TYPE);
+      assertThat(record.asVertex().getString("ldapId")).isEqualTo("heimdall");
+    }
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -4443,6 +4443,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           && doc.getType() != null) {
         builder.putProperties(Property.TYPE_PROPERTY, toGrpcValue(doc.getTypeName()));
       }
+
+      // @cat identifies the record's Java shape (document/vertex/edge), matching what JsonSerializer sends over
+      // HTTP (issue #6404). Sending it removes the client's need to resolve the type through the remote schema -
+      // RemoteGrpcDatabase.lookupByRID() has no result to fall back to when that resolution fails or lags.
+      if (!builder.getPropertiesMap().containsKey(Property.CAT_PROPERTY))
+        builder.putProperties(Property.CAT_PROPERTY, toGrpcValue(document instanceof Vertex ? "v" : document instanceof Edge ? "e" : "d"));
     }
 
     // If this is an Edge and @out/@in are not already in properties, add them
@@ -4509,6 +4515,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           builder.putProperties("@in", toGrpcValue(edge.getIn().getIdentity()));
         }
       }
+
+      // @cat identifies the record's Java shape (document/vertex/edge), matching what JsonSerializer sends over
+      // HTTP (issue #6404). Sending it removes the client's need to resolve the type through the remote schema -
+      // RemoteGrpcDatabase.lookupByRID() has no result to fall back to when that resolution fails or lags.
+      if (!builder.getPropertiesMap().containsKey(Property.CAT_PROPERTY))
+        builder.putProperties(Property.CAT_PROPERTY, toGrpcValue(dbRecord instanceof Vertex ? "v" : dbRecord instanceof Edge ? "e" : "d"));
     }
 
     LogManager.instance().log(this, Level.FINE, "ENC-REC DONE rid=%s type=%s props=%s", builder.getRid(),

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6404LookupByRidMissingCatIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6404LookupByRidMissingCatIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6404: {@code RemoteGrpcDatabase.lookupByRID()} threw {@code RecordNotFoundException}
+ * for an existing, previously persisted vertex, even though the same RID was returned by a SQL query on the same
+ * connection and was loadable through the HTTP client.
+ * <p>
+ * Root cause, at the wire level pinned here: {@link ArcadeDbGrpcService#convertToGrpcRecord} (and its
+ * {@code convertResultToGrpcRecord} sibling used by queries/commands) never sent the {@code @cat} metadata property
+ * that {@code JsonSerializer} always sends over HTTP for every Document/Vertex/Edge. The client's
+ * {@code grpcRecordToDBRecord()} treats a missing {@code @cat} as "resolve it through the remote schema instead",
+ * and {@code lookupByRID()} - unlike the query path, which has a property-only {@code Result} fallback - has no
+ * fallback for a {@code Record} it cannot categorize: a schema resolution that is stale, lagging, or simply not
+ * yet warm turns a real "found" answer into a spurious "not found" exception.
+ * <p>
+ * The fix sends {@code @cat} on the wire for every element, exactly as HTTP does, so the client never needs the
+ * schema round-trip for this at all. Pinned directly against the RPC response rather than through the schema-cache
+ * warm-up timing of the high-level client, which is not itself deterministic enough to fail reliably pre-fix.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6404LookupByRidMissingCatIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final String VERTEX_TYPE = "Issue6404Vertex";
+
+  private ManagedChannel                                    channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private ExecuteCommandResponse executeCommand(final String command) {
+    return authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand(command)
+            .setReturnRows(true)
+            .build());
+  }
+
+  @Test
+  void lookupByRidResponseCarriesCatForAVertex() {
+    executeCommand("CREATE VERTEX TYPE `" + VERTEX_TYPE + "` IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY `" + VERTEX_TYPE + "`.ldapId IF NOT EXISTS STRING");
+    executeCommand("DELETE FROM `" + VERTEX_TYPE + "`");
+
+    final ExecuteCommandResponse inserted = executeCommand("INSERT INTO `" + VERTEX_TYPE + "` SET ldapId = 'heimdall'");
+    assertThat(inserted.getRecordsCount()).isEqualTo(1);
+    final String rid = inserted.getRecords(0).getRid();
+    assertThat(rid).startsWith("#");
+
+    final LookupByRidResponse response = authenticatedStub.lookupByRid(
+        LookupByRidRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setRid(rid)
+            .build());
+
+    assertThat(response.getFound()).as("the record must be found").isTrue();
+
+    final GrpcRecord record = response.getRecord();
+    assertThat(record.getRid()).isEqualTo(rid);
+    assertThat(record.getType()).isEqualTo(VERTEX_TYPE);
+
+    // The bug: this property used to be entirely absent, forcing the client to re-derive the category through the
+    // remote schema - the only conversion path (lookupByRID) that has no fallback when that re-derivation fails.
+    assertThat(record.getPropertiesMap())
+        .as("the record must carry its own category rather than relying on the client's schema cache")
+        .containsEntry("@cat", GrpcValue.newBuilder().setStringValue("v").build());
+  }
+}


### PR DESCRIPTION
## Summary

- **#6418** - `SimpleCypherStatement.isReadOnly()` only inspected top-level `CALL` clauses resolving to a registered `CypherProcedure`. A write reached through a `DEFINE FUNCTION` call - in `CALL` position or in plain expression position (`WITH`/`RETURN`) - was invisible to it, and that flag backs HA leader routing, `Database.query()`'s idempotency gate, and `SubqueryStep`'s post-#4182 row-binding refresh (the #6362 fix). Fixed by walking every `FunctionCallExpression` (via the existing `CypherExpressionWalker`) and every `CALL` target, conservatively treating a name as a possible write unless it is confirmed pure - a bare (non-dotted) name can never reach a `DEFINE FUNCTION` body at all, since `CustomFunctionAdapter` requires a dotted `library.function` name. `CypherBuiltinFunctions` is a new shared name list, extracted out of `CypherFunctionFactory`'s previously private, executor-only switch, so the parse-time classifier and the executor read the same answer instead of two lists silently drifting.

  **Behavior change worth flagging for release notes**: `Database.query()` now rejects *any* Cypher call to a `DEFINE FUNCTION`-backed custom function (`CALL library.fn(...)`, or `library.fn(...)` in `WITH`/`RETURN`) with `QueryNotIdempotentException` - including genuinely read-only custom functions, not just writing ones. That's the correct conservative default (the classifier has no database access at parse time to confirm a custom function never writes), but it's a real change for any existing caller invoking a custom Cypher function through `query()` today; those callers need `command()` instead, matching the same contract `CALL` to a registered write procedure already had since #6094. All pre-existing tests exercising this were updated accordingly.

- **#6404** - `RemoteGrpcDatabase.lookupByRID()` threw a misleading `RecordNotFoundException` for a record the gRPC server had just reported as found, because `ArcadeDbGrpcService` never sent the `@cat` metadata property that `JsonSerializer` always sends over HTTP. Fixed by sending `@cat` on the wire for every element, matching HTTP, removing the client's need to fall back to resolving the category through the remote schema (a fallback `lookupByRID()`, unlike a plain query row, has no further fallback for).
- **#6415** - the `DictionaryMultiPageTest` premise flake this issue documents could not be reproduced locally (3300+ iterations, 2 full engine-module runs) and has not recurred in the 8 most recent `main` CI runs since #6351 merged. Rather than a speculative fix, added a diagnostic enrichment to the test's own premise assertion (the raw OS file length, bypassing the `FileChannel`) so a future recurrence is self-diagnosing. Left open - see the comment posted on the issue for the full write-up.

## Test plan

- [x] New regression test `Issue6418UnresolvedFunctionCallClassificationTest` - reproduces the bug pre-fix (6/8 cases red), passes post-fix; includes a dedicated test pinning the dotted-name branch resolved only through `DefaultSQLFunctionFactory` (`vector_norm`/`vector_distance`)
- [x] New regression tests `Issue6404LookupByRidMissingCatIT` (wire-level, in `grpcw`) and `Issue6404LookupByRidEndToEndIT` (end-to-end, in `grpc-client`) - reproduce the bug pre-fix, pass post-fix
- [x] Full `com.arcadedb.query.opencypher.**` package (8707 tests) green with the #6418 fix, including the OpenCypher TCK suite
- [x] Full `grpcw` + `grpc-client` module test suites green with the #6404 fix
- [x] `DictionaryMultiPageTest` (15 tests) green with the #6415 diagnostic enrichment
- [x] `mvn compile` clean across `engine`, `network`, `server`, `grpcw`, `grpc-client`