### PR TITLE
fix(#6442): RebuildTypeStatement.copy() normalized to shallow-copy settings

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildTypeStatement.java
@@ -373,8 +373,10 @@ public class RebuildTypeStatement extends DDLStatement {
     final RebuildTypeStatement result = new RebuildTypeStatement();
     result.typeName = typeName == null ? null : typeName.copy();
     result.polymorphic = polymorphic;
-    for (final Map.Entry<Expression, Expression> e : settings.entrySet())
-      result.settings.put(e.getKey().copy(), e.getValue().copy());
+    // Shallow-copy, matching RebuildIndexStatement/ExportDatabaseStatement/BackupDatabaseStatement/
+    // ImportDatabaseStatement: Expression nodes are effectively immutable post-parse, so there is nothing
+    // for a per-entry deep copy to protect against, and it only doubles the allocations on every copy() call.
+    result.settings.putAll(settings);
     return result;
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6401NodeIdentityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/Issue6401NodeIdentityTest.java
@@ -75,6 +75,13 @@ class Issue6401NodeIdentityTest extends AbstractParserTest {
    * {@code CaseExpression} never populates, so it OVER-matched: two structurally different {@code CASE WHEN}
    * expressions compared equal to each other. The rest is a representative spread of statement and expression
    * shapes rather than an exhaustive walk of the ~67 {@code getIdentityElements()} overrides.
+   * <p>
+   * Issue #6442, item 2 flagged this corpus as still not exhaustive and asked for exactly this kind of widening
+   * pass the next time it comes up - not a full audit, one batch of previously-unexercised shapes. This batch
+   * added {@code MATCH}, {@code CREATE EDGE}, {@code CREATE INDEX}, {@code LET}, {@code CONTAINS}, {@code
+   * INSTANCEOF} and {@code IF}; none of the seven surfaced a defect. That is a real (if less exciting) outcome
+   * of the recipe, not a reason to stop following it - the next widening pass is still the same one query at a
+   * time, on whichever shapes remain unexercised (window functions and less-common SQL extensions per the issue).
    */
   @Test
   void equalNodesAnswerEqualHashCodes() {
@@ -103,7 +110,17 @@ class Issue6401NodeIdentityTest extends AbstractParserTest {
         "REBUILD TYPE Foo WITH batchSize = 100, repartition = true", //
         "IMPORT DATABASE http://foo.bar WITH forceDatabaseCreate = true", //
         "EXPORT DATABASE file://foo.bar WITH format = 'graphml'", //
-        "BACKUP DATABASE file://foo.bar WITH compressionLevel = 5" }) {
+        "BACKUP DATABASE file://foo.bar WITH compressionLevel = 5", //
+        // Widened per issue #6442, item 2: MATCH patterns, CREATE EDGE/INDEX, LET, CONTAINS, INSTANCEOF and IF
+        // were not exercised by any query above. None of these five turned up a defect, so the corpus grew but
+        // no fix was needed for this batch - see the class javadoc for the recipe if a future widening finds one.
+        "MATCH { type: 'V', as: foo}-E->{ type: 'V', as: bar} RETURN foo, bar", //
+        "CREATE EDGE Friend FROM #1:1 TO #1:2 SET since = 2020", //
+        "CREATE INDEX ON Foo (bar, baz) UNIQUE", //
+        "SELECT FROM V LET $temp = (SELECT FROM E)", //
+        "SELECT FROM V WHERE tags CONTAINS 'x'", //
+        "SELECT FROM V WHERE a INSTANCEOF 'V'", //
+        "IF (1 = 1) { SELECT FROM V; }" }) {
       final SimpleNode one = checkRightSyntax(query);
       final SimpleNode other = checkRightSyntax(query);
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/RebuildTypeStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/RebuildTypeStatementTestParserTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.parser;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6442, item 1: {@code RebuildTypeStatement#copy()} deep-copied every {@code
+ * settings} entry's key and value, while the rest of the WITH-settings family ({@code RebuildIndex}/{@code
+ * Export}/{@code Backup}/{@code ImportDatabaseStatement}) shallow-copies the same kind of map via {@code
+ * settings.putAll(...)}. Normalized on the shallow copy, since {@link Expression} nodes are effectively
+ * immutable post-parse and the deep copy had nothing to protect against.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class RebuildTypeStatementTestParserTest extends AbstractParserTest {
+
+  @Test
+  void plain() {
+    checkRightSyntax("REBUILD TYPE Foo");
+    checkRightSyntax("rebuild type Foo");
+    checkRightSyntax("REBUILD TYPE Foo POLYMORPHIC");
+    checkRightSyntax("REBUILD TYPE Foo WITH batchSize = 1000");
+    checkRightSyntax("REBUILD TYPE Foo POLYMORPHIC WITH batchSize = 1000, repartition = true");
+
+    checkWrongSyntax("REBUILD TYPE");
+  }
+
+  @Test
+  void copyAndEqualsKeepTheWithSettings() {
+    final RebuildTypeStatement original = (RebuildTypeStatement) checkSyntax(
+        "REBUILD TYPE Foo WITH batchSize = 1000, repartition = true", true);
+
+    final RebuildTypeStatement copy = original.copy();
+    assertThat(renderSettings(copy)).isEqualTo(renderSettings(original));
+    assertThat(copy).isEqualTo(original);
+    assertThat(copy.hashCode()).isEqualTo(original.hashCode());
+
+    final RebuildTypeStatement differentSettings = (RebuildTypeStatement) checkSyntax(
+        "REBUILD TYPE Foo WITH batchSize = 2000", true);
+    assertThat(differentSettings).isNotEqualTo(original);
+  }
+
+  /**
+   * The fix normalizes on a shallow copy, matching the rest of the family: the copy's settings {@link Map}
+   * must be a distinct instance (mutating one must not affect the other), but the {@link Expression} key/value
+   * entries it holds are now the SAME instances as the original's, not fresh {@code .copy()} results. Asserting
+   * identity here (rather than just equality) is what makes this a regression test for the deep-copy - a
+   * revert back to per-entry {@code .copy()} still passes every equals()/hashCode() assertion but fails this one.
+   */
+  @Test
+  void copySettingsMapIsIndependentButSharesTheSameImmutableExpressionInstances() {
+    final RebuildTypeStatement original = (RebuildTypeStatement) checkSyntax(
+        "REBUILD TYPE Foo WITH batchSize = 1000", true);
+
+    final RebuildTypeStatement copy = original.copy();
+    assertThat(copy.settings).isNotSameAs(original.settings);
+    assertThat(copy.settings).isEqualTo(original.settings);
+
+    final Map.Entry<Expression, Expression> originalEntry = original.settings.entrySet().iterator().next();
+    final Map.Entry<Expression, Expression> copyEntry = copy.settings.entrySet().iterator().next();
+    assertThat(copyEntry.getKey()).isSameAs(originalEntry.getKey());
+    assertThat(copyEntry.getValue()).isSameAs(originalEntry.getValue());
+
+    copy.settings.clear();
+    assertThat(original.settings).isNotEmpty();
+  }
+
+  private static Map<String, String> renderSettings(final RebuildTypeStatement statement) {
+    final Map<String, String> rendered = new HashMap<>();
+    for (final Map.Entry<Expression, Expression> entry : statement.settings.entrySet())
+      rendered.put(entry.getKey().toString(), entry.getValue().toString());
+    return rendered;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6442.

- **Item 1** - `RebuildTypeStatement#copy()` deep-copied every `settings` map entry's key and value, while the rest of the `WITH`-settings family (`RebuildIndex`/`Export`/`Backup`/`ImportDatabaseStatement`) shallow-copies via `settings.putAll(...)`. `Expression` nodes are effectively immutable post-parse, so the deep copy protected against nothing and only doubled allocations on every `copy()` call. Normalized on the shallow copy the other four already use (the alternative - deep-copying the other four instead - would add allocations across the whole family for no behavioral benefit, so shallow is the better direction).
- **Item 2** - widened the `#6401`/`#6409`/`#6428` node-identity corpus test (`Issue6401NodeIdentityTest`) with a batch of previously-unexercised shapes: `MATCH`, `CREATE EDGE`, `CREATE INDEX`, `LET`, `CONTAINS`, `INSTANCEOF`, `IF`. None of the seven surfaced a new defect this round - a real (if less exciting) outcome of the recipe the issue asked for, not a full audit.

## Test plan
- [x] New `RebuildTypeStatementTestParserTest` - verifies `copy()`/`equals()`/`hashCode()` still round-trip `WITH` settings, and asserts the copy's settings map is a distinct instance holding the SAME `Expression` key/value references as the original (a regression test: reverting to the per-entry `.copy()` fails this assertion while still passing every `equals()`/`hashCode()` check - verified by reverting the fix locally and confirming the new test fails).
- [x] Widened `Issue6401NodeIdentityTest#equalNodesAnswerEqualHashCodes` corpus - all pass.
- [x] `mvn -o test -pl engine -am -Dtest='com.arcadedb.query.sql.parser.**'` - 406 tests, 0 failures.
- [x] `mvn -o test -pl engine -am -Dtest=RebuildTypeRepartitionTest` - 9 tests, 0 failures (existing executor-level coverage for `RebuildTypeStatement` unaffected).