### PR TITLE
fix(#6372): Console LOAD no longer echoes an empty prompt for blank lines

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -811,8 +811,16 @@ public class Console {
       return true;
 
     for (final String w : parsedLine.words()) {
+      final String trimmedWord = w.trim();
+      if (trimmedWord.isEmpty())
+        // AN EMPTY LINE (OR A LEFTOVER LINE TERMINATOR BETWEEN TWO COMMANDS) SPLITS INTO A BLANK "WORD": SKIP IT SO
+        // LOAD DOES NOT ECHO AN EMPTY PROMPT FOR IT (issue #6372)
+        continue;
+
       if (printCommand)
-        output(3, getPrompt() + w);
+        // USE THE TRIMMED WORD: AN UNTERMINATED LAST COMMAND CARRIES ITS TRAILING NEWLINE AS PART OF THE WORD, WHICH
+        // WOULD OTHERWISE PUSH THE RESULT DOWN BY AN EXTRA BLANK LINE (issue #6372)
+        output(3, getPrompt() + trimmedWord);
 
       if (batchMode) {
         try {

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -184,6 +184,49 @@ class ConsoleTest {
     }
   }
 
+  /**
+   * Issue https://github.com/ArcadeData/arcadedb/issues/6372: an empty line in a script loaded with LOAD must not echo an
+   * empty prompt of its own - only the real commands are echoed.
+   */
+  @Test
+  void loadScriptWithEmptyLinesDoesNotEchoEmptyPrompts() throws Exception {
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+
+    final File script = new File("./target/issue-6372.sql");
+    try {
+      Files.writeString(script.toPath(), """
+          CREATE DOCUMENT TYPE Loaded;
+
+
+          INSERT INTO Loaded SET id = 1;
+
+          INSERT INTO Loaded SET id = 2
+          """);
+
+      final StringBuilder buffer = new StringBuilder();
+      console.setOutput(output -> buffer.append(output));
+
+      assertThat(console.parse("load " + script.getAbsolutePath())).isTrue();
+
+      final String output = buffer.toString();
+      assertThat(output).doesNotContain("ERROR");
+
+      // ONLY THE 3 REAL COMMANDS (CREATE, INSERT, INSERT) MUST BE ECHOED WITH A PROMPT - THE 3 EMPTY LINES IN
+      // BETWEEN MUST NOT PRODUCE A PROMPT OF THEIR OWN
+      final String marker = "{" + DB_NAME + "}> ";
+      int promptCount = 0;
+      for (int idx = output.indexOf(marker); idx != -1; idx = output.indexOf(marker, idx + marker.length()))
+        ++promptCount;
+      assertThat(promptCount).isEqualTo(3);
+
+      buffer.setLength(0);
+      assertThat(console.parse("select count(*) as count from Loaded")).isTrue();
+      assertThat(buffer.toString()).contains("2");
+    } finally {
+      script.delete();
+    }
+  }
+
   @Test
   void listDatabases() throws Exception {
     assertThat(console.parse("list databases;")).isTrue();


### PR DESCRIPTION
Closes #6372

## Summary

`Console.executeLoad()` reads a script file line by line and hands each line to `TerminalParser.parse()`, which splits it into "words" on the `;` delimiter. An empty line in the script (or the leftover line terminator right after a semicolon-terminated command) parses into a single blank word made only of the newline character.

`Console.execute(ParsedLine, boolean printCommand)` iterated over every word and, when `printCommand` is `true` (the mode `executeLoad` uses), unconditionally echoed `getPrompt() + w` before executing it, including for these blank words. Since `getPrompt()` itself starts with a newline, each blank word produced an extra `{db}>` prompt line with nothing after it, exactly as reported in the issue.

The same untrimmed-word echo also explains the "PS" note in the issue: the last command in a script with no trailing semicolon carries its own trailing newline as part of the word, so its prompt echo (`getPrompt() + w`) contained an embedded newline that pushed the result table down by one extra blank line compared to a semicolon-terminated command.

### Fix

In `Console.execute(ParsedLine, boolean)`, each word is now trimmed first. A word that trims to empty is skipped entirely (no prompt echo, no execution - `execute(String)` already no-ops on blank input, so behavior is unchanged other than the suppressed echo). Non-blank words are echoed using the trimmed value, which also removes the stray embedded newline for an unterminated last command.

Interactive mode is unaffected: its prompt is printed by `LineReader.readLine(getPrompt())` before the line is even read, not through this method, so pressing Enter still starts a fresh prompt line exactly as before.

The heart emoji rendering as `?` in the console banner (the "PPS" note in the issue) is a separate terminal-charset concern, out of scope for this fix.

## Test plan

- [x] New regression test `ConsoleTest#loadScriptWithEmptyLinesDoesNotEchoEmptyPrompts`: loads a script with 3 real commands separated by empty lines and asserts exactly 3 prompts are echoed (previously 8), and that all rows were actually inserted despite the blank lines. Fails before the fix (`expected: 3 but was: 8`), passes after.
- [x] `mvn -o -pl console test`: full `ConsoleTest` suite green (40/40), plus `ConsoleBatchTest`, `TerminalParserTest`, `CompositeIndexUpdateTest` all green. `ConsoleAsyncInsertTest` fails with `SecurityException: User/Password not valid`, but this is a pre-existing environmental issue unrelated to this change - a brew-installed ArcadeDB server was already bound to port 2480 on the test machine, which is a documented false-failure signature for that test, not a regression from this fix.