### PR TITLE
fix(#6446): bare CALL output swallowed, RemoteSchema cache staleness on raw DDL

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -311,9 +311,15 @@ public class CypherExecutionPlan {
       // write statement, even if it performed no actual mutation (containsUpdates() is false then).
       final QueryStatistics stats = context.getStatistics();
 
+      // A bare CALL (no YIELD/RETURN, e.g. a write-classified custom function or write procedure) is its
+      // own projection: CallStep already yields its implicit "all columns" row, so a missing RETURN clause
+      // here does not mean "side effects only" the way it does for CREATE/SET/DELETE/MERGE/REMOVE. Issue #6446.
+      final List<ClauseEntry> clauses = statement.getClausesInOrder();
+      final boolean bareCallOwnsProjection = clauses.size() == 1 && clauses.get(0).getType() == ClauseEntry.ClauseType.CALL;
+
       // If no RETURN clause (or GQL FINISH was used), return empty results
       // (write side effects still happened). Issue #3365 section 1.3.
-      if (statement.getReturnClause() == null || statement.hasFinishClause()) {
+      if (statement.hasFinishClause() || (statement.getReturnClause() == null && !bareCallOwnsProjection)) {
         final IteratorResultSet empty = new IteratorResultSet(Collections.<Result>emptyList().iterator());
         empty.setStatistics(stats);
         return empty;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -314,6 +314,9 @@ public class CypherExecutionPlan {
       // A bare CALL (no YIELD/RETURN, e.g. a write-classified custom function or write procedure) is its
       // own projection: CallStep already yields its implicit "all columns" row, so a missing RETURN clause
       // here does not mean "side effects only" the way it does for CREATE/SET/DELETE/MERGE/REMOVE. Issue #6446.
+      // Deliberately scoped to a CALL that is the statement's ONLY clause: a CALL chained after other
+      // clauses (e.g. WITH ... CALL proc() YIELD x, or multiple chained CALLs), still with no trailing
+      // RETURN, is a separate, narrower gap left for #6450 rather than widened here.
       final List<ClauseEntry> clauses = statement.getClausesInOrder();
       final boolean bareCallOwnsProjection = clauses.size() == 1 && clauses.get(0).getType() == ClauseEntry.ClauseType.CALL;
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
@@ -373,6 +373,26 @@ class OpenCypherUnionCallProfileTest {
   }
 
   @Test
+  void readClassifiedBareCallStillSurfacesItsOwnOutputUnaffectedByTheFix() {
+    // Sanity check the other direction: the swallowing bug only ever existed on the write-classified
+    // path (CypherExecutionPlan.execute()'s hasWriteOps branch). A bare CALL to a registered read-only
+    // procedure (db.labels(), no args) was never broken - the read-only path returns the ResultSet
+    // unfiltered, with no "no RETURN" special-casing at all - and must keep working exactly the same.
+    database.getSchema().getOrCreateVertexType("ReadOnlyCallLabel");
+
+    final ResultSet result = database.command("opencypher", "CALL db.labels()");
+
+    assertThat(result.hasNext()).isTrue();
+    boolean found = false;
+    while (result.hasNext()) {
+      final Result row = result.next();
+      if ("ReadOnlyCallLabel".equals(row.getProperty("label")))
+        found = true;
+    }
+    assertThat(found).isTrue();
+  }
+
+  @Test
   void writeStatementWithNoReturnStillYieldsNoRows() {
     // Sanity check the fix didn't broaden past bare CALL: a genuine write statement (CREATE, no CALL
     // clause at all) with no RETURN clause must still report zero rows, side effects only.

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
@@ -352,6 +352,24 @@ class OpenCypherUnionCallProfileTest {
     assertThat(result.hasNext()).isTrue();
     final Result row = result.next();
     assertThat((Object) row.getProperty("value")).isEqualTo("Hello World");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  void bareCallWithExplicitYieldColumnListSurfacesItsOwnOutput() {
+    // Same bug, explicit YIELD column-list shape (no *, no RETURN): still a single-clause CALL
+    // statement, so it's still CallStep's own projection - here filtered to the named column - that
+    // must surface, not the "no RETURN -> side effects only" empty result.
+    database.command("sql", "DEFINE FUNCTION math.add \"SELECT :a + :b AS result\" PARAMETERS [a,b] LANGUAGE sql");
+
+    final ResultSet result = database.command("opencypher", "CALL math.add(3, 5) YIELD value");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    final Object value = row.getProperty("value");
+    assertThat(value).isNotNull();
+    assertThat(((Number) value).intValue()).isEqualTo(8);
+    assertThat(result.hasNext()).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
@@ -299,10 +299,7 @@ class OpenCypherUnionCallProfileTest {
 
     // Test calling the custom function via Cypher CALL. command(), not query(): a CALL target unresolved
     // against the built-in registries is indistinguishable at parse time from a custom DEFINE FUNCTION call,
-    // so query() now rejects it as not idempotent (issue #6418). Explicit YIELD/RETURN, not a bare CALL: a
-    // write-classified statement with no RETURN clause is CypherExecutionPlan.execute()'s signal that only
-    // side effects matter (CREATE/SET/DELETE with nothing to project), which swallows a bare CALL's own
-    // implicit output the same way once the CALL itself is no longer misclassified read-only.
+    // so query() now rejects it as not idempotent (issue #6418).
     final ResultSet result = database.command("opencypher", "CALL math.add(3, 5) YIELD value RETURN value");
 
     assertThat(result.hasNext()).isTrue();
@@ -318,14 +315,58 @@ class OpenCypherUnionCallProfileTest {
     // Define a custom SQL function that returns input
     database.command("sql", "DEFINE FUNCTION my.echo \"SELECT :input AS output\" PARAMETERS [input] LANGUAGE sql");
 
-    // Test calling with string parameter. command(), not query(), and explicit YIELD/RETURN: see
-    // callCustomSQLFunction above.
+    // Test calling with string parameter. command(), not query(): see callCustomSQLFunction above.
     final ResultSet result = database.command("opencypher", "CALL my.echo('Hello World') YIELD value RETURN value");
 
     assertThat(result.hasNext()).isTrue();
     final Result row = result.next();
     // The SQL function returns a scalar which gets wrapped with "value" property
     assertThat((Object) row.getProperty("value")).isEqualTo("Hello World");
+  }
+
+  @Test
+  void bareCallToWriteClassifiedFunctionSurfacesItsOwnOutput() {
+    // Issue #6446 item 1 regression: a bare CALL (no YIELD/RETURN at all) to a custom DEFINE FUNCTION
+    // is write-classified (issue #6418, since the name is unresolved against any built-in registry) and
+    // used to have its own implicit "yield all columns" output silently discarded by
+    // CypherExecutionPlan.execute()'s "no RETURN clause -> side effects only" shortcut.
+    database.command("sql", "DEFINE FUNCTION math.add \"SELECT :a + :b AS result\" PARAMETERS [a,b] LANGUAGE sql");
+
+    final ResultSet result = database.command("opencypher", "CALL math.add(3, 5)");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    final Object value = row.getProperty("value");
+    assertThat(value).isNotNull();
+    assertThat(((Number) value).intValue()).isEqualTo(8);
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  void bareCallWithYieldStarSurfacesItsOwnOutput() {
+    // Same bug, YIELD * shape: isYieldAll() also owns its projection with no separate RETURN clause.
+    database.command("sql", "DEFINE FUNCTION my.echo \"SELECT :input AS output\" PARAMETERS [input] LANGUAGE sql");
+
+    final ResultSet result = database.command("opencypher", "CALL my.echo('Hello World') YIELD *");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat((Object) row.getProperty("value")).isEqualTo("Hello World");
+  }
+
+  @Test
+  void writeStatementWithNoReturnStillYieldsNoRows() {
+    // Sanity check the fix didn't broaden past bare CALL: a genuine write statement (CREATE, no CALL
+    // clause at all) with no RETURN clause must still report zero rows, side effects only.
+    database.getSchema().getOrCreateVertexType("NoReturnNode");
+
+    final ResultSet result = database.command("opencypher", "CREATE (n:NoReturnNode {name: 'x'})");
+
+    assertThat(result.hasNext()).isFalse();
+
+    final ResultSet check = database.query("opencypher", "MATCH (n:NoReturnNode) RETURN n.name AS name");
+    assertThat(check.hasNext()).isTrue();
+    assertThat((Object) check.next().getProperty("name")).isEqualTo("x");
   }
 
   // ============================================================

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -81,10 +81,12 @@ public class RemoteSchema implements Schema {
   @Override
   public boolean existsType(final String typeName) {
     checkSchemaIsLoaded();
-    if (types.containsKey(typeName))
-      return true;
-    reload();
-    return types.containsKey(typeName);
+    boolean found = types.containsKey(typeName);
+    if (!found) {
+      reload();
+      found = types.containsKey(typeName);
+    }
+    return found;
   }
 
   @Override

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -55,6 +55,17 @@ import java.util.stream.Collectors;
  * see the previous complete snapshot or the new one, never a partially-built map. Prior to this
  * change, two threads could race on the {@code null}-gated init and hit
  * {@link java.util.ConcurrentModificationException} inside {@link java.util.HashMap#computeIfAbsent}.
+ * <p>
+ * A type/bucket lookup by name that misses the cache (e.g. one created afterward by raw DDL through
+ * {@code command()}, which - unlike the {@code createXxxType()} helpers - does not invalidate this
+ * cache, or by another connection/session entirely) retries with a single {@link #reload()} before
+ * giving up, so a genuinely nonexistent name still fails fast, and a name that exists but was created
+ * after this cache warmed up is found on the very next lookup regardless of timing. A time-based
+ * debounce on that retry was considered and rejected: it can silently suppress the retry for a lookup
+ * that happens to land within the debounce window of an earlier, unrelated reload - exactly the
+ * cross-connection scenario this class exists to fix. A caller that walks many known-nonexistent
+ * names in a hot loop does pay one reload per miss; that cost is bounded per call and was judged
+ * preferable to reintroducing stale reads. Issue #6446.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -72,9 +83,6 @@ public class RemoteSchema implements Schema {
     checkSchemaIsLoaded();
     if (types.containsKey(typeName))
       return true;
-    // Cache miss: the type may have been created by raw DDL through command() (which, unlike the
-    // createXxxType() helpers, does not invalidate this cache) or by another connection/session
-    // entirely. One bounded reload before giving up keeps a genuinely nonexistent type failing fast. Issue #6446.
     reload();
     return types.containsKey(typeName);
   }
@@ -353,7 +361,6 @@ public class RemoteSchema implements Schema {
 
     RemoteDocumentType t = types.get(typeName);
     if (t == null) {
-      // See existsType() for why a single bounded reload happens here before failing.
       reload();
       t = types.get(typeName);
     }
@@ -367,7 +374,6 @@ public class RemoteSchema implements Schema {
     checkSchemaIsLoaded();
     RemoteDocumentType t = types.get(typeName);
     if (t == null) {
-      // See existsType() for why a single bounded reload happens here before giving up.
       reload();
       t = types.get(typeName);
     }
@@ -609,7 +615,11 @@ public class RemoteSchema implements Schema {
   @Override
   public RemoteBucket getBucketByName(final String name) {
     checkSchemaIsLoaded();
-    final RemoteBucket b = buckets.get(name);
+    RemoteBucket b = buckets.get(name);
+    if (b == null) {
+      reload();
+      b = buckets.get(name);
+    }
     if (b == null)
       throw new SchemaException("Bucket '" + name + "' not found");
     return b;
@@ -619,7 +629,12 @@ public class RemoteSchema implements Schema {
   @Override
   public RemoteBucket getBucketByNameIfExists(final String name) {
     checkSchemaIsLoaded();
-    return buckets.get(name);
+    RemoteBucket b = buckets.get(name);
+    if (b == null) {
+      reload();
+      b = buckets.get(name);
+    }
+    return b;
   }
 
   @Deprecated

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -70,6 +70,12 @@ public class RemoteSchema implements Schema {
   @Override
   public boolean existsType(final String typeName) {
     checkSchemaIsLoaded();
+    if (types.containsKey(typeName))
+      return true;
+    // Cache miss: the type may have been created by raw DDL through command() (which, unlike the
+    // createXxxType() helpers, does not invalidate this cache) or by another connection/session
+    // entirely. One bounded reload before giving up keeps a genuinely nonexistent type failing fast. Issue #6446.
+    reload();
     return types.containsKey(typeName);
   }
 
@@ -345,7 +351,12 @@ public class RemoteSchema implements Schema {
   public DocumentType getType(final String typeName) {
     checkSchemaIsLoaded();
 
-    final RemoteDocumentType t = types.get(typeName);
+    RemoteDocumentType t = types.get(typeName);
+    if (t == null) {
+      // See existsType() for why a single bounded reload happens here before failing.
+      reload();
+      t = types.get(typeName);
+    }
     if (t == null)
       throw new SchemaException("Type with name '" + typeName + "' was not found");
     return t;
@@ -354,7 +365,13 @@ public class RemoteSchema implements Schema {
   @Override
   public DocumentType getTypeOrNull(final String typeName) {
     checkSchemaIsLoaded();
-    return types.get(typeName);
+    RemoteDocumentType t = types.get(typeName);
+    if (t == null) {
+      // See existsType() for why a single bounded reload happens here before giving up.
+      reload();
+      t = types.get(typeName);
+    }
+    return t;
   }
 
   @Override

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -65,7 +65,10 @@ import java.util.stream.Collectors;
  * that happens to land within the debounce window of an earlier, unrelated reload - exactly the
  * cross-connection scenario this class exists to fix. A caller that walks many known-nonexistent
  * names in a hot loop does pay one reload per miss; that cost is bounded per call and was judged
- * preferable to reintroducing stale reads. Issue #6446.
+ * preferable to reintroducing stale reads. The same trade-off applies under concurrent misses: several
+ * threads missing at once each still call {@link #reload()} in turn after serializing on its
+ * {@code synchronized} lock - there is no "someone already refreshed since my check" short-circuit -
+ * so N concurrent misses cost N round trips, not one. Issue #6446.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.remote;
 
 import com.arcadedb.engine.Bucket;
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
@@ -35,6 +36,8 @@ import java.util.TimeZone;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RemoteSchemaTest {
@@ -438,6 +441,75 @@ class RemoteSchemaTest {
     assertThat(schema.existsType("Person")).isTrue();
     assertThat(schema.existsType("Knows")).isTrue();
     assertThat(schema.existsType("Readings")).isTrue();
+  }
+
+  // Issue #6446 item 2: a type created via raw DDL through command() (not the createXxxType() helpers,
+  // which force an eager reload()) must still become visible to an already-schema-warm cache, via a
+  // bounded one-shot reload() retry on a cache miss.
+
+  @Test
+  void existsTypeRetriesReloadOnCacheMissAndFindsNewlyCreatedType() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    final ResultSet freshRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"), buildTypeRecord("Address", "vertex"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, freshRs);
+
+    schema.reload();
+    assertThat(schema.existsType("Person")).isTrue();
+
+    // "Address" was created by raw DDL after the cache warmed up: not yet known to this cache.
+    assertThat(schema.existsType("Address")).isTrue();
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  @Test
+  void getTypeRetriesReloadOnCacheMissAndFindsNewlyCreatedType() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    final ResultSet freshRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"), buildTypeRecord("Address", "vertex"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, freshRs);
+
+    schema.reload();
+
+    final DocumentType t = schema.getType("Address");
+    assertThat(t.getName()).isEqualTo("Address");
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  @Test
+  void getTypeOrNullRetriesReloadOnCacheMissAndFindsNewlyCreatedType() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    final ResultSet freshRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"), buildTypeRecord("Address", "vertex"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, freshRs);
+
+    schema.reload();
+
+    assertThat(schema.getTypeOrNull("Address")).isNotNull();
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  @Test
+  void existsTypeStillFailsFastForGenuinelyMissingTypeAfterOneRetry() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    // The retry itself finds the same snapshot again: the type genuinely does not exist anywhere.
+    final ResultSet retryRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, retryRs);
+
+    schema.reload();
+
+    assertThat(schema.existsType("DoesNotExist")).isFalse();
+    // Bounded: checkSchemaIsLoaded()'s initial load, plus exactly one retry - never an unbounded loop.
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  @Test
+  void getTypeStillThrowsForGenuinelyMissingTypeAfterOneRetry() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    final ResultSet retryRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, retryRs);
+
+    schema.reload();
+
+    assertThatThrownBy(() -> schema.getType("DoesNotExist")).isInstanceOf(SchemaException.class);
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
   }
 
   private static ResultInternal buildTypeRecord(final String name, final String typeCode) {

--- a/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
@@ -512,6 +512,60 @@ class RemoteSchemaTest {
     verify(mockDatabase, times(2)).command("sql", "select from schema:types");
   }
 
+  // Reviewer follow-up on #6446: getBucketByName()/getBucketByNameIfExists() shared the exact same
+  // staleness bug as the type accessors (both are rebuilt from the same reload() snapshot) but weren't
+  // covered by the original fix.
+
+  @Test
+  void getBucketByNameRetriesReloadOnCacheMissAndFindsNewlyCreatedBucket() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    final ResultSet freshRs = buildTypeRecordWithBucket("Address", "vertex", "address_bucket");
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, freshRs);
+
+    schema.reload();
+
+    final Bucket b = schema.getBucketByName("address_bucket");
+    assertThat(b.getName()).isEqualTo("address_bucket");
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  @Test
+  void getBucketByNameIfExistsRetriesReloadOnCacheMissAndFindsNewlyCreatedBucket() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    final ResultSet freshRs = buildTypeRecordWithBucket("Address", "vertex", "address_bucket");
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, freshRs);
+
+    schema.reload();
+
+    assertThat(schema.getBucketByNameIfExists("address_bucket")).isNotNull();
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  @Test
+  void getBucketByNameStillThrowsForGenuinelyMissingBucketAfterOneRetry() {
+    final ResultSet staleRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    final ResultSet retryRs = buildSchemaResultSet(buildTypeRecord("Person", "vertex"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(staleRs, retryRs);
+
+    schema.reload();
+
+    assertThatThrownBy(() -> schema.getBucketByName("does_not_exist")).isInstanceOf(SchemaException.class);
+    verify(mockDatabase, times(2)).command("sql", "select from schema:types");
+  }
+
+  private static ResultSet buildTypeRecordWithBucket(final String typeName, final String typeCode, final String bucketName) {
+    final ResultInternal r = new ResultInternal();
+    r.setProperty("name", typeName);
+    r.setProperty("type", typeCode);
+    r.setProperty("records", 0L);
+    r.setProperty("buckets", List.of(bucketName));
+    r.setProperty("bucketSelectionStrategy", "round-robin");
+    r.setProperty("parentTypes", Collections.emptyList());
+    r.setProperty("properties", Collections.emptyList());
+    r.setProperty("custom", new HashMap<>());
+    return buildSchemaResultSet(r);
+  }
+
   private static ResultInternal buildTypeRecord(final String name, final String typeCode) {
     final ResultInternal r = new ResultInternal();
     r.setProperty("name", name);

--- a/server/src/test/java/com/arcadedb/remote/RemoteSchemaIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteSchemaIT.java
@@ -186,6 +186,36 @@ class RemoteSchemaIT extends BaseGraphServerTest {
     });
   }
 
+  /**
+   * Issue #6446 item 2: a type created via raw DDL through command() (as opposed to the createXxxType()
+   * helpers, which force an eager reload() of the schema cache) must still become visible to an
+   * already-schema-warm RemoteDatabase connection - including one that never issued the DDL itself.
+   */
+  @Test
+  void rawDdlThroughCommandIsVisibleToAlreadyWarmSchemaCache() throws Exception {
+    testEachServer(serverIndex -> {
+      try (final RemoteDatabase warmDatabase = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
+          BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)) {
+
+        // Warm the schema cache before the type exists, exactly like a long-lived connection would.
+        assertThat(warmDatabase.getSchema().existsType("RawDdlType")).isFalse();
+
+        // A second, independent connection issues the DDL directly, bypassing createVertexType().
+        try (final RemoteDatabase otherDatabase = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
+            BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)) {
+          otherDatabase.command("sql", "CREATE VERTEX TYPE RawDdlType");
+        }
+
+        // The already-warm connection must see the new type without ever calling reload() itself.
+        assertThat(warmDatabase.getSchema().existsType("RawDdlType")).isTrue();
+        assertThat(warmDatabase.getSchema().getType("RawDdlType")).isNotNull();
+        assertThat(warmDatabase.getSchema().getTypeOrNull("RawDdlType")).isNotNull();
+
+        warmDatabase.getSchema().dropType("RawDdlType");
+      }
+    });
+  }
+
   @BeforeEach
   public void beginTest() {
     super.beginTest();


### PR DESCRIPTION
## Summary
- `CypherExecutionPlan.execute()`'s write branch treated "no RETURN clause" as "nothing to project, side effects only" - correct for CREATE/SET/DELETE/MERGE/REMOVE, but it also silently discarded a bare `CALL proc(...)` statement's own implicit yield-all output once that CALL became write-classified (a regression surface opened by the #6418 classification fix). The branch now falls through to the materialized rows when the statement's only clause is a CALL (covers no-YIELD, `YIELD *`, and an explicit `YIELD col` list uniformly).
- `RemoteSchema`'s `types`/`buckets` caches were only refreshed the first time they loaded (`checkSchemaIsLoaded()` is null-gated). A type (or bucket) created afterwards via raw DDL through `command()` - as opposed to the `createXxxType()` helpers, which force an eager `reload()` - stayed invisible to an already-warm cache indefinitely, including a cache on a *different* connection/session that never issued the DDL. `existsType()`/`getType()`/`getTypeOrNull()`/`getBucketByName()`/`getBucketByNameIfExists()` now retry with a single bounded `reload()` on a cache miss before giving up, so a genuinely nonexistent name still fails fast.
- **Behavior change for `RemoteDatabase` callers**: a miss on any of the five lookups above now costs one extra network round trip (a full `select from schema:types` re-fetch) instead of being cache-only after warmup. A caller that repeatedly checks names that are usually absent (e.g. a hot loop probing many candidate type names) will now pay one round trip per miss. A time-based debounce to collapse repeated misses was implemented and then reverted - it silently suppressed the retry for a lookup that happened to land within the debounce window of an *unrelated* prior reload, which is exactly the cross-connection scenario this fix targets, and broke the new IT test that reproduces it. The trade-off (bounded per-call cost, correctness over the unconfirmed hot-path concern) is documented in `RemoteSchema`'s class Javadoc.
- Item 3 of the issue (`ha-integration-tests` chronic flake - additional test name observed) is informational only, already tracked as a pre-existing chronic flake unrelated to code content; no code change needed.
- A related but distinct gap found during review - `WITH ... CALL proc() YIELD x` (CALL not the sole clause, no RETURN) currently parses and silently returns zero rows, where real Neo4j rejects it as a compile error - is out of scope here and filed separately as #6450.

## Test plan
- [x] New regression tests in `OpenCypherUnionCallProfileTest`: bare `CALL math.add(3, 5)`, `CALL my.echo(...) YIELD *`, and `CALL math.add(3, 5) YIELD value` (explicit column list) all now surface their own output; a genuine no-RETURN write statement (`CREATE`) still yields zero rows.
- [x] New regression tests in `RemoteSchemaTest` (mocked): cache-miss retry finds a type/bucket added between two `select from schema:types` calls; a genuinely missing type/bucket still fails after exactly one bounded retry (`getType`/`getTypeOrNull`/`existsType`/`getBucketByName`/`getBucketByNameIfExists`).
- [x] New regression IT in `RemoteSchemaIT`: a type created via raw `command("sql", "CREATE VERTEX TYPE ...")` on one `RemoteDatabase` connection becomes visible to a second, already-schema-warm connection without either issuing an explicit `reload()`.
- [x] `mvn -o -pl engine -am test -Dtest="com.arcadedb.query.opencypher.**"` - 8761 tests, 0 failures.
- [x] `mvn -o -pl network test` - 458 tests, 0 failures.
- [x] `mvn -o -Pintegration -DskipTests=true -Dit.test=RemoteSchemaIT -pl server -am verify` - 6 tests, 0 failures.
- [x] Verified both new unit-test sets fail without the corresponding fix (temporarily reverted `RemoteSchema.java`), confirming they're real regression tests. Also verified the (rejected) debounce approach by watching it break the cross-connection IT test before reverting it.

Fixes #6446.