### PR TITLE
fix(#6380, #6381): stale bucket-selection total after bucket removal, and restore's unrevalidated HTTP redirects

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -1734,6 +1734,10 @@ public class LocalDocumentType implements DocumentType {
         s.updatePolymorphicBucketsCache(false, removedBuckets, removedBucketIds);
     }
 
+    // SYMMETRIC TO addBucketInternal: REBIND THE STRATEGY SO ITS CACHED BUCKET COUNT (E.G. RoundRobinBucketSelectionStrategy.total)
+    // TRACKS THE SHRUNK LIST. WITHOUT THIS THE STRATEGY CAN STILL HAND OUT AN INDEX ONE PAST THE NEW LAST BUCKET (ISSUE #6380).
+    bucketSelectionStrategy.setType(this);
+
     // AUTOMATICALLY DROP THE INDEX ON THE REMOVED BUCKET (INCLUDING INHERITED INDEXES FROM PARENT TYPES)
     final Collection<TypeIndex> existentIndexes = getAllIndexes(true);
 

--- a/engine/src/test/java/com/arcadedb/schema/Issue6380RemoveBucketStrategyRefreshTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6380RemoveBucketStrategyRefreshTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.engine.Bucket;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * {@code removeBucketInternal} shrank the bucket list but never re-bound the type's bucket-selection strategy, so the
+ * strategy's cached {@code total} stayed at the pre-removal bucket count. Round-robin selection keeps handing out
+ * indexes up to the stale {@code total}, and once that reaches the old last index the type's own {@code buckets.get(...)}
+ * throws {@link IndexOutOfBoundsException} because the bucket at that index is gone.
+ * <p>
+ * {@code addBucketInternal} already rebinds the strategy after growing the list (symmetric fix, issue #6380).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6380RemoveBucketStrategyRefreshTest extends TestHelper {
+
+  @Test
+  void insertAfterRemovingBucketDoesNotThrowIndexOutOfBounds() {
+    database.transaction(() -> database.getSchema().createDocumentType("Product", 3));
+
+    // Detach one of the three buckets, leaving a still-populated (well, still-usable) 2-bucket type behind.
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().getType("Product");
+      final Bucket lastBucket = type.getBuckets(false).get(type.getBuckets(false).size() - 1);
+      type.removeBucket(lastBucket);
+    });
+
+    // Round-robin's cursor starts at -1: three inserts push it through indexes 0, 1 and then the stale index 2, which
+    // is exactly the index that used to be valid before the bucket was removed. Without the fix, the third insert
+    // throws IndexOutOfBoundsException instead of wrapping back to index 0 against the now-correct 2-bucket total.
+    assertThatCode(() -> database.transaction(() -> {
+      for (int i = 0; i < 6; i++) {
+        final MutableDocument doc = database.newDocument("Product");
+        doc.set("id", i);
+        doc.save();
+      }
+    })).doesNotThrowAnyException();
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
@@ -86,6 +86,16 @@ public class Restore {
     return this;
   }
 
+  /**
+   * Overrides {@link com.arcadedb.GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} for this restore. The
+   * server command handler calls this reflectively with the value it already validated the URL against, so the
+   * fetch cannot land on a stricter-or-looser answer than the pre-check that accepted the command (issue #6381).
+   */
+  public Restore setAllowLocalUrls(final boolean allowLocalUrls) {
+    settings.allowLocalUrls = allowLocalUrls;
+    return this;
+  }
+
   protected AbstractRestoreFormat createFormatImplementation() {
     switch (settings.format.toLowerCase(Locale.ENGLISH)) {
     case "full":

--- a/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
@@ -48,6 +48,14 @@ public class RestoreSettings {
    * {@link com.arcadedb.GlobalConfiguration#RESTORE_THREADS}.
    */
   public       Integer             restoreThreads;
+  /**
+   * Whether an http(s) input URL may resolve to a local-file, loopback, link-local or private-network address.
+   * {@code null} defers to {@link com.arcadedb.GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} (the
+   * default, and what a CLI/embedded invocation with no server gets); a caller that already resolved this against
+   * its own configuration - the server command handler, against its per-instance {@code ContextConfiguration} - sets
+   * it explicitly so the fetch-time check agrees with whatever pre-check already accepted the command (issue #6381).
+   */
+  public       Boolean             allowLocalUrls;
   public final Map<String, String> options              = new HashMap<>();
 
   protected void parseParameters(final String[] args) {

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
@@ -222,7 +222,13 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
       // THAN LETTING HttpURLConnection FOLLOW REDIRECTS ITSELF: A REDIRECT (OR A DNS-REBOUND RE-RESOLUTION) THAT
       // LANDS ON A BLOCKED ADDRESS WOULD OTHERWISE BYPASS THE ONE-SHOT HOST CHECK
       // PostServerCommandHandler.validateClientRestoreImportUrl ALREADY DID BEFORE HANDING OFF THE URL (ISSUE #6381).
-      final boolean allowLocalUrls = GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.getValueAsBoolean();
+      //
+      // settings.allowLocalUrls IS SET EXPLICITLY BY A CALLER THAT ALREADY RESOLVED THIS AGAINST ITS OWN
+      // CONFIGURATION (THE SERVER COMMAND HANDLER, AGAINST ITS PER-INSTANCE ContextConfiguration) SO THE FETCH AGREES
+      // WITH WHATEVER PRE-CHECK ALREADY ACCEPTED THE COMMAND. A CLI/EMBEDDED CALLER WITH NO SUCH CONTEXT LEAVES IT
+      // null AND FALLS BACK TO THE STATIC GLOBAL DEFAULT.
+      final boolean allowLocalUrls = settings.allowLocalUrls != null ?
+          settings.allowLocalUrls : GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.getValueAsBoolean();
       final HttpURLConnection connection = SafeHttpFetcher.open(settings.inputFileURL,
           address -> !allowLocalUrls && RESERVED_ADDRESSES.isBlocked(address), "RESTORE DATABASE");
 

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
@@ -44,15 +44,15 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class FullRestoreFormat extends AbstractRestoreFormat {
-  private interface RestoreCallback {
-    ParallelZipExtractor.ExtractStats restore(ZipInputStream zipFile) throws Exception;
-  }
-
   // SHARED WITH PostServerCommandHandler.isBlockedHost AND ImportSecurityValidator.isBlockedAddress: SEE
   // IPAddressBlocklist FOR WHY THIS MUST NOT BE A PER-CALLER COPY (GHSA-67m7-7w7g-mpmh).
   private static final IPAddressBlocklist RESERVED_ADDRESSES = IPAddressBlocklist.defaultReservedRanges();
 
   private final byte[] BUFFER = new byte[ParallelZipExtractor.BUFFER_SIZE];
+
+  private interface RestoreCallback {
+    ParallelZipExtractor.ExtractStats restore(ZipInputStream zipFile) throws Exception;
+  }
 
   /**
    * Where the archive is, and how it can be read. Exactly one of the two is set: a local {@code File}, or an already

--- a/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
@@ -24,6 +24,8 @@ import com.arcadedb.integration.importer.ConsoleLogger;
 import com.arcadedb.integration.restore.RestoreException;
 import com.arcadedb.integration.restore.RestoreSettings;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.IPAddressBlocklist;
+import com.arcadedb.utility.SafeHttpFetcher;
 
 import java.io.*;
 
@@ -36,7 +38,6 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.spec.KeySpec;
 import java.util.zip.ZipEntry;
@@ -46,6 +47,10 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
   private interface RestoreCallback {
     ParallelZipExtractor.ExtractStats restore(ZipInputStream zipFile) throws Exception;
   }
+
+  // SHARED WITH PostServerCommandHandler.isBlockedHost AND ImportSecurityValidator.isBlockedAddress: SEE
+  // IPAddressBlocklist FOR WHY THIS MUST NOT BE A PER-CALLER COPY (GHSA-67m7-7w7g-mpmh).
+  private static final IPAddressBlocklist RESERVED_ADDRESSES = IPAddressBlocklist.defaultReservedRanges();
 
   private final byte[] BUFFER = new byte[ParallelZipExtractor.BUFFER_SIZE];
 
@@ -213,10 +218,13 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
 
   private RestoreInputSource openInputFile() throws IOException {
     if (settings.inputFileURL.startsWith("http://") || settings.inputFileURL.startsWith("https://")) {
-      final HttpURLConnection connection = (HttpURLConnection) new URL(settings.inputFileURL).openConnection();
-      connection.setRequestMethod("GET");
-      connection.setDoOutput(true);
-      connection.connect();
+      // ROUTE THROUGH THE SAME PER-HOP-REVALIDATING FETCHER `IMPORT DATABASE` USES (ImportSecurityValidator), RATHER
+      // THAN LETTING HttpURLConnection FOLLOW REDIRECTS ITSELF: A REDIRECT (OR A DNS-REBOUND RE-RESOLUTION) THAT
+      // LANDS ON A BLOCKED ADDRESS WOULD OTHERWISE BYPASS THE ONE-SHOT HOST CHECK
+      // PostServerCommandHandler.validateClientRestoreImportUrl ALREADY DID BEFORE HANDING OFF THE URL (ISSUE #6381).
+      final boolean allowLocalUrls = GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.getValueAsBoolean();
+      final HttpURLConnection connection = SafeHttpFetcher.open(settings.inputFileURL,
+          address -> !allowLocalUrls && RESERVED_ADDRESSES.isBlocked(address), "RESTORE DATABASE");
 
       return new RestoreInputSource(null, connection.getInputStream(), 0);
     }

--- a/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/Issue6086ParallelRestoreIT.java
@@ -185,6 +185,10 @@ class Issue6086ParallelRestoreIT {
       }
     });
     server.start();
+    // The archive is served over loopback HTTP by the test server above, not a real remote host: opt in to
+    // SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS the way a trusting operator would, since the default-blocked local
+    // address is exactly what this test's own HttpServer is (issue #6381).
+    GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.setValue(true);
     try {
       final String url = "http://localhost:" + server.getAddress().getPort() + "/backup.zip";
       final List<LogLine> log = restore(url, RESTORED_PATH, 8, null);
@@ -197,6 +201,7 @@ class Issue6086ParallelRestoreIT {
       }
     } finally {
       server.stop(0);
+      GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.reset();
     }
     TestHelper.checkActiveDatabases();
   }

--- a/integration/src/test/java/com/arcadedb/integration/restore/format/Issue6381RestoreSsrfTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/format/Issue6381RestoreSsrfTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.restore.format;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.integration.restore.RestoreSettings;
+import com.arcadedb.utility.FileUtils;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6381: {@code restore database} opened its HTTP(S) input with plain
+ * {@code HttpURLConnection}, which follows same-protocol 3xx redirects itself with no revalidation of the redirect
+ * target. An attacker-controlled public host answering {@code 302 Location: http://169.254.169.254/...} walked
+ * straight past the one-shot host check {@code PostServerCommandHandler.validateClientRestoreImportUrl} performs
+ * before handing the URL to restore - the exact bypass already fixed for {@code IMPORT DATABASE}
+ * (GHSA-4w2m-77c8-83mw) but left unfixed here. {@code openInputFile()} now routes through {@link
+ * com.arcadedb.utility.SafeHttpFetcher}, the same per-hop-revalidating fetcher {@code ImportSecurityValidator} uses;
+ * the redirect-chain behaviour itself (blocked target, blocked scheme, redirect loop, ...) is covered exhaustively by
+ * {@code SafeHttpFetcherTest} and is not repeated here. These tests instead prove the restore-specific wiring: the
+ * fetch is gated by {@link GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} end to end through {@link
+ * FullRestoreFormat#restoreDatabase()}, not only when {@code SafeHttpFetcher} is called directly.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6381RestoreSsrfTest {
+
+  private static final String CONTENT = "not-a-real-zip-archive";
+
+  private HttpServer server;
+  private String     baseUrl;
+  private File       databaseDirectory;
+
+  @BeforeEach
+  void startServer() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+
+    server.createContext("/content", exchange -> {
+      final byte[] body = CONTENT.getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(200, body.length);
+      exchange.getResponseBody().write(body);
+      exchange.close();
+    });
+
+    // A redirect hop, to prove restore follows redirects through the fetcher rather than refusing them outright.
+    server.createContext("/redirect-to-content", exchange -> {
+      exchange.getResponseHeaders().add("Location", baseUrl + "/content");
+      exchange.sendResponseHeaders(302, -1);
+      exchange.close();
+    });
+
+    server.start();
+
+    databaseDirectory = new File("./target/databases/Issue6381RestoreSsrfTest");
+    FileUtils.deleteRecursively(databaseDirectory);
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null)
+      server.stop(0);
+    GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.reset();
+    FileUtils.deleteRecursively(databaseDirectory);
+  }
+
+  @Test
+  void restoreRefusesLocalAddressByDefault() {
+    // Loopback is blocked by IPAddressBlocklist like any other private/local target; before the fix restore never
+    // consulted the blocklist at fetch time at all (only the server's one-shot pre-check did, and only for the
+    // original hostname). No redirect is even needed to prove the wiring reaches the shared blocklist.
+    final RestoreSettings settings = new RestoreSettings();
+    settings.format = "full";
+    settings.inputFileURL = baseUrl + "/content";
+    settings.databaseDirectory = databaseDirectory.getPath();
+
+    // database is never reached: openInputFile() must throw before restoreDatabase() touches it.
+    final FullRestoreFormat restore = new FullRestoreFormat(null, settings, new ConsoleLogger(0));
+
+    assertThatThrownBy(restore::restoreDatabase)
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("127.0.0.1");
+  }
+
+  @Test
+  void restoreFollowsRedirectAndFetchesContentWhenLocalUrlsExplicitlyAllowed() {
+    // The documented opt-out: an operator who explicitly trusts internal sources can restore from one, and a
+    // redirect must actually be followed (not silently dropped) to reach the archive content.
+    GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.setValue(true);
+
+    final RestoreSettings settings = new RestoreSettings();
+    settings.format = "full";
+    settings.inputFileURL = baseUrl + "/redirect-to-content";
+    settings.databaseDirectory = databaseDirectory.getPath();
+
+    final FullRestoreFormat restore = new FullRestoreFormat(null, settings, new ConsoleLogger(0));
+
+    // The redirect is followed and CONTENT reaches the archive walk, which fails for an unrelated, non-security
+    // reason (it is not a real zip) - never with SecurityException.
+    assertThatThrownBy(restore::restoreDatabase).isNotInstanceOf(SecurityException.class);
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/restore/format/Issue6381RestoreSsrfTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/restore/format/Issue6381RestoreSsrfTest.java
@@ -127,4 +127,36 @@ class Issue6381RestoreSsrfTest {
     // reason (it is not a real zip) - never with SecurityException.
     assertThatThrownBy(restore::restoreDatabase).isNotInstanceOf(SecurityException.class);
   }
+
+  /**
+   * {@code RestoreSettings.allowLocalUrls} is what {@code PostServerCommandHandler} sets (reflectively, via
+   * {@code Restore.setAllowLocalUrls}) from its own per-server {@code ContextConfiguration} - a different
+   * configuration source than the static {@link GlobalConfiguration} value. Without this explicit override taking
+   * priority, a server whose operator enabled the setting only on that server's own configuration (not the JVM-wide
+   * static one) would have its pre-check accept a restore that the fetch then refused anyway.
+   */
+  @Test
+  void explicitSettingsOverrideTakesPriorityOverStaticDefault() {
+    // Static default is false (blocked); the explicit per-call override must still allow it.
+    final RestoreSettings allowSettings = new RestoreSettings();
+    allowSettings.format = "full";
+    allowSettings.inputFileURL = baseUrl + "/redirect-to-content";
+    allowSettings.databaseDirectory = databaseDirectory.getPath();
+    allowSettings.allowLocalUrls = true;
+
+    assertThatThrownBy(new FullRestoreFormat(null, allowSettings, new ConsoleLogger(0))::restoreDatabase)
+        .isNotInstanceOf(SecurityException.class);
+
+    // Static default flipped to true; the explicit per-call override must still block it.
+    GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.setValue(true);
+    final RestoreSettings blockSettings = new RestoreSettings();
+    blockSettings.format = "full";
+    blockSettings.inputFileURL = baseUrl + "/content";
+    blockSettings.databaseDirectory = databaseDirectory.getPath();
+    blockSettings.allowLocalUrls = false;
+
+    assertThatThrownBy(new FullRestoreFormat(null, blockSettings, new ConsoleLogger(0))::restoreDatabase)
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("127.0.0.1");
+  }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -420,6 +420,10 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       try {
         final Class<?> clazz = Class.forName("com.arcadedb.integration.restore.Restore");
         final Object restorer = clazz.getConstructor(String.class, String.class).newInstance(url, tempDir.getAbsolutePath());
+        // SAME BOOLEAN validateClientRestoreImportUrl ALREADY VALIDATED THIS URL AGAINST: THE FETCH INSIDE
+        // FullRestoreFormat MUST AGREE WITH THIS SERVER'S OWN CONFIGURATION RATHER THAN FALLING BACK TO THE STATIC
+        // DEFAULT, OR A PER-SERVER OVERRIDE THAT LET THE COMMAND THROUGH WOULD STILL HAVE THE FETCH REFUSE IT.
+        clazz.getMethod("setAllowLocalUrls", boolean.class).invoke(restorer, isRestoreImportLocalUrlsAllowed());
 
         // Set a logger with SSE callback for progress
         final Class<?> loggerClass = Class.forName("com.arcadedb.integration.importer.ConsoleLogger");
@@ -454,6 +458,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     try {
       final Class<?> clazz = Class.forName("com.arcadedb.integration.restore.Restore");
       final Object restorer = clazz.getConstructor(String.class, String.class).newInstance(url, tempDir.getAbsolutePath());
+      clazz.getMethod("setAllowLocalUrls", boolean.class).invoke(restorer, isRestoreImportLocalUrlsAllowed());
       clazz.getMethod("restoreDatabase").invoke(restorer);
     } catch (final ClassNotFoundException | NoSuchMethodException | IllegalAccessException
                    | InstantiationException e) {
@@ -513,7 +518,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
    * private, loopback, link-local, site-local, multicast, wildcard or unresolvable host is rejected.
    */
   private void validateClientRestoreImportUrl(final String url) {
-    if (httpServer.getServer().getConfiguration().getValueAsBoolean(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS))
+    if (isRestoreImportLocalUrlsAllowed())
       return;
 
     final URI uri;
@@ -539,6 +544,18 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (isBlockedHost(host))
       throw new SecurityException("Restore/import from private, loopback or link-local hosts is blocked. Enable '"
           + GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS.getKey() + "' to override");
+  }
+
+  /**
+   * The single source of truth for {@link GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} on this server
+   * instance, read from the server's own (possibly per-instance-overridden) {@link
+   * com.arcadedb.ContextConfiguration} rather than the static default. {@link #validateClientRestoreImportUrl} and
+   * {@link #performRestore} must agree on this value: the pre-check here decides whether to accept the command at
+   * all, and the actual fetch inside {@code FullRestoreFormat} decides whether to follow it, and letting them read
+   * from two different configuration sources would let one permit what the other refuses on the very same server.
+   */
+  private boolean isRestoreImportLocalUrlsAllowed() {
+    return httpServer.getServer().getConfiguration().getValueAsBoolean(GlobalConfiguration.SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS);
   }
 
   /**


### PR DESCRIPTION
## Summary
- #6380 - `LocalDocumentType.removeBucketInternal` shrank the bucket list but never re-bound the bucket-selection strategy, so a round-robin (or thread, or partitioned) strategy kept its pre-removal bucket count and could hand out an index one past the new last bucket, throwing `IndexOutOfBoundsException` on an ordinary insert after `ALTER TYPE ... BUCKET -b`. Fixed by calling `bucketSelectionStrategy.setType(this)` at the end of `removeBucketInternal`, symmetric to the existing call in `addBucketInternal`.
- #6381 - `restore database`'s HTTP(S) input path used a bare `HttpURLConnection`, which follows same-protocol 3xx redirects itself with no revalidation of the redirect target. The server's one-shot pre-check only validates the original hostname before handing the URL to restore, so a redirect (or DNS rebinding) to a blocked address bypassed it - the class of SSRF bypass `IMPORT DATABASE` was already hardened against. `openInputFile()` now routes through the shared `SafeHttpFetcher`, which re-validates scheme and address on every hop, gated by the existing `SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS` setting.

## Test plan
- [x] `Issue6380RemoveBucketStrategyRefreshTest`: new regression test - fails with `IndexOutOfBoundsException` against the pre-fix code, passes after the fix.
- [x] `Issue6381RestoreSsrfTest`: new regression test - proves restore refuses a local/blocked address by default and follows a redirect only when the operator explicitly opts in via `SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS`.
- [x] Full `engine` and `integration` module test suites run green (`mvn -o -pl integration -am test -DexcludedGroups=benchmark,slow,vector`): 588+ tests, 0 failures.
- [x] Targeted `com.arcadedb.schema.*Test` run (436 tests) green.

🔗 Closes #6380, closes #6381