### PR TITLE
fix(#6436): share the BM25 corpus scan across a CONTAINSTEXT conjunction's properties

### DIFF
--- a/docs/6436-bm25-conjunction-redundant-scans.md
+++ b/docs/6436-bm25-conjunction-redundant-scans.md
@@ -1,0 +1,80 @@
+# Issue #6436: BM25 conjunction re-scans the corpus once per constrained property
+
+## Summary
+
+A `CONTAINSTEXT` conjunction over several properties of a multi-property **BM25** full-text
+index (`title CONTAINSTEXT 'x' AND content CONTAINSTEXT 'y' AND tags CONTAINSTEXT 'z'`) was
+answered by `FullTextSearch.searchSimple` recursing once per constrained property. Each
+recursion independently ran `scanDocumentFrequencies` (a type-wide posting scan) and built its
+own `BM25ScoringContext` from scratch, even though the corpus statistics that context carries
+(`totalDocs`, `avgDocLength`, and the document frequency of every scoring token) are the same
+for every property in one query. Correctness was never in question (that is what #6414 fixed);
+this issue is about the redundant setup cost of doing that three separate times for a
+three-property conjunction.
+
+`searchSimple` now collects the scoring tokens for every constrained property up front, scans
+document frequencies once for their union, and builds a single shared `BM25ScoringContext`.
+Each property still runs its own posting walk against that shared context to produce the
+per-property match set `LSMTreeFullTextIndex.intersectPerProperty` intersects - that walk is
+the irreducible per-property work - but the repeated `scanDocumentFrequencies` scan and
+`BM25ScoringContext` construction collapses from one-per-property to one-per-query.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6478 (branch `fix/6436-bm25-conjunction-redundant-scans`)
+
+## Review cycles
+
+### Cycle 1 - head `1453cd51e3a8e4185519a9ba3e68b1fd24436658`
+
+Reviewer: `claude[bot]` (issue comment, 2026-08-19T21:13:50Z)
+
+Outcome: no correctness issues found; confirmed field-qualified tokens make the union-merge
+safe and per-token `documentFrequency` lookups keep the shared context sound. Two non-blocking
+nits raised:
+1. `getSimpleQueryTokenBoosts(propertyKey)` was called twice per property (once building the
+   union, once again inside `intersectPerProperty`'s lookup lambda).
+2. The test-only `documentFrequencyScanInvocations` static `AtomicLong` implicitly depends on
+   this module's tests running sequentially in one fork; worth a comment.
+
+Action taken (this session): both nits applied in commit `1d3b5a6703`, pushed as head
+`1d3b5a6703c6b0fbeb5cffdc1f68dfe4de0a08f0`:
+- Reused each property's already-computed token map (kept in an `IdentityHashMap<Object[], Map<String,Float>>`
+  keyed by the `propertyKey` array instance `intersectPerProperty` hands back to the lookup
+  closure) instead of re-deriving it a second time.
+- Added a one-line comment on `documentFrequencyScanInvocations` noting the sequential-single-fork
+  dependency.
+- Verified: `mvn -o -pl engine -am compile` clean; `mvn -o -pl engine -am test` over
+  `com.arcadedb.index.fulltext.**`, `ContainsText*`, `*BM25*` - 217/217 tests green, 0 failures.
+
+### Cycle 2 - head `1d3b5a6703c6b0fbeb5cffdc1f68dfe4de0a08f0`
+
+Reviewer: `claude[bot]` (issue comment, 2026-08-20T07:57:34Z)
+
+Outcome: correctness re-confirmed by an independent static trace (per-property scoring still
+reads only `tokensByProperty.get(propertyKey)`, never the shared union map; field-qualified
+tokens rule out cross-property collisions). Called out an unstated side benefit (the refactor
+also removes redundant `getBucketIndexes`/`isBM25`/`splitPositionalKey` calls the old recursive
+implementation implied). Two minor/non-blocking nits, both explicitly framed as optional:
+1. `unionScoringTokens`'s `Math::max`-merged boost values are computed but never read (`scanDocumentFrequencies`
+   only consults `.keySet()`) - flagged as "not a bug... just a bit of inert computation," with the
+   reviewer itself noting the alternative (a `Set<String>`-based overload) isn't clearly better.
+2. The test-only invocation counter is "instrumentation in production code," but the reviewer
+   assessed it as "well-justified... Fine as-is."
+
+No blocking issues found. Working tree was clean before this review landed (no in-flight
+changes), and neither nit is actionable-and-clear enough to warrant a churn commit: nit 1 is a
+sub-microsecond `Math::max` call on a handful of tokens with no correctness or clarity cost, and
+the reviewer's own alternative (a `Set`-typed overload) was judged not obviously better; nit 2
+was explicitly marked "fine as-is" by the reviewer. Treated as a clean approval.
+
+## Deferred items
+
+None requiring developer follow-up. The benchmark suggested by the original issue remains
+deferred to a future PR per the PR description's own "Notes / deferred" section - the
+invocation-count regression test already pins the exact behavior a benchmark would guard.
+
+## Final state
+
+**clean-approval** after 2 review cycles (satisfying the requirement of running at least a
+couple of cycles). PR left open for the developer to merge.

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -37,6 +37,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -56,7 +57,9 @@ public class FullTextSearch {
 
   // Test-only: counts how many times scanDocumentFrequencies() has run. Nothing in production reads it; it exists so a
   // regression test can assert a multi-property conjunction scans document frequencies once for the whole query rather
-  // than once per constrained property (issue #6436).
+  // than once per constrained property (issue #6436). A single JVM-wide counter is only safe to assert on because this
+  // module's tests run sequentially in one fork (forkCount=1, no parallel JUnit config); a concurrent test run would
+  // need this reworked into something scoped per-test.
   private static final AtomicLong documentFrequencyScanInvocations = new AtomicLong();
 
   static long getDocumentFrequencyScanInvocationsForTesting() {
@@ -214,17 +217,23 @@ public class FullTextSearch {
       // all of them - totalDocs, avgDocLength, and each token's document frequency - are computed once for their union,
       // rather than once per property (issue #6436). Only the per-property posting walk that follows still runs once per
       // property: it is what intersectPerProperty needs to answer the conjunction, and it is the irreducible work.
+      // Each property's token map is kept keyed by its propertyKey array (the same instance intersectPerProperty hands
+      // back to the lookup below) so the per-property text analysis in getSimpleQueryTokenBoosts runs once, not twice.
       final LinkedHashMap<String, Float> unionScoringTokens = new LinkedHashMap<>();
-      for (final Object[] propertyKey : perProperty)
-        for (final Map.Entry<String, Float> token : bucketIndexes.getFirst().getSimpleQueryTokenBoosts(propertyKey).entrySet())
+      final Map<Object[], Map<String, Float>> tokensByProperty = new IdentityHashMap<>();
+      for (final Object[] propertyKey : perProperty) {
+        final Map<String, Float> propertyTokens = bucketIndexes.getFirst().getSimpleQueryTokenBoosts(propertyKey);
+        tokensByProperty.put(propertyKey, propertyTokens);
+        for (final Map.Entry<String, Float> token : propertyTokens.entrySet())
           unionScoringTokens.merge(token.getKey(), token.getValue(), Math::max);
+      }
 
       final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes,
           scanDocumentFrequencies(bucketIndexes, unionScoringTokens));
 
       return LSMTreeFullTextIndex.rankedCursor(
           LSMTreeFullTextIndex.intersectPerProperty(perProperty, propertyKey -> scoreAcrossBuckets(bucketIndexes,
-              bucketIndexes.getFirst().getSimpleQueryTokenBoosts(propertyKey), propertyKey, -1, scoringContext)),
+              tokensByProperty.get(propertyKey), propertyKey, -1, scoringContext)),
           keys, effectiveLimit);
     }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextSearch.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Shared entry point for full-text search (BM25 or CLASSIC similarity) over a type's full-text index. Used by the
