### PR TITLE
fix(#6376): algo.maxKCut aligns edge weights with CSR adjacency, not iteration order

### DIFF
--- a/docs/6376-algo-maxkcut-csr-weight-alignment.md
+++ b/docs/6376-algo-maxkcut-csr-weight-alignment.md
@@ -26,16 +26,16 @@ by construction - no separate reconciliation step exists that can misalign them.
 
 `Issue6376AlgoMaxKCutWeightAlignmentTest` (engine module), mirroring
 `Issue6301AlgoSteinerTreeWeightAlignmentTest`'s pattern:
-- builds a 3-vertex weighted triangle (X-Y=1.0, X-Z=50.0, Y-Z=1.0) whose maximum 2-cut is uniquely
-  51.0 regardless of local-search starting point or node-processing order (verified analytically:
-  every distinct initial partition converges to 51.0 in the first local-search pass, so the
-  assertion is robust to whichever physical vertex a CSR provider numbers first);
-- runs `algo.maxKCut(2, {weightProperty:'w'})` once with no view (OLTP path) and once with a
-  `GraphAnalyticalView` built over the edge type + weight property (CSR path), both with a fixed
-  seed;
-- asserts `cutWeight == 51.0` in both cases, and that the CSR run actually went through the
-  provider (`CommandContext.CSR_ACCELERATED_VAR`), so the assertion is not vacuously true from an
-  OLTP fallback.
+- builds a star hub H with three unequal leaf weights (H-A=1.0, H-B=10.0, H-C=100.0) plus one
+  extra A-B=5.0 edge that breaks the leaf symmetry a pure star would have (without it, a
+  misassigned weight would just relabel an equally-valued answer and could never expose a
+  misalignment); the unique maximum 2-cut of this graph is 115.0, achieved by grouping {H, A}
+  against {B, C}, independent of seed or which physical vertex a CSR provider numbers first;
+- runs `algo.maxKCut(2, {weightProperty:'w'})` across 10 seeds with no view (OLTP path) and again
+  with a `GraphAnalyticalView` built over the edge type + weight property (CSR path);
+- asserts `cutWeight == 115.0` in both cases, and (in a separate test method) that a CSR run
+  actually went through the provider (`CommandContext.CSR_ACCELERATED_VAR`), so the comparison is
+  not vacuously true from a silent OLTP fallback.
 
 ## Verification
 

--- a/docs/6376-algo-maxkcut-csr-weight-alignment.md
+++ b/docs/6376-algo-maxkcut-csr-weight-alignment.md
@@ -1,0 +1,58 @@
+# Issue #6376 - algo.maxKCut CSR/OLTP weight misalignment
+
+## Root cause
+
+`AlgoMaxKCut.buildWeightedAdj` filled a weight array positionally against the CSR adjacency
+(`graph.adjacency(dir, relTypes)`, ordered by dense node id when a Graph Analytical View or other
+CSR provider backs the graph) by walking `graph.getVertex(i).getEdges(dir, relTypes)`, which is
+always OLTP order. When a GAV exists (or a relTypes filter reorders edges) the two orders diverge,
+so `adjW[i][j]` ends up being the weight of whatever edge OLTP iteration happened to visit at
+position `j`, not the weight of the edge to `adj[i][j]`. This is the same defect class fixed for
+APSP, Bellman-Ford, Steiner tree and the kShortestPaths CSR path by #6301 (see
+`GraphData.weightedAdjacency` / `WeightedAdjacency` in `AbstractAlgoProcedure`); `maxKCut` still
+hand-rolled the parallel array and was never converted.
+
+## Fix
+
+Replace the `graph.adjacency(...)` + `buildWeightedAdj(...)` pair with a single
+`graph.weightedAdjacency(guard, dir, weightProperty, relTypes)` call, exactly as APSP/Bellman-Ford/
+Steiner do. `WeightedAdjacency.neighbors()` and `.weights()` are produced together from one walk of
+the same edges, so `weights[i][j]` is guaranteed to be the weight of the edge to `neighbors[i][j]`
+by construction - no separate reconciliation step exists that can misalign them.
+
+`buildWeightedAdj` and its now-unused `Edge`/`RID` imports are removed.
+
+## Test
+
+`Issue6376AlgoMaxKCutWeightAlignmentTest` (engine module), mirroring
+`Issue6301AlgoSteinerTreeWeightAlignmentTest`'s pattern:
+- builds a 3-vertex weighted triangle (X-Y=1.0, X-Z=50.0, Y-Z=1.0) whose maximum 2-cut is uniquely
+  51.0 regardless of local-search starting point or node-processing order (verified analytically:
+  every distinct initial partition converges to 51.0 in the first local-search pass, so the
+  assertion is robust to whichever physical vertex a CSR provider numbers first);
+- runs `algo.maxKCut(2, {weightProperty:'w'})` once with no view (OLTP path) and once with a
+  `GraphAnalyticalView` built over the edge type + weight property (CSR path), both with a fixed
+  seed;
+- asserts `cutWeight == 51.0` in both cases, and that the CSR run actually went through the
+  provider (`CommandContext.CSR_ACCELERATED_VAR`), so the assertion is not vacuously true from an
+  OLTP fallback.
+
+## Verification
+
+- `Issue6376AlgoMaxKCutWeightAlignmentTest` confirmed RED against the unfixed code before the fix
+  was applied: the CSR/GAV path returned a non-integer `cutWeight` of `110.5` (a symptom of the
+  bug - the cut sums each edge's weight from both endpoints' adjacency rows and halves it, and
+  misaligned rows disagree with each other) instead of the true `115.0`, reproduced across seeds
+  0-9. The OLTP-only path (no view, no misalignment possible) reliably returned `115.0` even
+  pre-fix, confirming the bug is specific to the CSR/GAV path as the issue describes.
+- After the fix: `Issue6376AlgoMaxKCutWeightAlignmentTest` and the existing `AlgoMaxKCutTest`
+  suite are green (`mvn -pl engine -am test -Dtest=Issue6376AlgoMaxKCutWeightAlignmentTest,AlgoMaxKCutTest`).
+- Full `com.arcadedb.query.opencypher.procedures.algo` package test run (492 tests): one
+  unrelated pre-existing failure, `Issue6302AlgoGraphDrivenWorkGuardTest.apspObservesTheDeadlineInsideTheTripleLoop`
+  (a timing-based deadline test on `algo.apsp`/`WorkGuard`, untouched by this change) - reproduced
+  identically on a clean `main` checkout, confirming it is not a regression from this fix.
+- `mvn -pl engine -am compile` is clean.
+
+## Review cycles
+
+(filled in by resolve-issue-with-review Phase 6)

