### PR TITLE
fix(#6431): star-join count(*) push-down declines on inline node properties/dynamic labels

### DIFF
--- a/docs/6431-star-join-count-star-inline-props.md
+++ b/docs/6431-star-join-count-star-inline-props.md
@@ -1,0 +1,65 @@
+# Issue #6431: Star-join count(*) push-down ignores inline node properties and dynamic labels
+
+## Summary
+
+Follow-up to #6337 (PR #6430), flagged during that PR's review by `claude[bot]`. The claim: the two
+node-label decline checks in `tryDetectStarCountStar` (`CypherExecutionPlan.java`) - the central-variable
+one from #6322 and the arm-endpoint one added by #6337 - gate only on `node.hasLabels()`, and neither
+checks `node.hasProperties()` or `node.hasDynamicLabels()`, so an inline property filter or dynamic label
+on the central variable or an arm node would be silently dropped by the `DegreeProductOp` ("CSR degree
+product") push-down, the same over-count class #6337 fixed for plain labels.
+
+## Investigation finding: not reproducible on current `main`
+
+Before writing code, I reproduced the issue's own example query against current `main`
+(`MATCH (p:Post)<-[:WROTE]-(a:Author {status:'active'}), (p)-[:TAGGED]->(:Topic) RETURN count(*)`) and a
+central-variable variant. Both already **decline** the star-join push-down and return the correct answer.
+
+The reason: `tryOptimizeCountStar` (the single entry point that dispatches to `tryDetectStarCountStar` and
+its siblings) already has a blanket guard, `hasInlineNodePropertyOrDynamicLabel()`, added by the fix for
+issue #5071 (commit `0276115`, 2026-07-06). It walks every node in every `MATCH` path pattern of the
+statement and declines **all** count push-down detectors - the star one included - if any node carries
+`hasProperties()` or `hasDynamicLabels()`. That fix landed over a month **before** #6337/PR #6430
+(2026-08-19), so by the time the arm-endpoint *label* check was added, the property/dynamic-label case was
+already covered at the outer level. The PR review's static-code read of `tryDetectStarCountStar` in
+isolation missed the outer guard sitting in the caller.
+
+Verified with `EXPLAIN` on both example queries: the physical plan uses the ordinary Cost-Based Query
+Optimizer path (`Filter` + `ExpandAll` steps), not `COUNT STAR JOIN`, and the count matches the
+materialized pipeline's row count.
+
+## What this PR still does
+
+Even though the exact silent-over-count scenario in the issue isn't reachable today, the issue's suggested
+fix - adding `node.hasProperties() || node.hasDynamicLabels()` directly to `tryDetectStarCountStar`'s own
+two decline checks - has standalone value as defense-in-depth, matching how the pair-join and chain-hop
+detectors in the same file check these conditions at their own level rather than relying solely on the
+outer guard. It keeps the star-join detector correct on its own if `hasInlineNodePropertyOrDynamicLabel()`'s
+scope or call site ever changes. This PR makes that small, mechanical change:
+
+- Central-variable loop: now declines whenever an occurrence of the central variable carries
+  `hasProperties()`/`hasDynamicLabels()`, in addition to the existing label checks.
+- Arm-node loop: now declines whenever a non-central node carries `hasProperties()`/`hasDynamicLabels()`,
+  in addition to the existing `hasLabels()` check.
+
+## Test plan
+
+Added `CypherStarCountPropertyIssue6431Test` (4 tests), following the pattern of
+`CypherStarCountArmLabelIssue6337Test`: cross-checks the declined push-down's `count(*)` answer against the
+materialized pipeline's row count as ground truth, for:
+- a property filter on an arm endpoint
+- a property filter on the central variable
+- a dynamic label (`:$($param)`) on an arm endpoint
+- a dynamic label on the central variable
+
+Also re-ran the sibling suites to confirm no regression:
+- `CypherStarCountArmLabelIssue6337Test` (4 tests)
+- `CypherCountPushDownLabelIssue6322Test` (8 tests)
+- `GAVEligibilityTest` (43 tests)
+- Full `com.arcadedb.query.opencypher.**` package
+
+All green. `mvn -pl engine -am compile` clean.
+
+## Review history
+
+(updated as review cycles run)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -5105,12 +5105,21 @@ public class CypherExecutionPlan {
     // operator enumerates one type of central node, so every occurrence has to agree on it: a label
     // set the single name cannot stand for, or two occurrences naming different types, declines the
     // push-down and leaves the query to the ordinary pipeline, which applies each of them (#6322).
+    // An inline property filter or dynamic label on any occurrence is just as unenforceable as a
+    // rejected label set - the operator has no way to check either - so it declines the push-down
+    // too, exactly as the arm-endpoint loop below does (#6431). In practice this is caught earlier
+    // by hasInlineNodePropertyOrDynamicLabel() in tryOptimizeCountStar (#5071); this check exists so
+    // the detector is correct standing alone, not only in combination with that outer guard.
     for (final MatchClause mc : statement.getMatchClauses()) {
       if (!mc.hasPathPatterns()) continue;
       for (final PathPattern pp : mc.getPathPatterns())
         for (int i = 0; i <= pp.getRelationshipCount(); i++) {
           final NodePattern node = pp.getNode(i);
-          if (!centralVar.equals(node.getVariable()) || !node.hasLabels())
+          if (!centralVar.equals(node.getVariable()))
+            continue;
+          if (node.hasProperties() || node.hasDynamicLabels())
+            return null;
+          if (!node.hasLabels())
             continue;
           if (!hasPushDownRepresentableLabel(node))
             return null;
@@ -5158,15 +5167,17 @@ public class CypherExecutionPlan {
         final int totalHops = pathPattern.getRelationshipCount();
 
         // Every non-central node of the arm - the far endpoint and any interior node of a multi-hop
-        // arm alike - is a label the degree product cannot enforce: it counts degree off the arm's
-        // edge types and directions alone, with no field on Arm for a per-hop endpoint type, so
-        // (:Author) and () built the same operator and the same, over-counted, answer. Decline the
-        // push-down rather than silently drop the filter, exactly as the central variable's own label
-        // already does above (issue #6337, the arm-endpoint sibling of #6322).
+        // arm alike - is a label, inline property filter, or dynamic label the degree product cannot
+        // enforce: it counts degree off the arm's edge types and directions alone, with no field on
+        // Arm for a per-hop endpoint type or filter, so (:Author), (:Author {status:'active'}) and ()
+        // built the same operator and the same, over-counted, answer. Decline the push-down rather
+        // than silently drop the filter, exactly as the central variable's own check already does
+        // above (issue #6337 for labels, #6431 for properties/dynamic labels, both siblings of #6322).
         for (int i = 0; i <= totalHops; i++) {
           if (i == centralNodeIdx)
             continue;
-          if (pathPattern.getNode(i).hasLabels())
+          final NodePattern node = pathPattern.getNode(i);
+          if (node.hasLabels() || node.hasProperties() || node.hasDynamicLabels())
             return null;
         }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherStarCountPropertyIssue6431Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherStarCountPropertyIssue6431Test.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6431: {@code tryDetectStarCountStar}'s two node-label decline checks
+ * - the central-variable one (issue #6322) and the arm-endpoint one (issue #6337) - gated only on
+ * {@code node.hasLabels()}. Neither checked {@code node.hasProperties()} or {@code node.hasDynamicLabels()},
+ * so an inline property filter (e.g. {@code {status:'active'}}) or a dynamic label on the central variable
+ * or an arm node was silently dropped, exactly the same over-count class as #6337 fixed for plain labels -
+ * {@code DegreeProductOp.Arm} has no way to check either.
+ * <p>
+ * In practice the top-level {@code hasInlineNodePropertyOrDynamicLabel()} guard in
+ * {@code tryOptimizeCountStar} (added for issue #5071, which predates #6337) already declines the whole
+ * push-down before any detector - including the star one - runs, whenever any node in the statement carries
+ * an inline property or a dynamic label. So the silent over-count this issue describes is not reachable on
+ * current {@code main}: these tests pass before and after the {@code tryDetectStarCountStar} change. The
+ * change adds the same {@code hasProperties()}/{@code hasDynamicLabels()} decline directly to
+ * {@code tryDetectStarCountStar} anyway (matching the pair-join and chain-hop detectors, which check both
+ * at their own level rather than relying solely on the outer guard), so the detector stays correct on its
+ * own if the outer guard's scope or placement ever changes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherStarCountPropertyIssue6431Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (:Author {k:'a1', status:'active'})");
+    database.command("opencypher", "CREATE (:Author {k:'a2', status:'inactive'})");
+    database.command("opencypher", "CREATE (:Post {k:'p1', status:'published'})");
+    database.command("opencypher", "CREATE (:Post {k:'p2', status:'draft'})");
+    database.command("opencypher", "CREATE (:Topic {k:'t1'})");
+
+    // p1 is written by the INACTIVE author; p2 is written by the ACTIVE author.
+    database.command("opencypher", "MATCH (a:Author {k:'a2'}), (p:Post {k:'p1'}) CREATE (a)-[:WROTE]->(p)");
+    database.command("opencypher", "MATCH (a:Author {k:'a1'}), (p:Post {k:'p2'}) CREATE (a)-[:WROTE]->(p)");
+    database.command("opencypher", "MATCH (p:Post {k:'p1'}), (t:Topic {k:'t1'}) CREATE (p)-[:TAGGED]->(t)");
+    database.command("opencypher", "MATCH (p:Post {k:'p2'}), (t:Topic {k:'t1'}) CREATE (p)-[:TAGGED]->(t)");
+  }
+
+  /**
+   * Only {@code a1} is an active Author; {@code a2}, who wrote the tagged post {@code p1}, is inactive. The
+   * degree product would count the in-degree of {@code WROTE} on each tagged Post - 1 for both p1 and p2 -
+   * with no way to check the {@code status} property on the arm endpoint, so it would over-count p1 too.
+   */
+  @Test
+  void aPropertyFilteredArmEndpointDeclinesTheStarCountPushDown() {
+    final String query = "MATCH (p:Post)<-[:WROTE]-(a:Author {status:'active'}), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query)).isEqualTo(1);
+    assertThat(scalarOf(query)).isEqualTo(rowCountOf(
+        "MATCH (p:Post)<-[:WROTE]-(a:Author {status:'active'}), (p)-[:TAGGED]->(t:Topic) RETURN p"));
+  }
+
+  /**
+   * The same gap on the central variable itself: only {@code p1} is published, but the degree product
+   * enumerates every {@code Post} that is the central variable's label, with no way to check the
+   * {@code status} property filter written directly on it.
+   */
+  @Test
+  void aPropertyFilteredCentralVariableDeclinesTheStarCountPushDown() {
+    final String query = "MATCH (p:Post {status:'published'})<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    assertThat(explainOf(query)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query)).isEqualTo(1);
+    assertThat(scalarOf(query)).isEqualTo(rowCountOf(
+        "MATCH (p:Post {status:'published'})<-[:WROTE]-(a:Author), (p)-[:TAGGED]->(t:Topic) RETURN p"));
+  }
+
+  /** A dynamic label on an arm endpoint is just as unenforceable by the degree product as a static one. */
+  @Test
+  void aDynamicallyLabelledArmEndpointDeclinesTheStarCountPushDown() {
+    final String query = "MATCH (p:Post)<-[:WROTE]-(:$($armLabel)), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    final Map<String, Object> params = Map.of("armLabel", "Author");
+    assertThat(explainOf(query, params)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query, params)).isEqualTo(2);
+    assertThat(scalarOf(query, params)).isEqualTo(rowCountOf(
+        "MATCH (p:Post)<-[:WROTE]-(a:Author), (p)-[:TAGGED]->(t:Topic) RETURN p"));
+  }
+
+  /** A dynamic label on the central variable is just as unenforceable by the degree product as a static one. */
+  @Test
+  void aDynamicallyLabelledCentralVariableDeclinesTheStarCountPushDown() {
+    final String query = "MATCH (p:$($centralLabel))<-[:WROTE]-(:Author), (p)-[:TAGGED]->(:Topic) RETURN count(*) AS c";
+    final Map<String, Object> params = Map.of("centralLabel", "Post");
+    assertThat(explainOf(query, params)).doesNotContain("COUNT STAR JOIN");
+    assertThat(scalarOf(query, params)).isEqualTo(2);
+    assertThat(scalarOf(query, params)).isEqualTo(rowCountOf(
+        "MATCH (p:Post)<-[:WROTE]-(a:Author), (p)-[:TAGGED]->(t:Topic) RETURN p"));
+  }
+
+  // ===================================================================================================
+  // helpers
+  // ===================================================================================================
+
+  private long scalarOf(final String query) {
+    return scalarOf(query, Map.of());
+  }
+
+  private long scalarOf(final String query, final Map<String, Object> params) {
+    try (final ResultSet rs = database.query("opencypher", query, params)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private int rowCountOf(final String query) {
+    int count = 0;
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private String explainOf(final String query) {
+    return explainOf(query, Map.of());
+  }
+
+  private String explainOf(final String query, final Map<String, Object> params) {
+    try (final ResultSet rs = database.query("opencypher", "EXPLAIN " + query, params)) {
+      assertThat(rs.hasNext()).as(query).isTrue();
+      return rs.next().getProperty("executionPlanAsString");
+    }
+  }
+}


### PR DESCRIPTION
Closes #6431

## Summary

Follow-up to #6337 (PR #6430), flagged during that PR's review. `tryDetectStarCountStar` in
`CypherExecutionPlan.java` has two node-label decline checks that decide whether a star-join
`count(*)` query gets pushed down to `DegreeProductOp` ("CSR degree product"): one for the central
variable (from #6322), one for arm endpoints (from #6337). Both gated only on `node.hasLabels()`,
not `node.hasProperties()`/`node.hasDynamicLabels()`.

**Investigation finding, before writing any code:** I reproduced the issue's own example query
(`MATCH (p:Post)<-[:WROTE]-(a:Author {status:'active'}), (p)-[:TAGGED]->(:Topic) RETURN count(*)`)
against current `main` and it already declines the push-down and returns the correct answer. The
reason: `tryOptimizeCountStar` (the single dispatch point reaching `tryDetectStarCountStar` and its
siblings) already has a blanket `hasInlineNodePropertyOrDynamicLabel()` guard, added for issue #5071
(commit `0276115`, 2026-07-06) - **over a month before** #6337/PR #6430 (2026-08-19). That guard walks
every node in every `MATCH` path pattern and declines all count push-down detectors, star join
included, when any node carries an inline property or dynamic label. The PR #6430 review's static
read of `tryDetectStarCountStar` in isolation didn't account for that outer guard in the caller.

So the exact silent-over-count this issue describes is not reachable on `main` today. This PR still
makes the small, mechanical change the issue asked for, as defense-in-depth: it adds
`hasProperties()`/`hasDynamicLabels()` directly to `tryDetectStarCountStar`'s own two decline checks
(central variable and arm nodes), matching the pattern the pair-join and chain-hop detectors in the
same file already use at their own level rather than relying solely on the outer guard. That keeps
the star-join detector correct standing alone if the outer guard's scope or call site ever changes.

## Changes

- `tryDetectStarCountStar`: central-variable loop now declines on `hasProperties()`/`hasDynamicLabels()`
  for any occurrence of the central variable, in addition to the existing label checks.
- `tryDetectStarCountStar`: the arm-node loop now declines on `hasProperties()`/`hasDynamicLabels()`
  for any non-central node, in addition to the existing `hasLabels()` check.
- New regression test `CypherStarCountPropertyIssue6431Test` (4 tests), following the pattern of
  `CypherStarCountArmLabelIssue6337Test`: cross-checks the declined push-down's `count(*)` answer
  against the materialized pipeline's row count as ground truth, for a property filter on an arm
  endpoint, a property filter on the central variable, a dynamic label on an arm endpoint, and a
  dynamic label on the central variable.

## Test plan

- [x] `CypherStarCountPropertyIssue6431Test` (4 new tests) - all pass
- [x] `CypherStarCountArmLabelIssue6337Test` (4 tests) - no regression
- [x] `CypherCountPushDownLabelIssue6322Test` (8 tests) - no regression
- [x] `GAVEligibilityTest` (43 tests) - no regression
- [x] Full `com.arcadedb.query.opencypher.**` package (4897 tests) - green, aside from one unrelated,
      pre-existing timing-sensitive `@Tag("slow")` test
      (`Issue6302AlgoGraphDrivenWorkGuardTest.apspObservesTheDeadlineInsideTheTripleLoop`, an O(V³)
      Floyd-Warshall deadline test in an unrelated `algo` procedures package) that also fails
      intermittently under concurrent build load and passes in isolation on unmodified `main` - not
      touched by this change
- [x] `mvn -pl engine -am compile` clean