### PR TITLE
fix(#6447): Postgres wire SHORT/BYTE, DATETIME and DECIMAL type-path disagreements

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -16,8 +16,12 @@ right - PostgreSQL already has the correct type for this, `NUMERIC` (OID 1700) -
 `PostgresType.NUMERIC` entry with a real binary codec (PostgreSQL's own digit-group-of-4 wire format, not a
 lossy float64 detour), plus a text encoder that renders a `BigDecimal` as a plain decimal string rather than
 `BigDecimal.toString()`'s occasional scientific notation. Both the codec's decode side (attacker-controlled wire
-bytes) and encode side (a `BigDecimal` of unbounded scale, which ArcadeDB itself can produce) reject an
-out-of-range digit count rather than silently wrapping it through the wire format's `int16` header fields.
+bytes) and encode side (a `BigDecimal` of unbounded scale or magnitude, which ArcadeDB itself can produce) reject
+an out-of-range digit count rather than silently wrapping it through the wire format's `int16` header fields, and
+do so before any work proportional to that size runs. The cap - 16,000 total decimal digits - is deliberately
+well under real PostgreSQL's own `NUMERIC` limit (131,072 integer digits, 16,383 fractional): `DECIMAL` has no
+configured precision/scale limit in ArcadeDB, so this is the boundary between "large value real Postgres would
+also accept" and "value this protocol declines" rather than a hard technical ceiling.
 
 `SHORT`/`BYTE` had a narrower bug: the value path widened `Short`/`Byte` to `INTEGER` because there was nowhere
 narrower to point it, while the schema path already answered the correct `SMALLINT` (`int2`). The value path now

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3,36 +3,48 @@
 This is a living document: fixes, improvements, new features, and breaking changes are collected here as
 they land during the 26.9.1 development cycle, so the release notes are ready at tag time.
 
-## Postgres wire: `SHORT`/`BYTE`, `DATETIME` and `DECIMAL` no longer change type depending on whether a row was sampled (#6447)
+## Postgres wire: `SHORT`/`BYTE`, `DATE`, `DATETIME` and `DECIMAL` no longer change type depending on whether a row was sampled (#6447)
 
 A RowDescription column is typed either from a sample value, when the result set has a row, or from the declared
 schema, when it does not - and the two paths have to agree, or a client that prepares against an empty result and
 then re-executes against a populated one sees the column's OID change under it. #6411 fixed this for `BINARY`
-(`bytea`); three more types had the same shape of bug.
+(`bytea`); four more types had the same shape of bug.
 
-`DECIMAL` was the worst of the three: the schema path answered `DOUBLE`, lossy for an arbitrary-precision
+`DECIMAL` was the worst of the four: the schema path answered `DOUBLE`, lossy for an arbitrary-precision
 `BigDecimal`, and the value path answered `VARCHAR`, which makes a client treat the column as text. Neither was
 right - PostgreSQL already has the correct type for this, `NUMERIC` (OID 1700) - so both paths now point at a new
 `PostgresType.NUMERIC` entry with a real binary codec (PostgreSQL's own digit-group-of-4 wire format, not a
 lossy float64 detour), plus a text encoder that renders a `BigDecimal` as a plain decimal string rather than
-`BigDecimal.toString()`'s occasional scientific notation.
+`BigDecimal.toString()`'s occasional scientific notation. Both the codec's decode side (attacker-controlled wire
+bytes) and encode side (a `BigDecimal` of unbounded scale, which ArcadeDB itself can produce) reject an
+out-of-range digit count rather than silently wrapping it through the wire format's `int16` header fields.
 
 `SHORT`/`BYTE` had a narrower bug: the value path widened `Short`/`Byte` to `INTEGER` because there was nowhere
 narrower to point it, while the schema path already answered the correct `SMALLINT` (`int2`). The value path now
 answers `SMALLINT` too.
 
-`DATETIME` was different in kind: `java.util.Date` is the default Java runtime type of both `DATE` and every
-`DATETIME*` variant, so a bare sampled value cannot tell them apart and the value path always answered `DATE`.
-Rather than adding a wrapper type just to carry that distinction through a value the executor already has more
-context for, `PostgresNetworkExecutor.getColumns()` now resolves the ambiguity from the schema when the row is
-backed by one - the same mechanism it already used to type an empty `LIST` column from its declared `LIST OF`
-element type (#5289) rather than guessing from a value with nothing to sample.
+`DATE` and `DATETIME` both trace back to the same root cause, from two different directions. `Type.DATE`'s and
+`Type.DATETIME`'s runtime representations are configurable per database (`GlobalConfiguration.DATE_IMPLEMENTATION`
+/`DATE_TIME_IMPLEMENTATION`) and default to `LocalDate`/`LocalDateTime` - not `java.util.Date`. The value path had
+no case at all for a bare `LocalDate`, so a `DATE` column fell all the way through to `VARCHAR` on every
+default-configured database; it now resolves to `DATE`, matching the schema path. `java.util.Date` remains a
+supported alternative implementation for both types, and it is where the two collide: `Date` is `DATE`'s default
+representation too, so a `Date`-configured `DATETIME` column's sampled value cannot be told apart from `DATE` by
+value alone. Rather than adding a wrapper type just to carry that distinction through a value with nothing else to
+go on, `PostgresNetworkExecutor.getColumns()` now resolves the ambiguity from the schema - the same mechanism it
+already used to type an empty `LIST` column from its declared `LIST OF` element type (#5289). That mechanism only
+worked for a whole-entity projection (`SELECT FROM Type`) until this change, though: a query that projects specific
+columns (`SELECT col FROM Type`, the shape of essentially every real client query) produces rows that carry only
+the projected values, not the backing element the lookup needs - so the schema fallback is now also resolved from
+the query's `FROM` target when the row itself isn't one, closing the gap for the query shape it needed to cover
+most.
 
 > [!IMPORTANT]
-> **Behaviour change.** A populated `SHORT`, `BYTE` or `DECIMAL` column now announces `int2` or `numeric` instead
-> of the `int4`/`double`/`varchar` OID it used to. This corrects a client-visible bug (the OID depended on whether
-> the result set happened to be empty), but a client relying on the old, disagreeing OID for a non-empty result
-> sees a different type name and, for `DECIMAL`, a `BigDecimal` instead of a `Double`/`String`.
+> **Behaviour change.** A populated `SHORT`, `BYTE`, `DATE` or `DECIMAL` column now announces `int2`, `date` or
+> `numeric` instead of the `int4`/`varchar`/`double`/`varchar` OID it used to. This corrects a client-visible bug
+> (the OID depended on whether the result set happened to be empty, and for `DATE` on a default-configured
+> database it was `varchar` unconditionally), but a client relying on the old, disagreeing OID for a non-empty
+> result sees a different type name and, for `DECIMAL`, a `BigDecimal` instead of a `Double`/`String`.
 
 ## A Cypher node's labels are the ones it answers to, and adding one no longer takes one away (#6363)
 

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3,6 +3,37 @@
 This is a living document: fixes, improvements, new features, and breaking changes are collected here as
 they land during the 26.9.1 development cycle, so the release notes are ready at tag time.
 
+## Postgres wire: `SHORT`/`BYTE`, `DATETIME` and `DECIMAL` no longer change type depending on whether a row was sampled (#6447)
+
+A RowDescription column is typed either from a sample value, when the result set has a row, or from the declared
+schema, when it does not - and the two paths have to agree, or a client that prepares against an empty result and
+then re-executes against a populated one sees the column's OID change under it. #6411 fixed this for `BINARY`
+(`bytea`); three more types had the same shape of bug.
+
+`DECIMAL` was the worst of the three: the schema path answered `DOUBLE`, lossy for an arbitrary-precision
+`BigDecimal`, and the value path answered `VARCHAR`, which makes a client treat the column as text. Neither was
+right - PostgreSQL already has the correct type for this, `NUMERIC` (OID 1700) - so both paths now point at a new
+`PostgresType.NUMERIC` entry with a real binary codec (PostgreSQL's own digit-group-of-4 wire format, not a
+lossy float64 detour), plus a text encoder that renders a `BigDecimal` as a plain decimal string rather than
+`BigDecimal.toString()`'s occasional scientific notation.
+
+`SHORT`/`BYTE` had a narrower bug: the value path widened `Short`/`Byte` to `INTEGER` because there was nowhere
+narrower to point it, while the schema path already answered the correct `SMALLINT` (`int2`). The value path now
+answers `SMALLINT` too.
+
+`DATETIME` was different in kind: `java.util.Date` is the default Java runtime type of both `DATE` and every
+`DATETIME*` variant, so a bare sampled value cannot tell them apart and the value path always answered `DATE`.
+Rather than adding a wrapper type just to carry that distinction through a value the executor already has more
+context for, `PostgresNetworkExecutor.getColumns()` now resolves the ambiguity from the schema when the row is
+backed by one - the same mechanism it already used to type an empty `LIST` column from its declared `LIST OF`
+element type (#5289) rather than guessing from a value with nothing to sample.
+
+> [!IMPORTANT]
+> **Behaviour change.** A populated `SHORT`, `BYTE` or `DECIMAL` column now announces `int2` or `numeric` instead
+> of the `int4`/`double`/`varchar` OID it used to. This corrects a client-visible bug (the OID depended on whether
+> the result set happened to be empty), but a client relying on the old, disagreeing OID for a non-empty result
+> sees a different type name and, for `DECIMAL`, a `BigDecimal` instead of a `Double`/`String`.
+
 ## A Cypher node's labels are the ones it answers to, and adding one no longer takes one away (#6363)
 
 `labels()` decided a vertex's labels from a single question - does the type have supertypes - and answered "the

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresCatalog.java
@@ -750,7 +750,7 @@ public class PostgresCatalog {
                 "column_default", defaultValue == null ? null : defaultValue.toString(),//
                 "is_nullable", notNull ? "NO" : "YES", "data_type", pgType.typeName, "udt_catalog", schema,//
                 "udt_schema", "pg_catalog", "udt_name", pgType.typeName, "is_identity", "NO", "is_generated", "NEVER",//
-                "is_updatable", "YES", "numeric_precision_radix", pgType.isNativeScalarType() ? 2 : null);
+                "is_updatable", "YES", "numeric_precision_radix", numericPrecisionRadix(pgType));
 
         // The type row a client joins pg_attribute to in order to name the column's type. It describes the
         // column's own type, which is the only reading of that join that makes sense.
@@ -764,6 +764,19 @@ public class PostgresCatalog {
     }
 
     return rows;
+  }
+
+  /**
+   * information_schema.columns.numeric_precision_radix: 2 for the binary/approximate numeric types PostgreSQL
+   * itself reports it for, but 10 for NUMERIC specifically - it is the one numeric type PostgreSQL stores and
+   * reports precision in base 10 rather than base 2 (issue #6447). DECIMAL used to map to DOUBLE, so the flat
+   * "every native scalar type answers 2" below was accidentally correct for it; now that it maps to NUMERIC,
+   * it needs its own case.
+   */
+  private static Integer numericPrecisionRadix(final PostgresType pgType) {
+    if (pgType == PostgresType.NUMERIC)
+      return 10;
+    return pgType.isNativeScalarType() ? 2 : null;
   }
 
   private static Row databaseRow(final Context context) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -595,6 +595,11 @@ public class PostgresNetworkExecutor extends Thread {
       if (DEBUG)
         LogManager.instance().log(this, Level.INFO, "PSQL: query -> %s ", query);
 
+      // Parsed once, gated on language, and reused below for both the schema-fallback and the target-type
+      // resolution: parseStatement always goes through the SQL engine, so parsing a Cypher/Gremlin/Mongo/
+      // GraphQL query here would be a parse attempt guaranteed to throw and be discarded on every such query.
+      final Statement parsedStatement = "sql".equalsIgnoreCase(query.language) ? parseStatement(query.query) : null;
+
       final long engineStart = System.nanoTime();
       final ResultSet resultSet;
       final String upperCaseText = query.query.toUpperCase(Locale.ENGLISH);
@@ -635,9 +640,10 @@ public class PostgresNetworkExecutor extends Thread {
 
       final long serStart = System.nanoTime();
       Map<String, PostgresType> columns = catalogAnswer != null ? catalogAnswer.columns()
-          : getColumns(cachedResultSet, resolveQueryTargetType(parseStatement(query.query)));
+          : getColumns(cachedResultSet, resolveQueryTargetType(parsedStatement));
       if (columns.isEmpty() && cachedResultSet.isEmpty()) {
-        final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(query.query, query.language, NO_PARAMETERS, null);
+        final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(query.query, query.language, NO_PARAMETERS,
+            parsedStatement);
         if (schemaColumns != null)
           columns = schemaColumns;
       }
@@ -896,11 +902,10 @@ public class PostgresNetworkExecutor extends Thread {
     if (item == null || item.getIdentifier() == null)
       return null;
 
-    try {
-      return database.getSchema().getType(item.getIdentifier().getStringValue());
-    } catch (final Exception e) {
-      return null;
-    }
+    // getTypeOrNull, not getType: the identifier is very often not a registered type name at all (a bucket, a
+    // catalog target, a typo, a RID-producing expression, ...), which getType() reports by throwing - control
+    // flow this resolution runs on every query and so should not pay exception overhead for.
+    return database.getSchema().getTypeOrNull(item.getIdentifier().getStringValue());
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -595,10 +595,12 @@ public class PostgresNetworkExecutor extends Thread {
       if (DEBUG)
         LogManager.instance().log(this, Level.INFO, "PSQL: query -> %s ", query);
 
-      // Parsed once, gated on language, and reused below for both the schema-fallback and the target-type
-      // resolution: parseStatement always goes through the SQL engine, so parsing a Cypher/Gremlin/Mongo/
-      // GraphQL query here would be a parse attempt guaranteed to throw and be discarded on every such query.
-      final Statement parsedStatement = "sql".equalsIgnoreCase(query.language) ? parseStatement(query.query) : null;
+      // Reused below for both the schema-fallback and the target-type resolution, but only set in the one
+      // branch that reaches database.command(...) below: none of SET/SAVEPOINT/RELEASE/ROLLBACK TO/SHOW/a
+      // system query/BEGIN are valid SQL productions (no bare "SET"/"SHOW" statement exists in SQLParser.g4),
+      // so parsing any of them here would be a guaranteed parse-and-fail on every one of those statements -
+      // exactly the ones connection setup (JDBC drivers, psql, poolers) sends most.
+      Statement parsedStatement = null;
 
       final long engineStart = System.nanoTime();
       final ResultSet resultSet;
@@ -632,6 +634,7 @@ public class PostgresNetworkExecutor extends Thread {
         if (catalogAnswer != null) {
           resultSet = new IteratorResultSet(catalogAnswer.rows().iterator());
         } else {
+          parsedStatement = "sql".equalsIgnoreCase(query.language) ? parseStatement(query.query) : null;
           resultSet = database.command(query.language, query.query, server.getConfiguration());
         }
       }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -385,7 +385,7 @@ public class PostgresNetworkExecutor extends Thread {
         portal.executed = true;
         if (portal.isExpectingResult) {
           portal.cachedResultSet = browseAndCacheResultSet(resultSet, 0);
-          portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal.sqlStatement));
+          portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal));
           if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
             final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                 getParams(portal), portal.sqlStatement);
@@ -484,7 +484,7 @@ public class PostgresNetworkExecutor extends Thread {
               final long serStart = System.nanoTime();
               // A catalog answer already carries the columns it must be announced under.
               if (!portal.catalogQuery || portal.columns == null)
-                portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal.sqlStatement));
+                portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal));
               if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
                 final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                     getParams(portal), portal.sqlStatement);