--- a/docs/6376-algo-maxkcut-csr-weight-alignment.md
+++ b/docs/6376-algo-maxkcut-csr-weight-alignment.md
@@ -66,11 +66,25 @@ by construction - no separate reconciliation step exists that can misalign them.
   package for any other hand-rolled `graph.adjacency(...)` + manual weight-fill that might share
   this defect class, since this was the last converted instance of the #6301 pattern. Not applied
   in this PR - noted here as a follow-up sweep, out of scope for a single-issue fix.
+- Cycle 3, head `385af42c2b6f48825177847e845be468c64b9760`: `claude` review approved with "looks
+  correct and ready to merge pending CI". Two items, both explicitly marked non-blocking/stylistic
+  by the reviewer, so no code change applied: (1) `WorkGuard` construction site differs cosmetically
+  from `AlgoSteinerTree`/`AlgoAPSP` (functionally irrelevant); (2) the reviewer independently
+  grepped `algo.*` for the cycle-2 sweep suggestion and found no other instance of the defect class
+  - the other `weightProperty`-consuming procedures (`AlgoKShortestPaths`, `AlgoLongestPathDAG`,
+  `AlgoDijkstra*`, `AlgoLouvain`, `AlgoMST`, `AlgoMinSpanningArborescence`, `AlgoAStar`,
+  `AlgoPageRank`) read weights directly off the same `Edge` as the neighbour, so they were never
+  exposed. Working tree stayed clean this cycle - **clean approval**, loop exited after 3 cycles.
+
+PR: https://github.com/ArcadeData/arcadedb/pull/6483
+
+Final state: **clean-approval** (3 review cycles, `max-cycles=4`).
 
 ## Deferred / follow-up items
 