@@ -52,6 +53,19 @@ public class FullTextSearch {
   // The map-returning search paths expose scores by RID and never read the cursor entry keys, so one shared empty array
   // stands in for them rather than allocating a throwaway per bucket.
   private static final Object[] NO_KEYS           = new Object[0];
+
+  // Test-only: counts how many times scanDocumentFrequencies() has run. Nothing in production reads it; it exists so a
+  // regression test can assert a multi-property conjunction scans document frequencies once for the whole query rather
+  // than once per constrained property (issue #6436).
+  private static final AtomicLong documentFrequencyScanInvocations = new AtomicLong();
+
+  static long getDocumentFrequencyScanInvocationsForTesting() {
+    return documentFrequencyScanInvocations.get();
+  }
+
+  static void resetDocumentFrequencyScanInvocationsForTesting() {
+    documentFrequencyScanInvocations.set(0L);
+  }
 
   private FullTextSearch() {
   }
@@ -195,20 +209,44 @@ public class FullTextSearch {
     final int effectiveLimit = limit < 1 ? -1 : limit;
 
     final List<Object[]> perProperty = LSMTreeFullTextIndex.splitPositionalKey(typeIndex.getPropertyNames(), keys);
-    if (perProperty != null)
+    if (perProperty != null) {
+      // Collect the scoring tokens for EVERY constrained property first, so the corpus statistics that are the same for
+      // all of them - totalDocs, avgDocLength, and each token's document frequency - are computed once for their union,
+      // rather than once per property (issue #6436). Only the per-property posting walk that follows still runs once per
+      // property: it is what intersectPerProperty needs to answer the conjunction, and it is the irreducible work.
+      final LinkedHashMap<String, Float> unionScoringTokens = new LinkedHashMap<>();
+      for (final Object[] propertyKey : perProperty)
+        for (final Map.Entry<String, Float> token : bucketIndexes.getFirst().getSimpleQueryTokenBoosts(propertyKey).entrySet())
+          unionScoringTokens.merge(token.getKey(), token.getValue(), Math::max);
+
+      final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes,
+          scanDocumentFrequencies(bucketIndexes, unionScoringTokens));
+
       return LSMTreeFullTextIndex.rankedCursor(
-          LSMTreeFullTextIndex.intersectPerProperty(perProperty, key -> searchSimple(typeIndex, key, -1)), keys,
-          effectiveLimit);
+          LSMTreeFullTextIndex.intersectPerProperty(perProperty, propertyKey -> scoreAcrossBuckets(bucketIndexes,
+              bucketIndexes.getFirst().getSimpleQueryTokenBoosts(propertyKey), propertyKey, -1, scoringContext)),
+          keys, effectiveLimit);
+    }
 
     final Map<String, Float> scoringTokens = bucketIndexes.getFirst().getSimpleQueryTokenBoosts(keys);
     final BM25ScoringContext scoringContext = createScoringContext(bucketIndexes,
         scanDocumentFrequencies(bucketIndexes, scoringTokens));
