### PR TITLE
fix(#6438): CONTAINSTEXT coerces a non-String value like the full-text index does

### DIFF
--- a/docs/6438-containstext-nonstring-index-mismatch.md
+++ b/docs/6438-containstext-nonstring-index-mismatch.md
@@ -38,3 +38,36 @@ right-hand value with `.toString()` instead of rejecting non-`String` values out
 
 - `mvn -o -pl engine -am test -Dtest=Issue6438ContainsTextNonStringArgumentTest -Dmaven.repo.local=<worktree>/.m2repo`
 - Full `ContainsText*` / full-text index regression suite re-run to confirm no regressions.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6477
+
+## Review cycles
+
+- **Cycle 1** (head `34f61f6`): Claude review flagged two items:
+  1. Fully-qualified `java.util.*` names in the new test (style, contradicts `CLAUDE.md`).
+  2. A multivalue (list/array) right-hand side would now be stringified via `List.toString()` into a
+     bracket-notation substring search instead of the old unconditional `false`, with the existing
+     `ContainsTextWithArrayTest.containsTextWithArrayOfStrings` now passing "by coincidence" rather than by design.
+  Both applied: added a `MultiValue.isMultiValue(rightValue)` guard (mirroring `FetchFromIndexStep`'s own guard) so
+  a multivalue right-hand side still answers "no match", fixed the FQNs, and added two more regression tests
+  (`multiValueRightHandSideStillMatchesNothing`, `nullRightHandSideStillMatchesNothing`) per the reviewer's
+  "nice to have" suggestion. Pushed as `2178ae5`.
+- **Cycle 2** (head `2178ae5`): Claude review found the fix itself correct and the new test coverage "more thorough
+  than the minimum needed", but flagged one stale neighboring doc comment: `FetchFromIndexStep.java`'s Javadoc for
+  `processFullTextBlock` said `ContainsTextCondition#evaluate` treats "a non-String value" as never a match, which
+  this PR made false (only `null` and multivalue are never a match now). Applied: reworded that comment. Pushed as
+  `85ee3e4`.
+- **Cycle 3** (head `85ee3e4`): Claude review - "No blocking issues found." One non-blocking observation (whether
+  `docs/<issue>.md` tracking files are the right long-term convention) explicitly framed as "a call for the
+  maintainers on repo convention, not a defect" - no action taken, this file follows the same convention every
+  other tracked issue in this repo's `docs/` directory already uses. **Clean approval, loop ended.**
+
+## Deferred items
+
+None.
+
+## Final state
+
+`clean-approval` after 3 review cycles.

--- a/docs/6438-containstext-nonstring-index-mismatch.md
+++ b/docs/6438-containstext-nonstring-index-mismatch.md
@@ -1,0 +1,40 @@
+# Issue #6438: CONTAINSTEXT with a non-String argument diverges by index presence
+
+## Root cause
+
+`ContainsTextCondition.evaluate()` (both overloads, in
+`engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java`) refused any right-hand value that
+was not already a `String`:
+
+```java
+final Object rightValue = right.execute(currentRecord, context);
+if (!(rightValue instanceof String))
+  return false;
+```
+
+This is the fallback path used whenever no full-text index covers the property. The index path
+(`FetchFromIndexStep.processFullTextBlock` -> `LSMTreeFullTextIndex.get`) has no such restriction: it takes whatever
+non-null, non-multivalue value the right expression evaluates to and calls `.toString()` on it before analyzing/
+searching. So `title CONTAINSTEXT 2024` matched a row with `title = 'report 2024'` when `title` was covered by a
+full-text index, and matched nothing when it was not - the same operator meaning two different things depending on
+an index that has nothing to do with the query's semantics.
+
+## Fix
+
+Chosen direction (per the issue's own recommendation - "the more useful behaviour"): **coerce in the evaluator**,
+matching what the index path already does. `ContainsTextCondition.evaluate()` now stringifies any non-null
+right-hand value with `.toString()` instead of rejecting non-`String` values outright. `null` still means "no match"
+(unchanged), and the left-hand side is unchanged - it must already be a `String` (the text being searched in).
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/query/sql/operator/Issue6438ContainsTextNonStringArgumentTest.java`:
+- `numericLiteralMatchesTheSameWayIndexedAndUnindexed` - the same numeric literal against the same text matches on
+  both an indexed and an unindexed property (the assertion that could not pass before the fix, per the issue body).
+- `numericLiteralWithNoMatchingSubstringMatchesNothingEitherWay` - a numeric literal that is not a substring still
+  matches nothing (no false positives introduced by the coercion).
+
+## Verification
+
+- `mvn -o -pl engine -am test -Dtest=Issue6438ContainsTextNonStringArgumentTest -Dmaven.repo.local=<worktree>/.m2repo`
+- Full `ContainsText*` / full-text index regression suite re-run to confirm no regressions.

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -373,8 +373,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * A condition whose right side evaluates to {@code null} makes the whole block match NOTHING rather than leaving its
    * property unconstrained. The two readings share one slot - a {@code null} slot is exactly how the key says "this property
    * is not constrained" - so folding a null-valued condition into it would silently drop the condition instead of failing
-   * it. That is what {@link ContainsTextCondition#evaluate} does off the index (a non-String value is never a match), what
-   * a single-property index already did (an empty query text finds no term), and now what a multi-property one does too.
+   * it. That is what {@link ContainsTextCondition#evaluate} does off the index (a {@code null} value is never a match),
+   * what a single-property index already did (an empty query text finds no term), and now what a multi-property one
+   * does too.
    */
   private boolean processFullTextBlock() {
     if (index.getType() != Schema.INDEX_TYPE.FULL_TEXT || additionalRangeCondition != null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
@@ -22,6 +22,7 @@ package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.util.ArrayList;
@@ -42,10 +43,14 @@ import java.util.Map;
  * nothing else. Use {@code SEARCH_INDEX(...)} for the full Lucene query syntax, or {@code LIKE '%..%'} when substring
  * matching is what is wanted.
  * <p>
- * The right-hand (search text) side accepts any non-{@code null} value and compares its {@link Object#toString()}
- * form, matching what {@code LSMTreeFullTextIndex.get} already does on the index path - a numeric literal such as
- * {@code CONTAINSTEXT 2024} is a normal search, not a guaranteed non-match, whether or not the property happens to
- * be indexed (issue #6438). The left-hand (searched-in) side is unchanged: it must already be a {@code String}.
+ * The right-hand (search text) side accepts any non-{@code null}, non-multivalue value and compares its
+ * {@link Object#toString()} form, matching what {@code LSMTreeFullTextIndex.get} already does on the index path - a
+ * numeric literal such as {@code CONTAINSTEXT 2024} is a normal search, not a guaranteed non-match, whether or not
+ * the property happens to be indexed (issue #6438). A multivalue (list/array) right-hand side still answers
+ * {@code false} unconditionally, exactly as before - {@code FetchFromIndexStep.processFullTextBlock} rejects it the
+ * same way, via its own {@link MultiValue#isMultiValue(Object)} check - rather than falling into a bracket-notation
+ * string comparison via {@code List.toString()}. The left-hand (searched-in) side is unchanged: it must already be a
+ * {@code String}.
  */
 @SuppressWarnings("ALL")
 public class ContainsTextCondition extends BooleanExpression {
@@ -62,7 +67,7 @@ public class ContainsTextCondition extends BooleanExpression {
       return false;
 
     final Object rightValue = right.execute(currentRecord, context);
-    if (rightValue == null)
+    if (rightValue == null || MultiValue.isMultiValue(rightValue))
       return false;
 
     return ((String) leftValue).contains(rightValue.toString());
@@ -75,7 +80,7 @@ public class ContainsTextCondition extends BooleanExpression {
       return false;
 
     final Object rightValue = right.execute(currentRecord, context);
-    if (rightValue == null)
+    if (rightValue == null || MultiValue.isMultiValue(rightValue))
       return false;
 
     return ((String) leftValue).contains(rightValue.toString());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsTextCondition.java
@@ -41,6 +41,11 @@ import java.util.Map;
  * full-text index covers the property, which {@code EXPLAIN} answers - {@code FETCH FROM INDEX} versus a scan - and
  * nothing else. Use {@code SEARCH_INDEX(...)} for the full Lucene query syntax, or {@code LIKE '%..%'} when substring
  * matching is what is wanted.
+ * <p>
+ * The right-hand (search text) side accepts any non-{@code null} value and compares its {@link Object#toString()}
+ * form, matching what {@code LSMTreeFullTextIndex.get} already does on the index path - a numeric literal such as
+ * {@code CONTAINSTEXT 2024} is a normal search, not a guaranteed non-match, whether or not the property happens to
+ * be indexed (issue #6438). The left-hand (searched-in) side is unchanged: it must already be a {@code String}.
  */
 @SuppressWarnings("ALL")
 public class ContainsTextCondition extends BooleanExpression {
@@ -57,10 +62,10 @@ public class ContainsTextCondition extends BooleanExpression {
       return false;
 
     final Object rightValue = right.execute(currentRecord, context);
-    if (!(rightValue instanceof String))
+    if (rightValue == null)
       return false;
 
-    return ((String) leftValue).contains((String) rightValue);
+    return ((String) leftValue).contains(rightValue.toString());
   }
 
   @Override
@@ -70,10 +75,10 @@ public class ContainsTextCondition extends BooleanExpression {
       return false;
 
     final Object rightValue = right.execute(currentRecord, context);
-    if (!(rightValue instanceof String))
+    if (rightValue == null)
       return false;
 
-    return ((String) leftValue).contains((String) rightValue);
+    return ((String) leftValue).contains(rightValue.toString());
   }
 
   public void toString(final Map<String, Object> params, final StringBuilder builder) {

--- a/engine/src/test/java/com/arcadedb/query/sql/operator/Issue6438ContainsTextNonStringArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/operator/Issue6438ContainsTextNonStringArgumentTest.java
@@ -22,6 +22,9 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -71,8 +74,42 @@ class Issue6438ContainsTextNonStringArgumentTest extends TestHelper {
         idsMatching("SELECT id FROM Unindexed6438b WHERE content CONTAINSTEXT 1999")).isEmpty());
   }
 
-  private java.util.Set<String> idsMatching(final String query) {
-    final java.util.Set<String> ids = new java.util.LinkedHashSet<>();
+  /**
+   * A multivalue right-hand side must keep answering "no match" rather than being stringified via
+   * {@code List.toString()} into a bracket-notation substring search. {@code FetchFromIndexStep.processFullTextBlock}
+   * rejects it the same way (falls back off the index), so the two paths still agree here.
+   */
+  @Test
+  void multiValueRightHandSideStillMatchesNothing() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Unindexed6438c");
+      database.command("sql", "CREATE PROPERTY Unindexed6438c.content STRING");
+      // A row whose content literally contains the bracket-notation rendering of the array, so a regression that
+      // reintroduces List.toString() coercion would turn this into a false match instead of an empty result.
+      database.command("sql", "INSERT INTO Unindexed6438c SET id = 'a', content = 'literally [xyz, abc] here'");
+    });
+
+    database.transaction(() -> assertThat(
+        idsMatching("SELECT id FROM Unindexed6438c WHERE content CONTAINSTEXT ['xyz', 'abc']")).isEmpty());
+  }
+
+  /**
+   * A {@code null} right-hand side still means "no match", unchanged by the coercion to {@code toString()}.
+   */
+  @Test
+  void nullRightHandSideStillMatchesNothing() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Unindexed6438d");
+      database.command("sql", "CREATE PROPERTY Unindexed6438d.content STRING");
+      database.command("sql", "INSERT INTO Unindexed6438d SET id = 'a', content = 'report 2024'");
+    });
+
+    database.transaction(() -> assertThat(
+        idsMatching("SELECT id FROM Unindexed6438d WHERE content CONTAINSTEXT null")).isEmpty());
+  }
+
+  private Set<String> idsMatching(final String query) {
+    final Set<String> ids = new LinkedHashSet<>();
     try (final ResultSet rs = database.query("sql", query)) {
       while (rs.hasNext())
         ids.add(rs.next().getProperty("id"));

--- a/engine/src/test/java/com/arcadedb/query/sql/operator/Issue6438ContainsTextNonStringArgumentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/operator/Issue6438ContainsTextNonStringArgumentTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.operator;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6438: {@code CONTAINSTEXT} with a non-String right-hand argument meant one thing when a
+ * full-text index covered the property (the index stringifies the key and searches normally) and another when it did
+ * not ({@link com.arcadedb.query.sql.parser.ContainsTextCondition#evaluate} refused anything that was not already a
+ * {@code String} and answered {@code false}). Both paths must now agree: a numeric (or otherwise non-String) literal
+ * is coerced to its string form and searched like any other text.
+ */
+class Issue6438ContainsTextNonStringArgumentTest extends TestHelper {
+
+  @Test
+  void numericLiteralMatchesTheSameWayIndexedAndUnindexed() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Indexed6438");
+      database.command("sql", "CREATE PROPERTY Indexed6438.content STRING");
+      database.command("sql", "CREATE INDEX ON Indexed6438 (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Indexed6438 SET id = 'a', content = 'report 2024'");
+      database.command("sql", "INSERT INTO Indexed6438 SET id = 'b', content = 'no numbers here'");
+
+      database.command("sql", "CREATE DOCUMENT TYPE Unindexed6438");
+      database.command("sql", "CREATE PROPERTY Unindexed6438.content STRING");
+      database.command("sql", "INSERT INTO Unindexed6438 SET id = 'a', content = 'report 2024'");
+      database.command("sql", "INSERT INTO Unindexed6438 SET id = 'b', content = 'no numbers here'");
+    });
+
+    database.transaction(() -> {
+      // Indexed property: the lookup already stringified the key and matched before the fix.
+      assertThat(explain("SELECT id FROM Indexed6438 WHERE content CONTAINSTEXT 2024")).contains("FETCH FROM INDEX");
+      assertThat(idsMatching("SELECT id FROM Indexed6438 WHERE content CONTAINSTEXT 2024")).containsExactly("a");
+
+      // Unindexed property: before the fix ContainsTextCondition.evaluate() refused the non-String value outright
+      // and matched nothing here, even though the same value against the same text matched on the indexed type.
+      assertThat(idsMatching("SELECT id FROM Unindexed6438 WHERE content CONTAINSTEXT 2024")).containsExactly("a");
+    });
+  }
+
+  @Test
+  void numericLiteralWithNoMatchingSubstringMatchesNothingEitherWay() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Unindexed6438b");
+      database.command("sql", "CREATE PROPERTY Unindexed6438b.content STRING");
+      database.command("sql", "INSERT INTO Unindexed6438b SET id = 'a', content = 'report 2024'");
+    });
+
+    database.transaction(() -> assertThat(
+        idsMatching("SELECT id FROM Unindexed6438b WHERE content CONTAINSTEXT 1999")).isEmpty());
+  }
+
+  private java.util.Set<String> idsMatching(final String query) {
+    final java.util.Set<String> ids = new java.util.LinkedHashSet<>();
+    try (final ResultSet rs = database.query("sql", query)) {
+      while (rs.hasNext())
+        ids.add(rs.next().getProperty("id"));
+    }
+    return ids;
+  }
+
+  private String explain(final String query) {
+    try (final ResultSet rs = database.query("sql", "EXPLAIN " + query)) {
+      return rs.next().toJSON().toString();
+    }
+  }
+}


### PR DESCRIPTION
Closes #6438

## Summary

`ContainsTextCondition.evaluate()` (the fallback path used whenever no full-text index covers the property) refused
any right-hand value that was not already a `String` and answered `false`. The index path
(`FetchFromIndexStep.processFullTextBlock` -> `LSMTreeFullTextIndex.get`) has no such restriction - it takes
whatever non-null, non-multivalue value the right expression evaluates to and calls `.toString()` on it. So the same
operator meant two different things depending only on whether the property happened to be covered by a full-text
index: `title CONTAINSTEXT 2024` matched a row whose `title` was `report 2024` when `title` was indexed, and matched
nothing when it was not.

Per the issue's own analysis, this fixes it by **coercing in the evaluator** (the "more useful" of the two options
laid out in the issue) rather than rejecting on the index path: `ContainsTextCondition.evaluate()` now stringifies
any non-null right-hand value with `.toString()`, matching what the index already does. `null` still means "no
match" (unchanged), and the left-hand (searched-in) side is unchanged - it must still be a `String`.

## Test plan

- [x] New regression test `Issue6438ContainsTextNonStringArgumentTest`:
  - `numericLiteralMatchesTheSameWayIndexedAndUnindexed` - the same numeric literal against the same text matches on
    both an indexed and an unindexed property (the assertion the issue says cannot pass today whichever direction is
    chosen).
  - `numericLiteralWithNoMatchingSubstringMatchesNothingEitherWay` - a numeric literal that is not a substring still
    matches nothing (no false positives from the coercion).
- [x] Confirmed the new test fails on `main` (before the fix) and passes after it.
- [x] Re-ran the full `CONTAINSTEXT` / full-text index regression suite (`ContainsText*`, `Issue1062Test`,
  `Issue6414ContainsTextMultiPropertyIndexTest`, `Issue6382ContainsTextColonTest`, `FullTextBM25Test`,
  `FullTextBackwardCompatibilityTest`, `FullTextListByItemTest`, `FullTextNestedListByItemTest`,
  `ListIndexByItemTest`) - all green, no regressions.