-- **Sweep `algo.*` for other hand-rolled adjacency/weight builders.** Suggested by the cycle-2
-  review as a precaution now that maxKCut was the last known holdout of the #6301 defect class
-  (APSP, Bellman-Ford, Steiner tree, kShortestPaths were already converted). Not investigated as
-  part of this issue; worth a follow-up issue/PR if the developer wants the guarantee confirmed
-  across the whole package rather than issue-by-issue.
+- **Sweep `algo.*` for other hand-rolled adjacency/weight builders.** Raised as a precaution by the
+  cycle-2 review, then independently checked by the cycle-3 review, which found no other instance
+  of the defect class among the other `weightProperty`-consuming procedures (see cycle 3 above).
+  Low urgency as a result, but no automated test enforces this invariant package-wide, so a future
+  procedure added without going through `graph.weightedAdjacency(...)` could still reintroduce it.
+  Left as an optional follow-up issue for the developer, not filed here.

--- a/docs/6376-algo-maxkcut-csr-weight-alignment.md
+++ b/docs/6376-algo-maxkcut-csr-weight-alignment.md
@@ -55,4 +55,22 @@ by construction - no separate reconciliation step exists that can misalign them.
 
 ## Review cycles
 
-(filled in by resolve-issue-with-review Phase 6)
+- Cycle 1, head `bd19c45025cac79867284dec6c7ddc72f8aac577`: `claude` review flagged that this
+  doc's Test section described a stale 3-vertex triangle fixture that no longer matched the
+  actual test (a 4-node star). Fixed by rewriting the Test section to describe the star fixture
+  actually implemented in `Issue6376AlgoMaxKCutWeightAlignmentTest`.
+- Cycle 2, head `31331ed23875c921dc2aad1e6b7feea36534a282`: `claude` review approved the fix and
+  test coverage with no correctness/security/performance concerns. Two minor items: (1) this
+  placeholder text itself, shipped verbatim - fixed by replacing it with real content; (2) a
+  suggestion (explicitly marked non-blocking by the reviewer) to grep the rest of the `algo.*`
+  package for any other hand-rolled `graph.adjacency(...)` + manual weight-fill that might share
+  this defect class, since this was the last converted instance of the #6301 pattern. Not applied
+  in this PR - noted here as a follow-up sweep, out of scope for a single-issue fix.
+
+## Deferred / follow-up items
+
+- **Sweep `algo.*` for other hand-rolled adjacency/weight builders.** Suggested by the cycle-2
+  review as a precaution now that maxKCut was the last known holdout of the #6301 defect class
+  (APSP, Bellman-Ford, Steiner tree, kShortestPaths were already converted). Not investigated as
+  part of this issue; worth a follow-up issue/PR if the developer wants the guarantee confirmed
+  across the whole package rather than issue-by-issue.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxKCut.java
@@ -19,8 +19,6 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.RID;
-import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.WorkGuard;
@@ -133,13 +131,16 @@ public class AlgoMaxKCut extends AbstractAlgoProcedure {
     // single-node graph a bare Math.min would hand the local search k = 1, i.e. a "cut" into one
     // partition, which is not the degenerate-but-valid answer to what the caller asked for.
     final int k = Math.max(2, Math.min(rawK, n));
-    final int[][] adj = graph.adjacency(dir, relTypes);
-
-    // Build weighted adjacency (null weightProperty → all weights = 1.0)
-    final double[][] adjW = buildWeightedAdj(graph, adj, dir, relTypes, weightProperty);
+    final WorkGuard guard = newWorkGuard(context);
+    // Neighbours and weights come from a single walk of the same edges (null weightProperty →
+    // all weights = 1.0), so weights[i][j] is guaranteed to be the weight of the edge to
+    // neighbors[i][j] - see GraphData.weightedAdjacency and issue #6301, which converted the other
+    // weighted algorithms off the same hand-rolled parallel array this one used to build.
+    final GraphData.WeightedAdjacency weighted = graph.weightedAdjacency(guard, dir, weightProperty, relTypes);
+    final int[][] adj = weighted.neighbors();
+    final double[][] adjW = weighted.weights();
 
     final Random rng = seed >= 0 ? new Random(seed) : new Random();
-    final WorkGuard guard = newWorkGuard(context);
     int[] bestAssign = new int[n];
     double bestCut = -1.0;
 
@@ -202,38 +203,6 @@ public class AlgoMaxKCut extends AbstractAlgoProcedure {
       r.setProperty("cutWeight", finalCut);
       return (Result) r;
     });