+
+    return scoreAcrossBuckets(bucketIndexes, scoringTokens, keys, effectiveLimit, scoringContext);
+  }
+
+  /**
+   * Scores every bucket of the type against one already-built corpus-wide context and merges the per-bucket results into
+   * a single ranked cursor. Shared by {@link #searchSimple}'s single-property path and the per-property lookup a
+   * conjunction runs through {@link LSMTreeFullTextIndex#intersectPerProperty}.
+   */
+  private static IndexCursor scoreAcrossBuckets(final List<LSMTreeFullTextIndex> bucketIndexes,
+      final Map<String, Float> scoringTokens, final Object[] keys, final int limit, final BM25ScoringContext scoringContext) {
     final Map<RID, Float> allResults = new HashMap<>();
     for (final LSMTreeFullTextIndex ftIndex : bucketIndexes)
-      mergeCursor(allResults,
-          ftIndex.scoreBM25WithContext(null, scoringTokens, keys, effectiveLimit, scoringContext));
+      mergeCursor(allResults, ftIndex.scoreBM25WithContext(null, scoringTokens, keys, limit, scoringContext));
 
-    return LSMTreeFullTextIndex.rankedCursor(allResults, keys, effectiveLimit);
+    return LSMTreeFullTextIndex.rankedCursor(allResults, keys, limit);
   }
 
   /**
@@ -309,6 +347,7 @@ public class FullTextSearch {
    */
   private static Map<String, Long> scanDocumentFrequencies(final List<LSMTreeFullTextIndex> bucketIndexes,
       final Map<String, Float> scoringTokens) {
+    documentFrequencyScanInvocations.incrementAndGet();
     final Map<String, Long> documentFrequencies = new HashMap<>();
     for (final String token : scoringTokens.keySet()) {
       long df = 0L;

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6436Bm25ConjunctionSharedCorpusScanTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6436Bm25ConjunctionSharedCorpusScanTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A BM25 CONTAINSTEXT conjunction over several properties of a multi-property full-text index answers each constrained
+ * property as one type-wide scoring pass, intersected. Before the fix, EVERY one of those passes independently scanned
+ * document frequencies for the whole corpus - the same, corpus-wide statistics recomputed once per constrained property
+ * instead of once for the whole query (issue #6436). This pins two things: the document-frequency scan now runs exactly
+ * once per query regardless of how many properties are constrained, and the scored/intersected results are unchanged.
+ */
+class Issue6436Bm25ConjunctionSharedCorpusScanTest extends TestHelper {
+
+  @Test
+  void aThreePropertyConjunctionScansDocumentFrequenciesOnce() {
+    createArticles();
+
+    database.transaction(() -> {
+      FullTextSearch.resetDocumentFrequencyScanInvocationsForTesting();
+
+      assertThat(idsMatching(
+          "SELECT id FROM Article6436 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'jvm' "
+              + "AND tags CONTAINSTEXT 'backend'"))
+          .containsExactly("a");
+
+      // One shared corpus scan for the whole conjunction, not one per constrained property.
+      assertThat(FullTextSearch.getDocumentFrequencyScanInvocationsForTesting()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void aTwoPropertyConjunctionScansDocumentFrequenciesOnce() {
+    createArticles();
+
+    database.transaction(() -> {
+      FullTextSearch.resetDocumentFrequencyScanInvocationsForTesting();
+
+      assertThat(idsMatching("SELECT id FROM Article6436 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'jvm'"))
+          .containsExactlyInAnyOrder("a", "c");
+
+      assertThat(FullTextSearch.getDocumentFrequencyScanInvocationsForTesting()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void aSinglePropertyConditionStillScansDocumentFrequenciesOnce() {
+    createArticles();
+
+    database.transaction(() -> {
+      FullTextSearch.resetDocumentFrequencyScanInvocationsForTesting();
+
+      assertThat(idsMatching("SELECT id FROM Article6436 WHERE title CONTAINSTEXT 'java'"))
+          .containsExactlyInAnyOrder("a", "c");
+
+      assertThat(FullTextSearch.getDocumentFrequencyScanInvocationsForTesting()).isEqualTo(1);
+    });
+  }
+
+  /**
+   * The scan-sharing refactor must not change what a conjunction answers: same intersected, scored result as the
+   * per-property path it replaces.
+   */
+  @Test
+  void theConjunctionResultIsUnaffectedByHowManyPropertiesAreConstrained() {
+    createArticles();
+
+    database.transaction(() -> {
+      assertThat(idsMatching(
+          "SELECT id FROM Article6436 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'jvm' "
+              + "AND tags CONTAINSTEXT 'backend'"))
+          .containsExactly("a");
+      assertThat(idsMatching(
+          "SELECT id FROM Article6436 WHERE title CONTAINSTEXT 'java' AND content CONTAINSTEXT 'jvm' "
+              + "AND tags CONTAINSTEXT 'zzz'"))
+          .isEmpty();
+      assertThat(idsMatching(
+          "SELECT id FROM Article6436 WHERE title CONTAINSTEXT 'python' AND content CONTAINSTEXT 'scripting'"))
+          .containsExactly("b");
+    });
+  }
+
+  private void createArticles() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Article6436");
+      database.command("sql", "CREATE PROPERTY Article6436.title STRING");
+      database.command("sql", "CREATE PROPERTY Article6436.content STRING");
+      database.command("sql", "CREATE PROPERTY Article6436.tags STRING");
+      database.command("sql",
+          "CREATE INDEX ON Article6436 (title, content, tags) FULL_TEXT METADATA {\"similarity\": \"BM25\"}");
+
+      database.command("sql",
+          "INSERT INTO Article6436 SET id = 'a', title = 'java concurrency', content = 'jvm internals', "
+              + "tags = 'backend performance'");
+      database.command("sql",
+          "INSERT INTO Article6436 SET id = 'b', title = 'python basics', content = 'scripting tips', "
+              + "tags = 'frontend tooling'");
+      database.command("sql",
+          "INSERT INTO Article6436 SET id = 'c', title = 'JAVA rocks', content = 'jvm tuning', tags = 'frontend'");
+      database.command("sql",
+          "INSERT INTO Article6436 SET id = 'd', title = 'cooking notes', content = 'pasta recipes', tags = 'food'");
+    });
+  }
+
+  private Set<String> idsMatching(final String query) {
+    final Set<String> ids = new LinkedHashSet<>();
+    try (final ResultSet rs = database.query("sql", query, Map.of())) {
+      while (rs.hasNext())
+        ids.add(rs.next().getProperty("id"));
+    }
+    return ids;
+  }
+}


### PR DESCRIPTION
Closes #6436

## Summary

A `CONTAINSTEXT` conjunction over several properties of a multi-property **BM25** full-text
index (`title CONTAINSTEXT 'x' AND content CONTAINSTEXT 'y' AND tags CONTAINSTEXT 'z'`) was
answered by `FullTextSearch.searchSimple` recursing once per constrained property. Each
recursion independently ran `scanDocumentFrequencies` (a type-wide posting scan) and built its
own `BM25ScoringContext` from scratch, even though the corpus statistics that context carries
- `totalDocs`, `avgDocLength`, and the document frequency of every scoring token - are the
same for every property in one query. Correctness was never in question (this is what #6414
fixed); this issue is about the redundant setup cost of doing that three separate times for a
three-property conjunction.

`searchSimple` now collects the scoring tokens for **every** constrained property up front
(`getSimpleQueryTokenBoosts` already builds them per property key), scans document frequencies
**once** for their union, and builds a single shared `BM25ScoringContext`. Each property still
runs its own posting walk against that shared context to produce the per-property match set
`LSMTreeFullTextIndex.intersectPerProperty` intersects - that walk is the irreducible,
per-property work - but the repeated `scanDocumentFrequencies` scan and `BM25ScoringContext`
construction (one per property) collapses to one per query.

`intersectPerProperty` itself is unchanged; only what its lookup closure closes over changed,
per the issue's suggested direction. The single-property (non-positional) path was refactored
to share the same `scoreAcrossBuckets` helper, so there is one code path for "score every
bucket of the type against an already-built context" instead of two.

## Test plan

- Added `Issue6436Bm25ConjunctionSharedCorpusScanTest` (`engine/src/test/java/com/arcadedb/index/fulltext/`):
  - Asserts a 3-property BM25 conjunction now runs the document-frequency scan **exactly once**
    (was 3 times before the fix), via a test-only invocation counter on
    `FullTextSearch.scanDocumentFrequencies` (`getDocumentFrequencyScanInvocationsForTesting()` /
    `resetDocumentFrequencyScanInvocationsForTesting()`, package-private, read only by tests).
  - Same assertion for a 2-property conjunction and for a single-property condition (still 1,
    unchanged baseline).
  - Pins that the scan-sharing refactor does not change what a conjunction answers: same
    intersected result set across 1-, 2- and 3-property conjunctions.
- Ran the full `com.arcadedb.index.fulltext` package plus the SQL `CONTAINSTEXT` operator
  tests (`Issue6414ContainsTextMultiPropertyIndexTest`, `FullTextBM25Test`,
  `Issue6382ContainsTextColonTest`, `ContainsTextWithFullTextIndexTest`,
  `ContainsTextIndexUsageTest`, `ContainsTextWithArrayTest`, and others) - all green, no
  regressions.
- `mvn -pl engine -am compile` clean.

## Notes / deferred

The issue also suggested a `@Tag("benchmark")` micro-benchmark comparing 1-, 2- and 3-property
conjunctions to show the cost no longer triples. That's left for a follow-up rather than this
PR: the functional fix and the invocation-count regression test above already pin the exact
behavior the issue asks for (one shared scan instead of one per property), and a wall-clock
benchmark needs more care to be a stable regression guard than this fix strictly requires.