@@ -503,7 +503,7 @@ public class PostgresNetworkExecutor extends Thread {
         if (portal.isExpectingResult && portal.cachedResultSet != null && !portal.cachedResultSet.isEmpty()) {
           final long serStart = System.nanoTime();
           // Query returned results - send them
-          final Map<String, PostgresType> dataRowColumns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal.sqlStatement));
+          final Map<String, PostgresType> dataRowColumns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal));
 
           if (DEBUG)
             LogManager.instance().log(this, Level.INFO,
@@ -891,6 +891,20 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   /**
+   * Memoized on the portal (issue #6447): a portal can be described and executed - possibly executed
+   * repeatedly, for a cursor-based fetch with a LIMIT - several times over its lifetime, and every one of
+   * those calls resolves the same FROM-target type, so it is resolved at most once per portal rather than
+   * once per call.
+   */
+  private DocumentType resolveQueryTargetType(final PostgresPortal portal) {
+    if (!portal.queryTargetTypeResolved) {
+      portal.queryTargetType = resolveQueryTargetType(portal.sqlStatement);
+      portal.queryTargetTypeResolved = true;
+    }
+    return portal.queryTargetType;
+  }
+
+  /**
    * The schema type a SELECT statement's simple FROM target names, or null when the target is not a plain
    * "FROM &lt;type&gt;" (a subquery, a function call, a RID, a MATCH, ...) or does not resolve to a known type.
    * Resolved once per query and passed into {@link #getColumns(List, DocumentType)} as the fallback source for
@@ -919,6 +933,12 @@ public class PostgresNetworkExecutor extends Thread {
    * target names, resolved once by the caller - is the fallback for that (very common) case. Shared lookup
    * behind {@link #getDeclaredListType} and {@link #isDeclaredAsDatetime}, both of which prefer the schema's
    * declared type over a guess made from a single sample value.
+   * <p>
+   * {@code propertyName} is the row's own column name, which for an aliased or computed projection ({@code
+   * SELECT amount AS x FROM Type}) is the alias, not the source property - so the lookup misses and the caller
+   * falls back to a value-only guess for that column. Pre-existing limitation shared with #5289's {@link
+   * #getDeclaredListType}, not something introduced here; resolving an alias back to its source property would
+   * need to walk the SELECT projection's expression tree, which is a materially larger piece of work.
    */
   private Property getDeclaredProperty(final Result row, final String propertyName, final DocumentType queryTargetType) {
     final Document element = row.getElement().orElse(null);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -844,6 +844,12 @@ public class PostgresNetworkExecutor extends Thread {
             final PostgresType declaredType = getDeclaredListType(row, p);
             if (declaredType != null)
               pgType = declaredType;
+          } else if (pgType == PostgresType.DATE && isDeclaredAsDatetime(row, p)) {
+            // java.util.Date is the default Java runtime type of both Type.DATE and Type.DATETIME* (issue
+            // #6447), so getTypeForValue cannot tell them apart from the value alone and always answers DATE.
+            // Prefer the schema's declared type when the row is backed by one, the same way the empty-list
+            // case above prefers the declared "LIST OF" over a value-based guess.
+            pgType = PostgresType.TIMESTAMP;
           }
 
           if (pgType.isArrayType() || pgType.isNativeScalarType() || pgType == PostgresType.JSON)
@@ -864,10 +870,12 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   /**
-   * Returns the array type declared by the schema for a LIST property, or null when the row is not a schema
-   * element or the property is not a declared LIST.
+   * Returns the schema property backing {@code propertyName} on {@code row}, or null when the row is not a
+   * schema element or the property is not declared. Shared lookup behind {@link #getDeclaredListType} and
+   * {@link #isDeclaredAsDatetime}, both of which prefer the schema's declared type over a guess made from a
+   * single sample value.
    */
-  private PostgresType getDeclaredListType(final Result row, final String propertyName) {
+  private Property getDeclaredProperty(final Result row, final String propertyName) {
     final Document element = row.getElement().orElse(null);
     if (element == null)
       return null;
@@ -876,11 +884,35 @@ public class PostgresNetworkExecutor extends Thread {
     if (documentType == null)
       return null;
 
-    final Property property = documentType.getPolymorphicPropertyIfExists(propertyName);
+    return documentType.getPolymorphicPropertyIfExists(propertyName);
+  }
+
+  /**
+   * Returns the array type declared by the schema for a LIST property, or null when the row is not a schema
+   * element or the property is not a declared LIST.
+   */
+  private PostgresType getDeclaredListType(final Result row, final String propertyName) {
+    final Property property = getDeclaredProperty(row, propertyName);
     if (property == null || property.getType() != Type.LIST)
       return null;
 
     return PostgresType.getTypeFromArcade(property.getType(), property.getOfType());
+  }
+
+  /**
+   * True when the schema declares {@code propertyName} as one of the DATETIME variants (issue #6447). Used to
+   * disambiguate a sampled {@code java.util.Date} value, which is the default Java runtime type of both
+   * Type.DATE and every Type.DATETIME* and so cannot tell them apart on its own.
+   */
+  private boolean isDeclaredAsDatetime(final Result row, final String propertyName) {
+    final Property property = getDeclaredProperty(row, propertyName);
+    if (property == null)
+      return false;
+
+    return switch (property.getType()) {
+      case DATETIME, DATETIME_MICROS, DATETIME_NANOS, DATETIME_SECOND -> true;
+      default -> false;
+    };
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -936,9 +936,11 @@ public class PostgresNetworkExecutor extends Thread {
    * <p>
    * {@code propertyName} is the row's own column name, which for an aliased or computed projection ({@code
    * SELECT amount AS x FROM Type}) is the alias, not the source property - so the lookup misses and the caller
-   * falls back to a value-only guess for that column. Pre-existing limitation shared with #5289's {@link
-   * #getDeclaredListType}, not something introduced here; resolving an alias back to its source property would
-   * need to walk the SELECT projection's expression tree, which is a materially larger piece of work.
+   * falls back to a value-only guess for that column. The "look up by row column name" pattern is inherited
+   * from #5289's {@link #getDeclaredListType}, which has the identical gap for an empty aliased LIST; the
+   * {@code queryTargetType} fallback added here for #6447 does not close it either. Resolving an alias back to
+   * its source property would need to walk the SELECT projection's expression tree, a materially larger piece
+   * of work than either fix.
    */
   private Property getDeclaredProperty(final Result row, final String propertyName, final DocumentType queryTargetType) {
     final Document element = row.getElement().orElse(null);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -385,7 +385,7 @@ public class PostgresNetworkExecutor extends Thread {
         portal.executed = true;
         if (portal.isExpectingResult) {
           portal.cachedResultSet = browseAndCacheResultSet(resultSet, 0);
-          portal.columns = getColumns(portal.cachedResultSet);
+          portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal.sqlStatement));
           if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
             final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                 getParams(portal), portal.sqlStatement);
@@ -484,7 +484,7 @@ public class PostgresNetworkExecutor extends Thread {
               final long serStart = System.nanoTime();
               // A catalog answer already carries the columns it must be announced under.
               if (!portal.catalogQuery || portal.columns == null)
-                portal.columns = getColumns(portal.cachedResultSet);
+                portal.columns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal.sqlStatement));
               if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
                 final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query, portal.language,
                     getParams(portal), portal.sqlStatement);
@@ -503,7 +503,7 @@ public class PostgresNetworkExecutor extends Thread {
         if (portal.isExpectingResult && portal.cachedResultSet != null && !portal.cachedResultSet.isEmpty()) {
           final long serStart = System.nanoTime();
           // Query returned results - send them
-          final Map<String, PostgresType> dataRowColumns = getColumns(portal.cachedResultSet);
+          final Map<String, PostgresType> dataRowColumns = getColumns(portal.cachedResultSet, resolveQueryTargetType(portal.sqlStatement));
 
           if (DEBUG)
             LogManager.instance().log(this, Level.INFO,
@@ -634,7 +634,8 @@ public class PostgresNetworkExecutor extends Thread {
       profile.addEngineNanos(System.nanoTime() - engineStart);
 
       final long serStart = System.nanoTime();
-      Map<String, PostgresType> columns = catalogAnswer != null ? catalogAnswer.columns() : getColumns(cachedResultSet);
+      Map<String, PostgresType> columns = catalogAnswer != null ? catalogAnswer.columns()
+          : getColumns(cachedResultSet, resolveQueryTargetType(parseStatement(query.query)));
       if (columns.isEmpty() && cachedResultSet.isEmpty()) {
         final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(query.query, query.language, NO_PARAMETERS, null);
         if (schemaColumns != null)
@@ -818,6 +819,17 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   private Map<String, PostgresType> getColumns(final List<Result> resultSet) {
+    return getColumns(resultSet, null);
+  }
+
+  /**
+   * @param queryTargetType the schema type the query's FROM target names, or null when it is not a plain
+   *                        "FROM &lt;type&gt;" or was not resolved. Falls back {@link #getDeclaredProperty} to
+   *                        this type when a row is not itself an element - which a query that projects specific
+   *                        columns ("SELECT col FROM Type") produces for every row, since only the projected
+   *                        values travel with it, not the backing element.
+   */
+  private Map<String, PostgresType> getColumns(final List<Result> resultSet, final DocumentType queryTargetType) {
     final Map<String, PostgresType> columns = new LinkedHashMap<>();
 
     boolean atLeastOneElement = false;
@@ -841,14 +853,14 @@ public class PostgresNetworkExecutor extends Thread {
           // Prefer the declared "LIST OF <type>" (issue #5289) so a column's OID does not depend on whether
           // the first row's list happens to be empty.
           if (value instanceof Collection<?> collection && collection.isEmpty()) {
-            final PostgresType declaredType = getDeclaredListType(row, p);
+            final PostgresType declaredType = getDeclaredListType(row, p, queryTargetType);
             if (declaredType != null)
               pgType = declaredType;
-          } else if (pgType == PostgresType.DATE && isDeclaredAsDatetime(row, p)) {
+          } else if (pgType == PostgresType.DATE && isDeclaredAsDatetime(row, p, queryTargetType)) {
             // java.util.Date is the default Java runtime type of both Type.DATE and Type.DATETIME* (issue
             // #6447), so getTypeForValue cannot tell them apart from the value alone and always answers DATE.
-            // Prefer the schema's declared type when the row is backed by one, the same way the empty-list
-            // case above prefers the declared "LIST OF" over a value-based guess.
+            // Prefer the schema's declared type when it can be found, the same way the empty-list case above
+            // prefers the declared "LIST OF" over a value-based guess.
             pgType = PostgresType.TIMESTAMP;
           }
 
@@ -870,17 +882,39 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   /**
-   * Returns the schema property backing {@code propertyName} on {@code row}, or null when the row is not a
-   * schema element or the property is not declared. Shared lookup behind {@link #getDeclaredListType} and
-   * {@link #isDeclaredAsDatetime}, both of which prefer the schema's declared type over a guess made from a
-   * single sample value.
+   * The schema type a SELECT statement's simple FROM target names, or null when the target is not a plain
+   * "FROM &lt;type&gt;" (a subquery, a function call, a RID, a MATCH, ...) or does not resolve to a known type.
+   * Resolved once per query and passed into {@link #getColumns(List, DocumentType)} as the fallback source for
+   * a row that is not itself an element (issue #6447).
    */
-  private Property getDeclaredProperty(final Result row, final String propertyName) {
-    final Document element = row.getElement().orElse(null);
-    if (element == null)
+  private DocumentType resolveQueryTargetType(final Statement statement) {
+    if (!(statement instanceof SelectStatement select))
       return null;
 
-    final DocumentType documentType = element.getType();
+    final FromClause target = select.getTarget();
+    final FromItem item = target != null ? target.getItem() : null;
+    if (item == null || item.getIdentifier() == null)
+      return null;
+
+    try {
+      return database.getSchema().getType(item.getIdentifier().getStringValue());
+    } catch (final Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Returns the schema property backing {@code propertyName}, or null when it cannot be found. {@code row}
+   * itself is an element - and so carries its own {@link DocumentType} - only for a whole-entity projection
+   * ("SELECT FROM Type" or "SELECT *"); a query that projects specific columns ("SELECT col FROM Type") produces
+   * rows that carry only the projected values, so {@code queryTargetType} - the schema type the query's FROM
+   * target names, resolved once by the caller - is the fallback for that (very common) case. Shared lookup
+   * behind {@link #getDeclaredListType} and {@link #isDeclaredAsDatetime}, both of which prefer the schema's
+   * declared type over a guess made from a single sample value.
+   */
+  private Property getDeclaredProperty(final Result row, final String propertyName, final DocumentType queryTargetType) {
+    final Document element = row.getElement().orElse(null);
+    final DocumentType documentType = element != null ? element.getType() : queryTargetType;
     if (documentType == null)
       return null;
 
@@ -888,11 +922,10 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   /**
-   * Returns the array type declared by the schema for a LIST property, or null when the row is not a schema
-   * element or the property is not a declared LIST.
+   * Returns the array type declared by the schema for a LIST property, or null when it is not a declared LIST.
    */
-  private PostgresType getDeclaredListType(final Result row, final String propertyName) {
-    final Property property = getDeclaredProperty(row, propertyName);
+  private PostgresType getDeclaredListType(final Result row, final String propertyName, final DocumentType queryTargetType) {
+    final Property property = getDeclaredProperty(row, propertyName, queryTargetType);
     if (property == null || property.getType() != Type.LIST)
       return null;
 
@@ -904,8 +937,8 @@ public class PostgresNetworkExecutor extends Thread {
    * disambiguate a sampled {@code java.util.Date} value, which is the default Java runtime type of both
    * Type.DATE and every Type.DATETIME* and so cannot tell them apart on its own.
    */
-  private boolean isDeclaredAsDatetime(final Result row, final String propertyName) {
-    final Property property = getDeclaredProperty(row, propertyName);
+  private boolean isDeclaredAsDatetime(final Result row, final String propertyName, final DocumentType queryTargetType) {
+    final Property property = getDeclaredProperty(row, propertyName, queryTargetType);
     if (property == null)
       return false;
 
@@ -1093,7 +1126,7 @@ public class PostgresNetworkExecutor extends Thread {
 
       if (!sampleRows.isEmpty()) {
         // Use the sample row to discover columns
-        final Map<String, PostgresType> cols = getColumns(sampleRows);
+        final Map<String, PostgresType> cols = getColumns(sampleRows, docType);
         if (DEBUG)
           LogManager.instance().log(this, Level.INFO,
               "PSQL: getColumnsFromType('%s') -> sampleQuery='%s', found %d rows, columns=%s (thread=%s)",
@@ -1317,7 +1350,7 @@ public class PostgresNetworkExecutor extends Thread {
 
       final ResultSet resultSet = sample.execute(database, parameters != null ? parameters : NO_PARAMETERS, context);
       final List<Result> sampleRows = browseAndCacheResultSet(resultSet, 1, false);
-      return sampleRows.isEmpty() ? null : getColumns(sampleRows);
+      return sampleRows.isEmpty() ? null : getColumns(sampleRows, resolveQueryTargetType(select));
     } catch (final Exception e) {
       if (DEBUG)
         LogManager.instance().log(this, Level.WARNING, "PSQL: cannot replay the schema probe '%s': %s", parsed, e.getMessage());

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
@@ -20,6 +20,7 @@ package com.arcadedb.postgres;
 
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.parser.Statement;
+import com.arcadedb.schema.DocumentType;
 
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,13 @@ public class PostgresPortal {
   public boolean                   isExpectingResult;
   public boolean                   executed             = false;
   public boolean                   rowDescriptionSent   = false;
+  /**
+   * Memoizes {@code PostgresNetworkExecutor.resolveQueryTargetType(sqlStatement)} (issue #6447): a portal can
+   * be described and executed - possibly executed repeatedly, for a cursor-based fetch with a LIMIT - several
+   * times over its lifetime, and the schema type its FROM target names does not change between them.
+   */
+  public DocumentType               queryTargetType;
+  public boolean                    queryTargetTypeResolved = false;
   /**
    * True when the query is about the emulated system catalog and could not be answered at Parse time because
    * its filters are bound parameters, whose values only arrive with the Bind message (issue #6412).

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -579,6 +579,11 @@ public enum PostgresType {
       };
     } else if (val instanceof Date) {
       return PostgresType.DATE;
+    } else if (val instanceof LocalDate) {
+      // Type.DATE's runtime representation is configurable per database (GlobalConfiguration.DATE_IMPLEMENTATION)
+      // and defaults to LocalDate, not Date - so a sampled value from a default-configured database never hit
+      // the Date branch above and fell all the way through to VARCHAR, disagreeing with the schema path's DATE.
+      return PostgresType.DATE;
     } else if (val instanceof LocalDateTime) {
       return PostgresType.TIMESTAMP;
     }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -372,6 +372,13 @@ public enum PostgresType {
     // setScale below would otherwise pad a BigInteger out to it. Same bound the encode side rejects at.
     if (dscale > NUMERIC_MAX_DIGITS * NUMERIC_DIGIT_WIDTH)
       throw new PostgresProtocolException("NUMERIC scale exceeds the supported maximum: " + dscale);
+    // weight is otherwise unbounded within its short range: a payload with an extreme weight combined with a
+    // small ndigits and the max-allowed dscale derives a `scale` far apart from dscale, and setScale below
+    // would materialize a BigInteger to bridge that gap - the same class of unbounded-materialization risk
+    // putNumericBinary guards against on the encode side, just with a smaller blast radius here because weight
+    // is capped by its own wire width rather than an arbitrary int.
+    if (weight < -NUMERIC_MAX_DIGITS || weight > NUMERIC_MAX_DIGITS)
+      throw new PostgresProtocolException("NUMERIC weight exceeds the supported range: " + weight);
 
     if (ndigits == 0)
       return BigDecimal.ZERO.setScale(dscale);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -81,7 +81,7 @@ public enum PostgresType {
   // path (lossy for a BigDecimal outside float64's range/precision) and as VARCHAR by the value path (forces a
   // client to treat the column as text) - neither was right, and the two disagreeing meant a column's OID also
   // depended on whether the result set was empty. NUMERIC is the honest answer PostgreSQL already has for this.
-  NUMERIC(1700, "numeric", 0, 1231, BigDecimal.class, -1, value -> new BigDecimal(value)),
+  NUMERIC(1700, "numeric", 0, 1231, BigDecimal.class, -1, BigDecimal::new),
   // Adding array types with PostgreSQL array type codes
   ARRAY_INT(1007, "_int4", 23, 0, Collection.class, -1, value -> parseArrayFromString(value, Integer::parseInt)),
   // 1002 is "char"[], the array of the single-byte CHAR (OID 18) this enum pairs it with. It used to be
@@ -306,7 +306,7 @@ public enum PostgresType {
     // O(n) toString()/padding work below before the digit-count check further down ever gets a chance to
     // reject it.
     if (unscaled.bitLength() > NUMERIC_MAX_UNSCALED_BITS)
-      throw new PostgresProtocolException("NUMERIC precision exceeds the supported maximum");
+      throw new PostgresProtocolException("NUMERIC precision exceeds the supported maximum: " + unscaled.bitLength() + " bits");
 
     if (unscaled.equals(BigInteger.ZERO)) {
       typeBuffer.putInt(8);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -276,6 +276,15 @@ public enum PostgresType {
    * wrapped {@code ndigits}/{@code weight}/{@code dscale} out of that payload would not agree with it.
    */
   private static void putNumericBinary(final Binary typeBuffer, final BigDecimal decimalValue) {
+    // Checked on the RAW scale, before any normalization. BigDecimal(String) parsing scientific notation (e.g.
+    // a plain SQL literal like '1E2000000000' - DECIMAL has no configured precision/scale limit) is itself O(1):
+    // it just stores unscaledValue=1, scale=-2000000000. setScale(0) below is not - going from a very negative
+    // scale up to 0 has to actually materialize unscaledValue * 10^|scale| as a real BigInteger. Rejecting the
+    // raw scale first means that materialization, and the multi-GB allocation it would otherwise trigger, never
+    // starts. -(long) avoids the int overflow of negating Integer.MIN_VALUE.
+    if (decimalValue.scale() < 0 && -(long) decimalValue.scale() > NUMERIC_MAX_DIGITS * NUMERIC_DIGIT_WIDTH)
+      throw new PostgresProtocolException("NUMERIC scale exceeds the supported maximum: " + decimalValue.scale());
+
     final BigDecimal normalized = decimalValue.scale() < 0 ? decimalValue.setScale(0) : decimalValue;
     final int dscale = normalized.scale();
     // Checked before any padding so a value with an absurd scale fails fast instead of first allocating a
@@ -383,8 +392,14 @@ public enum PostgresType {
       result = result.negate();
 
     // Trailing zero digit groups are dropped by the encoder, so the scale derived from `weight`/`ndigits` can
-    // be smaller than dscale; padding back up to it is always exact (the dropped digits were zero).
-    return result.setScale(dscale, RoundingMode.UNNECESSARY);
+    // be smaller than dscale; padding back up to it is always exact (the dropped digits were zero) - unless the
+    // payload is malformed and dscale does not actually match the precision ndigits/weight encode, in which
+    // case this is a value this codec could never have produced rather than a genuine JVM arithmetic error.
+    try {
+      return result.setScale(dscale, RoundingMode.UNNECESSARY);
+    } catch (final ArithmeticException e) {
+      throw new PostgresProtocolException("NUMERIC dscale does not match the encoded precision: " + dscale);
+    }
   }
 
   private static boolean toBooleanValue(final Object value) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -267,10 +267,22 @@ public enum PostgresType {
   // above this cannot be a value this codec produced, only a malformed or adversarial payload.
   private static final int NUMERIC_MAX_DIGITS  = 4000;
 
-  /** Encodes a BigDecimal in PostgreSQL's NUMERIC binary wire format. */
+  /**
+   * Encodes a BigDecimal in PostgreSQL's NUMERIC binary wire format. Unlike {@link #parseNumericBinary}, which
+   * only has to reject bytes an attacker sent, this also has to reject a BigDecimal ArcadeDB itself produced:
+   * a DECIMAL property has no configured precision/scale limit, so a value with a large enough scale would
+   * otherwise silently wrap through the header fields' {@code (short)} casts below and write a self-
+   * inconsistent payload - the {@code putInt} length prefix would stay correct, but a real client decoding the
+   * wrapped {@code ndigits}/{@code weight}/{@code dscale} out of that payload would not agree with it.
+   */
   private static void putNumericBinary(final Binary typeBuffer, final BigDecimal decimalValue) {
     final BigDecimal normalized = decimalValue.scale() < 0 ? decimalValue.setScale(0) : decimalValue;
     final int dscale = normalized.scale();
+    // Checked before any padding so a value with an absurd scale fails fast instead of first allocating a
+    // proportionally huge digit string.
+    if (dscale < 0 || dscale > NUMERIC_MAX_DIGITS * NUMERIC_DIGIT_WIDTH)
+      throw new PostgresProtocolException("NUMERIC scale exceeds the supported maximum: " + dscale);
+
     final boolean negative = normalized.signum() < 0;
     final BigInteger unscaled = normalized.unscaledValue().abs();
 
@@ -314,6 +326,13 @@ public enum PostgresType {
 
     final int ndigits = end - start + 1;
     final int weight = integerGroups - 1 - start;
+
+    // Both fields are about to go through a (short) cast: reject rather than let either wrap silently into a
+    // header that no longer matches the digits actually written.
+    if (ndigits > NUMERIC_MAX_DIGITS)
+      throw new PostgresProtocolException("NUMERIC digit count exceeds the supported maximum: " + ndigits);
+    if (weight < Short.MIN_VALUE || weight > Short.MAX_VALUE)
+      throw new PostgresProtocolException("NUMERIC weight exceeds the supported range: " + weight);
 
     typeBuffer.putInt(8 + ndigits * 2);
     typeBuffer.putShort((short) ndigits);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -358,6 +358,11 @@ public enum PostgresType {
       throw new PostgresProtocolException("NUMERIC digit count exceeds the supported maximum: " + ndigits);
     if (ndigits * 2 > buffer.remaining())
       throw new PostgresProtocolException("NUMERIC digit count exceeds remaining buffer bytes");
+    // dscale is an unsigned 16-bit field, so this cannot runaway unbounded, but a declared scale wildly beyond
+    // what ndigits could ever back is still a malformed payload rather than one this codec produced - and
+    // setScale below would otherwise pad a BigInteger out to it. Same bound the encode side rejects at.
+    if (dscale > NUMERIC_MAX_DIGITS * NUMERIC_DIGIT_WIDTH)
+      throw new PostgresProtocolException("NUMERIC scale exceeds the supported maximum: " + dscale);
 
     if (ndigits == 0)
       return BigDecimal.ZERO.setScale(dscale);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -28,6 +28,8 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -75,6 +77,11 @@ public enum PostgresType {
   // right: an array of one-byte characters makes the client decode arbitrary bytes as text, which for any
   // non-UTF-8 payload loses data rather than merely looking odd.
   BYTEA(17, "bytea", 0, 1001, byte[].class, -1, PostgresType::parseByteaText),
+  // PostgreSQL's arbitrary-precision decimal (issue #6447). DECIMAL used to be typed as DOUBLE by the schema
+  // path (lossy for a BigDecimal outside float64's range/precision) and as VARCHAR by the value path (forces a
+  // client to treat the column as text) - neither was right, and the two disagreeing meant a column's OID also
+  // depended on whether the result set was empty. NUMERIC is the honest answer PostgreSQL already has for this.
+  NUMERIC(1700, "numeric", 0, 1231, BigDecimal.class, -1, value -> new BigDecimal(value)),
   // Adding array types with PostgreSQL array type codes
   ARRAY_INT(1007, "_int4", 23, 0, Collection.class, -1, value -> parseArrayFromString(value, Integer::parseInt)),
   // 1002 is "char"[], the array of the single-byte CHAR (OID 18) this enum pairs it with. It used to be
@@ -237,6 +244,125 @@ public enum PostgresType {
     return new BigDecimal(value.toString());
   }
 
+  private static BigDecimal toBigDecimalValue(final Object value) {
+    if (value instanceof BigDecimal bd)
+      return bd;
+    if (value instanceof Number n)
+      return new BigDecimal(n.toString());
+    return new BigDecimal(value.toString());
+  }
+
+  // NUMERIC's binary wire format (PostgreSQL src/backend/utils/adt/numeric.c) is a header of four int16s -
+  // ndigits, weight, sign, dscale - followed by ndigits base-10000 digits, most significant first. weight is
+  // the base-10000 exponent of the first digit, so the decimal point always falls on a 4-decimal-digit
+  // boundary; leading and trailing all-zero digit groups are dropped (weight/dscale carry that information
+  // instead), which is why a value like 0.5 encodes as a single digit [5000] at weight -1 rather than padding
+  // out to whatever precision produced it.
+  private static final int NUMERIC_DIGIT_WIDTH = 4;
+  private static final int NUMERIC_BASE        = 10000;
+  private static final int NUMERIC_POS_SIGN    = 0x0000;
+  private static final int NUMERIC_NEG_SIGN    = 0x4000;
+  private static final int NUMERIC_NAN_SIGN    = 0xC000;
+  // PostgreSQL's own cap (NUMERIC_MAX_RESULT_SCALE-derived) on digit groups in one value; a declared count
+  // above this cannot be a value this codec produced, only a malformed or adversarial payload.
+  private static final int NUMERIC_MAX_DIGITS  = 4000;
+
+  /** Encodes a BigDecimal in PostgreSQL's NUMERIC binary wire format. */
+  private static void putNumericBinary(final Binary typeBuffer, final BigDecimal decimalValue) {
+    final BigDecimal normalized = decimalValue.scale() < 0 ? decimalValue.setScale(0) : decimalValue;
+    final int dscale = normalized.scale();
+    final boolean negative = normalized.signum() < 0;
+    final BigInteger unscaled = normalized.unscaledValue().abs();
+
+    if (unscaled.equals(BigInteger.ZERO)) {
+      typeBuffer.putInt(8);
+      typeBuffer.putShort((short) 0);
+      typeBuffer.putShort((short) 0);
+      typeBuffer.putShort((short) NUMERIC_POS_SIGN);
+      typeBuffer.putShort((short) dscale);
+      return;
+    }
+
+    // Position the digits so index 0 is the most significant decimal digit and the decimal point sits
+    // `dscale` digits from the right, padding with leading/trailing zeros so both the integer part and the
+    // fractional part are a whole number of 4-digit groups.
+    String digits = unscaled.toString();
+    if (dscale > digits.length())
+      digits = "0".repeat(dscale - digits.length()) + digits;
+    int integerDigitCount = digits.length() - dscale;
+
+    final int fractionPad = (NUMERIC_DIGIT_WIDTH - dscale % NUMERIC_DIGIT_WIDTH) % NUMERIC_DIGIT_WIDTH;
+    digits = digits + "0".repeat(fractionPad);
+
+    final int leadPad = (NUMERIC_DIGIT_WIDTH - integerDigitCount % NUMERIC_DIGIT_WIDTH) % NUMERIC_DIGIT_WIDTH;
+    digits = "0".repeat(leadPad) + digits;
+    integerDigitCount += leadPad;
+
+    final int groupCount = digits.length() / NUMERIC_DIGIT_WIDTH;
+    final int integerGroups = integerDigitCount / NUMERIC_DIGIT_WIDTH;
+
+    final int[] groups = new int[groupCount];
+    for (int i = 0; i < groupCount; i++)
+      groups[i] = Integer.parseInt(digits.substring(i * NUMERIC_DIGIT_WIDTH, (i + 1) * NUMERIC_DIGIT_WIDTH));
+
+    int start = 0;
+    while (start < groupCount - 1 && groups[start] == 0)
+      start++;
+    int end = groupCount - 1;
+    while (end > start && groups[end] == 0)
+      end--;
+
+    final int ndigits = end - start + 1;
+    final int weight = integerGroups - 1 - start;
+
+    typeBuffer.putInt(8 + ndigits * 2);
+    typeBuffer.putShort((short) ndigits);
+    typeBuffer.putShort((short) weight);
+    typeBuffer.putShort((short) (negative ? NUMERIC_NEG_SIGN : NUMERIC_POS_SIGN));
+    typeBuffer.putShort((short) dscale);
+    for (int i = 0; i < ndigits; i++)
+      typeBuffer.putShort((short) groups[start + i]);
+  }
+
+  /** Decodes PostgreSQL's NUMERIC binary wire format, the inverse of {@link #putNumericBinary}. */
+  private static BigDecimal parseNumericBinary(final ByteBuffer buffer) {
+    final int ndigits = buffer.getShort() & 0xFFFF;
+    final int weight = buffer.getShort();
+    final int sign = buffer.getShort() & 0xFFFF;
+    final int dscale = buffer.getShort() & 0xFFFF;
+
+    if (sign == NUMERIC_NAN_SIGN)
+      throw new PostgresProtocolException("NaN NUMERIC values are not supported");
+    if (sign != NUMERIC_POS_SIGN && sign != NUMERIC_NEG_SIGN)
+      throw new PostgresProtocolException("Invalid NUMERIC sign: " + sign);
+    if (ndigits > NUMERIC_MAX_DIGITS)
+      throw new PostgresProtocolException("NUMERIC digit count exceeds the supported maximum: " + ndigits);
+    if (ndigits * 2 > buffer.remaining())
+      throw new PostgresProtocolException("NUMERIC digit count exceeds remaining buffer bytes");
+
+    if (ndigits == 0)
+      return BigDecimal.ZERO.setScale(dscale);
+
+    BigInteger magnitude = BigInteger.ZERO;
+    for (int i = 0; i < ndigits; i++) {
+      final int digit = buffer.getShort() & 0xFFFF;
+      if (digit >= NUMERIC_BASE)
+        throw new PostgresProtocolException("Invalid NUMERIC digit: " + digit);
+      magnitude = magnitude.multiply(BigInteger.valueOf(NUMERIC_BASE)).add(BigInteger.valueOf(digit));
+    }
+
+    // The digit sequence runs from base-10000 exponent `weight` down to `weight - ndigits + 1`; each step is
+    // NUMERIC_DIGIT_WIDTH decimal digits, so the whole magnitude sits at decimal scale -4*(weight-ndigits+1).
+    final int scale = NUMERIC_DIGIT_WIDTH * (ndigits - 1 - weight);
+    BigDecimal result = new BigDecimal(magnitude, scale);
+    if (sign == NUMERIC_NEG_SIGN)
+      result = result.negate();
+
+    // Trailing zero digit groups are dropped by the encoder, so the scale derived from `weight`/`ndigits` can
+    // be smaller than dscale; padding back up to it is always exact (the dropped digits were zero).
+    return result.setScale(dscale, RoundingMode.UNNECESSARY);
+  }
+
   private static boolean toBooleanValue(final Object value) {
     if (value instanceof Boolean b)
       return b;
@@ -358,8 +484,12 @@ public enum PostgresType {
       return PostgresType.REAL;
     } else if (val instanceof Double) {
       return PostgresType.DOUBLE;
-    } else if (val instanceof Integer || val instanceof Short || val instanceof Byte) {
+    } else if (val instanceof Integer) {
       return PostgresType.INTEGER;
+    } else if (val instanceof Short || val instanceof Byte) {
+      // Matches the schema path (Type.SHORT/Type.BYTE -> SMALLINT, issue #6447): widening to INTEGER here made
+      // a column's OID depend on whether the result set happened to be empty.
+      return PostgresType.SMALLINT;
     } else if (val instanceof Long) {
       return PostgresType.LONG;
     } else if (val instanceof Boolean) {
@@ -368,6 +498,8 @@ public enum PostgresType {
       return PostgresType.VARCHAR;
     } else if (val instanceof Character) {
       return PostgresType.CHAR;
+    } else if (val instanceof BigDecimal) {
+      return PostgresType.NUMERIC;
     } else if (val instanceof JSONObject) {
       return PostgresType.JSON;
     } else if (val instanceof Result) {
@@ -516,7 +648,7 @@ public enum PostgresType {
       case ARRAY_OF_DOUBLES -> PostgresType.ARRAY_DOUBLE;
       case MAP, EMBEDDED -> PostgresType.JSON;
       case LINK -> PostgresType.VARCHAR;
-      case DECIMAL -> PostgresType.DOUBLE;
+      case DECIMAL -> PostgresType.NUMERIC;
       default -> PostgresType.VARCHAR;
     };
   }
@@ -553,6 +685,10 @@ public enum PostgresType {
     } else if (value instanceof Boolean b) {
       // PostgreSQL BOOL text format is "t"/"f"
       serializedValue = b ? "t" : "f";
+    } else if (value instanceof BigDecimal bd) {
+      // BigDecimal.toString() switches to scientific notation outside a small exponent range (e.g. "1E+10"),
+      // which is not a NUMERIC text value PostgreSQL itself would ever emit or a client would expect to parse.
+      serializedValue = bd.toPlainString();
     } else if (value instanceof Date date) {
       // DATE (OID 1082) expects "YYYY-MM-DD" in text format
       serializedValue = date.toInstant().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE);
@@ -620,6 +756,7 @@ public enum PostgresType {
       typeBuffer.putInt(bytes.length);
       typeBuffer.putByteArray(bytes);
     }
+    case NUMERIC -> putNumericBinary(typeBuffer, toBigDecimalValue(value));
     case CHAR -> {
       // Postgres "char" (OID 18) is a single byte on the wire.
       typeBuffer.putInt(1);
@@ -936,6 +1073,7 @@ public enum PostgresType {
         yield LocalDateTime.ofEpochSecond(secs, nanos, ZoneOffset.UTC);
       }
       case BYTEA -> valueAsBytes.clone();
+      case NUMERIC -> parseNumericBinary(buffer);
       case CHAR -> (char) buffer.get();
       case BOOLEAN -> buffer.get() == 1;
       case JSON -> {
@@ -1038,6 +1176,7 @@ public enum PostgresType {
         this == LONG ||
         this == REAL ||
         this == DOUBLE ||
+        this == NUMERIC ||
         this == CHAR ||
         this == BOOLEAN ||
         this == DATE ||

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -266,6 +266,11 @@ public enum PostgresType {
   // PostgreSQL's own cap (NUMERIC_MAX_RESULT_SCALE-derived) on digit groups in one value; a declared count
   // above this cannot be a value this codec produced, only a malformed or adversarial payload.
   private static final int NUMERIC_MAX_DIGITS  = 4000;
+  // The largest bit length a BigInteger with NUMERIC_MAX_DIGITS * NUMERIC_DIGIT_WIDTH (16000) decimal digits
+  // can have: ceil(16000 * log2(10)) = ceil(16000 * 3.321928094887362) = 53151. Any BigInteger past this bound
+  // has more than 16000 decimal digits, guaranteed - checking bitLength() (already computed, effectively O(1))
+  // catches that before putNumericBinary calls toString() on it, which is not.
+  private static final int NUMERIC_MAX_UNSCALED_BITS = 53151;
 
   /**
    * Encodes a BigDecimal in PostgreSQL's NUMERIC binary wire format. Unlike {@link #parseNumericBinary}, which
@@ -294,6 +299,14 @@ public enum PostgresType {
 
     final boolean negative = normalized.signum() < 0;
     final BigInteger unscaled = normalized.unscaledValue().abs();
+    // Bounds the MAGNITUDE the same way the checks above bound the SCALE: a short scientific-notation literal
+    // like '1E2000000000' is already rejected by the scale check (it always implies a very negative scale),
+    // but a value that is simply a great many literal digits at a small/zero scale - reachable from a compact
+    // SQL expression rather than a giant literal - would otherwise sail past both scale checks and reach the
+    // O(n) toString()/padding work below before the digit-count check further down ever gets a chance to
+    // reject it.
+    if (unscaled.bitLength() > NUMERIC_MAX_UNSCALED_BITS)
+      throw new PostgresProtocolException("NUMERIC precision exceeds the supported maximum");
 
     if (unscaled.equals(BigInteger.ZERO)) {
       typeBuffer.putInt(8);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresTypeCatalog.java
@@ -296,7 +296,7 @@ public class PostgresTypeCatalog {
   /**
    * pg_type.typinput, the name of the C function PostgreSQL parses the type's text representation with.
    * Spelled out rather than synthesised from the type name, because PostgreSQL is not consistent about it:
-   * most are {@code <name>in}, but the temporal types and json take an underscore.
+   * most are {@code <name>in}, but the temporal types, json and numeric take an underscore.
    */
   private static String inputFunction(final PostgresType type) {
     if (type.isArrayType())
@@ -305,6 +305,7 @@ public class PostgresTypeCatalog {
       case DATE -> "date_in";
       case TIMESTAMP -> "timestamp_in";
       case JSON -> "json_in";
+      case NUMERIC -> "numeric_in";
       default -> type.typeName + "in";
     };
   }
@@ -315,7 +316,7 @@ public class PostgresTypeCatalog {
       return "A";
     return switch (type) {
       case BOOLEAN -> "B";
-      case SMALLINT, INTEGER, LONG, REAL, DOUBLE -> "N";
+      case SMALLINT, INTEGER, LONG, REAL, DOUBLE, NUMERIC -> "N";
       case DATE, TIMESTAMP -> "D";
       case CHAR, VARCHAR, TEXT, BPCHAR -> "S";
       default -> "U"; // user-defined, which is where PostgreSQL itself files json

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6447TypeResolutionIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6447TypeResolutionIT.java
@@ -175,6 +175,44 @@ public class Issue6447TypeResolutionIT extends PostgresWireProtocolTestBase {
     }
   }
 
+  @Test
+  void aDatetimePropertyRoundTripsAsTimestampWhenDateTimeImplementationIsJavaUtilDate() throws Exception {
+    // Type.DATETIME's runtime representation defaults to LocalDateTime, which the value path already told
+    // apart from DATE before this fix (that's what the previous test exercises). java.util.Date is the
+    // *other* supported representation, and it is ALSO Type.DATE's default - so with this configuration a
+    // sampled value alone genuinely cannot disambiguate, and PostgresNetworkExecutor.isDeclaredAsDatetime
+    // (the mechanism this PR adds) is what makes the populated-row case answer correctly instead of "date".
+    try (final Connection connection = openJdbcConnection()) {
+      try (final Statement configure = connection.createStatement()) {
+        configure.execute("ALTER DATABASE dateTimeImplementation `java.util.Date`");
+      }
+      createTestType(connection);
+
+      try (final Statement insert = connection.createStatement()) {
+        insert.execute("INSERT INTO Types6447 SET id = 1, whenHappened = '2026-08-19 12:34:56'");
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT whenHappened FROM Types6447 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      final String typeFromSchema;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT whenHappened FROM Types6447 WHERE id = 2");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isFalse();
+        typeFromSchema = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow)
+          .as("without isDeclaredAsDatetime, a java.util.Date-backed DATETIME sample resolves to plain date")
+          .isEqualTo("timestamp");
+      assertThat(typeFromSchema).isEqualTo(typeFromRow);
+    }
+  }
+
   private void createTestType(final Connection connection) throws Exception {
     try (final Statement statement = connection.createStatement()) {
       statement.execute("CREATE DOCUMENT TYPE Types6447 IF NOT EXISTS");

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6447TypeResolutionIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6447TypeResolutionIT.java
@@ -213,6 +213,32 @@ public class Issue6447TypeResolutionIT extends PostgresWireProtocolTestBase {
     }
   }
 
+  @Test
+  void aDatetimePropertyRoundTripsAsTimestampOverTheSimpleQueryProtocolToo() throws Exception {
+    // The previous two tests go through the extended query protocol (PreparedStatement), which is what every
+    // real JDBC/ORM client uses. This forces pgjdbc's simple query protocol instead - the path
+    // PostgresNetworkExecutor.queryCommand() implements, where a review round found the query-target-type
+    // parse being computed unconditionally (before the SET/SHOW/SAVEPOINT/BEGIN dispatch) was both a
+    // performance regression and something worth a dedicated regression test. Same narrow column projection
+    // ("SELECT col FROM Type", not "SELECT * FROM Type") that requires resolveQueryTargetType's fallback.
+    try (final Connection connection = openJdbcConnection(true)) {
+      try (final Statement configure = connection.createStatement()) {
+        configure.execute("ALTER DATABASE dateTimeImplementation `java.util.Date`");
+      }
+      createTestType(connection);
+
+      try (final Statement insert = connection.createStatement()) {
+        insert.execute("INSERT INTO Types6447 SET id = 1, whenHappened = '2026-08-19 12:34:56'");
+      }
+
+      try (final Statement select = connection.createStatement();
+          final ResultSet resultSet = select.executeQuery("SELECT whenHappened FROM Types6447 WHERE id = 1")) {
+        assertThat(resultSet.next()).isTrue();
+        assertThat(resultSet.getMetaData().getColumnTypeName(1)).isEqualTo("timestamp");
+      }
+    }
+  }
+
   private void createTestType(final Connection connection) throws Exception {
     try (final Statement statement = connection.createStatement()) {
       statement.execute("CREATE DOCUMENT TYPE Types6447 IF NOT EXISTS");
@@ -225,12 +251,18 @@ public class Issue6447TypeResolutionIT extends PostgresWireProtocolTestBase {
   }
 
   private Connection openJdbcConnection() throws Exception {
+    return openJdbcConnection(false);
+  }
+
+  private Connection openJdbcConnection(final boolean simpleQueryProtocol) throws Exception {
     Class.forName("org.postgresql.Driver");
     final Properties properties = new Properties();
     properties.setProperty("user", "root");
     properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
     properties.setProperty("ssl", "false");
     properties.setProperty("sslMode", "disable");
+    if (simpleQueryProtocol)
+      properties.setProperty("preferQueryMode", "simple");
     return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6447TypeResolutionIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6447TypeResolutionIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6447, the follow-up to #6411 (BYTEA): a column's announced OID depended on
+ * whether the result set happened to be empty (typed from the declared schema, {@link PostgresType#getTypeFromArcade})
+ * or had a sampled row (typed from the value, {@link PostgresType#getTypeForValue}), for three more types
+ * ({@code SHORT}/{@code BYTE}, {@code DATETIME} and {@code DECIMAL}) beyond the one #6411 already fixed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6447TypeResolutionIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  void aDecimalPropertyRoundTripsAsNumericWhetherOrNotARowWasSampled() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createTestType(connection);
+
+      final BigDecimal payload = new BigDecimal("12345.6789");
+      try (final PreparedStatement insert = connection.prepareStatement("INSERT INTO Types6447 SET id = 1, amount = ?")) {
+        insert.setBigDecimal(1, payload);
+        insert.execute();
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT amount FROM Types6447 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+        assertThat(resultSet.getBigDecimal("amount")).isEqualByComparingTo(payload);
+      }
+
+      final String typeFromSchema;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT amount FROM Types6447 WHERE id = 2");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isFalse();
+        final ResultSetMetaData metaData = resultSet.getMetaData();
+        typeFromSchema = metaData.getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow).isEqualTo("numeric");
+      assertThat(typeFromSchema)
+          .as("the column's OID must not depend on whether the result set happens to be empty")
+          .isEqualTo(typeFromRow);
+    }
+  }
+
+  @Test
+  void aShortPropertyRoundTripsAsSmallintWhetherOrNotARowWasSampled() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createTestType(connection);
+
+      try (final PreparedStatement insert = connection.prepareStatement("INSERT INTO Types6447 SET id = 1, aShort = ?")) {
+        insert.setShort(1, (short) 1234);
+        insert.execute();
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT aShort FROM Types6447 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+        assertThat(resultSet.getShort("aShort")).isEqualTo((short) 1234);
+      }
+
+      final String typeFromSchema;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT aShort FROM Types6447 WHERE id = 2");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isFalse();
+        typeFromSchema = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow).isEqualTo("int2");
+      assertThat(typeFromSchema)
+          .as("the column's OID must not depend on whether the result set happens to be empty")
+          .isEqualTo(typeFromRow);
+    }
+  }
+
+  @Test
+  void aBytePropertyRoundTripsAsSmallintWhetherOrNotARowWasSampled() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createTestType(connection);
+
+      try (final PreparedStatement insert = connection.prepareStatement("INSERT INTO Types6447 SET id = 1, aByte = ?")) {
+        insert.setByte(1, (byte) 42);
+        insert.execute();
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT aByte FROM Types6447 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+        assertThat(resultSet.getByte("aByte")).isEqualTo((byte) 42);
+      }
+
+      final String typeFromSchema;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT aByte FROM Types6447 WHERE id = 2");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isFalse();
+        typeFromSchema = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow).isEqualTo("int2");
+      assertThat(typeFromSchema)
+          .as("the column's OID must not depend on whether the result set happens to be empty")
+          .isEqualTo(typeFromRow);
+    }
+  }
+
+  @Test
+  void aDatetimePropertyRoundTripsAsTimestampWhetherOrNotARowWasSampled() throws Exception {
+    try (final Connection connection = openJdbcConnection()) {
+      createTestType(connection);
+
+      final LocalDateTime payload = LocalDateTime.of(2026, 8, 19, 12, 34, 56);
+      try (final Statement insert = connection.createStatement()) {
+        insert.execute("INSERT INTO Types6447 SET id = 1, whenHappened = '2026-08-19 12:34:56'");
+      }
+
+      final String typeFromRow;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT whenHappened FROM Types6447 WHERE id = 1");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        typeFromRow = resultSet.getMetaData().getColumnTypeName(1);
+        // Timestamp.toString() formats in the JVM default timezone, so compare via toLocalDateTime() instead.
+        assertThat(resultSet.getTimestamp("whenHappened").toLocalDateTime()).isEqualTo(payload);
+      }
+
+      final String typeFromSchema;
+      try (final PreparedStatement select = connection.prepareStatement("SELECT whenHappened FROM Types6447 WHERE id = 2");
+          final ResultSet resultSet = select.executeQuery()) {
+        assertThat(resultSet.next()).isFalse();
+        typeFromSchema = resultSet.getMetaData().getColumnTypeName(1);
+      }
+
+      assertThat(typeFromRow)
+          .as("a DATETIME property must not be reported as plain date - it has a time component")
+          .isEqualTo("timestamp");
+      assertThat(typeFromSchema)
+          .as("the column's OID must not depend on whether the result set happens to be empty")
+          .isEqualTo(typeFromRow);
+    }
+  }
+
+  private void createTestType(final Connection connection) throws Exception {
+    try (final Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DOCUMENT TYPE Types6447 IF NOT EXISTS");
+      statement.execute("CREATE PROPERTY Types6447.id IF NOT EXISTS INTEGER");
+      statement.execute("CREATE PROPERTY Types6447.amount IF NOT EXISTS DECIMAL");
+      statement.execute("CREATE PROPERTY Types6447.aShort IF NOT EXISTS SHORT");
+      statement.execute("CREATE PROPERTY Types6447.aByte IF NOT EXISTS BYTE");
+      statement.execute("CREATE PROPERTY Types6447.whenHappened IF NOT EXISTS DATETIME");
+    }
+  }
+
+  private Connection openJdbcConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final Properties properties = new Properties();
+    properties.setProperty("user", "root");
+    properties.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    properties.setProperty("ssl", "false");
+    properties.setProperty("sslMode", "disable");
+    return DriverManager.getConnection("jdbc:postgresql://localhost:5432/" + getDatabaseName(), properties);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresCatalogTest.java
@@ -256,6 +256,20 @@ class PostgresCatalogTest {
   }
 
   @Test
+  void aDecimalColumnReportsBase10PrecisionRadix() {
+    // issue #6447: DECIMAL used to map to DOUBLE, so the flat "every native scalar type answers 2" here was
+    // accidentally correct for it. Now that it maps to NUMERIC, real PostgreSQL reports 10 for that type
+    // specifically - every other native scalar type this catalog emulates is still binary (base 2).
+    database.transaction(() -> database.getSchema().createDocumentType("Invoice6447").createProperty("amount", Type.DECIMAL));
+
+    final PostgresCatalog.Answer answer = resolve(
+        "SELECT column_name, numeric_precision_radix FROM information_schema.columns WHERE table_name = 'Invoice6447'");
+
+    assertThat(answer.rows).hasSize(1);
+    assertThat(answer.rows.get(0)).containsEntry("numeric_precision_radix", 10);
+  }
+
+  @Test
   void aStarProjectionExpandsToTheRelationsColumns() {
     final PostgresCatalog.Answer answer = resolve("SELECT * FROM pg_catalog.pg_namespace");
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeCatalogTest.java
@@ -182,7 +182,7 @@ class PostgresTypeCatalogTest {
 
   @Test
   void inputFunctionsAreSpelledTheWayPostgresSpellsThem() {
-    // Synthesising <name> + "in" is right for most types but not for the temporal ones or json, which
+    // Synthesising <name> + "in" is right for most types but not for the temporal ones, json or numeric, which
     // PostgreSQL spells with an underscore.
     final Map<Integer, Object> byOid = new HashMap<>();
     for (final Map<String, Object> row : PostgresTypeCatalog.resolve("SELECT oid, typinput FROM pg_type"))
@@ -193,7 +193,17 @@ class PostgresTypeCatalogTest {
     assertThat(byOid).containsEntry(PostgresType.DATE.code, "date_in");
     assertThat(byOid).containsEntry(PostgresType.TIMESTAMP.code, "timestamp_in");
     assertThat(byOid).containsEntry(PostgresType.JSON.code, "json_in");
+    assertThat(byOid).containsEntry(PostgresType.NUMERIC.code, "numeric_in");
     assertThat(byOid).containsEntry(PostgresType.ARRAY_TEXT.code, "array_in");
+  }
+
+  @Test
+  void numericIsCategorisedAsNumberLikeEveryOtherNumericType() {
+    // issue #6447: NUMERIC used to fall through category()'s default "U" (user-defined) arm, the same bucket
+    // real PostgreSQL uses for json - wrong for a type PostgreSQL itself files under "N" alongside int4/float8.
+    final Map<String, Object> row = PostgresTypeCatalog.resolve("SELECT oid, typcategory FROM pg_type")
+        .stream().filter(r -> r.get("oid").equals(PostgresType.NUMERIC.code)).findFirst().orElseThrow();
+    assertThat(row.get("typcategory")).isEqualTo("N");
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
@@ -76,24 +76,24 @@ class PostgresTypeResolutionPathTest {
   }
 
   /**
-   * Types whose two paths are known to disagree, each pending a fix that is not a missing switch case:
+   * Types whose two paths are known to disagree when called in isolation, as this test calls them:
    * <ul>
-   *   <li>SHORT/BYTE: the value path widens Short/Byte to INTEGER, because PostgresType has no int2[] to pair
-   *       with it; reconciling on SMALLINT changes the OID existing clients already receive for populated rows.
-   *   <li>DATETIME: java.util.Date is the default Java type of both DATE and DATETIME, so the value path cannot
-   *       tell them apart and answers DATE for either.
-   *   <li>DECIMAL: neither DOUBLE (lossy) nor VARCHAR is right; the fix is a NUMERIC (OID 1700) entry with a
-   *       binary encoder.
+   *   <li>DATETIME: java.util.Date is the default Java type of both DATE and every DATETIME* variant, so
+   *       {@link PostgresType#getTypeForValue} cannot tell them apart from a bare value and always answers DATE.
+   *       This is not client-visible for a real column, though: {@code PostgresNetworkExecutor.getColumns()}
+   *       resolves the ambiguity from the schema before calling getTypeForValue, the same way it already did for
+   *       an empty LIST's element type (issue #5289) - see {@code isDeclaredAsDatetime}/{@code getDeclaredProperty}.
+   *       It stays disagreeing here on purpose: a value with no schema behind it (a computed expression, a
+   *       schemaless document) has no better answer than DATE, so the two pure functions are not meant to
+   *       converge for this one.
    * </ul>
-   * Removing an entry here is the intended way to land one of those fixes.
+   * Removing an entry here is the intended way to land a fix that makes the two functions actually agree - see
+   * SHORT/BYTE (widening to INTEGER) and DECIMAL (DOUBLE/VARCHAR vs NUMERIC), both fixed this way for #6447.
    */
   private static final Map<Type, PathDisagreement> KNOWN_DISAGREEMENTS = new EnumMap<>(Type.class);
 
   static {
-    KNOWN_DISAGREEMENTS.put(Type.SHORT, new PathDisagreement(PostgresType.SMALLINT, PostgresType.INTEGER));
-    KNOWN_DISAGREEMENTS.put(Type.BYTE, new PathDisagreement(PostgresType.SMALLINT, PostgresType.INTEGER));
     KNOWN_DISAGREEMENTS.put(Type.DATETIME, new PathDisagreement(PostgresType.TIMESTAMP, PostgresType.DATE));
-    KNOWN_DISAGREEMENTS.put(Type.DECIMAL, new PathDisagreement(PostgresType.DOUBLE, PostgresType.VARCHAR));
   }
 
   private record PathDisagreement(PostgresType schemaPath, PostgresType valuePath) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeResolutionPathTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.EnumMap;
@@ -44,7 +45,10 @@ class PostgresTypeResolutionPathTest {
 
   /**
    * A representative value of each Type's default Java type, as the value path would receive it from a stored
-   * record.
+   * record in a database left at its default configuration. DATE and DATETIME are configurable per database
+   * (GlobalConfiguration.DATE_IMPLEMENTATION/DATE_TIME_IMPLEMENTATION) and default to LocalDate/LocalDateTime,
+   * not java.util.Date (issue #6447) - {@link #datetimeValuePathDisagreesWithSchemaWhenConfiguredForJavaUtilDate}
+   * covers the non-default configuration separately, since a single sample per Type can only model one of them.
    */
   private static final Map<Type, Object> SAMPLE_VALUES = new EnumMap<>(Type.class);
 
@@ -55,14 +59,14 @@ class PostgresTypeResolutionPathTest {
     SAMPLE_VALUES.put(Type.LONG, 100L);
     SAMPLE_VALUES.put(Type.FLOAT, 1.5f);
     SAMPLE_VALUES.put(Type.DOUBLE, 2.5d);
-    SAMPLE_VALUES.put(Type.DATETIME, new Date());
+    SAMPLE_VALUES.put(Type.DATETIME, LocalDateTime.now());
     SAMPLE_VALUES.put(Type.STRING, "text");
     SAMPLE_VALUES.put(Type.BINARY, new byte[] { 1, 2 });
     SAMPLE_VALUES.put(Type.LIST, List.of("a", "b"));
     SAMPLE_VALUES.put(Type.MAP, Map.of("k", "v"));
     SAMPLE_VALUES.put(Type.LINK, new RID(1, 1));
     SAMPLE_VALUES.put(Type.BYTE, (byte) 5);
-    SAMPLE_VALUES.put(Type.DATE, new Date());
+    SAMPLE_VALUES.put(Type.DATE, LocalDate.now());
     SAMPLE_VALUES.put(Type.DECIMAL, new BigDecimal("10.55"));
     SAMPLE_VALUES.put(Type.EMBEDDED, new JSONObject());
     SAMPLE_VALUES.put(Type.DATETIME_MICROS, LocalDateTime.now());
@@ -75,30 +79,6 @@ class PostgresTypeResolutionPathTest {
     SAMPLE_VALUES.put(Type.ARRAY_OF_DOUBLES, new double[] { 1.5d, 2.5d });
   }
 
-  /**
-   * Types whose two paths are known to disagree when called in isolation, as this test calls them:
-   * <ul>
-   *   <li>DATETIME: java.util.Date is the default Java type of both DATE and every DATETIME* variant, so
-   *       {@link PostgresType#getTypeForValue} cannot tell them apart from a bare value and always answers DATE.
-   *       This is not client-visible for a real column, though: {@code PostgresNetworkExecutor.getColumns()}
-   *       resolves the ambiguity from the schema before calling getTypeForValue, the same way it already did for
-   *       an empty LIST's element type (issue #5289) - see {@code isDeclaredAsDatetime}/{@code getDeclaredProperty}.
-   *       It stays disagreeing here on purpose: a value with no schema behind it (a computed expression, a
-   *       schemaless document) has no better answer than DATE, so the two pure functions are not meant to
-   *       converge for this one.
-   * </ul>
-   * Removing an entry here is the intended way to land a fix that makes the two functions actually agree - see
-   * SHORT/BYTE (widening to INTEGER) and DECIMAL (DOUBLE/VARCHAR vs NUMERIC), both fixed this way for #6447.
-   */
-  private static final Map<Type, PathDisagreement> KNOWN_DISAGREEMENTS = new EnumMap<>(Type.class);
-
-  static {
-    KNOWN_DISAGREEMENTS.put(Type.DATETIME, new PathDisagreement(PostgresType.TIMESTAMP, PostgresType.DATE));
-  }
-
-  private record PathDisagreement(PostgresType schemaPath, PostgresType valuePath) {
-  }
-
   @Test
   void everyTypeHasASampleValue() {
     // Guards the table below against silently skipping a Type added to the enum later.
@@ -107,10 +87,10 @@ class PostgresTypeResolutionPathTest {
 
   @Test
   void schemaPathAgreesWithValuePathForEveryType() {
+    // No skips: every Type's two paths now agree for the sample a default-configured database would actually
+    // produce (issue #6447). The one remaining disagreement only a non-default configuration reaches - see
+    // datetimeValuePathDisagreesWithSchemaWhenConfiguredForJavaUtilDate below.
     for (final Type arcadeType : Type.values()) {
-      if (KNOWN_DISAGREEMENTS.containsKey(arcadeType))
-        continue;
-
       final PostgresType fromSchema = PostgresType.getTypeFromArcade(arcadeType);
       final PostgresType fromValue = PostgresType.getTypeForValue(SAMPLE_VALUES.get(arcadeType));
 
@@ -122,14 +102,19 @@ class PostgresTypeResolutionPathTest {
   }
 
   @Test
-  void knownDisagreementsStillDisagree() {
-    // Pins the documented exceptions so that fixing one forces its entry to be removed above rather than leaving
-    // a stale exemption that would mask a regression.
-    KNOWN_DISAGREEMENTS.forEach((arcadeType, expected) -> {
-      assertThat(PostgresType.getTypeFromArcade(arcadeType)).as("schema path of %s", arcadeType).isEqualTo(expected.schemaPath());
-      assertThat(PostgresType.getTypeForValue(SAMPLE_VALUES.get(arcadeType))).as("value path of %s", arcadeType)
-          .isEqualTo(expected.valuePath());
-    });
+  void datetimeValuePathDisagreesWithSchemaWhenConfiguredForJavaUtilDate() {
+    // Type.DATETIME's runtime representation is configurable per database (GlobalConfiguration.
+    // DATE_TIME_IMPLEMENTATION) and java.util.Date is one of the supported alternatives to the LocalDateTime
+    // default. java.util.Date is ALSO Type.DATE's default representation, so a sampled Date value cannot tell
+    // the two apart on its own and getTypeForValue always answers DATE - disagreeing with the schema path's
+    // TIMESTAMP for a DATETIME column. This is not client-visible for a real column, though:
+    // PostgresNetworkExecutor.getColumns() resolves the ambiguity from the schema - either the row's own
+    // element or, for a narrow column projection whose rows carry no element, the query's FROM-target type
+    // (isDeclaredAsDatetime/getDeclaredProperty/resolveQueryTargetType) - the same mechanism already used to
+    // type an empty LIST column from its declared element type (issue #5289). Pinned here, rather than fixed,
+    // because the two *pure* functions have no schema to consult and so are not meant to converge for this one.
+    assertThat(PostgresType.getTypeFromArcade(Type.DATETIME)).isEqualTo(PostgresType.TIMESTAMP);
+    assertThat(PostgresType.getTypeForValue(new Date())).isEqualTo(PostgresType.DATE);
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -858,6 +858,21 @@ class PostgresTypeTest {
   }
 
   @Test
+  void deserializeBinaryNumericRejectsOversizedScale() {
+    // dscale is checked against the same bound the encode side rejects at (issue #6447 review), even though
+    // being an unsigned 16-bit field already caps it - a declared scale this codec could never have produced
+    // is still a malformed payload, not a value setScale should be asked to pad a BigInteger out to.
+    final ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+    buf.putShort((short) 0);              // ndigits
+    buf.putShort((short) 0);              // weight
+    buf.putShort((short) 0x0000);         // sign: positive
+    buf.putShort(Short.MAX_VALUE);        // dscale: absurd
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array()))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("scale exceeds");
+  }
+
+  @Test
   void serializeAsBinaryNumericRejectsExcessiveScale() {
     // Unlike deserialize, which only has to reject bytes an attacker sent, serializeAsBinary also has to reject
     // a BigDecimal ArcadeDB itself produced: an unbounded DECIMAL property scale would otherwise wrap silently

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -144,6 +144,14 @@ class PostgresTypeTest {
   }
 
   @Test
+  void getTypeForValueLocalDate() {
+    // Matches getTypeFromArcade(Type.DATE) (issue #6447): Type.DATE's runtime representation defaults to
+    // LocalDate (GlobalConfiguration.DATE_IMPLEMENTATION), not java.util.Date, so a sampled value from a
+    // default-configured database used to fall through every branch here to the generic VARCHAR default.
+    assertThat(PostgresType.getTypeForValue(LocalDate.now())).isEqualTo(PostgresType.DATE);
+  }
+
+  @Test
   void getTypeForValueLocalDateTime() {
     assertThat(PostgresType.getTypeForValue(LocalDateTime.now())).isEqualTo(PostgresType.TIMESTAMP);
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -875,6 +875,26 @@ class PostgresTypeTest {
   }
 
   @Test
+  void deserializeBinaryNumericRejectsOversizedWeight() {
+    // ndigits, dscale and sign are each individually bounded (issue #6447 review), but weight wasn't: a
+    // payload with an extreme weight - within its own short range - combined with a small ndigits and the
+    // max-allowed dscale derives a `scale` far apart from dscale, and setScale would materialize a BigInteger
+    // to bridge that gap. Smaller blast radius than the encode-side DoS this PR already fixed (weight is
+    // capped by its wire width), but the same class of bug the decode side is supposed to defend against.
+    // A digit follows the header only so the buffer-remaining check (ndigits * 2 <= remaining) doesn't reject
+    // this payload first; the weight check itself throws before that digit is ever read.
+    final ByteBuffer buf = ByteBuffer.allocate(10).order(ByteOrder.BIG_ENDIAN);
+    buf.putShort((short) 1);          // ndigits
+    buf.putShort(Short.MAX_VALUE);    // weight: absurd
+    buf.putShort((short) 0x0000);     // sign: positive
+    buf.putShort((short) 0);          // dscale
+    buf.putShort((short) 1);          // digit
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array()))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("weight exceeds");
+  }
+
+  @Test
   void deserializeBinaryNumericRejectsDscaleThatDoesNotMatchTheEncodedPrecision() {
     // ndigits=1, weight=-1, digit=9999 encodes 0.9999 (issue #6447 review): a declared dscale of 0 does not
     // match that precision, so the final setScale(dscale, UNNECESSARY) has no exact answer. This must surface

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -78,20 +78,31 @@ class PostgresTypeTest {
 
   @Test
   void getTypeForValueShort() {
-    assertThat(PostgresType.getTypeForValue((short) 10)).isEqualTo(PostgresType.INTEGER);
-    assertThat(PostgresType.getTypeForValue(Short.valueOf((short) 10))).isEqualTo(PostgresType.INTEGER);
+    // Matches getTypeFromArcade(Type.SHORT) (issue #6447): widening to INTEGER made a column's OID depend on
+    // whether the result set happened to be empty.
+    assertThat(PostgresType.getTypeForValue((short) 10)).isEqualTo(PostgresType.SMALLINT);
+    assertThat(PostgresType.getTypeForValue(Short.valueOf((short) 10))).isEqualTo(PostgresType.SMALLINT);
   }
 
   @Test
   void getTypeForValueByte() {
-    assertThat(PostgresType.getTypeForValue((byte) 5)).isEqualTo(PostgresType.INTEGER);
-    assertThat(PostgresType.getTypeForValue(Byte.valueOf((byte) 5))).isEqualTo(PostgresType.INTEGER);
+    // Matches getTypeFromArcade(Type.BYTE) (issue #6447): widening to INTEGER made a column's OID depend on
+    // whether the result set happened to be empty.
+    assertThat(PostgresType.getTypeForValue((byte) 5)).isEqualTo(PostgresType.SMALLINT);
+    assertThat(PostgresType.getTypeForValue(Byte.valueOf((byte) 5))).isEqualTo(PostgresType.SMALLINT);
   }
 
   @Test
   void getTypeForValueLong() {
     assertThat(PostgresType.getTypeForValue(100L)).isEqualTo(PostgresType.LONG);
     assertThat(PostgresType.getTypeForValue(Long.valueOf(100L))).isEqualTo(PostgresType.LONG);
+  }
+
+  @Test
+  void getTypeForValueDecimal() {
+    // Matches getTypeFromArcade(Type.DECIMAL) (issue #6447): DOUBLE is lossy for arbitrary-precision
+    // BigDecimal, and VARCHAR makes a client treat the column as text.
+    assertThat(PostgresType.getTypeForValue(new BigDecimal("10.55"))).isEqualTo(PostgresType.NUMERIC);
   }
 
   @Test
@@ -402,8 +413,9 @@ class PostgresTypeTest {
 
   /**
    * The declared-schema path and the value path must agree, otherwise a column's OID would depend on whether
-   * its list happens to be empty. A list of BigDecimal is typed ARRAY_TEXT by getArrayTypeForElementType, so
-   * LIST OF DECIMAL must resolve to ARRAY_TEXT too, despite the scalar DECIMAL mapping to DOUBLE.
+   * its list happens to be empty. A list of BigDecimal is typed ARRAY_TEXT by getArrayTypeForElementType (there
+   * is no ARRAY_NUMERIC), so LIST OF DECIMAL must resolve to ARRAY_TEXT too, despite the scalar DECIMAL mapping
+   * to NUMERIC.
    */
   @Test
   void getTypeFromArcadeListOfDecimalMatchesValuePath() {
@@ -435,7 +447,8 @@ class PostgresTypeTest {
 
   @Test
   void getTypeFromArcadeDecimal() {
-    assertThat(PostgresType.getTypeFromArcade(Type.DECIMAL)).isEqualTo(PostgresType.DOUBLE);
+    // NUMERIC (issue #6447), not the lossy DOUBLE: BigDecimal's whole point is precision float64 doesn't have.
+    assertThat(PostgresType.getTypeFromArcade(Type.DECIMAL)).isEqualTo(PostgresType.NUMERIC);
   }
 
   // ==================== Text Deserialization Tests ====================
@@ -738,6 +751,101 @@ class PostgresTypeTest {
     final byte b = buffer.getByte();
     final Object decoded = PostgresType.deserialize(PostgresType.CHAR.code, 1, new byte[]{b});
     assertThat(decoded).isEqualTo('Z');
+  }
+
+  /**
+   * Round-trips a representative spread of BigDecimal values (issue #6447) through NUMERIC's binary codec:
+   * plain integers, values needing leading-zero-group stripping (0.5), trailing-zero-group stripping (100.5),
+   * fractional leading zeros wider than the significant digits (0.00001005), negatives, zero itself, and a
+   * value whose declared BigDecimal scale is negative (1E+2). {@link BigDecimal#equals} is scale-sensitive, so
+   * both the numeric value and the exact scale are asserted.
+   */
+  @Test
+  void serializeAsBinaryNumericRoundTrip() {
+    for (final BigDecimal value : List.of(
+        new BigDecimal("10.55"), new BigDecimal("0.5"), new BigDecimal("100.5"),
+        new BigDecimal("0.00001005"), new BigDecimal("100"), BigDecimal.ZERO,
+        new BigDecimal("-42.42"), new BigDecimal("123456789.987654321"), new BigDecimal("0.0001"),
+        new BigDecimal("1000000"), new BigDecimal("-0.5"), new BigDecimal("3.14159265358979323846"),
+        new BigDecimal("1E+2"), new BigDecimal("0.00"))) {
+      final Binary buffer = new Binary();
+      PostgresType.NUMERIC.serializeAsBinary(PostgresType.NUMERIC, buffer, value);
+      buffer.flip();
+      final int length = buffer.getInt();
+      final byte[] data = new byte[length];
+      buffer.getByteArray(data);
+
+      final Object decoded = PostgresType.deserialize(PostgresType.NUMERIC.code, 1, data);
+      assertThat(decoded).as("value of %s", value).isInstanceOf(BigDecimal.class);
+      final BigDecimal decimal = (BigDecimal) decoded;
+      assertThat(decimal).as("value of %s", value).isEqualByComparingTo(value.scale() < 0 ? value.setScale(0) : value);
+      assertThat(decimal.scale()).as("scale of %s", value).isEqualTo(Math.max(value.scale(), 0));
+    }
+  }
+
+  @Test
+  void serializeAsBinaryNumericMatchesKnownEncoding() {
+    // Hand-computed against PostgreSQL's own numeric.c layout: header of four int16s (ndigits, weight, sign,
+    // dscale) then ndigits base-10000 digits, most significant first.
+    final Binary buffer = new Binary();
+    PostgresType.NUMERIC.serializeAsBinary(PostgresType.NUMERIC, buffer, new BigDecimal("10.55"));
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(12); // 4 header shorts + 2 digit shorts
+    assertThat(buffer.getShort()).isEqualTo((short) 2);      // ndigits
+    assertThat(buffer.getShort()).isEqualTo((short) 0);      // weight
+    assertThat(buffer.getShort()).isEqualTo((short) 0x0000); // sign: positive
+    assertThat(buffer.getShort()).isEqualTo((short) 2);      // dscale
+    assertThat(buffer.getShort()).isEqualTo((short) 10);
+    assertThat(buffer.getShort()).isEqualTo((short) 5500);
+  }
+
+  @Test
+  void deserializeBinaryNumericZero() {
+    final ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+    buf.putShort((short) 0);      // ndigits
+    buf.putShort((short) 0);      // weight
+    buf.putShort((short) 0x0000); // sign: positive
+    buf.putShort((short) 2);      // dscale
+    final Object decoded = PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array());
+    assertThat(decoded).isEqualTo(new BigDecimal("0.00"));
+  }
+
+  @Test
+  void deserializeBinaryNumericRejectsNaN() {
+    final ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+    buf.putShort((short) 0);
+    buf.putShort((short) 0);
+    buf.putShort((short) 0xC000); // sign: NaN
+    buf.putShort((short) 0);
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array()))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("NaN");
+  }
+
+  @Test
+  void deserializeBinaryNumericRejectsInvalidSign() {
+    final ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+    buf.putShort((short) 0);
+    buf.putShort((short) 0);
+    buf.putShort((short) 0x1234); // not one of NUMERIC_{POS,NEG,NAN}_SIGN
+    buf.putShort((short) 0);
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array()))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("Invalid NUMERIC sign");
+  }
+
+  @Test
+  void deserializeBinaryNumericRejectsOversizedDigitCount() {
+    // A declared digit count this codec never produces and the (short) buffer cannot possibly back - must be
+    // rejected rather than read out of bounds.
+    final ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+    buf.putShort(Short.MAX_VALUE); // ndigits: absurd
+    buf.putShort((short) 0);
+    buf.putShort((short) 0x0000);
+    buf.putShort((short) 0);
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array()))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("exceeds");
   }
 
   @Test
@@ -1149,6 +1257,19 @@ class PostgresTypeTest {
     byte[] data = new byte[length];
     buffer.getByteBuffer().get(data);
     assertThat(new String(data)).isEqualTo("42");
+  }
+
+  @Test
+  void serializeAsTextNumericAvoidsScientificNotation() {
+    // BigDecimal.toString() switches to scientific notation outside a small exponent range (issue #6447):
+    // "1E+10" is not a NUMERIC text value PostgreSQL would emit or a client would expect to parse.
+    Binary buffer = new Binary();
+    PostgresType.NUMERIC.serializeAsText(PostgresType.NUMERIC, buffer, new BigDecimal("1E+10"));
+    buffer.flip();
+    int length = buffer.getInt();
+    byte[] data = new byte[length];
+    buffer.getByteBuffer().get(data);
+    assertThat(new String(data)).isEqualTo("10000000000");
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -941,6 +941,24 @@ class PostgresTypeTest {
   }
 
   @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void serializeAsBinaryNumericRejectsExtremeMagnitudeWithoutMaterializingItsDigitString() {
+    // The scale check above closes the amplification vector a short scientific-notation literal opens - that
+    // pattern always implies a very negative scale - but says nothing about a value that is simply a great many
+    // literal digits at a small/zero scale, reachable from a compact SQL expression rather than a giant literal.
+    // BigInteger.ONE.shiftLeft(...) builds a value with a huge bitLength in O(1) (it is one set bit), the same
+    // way scientific-notation parsing was O(1) for the scale case - so the @Timeout here is, again, a hang/OOM
+    // detector: an unfixed version of this check would call toString() on the several-hundred-thousand-digit
+    // unscaled value this decodes to and build a proportionally huge digit string before ever reaching the
+    // ndigits check.
+    final BigDecimal extremeMagnitude = new BigDecimal(BigInteger.ONE.shiftLeft(2_500_000), 0);
+    final Binary buffer = new Binary();
+    assertThatThrownBy(() -> PostgresType.NUMERIC.serializeAsBinary(PostgresType.NUMERIC, buffer, extremeMagnitude))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("precision exceeds");
+  }
+
+  @Test
   void deserializeBinaryVarchar() {
     byte[] data = "hello binary".getBytes();
     Object result = PostgresType.deserialize(PostgresType.VARCHAR.code, 1, data);

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -873,6 +875,23 @@ class PostgresTypeTest {
   }
 
   @Test
+  void deserializeBinaryNumericRejectsDscaleThatDoesNotMatchTheEncodedPrecision() {
+    // ndigits=1, weight=-1, digit=9999 encodes 0.9999 (issue #6447 review): a declared dscale of 0 does not
+    // match that precision, so the final setScale(dscale, UNNECESSARY) has no exact answer. This must surface
+    // as the same PostgresProtocolException every other rejection in this codec uses, not a bare JDK
+    // ArithmeticException the caller has no reason to expect from a "deserialize" call.
+    final ByteBuffer buf = ByteBuffer.allocate(10).order(ByteOrder.BIG_ENDIAN);
+    buf.putShort((short) 1);      // ndigits
+    buf.putShort((short) -1);     // weight
+    buf.putShort((short) 0x0000); // sign: positive
+    buf.putShort((short) 0);      // dscale: does not match 0.9999's precision
+    buf.putShort((short) 9999);   // digit
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array()))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("does not match");
+  }
+
+  @Test
   void serializeAsBinaryNumericRejectsExcessiveScale() {
     // Unlike deserialize, which only has to reject bytes an attacker sent, serializeAsBinary also has to reject
     // a BigDecimal ArcadeDB itself produced: an unbounded DECIMAL property scale would otherwise wrap silently
@@ -880,6 +899,23 @@ class PostgresTypeTest {
     final BigDecimal absurdScale = new BigDecimal(BigInteger.ONE, 16001);
     final Binary buffer = new Binary();
     assertThatThrownBy(() -> PostgresType.NUMERIC.serializeAsBinary(PostgresType.NUMERIC, buffer, absurdScale))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("scale exceeds");
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void serializeAsBinaryNumericRejectsExtremeNegativeScaleWithoutMaterializingIt() {
+    // A DECIMAL property has no configured precision limit, and BigDecimal(String) parsing scientific notation
+    // is O(1) - new BigDecimal("1E2000000000") just stores unscaledValue=1, scale=-2000000000, no digits
+    // materialized - so a value with an extreme negative scale reaches this codec from a plain SQL literal.
+    // BigDecimal.setScale(0) from that scale is NOT O(1): it has to build unscaledValue * 10^|scale| as a real
+    // BigInteger. The @Timeout is a hang/OOM detector, not a latency bound: an unfixed version of this check
+    // (bounding the scale only after normalizing) would try to allocate that BigInteger and this test would
+    // hang or run the JVM out of heap rather than fail fast.
+    final BigDecimal extremeNegativeScale = new BigDecimal(BigInteger.ONE, -1_000_000_000);
+    final Binary buffer = new Binary();
+    assertThatThrownBy(() -> PostgresType.NUMERIC.serializeAsBinary(PostgresType.NUMERIC, buffer, extremeNegativeScale))
         .isInstanceOf(PostgresProtocolException.class)
         .hasMessageContaining("scale exceeds");
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -846,6 +847,18 @@ class PostgresTypeTest {
     assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.NUMERIC.code, 1, buf.array()))
         .isInstanceOf(PostgresProtocolException.class)
         .hasMessageContaining("exceeds");
+  }
+
+  @Test
+  void serializeAsBinaryNumericRejectsExcessiveScale() {
+    // Unlike deserialize, which only has to reject bytes an attacker sent, serializeAsBinary also has to reject
+    // a BigDecimal ArcadeDB itself produced: an unbounded DECIMAL property scale would otherwise wrap silently
+    // through the header fields' (short) casts and write a self-inconsistent NUMERIC payload.
+    final BigDecimal absurdScale = new BigDecimal(BigInteger.ONE, 16001);
+    final Binary buffer = new Binary();
+    assertThatThrownBy(() -> PostgresType.NUMERIC.serializeAsBinary(PostgresType.NUMERIC, buffer, absurdScale))
+        .isInstanceOf(PostgresProtocolException.class)
+        .hasMessageContaining("scale exceeds");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #6411 (BYTEA, merged in #6424): a RowDescription column is typed either from a sample value (`PostgresType.getTypeForValue`, the value path) or from the declared schema (`PostgresType.getTypeFromArcade`, the schema path, taken when a query returns no rows). When the two disagree, a column's advertised OID depends on whether the result set happens to be empty, and a client that prepares against an empty result and then re-executes sees the type change under it. #6411 fixed this for `BINARY`; this PR fixes the three remaining pinned disagreements in `PostgresTypeResolutionPathTest`.

- **DECIMAL**: neither existing answer was right - `DOUBLE` (value path) is lossy for arbitrary-precision `BigDecimal`, and `VARCHAR` (schema path) makes a client treat the column as text. Adds a proper `PostgresType.NUMERIC` (OID 1700) entry with a real binary codec (PostgreSQL's digit-group-of-4 wire format, same shape of work #6411 did for `BYTEA`), and a text encoder that renders via `BigDecimal.toPlainString()` instead of `toString()`'s occasional scientific notation. Both paths now point at it.
- **SHORT/BYTE**: the value path widened `Short`/`Byte` to `INTEGER` because there was nowhere narrower to point it; the schema path already answered the correct `SMALLINT`. The value path now answers `SMALLINT` too.
- **DATETIME**: `java.util.Date` is the default Java runtime type of both `DATE` and every `DATETIME*` variant, so a bare sampled value can't tell them apart, and the value path always answered `DATE`. Rather than adding a wrapper/marker value (one option the issue raised) or making the schema path lossy to match (the other), `PostgresNetworkExecutor.getColumns()` now resolves the ambiguity from the schema when the row is backed by one - reusing the mechanism already in place for typing an empty `LIST` column from its declared `LIST OF` element type (#5289), rather than a value-only guess. This keeps the DATETIME entry in `PostgresTypeResolutionPathTest.KNOWN_DISAGREEMENTS` on purpose: the two *pure* functions still disagree for a bare, schema-less `Date` (there is no better answer than `DATE` for one), but every real column now resolves correctly.

**Behaviour change**: a populated `SHORT`, `BYTE` or `DECIMAL` column now announces `int2`/`numeric` instead of the `int4`/`double`/`varchar` OID it used to. This corrects the client-visible bug (OID depending on emptiness), but a client relying on the old, disagreeing OID for a non-empty result sees a different type name and, for `DECIMAL`, a `BigDecimal` instead of a `Double`/`String`. Documented in `docs/release-26.9.1.md`.

## Test plan

- [x] `PostgresTypeResolutionPathTest`: `SHORT`/`BYTE`/`DECIMAL` removed from `KNOWN_DISAGREEMENTS`; `schemaPathAgreesWithValuePathForEveryType()` now covers them
- [x] `PostgresTypeTest`: updated pre-existing pinned expectations (`getTypeForValueShort/Byte`, `getTypeFromArcadeDecimal`) + new unit tests for the NUMERIC binary codec (round-trip over a wide spread of values including zero, negatives, leading/trailing zero-group stripping, negative-scale BigDecimal; a hand-verified known-encoding pin; malformed-payload rejection for NaN/invalid sign/oversized digit count)
- [x] New `Issue6447TypeResolutionIT`: end-to-end JDBC round trip for each of DECIMAL/SHORT/BYTE/DATETIME, asserting the announced type name and round-tripped value agree whether or not a row was sampled
- [x] Full `postgresw` unit suite (399 tests) and the relevant IT classes (`PostgresWJdbcIT`, `Issue6411ByteaIT`, `Issue5290ClientCompatibilityIT`, `Issue6412CatalogIT`) green, no regressions
- [x] `engine`/`server`/`postgresw` compile clean

Closes #6447

https://claude.ai/code/session_016yjKJXMNMQeLPKdCno7cFX