### PR TITLE
fix(#6426): the test asks the server which port it bound, and a raw NUL byte no longer hides a class from grep

### DIFF
--- a/.github/scripts/check-source-control-chars.py
+++ b/.github/scripts/check-source-control-chars.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Fails when a source file carries a raw control byte.
+
+A NUL byte reached `ArcadeDBServer.java` as a char literal written out as the byte itself instead of
+the escape `\0` (issue #6426). It compiled and behaved correctly, so nothing flagged it for years -
+but one control byte makes grep classify the file as binary, and every search over that 1351-line
+class silently returned NOTHING. A search for a method that *is* declared there came back empty, so
+both people and tools concluded it did not exist. The cost is not the byte, it is that the file
+stops answering questions.
+
+Checked bytes are the C0 controls except tab, newline and carriage return, plus DEL. Every one of
+them has an escape that reads better anyway, so there is no reason for the raw byte to be in a
+source file.
+
+Usage:
+  check-source-control-chars.py [path ...]   # defaults to the whole repository
+
+@author Luca Garulli (l.garulli@arcadedata.com)
+"""
+
+import sys
+from pathlib import Path
+
+# TAB (0x09), LF (0x0a) and CR (0x0d) are the layout of the file, everything else in C0 plus DEL is a control byte.
+FORBIDDEN = bytes(b for b in range(0x00, 0x20) if b not in (0x09, 0x0A, 0x0D)) + b"\x7f"
+
+SUFFIXES = {".java", ".py", ".sh", ".js", ".ts", ".json", ".xml", ".yml", ".yaml", ".md", ".sql", ".properties"}
+
+# Directories that hold build output or third-party text nobody edits by hand.
+SKIPPED_DIRS = {".git", "target", "node_modules", "build", "dist", ".idea", "venv", ".venv"}
+
+NAMES = {0x00: "NUL", 0x07: "BEL", 0x08: "BS", 0x0B: "VT", 0x0C: "FF", 0x1A: "SUB", 0x1B: "ESC", 0x7F: "DEL"}
+
+
+def offenders(path):
+    """Yields (line, column, byte) for every control byte in the file, 1-based, in file order."""
+    try:
+        content = path.read_bytes()
+    except OSError as e:
+        print(f"{path}: cannot read ({e})", file=sys.stderr)
+        return
+
+    # The membership test is one pass over the distinct bytes; only a file that has one pays for the locating.
+    if not any(b in FORBIDDEN for b in set(content)):
+        return
+
+    line = column = 1
+    for byte in content:
+        if byte in FORBIDDEN:
+            yield line, column, byte
+        if byte == 0x0A:
+            line, column = line + 1, 1
+        else:
+            column += 1
+
+
+def walk(root):
+    if root.is_file():
+        yield root
+        return
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in SUFFIXES:
+            continue
+        if SKIPPED_DIRS.intersection(path.parts):
+            continue
+        yield path
+
+
+def main(argv):
+    roots = [Path(a) for a in argv[1:]] or [Path(__file__).resolve().parents[2]]
+
+    found = 0
+    for root in roots:
+        for path in walk(root):
+            for line, column, byte in offenders(path):
+                found += 1
+                name = NAMES.get(byte, f"0x{byte:02x}")
+                # Print the location the way a compiler does, so an editor can jump straight to it.
+                print(f"{path}:{line}:{column}: raw {name} control byte (0x{byte:02x})")
+
+    if found:
+        print()
+        print(f"{found} raw control byte(s) found in source files.")
+        print("Write the escape instead: a raw control byte makes grep treat the whole file as binary, so")
+        print("every search over it silently returns nothing (issue #6426).")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -26,6 +26,7 @@ RESULTS="$SCRIPTS/check-test-results.py"
 GUARDS="$SCRIPTS/check-test-reporter-guards.py"
 ALLOWLIST="$SCRIPTS/check-license-allowlist.py"
 DBDOCSSYNC="$SCRIPTS/check-database-docs-sync.py"
+CONTROLCHARS="$SCRIPTS/check-source-control-chars.py"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -1055,6 +1056,36 @@ CHECK DATABASE [ TYPE <type-name>[,]* ] [ RECLAIM UNREFERENCED FILES[,]* ]
 EOF
 expect "recovers a full keyword phrase when a placeholder touches the last keyword" 0 "agree on 2 clause" \
     "$DBDOCSSYNC" "$work/dbdocs-adjacent-bracket/SQLParser.g4" "$work/dbdocs-adjacent-bracket/sql-database-admin.adoc"
+
+# The raw NUL that reached ArcadeDBServer.java (issue #6426) compiled and behaved correctly, so the
+# only thing that noticed was grep - which reported the whole 1351-line file as binary and returned
+# nothing for every search over it. The guard has to catch the byte wherever it sits, and must not
+# trip on the tab/newline/carriage-return that every source file is made of.
+mkdir -p "$work/controlchars-clean"
+printf 'class A {\n\tvoid a() {\n\t\tb("x\\0y");\r\n\t}\n}\n' >"$work/controlchars-clean/A.java"
+expect "accepts tabs, CRLF and an escaped NUL" 0 "" \
+    "$CONTROLCHARS" "$work/controlchars-clean"
+
+mkdir -p "$work/controlchars-nul"
+printf 'class A {\n  int i = "x".indexOf('"'"'\000'"'"');\n}\n' >"$work/controlchars-nul/A.java"
+expect "rejects a raw NUL byte and points at its line" 1 "A.java:2:" \
+    "$CONTROLCHARS" "$work/controlchars-nul"
+
+# ESC is the one that reads as harmless - it is how a terminal colour code is written - and it makes
+# the file just as invisible to grep as the NUL does.
+mkdir -p "$work/controlchars-esc"
+printf 'RED = "\033[31m"\n' >"$work/controlchars-esc/colors.py"
+expect "rejects a raw ESC byte" 1 "ESC" \
+    "$CONTROLCHARS" "$work/controlchars-esc"
+
+# A control byte in build output or in a vendored bundle is not ours to fix, and a binary suffix is
+# not a source file at all - neither may fail the build.
+mkdir -p "$work/controlchars-skipped/target" "$work/controlchars-skipped/node_modules"
+printf 'class B {\000}\n' >"$work/controlchars-skipped/target/B.java"
+printf 'var x = "\000";\n' >"$work/controlchars-skipped/node_modules/bundle.js"
+printf '\000\001\002' >"$work/controlchars-skipped/logo.png"
+expect "ignores build output, vendored bundles and non-source files" 0 "" \
+    "$CONTROLCHARS" "$work/controlchars-skipped"
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -42,6 +42,8 @@ jobs:
         run: ./.github/scripts/check-workflow-artifact-deps.py
       - name: Check test reporter guards
         run: ./.github/scripts/check-test-reporter-guards.py
+      - name: Check source files for raw control bytes
+        run: ./.github/scripts/check-source-control-chars.py
       - name: Check CI scripts
         run: ./.github/scripts/tests/test-ci-scripts.sh
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/console/src/test/java/com/arcadedb/console/ConsoleAsyncInsertTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleAsyncInsertTest.java
@@ -148,7 +148,7 @@ public class ConsoleAsyncInsertTest {
   }
 
   @Test
-  void bulkAsyncInsertProductsUsingSQL() {
+  void bulkAsyncInsertProductsUsingSQL() throws IOException {
     GlobalConfiguration.SERVER_ROOT_PATH.setValue(".");
     GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue("./target/databases");
 
@@ -206,8 +206,6 @@ public class ConsoleAsyncInsertTest {
       LocalDateTime start, stop, ref;
       ref = LocalDateTime.now().minusMonths(1);
 
-      final long begin = System.currentTimeMillis();
-
       for (int i = 0; i < N; i++) {
         name = UUID.randomUUID().toString();
         start = ref.plusMinutes(i);
@@ -216,7 +214,7 @@ public class ConsoleAsyncInsertTest {
         inventoryProductAsyncWithSQL(database, product, okCount, errCount);
       }
 
-      checkResults(txErrorCounter, database, okCount, errCount, N, begin);
+      checkResults(arcadeDBServer, txErrorCounter, database, okCount, errCount, N);
     } finally {
       arcadeDBServer.stop();
       FileUtils.deleteRecursively(new File(arcadeDBServer.getRootPath() + File.separator + "config"));
@@ -224,7 +222,7 @@ public class ConsoleAsyncInsertTest {
   }
 
   @Test
-  void bulkAsyncInsertProductsUsingAPI() {
+  void bulkAsyncInsertProductsUsingAPI() throws IOException {
     GlobalConfiguration.SERVER_ROOT_PATH.setValue(".");
     GlobalConfiguration.SERVER_DATABASE_DIRECTORY.setValue("./target/databases");
 
@@ -283,8 +281,6 @@ public class ConsoleAsyncInsertTest {
       LocalDateTime start, stop, ref;
       ref = LocalDateTime.now().minusMonths(1);
 
-      final long begin = System.currentTimeMillis();
-
       for (int i = 0; i < N; i++) {
         name = UUID.randomUUID().toString();
         start = ref.plusMinutes(i);
@@ -293,7 +289,7 @@ public class ConsoleAsyncInsertTest {
         inventoryProductAsyncWithAPI(database, product, okCount, errCount);
       }
 
-      checkResults(txErrorCounter, database, okCount, errCount, N, begin);
+      checkResults(arcadeDBServer, txErrorCounter, database, okCount, errCount, N);
     } finally {
       arcadeDBServer.stop();
       FileUtils.deleteRecursively(new File(arcadeDBServer.getRootPath() + File.separator + "config"));
@@ -398,11 +394,9 @@ public class ConsoleAsyncInsertTest {
     }
   }
 
-  private void checkResults(AtomicLong txErrorCounter, Database database, AtomicLong okCount, AtomicLong errCount, long N,
-      long begin) {
+  private void checkResults(ArcadeDBServer server, AtomicLong txErrorCounter, Database database, AtomicLong okCount,
+      AtomicLong errCount, long N) throws IOException {
     assertThat(database.async().waitCompletion(30_000)).isTrue();
-
-    System.out.println("Total async insertion of " + N + " elements in " + (System.currentTimeMillis() - begin));
 
     assertThat(N).isEqualTo(okCount.get());
     assertThat(errCount.get()).isEqualTo(0);
@@ -411,16 +405,20 @@ public class ConsoleAsyncInsertTest {
       Result result = resultSet.next();
       assertThat(N).isEqualTo((Long) result.getProperty("total"));
       Console console = new Console();
-      String URL = "remote:localhost/" + DATABASE_NAME + " " + userName + " " + password;
+      // CONNECT TO THE PORT THE SERVER ACTUALLY BOUND: THE DEFAULT IS A RANGE, SO WITH 2480 ALREADY TAKEN THIS SERVER LISTENS
+      // ELSEWHERE AND A PORT-LESS URL WOULD REACH THE FOREIGN ONE INSTEAD, FAILING AS 'User/Password not valid'
+      String URL = "remote:localhost:" + server.getHttpServer().getPort() + "/" + DATABASE_NAME + " " + userName + " " + password;
       assertThat(console.parse("connect " + URL)).isTrue();
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(buffer::append);
       assertThat(console.parse("select count(*) from Product")).isTrue();
-      String[] lines = buffer.toString().split("\\r?\\n|\\r");
+      final String output = buffer.toString();
+      // SAY WHAT CAME BACK: WHEN THE ANSWER IS NOT THIS SERVER'S THE ROW IS MISSING, AND INDEXING INTO IT REPORTS AN
+      // ArrayIndexOutOfBoundsException THAT NAMES NEITHER THE QUERY NOR THE SERVER THAT ANSWERED IT
+      assertThat(output).as("console output of the remote count").contains("count(*)");
+      String[] lines = output.split("\\r?\\n|\\r");
       int count = Integer.parseInt(lines[4].split("\\|")[2].trim());
       assertThat(count).isEqualTo(N);
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
     }
   }
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -852,7 +852,7 @@ public class ArcadeDBServer {
     if (databaseName == null || databaseName.trim().isEmpty())
       throw new IllegalArgumentException("Database name is empty");
 
-    if (databaseName.indexOf('/') > -1 || databaseName.indexOf('\\') > -1 || databaseName.indexOf(' ') > -1
+    if (databaseName.indexOf('/') > -1 || databaseName.indexOf('\\') > -1 || databaseName.indexOf('\0') > -1
         || databaseName.equals(".") || databaseName.equals("..") || databaseName.contains(".."))
       throw new IllegalArgumentException("Database name '" + databaseName + "' contains invalid characters");
 


### PR DESCRIPTION
Fixes items **3** and **4** of #6426. Items 1 and 2 in that issue need a design decision first and are deliberately not touched here, so the issue stays open.

## Item 3 - `ConsoleAsyncInsertTest` talked to whatever server owned 2480

The test starts a real `ArcadeDBServer` and verifies through the console:

```java
String URL = "remote:localhost/" + DATABASE_NAME + " " + userName + " " + password;
```

No port, so the client uses `RemoteHttpComponent.DEFAULT_PORT` = 2480. The server, however, binds the **first free port in the 2480-2489 range** (`HttpServer.startService()` loops over `SERVER_HTTP_INCOMING_PORT`, default `2480-2489`). With 2480 already held - another agent's server, an IDE run, a leftover process - the test's own server starts on 2481 and the console queries the **foreign** one. The failure surfaces as `Security User/Password not valid`, which reads as an authentication bug and never mentions a port.

The server knows where it is listening, so the URL now asks it: `server.getHttpServer().getPort()`.

**Reproduced, both directions.** Holding 2480 the way Undertow does (IPv6 wildcard, dual-stack, no `SO_REUSEADDR`, so the second bind really fails):

| | 2480 held |
|---|---|
| before | `bulkAsyncInsertProductsUsingSQL` FAILS after 92.53s |
| after | 3/3 pass, and the whole `server` + `console` modules stay green (794 + 81 tests) with the port still held |

A first attempt to reproduce with an IPv4 `127.0.0.1` listener was misleading and is worth recording: Undertow binds IPv6 dual-stack, so the two sockets coexisted, `getPort()` still reported 2480, and the client hit the dead socket instead. The 77-92s runtimes seen while diagnosing were **not** the inserts - those take ~1.5s - they were the doomed HTTP request timing out.

Two further defects in the same method, both found on the way:

- The verification block was wrapped in `catch (IOException e) { System.out.println(...) }` with every assertion that matters **inside** the `try`. A connect failure made the test print a line and pass. It could only ever fail because the security error happened to be a `RuntimeException`. The exception now fails the test.
- When the answer came from the wrong server the table row was missing, and indexing into it threw `ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 1` - naming neither the query nor the server that answered. The output is now asserted first, so the failure shows what came back.

The debug `System.out.println` of the insertion time is gone, and with it the `begin` parameter that only fed it.

## Item 4 - a raw NUL byte made `ArcadeDBServer.java` invisible to `grep`

The reserved-database-name guard at `ArcadeDBServer.java:855` contained an actual NUL **byte** where the char literal should have been the escape `'\0'`. It compiles - a NUL is a legal character in a Java char literal - and the guard has always behaved correctly, so nothing flagged it. But one control byte makes `grep` classify the file as binary and report **no matches at all**:

```
$ grep -c "" server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
(no output, exit 1)
$ file server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
server/.../ArcadeDBServer.java: data
```

So a search for a method that **is** declared in this 1351-line class comes back empty and reads as "it does not exist". That is exactly how it was found: while fixing the test above, `grep getHttpServer` over the file returned nothing, even though `ServerSecurity`, `RaftHAServer`, `GrpcServerPlugin` and others all call it. After the fix the same grep finds it, and `file` reports `Java source, Unicode text, UTF-8 text`.

Note the diff for this hunk renders the removed byte as an invisible character - the bug is as hard to see in review as it was in the editor, which is the argument for the guard below rather than for vigilance.

### `check-source-control-chars.py`

New guard in the house style of `.github/scripts/check-*`, wired into the `setup` job beside the other guards. It rejects the C0 control bytes except tab, LF and CR, plus DEL, in the text suffixes, skipping build output and vendored trees. It reports `path:line:column` so an editor can jump straight there.

Covered in `tests/test-ci-scripts.sh` in both directions - it must catch a raw NUL and a raw ESC and point at the line, and must **not** trip on tabs, CRLF, an escaped `\0`, `target/`, `node_modules/`, or a `.png`. Verified against the real defect: reintroducing the byte into a copy of `ArcadeDBServer.java` reports `855:100: raw NUL control byte (0x00)`. The full harness passes 70 checks.

## Verification

- `mvn -o -pl console -am test` with 2480 held: 794 server + 81 console tests, all green.
- `ConsoleAsyncInsertTest` alone, port free: 3/3.
- `.github/scripts/tests/test-ci-scripts.sh`: 70 checks passed.
- `check-source-control-chars.py` over the whole repository: clean.