### PR TITLE
fix(#6391, #6386, #6387, #6384, #6383): vector sparse/ANN guards, approxDistance sign bugs, keys()/values() wrapping, GraphQL alias NPE and Boolean/Float args

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
@@ -131,10 +131,13 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
     if (q1.length != q2.length)
       throw new CommandSQLParsingException("Quantized vectors must have same length: " + q1.length + " vs " + q2.length);
 
-    // Compute L2 distance: sqrt(sum((q1[i] - q2[i])^2))
+    // Compute L2 distance: sqrt(sum((q1[i] - q2[i])^2)). The codes are signed and order-preserving
+    // (quantizeInt8 stores (byte)(scaled - 128)), so the plain signed difference already matches the
+    // difference between the pre-shift [0,255] values; reinterpreting as unsigned via "& 0xFF" would
+    // instead produce a huge spurious difference for codes straddling the signed/unsigned midpoint.
     double sumSquares = 0.0;
     for (int i = 0; i < q1.length; i++) {
-      final int diff = (q1[i] & 0xFF) - (q2[i] & 0xFF);
+      final int diff = q1[i] - q2[i];
       sumSquares += diff * diff;
     }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -81,6 +81,8 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       key = list.toArray();
 
     final int limit = params[2] instanceof Number n ? n.intValue() : Integer.parseInt(params[2].toString());
+    if (limit <= 0)
+      return new ArrayList<>(0);
 
     // Optional 4th parameter. Either:
     //   - a number: efSearch (backward-compatible positional form)

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorQuantizeBinary.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorQuantizeBinary.java
@@ -117,10 +117,11 @@ public class SQLFunctionVectorQuantizeBinary extends SQLFunctionVectorAbstract {
           throw new IllegalArgumentException("Vectors must have same length");
 
         int distance = 0;
-        // Count differing bits
+        // Count differing bits. packed[i]/other.packed[i] are byte: mask to 8 bits before XOR so a
+        // set sign bit (bit 7) does not sign-extend into the upper 24 bits of the int operands, which
+        // would make bitCount() count up to 24 phantom differing bits per byte.
         for (int i = 0; i < Math.min(packed.length, other.packed.length); i++) {
-          // XOR gives 1 for differing bits, count the 1s
-          distance += Integer.bitCount(packed[i] ^ other.packed[i]);
+          distance += Integer.bitCount((packed[i] ^ other.packed[i]) & 0xFF);
         }
 
         return distance;

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseCreate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseCreate.java
@@ -56,7 +56,7 @@ public class SQLFunctionVectorSparseCreate extends SQLFunctionVectorAbstract {
     try {
       indices = VectorUtils.toIntArray(indicesObj);
     } catch (final IllegalArgumentException e) {
-      throw new CommandSQLParsingException(e.getMessage());
+      throw new CommandSQLParsingException(e.getMessage(), e);
     }
     final float[] values = toFloatArray(valuesObj);
 

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseCreate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseCreate.java
@@ -20,8 +20,8 @@ package com.arcadedb.function.sql.vector;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.index.vector.VectorUtils;
 import com.arcadedb.query.sql.executor.CommandContext;
-import java.util.List;
 
 /**
  * Creates a sparse vector from indices and values arrays.
@@ -52,7 +52,12 @@ public class SQLFunctionVectorSparseCreate extends SQLFunctionVectorAbstract {
     if (indicesObj == null || valuesObj == null)
       return null;
 
-    final int[] indices = toIntArray(indicesObj);
+    final int[] indices;
+    try {
+      indices = VectorUtils.toIntArray(indicesObj);
+    } catch (final IllegalArgumentException e) {
+      throw new CommandSQLParsingException(e.getMessage());
+    }
     final float[] values = toFloatArray(valuesObj);
 
     if (indices.length != values.length)
@@ -75,35 +80,6 @@ public class SQLFunctionVectorSparseCreate extends SQLFunctionVectorAbstract {
       }
 
       return new SparseVector(indices, values, dimensions);
-    }
-  }
-
-  private int[] toIntArray(final Object indices) {
-    if (indices instanceof int[] intArray) {
-      return intArray;
-    } else if (indices instanceof Object[] objArray) {
-      final int[] result = new int[objArray.length];
-      for (int i = 0; i < objArray.length; i++) {
-        if (objArray[i] instanceof Number num) {
-          result[i] = num.intValue();
-        } else {
-          throw new CommandSQLParsingException("Index values must be integers, found: " + objArray[i].getClass().getSimpleName());
-        }
-      }
-      return result;
-    } else if (indices instanceof List<?> list) {
-      final int[] result = new int[list.size()];
-      for (int i = 0; i < list.size(); i++) {
-        final Object elem = list.get(i);
-        if (elem instanceof Number num) {
-          result[i] = num.intValue();
-        } else {
-          throw new CommandSQLParsingException("Index values must be integers, found: " + elem.getClass().getSimpleName());
-        }
-      }
-      return result;
-    } else {
-      throw new CommandSQLParsingException("Indices must be an array or list, found: " + indices.getClass().getSimpleName());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SparseVector.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SparseVector.java
@@ -137,12 +137,12 @@ public class SparseVector {
   }
 
   /**
-   * Calculate dot product with another sparse vector.
+   * Calculate dot product with another sparse vector. Dimensions are only used to size a dense
+   * expansion ({@link #toDense()}); the dot product itself only needs the indices the two vectors
+   * have in common (it is implicitly 0 over every non-overlapping index), so vectors whose inferred
+   * dimensions differ are still valid operands.
    */
   public float dotProduct(final SparseVector other) {
-    if (this.dimensions != other.dimensions)
-      throw new IllegalArgumentException("Vector dimensions must match: " + this.dimensions + " vs " + other.dimensions);
-
     // Iterate over the smaller vector to optimize
     final Map<Integer, Float> smallerMap = this.getNonZeroCount() <= other.getNonZeroCount() ? this.values : other.values;
     final Map<Integer, Float> largerMap = smallerMap == this.values ? other.values : this.values;

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodKeys.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodKeys.java
@@ -24,6 +24,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -46,15 +47,23 @@ public class SQLMethodKeys extends AbstractSQLMethod {
       return map.keySet();
 
     if (value instanceof Document document)
-      return List.of(document.getPropertyNames());
+      return new ArrayList<>(document.getPropertyNames());
 
     if (value instanceof Result result) {
       return result.getPropertyNames();
     }
 
     if (value instanceof Collection<?> collection) {
-      final List<Object> result = collection.stream()
-          .flatMap(o -> ((Collection<Object>) execute(o, currentRecord, context, params)).stream()).toList();
+      final List<Object> result = new ArrayList<>();
+      for (final Object o : collection) {
+        if (o instanceof Map || o instanceof Document || o instanceof Result || o instanceof Collection) {
+          final Object keys = execute(o, currentRecord, context, params);
+          if (keys instanceof Collection<?> keysCollection)
+            result.addAll(keysCollection);
+        }
+        // scalar/null elements have no keys: skip them rather than recursing into execute(), which
+        // returns null for them
+      }
       return result;
     }
     return null;

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
@@ -24,6 +24,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -48,12 +49,20 @@ public class SQLMethodValues extends AbstractSQLMethod {
     if (value instanceof Map map)
       return map.values();
     else if (value instanceof Document document)
-      return List.of(document.toMap().values());
+      return new ArrayList<>(document.toMap().values());
     else if (value instanceof Result result)
       return result.toMap().values();
     else if (value instanceof Collection<?> collection) {
-      final List<Object> result = collection.stream()
-          .flatMap(o -> ((Collection<Object>) execute(o, currentRecord, context, params)).stream()).toList();
+      final List<Object> result = new ArrayList<>();
+      for (final Object o : collection) {
+        if (o instanceof Map || o instanceof Document || o instanceof Result || o instanceof Collection) {
+          final Object values = execute(o, currentRecord, context, params);
+          if (values instanceof Collection<?> valuesCollection)
+            result.addAll(valuesCollection);
+        }
+        // scalar/null elements have no values: skip them rather than recursing into execute(), which
+        // returns null for them
+      }
       return result;
     }
 

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/Issue6386VectorApproxDistanceTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/Issue6386VectorApproxDistanceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Regression tests for issue #6386: {@code vector.approxDistance} computed wrong distances for
+ * both quantization modes, silently corrupting top-k ordering. The binary (Hamming) path
+ * sign-extended {@code byte} operands into {@link Integer#bitCount}; the int8 path masked
+ * signed, order-preserving codes with {@code & 0xFF}, breaking the ordering across the
+ * mid-range.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6386VectorApproxDistanceTest {
+
+  private final SQLFunctionVectorQuantizeBinary quantizeBinary = new SQLFunctionVectorQuantizeBinary();
+  private final SQLFunctionVectorApproxDistance approxDistance = new SQLFunctionVectorApproxDistance();
+  private final BasicCommandContext             context        = new BasicCommandContext();
+
+  @Test
+  void binaryApproxDistanceIgnoresTheByteSignBit() {
+    // Both quantize to 8 bits with median 1.0; the two vectors differ only on the sign of the
+    // last component, so only bit 7 differs -> true Hamming distance is 1, not ~25.
+    final Object q1 = quantizeBinary.execute(null, null, null,
+        new Object[] { new float[] { 1, 1, 1, 1, 1, 1, 1, 9.0f } }, context);
+    final Object q2 = quantizeBinary.execute(null, null, null,
+        new Object[] { new float[] { 1, 1, 1, 1, 1, 1, 1, -9.0f } }, context);
+
+    final Object result = approxDistance.execute(null, null, null, new Object[] { q1, q2 }, context);
+    assertThat((Float) result).isEqualTo(0.125f, within(0.0001f)); // 1 / 8 bits
+  }
+
+  @Test
+  void int8ApproxDistanceUsesSignedDifferenceAcrossTheMidpoint() {
+    // Codes straddling the signed/unsigned midpoint (-1 and 0): the true (pre-shift) values are
+    // 127 and 128, one apart. Masking with & 0xFF would instead read them as 255 and 0.
+    final byte[] q1 = { -1 };
+    final byte[] q2 = { 0 };
+
+    final Object result = approxDistance.execute(null, null, null, new Object[] { q1, q2, "INT8" }, context);
+    assertThat((Float) result).isEqualTo(1.0f, within(0.0001f));
+  }
+
+  @Test
+  void int8ApproxDistancePreservesTopKOrderingAcrossTheMidpoint() {
+    // Query code -1 (raw 127) should rank a neighbor at 0 (raw 128, distance 1) closer than one
+    // at 100 (raw 228, distance 101). The pre-fix "& 0xFF" reinterpretation inverted this: it
+    // read -1 as 255, making the near neighbor (0) look like the far one (distance 255).
+    final byte[] query = { -1 };
+    final byte[] near = { 0 };
+    final byte[] far = { 100 };
+
+    final float distanceToNear = (Float) approxDistance.execute(null, null, null, new Object[] { query, near, "INT8" }, context);
+    final float distanceToFar = (Float) approxDistance.execute(null, null, null, new Object[] { query, far, "INT8" }, context);
+
+    assertThat(distanceToNear).isLessThan(distanceToFar);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/Issue6391VectorSparseAnnGuardsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/Issue6391VectorSparseAnnGuardsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6391: three {@code vector.*} sparse/ANN functions threw raw
+ * exceptions (or imposed an unnecessary restriction) on valid input, inconsistent with their own
+ * siblings.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6391VectorSparseAnnGuardsTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY Doc.name IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX IF NOT EXISTS ON Doc (name) UNIQUE");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON Doc (embedding) LSM_VECTOR
+          METADATA {
+            dimensions: 3,
+            similarity: 'COSINE',
+            idPropertyName: 'name'
+          }""");
+    });
+
+    database.transaction(() -> {
+      database.newVertex("Doc").set("name", "docA").set("embedding", new float[] { 1.0f, 0.0f, 0.0f }).save();
+      database.newVertex("Doc").set("name", "docB").set("embedding", new float[] { 0.9f, 0.1f, 0.0f }).save();
+    });
+  }
+
+  // 1. sparseDot must not require equal inferred dimensions: it is implicitly 0 over non-overlapping indices.
+  @Test
+  void sparseDotOnDisjointIndicesReturnsZeroInsteadOfThrowing() {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT `vector.sparseDot`(`vector.sparseCreate`([0,2],[0.5,0.3]), `vector.sparseCreate`([1,5],[0.2,0.8])) as score")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result result = rs.next();
+      assertThat(result.<Float>getProperty("score")).isEqualTo(0.0f);
+    }
+  }
+
+  @Test
+  void sparseDotOnDifferentDimensionsWithOverlapStillComputesCorrectly() {
+    try (final ResultSet rs = database.query("sql",
+        "SELECT `vector.sparseDot`(`vector.sparseCreate`([0,2],[0.5,0.3]), `vector.sparseCreate`([0,1,5],[0.6,0.2,0.8])) as score")) {
+      final Result result = rs.next();
+      // only index 0 overlaps: 0.5 * 0.6 = 0.30
+      assertThat(result.<Float>getProperty("score")).isEqualTo(0.30f, org.assertj.core.data.Offset.offset(0.0001f));
+    }
+  }
+
+  // 2. sparseCreate must accept long[] indices (how integer JSON arrays arrive from HTTP), not just int[]/Object[].
+  @Test
+  void sparseCreateAcceptsLongArrayIndices() {
+    final long[] indices = { 0L, 2L, 5L };
+    final float[] values = { 0.5f, 0.3f, 0.8f };
+
+    try (final ResultSet rs = database.query("sql", "SELECT `vector.sparseCreate`(?, ?) as sparse_emb",
+        (Object) indices, (Object) values)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result result = rs.next();
+      assertThat((Object) result.getProperty("sparse_emb")).isNotNull();
+    }
+  }
+
+  // 3. vector.neighbors(k <= 0) must return empty, matching rerank/recommend/discover/sparseNeighbors,
+  //    instead of reaching a negative-capacity ArrayList allocation deep in LSMVectorIndex.
+  @Test
+  void neighborsWithNonPositiveKReturnsEmptyInsteadOfThrowing() {
+    final SQLFunctionVectorNeighbors function = new SQLFunctionVectorNeighbors();
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+
+    @SuppressWarnings("unchecked")
+    final List<Map<String, Object>> negative = (List<Map<String, Object>>) function.execute(null, null, null,
+        new Object[] { "Doc[embedding]", new float[] { 1.0f, 0.0f, 0.0f }, -1 }, context);
+    assertThat(negative).isNotNull().isEmpty();
+
+    @SuppressWarnings("unchecked")
+    final List<Map<String, Object>> zero = (List<Map<String, Object>>) function.execute(null, null, null,
+        new Object[] { "Doc[embedding]", new float[] { 1.0f, 0.0f, 0.0f }, 0 }, context);
+    assertThat(zero).isNotNull().isEmpty();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionPhase4Test.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionPhase4Test.java
@@ -324,7 +324,11 @@ class SQLFunctionPhase4Test extends TestHelper {
   }
 
   @Test
-  void sparseVectorDotDimensionMismatch() {
+  void sparseVectorDotAllowsDifferentInferredDimensions() {
+    // Issue #6391: a dot product only needs the indices the two vectors have in common (it is
+    // implicitly 0 over every non-overlapping index), so differing inferred dimensions must not
+    // throw - the sibling functions (sparseCosine, sparseNeighbors, ...) never imposed this
+    // restriction either.
     final SQLFunctionVectorSparseDot function = new SQLFunctionVectorSparseDot();
     final BasicCommandContext context = new BasicCommandContext();
     context.setDatabase(database);
@@ -332,11 +336,8 @@ class SQLFunctionPhase4Test extends TestHelper {
     final SparseVector v1 = new SparseVector(new int[] { 0 }, new float[] { 0.5f }, 3);
     final SparseVector v2 = new SparseVector(new int[] { 0 }, new float[] { 0.5f }, 5);
 
-    assertThatThrownBy(() -> function.execute(null, null, null,
-        new Object[] { v1, v2 },
-        context))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("dimensions");
+    final Object result = function.execute(null, null, null, new Object[] { v1, v2 }, context);
+    assertThat((Float) result).isEqualTo(0.25f);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodKeysTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodKeysTest.java
@@ -18,18 +18,23 @@
  */
 package com.arcadedb.query.sql.method.collection;
 
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.executor.SQLMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class SQLMethodKeysTest {
+class SQLMethodKeysTest extends TestHelper {
 
   private SQLMethod function;
 
@@ -60,5 +65,40 @@ class SQLMethodKeysTest {
   void withNull() {
     Object result = function.execute(null, null, null, null);
     assertThat(result).isNull();
+  }
+
+  // Regression tests for issue #6387
+
+  @Test
+  void withDocumentReturnsFlatListNotNestedOneElementList() {
+    database.transaction(() -> database.getSchema().createDocumentType("Person"));
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("Person");
+      doc.set("name", "Alice");
+      doc.set("age", 30);
+      doc.save();
+
+      final Object result = function.execute(doc, null, null, null);
+      assertThat(result).isInstanceOf(List.class);
+      assertThat((List<Object>) result).containsExactlyInAnyOrder("name", "age");
+    });
+  }
+
+  @Test
+  void withCollectionContainingScalarAndNullDoesNotThrow() {
+    final List<Object> mixed = Arrays.asList(Map.of("a", 1), null, "scalar", 42, Map.of("b", 2));
+
+    final Object result = function.execute(mixed, null, null, null);
+    assertThat(result).isEqualTo(List.of("a", "b"));
+  }
+
+  @Test
+  void withSQLScalarCollectionDoesNotThrow() {
+    // SELECT [1,2,3].keys() -- a collection of scalars has no keys, so this used to NPE
+    try (final ResultSet resultSet = database.query("sql", "SELECT [1,2,3].keys() AS keys")) {
+      final Result record = resultSet.next();
+      assertThat(record.<List<Object>>getProperty("keys")).isEqualTo(List.of());
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SQLMethodValuesTest extends TestHelper {
   private SQLMethod function;
@@ -91,14 +90,11 @@ class SQLMethodValuesTest extends TestHelper {
 
       Object result = function.execute(doc, null, null, null);
 
-      // Note: The implementation has a bug on line 51 - it wraps values in List.of()
-      // This test verifies current behavior: returns nested list with ALL document properties
-      // including internal fields like RID, type marker ("d"), type name
+      // Flat collection of the document's property values (toMap() also carries the internal
+      // fields RID, type marker "d", type name), not wrapped in an extra one-element list.
       assertThat(result).isInstanceOf(Collection.class);
-      Collection<?> values = (Collection<?>) result;
-      assertThat(values).hasSize(1); // Bug: wrapped in extra List.of()
-      // The single element is actually a Collection of all document properties
-      assertThat(values.iterator().next()).isInstanceOf(Collection.class);
+      final Collection<Object> values = (Collection<Object>) result;
+      assertThat(values).containsExactlyInAnyOrder("Alice", 30, doc.getIdentity().toString(), "d", "Person");
     });
   }
 
@@ -126,11 +122,10 @@ class SQLMethodValuesTest extends TestHelper {
 
     assertThat(result).isInstanceOf(List.class);
     List<?> flattenedValues = (List<?>) result;
-    // Bug on line 51: wraps each document's values in List.of(), so we get 2 Collections instead of 4+ values
-    assertThat(flattenedValues).hasSize(2);
-    // Each element is a Collection containing all properties (including internal ones)
-    assertThat(flattenedValues.get(0)).isInstanceOf(Collection.class);
-    assertThat(flattenedValues.get(1)).isInstanceOf(Collection.class);
+    // Each document contributes its own (unwrapped) toMap() values: name, age plus the 3
+    // internal fields (RID, type marker, type name) = 5 values per document.
+    assertThat(flattenedValues).hasSize(10);
+    assertThat((List<Object>) flattenedValues).contains("Alice", 30, "Bob", 25);
   }
 
   // NEW TESTS - Result object handling
@@ -160,28 +155,25 @@ class SQLMethodValuesTest extends TestHelper {
 
   @Test
   void withCollectionOfMixedMapAndString() {
-    // This should handle gracefully - strings return null, maps return values
+    // Scalar elements (e.g. plain strings) have no values of their own: they are skipped rather
+    // than crashing the whole collection.
     List<Object> mixed = List.of(
         Map.of("key1", "value1"),
-        "some string",  // This will return null from execute()
+        "some string",
         Map.of("key2", "value2")
     );
 
-    // Current implementation throws NullPointerException on line 56
-    // because execute("some string") returns null, and flatMap tries to call .stream() on null
-    assertThatThrownBy(() -> function.execute(mixed, null, null, null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("Cannot invoke \"java.util.Collection.stream()\"");
+    final Object result = function.execute(mixed, null, null, null);
+    assertThat(result).isEqualTo(List.of("value1", "value2"));
   }
 
   @Test
   void withCollectionOfUnsupportedTypes() {
     List<Object> unsupported = List.of(42, true, "text");
 
-    // All these return null, which causes NullPointerException in flatMap when calling .stream()
-    assertThatThrownBy(() -> function.execute(unsupported, null, null, null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("Cannot invoke \"java.util.Collection.stream()\"");
+    // Every element is a scalar with no values: they are all skipped, yielding an empty list.
+    final Object result = function.execute(unsupported, null, null, null);
+    assertThat(result).isEqualTo(List.of());
   }
 
   @Test
@@ -225,14 +217,33 @@ class SQLMethodValuesTest extends TestHelper {
       product2.save();
     });
 
-    // Current implementation fails when list() returns documents because of the bugs
-    // list() creates a collection, and .values() on that collection tries to process Documents
-    // which triggers the wrapping bug and eventually causes NullPointerException
-    assertThatThrownBy(() -> {
-      ResultSet resultSet = database.query("sql",
-          "SELECT list(name, price).values() AS allValues FROM Product");
-      resultSet.next();
-    }).isInstanceOf(NullPointerException.class);
+    // list(name, price) builds a list of scalars (e.g. ["Laptop", 999]); .values() on a
+    // collection of scalars has nothing to recurse into, so it no longer NPEs - it yields an
+    // empty list per row instead.
+    try (ResultSet resultSet = database.query("sql",
+        "SELECT list(name, price).values() AS allValues FROM Product")) {
+      while (resultSet.hasNext())
+        assertThat(resultSet.next().<List<Object>>getProperty("allValues")).isEqualTo(List.of());
+    }
+  }
+
+  // Regression tests for issue #6387
+
+  @Test
+  void withCollectionContainingScalarAndNullDoesNotThrow() {
+    final List<Object> mixed = Arrays.asList(Map.of("a", 1), null, "scalar", 42, Map.of("b", 2));
+
+    final Object result = function.execute(mixed, null, null, null);
+    assertThat(result).isEqualTo(List.of(1, 2));
+  }
+
+  @Test
+  void withSQLScalarCollectionDoesNotThrow() {
+    // SELECT [1,2,3].values() -- a collection of scalars has no values, so this used to NPE
+    try (final ResultSet resultSet = database.query("sql", "SELECT [1,2,3].values() AS vals")) {
+      final Result record = resultSet.next();
+      assertThat(record.<List<Object>>getProperty("vals")).isEqualTo(List.of());
+    }
   }
 
   @Test

--- a/graphql/src/main/java/com/arcadedb/graphql/parser/BooleanValue.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/parser/BooleanValue.java
@@ -28,7 +28,7 @@ public class BooleanValue extends AbstractValue {
 
   @Override
   public Object getValue() {
-    return null;
+    return val;
   }
 
 

--- a/graphql/src/main/java/com/arcadedb/graphql/parser/FieldWithAlias.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/parser/FieldWithAlias.java
@@ -19,24 +19,26 @@
 /* ParserGeneratorCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_CLASS_VISIBILITY_PUBLIC=true */
 package com.arcadedb.graphql.parser;
 
-public class FieldWithAlias extends SimpleNode {
-  Name alias;
-  protected Name         name;
+/**
+ * A selection field written with a GraphQL alias ({@code alias: fieldName}). The alias itself is
+ * carried by the enclosing {@link Selection#getName()} (the parser assigns it there before it knows
+ * whether a colon follows); this node's {@code name} - inherited from {@link AbstractField} - is the
+ * real, aliased-away field name used to resolve the property.
+ */
+public class FieldWithAlias extends AbstractField {
   protected Arguments    arguments;
-  protected Directives   directives;
   protected SelectionSet selectionSet;
-
-  public FieldWithAlias(final Name alias, final int line, final int column, final int tokenId) {
-    this(-1);
-    this.alias = alias;
-  }
 
   public FieldWithAlias(final int id) {
     super(id);
   }
 
-  public String getName() {
-    return name != null ? name.value : null;
+  public Arguments getArguments() {
+    return arguments;
+  }
+
+  public SelectionSet getSelectionSet() {
+    return selectionSet;
   }
 }
 /* ParserGeneratorCC - OriginalChecksum=46c98ffd2c99423a541cd9d46c3fc779 (do not edit this line) */

--- a/graphql/src/main/java/com/arcadedb/graphql/parser/FloatValue.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/parser/FloatValue.java
@@ -19,6 +19,8 @@
 /* ParserGeneratorCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_CLASS_VISIBILITY_PUBLIC=true */
 package com.arcadedb.graphql.parser;
 
+import java.math.BigDecimal;
+
 public class FloatValue extends AbstractValue {
   protected String stringValue;
 
@@ -28,7 +30,7 @@ public class FloatValue extends AbstractValue {
 
   @Override
   public Object getValue() {
-    return stringValue;
+    return new BigDecimal(stringValue);
   }
 
   @Override

--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
@@ -27,6 +27,7 @@ import com.arcadedb.graphql.parser.AbstractField;
 import com.arcadedb.graphql.parser.Argument;
 import com.arcadedb.graphql.parser.Directive;
 import com.arcadedb.graphql.parser.Directives;
+import com.arcadedb.graphql.parser.Field;
 import com.arcadedb.graphql.parser.FieldDefinition;
 import com.arcadedb.graphql.parser.FieldWithAlias;
 import com.arcadedb.graphql.parser.ObjectTypeDefinition;
@@ -105,10 +106,16 @@ public class GraphQLResultSet implements ResultSet {
     for (final Selection selection : definedProjections) {
       // A selection written as `alias: field` parses into fieldWithAlias (name = the real field,
       // alias carried by Selection.getName()); an unaliased selection parses into field instead.
+      // Neither is set for an ellipsis selection (fragment spread / inline fragment).
       final FieldWithAlias aliasedField = selection.getFieldWithAlias();
-      final AbstractField  field = aliasedField != null ? aliasedField : selection.getField();
+      final Field          plainField = selection.getField();
+      final AbstractField  field = aliasedField != null ? aliasedField : plainField;
       final String         fieldName = aliasedField != null ? aliasedField.getName() : selection.getName();
-      final SelectionSet   set = aliasedField != null ? aliasedField.getSelectionSet() : selection.getField().getSelectionSet();
+      final SelectionSet   set;
+      if (aliasedField != null)
+        set = aliasedField.getSelectionSet();
+      else
+        set = plainField != null ? plainField.getSelectionSet() : null;
       projections.add(
           new Projection(selection.getName(), fieldName, field, null, set != null ? set.getSelections() : null));
     }

--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
@@ -27,8 +27,8 @@ import com.arcadedb.graphql.parser.AbstractField;
 import com.arcadedb.graphql.parser.Argument;
 import com.arcadedb.graphql.parser.Directive;
 import com.arcadedb.graphql.parser.Directives;
-import com.arcadedb.graphql.parser.Field;
 import com.arcadedb.graphql.parser.FieldDefinition;
+import com.arcadedb.graphql.parser.FieldWithAlias;
 import com.arcadedb.graphql.parser.ObjectTypeDefinition;
 import com.arcadedb.graphql.parser.Selection;
 import com.arcadedb.graphql.parser.SelectionSet;
@@ -53,13 +53,16 @@ public class GraphQLResultSet implements ResultSet {
   private final ObjectTypeDefinition returnType;
 
   private static class Projection {
-    final String               name;
+    final String               name;      // output key: the alias when present, otherwise the field name
+    final String               fieldName; // real field/property name to resolve, ignoring any alias
     final AbstractField        field;
     final ObjectTypeDefinition type;
     final List<Selection>      set;
 
-    private Projection(final String name, final Field field, final ObjectTypeDefinition type, final List<Selection> set) {
+    private Projection(final String name, final String fieldName, final AbstractField field, final ObjectTypeDefinition type,
+        final List<Selection> set) {
       this.name = name;
+      this.fieldName = fieldName;
       this.field = field;
       this.type = type;
       this.set = set;
@@ -92,17 +95,22 @@ public class GraphQLResultSet implements ResultSet {
     // ADD ALL THE TYPE FIELDS AUTOMATICALLY
     for (final FieldDefinition fieldDefinition : type.getFieldDefinitions()) {
       final ObjectTypeDefinition subType = schema.getTypeFromField(fieldDefinition);
-      projections.add(new Projection(fieldDefinition.getName(), null, subType, null));
+      projections.add(new Projection(fieldDefinition.getName(), fieldDefinition.getName(), null, subType, null));
     }
     return mapProjections(current, projections);
   }
 
   private GraphQLResult mapBySelections(final Result current, final List<Selection> definedProjections) {
     final List<Projection> projections = new ArrayList<>(definedProjections.size());
-    for (final Selection fieldDefinition : definedProjections) {
-      final SelectionSet set = fieldDefinition.getField().getSelectionSet();
+    for (final Selection selection : definedProjections) {
+      // A selection written as `alias: field` parses into fieldWithAlias (name = the real field,
+      // alias carried by Selection.getName()); an unaliased selection parses into field instead.
+      final FieldWithAlias aliasedField = selection.getFieldWithAlias();
+      final AbstractField  field = aliasedField != null ? aliasedField : selection.getField();
+      final String         fieldName = aliasedField != null ? aliasedField.getName() : selection.getName();
+      final SelectionSet   set = aliasedField != null ? aliasedField.getSelectionSet() : selection.getField().getSelectionSet();
       projections.add(
-          new Projection(fieldDefinition.getName(), fieldDefinition.getField(), null, set != null ? set.getSelections() : null));
+          new Projection(selection.getName(), fieldName, field, null, set != null ? set.getSelections() : null));
     }
     return mapProjections(current, projections);
   }
@@ -169,19 +177,20 @@ public class GraphQLResultSet implements ResultSet {
 
     for (final Projection entry : projections) {
       final String projName = entry.name;
+      final String realName = entry.fieldName;
 
-      Object projectionValue = current.getProperty(projName);
+      Object projectionValue = current.getProperty(realName);
 
       if (projectionValue == null && current.getElement().isPresent())
         // PROPERTY NOT FOUND IN PROJECTION, TRY DIRECTLY FROM THE ELEMENT (E.G. CYPHER RETURN)
-        projectionValue = current.getElement().get().get(projName);
+        projectionValue = current.getElement().get().get(realName);
 
       if (projectionValue == null) {
         // TRY THE FIELD FIRST
         projectionValue = evaluateDirectives(current, entry.field);
         if (projectionValue == null) {
           // SEARCH IN THE SCHEMA
-          final AbstractField fieldDefinition = returnType.getFieldDefinitionByName(projName);
+          final AbstractField fieldDefinition = returnType.getFieldDefinitionByName(realName);
           projectionValue = evaluateDirectives(current, fieldDefinition);
         }
       }

--- a/graphql/src/test/java/com/arcadedb/graphql/Issue6383BooleanAndFloatArgumentsTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/Issue6383BooleanAndFloatArgumentsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graphql;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6383: {@code BooleanValue.getValue()} always returned {@code null}
+ * (the parsed literal was discarded) and {@code FloatValue.getValue()} returned the raw string
+ * image instead of a number, corrupting the generated SQL WHERE clause for Boolean/Float
+ * GraphQL query arguments.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6383BooleanAndFloatArgumentsTest {
+
+  private static final String DB_PATH = "./target/testgraphql_issue6383";
+
+  @BeforeEach
+  @AfterEach
+  public void clean() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void booleanAndFloatArgumentsFilterCorrectly() {
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      if (factory.exists())
+        factory.open().drop();
+
+      final Database database = factory.create();
+      try {
+        database.transaction(() -> {
+          final Schema schema = database.getSchema();
+          schema.getOrCreateVertexType("Book");
+
+          final MutableVertex book1 = database.newVertex("Book");
+          book1.set("title", "In Stock Cheap");
+          book1.set("inStock", true);
+          book1.set("rating", 3.5f);
+          book1.save();
+
+          final MutableVertex book2 = database.newVertex("Book");
+          book2.set("title", "Out Of Stock Expensive");
+          book2.set("inStock", false);
+          book2.set("rating", 4.5f);
+          book2.save();
+        });
+
+        database.transaction(() -> {
+          final String types = """
+              type Query {
+                books(inStock: Boolean rating: Float): [Book]
+              }
+
+              type Book {
+                title: String
+                inStock: Boolean
+                rating: Float
+              }""";
+          database.command("graphql", types);
+
+          // Boolean argument: before the fix, getValue() returned null, so the generated WHERE
+          // compared against `null` and matched nothing.
+          try (final ResultSet resultSet = database.query("graphql", "{ books(inStock: true) { title } }")) {
+            assertThat(resultSet.hasNext()).isTrue();
+            final Result record = resultSet.next();
+            assertThat(record.<String>getProperty("title")).isEqualTo("In Stock Cheap");
+            assertThat(resultSet.hasNext()).isFalse();
+          }
+
+          try (final ResultSet resultSet = database.query("graphql", "{ books(inStock: false) { title } }")) {
+            assertThat(resultSet.hasNext()).isTrue();
+            final Result record = resultSet.next();
+            assertThat(record.<String>getProperty("title")).isEqualTo("Out Of Stock Expensive");
+            assertThat(resultSet.hasNext()).isFalse();
+          }
+
+          // Float argument: before the fix, getValue() returned the raw string "4.5", so the
+          // generated WHERE quoted it (`rating = "4.5"`) and a numeric property never matched.
+          try (final ResultSet resultSet = database.query("graphql", "{ books(rating: 4.5) { title } }")) {
+            assertThat(resultSet.hasNext()).isTrue();
+            final Result record = resultSet.next();
+            assertThat(record.<String>getProperty("title")).isEqualTo("Out Of Stock Expensive");
+            assertThat(resultSet.hasNext()).isFalse();
+          }
+        });
+      } finally {
+        if (database.isTransactionActive())
+          database.rollback();
+        database.drop();
+      }
+    }
+  }
+}

--- a/graphql/src/test/java/com/arcadedb/graphql/Issue6384FieldAliasTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/Issue6384FieldAliasTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graphql;
+
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6384: a GraphQL query using a field alias (standard GraphQL syntax)
+ * threw an unhandled {@link NullPointerException} instead of resolving the aliased field.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6384FieldAliasTest extends AbstractGraphQLTest {
+
+  @Test
+  void topLevelFieldAliasIsResolvedUnderTheAliasKey() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ bookByName(name: \"Mr. brain\") { myTitle: name pageCount } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        // the alias is the output key, not the real field name
+        assertThat(record.getPropertyNames()).contains("myTitle", "pageCount");
+        assertThat(record.getPropertyNames()).doesNotContain("name");
+        assertThat(record.<String>getProperty("myTitle")).isEqualTo("Mr. brain");
+        assertThat(record.<Integer>getProperty("pageCount")).isEqualTo(422);
+      }
+
+      return null;
+    });
+  }
+
+  @Test
+  void nestedFieldAliasIsResolvedUnderTheAliasKey() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      try (final ResultSet resultSet = database.query("graphql", """
+          { bookById(id: "book-1") {
+              writers: authors {
+                first: firstName
+                lastName
+              }
+            }
+          }""")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        assertThat(record.getPropertyNames()).contains("writers");
+        final Collection<?> writers = record.getProperty("writers");
+        assertThat(writers).hasSize(1);
+        final Result author = (Result) writers.iterator().next();
+        assertThat(author.getPropertyNames()).contains("first", "lastName");
+        assertThat(author.<String>getProperty("first")).isEqualTo("Joanne");
+        assertThat(author.<String>getProperty("lastName")).isEqualTo("Rowling");
+      }
+
+      return null;
+    });
+  }
+
+  @Test
+  void mixingAliasedAndPlainFieldsInSameSelectionSetWorks() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ bookByName(name: \"Harry Potter and the Philosopher's Stone\") { id title: name pageCount } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        assertThat(record.getPropertyNames()).contains("id", "title", "pageCount");
+        assertThat(record.<String>getProperty("id")).isEqualTo("book-1");
+        assertThat(record.<String>getProperty("title")).isEqualTo("Harry Potter and the Philosopher's Stone");
+      }
+
+      return null;
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Five independent, self-contained fixes surfaced by prior analysis passes:

- **#6391** - three `vector.*` sparse/ANN functions rejected valid input inconsistently with their own siblings:
  - `vector.sparseDot` required equal *inferred* dimensions even though a dot product only needs the indices two vectors have in common (implicitly 0 elsewhere).
  - `vector.sparseCreate` rejected `long[]` indices (how integer JSON arrays arrive from HTTP) - its private `toIntArray` shadowed the already-`long[]`-aware `VectorUtils.toIntArray`.
  - `vector.neighbors` had no `k <= 0` guard, unlike `rerank`/`recommend`/`discover`/`sparseNeighbors`, and could reach a negative-capacity `ArrayList` allocation.
- **#6386** - `vector.approxDistance` computed wrong distances for both quantization modes, silently corrupting top-k ordering:
  - The binary (Hamming) path sign-extended `byte` operands into `Integer.bitCount`, counting up to ~24 phantom differing bits per byte.
  - The int8 path masked signed, order-preserving codes with `& 0xFF`, inverting ordering for codes straddling the signed/unsigned midpoint.
- **#6387** - `keys()`/`values()` on a `Document` wrapped the property set in a spurious one-element list, and both NPE'd on a collection containing a scalar or `null` element.
- **#6384** - a GraphQL query using a field alias (`alias: field`, standard GraphQL syntax) threw an unhandled `NullPointerException` that surfaced as a 500. `FieldWithAlias` now extends `AbstractField` (like `Field`) so it flows through the same directive/selection-set handling instead of needing special-casing.
- **#6383** - `BooleanValue.getValue()` always returned `null` (parsed literal discarded) and `FloatValue.getValue()` returned the raw string image instead of a number, corrupting generated SQL WHERE clauses for Boolean/Float GraphQL query arguments.

Issue #6379 (sparse-vector partial-compaction correctness bug) was scoped for this batch but excluded per explicit request - it needs a larger, separately-reviewed design (a persisted recency ordinal for merged segments) rather than a one-line fix.

## Test plan
- [x] New regression tests per issue: `Issue6391VectorSparseAnnGuardsTest`, `Issue6386VectorApproxDistanceTest`, additions to `SQLMethodKeysTest`/`SQLMethodValuesTest`, `Issue6384FieldAliasTest`, `Issue6383BooleanAndFloatArgumentsTest`
- [x] Updated the one existing test (`SQLFunctionPhase4Test.sparseVectorDotDimensionMismatch`) and the several `SQLMethodValuesTest` cases that were asserting the pre-fix buggy behavior, to assert the corrected behavior instead
- [x] Full `engine` + `graphql` module test suites run clean (excluding `benchmark`/`slow`/`vector` lanes); the two anomalies seen during the run (`GAVEligibilityTest` under full-suite DB-path contention, and one `server`-module HTTP test under a concurrent agent's port contention) were confirmed pre-existing/environmental by re-running each in isolation, unrelated to this diff
- [x] `mvn -o -pl engine,graphql -am compile` clean