### PR TITLE
fix(#6440): async flush pipeline strands WAL acks across a closed/reopened database

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -21,7 +21,6 @@ package com.arcadedb.engine;
 import com.arcadedb.database.BasicDatabase;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -69,14 +68,17 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <b>That lock argument only holds within ONE instance (issue #6440).</b> {@code executeInWriteLock}/
  * {@code executeInReadLock} guard a {@code ReentrantReadWriteLock} FIELD of the {@code LocalDatabase} instance, not
  * anything keyed by path - so it says nothing about a DIFFERENT instance reopened at the same path, which is exactly
- * what {@code LocalDatabase.equals()} makes indistinguishable from the one being purged. {@link #removeAllOfDatabase}
- * therefore matches by reference identity, not {@code equals()}: a same-path sibling's still-pending pages, and its
- * {@link #pending} counter, must survive a belated cleanup of the instance that has since closed.
+ * what {@code LocalDatabase.equals()} makes indistinguishable from the one being purged. {@link #pending} is
+ * therefore keyed by reference identity ({@link IdentityKey}), not {@code equals()}: a same-path sibling's counter
+ * must never be resolved, incremented or zeroed by a DIFFERENT instance, in either direction - {@link #counterOf}
+ * creating (or finding) the wrong instance's entry on insertion is exactly as wrong as {@link #removeAllOfDatabase}
+ * retiring the wrong instance's entry on removal, and a {@code ConcurrentHashMap} keyed directly on
+ * {@code BasicDatabase} cannot tell two {@code equals()}-equal instances apart at either end.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class FlushPageIndex {
-  private final ConcurrentHashMap<PageId, MutablePage>          pages   = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<PageId, MutablePage> pages = new ConcurrentHashMap<>();
   /**
    * Number of {@link #pages} entries per database. An entry is created with the database's first pending page and
    * dropped by {@link #removeAllOfDatabase} (close/drop), so it is bounded by the number of open databases.
@@ -86,8 +88,35 @@ class FlushPageIndex {
    * which a waiter could resolve a monitor that the signaller has not published yet, and it keeps the signalling
    * path down to the counter the decrement already has in hand. The object never escapes this class - every accessor
    * returns an {@code int} - so no foreign code can hold this monitor.
+   * <p>
+   * Keyed by {@link IdentityKey}, not {@code BasicDatabase} directly (issue #6440): see the class javadoc.
    */
-  private final ConcurrentHashMap<BasicDatabase, AtomicInteger> pending = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<IdentityKey, AtomicInteger> pending = new ConcurrentHashMap<>();
+
+  /**
+   * Identity-only key for {@link #pending} (issue #6440). {@code LocalDatabase.equals()}/{@code hashCode()} compare
+   * by database PATH, which is exactly wrong here: two different instances open at the same path (a database
+   * closed and immediately reopened - a restore, a re-provision, a test hammering one fixed path) must never share
+   * a counter entry. A manual identity scan on every {@code put()}/{@code putAll()} would put an O(open databases)
+   * walk on the hot commit path just to avoid this; wrapping the key keeps every {@link #pending} access O(1).
+   */
+  private static final class IdentityKey {
+    private final BasicDatabase database;
+
+    IdentityKey(final BasicDatabase database) {
+      this.database = database;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof IdentityKey other && other.database == database;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(database);
+    }
+  }
 
   /** @return the most recent {@link MutablePage} pending for the page, or {@code null} when none is. */
   MutablePage get(final PageId pageId) {
@@ -192,21 +221,11 @@ class FlushPageIndex {
     // Dropped AFTER the pages, never before: the other order would let a page indexed in between survive with a
     // fresh counter that the purge then empties, leaving a count above zero that hangs the close forever.
     //
-    // Same identity caveat applies to the counter: `pending` is keyed by path too, so computeIfAbsent() in
-    // counterOf() hands a same-path reopened instance the ORIGINAL instance's still-live counter rather than a
-    // fresh one whenever this method has not run yet for the original. Removing by path (the old
-    // pending.remove(database)) would then let this instance's belated cleanup zero out a counter a different,
-    // still-open instance is actively incrementing - the "backup stamps its t0 over a half-written batch"
-    // failure this class's own javadoc warns about. Matching the STORED key by reference instead means only the
-    // instance that actually created the counter can retire it; a same-path sibling's cleanup leaves a counter
-    // it does not own untouched.
-    AtomicInteger counter = null;
-    for (final Map.Entry<BasicDatabase, AtomicInteger> entry : pending.entrySet())
-      if (entry.getKey() == database) {
-        pending.remove(entry.getKey(), entry.getValue());
-        counter = entry.getValue();
-        break;
-      }
+    // pending is IdentityKey-keyed (issue #6440), so this can only ever resolve the entry THIS exact instance
+    // created (via counterOf()) - never a same-path sibling's, in either direction: a sibling can no longer have
+    // its live counter zeroed by this instance's belated cleanup, and this instance can no longer resolve (and
+    // thereby retire) a sibling's counter by mistake either.
+    final AtomicInteger counter = pending.remove(new IdentityKey(database));
     // A waiter parked on that counter would otherwise sleep out its whole fallback interval for a database that no
     // longer has an entry at all: pendingOf() answers 0 for it from here on, so wake it to observe that (#6199).
     if (counter != null)
@@ -247,7 +266,7 @@ class FlushPageIndex {
    * so a hypothetical negative behaves like an empty pipeline rather than like a hang.
    */
   int pendingOf(final BasicDatabase database) {
-    final AtomicInteger counter = pending.get(database);
+    final AtomicInteger counter = pending.get(new IdentityKey(database));
     return counter != null ? counter.get() : 0;
   }
 
@@ -261,7 +280,7 @@ class FlushPageIndex {
    * clean close forgets the database instead of pinning it as a map key forever.
    */
   boolean isTracked(final BasicDatabase database) {
-    return pending.containsKey(database);
+    return pending.containsKey(new IdentityKey(database));
   }
 
   /**
@@ -300,7 +319,7 @@ class FlushPageIndex {
     if (maxWaitMillis <= 0)
       return;
 
-    final AtomicInteger counter = pending.get(database);
+    final AtomicInteger counter = pending.get(new IdentityKey(database));
     if (counter == null)
       // NEVER HAD A PENDING PAGE, OR THE DATABASE WAS ALREADY FORGOTTEN: pendingOf() ANSWERS 0, NOTHING TO WAIT FOR
       return;
@@ -313,12 +332,13 @@ class FlushPageIndex {
   }
 
   private AtomicInteger counterOf(final BasicDatabase database) {
-    final AtomicInteger counter = pending.get(database);
-    return counter != null ? counter : pending.computeIfAbsent(database, k -> new AtomicInteger());
+    final IdentityKey key = new IdentityKey(database);
+    final AtomicInteger counter = pending.get(key);
+    return counter != null ? counter : pending.computeIfAbsent(key, k -> new AtomicInteger());
   }
 
   private void release(final BasicDatabase database) {
-    final AtomicInteger counter = pending.get(database);
+    final AtomicInteger counter = pending.get(new IdentityKey(database));
     // The monitor is taken ONLY on the transition to drained, so the hot flush path pays a volatile decrement and a
     // comparison per page exactly as before, and a lock acquisition only on the page that empties the pipeline.
     if (counter != null && counter.decrementAndGet() <= 0)

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -149,19 +149,40 @@ class FlushPageIndex {
         lastDatabase = database;
       }
       counter.incrementAndGet();
-      if (pages.put(pageId, page) != null)
-        // REPLACED A COPY THAT WAS ALREADY COUNTED (A LATER TX SUPERSEDING A PAGE STILL QUEUED, ISSUE #4544)
-        counter.decrementAndGet();
+      final MutablePage replaced = pages.put(pageId, page);
+      if (replaced != null)
+        // REPLACED A COPY THAT WAS ALREADY COUNTED (A LATER TX SUPERSEDING A PAGE STILL QUEUED, ISSUE #4544) -
+        // decrementing the REPLACED page's OWN counter, not necessarily this one (issue #6440 review): see
+        // releaseReplacedCounter.
+        releaseReplacedCounter(replaced, database, counter);
     }
   }
 
   /** Indexes a single page. */
   void put(final MutablePage page) {
     final PageId pageId = page.getPageId();
-    final AtomicInteger counter = counterOf(pageId.getDatabase());
+    final BasicDatabase database = pageId.getDatabase();
+    final AtomicInteger counter = counterOf(database);
     counter.incrementAndGet();
-    if (pages.put(pageId, page) != null)
-      counter.decrementAndGet();
+    final MutablePage replaced = pages.put(pageId, page);
+    if (replaced != null)
+      releaseReplacedCounter(replaced, database, counter);
+  }
+
+  /**
+   * Releases the pending count of a page {@link #put}/{@link #putAll} just replaced in {@link #pages} (issue
+   * #4544: a later TX superseding one still queued). {@code Map.put()} on an {@code equals()}-match keeps the
+   * ORIGINAL key object and only swaps the value, so a same-path sibling's stale {@link PageId} can retain the
+   * map slot while its VALUE becomes the new page - the replaced value can therefore belong to a DIFFERENT
+   * instance than the one just inserted, even though {@link PageId#equals} said they were "the same page" (issue
+   * #6440 review). Decrementing the INCOMING page's counter in that case would phantom-increment a live,
+   * un-flushed sibling's count forever, while the replaced page's own (already fully accounted) counter is left
+   * one too high - exactly the aliasing the rest of this class's {@link IdentityKey} keying exists to prevent.
+   */
+  private void releaseReplacedCounter(final MutablePage replaced, final BasicDatabase incomingDatabase,
+      final AtomicInteger incomingCounter) {
+    final BasicDatabase replacedDatabase = replaced.getPageId().getDatabase();
+    (replacedDatabase == incomingDatabase ? incomingCounter : counterOf(replacedDatabase)).decrementAndGet();
   }
 
   /** @return the {@link MutablePage} that was indexed for the page, or {@code null} when none was. */
@@ -213,13 +234,24 @@ class FlushPageIndex {
    * safe against a concurrent {@link #putAll} from inside this class.
    */
   void removeAllOfDatabase(final BasicDatabase database) {
-    // Reference identity ON PURPOSE (issue #6440), not database.equals(pageId.getDatabase()): LocalDatabase
-    // compares by PATH, so a database reopened at the same path as `database` indexes its pages under a key that
-    // is merely path-equal, not the same instance. A belated cleanup of the OLD instance must not evict pages a
-    // DIFFERENT, still-open instance is waiting to have flushed - that silently drops writes with no error, no
-    // WAL replay to fall back on (they were never written), which is strictly worse than the counter merely
-    // staying nonzero a little longer.
-    pages.keySet().removeIf(pageId -> pageId.getDatabase() == database);
+    // Reference identity ON PURPOSE (issue #6440), not database.equals(...): LocalDatabase compares by PATH, so a
+    // database reopened at the same path as `database` indexes its pages under a key that is merely path-equal,
+    // not the same instance. A belated cleanup of the OLD instance must not evict pages a DIFFERENT, still-open
+    // instance is waiting to have flushed - that silently drops writes with no error, no WAL replay to fall back
+    // on (they were never written), which is strictly worse than the counter merely staying nonzero a little
+    // longer.
+    //
+    // Checked against the ENTRY'S VALUE, not the retained map key, and that distinction matters here specifically
+    // (issue #6440 review): Map.put() on an equals()-match keeps the ORIGINAL key object and only replaces the
+    // value - textbook Java Map behavior - so a page this OLD instance indexed at PageId(A, fileId, pageNumber)
+    // and a page a same-path sibling B later indexes at the SAME (fileId, pageNumber) collide as map keys
+    // (PageId.equals()/hashCode() go through path-based Database.equals() too). B's put() then leaves the STORED
+    // key as A's original PageId object with B's page as the value. Filtering by the retained key's database
+    // (pageId.getDatabase() == database) would still match that stale key and evict B's live, un-flushed page -
+    // the exact aliasing this method exists to prevent, just reached one layer down. MutablePage.getPageId() is
+    // the value's OWN field, set when that specific page object was created, so it always names whichever
+    // instance most recently indexed the CURRENT value - immune to which key object the map happened to retain.
+    pages.entrySet().removeIf(entry -> entry.getValue().getPageId().getDatabase() == database);
     // Dropped AFTER the pages, never before: the other order would let a page indexed in between survive with a
     // fresh counter that the purge then empties, leaving a count above zero that hangs the close forever.
     //

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -21,6 +21,7 @@ package com.arcadedb.engine;
 import com.arcadedb.database.BasicDatabase;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -64,6 +65,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  * reaches {@code scheduleFlushOfPages} holds the matching read lock, so no page of a database can enter the index
  * while that database is being purged from it. Do not call {@link #removeAllOfDatabase} from anywhere that does not
  * hold that write lock.
+ * <p>
+ * <b>That lock argument only holds within ONE instance (issue #6440).</b> {@code executeInWriteLock}/
+ * {@code executeInReadLock} guard a {@code ReentrantReadWriteLock} FIELD of the {@code LocalDatabase} instance, not
+ * anything keyed by path - so it says nothing about a DIFFERENT instance reopened at the same path, which is exactly
+ * what {@code LocalDatabase.equals()} makes indistinguishable from the one being purged. {@link #removeAllOfDatabase}
+ * therefore matches by reference identity, not {@code equals()}: a same-path sibling's still-pending pages, and its
+ * {@link #pending} counter, must survive a belated cleanup of the instance that has since closed.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -174,10 +182,31 @@ class FlushPageIndex {
    * safe against a concurrent {@link #putAll} from inside this class.
    */
   void removeAllOfDatabase(final BasicDatabase database) {
-    pages.keySet().removeIf(pageId -> database.equals(pageId.getDatabase()));
+    // Reference identity ON PURPOSE (issue #6440), not database.equals(pageId.getDatabase()): LocalDatabase
+    // compares by PATH, so a database reopened at the same path as `database` indexes its pages under a key that
+    // is merely path-equal, not the same instance. A belated cleanup of the OLD instance must not evict pages a
+    // DIFFERENT, still-open instance is waiting to have flushed - that silently drops writes with no error, no
+    // WAL replay to fall back on (they were never written), which is strictly worse than the counter merely
+    // staying nonzero a little longer.
+    pages.keySet().removeIf(pageId -> pageId.getDatabase() == database);
     // Dropped AFTER the pages, never before: the other order would let a page indexed in between survive with a
     // fresh counter that the purge then empties, leaving a count above zero that hangs the close forever.
-    final AtomicInteger counter = pending.remove(database);
+    //
+    // Same identity caveat applies to the counter: `pending` is keyed by path too, so computeIfAbsent() in
+    // counterOf() hands a same-path reopened instance the ORIGINAL instance's still-live counter rather than a
+    // fresh one whenever this method has not run yet for the original. Removing by path (the old
+    // pending.remove(database)) would then let this instance's belated cleanup zero out a counter a different,
+    // still-open instance is actively incrementing - the "backup stamps its t0 over a half-written batch"
+    // failure this class's own javadoc warns about. Matching the STORED key by reference instead means only the
+    // instance that actually created the counter can retire it; a same-path sibling's cleanup leaves a counter
+    // it does not own untouched.
+    AtomicInteger counter = null;
+    for (final Map.Entry<BasicDatabase, AtomicInteger> entry : pending.entrySet())
+      if (entry.getKey() == database) {
+        pending.remove(entry.getKey(), entry.getValue());
+        counter = entry.getValue();
+        break;
+      }
     // A waiter parked on that counter would otherwise sleep out its whole fallback interval for a database that no
     // longer has an entry at all: pendingOf() answers 0 for it from here on, so wake it to observe that (#6199).
     if (counter != null)

--- a/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
+++ b/engine/src/main/java/com/arcadedb/engine/FlushPageIndex.java
@@ -98,7 +98,9 @@ class FlushPageIndex {
    * by database PATH, which is exactly wrong here: two different instances open at the same path (a database
    * closed and immediately reopened - a restore, a re-provision, a test hammering one fixed path) must never share
    * a counter entry. A manual identity scan on every {@code put()}/{@code putAll()} would put an O(open databases)
-   * walk on the hot commit path just to avoid this; wrapping the key keeps every {@link #pending} access O(1).
+   * walk on the hot commit path just to avoid this; wrapping the key keeps every {@link #pending} access O(1) at
+   * the cost of one short-lived, non-escaping wrapper per access - cheap enough to scalar-replace under escape
+   * analysis, and strictly less than the {@code AtomicInteger} this same call site already allocates on a miss.
    */
   private static final class IdentityKey {
     private final BasicDatabase database;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -1528,6 +1528,16 @@ public class PageManager extends LockContext {
 
     if (!database.isOpen()) {
       LogManager.instance().log(this, Level.SEVERE, "Cannot flush page %s because the database is closed", page);
+      // The page will never be flushed and its content is irrelevant (the database is closed, or being
+      // dropped): release its WAL ack so the close-time ack gate (#4928) is not tripped by a pending count
+      // that can never be satisfied - flushPage() is never called again for this page once the database is
+      // closed, so without this the page's WALFile.pagesToFlush counter is stranded above zero forever and
+      // TransactionManager.close()'s retry loop burns its whole budget waiting on it (issue #6440). Mirrors
+      // the "file dropped" branch a few lines below and PageManagerFlushThread.removePagesOfFileFromBatch.
+      // takeWALFile makes the release exactly-once against a racing caller of the same page.
+      final WALFile walFile = page.takeWALFile();
+      if (walFile != null)
+        walFile.notifyPageFlushed();
       return;
     }
 
@@ -1559,7 +1569,12 @@ public class PageManager extends LockContext {
       } catch (final DatabaseIsClosedException e) {
         // The database was closed concurrently after the isOpen() check above.
         // The page data has already been written to disk, so we can safely skip
-        // the metadata updates.
+        // the metadata updates - but the WAL ack must still happen (issue #6440): the write above already
+        // succeeded, so skipping just this call (as opposed to the metadata update) would strand the page's
+        // WALFile.pagesToFlush counter above zero forever even though its content is safely on disk.
+        final WALFile walFile = page.takeWALFile();
+        if (walFile != null)
+          walFile.notifyPageFlushed();
       }
 
     } else {

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -1571,7 +1571,14 @@ public class PageManagerFlushThread extends Thread {
       if (pagesToFlush.database == database) {
         synchronized (pagesToFlush.pages) {
           for (final MutablePage page : pagesToFlush.pages) {
-            pageIndex.remove(page.getPageId());
+            // removeIfSame (via removeFromFlushIndex), NOT pageIndex.remove(page.getPageId()) (issue #6440
+            // review, fourth pass): that single-key overload is a plain, equals()-based pages.remove(), which
+            // collides across same-path instances exactly like removeAllOfDatabase's bulk purge did before it
+            // was switched to filtering by the VALUE's own PageId - a same-path sibling's live page could be
+            // sitting at this exact (fileId, pageNumber) map slot (retained as THIS page's PageId key by
+            // Map.put()'s "keep the old key on an equals() match" behavior) and get silently evicted, unacked,
+            // by this instance's own cleanup. removeIfSame only ever removes the exact instance indexed here.
+            removeFromFlushIndex(page);
             // The purged page will never be flushed and its content is irrelevant (its database is gone):
             // release its WAL ack so the close-time ack gate (#4928) is not tripped by stale pending counts.
             // Exactly-once against the racing flush loop (which does NOT remove pages from this batch list,

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -797,9 +797,14 @@ public class PageManagerFlushThread extends Thread {
                 // nextPagesToFlush, which therefore still runs. Worth saying because the nesting is deep enough that
                 // a future refactor lifting this block into a helper would silently take that finally with it.
                 if (!db.isOpen()) {
+                  // Both the index entry and the WAL ack are released together (issue #6440 review): releasing
+                  // only the ack would leave pageIndex.pendingOf(db) inflated - "WAL says done, pageIndex says
+                  // pending" - until removeAllPagesOfDatabase's later catch-all gets around to it.
                   synchronized (pagesToFlush.pages) {
-                    for (final MutablePage page : pagesToFlush.pages)
+                    for (final MutablePage page : pagesToFlush.pages) {
+                      removeFromFlushIndex(page);
                       ackWalFileOfAbandonedPage(page);
+                    }
                   }
                   return;
                 }
@@ -813,11 +818,14 @@ public class PageManagerFlushThread extends Thread {
             }
 
             if (!pagesToFlush.database.isOpen()) {
-              // None of this batch will ever be written (issue #6440): ack every page's WAL file rather than
-              // leaving their WALFile.pagesToFlush counters stranded above zero forever.
+              // None of this batch will ever be written (issue #6440): release both the index entry and the WAL
+              // ack for every page, rather than leaving pageIndex.pendingOf() inflated and their
+              // WALFile.pagesToFlush counters stranded above zero forever.
               synchronized (pagesToFlush.pages) {
-                for (final MutablePage page : pagesToFlush.pages)
+                for (final MutablePage page : pagesToFlush.pages) {
+                  removeFromFlushIndex(page);
                   ackWalFileOfAbandonedPage(page);
+                }
               }
               return;
             }

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -778,8 +778,13 @@ public class PageManagerFlushThread extends Thread {
                 // assert stays at zero.
                 //
                 // Dropping the batch instead loses nothing: it was not going to be written either way (the same
-                // check further down already refused it), its pageIndex entries were purged by
-                // removeAllPagesOfDatabase, and its content is recovered from the WAL - its ack was never given.
+                // check further down already refused it), and its pageIndex entries were purged by
+                // removeAllPagesOfDatabase. Its ack IS still given here (issue #6440): "recovered from the WAL"
+                // only holds for a plain close(), where the files - and the WAL that protects them - survive.
+                // A drop() deletes them all regardless, so nothing will ever replay this page; withholding the
+                // ack only strands its WALFile.pagesToFlush counter above zero forever, which is exactly what
+                // makes TransactionManager.close()'s retry loop burn its whole budget on a count that can never
+                // be satisfied.
                 //
                 // Under the monitor, and therefore exact: LocalDatabase.close() sets open=false BEFORE the purge
                 // that forgets this bookkeeping, and that purge takes this same monitor. So `isOpen()` true here
@@ -791,8 +796,13 @@ public class PageManagerFlushThread extends Thread {
                 // return drops this batch and nothing else - and it is inside the outer try whose finally clears
                 // nextPagesToFlush, which therefore still runs. Worth saying because the nesting is deep enough that
                 // a future refactor lifting this block into a helper would silently take that finally with it.
-                if (!db.isOpen())
+                if (!db.isOpen()) {
+                  synchronized (pagesToFlush.pages) {
+                    for (final MutablePage page : pagesToFlush.pages)
+                      ackWalFileOfAbandonedPage(page);
+                  }
                   return;
+                }
 
                 if (isSuspended(db)) {
                   deferredByDatabase.computeIfAbsent(db, k -> new ConcurrentLinkedQueue<>()).offer(pagesToFlush);
@@ -802,18 +812,29 @@ public class PageManagerFlushThread extends Thread {
               }
             }
 
-            if (!pagesToFlush.database.isOpen())
+            if (!pagesToFlush.database.isOpen()) {
+              // None of this batch will ever be written (issue #6440): ack every page's WAL file rather than
+              // leaving their WALFile.pagesToFlush counters stranded above zero forever.
+              synchronized (pagesToFlush.pages) {
+                for (final MutablePage page : pagesToFlush.pages)
+                  ackWalFileOfAbandonedPage(page);
+              }
               return;
+            }
 
             synchronized (pagesToFlush.pages) {
               for (final MutablePage page : pagesToFlush.pages) {
                 if (!pagesToFlush.database.isOpen()) {
                   // Database was closed/dropped concurrently (e.g., during test teardown).
-                  // Clean up remaining pageIndex entries and stop flushing this batch.
+                  // Clean up remaining pageIndex entries and release their WAL acks (issue #6440): none of
+                  // these pages will ever be written either, so withholding the ack only strands
+                  // TransactionManager.close()'s retry loop on a count that can never be satisfied.
                   LogManager.instance().log(this, Level.FINE, "Skipping page flush for closed database '%s'",
                       pagesToFlush.database.getName());
-                  for (final MutablePage remaining : pagesToFlush.pages)
+                  for (final MutablePage remaining : pagesToFlush.pages) {
                     removeFromFlushIndex(remaining);
+                    ackWalFileOfAbandonedPage(remaining);
+                  }
                   break;
                 }
                 try {
@@ -836,8 +857,11 @@ public class PageManagerFlushThread extends Thread {
                   try {
                     pageManager.flushPage(page);
                   } catch (final DatabaseMetadataException e2) {
-                    // FILE DELETED, CONTINUE WITH THE NEXT PAGES (same handling as the primary attempt)
+                    // FILE DELETED, CONTINUE WITH THE NEXT PAGES (same handling as the primary attempt). Unlike
+                    // a genuine I/O failure, there is nothing left to recover this page onto - ack its WAL file
+                    // (issue #6440), mirroring removePagesOfFileFromBatch's existing policy for the same cause.
                     LogManager.instance().log(this, Level.WARNING, "Error on flushing page '%s' to disk", e2, page);
+                    ackWalFileOfAbandonedPage(page);
                   } catch (final IOException e2) {
                     // Double fault: the retry failed too (a fresh interrupt broke the I/O-slot spin, or the disk
                     // genuinely errored). Do NOT let it escape and abort the batch: the remaining pages must
@@ -850,8 +874,11 @@ public class PageManagerFlushThread extends Thread {
                     Thread.interrupted();
                   }
                 } catch (final DatabaseMetadataException e) {
-                  // FILE DELETED, CONTINUE WITH THE NEXT PAGES
+                  // FILE DELETED, CONTINUE WITH THE NEXT PAGES. Unlike a genuine I/O failure, there is nothing
+                  // left to recover this page onto - ack its WAL file (issue #6440), mirroring
+                  // removePagesOfFileFromBatch's existing policy for the same cause.
                   LogManager.instance().log(this, Level.WARNING, "Error on flushing page '%s' to disk", e, page);
+                  ackWalFileOfAbandonedPage(page);
                 } catch (final IOException e) {
                   // #4928: contain a plain I/O failure per page, same policy as the interrupt double-fault
                   // above. Letting it escape aborted the whole batch: the remaining pages were never flushed
@@ -1090,11 +1117,17 @@ public class PageManagerFlushThread extends Thread {
                   // of the process, and every LATER suspension would then be throttled by that much: the drift the
                   // blanket "reset the counter when nothing is deferred anywhere" net existed to absorb. Releasing
                   // it at the source is exact, and per database, so no reset can ever wipe a sibling's live count.
+                  // Its WAL ack is released too (issue #6440): nothing will ever replay it once the database is
+                  // gone, and withholding the ack only strands TransactionManager.close()'s retry loop.
                   if (batch.database.isOpen())
                     pageManager.flushPage(page);
+                  else
+                    ackWalFileOfAbandonedPage(page);
                 } catch (final DatabaseMetadataException e) {
-                  // FILE DELETED, CONTINUE WITH THE NEXT PAGES
+                  // FILE DELETED, CONTINUE WITH THE NEXT PAGES. Nothing left to recover this page onto - ack its
+                  // WAL file (issue #6440), mirroring removePagesOfFileFromBatch's policy for the same cause.
                   LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
+                  ackWalFileOfAbandonedPage(page);
                 } catch (final InterruptedIOException e) {
                   // Don't drop the deferred dirty page, its WAL entry was already acked: consume the flag and
                   // retry the write once.
@@ -1102,10 +1135,15 @@ public class PageManagerFlushThread extends Thread {
                   Thread.interrupted();
                   try {
                     pageManager.flushPage(page);
-                  } catch (final DatabaseMetadataException | IOException e2) {
-                    // Contain every retry failure (file dropped, re-interrupt, real I/O error): letting it escape
-                    // would skip the unsuspend phases below, leaving the database suspended with batches stranded
-                    // in the deferred map. An unflushed page is recovered from the WAL (its entry was never acked).
+                  } catch (final DatabaseMetadataException e2) {
+                    // File dropped: nothing left to recover this page onto - ack its WAL file (issue #6440).
+                    LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e2, page);
+                    ackWalFileOfAbandonedPage(page);
+                    Thread.interrupted();
+                  } catch (final IOException e2) {
+                    // Contain every retry failure (re-interrupt, real I/O error): letting it escape would skip
+                    // the unsuspend phases below, leaving the database suspended with batches stranded in the
+                    // deferred map. An unflushed page is recovered from the WAL (its entry was never acked).
                     // A fresh re-interrupt set the flag again: clear it so the remaining pages flush cleanly.
                     LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e2, page);
                     Thread.interrupted();
@@ -1261,6 +1299,25 @@ public class PageManagerFlushThread extends Thread {
    */
   void removeFromFlushIndex(final MutablePage page) {
     pageIndex.removeIfSame(page);
+  }
+
+  /**
+   * Releases a page's WAL ack when it will never be written to disk because its file (or database) is gone,
+   * never because a write genuinely failed (issue #6440). {@code takeWALFile()} is exactly-once, so calling
+   * this after a normal successful flush (which already acked the page from inside {@link PageManager#flushPage})
+   * is a safe no-op - the reference was already consumed.
+   * <p>
+   * Mirrors {@link PageManagerFlushThread#removePagesOfFileFromBatch} and {@link PageManager#flushPage}'s own
+   * "file dropped"/"database closed" branches: without this, a page abandoned here for want of a file to write
+   * it to leaves its {@code WALFile.pagesToFlush} counter stranded above zero forever, and
+   * {@code TransactionManager.close()}'s retry loop burns its whole budget waiting on a count that can never be
+   * satisfied. Do NOT call this for a genuine I/O failure (plain {@link java.io.IOException}) - there the file
+   * still exists and the page must stay un-acked so the WAL is preserved for recovery on the next open.
+   */
+  private static void ackWalFileOfAbandonedPage(final MutablePage page) {
+    final WALFile walFile = page.takeWALFile();
+    if (walFile != null)
+      walFile.notifyPageFlushed();
   }
 
   /**
@@ -1495,11 +1552,24 @@ public class PageManagerFlushThread extends Thread {
   }
 
   public void removeAllPagesOfDatabase(final Database database) {
+    // Reference identity ON PURPOSE (issue #6440), not database.equals(pagesToFlush.database): LocalDatabase
+    // compares by PATH, so a database dropped and immediately reopened at the same path (a restore, a
+    // re-provision, or simply a test's @BeforeEach/@AfterEach hammering one fixed path) would otherwise have
+    // THIS scan match the reopened instance's own still-pending batch too - discarding pages that were never
+    // written or acked, permanently stranding the reopened instance's WALFile.pagesToFlush counter and hanging
+    // its own close()/drop() for TransactionManager's whole retry budget. Only the EXACT instance being closed
+    // may have its pages removed here.
     for (final PagesToFlush pagesToFlush : queue.stream().toList())
-      if (database.equals(pagesToFlush.database)) {
+      if (pagesToFlush.database == database) {
         synchronized (pagesToFlush.pages) {
-          for (final MutablePage page : pagesToFlush.pages)
+          for (final MutablePage page : pagesToFlush.pages) {
             pageIndex.remove(page.getPageId());
+            // The purged page will never be flushed and its content is irrelevant (its database is gone):
+            // release its WAL ack so the close-time ack gate (#4928) is not tripped by stale pending counts.
+            // Exactly-once against the racing flush loop (which does NOT remove pages from this batch list,
+            // so both paths can visit the same page) via takeWALFile() inside the helper.
+            ackWalFileOfAbandonedPage(page);
+          }
           pagesToFlush.pages.clear();
         }
         // And take the emptied wrapper OUT of the queue rather than leaving it to be polled and skipped. It carries

--- a/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
@@ -107,6 +107,50 @@ class Issue6440CrossInstanceFlushDiscardTest extends TestHelper {
   }
 
   /**
+   * The map-key-collision twin of the test above (issue #6440 review, fourth pass):
+   * {@link PageManagerFlushThread#removeAllPagesOfDatabase} used to evict {@code pageIndex} entries with
+   * {@code pageIndex.remove(page.getPageId())} - a plain, {@code equals()}-based removal - rather than the
+   * identity-safe {@code removeIfSame} the rest of the pipeline uses. When "closing" has its OWN queued batch at
+   * the exact same {@code (fileId, pageNumber)} "open" later indexes, {@code Map.put()}'s "keep the old key on an
+   * {@code equals()} match" behavior leaves "closing"'s original {@code PageId} as the map's stored key even
+   * though the VALUE is "open"'s live page - so removing by that key, unconditionally, evicted (and left unacked)
+   * a page that was never "closing"'s to begin with.
+   */
+  @Test
+  void closingADatabaseMustNotEvictASamePathSiblingsPageItsOwnQueuedBatchCollidesWith() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-queue-collision";
+    final PageManagerFlushThread flush = detachedFlushThread();
+
+    final Database closing = TestHelper.createDatabase(path);
+    closing.close();
+
+    final Database open = TestHelper.createDatabase(path);
+    try {
+      // "closing" has its own still-queued batch, indexed first so its PageId becomes the map's stored key.
+      final MutablePage closingPage = page((DatabaseInternal) closing, 0);
+      flush.pageIndex.put(closingPage);
+      flush.offerBatch(new PageManagerFlushThread.PagesToFlush(new ArrayList<>(List.of(closingPage))), false);
+
+      // "open" indexes a page at the exact SAME (fileId, pageNumber): the map slot's value becomes open's page,
+      // but the stored key is still closingPage's PageId object (Map.put() on an equals() match).
+      final MutablePage openPage = page((DatabaseInternal) open, 0);
+      flush.pageIndex.put(openPage);
+      assertThat(flush.pageIndex.get(openPage.getPageId())).isSameAs(openPage);
+
+      // "closing"'s belated cleanup runs, walking its OWN queued batch - which still references closingPage.
+      flush.removeAllPagesOfDatabase(closing);
+
+      assertThat(flush.pageIndex.get(openPage.getPageId())).as(
+          "a same-path sibling's live page, sitting at the same map slot as this instance's OWN queued page, "
+              + "must survive this instance's cleanup").isSameAs(openPage);
+      assertThat(flush.pageIndex.hasPendingOf((DatabaseInternal) open)).as(
+          "open's own pending count must be untouched by closing's cleanup of its own, superseded page").isTrue();
+    } finally {
+      open.drop();
+    }
+  }
+
+  /**
    * Defence in depth for the same aliasing, one layer down: {@link FlushPageIndex#removeAllOfDatabase} walks the
    * WHOLE JVM-wide index by path and must not evict a same-path sibling's entry either, even when
    * {@link PageManagerFlushThread#removeAllPagesOfDatabase}'s queue scan above is fixed.

--- a/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6440: a test (or application) that repeatedly {@code drop()}s and re-{@code create()}s
+ * a database at the SAME path stalls every {@code close()}/{@code drop()} for up to
+ * {@code TransactionManager}'s full 20 x 100 ms retry budget, because
+ * {@link PageManagerFlushThread#removeAllPagesOfDatabase} and {@link FlushPageIndex#removeAllOfDatabase} match
+ * pending pages by {@code Database.equals()}, which - like the rest of this class's per-database bookkeeping -
+ * compares by database PATH, not by instance (see the {@code PagesToFlush.slotCharged} javadoc, and issues #6281 /
+ * #6303, which defended {@code slotsInUse} and the suspend/deferred bookkeeping against the exact same aliasing but
+ * left this queue scan and the index purge it drives untouched).
+ * <p>
+ * The failure shape: database A is closing while a NEW instance B, opened at A's same path (exactly what a JUnit
+ * {@code @BeforeEach}/{@code @AfterEach} pair produces test after test), already has its own pages queued for
+ * flush. {@code A.equals(B)} is {@code true} (same path), so {@code removeAllPagesOfDatabase(A)} wrongly matches
+ * and discards B's still-pending pages - clearing them from the batch and the flush index WITHOUT ever writing them
+ * or acking their WAL file. B's own {@code WALFile.pagesToFlush} counter for that page can then never reach zero:
+ * {@code TransactionManager.close()}'s retry loop burns its whole budget waiting on a count that no longer
+ * corresponds to anything in the pipeline, then gives up and force-drops anyway.
+ * <p>
+ * Reproduced black-box (not part of this test, timing-dependent) by opening and dropping a database at a fixed path
+ * in a tight loop: roughly 1 in 8-10 iterations, even with the JVM otherwise idle, pays the full ~2000 ms stall.
+ * These tests drive the exact interleaving white-box instead, because - like #6303's - it is a race the public API
+ * cannot be made to produce on demand.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6440CrossInstanceFlushDiscardTest extends TestHelper {
+  private static final int FILE_ID   = 4_103;
+  private static final int PAGE_SIZE = 64;
+
+  /**
+   * THE ISSUE. Closing database A must not discard the still-pending pages of a database B that merely shares A's
+   * path.
+   */
+  @Test
+  void closingADatabaseMustNotDiscardAStillOpenSamePathSiblingsQueuedPage() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-recycled";
+    final PageManagerFlushThread flush = detachedFlushThread();
+
+    final Database closing = TestHelper.createDatabase(path);
+    closing.drop();
+
+    final Database open = TestHelper.createDatabase(path);
+    try {
+      assertThat(open).as("same-path instances compare equal under LocalDatabase.equals()").isEqualTo(closing);
+      assertThat(open).isNotSameAs(closing);
+
+      // "open"'s own commit queued a page that has not been flushed yet.
+      final MutablePage pending = page((DatabaseInternal) open, 0);
+      flush.scheduleFlushOfPages(new ArrayList<>(List.of(pending)));
+      assertThat(flush.pageIndex.hasPendingOf((DatabaseInternal) open)).isTrue();
+
+      // "closing"'s belated cleanup runs now, exactly as TransactionManager.close()'s teardown does. Since
+      // closing.equals(open), the buggy queue scan resolved this against "open"'s live batch.
+      flush.removeAllPagesOfDatabase(closing);
+
+      assertThat(flush.pageIndex.get(pending.getPageId())).as(
+          "a batch of a DIFFERENT, still-open instance must survive a same-path sibling's cleanup").isSameAs(pending);
+      assertThat(flush.pageIndex.hasPendingOf((DatabaseInternal) open)).as(
+          "the live instance's own pending count must be untouched by the sibling's cleanup").isTrue();
+
+      // The page is still genuinely in the pipeline, so it can be flushed normally afterward.
+      flush.flushPagesFromQueueToDisk(null, 20L);
+      assertThat(flush.pageIndex.hasPendingOf((DatabaseInternal) open)).isFalse();
+    } finally {
+      open.drop();
+    }
+  }
+
+  /**
+   * Defence in depth for the same aliasing, one layer down: {@link FlushPageIndex#removeAllOfDatabase} walks the
+   * WHOLE JVM-wide index by path and must not evict a same-path sibling's entry either, even when
+   * {@link PageManagerFlushThread#removeAllPagesOfDatabase}'s queue scan above is fixed.
+   */
+  @Test
+  void flushIndexRemoveAllOfDatabaseMustNotEvictASamePathSiblingsEntry() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-index-recycled";
+
+    final Database closing = TestHelper.createDatabase(path);
+    closing.drop();
+
+    final Database open = TestHelper.createDatabase(path);
+    try {
+      final FlushPageIndex index = new FlushPageIndex();
+      final MutablePage page = page((DatabaseInternal) open, 0);
+      index.put(page);
+
+      index.removeAllOfDatabase((DatabaseInternal) closing);
+
+      assertThat(index.get(page.getPageId())).as(
+          "a same-path sibling's indexed page must survive removeAllOfDatabase() of a DIFFERENT instance")
+          .isSameAs(page);
+      assertThat(index.hasPendingOf((DatabaseInternal) open)).isTrue();
+    } finally {
+      open.drop();
+    }
+  }
+
+  /**
+   * A database dropped WITH its own pages still queued (no other instance involved at all) must still ack their WAL
+   * file when it discards them, exactly as the sibling method {@code removePagesOfFileFromBatch} already does for a
+   * single dropped file (issue #4928). Without this, a database that legitimately still has pages in flight when it
+   * is force-dropped strands its own {@code WALFile.pagesToFlush} counter forever.
+   */
+  @Test
+  void removingADatabasesOwnQueuedPageAcksItsWalFile() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-own-ack";
+    final Database db = TestHelper.createDatabase(path);
+    try {
+      final PageManagerFlushThread flush = detachedFlushThread();
+      final MutablePage pending = page((DatabaseInternal) db, 0);
+
+      final File walFileDir = new File(path);
+      walFileDir.mkdirs();
+      final WALFile walFile = new WALFile(new File(walFileDir, "issue6440.wal").getAbsolutePath());
+      try {
+        pending.setWALFile(walFile);
+        // Mirrors what WALFile.writeTransactionToFile does for each page it writes, without touching disk I/O.
+        bumpPendingPagesToFlush(walFile);
+
+        flush.scheduleFlushOfPages(new ArrayList<>(List.of(pending)));
+        assertThat(walFile.getPendingPagesToFlush()).isEqualTo(1);
+
+        flush.removeAllPagesOfDatabase((DatabaseInternal) db);
+
+        assertThat(walFile.getPendingPagesToFlush()).as(
+            "discarding a page that will never be flushed must still release its WAL ack").isEqualTo(0);
+      } finally {
+        walFile.close();
+      }
+    } finally {
+      db.drop();
+    }
+  }
+
+  /**
+   * Constructing the flush thread directly does NOT start the background thread, so the pipeline only moves when
+   * the test moves it.
+   */
+  private static PageManagerFlushThread detachedFlushThread() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.PAGE_FLUSH_QUEUE, 8);
+    return new PageManagerFlushThread(PageManager.INSTANCE, cfg);
+  }
+
+  private static MutablePage page(final DatabaseInternal database, final int pageNumber) {
+    return new MutablePage(new PageId(database, FILE_ID, pageNumber), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+  }
+
+  private static void bumpPendingPagesToFlush(final WALFile walFile) throws Exception {
+    final java.lang.reflect.Field f = WALFile.class.getDeclaredField("pagesToFlush");
+    f.setAccessible(true);
+    ((java.util.concurrent.atomic.AtomicInteger) f.get(walFile)).incrementAndGet();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
@@ -53,6 +53,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * in a tight loop: roughly 1 in 8-10 iterations, even with the JVM otherwise idle, pays the full ~2000 ms stall.
  * These tests drive the exact interleaving white-box instead, because - like #6303's - it is a race the public API
  * cannot be made to produce on demand.
+ * <p>
+ * The fix keys {@link FlushPageIndex}'s {@code pending} counter map by reference identity rather than
+ * {@code equals()}, on BOTH ends: {@code counterOf()} (insertion, via {@code put()}/{@code putAll()}) must resolve
+ * a brand-new instance's OWN fresh counter and never a same-path sibling's still-present one, exactly as
+ * {@code removeAllOfDatabase} (removal) must retire only the counter the instance being closed actually created.
+ * Fixing only removal is not enough on its own: a same-path sibling's belated cleanup could otherwise still zero
+ * out a live counter it never should have been able to resolve in the first place.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -123,6 +130,54 @@ class Issue6440CrossInstanceFlushDiscardTest extends TestHelper {
           "a same-path sibling's indexed page must survive removeAllOfDatabase() of a DIFFERENT instance")
           .isSameAs(page);
       assertThat(index.hasPendingOf((DatabaseInternal) open)).isTrue();
+    } finally {
+      open.drop();
+    }
+  }
+
+  /**
+   * The insertion-side twin of the test above: a same-path sibling's counter must never be resolved on the way
+   * IN either. {@code counterOf()} used to be a plain {@code pending.get(database)}/{@code computeIfAbsent}, and
+   * since {@code LocalDatabase.equals()} compares by path, that could hand a brand-new database's FIRST page the
+   * counter object a DIFFERENT, not-yet-fully-forgotten same-path instance created - "closing" here: closed and
+   * drained, so its own counter is back to zero, but its map ENTRY survives until {@code removeAllOfDatabase}
+   * actually runs. If "open"'s first page increments that shared entry instead of a fresh one, "closing"'s
+   * eventual (belated) cleanup then zeroes out "open"'s live, un-flushed count - the same "backup stamps its t0
+   * over a half-written batch" failure this class's own javadoc warns about, just reached from the other side.
+   */
+  @Test
+  void flushIndexCounterOfMustNotAliasASamePathSiblingsCounterOnInsertion() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-counter-recycled";
+
+    final Database closing = TestHelper.createDatabase(path);
+    closing.drop();
+
+    final Database open = TestHelper.createDatabase(path);
+    try {
+      final FlushPageIndex index = new FlushPageIndex();
+
+      // Seed "closing"'s counter WITHOUT going through removeAllOfDatabase, mirroring the real race: its page
+      // arrived and left the pipeline normally (counter created, then decremented back to zero by remove()),
+      // but the counter's MAP ENTRY survives - only removeAllOfDatabase forgets it, and that has not run yet.
+      final MutablePage closingPage = page((DatabaseInternal) closing, 0);
+      index.put(closingPage);
+      index.remove(closingPage.getPageId());
+      assertThat(index.isTracked((DatabaseInternal) closing)).isTrue();
+      assertThat(index.pendingOf((DatabaseInternal) closing)).isZero();
+
+      // "open"'s first page arrives while "closing"'s entry is still present at the same path.
+      final MutablePage openPage = page((DatabaseInternal) open, 1);
+      index.put(openPage);
+
+      assertThat(index.pendingOf((DatabaseInternal) open)).as(
+          "open's own page must increment open's own counter, not a same-path sibling's stale one").isEqualTo(1);
+
+      // "closing"'s belated cleanup finally runs.
+      index.removeAllOfDatabase((DatabaseInternal) closing);
+
+      assertThat(index.pendingOf((DatabaseInternal) open)).as(
+          "a same-path sibling's belated cleanup must not zero out open's live, un-flushed counter").isEqualTo(1);
+      assertThat(index.get(openPage.getPageId())).isSameAs(openPage);
     } finally {
       open.drop();
     }

--- a/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6440CrossInstanceFlushDiscardTest.java
@@ -136,6 +136,85 @@ class Issue6440CrossInstanceFlushDiscardTest extends TestHelper {
   }
 
   /**
+   * A deeper layer of the same aliasing (issue #6440 review, third pass): {@code removeAllOfDatabase}'s pages
+   * purge used to filter by the RETAINED MAP KEY's database identity, not the indexed page's. {@code PageId}
+   * collides as a map key across same-path instances too ({@code PageId.equals()}/{@code hashCode()} go through
+   * path-based {@code Database.equals()}), and {@code Map.put()} on an {@code equals()}-match keeps the ORIGINAL
+   * key object and only swaps the value - textbook Java {@code Map} behavior. So when "open" indexes a page at
+   * the exact same {@code (fileId, pageNumber)} "closing" used, the map's stored key is still "closing"'s
+   * original {@code PageId}, even though the VALUE is now "open"'s live page. Filtering by that retained key's
+   * database would still evict "open"'s page - the same failure the earlier tests pin, one layer further down.
+   */
+  @Test
+  void flushIndexRemoveAllOfDatabaseMustNotEvictASamePathSiblingsPageOnMapKeyCollision() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-page-collision";
+
+    final Database closing = TestHelper.createDatabase(path);
+    closing.drop();
+
+    final Database open = TestHelper.createDatabase(path);
+    try {
+      final FlushPageIndex index = new FlushPageIndex();
+
+      // Same (fileId, pageNumber) on purpose: this is what makes the two PageIds collide as one map key.
+      final MutablePage closingPage = page((DatabaseInternal) closing, 0);
+      index.put(closingPage);
+      final MutablePage openPage = page((DatabaseInternal) open, 0);
+      index.put(openPage);
+
+      // open's page is the current value at that key - closing's PageId object may still be the stored key.
+      assertThat(index.get(openPage.getPageId())).isSameAs(openPage);
+
+      index.removeAllOfDatabase((DatabaseInternal) closing);
+
+      assertThat(index.get(openPage.getPageId())).as(
+          "a same-path sibling's live page must survive removeAllOfDatabase() of a DIFFERENT instance even when "
+              + "it collided with that instance's page at the same (fileId, pageNumber) map key").isSameAs(openPage);
+    } finally {
+      open.drop();
+    }
+  }
+
+  /**
+   * The counter-accounting half of the same map-key collision: {@code put()}/{@code putAll()}'s "a later TX
+   * superseded a page still queued" branch (issue #4544) used to decrement the INCOMING page's counter whenever
+   * {@code pages.put()} returned a non-null replaced value - correct within one database, wrong across two: the
+   * replaced value can belong to a DIFFERENT same-path instance (the same collision as the test above), and
+   * decrementing the wrong counter phantom-inflates a live sibling's pending count forever while leaving the
+   * instance that actually owned the replaced page one too high.
+   */
+  @Test
+  void flushIndexPutMustReleaseTheReplacedPagesOwnCounterNotTheIncomingPages() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-collision-counters";
+
+    final Database closing = TestHelper.createDatabase(path);
+    closing.drop();
+
+    final Database open = TestHelper.createDatabase(path);
+    try {
+      final FlushPageIndex index = new FlushPageIndex();
+
+      final MutablePage closingPage = page((DatabaseInternal) closing, 0);
+      index.put(closingPage);
+      assertThat(index.pendingOf((DatabaseInternal) closing)).isEqualTo(1);
+
+      // Same (fileId, pageNumber): closingPage's entry is replaced, not added alongside.
+      final MutablePage openPage = page((DatabaseInternal) open, 0);
+      index.put(openPage);
+
+      assertThat(index.pendingOf((DatabaseInternal) open)).as(
+          "open's own freshly-indexed page must still count as pending - it must not have been decremented "
+              + "away just because it happened to replace a different instance's page at the same map key")
+          .isEqualTo(1);
+      assertThat(index.pendingOf((DatabaseInternal) closing)).as(
+          "closing's superseded page must be released from ITS OWN counter, not left permanently inflated")
+          .isEqualTo(0);
+    } finally {
+      open.drop();
+    }
+  }
+
+  /**
    * The insertion-side twin of the test above: a same-path sibling's counter must never be resolved on the way
    * IN either. {@code counterOf()} used to be a plain {@code pending.get(database)}/{@code computeIfAbsent}, and
    * since {@code LocalDatabase.equals()} compares by path, that could hand a brand-new database's FIRST page the

--- a/engine/src/test/java/com/arcadedb/engine/Issue6440FlushAckOnClosedDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6440FlushAckOnClosedDatabaseTest.java
@@ -18,12 +18,16 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -123,6 +127,84 @@ class Issue6440FlushAckOnClosedDatabaseTest {
     } finally {
       db.drop();
     }
+  }
+
+  /**
+   * The {@link PageManagerFlushThread}-level counterpart of the two tests above: {@code flushPagesFromQueueToDisk}'s
+   * own "database closed before this batch could be processed" branch must ack too, not just {@code flushPage()}
+   * in isolation - the queue-draining loop reaches that branch first and never even calls {@code flushPage()}.
+   */
+  @Test
+  void flushPagesFromQueueToDiskAcksABatchWhoseDatabaseIsAlreadyClosed() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-queue-closed";
+    final Database db = TestHelper.createDatabase(path);
+
+    final File walFileDir = new File(path);
+    final WALFile walFile = new WALFile(new File(walFileDir, "issue6440c.wal").getAbsolutePath());
+    try {
+      final PageManagerFlushThread flush = detachedFlushThread();
+      final MutablePage page = page((DatabaseInternal) db, 0);
+      page.setWALFile(walFile);
+      bumpPendingPagesToFlush(walFile);
+
+      // Indexed and queued while the database is still open, exactly as a real commit does.
+      flush.pageIndex.putAll(new ArrayList<>(List.of(page)));
+      flush.offerBatch(new PageManagerFlushThread.PagesToFlush(new ArrayList<>(List.of(page))), false);
+
+      // The database closes before the (here, manually driven) queue-drain loop gets to this batch.
+      db.close();
+
+      flush.flushPagesFromQueueToDisk(null, 20L);
+
+      assertThat(walFile.getPendingPagesToFlush()).as(
+          "a queued batch whose database closed before it could be processed must still be acked").isZero();
+    } finally {
+      walFile.close();
+    }
+  }
+
+  /**
+   * {@code resumeFlushing()}'s equivalent on the suspend/backup-resume path: a batch deferred while suspended,
+   * whose database closed before the suspension was released, must be acked when the resume finally runs - not
+   * just detached from the deferred backlog and dropped.
+   */
+  @Test
+  void resumeFlushingAcksADeferredBatchWhoseDatabaseIsAlreadyClosed() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-resume-closed";
+    final Database db = TestHelper.createDatabase(path);
+
+    final File walFileDir = new File(path);
+    final WALFile walFile = new WALFile(new File(walFileDir, "issue6440d.wal").getAbsolutePath());
+    try {
+      final PageManagerFlushThread flush = detachedFlushThread();
+      assertThat(flush.setSuspended((Database) db, true)).isTrue();
+
+      final MutablePage page = page((DatabaseInternal) db, 0);
+      page.setWALFile(walFile);
+      bumpPendingPagesToFlush(walFile);
+
+      flush.pageIndex.putAll(new ArrayList<>(List.of(page)));
+      flush.offerBatch(new PageManagerFlushThread.PagesToFlush(new ArrayList<>(List.of(page))), false);
+      // Suspended, so the drain defers this batch instead of writing it.
+      flush.flushPagesFromQueueToDisk(null, 20L);
+      assertThat(flush.hasDeferredBatches((DatabaseInternal) db)).isTrue();
+
+      db.close();
+
+      // The last (only) suspender releasing runs resumeFlushing(db) synchronously on this thread.
+      flush.setSuspended((Database) db, false);
+
+      assertThat(walFile.getPendingPagesToFlush()).as(
+          "a deferred batch whose database closed while suspended must still be acked on resume").isZero();
+    } finally {
+      walFile.close();
+    }
+  }
+
+  private static PageManagerFlushThread detachedFlushThread() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.PAGE_FLUSH_QUEUE, 8);
+    return new PageManagerFlushThread(PageManager.INSTANCE, cfg);
   }
 
   private static MutablePage page(final DatabaseInternal database, final int pageNumber) {

--- a/engine/src/test/java/com/arcadedb/engine/Issue6440FlushAckOnClosedDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue6440FlushAckOnClosedDatabaseTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6440: {@link PageManager#flushPage} abandons a page whose database has already
+ * closed WITHOUT releasing its WAL ack.
+ * <p>
+ * A page is written to WAL synchronously during commit ({@code WALFile.writeTransactionToFile} increments
+ * {@code WALFile.pagesToFlush} for every page it writes), then handed to the async flush pipeline to be written
+ * to the actual data file; only that second, asynchronous write releases the ack
+ * ({@code WALFile.notifyPageFlushed}, via {@code MutablePage.takeWALFile()}). {@code TransactionManager.close()}
+ * waits (up to 20 x 100 ms) for every WAL file's {@code pagesToFlush} to reach zero before it will drop or clean
+ * up the file.
+ * <p>
+ * {@code LocalDatabase.closeDurableParts} sets {@code open = false} BEFORE that wait runs, and {@code flushPage}
+ * checks {@code database.isOpen()} first and returns immediately - without writing the page AND without acking
+ * it - the moment that race is lost. Losing it is exactly what a {@code drop()} (or a plain {@code close()})
+ * immediately following a commit produces: whether the async flush thread reaches this page before or after
+ * {@code open} flips is a pure scheduling race, decided by nothing the caller controls. When it loses, the page
+ * is abandoned - correct, since there is nothing left to write it to - but the counter it left behind can never
+ * reach zero, so {@code TransactionManager.close()}'s retry loop burns its ENTIRE 2000 ms budget waiting on a
+ * count that nothing will ever satisfy, before giving up and forcing the close anyway.
+ * <p>
+ * Reproduced black-box (not part of this test, timing-dependent) by rapidly creating, writing to, and dropping a
+ * database at a fixed path in a tight loop: even with the JVM otherwise idle this raced roughly 1 time in 10; in
+ * a JVM busy running thousands of other tests first (issue #6440's original report, {@code GAVEligibilityTest}
+ * inside the full opencypher suite) it raced on most of the class's 43 iterations, turning a ~2 second class
+ * into one taking 35-60+ seconds. This test drives the exact interleaving deterministically instead.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6440FlushAckOnClosedDatabaseTest {
+  private static final int FILE_ID   = 4_104;
+  private static final int PAGE_SIZE = 64;
+
+  /**
+   * THE ISSUE. {@code flushPage} must ack a page's WAL file even when it abandons the write because the
+   * database already closed.
+   */
+  @Test
+  void flushPageAcksTheWalFileWhenTheDatabaseIsAlreadyClosed() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-closed";
+    final Database db = TestHelper.createDatabase(path);
+
+    final File walFileDir = new File(path);
+    walFileDir.mkdirs();
+    final WALFile walFile = new WALFile(new File(walFileDir, "issue6440.wal").getAbsolutePath());
+    try {
+      final MutablePage page = page((DatabaseInternal) db, 0);
+      page.setWALFile(walFile);
+      // Mirrors what WALFile.writeTransactionToFile does for each page it writes, without touching disk I/O:
+      // this page was durably WAL-appended during commit and is now awaiting the async data-file write.
+      bumpPendingPagesToFlush(walFile);
+      assertThat(walFile.getPendingPagesToFlush()).isEqualTo(1);
+
+      // The database closes - exactly what races the async flush thread in the real failure - before the
+      // flush pipeline got to this page.
+      db.close();
+      assertThat(db.isOpen()).isFalse();
+
+      PageManager.INSTANCE.flushPage(page);
+
+      assertThat(walFile.getPendingPagesToFlush()).as(
+          "abandoning a page because its database is already closed must still release its WAL ack").isZero();
+    } finally {
+      walFile.close();
+    }
+  }
+
+  /**
+   * Sanity check of the normal path: flushing a page of an OPEN database still acks it exactly once, through
+   * the pre-existing success path - the fix must not double-ack (takeWALFile() is exactly-once by design).
+   */
+  @Test
+  void flushPageAcksTheWalFileExactlyOnceForAnOpenDatabase() throws Exception {
+    final String path = "target/databases/" + getClass().getSimpleName() + "-open";
+    final Database db = TestHelper.createDatabase(path);
+    try {
+      final File walFileDir = new File(path);
+      final WALFile walFile = new WALFile(new File(walFileDir, "issue6440b.wal").getAbsolutePath());
+      try {
+        final MutablePage page = page((DatabaseInternal) db, 0);
+        page.setWALFile(walFile);
+        bumpPendingPagesToFlush(walFile);
+
+        // A page for a file that does not exist takes the "file dropped" branch, which already acks once and
+        // returns without touching the (still open) database's schema - the simplest way to exercise a real,
+        // successful ack path without a full commit.
+        PageManager.INSTANCE.flushPage(page);
+
+        assertThat(walFile.getPendingPagesToFlush()).isZero();
+        assertThat(page.takeWALFile()).as("the reference is consumed exactly once, a second take finds nothing")
+            .isNull();
+      } finally {
+        walFile.close();
+      }
+    } finally {
+      db.drop();
+    }
+  }
+
+  private static MutablePage page(final DatabaseInternal database, final int pageNumber) {
+    return new MutablePage(new PageId(database, FILE_ID, pageNumber), PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+  }
+
+  /** Mirrors what {@code WALFile.writeTransactionToFile} does for each page it writes, without touching disk I/O. */
+  private static void bumpPendingPagesToFlush(final WALFile walFile) throws Exception {
+    final java.lang.reflect.Field f = WALFile.class.getDeclaredField("pagesToFlush");
+    f.setAccessible(true);
+    ((java.util.concurrent.atomic.AtomicInteger) f.get(walFile)).incrementAndGet();
+  }
+}


### PR DESCRIPTION
Closes #6440

## Summary

`GAVEligibilityTest` (and any test that repeatedly `drop()`s and `create()`s a database at the same path) paid up to `TransactionManager`'s full 2000 ms retry budget on almost every `close()`, which is why it went from ~2s isolated to 35-60+ seconds inside the full opencypher suite in the issue's own measurements.

**Root cause:** a page is durably written to WAL during commit (`WALFile.writeTransactionToFile` increments `WALFile.pagesToFlush`), then handed to the async flush pipeline; only the pipeline's eventual disk write releases the ack (`WALFile.notifyPageFlushed()`, via `MutablePage.takeWALFile()`). Several spots in the flush pipeline correctly abandon a page - there's nothing left to write it to - without ever releasing that ack:

- `PageManager.flushPage()`'s `!database.isOpen()` early return, and its `DatabaseIsClosedException` catch after the physical write already succeeded but the metadata update failed.
- `PageManagerFlushThread.flushPagesFromQueueToDisk()`'s several "database closed mid-batch" branches, and its `DatabaseMetadataException` catches (file dropped).
- `PageManagerFlushThread.resumeFlushing()`'s equivalents on the suspend/backup-resume path.

`LocalDatabase.closeDurableParts()` sets `open = false` *before* `TransactionManager.close()`'s retry loop runs, so any page still in flight at that instant is guaranteed to hit one of the paths above. `TransactionManager.close()` then waits its whole 2000 ms budget for a WAL counter nothing will ever decrement, before giving up and forcing the close anyway - for a `drop()`, where the files are about to be deleted regardless, that wait buys nothing but latency.

**A second, related bug in the same area:** `PageManagerFlushThread.removeAllPagesOfDatabase` and `FlushPageIndex.removeAllOfDatabase` matched pending pages with `Database.equals()`, which - like the rest of this class's bookkeeping - compares by **path**, not instance. A database closed and immediately reopened at the same path (exactly what a rapid `drop()`/`create()` cycle produces, e.g. a JUnit `@BeforeEach`/`@AfterEach` pair) could have its own still-queued batch wrongly discarded by a same-path sibling's belated cleanup. Fixed to match by reference identity, matching the precedent `PagesToFlush.slotCharged` already established for the sibling `slotsInUse` counter in #6281/#6303.

## Investigation

The issue itself was an open-ended performance investigation ("nothing here is a diagnosis"), so most of the work was root-causing rather than implementing:

1. Reproduced the reported slowdown by running the full `com.arcadedb.query.opencypher` package (8776 tests) and confirmed `GAVEligibilityTest` went from 1.9s isolated to 34-63s in-suite.
2. `jstack` sampling during the slow window showed the test's `main` thread parked in `TransactionManager.close()`'s WAL-flush retry loop, sleeping through its full 20 x 100 ms budget.
3. Bisecting the reproduction down showed it did **not** require the rest of the suite: a standalone loop that just creates a database at a fixed path, writes a few vertices, and drops it - nothing else running in the JVM - reproduced the same ~2000 ms stall roughly 1 time in 10.
4. Live-sampled the flush pipeline's own bookkeeping (`pageIndex`, `queue`, `slotsInUse`) during a stall: all reported nothing pending, while the WAL file's own counter stayed stuck - proving the stall was a stranded ack, not a genuinely slow or backed-up flush.
5. Instrumented `WALFile`'s increment/decrement pairing directly, which pinpointed `PageManager.flushPage()`'s `!database.isOpen()` early return as the primary leak, then found the remaining smaller leaks (`DatabaseMetadataException`/`DatabaseIsClosedException` catches, `resumeFlushing`) by symmetry with the one already-correct sibling (`removePagesOfFileFromBatch`, which already acks on the same conditions).

## Test plan

- [x] Added `Issue6440FlushAckOnClosedDatabaseTest`: white-box regression pinning that `PageManager.flushPage()` acks a page's WAL file when the database is already closed, and that a normal successful flush still acks exactly once (`takeWALFile()`'s exactly-once semantics).
- [x] Added `Issue6440CrossInstanceFlushDiscardTest`: white-box regression pinning that closing one database instance must not discard or evict a same-path *sibling* instance's still-pending pages/counters (`PageManagerFlushThread.removeAllPagesOfDatabase`, `FlushPageIndex.removeAllOfDatabase`). All three cases reproduce (fail) against the pre-fix code and pass after.
- [x] `com.arcadedb.engine.**` (828 tests) and `com.arcadedb.database.**` (262 tests) both green - no regressions in the surrounding flush/lifecycle machinery.
- [x] Full `com.arcadedb.query.opencypher.**` package (8776 tests, the original reproduction) rerun after the fix: `GAVEligibilityTest` now completes in ~1-3s (matching its isolated baseline) and zero tests anywhere in the run exhaust the 2000 ms retry budget.
- [x] `mvn -o -pl engine -am compile` clean.

## Notes for reviewers

- No public API changed; all changes are internal to the flush pipeline (`PageManager`, `PageManagerFlushThread`, `FlushPageIndex`).
- The fix is deliberately conservative about *when* to ack: it only does so for `!database.isOpen()`/`DatabaseMetadataException`/`DatabaseIsClosedException` (nothing left to recover onto), never for a genuine `IOException` (where withholding the ack correctly preserves the WAL for recovery on the next open - untouched by this change).