-  }
-
-  /** Builds a parallel weight array for each adjacency list entry. */
-  private double[][] buildWeightedAdj(final GraphData graph,
-      final int[][] adj, final Vertex.DIRECTION dir, final String[] relTypes, final String weightProp) {
-    final int n = graph.nodeCount;
-    final double[][] adjW = new double[n][];
-    for (int i = 0; i < n; i++) {
-      adjW[i] = new double[adj[i].length];
-      Arrays.fill(adjW[i], 1.0);
-    }
-    if (weightProp == null)
-      return adjW;
-
-    // Fill weights from edge properties
-    for (int i = 0; i < n; i++) {
-      final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
-          graph.getVertex(i).getEdges(dir, relTypes) :
-          graph.getVertex(i).getEdges(dir);
-      int pos = 0;
-      for (final Edge e : edges) {
-        final RID nbRid = neighborRid(e, graph.getRID(i), dir);
-        if (nbRid == null || graph.indexOf(nbRid) < 0)
-          continue;
-        if (pos < adjW[i].length) {
-          final Object w = e.get(weightProp);
-          adjW[i][pos] = w instanceof Number num ? num.doubleValue() : 1.0;
-          pos++;
-        }
-      }
-    }
-    return adjW;
   }
 
   private static double computeCutWeight(final int n, final int[][] adj, final double[][] adjW,

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6376AlgoMaxKCutWeightAlignmentTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6376AlgoMaxKCutWeightAlignmentTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6376 - {@code algo.maxKCut} paired an edge weight with the neighbour
+ * it was <em>iterated at</em> rather than with the neighbour it belongs to, the same defect class
+ * #6301 fixed for {@code algo.apsp}, {@code algo.bellmanford}, {@code algo.steinerTree} and the
+ * kShortestPaths CSR path.
+ * <p>
+ * {@code buildWeightedAdj} filled a weight array positionally against
+ * {@code graph.adjacency(dir, relTypes)} - CSR order (sorted by dense node id after the Graph
+ * Analytical View's BFS/RCM cache-locality reordering) - by walking
+ * {@code graph.getVertex(i).getEdges(dir, relTypes)}, which is always OLTP (edge-record) order.
+ * When a view exists the two orders diverge - confirmed for the graph below by printing both
+ * orders directly - so {@code adjW[i][j]} ends up being the weight of whatever edge OLTP
+ * iteration happened to visit at position {@code j}, not the weight of the edge to
+ * {@code adj[i][j]}.
+ * <p>
+ * H-A(1.0), H-B(10.0), H-C(100.0) plus one extra A-B(5.0) edge breaks the leaf symmetry a pure
+ * star would have (under which a misassigned weight would just relabel an otherwise-identical
+ * answer): the unique maximum 2-cut of this graph is 115.0, achieved by grouping {H, A} against
+ * {B, C}. Empirically, the unfixed code returns a non-integer 110.5 through a Graph Analytical
+ * View - itself a symptom of the bug: the cut sums each edge's weight from <em>both</em>
+ * endpoints' adjacency rows and halves it, and misaligned rows disagree with each other - while
+ * the OLTP path (no view, no misalignment) reliably returns the true 115.0, both independent of
+ * seed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6376AlgoMaxKCutWeightAlignmentTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6376-maxkcut-weights");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("N");
+    // The weight is a DECLARED property: a Graph Analytical View only materialises an edge property
+    // column for a property the schema knows about, and without the column the view falls back to
+    // the edge records - which would leave the columnar half of the fix untested.
+    database.getSchema().createEdgeType("ROAD").createProperty("w", Type.DOUBLE);
+
+    // Star hub H with three unequal leaf weights, plus one extra A-B edge that makes the leaves
+    // structurally distinguishable (without it, permuting which leaf gets the heaviest edge would
+    // just relabel an equally-valued answer and could never expose a misalignment).
+    database.transaction(() -> {
+      final MutableVertex h = database.newVertex("N").set("name", "H").save();
+      final MutableVertex a = database.newVertex("N").set("name", "A").save();
+      final MutableVertex b = database.newVertex("N").set("name", "B").save();
+      final MutableVertex c = database.newVertex("N").set("name", "C").save();
+      h.newEdge("ROAD", c, true, new Object[] { "w", 100.0 }).save();
+      h.newEdge("ROAD", b, true, new Object[] { "w", 10.0 }).save();
+      h.newEdge("ROAD", a, true, new Object[] { "w", 1.0 }).save();
+      a.newEdge("ROAD", b, true, new Object[] { "w", 5.0 }).save();
+    });
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      if (database.isTransactionActive())
+        database.rollback();
+      database.drop();
+    }
+  }
+
+  @Test
+  void theAnalyticalViewDoesNotChangeTheMaxCut() {
+    for (long seed = 0; seed < 10; seed++) {
+      assertThat(maxKCutWeight(seed))
+          .as("OLTP: the unique maximum 2-cut ({H,A} vs {B,C}) is 115.0, seed " + seed)
+          .isEqualTo(115.0);
+    }
+
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("maxkcut-view")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      for (long seed = 0; seed < 10; seed++) {
+        assertThat(maxKCutWeight(seed))
+            .as("a Graph Analytical View is a transparent accelerator: same graph, same max-cut, seed " + seed)
+            .isEqualTo(115.0);
+      }
+    } finally {
+      view.drop();
+    }
+  }
+
+  @Test
+  void theViewIsActuallyExercised() {
+    // The counterweight to the test above: if the view were silently ignored, both halves of it
+    // would be the OLTP run and it would pin nothing. CSR_ACCELERATED_VAR is what loadGraph() sets
+    // when it resolves a provider, so asserting on it is what makes the comparison meaningful.
+    final GraphAnalyticalView view = GraphAnalyticalView.builder(database)
+        .withName("maxkcut-view-probe")
+        .withVertexTypes("N")
+        .withEdgeTypes("ROAD")
+        .withEdgeProperties("w")
+        .build();
+    try {
+      database.begin();
+      try {
+        final BasicCommandContext context = new BasicCommandContext();
+        context.setDatabase(database);
+        final List<Result> rows = collect(new AlgoMaxKCut().execute(
+            new Object[] { 2, Map.of("weightProperty", "w", "seed", 7L) }, null, context));
+
+        assertThat(context.getVariable(CommandContext.CSR_ACCELERATED_VAR))
+            .as("the view must actually back the call")
+            .isEqualTo(true);
+        assertThat(rows).hasSize(4);
+        assertThat(((Number) rows.getFirst().getProperty("cutWeight")).doubleValue()).isEqualTo(115.0);
+      } finally {
+        database.rollback();
+      }
+    } finally {
+      view.drop();
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /** The {@code cutWeight} of an {@code algo.maxKCut(2, ...)} run over the {@code w} property, for a fixed seed. */
+  private double maxKCutWeight(final long seed) {
+    database.begin();
+    try {
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(database);
+      final List<Result> rows = collect(new AlgoMaxKCut().execute(
+          new Object[] { 2, Map.of("weightProperty", "w", "seed", seed) }, null, context));
+      assertThat(rows).hasSize(4);
+      return ((Number) rows.getFirst().getProperty("cutWeight")).doubleValue();
+    } finally {
+      database.rollback();
+    }
+  }
+
+  private static List<Result> collect(final Stream<Result> rows) {
+    final List<Result> collected = new ArrayList<>();
+    rows.forEach(collected::add);
+    return collected;
+  }
+}


### PR DESCRIPTION
Closes #6376

## Summary

`AlgoMaxKCut.buildWeightedAdj` filled its per-edge weight array positionally against `graph.adjacency(dir, relTypes)` (CSR/GAV order - neighbours sorted by dense node id, and reordered further by the Graph Analytical View's BFS/RCM cache-locality pass) by walking `graph.getVertex(i).getEdges(dir, relTypes)`, which is always OLTP (edge-record) order. Whenever a Graph Analytical View exists over the graph, the two orders can diverge, so `adjW[i][j]` ended up being the weight of whatever edge the OLTP walk happened to visit at position `j`, not the weight of the edge to `adj[i][j]` - silently wrong cut weights and partition assignments, with no crash. This is the same defect class issue #6301 fixed for `algo.apsp`, `algo.bellmanford`, `algo.steinerTree` and the `kShortestPaths` CSR path (all converted to `GraphData.weightedAdjacency`, which builds a neighbour list and its weights from a single walk of the same edges so the two can't be paired wrong); `algo.maxKCut` was never converted and still hand-rolled the parallel array.

The fix replaces the `graph.adjacency(...)` + `buildWeightedAdj(...)` pair with a single `graph.weightedAdjacency(guard, dir, weightProperty, relTypes)` call, matching the other algorithms exactly. The now-unused `buildWeightedAdj` method and its `Edge`/`RID` imports are removed.

## Root cause confirmation

Before writing the fix I built a small diagnostic to print both orderings directly for a Graph-Analytical-View-backed graph and confirmed they genuinely diverge (e.g. node `X`'s CSR-adjacency-row lists `[Z, Y]` while its OLTP edge walk visits `[Y, Z]`) - it isn't merely a theoretical mismatch.

## Test plan

- [x] Added `Issue6376AlgoMaxKCutWeightAlignmentTest` (engine module), mirroring the pattern of `Issue6301AlgoSteinerTreeWeightAlignmentTest`:
  - Builds a 4-node star (`H`-`A`=1.0, `H`-`B`=10.0, `H`-`C`=100.0) plus one extra `A`-`B`=5.0 edge that breaks the pure-star leaf symmetry a plain star would have (without it, a misassigned weight would just relabel an equally-valued answer and could never expose the bug via the aggregate `cutWeight`). The unique maximum 2-cut of this graph is `115.0` ({H,A} vs {B,C}).
  - Runs `algo.maxKCut(2, {weightProperty:'w'})` across 10 seeds with no view (OLTP path) and again with a `GraphAnalyticalView` built over the edge type + weight property (CSR path), asserting `cutWeight == 115.0` in both cases.
  - Asserts the CSR run actually went through the provider (`CommandContext.CSR_ACCELERATED_VAR`), so the comparison isn't vacuously true from an OLTP fallback.
- [x] Verified the test is RED against the pre-fix code: the CSR/view path reliably returned a non-integer `110.5` (a direct symptom of the bug - the cut sums each edge's weight from both endpoints' adjacency rows and halves it, and misaligned rows disagree with each other) across all 20 seeds sampled, while the OLTP path reliably returned the correct `115.0`.
- [x] Verified GREEN after the fix: `mvn -pl engine -am test -Dtest=Issue6376AlgoMaxKCutWeightAlignmentTest,AlgoMaxKCutTest`.
- [x] Ran the full `com.arcadedb.query.opencypher.procedures.algo` package (492 tests): one unrelated pre-existing failure (`Issue6302AlgoGraphDrivenWorkGuardTest.apspObservesTheDeadlineInsideTheTripleLoop`, a timing-based `algo.apsp`/`WorkGuard` deadline test untouched by this change) - reproduced identically on a clean `main` checkout, confirming it predates this PR.
- [x] `mvn -pl engine -am compile` is clean.

Analysis and verification detail: `docs/6376-algo-maxkcut-csr-weight-alignment.md`.