### PR TITLE
fix(#6474): import database server command and deep fetch disagreed on the local-URL policy

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -20,6 +20,7 @@
 /* ParserGeneratorCCOptions:MULTI=true,NODE_USES_PARSER=false,VISITOR=true,TRACK_TOKENS=true,NODE_PREFIX=,NODE_EXTENDS=,NODE_FACTORY=,SUPPORT_CLASS_VISIBILITY_PUBLIC=true */
 package com.arcadedb.query.sql.parser;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Identifiable;
@@ -73,6 +74,19 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
       final Database db = context.getDatabase();
       final Database effectiveDb = db instanceof DatabaseInternal di ? di.getWrappedDatabaseInstance() : db;
       final Object importer = clazz.getConstructor(Database.class, String.class).newInstance(effectiveDb, url != null ? url.getUrlString() : null);
+
+      // Threads this command's resolved SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS through to the importer's deep
+      // fetch explicitly, rather than letting SourceDiscovery re-derive it from the static GlobalConfiguration value
+      // on its own. context.getConfiguration() falls back to that same static value when no caller overrode it (a
+      // client-issued 'IMPORT DATABASE ...' reaches here with no override and sees no behaviour change), but when
+      // PostServerCommandHandler's 'import database' server command already validated the URL against its own,
+      // possibly per-instance-overridden SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS, it passes the resolved answer down
+      // via the ContextConfiguration it hands to database.command(...) so the two layers cannot disagree (#6474).
+      // This is NOT settable through the statement's own 'WITH ...' settings map below: those settings map to
+      // ImporterSettings fields one at a time by name, and allowLocalUrls is deliberately not one of them, or any
+      // client able to run IMPORT DATABASE could self-authorize past the SSRF guard from SQL text alone.
+      final boolean blockLocalNetworks = context.getConfiguration().getValue(GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS);
+      clazz.getMethod("setAllowLocalUrls", boolean.class).invoke(importer, !blockLocalNetworks);
 
       // TRANSFORM SETTINGS
       final Map<String, String> settingsToString = new HashMap<>();

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImportSecurityValidator.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImportSecurityValidator.java
@@ -75,7 +75,23 @@ public class ImportSecurityValidator {
    * @throws SecurityException if a scheme or address is refused on any hop
    */
   public static HttpURLConnection openRemoteConnection(final String url) throws IOException {
-    final boolean blockLocalNetworks = GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.getValueAsBoolean();
+    return openRemoteConnection(url, GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.getValueAsBoolean());
+  }
+
+  /**
+   * Same as {@link #openRemoteConnection(String)}, but with the local-network block decision resolved by the caller
+   * instead of re-derived here from the static {@link GlobalConfiguration#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS}.
+   * <p>
+   * {@code PostServerCommandHandler}'s {@code import database} pre-check gates the command itself on a different key,
+   * {@code SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS}, read from that server's own (possibly per-instance-overridden)
+   * configuration. Without this overload the pre-check and this fetch could disagree - one server enabling the
+   * documented opt-out only on its own configuration would have its pre-check accept a URL that this fetch then
+   * refused anyway, using an entirely different, undocumented-for-this-purpose key (issue #6474, mirroring the
+   * restore-side fix in #6381/#6449).
+   *
+   * @throws SecurityException if a scheme or address is refused on any hop
+   */
+  public static HttpURLConnection openRemoteConnection(final String url, final boolean blockLocalNetworks) throws IOException {
     return SafeHttpFetcher.open(url, address -> blockLocalNetworks && isBlockedAddress(address), "IMPORT DATABASE");
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
@@ -47,6 +47,17 @@ public class Importer extends AbstractImporter {
     System.exit(0);
   }
 
+  /**
+   * Overrides {@link com.arcadedb.GlobalConfiguration#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS} for this import.
+   * The server command handler calls this reflectively with the value it already validated the URL against, so the
+   * deep fetch inside {@link SourceDiscovery} cannot land on a stricter-or-looser answer than the pre-check that
+   * accepted the command (issue #6474, mirroring the restore-side fix in #6381/#6449).
+   */
+  public Importer setAllowLocalUrls(final boolean allowLocalUrls) {
+    settings.allowLocalUrls = allowLocalUrls;
+    return this;
+  }
+
   public Map<String, Object> load() {
     source = null;
 
@@ -104,7 +115,7 @@ public class Importer extends AbstractImporter {
       // SKIP IT
       return;
 
-    final SourceDiscovery sourceDiscovery = new SourceDiscovery(url);
+    final SourceDiscovery sourceDiscovery = new SourceDiscovery(url, settings.allowLocalUrls);
 
     if (settings.probeOnly) {
       sourceDiscovery.getSource();

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
@@ -78,6 +78,17 @@ public class ImporterSettings {
    */
   public String  onRowError             = "abort";
 
+  /**
+   * Explicit override for whether the importer's remote fetches may reach a private/loopback/link-local host,
+   * resolved by a caller that already validated the URL against its own policy (see {@link
+   * com.arcadedb.integration.importer.Importer#setAllowLocalUrls}). {@code null} (the default) falls back to {@link
+   * com.arcadedb.GlobalConfiguration#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS}. Deliberately absent from {@link
+   * #parseParameter}: unlike every other setting here, this one must never be settable from SQL {@code WITH ...}
+   * syntax, or any client able to run {@code IMPORT DATABASE} could self-authorize past the SSRF guard regardless of
+   * server configuration (issue #6474).
+   */
+  public Boolean allowLocalUrls;
+
   public final Map<String, Object> options = new HashMap<>();
 
   public ImporterSettings() {

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.integration.importer;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.integration.importer.format.CSVImporterFormat;
 import com.arcadedb.integration.importer.format.FormatImporter;
 import com.arcadedb.integration.importer.format.GloVeImporterFormat;
@@ -55,12 +56,24 @@ public class SourceDiscovery {
   private static final String RESOURCE_SEPARATOR = ":::";
   private static final String FILE_PREFIX        = "file://";
   private static final String CLASSPATH_PREFIX   = "classpath://";
-  private              String url;
-  private              long   limitBytes         = 10000000;
-  private              long   limitEntries       = 0;
+  private              String  url;
+  private final        Boolean allowLocalUrls;
+  private              long    limitBytes         = 10000000;
+  private              long    limitEntries       = 0;
 
   public SourceDiscovery(final String url) {
+    this(url, null);
+  }
+
+  /**
+   * @param allowLocalUrls explicit override for whether a remote fetch may reach a private/loopback/link-local host,
+   *                       resolved by a caller that already validated the URL against its own policy (issue #6474).
+   *                       {@code null} (the default via {@link #SourceDiscovery(String)}) falls back to {@link
+   *                       GlobalConfiguration#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS}.
+   */
+  public SourceDiscovery(final String url, final Boolean allowLocalUrls) {
     this.url = url;
+    this.allowLocalUrls = allowLocalUrls;
   }
 
   public SourceSchema getSchema(final ImporterSettings settings,
@@ -117,14 +130,20 @@ public class SourceDiscovery {
     // callback below re-opens the source and MUST go through the same path: it previously built a second raw
     // connection with no validation at all, so a redirect (or a rebind) on that second fetch was entirely unchecked
     // even once the first one was validated (GHSA-4w2m-77c8-83mw).
-    final HttpURLConnection connection = ImportSecurityValidator.openRemoteConnection(urlPath);
+    //
+    // blockLocalNetworks resolves allowLocalUrls once, up front, so both the initial fetch and the reset callback's
+    // re-fetch below agree with each other (and with whatever caller-resolved policy allowLocalUrls carries - #6474).
+    final boolean blockLocalNetworks = allowLocalUrls != null ?
+        !allowLocalUrls : GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.getValueAsBoolean();
+
+    final HttpURLConnection connection = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
 
     return getSourceFromContent(new BufferedInputStream(connection.getInputStream()), connection.getContentLengthLong(), resource,
         source -> {
           try {
             connection.disconnect();
 
-            final HttpURLConnection connection1 = ImportSecurityValidator.openRemoteConnection(urlPath);
+            final HttpURLConnection connection1 = ImportSecurityValidator.openRemoteConnection(urlPath, blockLocalNetworks);
 
             if (source.inputStream instanceof GZIPInputStream)
               source.inputStream = new GZIPInputStream(connection1.getInputStream(), 2048);

--- a/integration/src/test/java/com/arcadedb/integration/importer/Issue6474ImportSsrfFlagDivergenceTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Issue6474ImportSsrfFlagDivergenceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.GlobalConfiguration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6474: {@code import database <name> <url>} (the HTTP server command) gated on two
+ * independent, independently-configured SSRF flags. {@code PostServerCommandHandler.validateClientRestoreImportUrl}
+ * pre-checked the URL against {@link GlobalConfiguration#SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS}, read from that
+ * server's own configuration, while the actual fetch inside {@link SourceDiscovery} re-derived its own answer from
+ * the different, static-only {@link GlobalConfiguration#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS} - so enabling
+ * the documented opt-out for one did not affect the other.
+ * <p>
+ * This mirrors {@code Issue6381RestoreSsrfTest}'s coverage of the analogous restore-side fix (#6381/#6449): it
+ * proves an explicit {@link SourceDiscovery#SourceDiscovery(String, Boolean)} / {@link
+ * Importer#setAllowLocalUrls(boolean)} override takes priority over the static default in both directions, which is
+ * exactly what {@code PostServerCommandHandler} now relies on to thread its pre-check's resolved answer through.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6474ImportSsrfFlagDivergenceTest {
+
+  private static final String LOOPBACK_URL = "http://127.0.0.1:1/unreachable";
+
+  @AfterEach
+  void reset() {
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.reset();
+  }
+
+  @Test
+  void sourceDiscoveryWithNoOverrideFallsBackToStaticDefault() {
+    // No explicit override (null, the SourceDiscovery(String) constructor's behaviour): must still honour the
+    // static default exactly like before this fix, for every caller that never resolved its own answer.
+    assertThatThrownBy(() -> new SourceDiscovery(LOOPBACK_URL).getSource())
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("127.0.0.1");
+  }
+
+  @Test
+  void explicitOverrideAllowsLocalUrlEvenWhenStaticDefaultBlocks() throws IOException {
+    // Static default is true (blocking); the explicit per-call override must still allow the fetch to be attempted.
+    // (It still fails - port 1 refuses the connection - but with a connection error, never a SecurityException.)
+    assertThatThrownBy(() -> new SourceDiscovery(LOOPBACK_URL, true).getSource())
+        .isNotInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  void explicitOverrideBlocksLocalUrlEvenWhenStaticDefaultAllows() {
+    // Static default flipped to allow local URLs; the explicit per-call override must still block it - proving the
+    // override is consulted at all, not just used as a permissive fallback.
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.setValue(false);
+
+    assertThatThrownBy(() -> new SourceDiscovery(LOOPBACK_URL, false).getSource())
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("127.0.0.1");
+  }
+
+  @Test
+  void importerSetAllowLocalUrlsThreadsThroughToSettings() {
+    // The exact reflective call PostServerCommandHandler makes on the SSE path. settings is package-visible
+    // (protected in AbstractImporter, this test is in the same package), so this checks the override reaches the
+    // same field SourceDiscovery(url, settings.allowLocalUrls) reads in Importer.loadFromSource() - without paying
+    // for a full load() cycle (database creation, background timer) just to prove a one-field assignment.
+    final Importer importer = new Importer(null, LOOPBACK_URL);
+    assertThat(importer.settings.allowLocalUrls).isNull();
+
+    importer.setAllowLocalUrls(true);
+    assertThat(importer.settings.allowLocalUrls).isTrue();
+
+    importer.setAllowLocalUrls(false);
+    assertThat(importer.settings.allowLocalUrls).isFalse();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
@@ -631,6 +632,10 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       try {
         final Class<?> clazz = Class.forName("com.arcadedb.integration.importer.Importer");
         final Object importer = clazz.getConstructor(Database.class, String.class).newInstance(database, url);
+        // SAME BOOLEAN validateClientRestoreImportUrl ALREADY VALIDATED THIS URL AGAINST: THE FETCH INSIDE
+        // SourceDiscovery MUST AGREE WITH THIS SERVER'S OWN CONFIGURATION RATHER THAN FALLING BACK TO THE STATIC
+        // DEFAULT, OR A PER-SERVER OVERRIDE THAT LET THE COMMAND THROUGH WOULD STILL HAVE THE FETCH REFUSE IT (#6474).
+        clazz.getMethod("setAllowLocalUrls", boolean.class).invoke(importer, isRestoreImportLocalUrlsAllowed());
 
         // Set a logger with SSE callback
         final Class<?> loggerClass = Class.forName("com.arcadedb.integration.importer.ConsoleLogger");
@@ -695,8 +700,12 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       return null;
     }
 
-    // Synchronous fallback
-    try (final var rs = database.command("sql", "import database " + url)) {
+    // Synchronous fallback. Threads the same resolved boolean validateClientRestoreImportUrl() already validated
+    // this URL against into the SQL command's execution context, so ImportDatabaseStatement's deep fetch cannot
+    // disagree with the pre-check that accepted the command (#6474, mirroring the setAllowLocalUrls call above).
+    final ContextConfiguration importConfiguration = new ContextConfiguration();
+    importConfiguration.setValue(GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS, !isRestoreImportLocalUrlsAllowed());
+    try (final var rs = database.command("sql", "import database " + url, importConfiguration, Map.of())) {
       // try-with-resources releases the execution-plan state held by the import ResultSet.
     }
     return new ExecutionResponse(200, new JSONObject().put("result", "ok").toString());

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
@@ -422,6 +422,57 @@ class PostServerCommandHandlerIT extends BaseGraphServerTest {
   }
 
   /**
+   * Same regression as {@link #importDatabaseCommandHonorsTheSameLocalUrlsFlagAtTheFetchLayer()}, but for the SSE
+   * code path: {@code PostServerCommandHandler.importDatabase()} takes a different branch (constructing {@code
+   * Importer} directly, rather than going through {@code ImportDatabaseStatement}) when the request sends {@code
+   * Accept: text/event-stream}, and that branch has its own {@code setAllowLocalUrls} call site to get right.
+   */
+  @Test
+  void importDatabaseCommandSsePathHonorsTheSameLocalUrlsFlagAtTheFetchLayer() throws Exception {
+    final com.sun.net.httpserver.HttpServer localServer =
+        com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress(java.net.InetAddress.getLoopbackAddress(), 0), 0);
+    try {
+      localServer.createContext("/data", exchange -> {
+        final byte[] body = "not a real export file, only the SSRF gate is under test here".getBytes();
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+      });
+      localServer.start();
+
+      final String url = "http://127.0.0.1:" + localServer.getAddress().getPort() + "/data";
+
+      final HttpRequest request = HttpRequest.newBuilder()
+          .uri(new URI("http://localhost:2480/api/v1/server"))
+          .POST(HttpRequest.BodyPublishers.ofString(new JSONObject()
+              .put("command", "import database issue6474_import_ssrf_test_sse " + url)
+              .toString()))
+          .setHeader("Authorization",
+              "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+          .setHeader("Accept", "text/event-stream")
+          .build();
+      final HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).as(response.body()).isEqualTo(200);
+
+      // Parse the SSE frames looking for the specific "blocked" error a pre-fix disagreement between the two flags
+      // would have produced. Any other outcome (completed, or an error about the unparsable fake content) is fine -
+      // only the SSRF-specific refusal is what this test rules out.
+      for (final String frame : response.body().split("\n\n")) {
+        final String trimmed = frame.trim();
+        if (trimmed.startsWith("data: ")) {
+          final JSONObject event = new JSONObject(trimmed.substring("data: ".length()));
+          if ("error".equals(event.getString("status")))
+            assertThat(event.getString("message")).as(event.toString()).doesNotContain("non-public or restricted address");
+        }
+      }
+    } finally {
+      localServer.stop(0);
+      executeServerCommand("drop database issue6474_import_ssrf_test_sse");
+    }
+  }
+
+  /**
    * Helper method to execute server commands consistently
    */
   private HttpResponse<String> executeServerCommand(String command) throws Exception {

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
@@ -379,6 +379,49 @@ class PostServerCommandHandlerIT extends BaseGraphServerTest {
   }
 
   /**
+   * Regression test for issue #6474: {@code import database <name> <url>}'s pre-check
+   * ({@code PostServerCommandHandler.validateClientRestoreImportUrl}) and the importer's actual fetch (deep inside
+   * {@code SourceDiscovery}) used to consult two different, independently-configured flags -
+   * {@code SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS} (set on this server's own configuration by {@code
+   * onServerConfiguration} above) and {@code SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS} (left at its static
+   * default here, blocking). Before the fix, the pre-check accepted a loopback URL because of the first flag, but
+   * the deep fetch refused it anyway because of the second, unrelated one - a confusing fail-closed divergence, not
+   * an active SSRF hole, but the same class of bug already fixed for {@code restore database} in #6381/#6449.
+   * <p>
+   * This exercises the synchronous (non-SSE) code path specifically, since that is the one that goes through {@code
+   * ImportDatabaseStatement} rather than constructing {@code Importer} directly.
+   */
+  @Test
+  void importDatabaseCommandHonorsTheSameLocalUrlsFlagAtTheFetchLayer() throws Exception {
+    final com.sun.net.httpserver.HttpServer localServer =
+        com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress(java.net.InetAddress.getLoopbackAddress(), 0), 0);
+    try {
+      localServer.createContext("/data", exchange -> {
+        final byte[] body = "not a real export file, only the SSRF gate is under test here".getBytes();
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+      });
+      localServer.start();
+
+      final String url = "http://127.0.0.1:" + localServer.getAddress().getPort() + "/data";
+
+      // onServerConfiguration() already enabled SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS: the pre-check accepts this
+      // loopback URL. SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS is left at its default (blocking) - before the
+      // fix the deep fetch re-derived its own answer from that untouched key and refused the loopback host the
+      // pre-check had just accepted, surfacing as a 403 "blocked ... non-public or restricted address" instead of
+      // whatever error the (deliberately unparsable) content would otherwise cause.
+      final HttpResponse<String> response = executeServerCommand("import database issue6474_import_ssrf_test " + url);
+
+      assertThat(response.statusCode()).as(response.body()).isNotEqualTo(403);
+      assertThat(response.body()).as(response.body()).doesNotContain("non-public or restricted address");
+    } finally {
+      localServer.stop(0);
+      executeServerCommand("drop database issue6474_import_ssrf_test");
+    }
+  }
+
+  /**
    * Helper method to execute server commands consistently
    */
   private HttpResponse<String> executeServerCommand(String command) throws Exception {


### PR DESCRIPTION
## Summary

`import database <name> <url>` (the HTTP server command) was gated by two independent SSRF checks
reading two different, independently-configured keys:

- The pre-check in `PostServerCommandHandler.validateClientRestoreImportUrl` gates on
  `SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS`, read from this server's own (possibly per-instance-overridden)
  configuration.
- The actual fetch, deep inside `SourceDiscovery` -> `ImportSecurityValidator.openRemoteConnection`, gated
  on the different, static-only `SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS`.

Both default to blocking, so this was not an active bypass, but an operator enabling the documented
opt-out for one flag (exactly what its javadoc tells them to do for `import database`) would have the
pre-check accept the command, only to have the deep fetch refuse the same URL anyway with a confusing,
unrelated error - the same class of divergence already fixed for `restore database` in #6381/#6449.

## Fix

Threads the pre-check's resolved boolean explicitly into the importer, mirroring the restore-side fix:

- `Importer.setAllowLocalUrls(boolean)` (new), threaded through `ImporterSettings`/`SourceDiscovery` down
  to `ImportSecurityValidator.openRemoteConnection` - the same shape as `Restore.setAllowLocalUrls`.
- The server command's SSE path calls it reflectively, the exact same call restore already makes.
- The synchronous fallback goes through `ImportDatabaseStatement` (a SQL command) instead of constructing
  `Importer` directly, so it threads the resolved boolean via the command's per-call `ContextConfiguration`
  instead - the same existing mechanism `BackupDatabaseStatement` uses for `SERVER_BACKUP_DIRECTORY`.
- The override is deliberately **not** exposed through `IMPORT DATABASE`'s own `WITH ...` settings syntax,
  so a client cannot self-authorize past the SSRF guard purely from SQL text.

Callers that never resolve their own answer (a raw SQL `IMPORT DATABASE ...` from a client, the CLI) keep
falling back to the static `SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS` default unchanged.

## Test plan

- [x] New unit tests (`Issue6474ImportSsrfFlagDivergenceTest`) proving the explicit override takes priority
      over the static default in both directions, and that `Importer.setAllowLocalUrls` threads through to
      `ImporterSettings`.
- [x] New end-to-end IT (`PostServerCommandHandlerIT#importDatabaseCommandHonorsTheSameLocalUrlsFlagAtTheFetchLayer`)
      reproducing the exact reported scenario against a real server: with
      `SERVER_RESTORE_IMPORT_ALLOW_LOCAL_URLS=true` on the server's own config but
      `SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS` left at its default, confirmed this test fails with a
      403 "blocked ... non-public or restricted address" on the pre-fix code, and passes after the fix.
- [x] Full `integration` module test suite green.
- [x] `ImportDatabaseSecurityIT`, `ServerImportDatabaseIT`, `RestoreImportSecurityDurabilityIT`, full
      `PostServerCommandHandlerIT` class green.
- [x] All modules compile clean.

Closes #6474.