### PR TITLE
feat(#5358): add native variable-length Cypher expansion

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -363,7 +363,7 @@ public class CypherExecutionPlan {
   private boolean canUseOptimizedPhysicalPlan() {
     return physicalPlan != null && physicalPlan.getRootOperator() != null
         && !statement.hasUnwindBeforeMatch() && !statement.hasSubquery()
-        && !statement.hasWithBeforeMatch() && !statement.hasVariableLengthPath()
+        && !statement.hasWithBeforeMatch()
         && !statement.hasWriteBeforeMatch();
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/CartesianProduct.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/CartesianProduct.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.function.BiPredicate;
 
 /**
  * Physical operator that produces a Cartesian product of two independent operators.
@@ -41,11 +42,24 @@ import java.util.NoSuchElementException;
  */
 public class CartesianProduct extends AbstractPhysicalOperator {
   private final PhysicalOperator right;
+  private final BiPredicate<Result, Result> pairFilter;
 
   public CartesianProduct(final PhysicalOperator left, final PhysicalOperator right,
                           final double estimatedCost, final long estimatedCardinality) {
+    this(left, right, estimatedCost, estimatedCardinality, null);
+  }
+
+  /**
+   * @param pairFilter when non-null, tested against every candidate (left, right) pair before it is
+   *                    merged into a row; a pair for which it returns {@code false} is skipped
+   *                    without ever allocating the merged row
+   */
+  public CartesianProduct(final PhysicalOperator left, final PhysicalOperator right,
+                          final double estimatedCost, final long estimatedCardinality,
+                          final BiPredicate<Result, Result> pairFilter) {
     super(left, estimatedCost, estimatedCardinality);
     this.right = right;
+    this.pairFilter = pairFilter;
   }
 
   @Override
@@ -60,13 +74,17 @@ public class CartesianProduct extends AbstractPhysicalOperator {
       private Result currentLeft = null;
       private int rightIndex = 0;
       private boolean finished = false;
+      private boolean initialized = false;
+      private Result pendingRight;
 
       @Override
       public boolean hasNext() {
+        ensureInitialized(context, nRecords);
         if (finished)
           return false;
-        ensureInitialized(context, nRecords);
-        return currentLeft != null && rightIndex < rightResultsCache.size();
+        if (pendingRight != null)
+          return true;
+        return advance();
       }
 
       @Override
@@ -74,9 +92,8 @@ public class CartesianProduct extends AbstractPhysicalOperator {
         if (!hasNext())
           throw new NoSuchElementException();
 
-        guard.check();
-
-        final Result rightResult = rightResultsCache.get(rightIndex);
+        final Result rightResult = pendingRight;
+        pendingRight = null;
 
         // Merge left and right properties into one result
         final ResultInternal merged = new ResultInternal();
@@ -85,22 +102,35 @@ public class CartesianProduct extends AbstractPhysicalOperator {
         for (final String prop : rightResult.getPropertyNames())
           merged.setProperty(prop, rightResult.getProperty(prop));
 
-        rightIndex++;
-        // Advance to next left row if we've exhausted right side
-        if (rightIndex >= rightResultsCache.size()) {
+        return merged;
+      }
+
+      // Scans forward from the current (left, right) position for the next pair the filter accepts,
+      // leaving it in pendingRight without merging it - a rejected pair never allocates a merged row.
+      private boolean advance() {
+        while (currentLeft != null) {
+          while (rightIndex < rightResultsCache.size()) {
+            guard.check();
+            final Result candidate = rightResultsCache.get(rightIndex++);
+            if (pairFilter == null || pairFilter.test(currentLeft, candidate)) {
+              pendingRight = candidate;
+              return true;
+            }
+          }
           if (leftResults.hasNext()) {
             currentLeft = leftResults.next();
             rightIndex = 0;
           } else
-            finished = true;
+            currentLeft = null;
         }
-
-        return merged;
+        finished = true;
+        return false;
       }
 
       private void ensureInitialized(final CommandContext ctx, final int n) {
-        if (leftResults != null)
+        if (initialized)
           return;
+        initialized = true;
 
         // Execute left and right operators
         leftResults = child.execute(ctx, n);
@@ -137,6 +167,8 @@ public class CartesianProduct extends AbstractPhysicalOperator {
     final String indent = getIndent(depth);
     final StringBuilder sb = new StringBuilder();
     sb.append(indent).append("+ CartesianProduct");
+    if (pairFilter != null)
+      sb.append(" [RelationshipUniquenessFilter pushed into join]");
     sb.append(" [cost=").append(String.format(Locale.US, "%.2f", estimatedCost));
     sb.append(", rows=").append(estimatedCardinality);
     sb.append("]\n");

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
@@ -298,18 +298,7 @@ public class ExpandAll extends AbstractPhysicalOperator {
    * check stays free in the common single-hop case.
    */
   private EdgeIdentitySet collectUsedEdgeRids(final Result row) {
-    if (sameClausePrecedingRelVars == null || sameClausePrecedingRelVars.isEmpty())
-      return null;
-    EdgeIdentitySet used = null;
-    for (final String relVar : sameClausePrecedingRelVars) {
-      final Object val = row.getProperty(relVar);
-      if (val instanceof Edge) {
-        if (used == null)
-          used = new EdgeIdentitySet();
-        used.add(((Edge) val).getIdentity());
-      }
-    }
-    return used;
+    return RelationshipBindings.collectEdgeIdentities(row, sameClausePrecedingRelVars);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandInto.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.executor.operators;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.EdgeIdentitySet;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.VertexInternal;
 import com.arcadedb.query.opencypher.ast.Direction;
@@ -30,7 +31,6 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.executor.WorkGuard;
-import com.arcadedb.utility.RidHashSet;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -110,7 +110,7 @@ public class ExpandInto extends AbstractPhysicalOperator {
       private       Iterator<Edge> edgeIterator             = null;
       // Edge RIDs already bound by same-clause preceding rel vars in the current input row.
       // Computed once per input row, queried per edge.
-      private       RidHashSet     currentInputUsedEdgeRids = null;
+      private       EdgeIdentitySet currentInputUsedEdgeRids = null;
       private final List<Result>   buffer                   = new ArrayList<>();
       private       int            bufferIndex              = 0;
       private       boolean        finished                 = false;
@@ -265,19 +265,8 @@ public class ExpandInto extends AbstractPhysicalOperator {
    * the input row. Returns null when no relevant binding is present, so the per-edge check stays free
    * in the common single-hop case.
    */
-  private RidHashSet collectUsedEdgeRids(final Result row) {
-    if (sameClausePrecedingRelVars == null || sameClausePrecedingRelVars.isEmpty())
-      return null;
-    RidHashSet used = null;
-    for (final String relVar : sameClausePrecedingRelVars) {
-      final Object val = row.getProperty(relVar);
-      if (val instanceof Edge edge) {
-        if (used == null)
-          used = new RidHashSet();
-        used.add(edge.getIdentity());
-      }
-    }
-    return used;
+  private EdgeIdentitySet collectUsedEdgeRids(final Result row) {
+    return RelationshipBindings.collectEdgeIdentities(row, sameClausePrecedingRelVars);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/RelationshipBindings.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/RelationshipBindings.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.operators;
+
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.EdgeIdentitySet;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
+import com.arcadedb.query.sql.executor.Result;
+
+import java.util.Set;
+
+/** Shared extraction of edge identities from scalar, list, and path relationship bindings. */
+final class RelationshipBindings {
+  private RelationshipBindings() {
+  }
+
+  static EdgeIdentitySet collectEdgeIdentities(final Result row, final Set<String> variables) {
+    if (variables == null || variables.isEmpty())
+      return null;
+
+    EdgeIdentitySet identities = null;
+    for (final String variable : variables)
+      identities = addEdges(identities, row.getProperty(variable));
+    return identities;
+  }
+
+  static boolean overlaps(final EdgeIdentitySet used, final TraversalPath path) {
+    if (used == null || path == null)
+      return false;
+    for (final Edge edge : path.getEdges())
+      if (used.contains(edge.getIdentity()))
+        return true;
+    return false;
+  }
+
+  /**
+   * Adds one relationship binding to a clause-level set and reports overlap with a different
+   * binding. Repeated edges inside the same binding are collapsed first so WALK mode is not
+   * mistaken for reuse between separate MATCH pattern relationships.
+   */
+  static boolean addBindingAndDetectOverlap(final EdgeIdentitySet used, final Object binding) {
+    final EdgeIdentitySet bindingEdges = new EdgeIdentitySet();
+    boolean overlap = false;
+    if (binding instanceof Edge edge)
+      return addEdgeAndDetectOverlap(used, bindingEdges, edge);
+    if (binding instanceof TraversalPath path)
+      for (final Edge edge : path.getEdges())
+        overlap |= addEdgeAndDetectOverlap(used, bindingEdges, edge);
+    if (binding instanceof Iterable<?> iterable)
+      for (final Object item : iterable)
+        if (item instanceof Edge edge)
+          overlap |= addEdgeAndDetectOverlap(used, bindingEdges, edge);
+    return overlap;
+  }
+
+  private static EdgeIdentitySet addEdges(EdgeIdentitySet target, final Object binding) {
+    if (binding instanceof Edge edge) {
+      if (target == null)
+        target = new EdgeIdentitySet();
+      target.add(edge.getIdentity());
+    } else if (binding instanceof TraversalPath path) {
+      for (final Edge edge : path.getEdges()) {
+        if (target == null)
+          target = new EdgeIdentitySet();
+        target.add(edge.getIdentity());
+      }
+    } else if (binding instanceof Iterable<?> iterable) {
+      for (final Object item : iterable)
+        if (item instanceof Edge edge) {
+          if (target == null)
+            target = new EdgeIdentitySet();
+          target.add(edge.getIdentity());
+        }
+    }
+    return target;
+  }
+
+  private static boolean addEdgeAndDetectOverlap(final EdgeIdentitySet used,
+      final EdgeIdentitySet bindingEdges, final Edge edge) {
+    if (!bindingEdges.add(edge.getIdentity()))
+      return false;
+    final boolean overlap = used.contains(edge.getIdentity());
+    used.add(edge.getIdentity());
+    return overlap;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/RelationshipUniquenessFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/RelationshipUniquenessFilter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.operators;
+
+import com.arcadedb.graph.EdgeIdentitySet;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Rejects a row when separate relationship bindings from the same MATCH clause share an edge.
+ * Expansion operators enforce the rule while walking one connected component; this filter closes
+ * the only remaining gap, after independently planned components are joined by Cartesian product.
+ */
+public class RelationshipUniquenessFilter extends AbstractPhysicalOperator {
+  private final Map<Integer, Set<String>> relationshipVariablesByClause;
+
+  public RelationshipUniquenessFilter(final PhysicalOperator child,
+      final Map<Integer, Set<String>> relationshipVariablesByClause,
+      final double estimatedCost, final long estimatedCardinality) {
+    super(child, estimatedCost, estimatedCardinality);
+    this.relationshipVariablesByClause = new LinkedHashMap<>();
+    relationshipVariablesByClause.forEach((clause, variables) ->
+        this.relationshipVariablesByClause.put(clause, new LinkedHashSet<>(variables)));
+  }
+
+  @Override
+  public ResultSet execute(final CommandContext context, final int nRecords) {
+    final ResultSet input = child.execute(context, nRecords);
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
+    return new ResultSet() {
+      private Result next;
+      private boolean finished;
+
+      @Override
+      public boolean hasNext() {
+        if (next != null)
+          return true;
+        if (finished)
+          return false;
+
+        while (input.hasNext()) {
+          guard.check();
+          final Result candidate = input.next();
+          if (!hasConflict(candidate)) {
+            next = candidate;
+            return true;
+          }
+        }
+        finished = true;
+        return false;
+      }
+
+      @Override
+      public Result next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        final Result result = next;
+        next = null;
+        return result;
+      }
+
+      @Override
+      public void close() {
+        input.close();
+      }
+    };
+  }
+
+  private boolean hasConflict(final Result row) {
+    for (final Set<String> variables : relationshipVariablesByClause.values()) {
+      if (variables.size() < 2)
+        continue;
+      final EdgeIdentitySet used = new EdgeIdentitySet();
+      for (final String variable : variables)
+        if (RelationshipBindings.addBindingAndDetectOverlap(used, row.getProperty(variable)))
+          return true;
+    }
+    return false;
+  }
+
+  @Override
+  public String getOperatorType() {
+    return "RelationshipUniquenessFilter";
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/RelationshipUniquenessFilter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/RelationshipUniquenessFilter.java
@@ -19,92 +19,47 @@
 package com.arcadedb.query.opencypher.executor.operators;
 
 import com.arcadedb.graph.EdgeIdentitySet;
-import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
-import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.query.sql.executor.WorkGuard;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 /**
- * Rejects a row when separate relationship bindings from the same MATCH clause share an edge.
- * Expansion operators enforce the rule while walking one connected component; this filter closes
- * the only remaining gap, after independently planned components are joined by Cartesian product.
+ * Builds the relationship-uniqueness check for two independently planned components of the same
+ * MATCH clause, joined by {@link CartesianProduct}. Expansion operators already enforce the rule
+ * while walking one connected component; this closes the only remaining gap, between components
+ * joined by a Cartesian product, as a predicate the join applies to each candidate pair before
+ * merging it into a row - so a pair that would bind the same edge to two different relationship
+ * variables is rejected before a row is ever allocated for it, and never reaches a further join.
  */
-public class RelationshipUniquenessFilter extends AbstractPhysicalOperator {
-  private final Map<Integer, Set<String>> relationshipVariablesByClause;
-
-  public RelationshipUniquenessFilter(final PhysicalOperator child,
-      final Map<Integer, Set<String>> relationshipVariablesByClause,
-      final double estimatedCost, final long estimatedCardinality) {
-    super(child, estimatedCost, estimatedCardinality);
-    this.relationshipVariablesByClause = new LinkedHashMap<>();
-    relationshipVariablesByClause.forEach((clause, variables) ->
-        this.relationshipVariablesByClause.put(clause, new LinkedHashSet<>(variables)));
+public final class RelationshipUniquenessFilter {
+  private RelationshipUniquenessFilter() {
   }
 
-  @Override
-  public ResultSet execute(final CommandContext context, final int nRecords) {
-    final ResultSet input = child.execute(context, nRecords);
-    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
-
-    return new ResultSet() {
-      private Result next;
-      private boolean finished;
-
-      @Override
-      public boolean hasNext() {
-        if (next != null)
-          return true;
-        if (finished)
-          return false;
-
-        while (input.hasNext()) {
-          guard.check();
-          final Result candidate = input.next();
-          if (!hasConflict(candidate)) {
-            next = candidate;
-            return true;
-          }
-        }
-        finished = true;
-        return false;
-      }
-
-      @Override
-      public Result next() {
-        if (!hasNext())
-          throw new NoSuchElementException();
-        final Result result = next;
-        next = null;
-        return result;
-      }
-
-      @Override
-      public void close() {
-        input.close();
-      }
-    };
+  public static BiPredicate<Result, Result> pushdownPredicate(final Map<Integer, Set<String>> relationshipVariablesByClause) {
+    return (left, right) -> !conflicts(relationshipVariablesByClause, left, right);
   }
 
-  private boolean hasConflict(final Result row) {
+  private static boolean conflicts(final Map<Integer, Set<String>> relationshipVariablesByClause,
+      final Result left, final Result right) {
     for (final Set<String> variables : relationshipVariablesByClause.values()) {
       if (variables.size() < 2)
         continue;
-      final EdgeIdentitySet used = new EdgeIdentitySet();
-      for (final String variable : variables)
-        if (RelationshipBindings.addBindingAndDetectOverlap(used, row.getProperty(variable)))
+      EdgeIdentitySet used = null;
+      for (final String variable : variables) {
+        // A variable owned by a component not yet joined is bound on neither side and is skipped:
+        // it cannot conflict with anything until the join that introduces it.
+        final Object binding = left.hasProperty(variable) ? left.getProperty(variable)
+            : right.hasProperty(variable) ? right.getProperty(variable) : null;
+        if (binding == null)
+          continue;
+        if (used == null)
+          used = new EdgeIdentitySet();
+        if (RelationshipBindings.addBindingAndDetectOverlap(used, binding))
           return true;
+      }
     }
     return false;
-  }
-
-  @Override
-  public String getOperatorType() {
-    return "RelationshipUniquenessFilter";
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/VarLengthExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/VarLengthExpand.java
@@ -48,6 +48,13 @@ import java.util.Set;
  * implementation while allowing the cost-based planner to choose the anchor and surrounding joins.
  */
 public class VarLengthExpand extends AbstractPhysicalOperator {
+  public record ExpansionVariables(String source, String relationship, String target, String path) {
+  }
+
+  public record TraversalSpec(RelationshipPattern pattern, Direction direction, boolean reverseResultPath,
+      PathMode pathMode) {
+  }
+
   private final String sourceVariable;
   private final String relationshipVariable;
   private final String targetVariable;
@@ -60,22 +67,24 @@ public class VarLengthExpand extends AbstractPhysicalOperator {
   private Set<String> sameClausePrecedingRelVars;
   private String edgeTrackingVar;
 
-  public VarLengthExpand(final PhysicalOperator child, final String sourceVariable,
-      final String relationshipVariable, final String targetVariable, final String pathVariable,
-      final RelationshipPattern pattern, final Direction direction, final boolean reverseResultPath,
-      final PathMode pathMode, final double estimatedCost, final long estimatedCardinality) {
+  public VarLengthExpand(final PhysicalOperator child, final ExpansionVariables variables,
+      final TraversalSpec traversal, final double estimatedCost, final long estimatedCardinality) {
     super(child, estimatedCost, estimatedCardinality);
+    final RelationshipPattern pattern = traversal != null ? traversal.pattern() : null;
     if (pattern == null || !pattern.isVariableLength())
       throw new IllegalArgumentException("VarLengthExpand requires a variable-length relationship pattern");
 
-    this.sourceVariable = sourceVariable;
-    this.relationshipVariable = relationshipVariable;
-    this.targetVariable = targetVariable;
-    this.pathVariable = pathVariable;
+    if (variables == null)
+      throw new IllegalArgumentException("VarLengthExpand requires variable bindings");
+
+    this.sourceVariable = variables.source();
+    this.relationshipVariable = variables.relationship();
+    this.targetVariable = variables.target();
+    this.pathVariable = variables.path();
     this.pattern = pattern;
-    this.direction = direction;
-    this.reverseResultPath = reverseResultPath;
-    this.pathMode = pathMode;
+    this.direction = traversal.direction();
+    this.reverseResultPath = traversal.reverseResultPath();
+    this.pathMode = traversal.pathMode();
   }
 
   public void setSameClausePrecedingRelVars(final Set<String> sameClausePrecedingRelVars) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/VarLengthExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/VarLengthExpand.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.operators;
+
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.EdgeIdentitySet;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.opencypher.InlineProperties;
+import com.arcadedb.query.opencypher.ast.Direction;
+import com.arcadedb.query.opencypher.ast.PathMode;
+import com.arcadedb.query.opencypher.ast.RelationshipPattern;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
+import com.arcadedb.query.opencypher.traversal.VariableLengthPathTraverser;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.executor.WorkGuard;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Lazy physical operator for an ordinary variable-length MATCH relationship. It deliberately
+ * delegates path enumeration to the same depth-first traverser as the traditional execution step,
+ * keeping path modes, inline edge predicates, zero-hop behavior, and edge identity semantics in one
+ * implementation while allowing the cost-based planner to choose the anchor and surrounding joins.
+ */
+public class VarLengthExpand extends AbstractPhysicalOperator {
+  private final String sourceVariable;
+  private final String relationshipVariable;
+  private final String targetVariable;
+  private final String pathVariable;
+  private final RelationshipPattern pattern;
+  private final Direction direction;
+  private final boolean reverseResultPath;
+  private final PathMode pathMode;
+  private String targetLabel;
+  private Set<String> sameClausePrecedingRelVars;
+  private String edgeTrackingVar;
+
+  public VarLengthExpand(final PhysicalOperator child, final String sourceVariable,
+      final String relationshipVariable, final String targetVariable, final String pathVariable,
+      final RelationshipPattern pattern, final Direction direction, final boolean reverseResultPath,
+      final PathMode pathMode, final double estimatedCost, final long estimatedCardinality) {
+    super(child, estimatedCost, estimatedCardinality);
+    if (pattern == null || !pattern.isVariableLength())
+      throw new IllegalArgumentException("VarLengthExpand requires a variable-length relationship pattern");
+
+    this.sourceVariable = sourceVariable;
+    this.relationshipVariable = relationshipVariable;
+    this.targetVariable = targetVariable;
+    this.pathVariable = pathVariable;
+    this.pattern = pattern;
+    this.direction = direction;
+    this.reverseResultPath = reverseResultPath;
+    this.pathMode = pathMode;
+  }
+
+  public void setSameClausePrecedingRelVars(final Set<String> sameClausePrecedingRelVars) {
+    this.sameClausePrecedingRelVars = sameClausePrecedingRelVars;
+  }
+
+  public void setEdgeTrackingVar(final String edgeTrackingVar) {
+    this.edgeTrackingVar = edgeTrackingVar;
+  }
+
+  public void setTargetLabel(final String targetLabel) {
+    this.targetLabel = targetLabel;
+  }
+
+  public String getTargetVariable() {
+    return targetVariable;
+  }
+
+  @Override
+  public ResultSet execute(final CommandContext context, final int nRecords) {
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+    final ResultSet inputResults = child.execute(context, nRecords);
+    final int batchSize = nRecords > 0 ? nRecords : 100;
+
+    return new ResultSet() {
+      private Result currentInput;
+      private Vertex boundTarget;
+      private Iterator<TraversalPath> currentPaths;
+      private EdgeIdentitySet usedEdges;
+      private final List<Result> buffer = new ArrayList<>();
+      private int bufferIndex;
+      private boolean finished;
+
+      @Override
+      public boolean hasNext() {
+        if (bufferIndex < buffer.size())
+          return true;
+        if (finished)
+          return false;
+        fetchMore();
+        return bufferIndex < buffer.size();
+      }
+
+      @Override
+      public Result next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return buffer.get(bufferIndex++);
+      }
+
+      private void fetchMore() {
+        buffer.clear();
+        bufferIndex = 0;
+
+        while (buffer.size() < batchSize) {
+          guard.check();
+          if (currentPaths != null && currentPaths.hasNext()) {
+            final TraversalPath traversedPath = currentPaths.next();
+            final Vertex traversedTarget = traversedPath.getEndVertex();
+            if (targetLabel != null && !traversedTarget.getType().instanceOf(targetLabel))
+              continue;
+            if (boundTarget != null && !traversedTarget.getIdentity().equals(boundTarget.getIdentity()))
+              continue;
+            if (RelationshipBindings.overlaps(usedEdges, traversedPath))
+              continue;
+
+            final TraversalPath resultPath = reverseResultPath ? traversedPath.reversed() : traversedPath;
+            final ResultInternal result = VarLengthExpand.copy(currentInput);
+            if (pathVariable != null && !pathVariable.isEmpty())
+              result.setProperty(pathVariable, extendPath(currentInput.getProperty(pathVariable), resultPath));
+
+            final List<Edge> edges = new ArrayList<>(resultPath.getEdges());
+            if (relationshipVariable != null && !relationshipVariable.isEmpty())
+              result.setProperty(relationshipVariable, edges);
+            else if (edgeTrackingVar != null)
+              result.setProperty(edgeTrackingVar, edges);
+            result.setProperty(targetVariable, traversedTarget);
+            buffer.add(result);
+            continue;
+          }
+
+          if (!inputResults.hasNext()) {
+            finished = true;
+            break;
+          }
+
+          currentInput = inputResults.next();
+          final Object source = currentInput.getProperty(sourceVariable);
+          final Object target = currentInput.getProperty(targetVariable);
+          boundTarget = target instanceof Vertex vertex ? vertex : null;
+          usedEdges = RelationshipBindings.collectEdgeIdentities(currentInput, sameClausePrecedingRelVars);
+          currentPaths = source instanceof Vertex vertex ? createTraverser(currentInput, context).traversePaths(vertex) : null;
+        }
+      }
+
+      @Override
+      public void close() {
+        inputResults.close();
+      }
+    };
+  }
+
+  private VariableLengthPathTraverser createTraverser(final Result row, final CommandContext context) {
+    final String[] types = pattern.hasTypes() ? pattern.getTypes().toArray(new String[0]) : null;
+    final Map<String, Object> properties = InlineProperties.resolveAll(pattern.getProperties(), row, context);
+    final VariableLengthPathTraverser traverser = new VariableLengthPathTraverser(
+        direction, types, properties, pattern.getEffectiveMinHops(), pattern.getEffectiveMaxHops(),
+        true, false, pathMode != null ? pathMode : PathMode.TRAIL);
+    traverser.withEdgePredicate(pattern.buildInlineWherePredicate(row, context));
+    return traverser;
+  }
+
+  private static ResultInternal copy(final Result input) {
+    final ResultInternal result = new ResultInternal();
+    for (final String property : input.getPropertyNames())
+      result.setProperty(property, input.getProperty(property));
+    return result;
+  }
+
+  private static TraversalPath extendPath(final Object existing, final TraversalPath extension) {
+    if (!(existing instanceof TraversalPath path))
+      return extension;
+    if (sameVertex(path.getEndVertex(), extension.getStartVertex()))
+      return new TraversalPath(path, extension);
+    if (sameVertex(extension.getEndVertex(), path.getStartVertex()))
+      return new TraversalPath(extension, path);
+    return extension;
+  }
+
+  private static boolean sameVertex(final Vertex left, final Vertex right) {
+    return left != null && right != null && left.getIdentity().equals(right.getIdentity());
+  }
+
+  @Override
+  public String getOperatorType() {
+    return "VarLengthExpand";
+  }
+
+  @Override
+  public String explain(final int depth) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(getIndent(depth)).append("+ VarLengthExpand(").append(sourceVariable).append(")");
+    sb.append(direction == Direction.IN ? "<-[" : "-[");
+    if (relationshipVariable != null)
+      sb.append(relationshipVariable);
+    if (pattern.hasTypes())
+      sb.append(":").append(String.join("|", pattern.getTypes()));
+    sb.append("*");
+    if (pattern.getMinHops() != null)
+      sb.append(pattern.getMinHops());
+    sb.append("..");
+    if (pattern.getMaxHops() != null)
+      sb.append(pattern.getMaxHops());
+    sb.append(direction == Direction.OUT ? "]->" : "]-");
+    sb.append("(").append(targetVariable);
+    if (targetLabel != null)
+      sb.append(":").append(targetLabel);
+    sb.append(") [DFS, cost=").append(String.format(Locale.US, "%.2f", estimatedCost));
+    sb.append(", rows=").append(estimatedCardinality).append("]\n");
+    if (child != null)
+      sb.append(child.explain(depth + 1));
+    return sb.toString();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -723,10 +723,11 @@ public class CypherOptimizer {
         relationship.getEffectiveMinHops(), relationship.getEffectiveMaxHops());
     final double totalCost = CostModel.saturatingAdd(input.getEstimatedCost(), expansionCost);
 
-    final VarLengthExpand expand = new VarLengthExpand(input, sourceVariable,
-        relationship.getVariable(), targetVariable,
-        relationship.getPathVariable(), relationship.getPattern(), direction, reverseResultPath,
-        relationship.getPathMode(), totalCost, outputCardinality);
+    final VarLengthExpand.ExpansionVariables variables = new VarLengthExpand.ExpansionVariables(sourceVariable,
+        relationship.getVariable(), targetVariable, relationship.getPathVariable());
+    final VarLengthExpand.TraversalSpec traversal = new VarLengthExpand.TraversalSpec(relationship.getPattern(),
+        direction, reverseResultPath, relationship.getPathMode());
+    final VarLengthExpand expand = new VarLengthExpand(input, variables, traversal, totalCost, outputCardinality);
     expand.setSameClausePrecedingRelVars(sameClausePrecedingRelVars);
     return expand;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -214,22 +214,21 @@ public class CypherOptimizer {
         if (rootOperator == null)
           rootOperator = expansion.root();
         else {
-          final double cost = CostModel.saturatingAdd(rootOperator.getEstimatedCost(),
+          final double joinCost = CostModel.saturatingAdd(rootOperator.getEstimatedCost(),
               expansion.root().getEstimatedCost());
           final long cardinality = CostModel.saturatingCardinalityProduct(
               Math.max(1, rootOperator.getEstimatedCardinality()),
               Math.max(1, expansion.root().getEstimatedCardinality()));
-          rootOperator = new CartesianProduct(rootOperator, expansion.root(), cost, cardinality);
+          // Expansion operators see relationships bound earlier in their own connected chain. A row
+          // joining two components still has to obey the same MATCH-wide uniqueness rule, so the check
+          // is pushed into the join itself: a conflicting pair is rejected before it is merged into a
+          // row at all, instead of being merged and then discarded by a filter further downstream -
+          // which also keeps a conflicting pair from ever reaching a subsequent component's join.
+          final double cost = CostModel.saturatingAdd(joinCost,
+              CostModel.saturatingMultiply(cardinality, costModel.FILTER_COST_PER_ROW));
+          rootOperator = new CartesianProduct(rootOperator, expansion.root(), cost, cardinality,
+              RelationshipUniquenessFilter.pushdownPredicate(relVarsPerClause));
         }
-      }
-
-      // Expansion operators see relationships bound earlier in their own connected chain. After a
-      // Cartesian product, enforce the same MATCH-wide rule across component boundaries as well.
-      if (components.size() > 1) {
-        final double uniquenessCost = CostModel.saturatingAdd(rootOperator.getEstimatedCost(),
-            CostModel.saturatingMultiply(rootOperator.getEstimatedCardinality(), costModel.FILTER_COST_PER_ROW));
-        rootOperator = new RelationshipUniquenessFilter(rootOperator, relVarsPerClause,
-            uniquenessCost, rootOperator.getEstimatedCardinality());
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -40,6 +40,8 @@ import com.arcadedb.query.opencypher.executor.operators.GAVExpandInto;
 import com.arcadedb.query.opencypher.executor.operators.GAVFusedChainOperator;
 import com.arcadedb.query.opencypher.executor.operators.NodeByLabelScan;
 import com.arcadedb.query.opencypher.executor.operators.PhysicalOperator;
+import com.arcadedb.query.opencypher.executor.operators.RelationshipUniquenessFilter;
+import com.arcadedb.query.opencypher.executor.operators.VarLengthExpand;
 import com.arcadedb.query.opencypher.optimizer.plan.AnchorSelection;
 import com.arcadedb.query.opencypher.optimizer.plan.LogicalNode;
 import com.arcadedb.query.opencypher.optimizer.plan.LogicalPlan;
@@ -61,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -151,9 +154,9 @@ public class CypherOptimizer {
     final List<String> typeNames = extractTypeNames(logicalPlan);
     statisticsProvider.collectStatistics(typeNames);
 
-    // Handle multiple independent MATCH clauses (e.g., MATCH (a:T) MATCH (b:T) CREATE ...)
-    // Each MATCH has a single node pattern — create operators for each and chain with CartesianProduct
-    if (statement.getMatchClauses().size() > 1 && logicalPlan.getRelationships().isEmpty()) {
+    // Handle independent node-only patterns whether they are written as separate MATCH clauses or
+    // comma-separated parts of one MATCH (e.g. MATCH (a:T), (b:T) CREATE ...).
+    if (logicalPlan.getRelationships().isEmpty() && logicalPlan.getNodes().size() > 1) {
       return optimizeMultiMatchIndependent(logicalPlan);
     }
 
@@ -170,27 +173,64 @@ public class CypherOptimizer {
         if (!logicalPlan.isNodeConnected(node.getVariable()))
           isolatedNodes.add(node);
 
-    final Set<String> isolatedVariables = new HashSet<>();
-    for (final LogicalNode node : isolatedNodes)
-      isolatedVariables.add(node.getVariable());
+    AnchorSelection anchor;
+    PhysicalOperator anchorOperator;
+    PhysicalOperator rootOperator;
+    final List<RelationshipComponent> components = relationshipComponents(logicalPlan.getRelationships());
 
-    // 3. Select anchor node (best starting point) among the relationship-connected nodes only
-    AnchorSelection anchor = anchorSelector.selectAnchor(logicalPlan, isolatedVariables);
+    if (components.isEmpty()) {
+      anchor = anchorSelector.selectAnchor(logicalPlan);
+      anchorOperator = createAnchorOperator(anchor);
+      rootOperator = anchorOperator;
+    } else {
+      anchor = null;
+      anchorOperator = null;
+      rootOperator = null;
+      final Set<LogicalRelationship> needsEdgeTracking =
+          computeNeedsEdgeTracking(logicalPlan.getRelationships());
+      final int[] syntheticEdgeVarCounter = { 0 };
+      final Map<Integer, Set<String>> relVarsPerClause = new HashMap<>();
 
-    // 3a. Validate anchor against UNIDIRECTIONAL edge constraints.
-    // UNIDIRECTIONAL edges only store outgoing links on the source vertex,
-    // so reverse traversal (incoming from target) finds nothing. If the selected
-    // anchor would force reverse traversal of a UNIDIRECTIONAL edge, re-select
-    // the source side as anchor instead.
-    anchor = validateAnchorForUnidirectionalEdges(anchor, logicalPlan);
+      // A disconnected relationship component gets its own selective anchor and expansion chain.
+      // The components are combined only after each chain has applied its local constraints.
+      for (final RelationshipComponent component : components) {
+        final Set<String> excludedVariables = new HashSet<>(logicalPlan.getPatternNodes().keySet());
+        excludedVariables.removeAll(component.variables());
 
-    // 4. Create anchor operator (index seek or scan)
-    final PhysicalOperator anchorOperator = createAnchorOperator(anchor);
+        AnchorSelection componentAnchor = anchorSelector.selectAnchor(logicalPlan, excludedVariables);
+        componentAnchor = validateAnchorForUnidirectionalEdges(componentAnchor, logicalPlan,
+            component.relationships(), component.variables());
+        final PhysicalOperator componentAnchorOperator = createAnchorOperator(componentAnchor);
+        final ExpansionPlan expansion = buildExpansionChain(logicalPlan, component.relationships(),
+            componentAnchor, componentAnchorOperator, needsEdgeTracking, syntheticEdgeVarCounter);
 
-    // 5. Build expansion chain (ordered by cardinality)
-    PhysicalOperator rootOperator = anchorOperator;
-    if (!logicalPlan.getRelationships().isEmpty()) {
-      rootOperator = buildExpansionChain(logicalPlan, anchor, anchorOperator);
+        if (anchor == null) {
+          anchor = componentAnchor;
+          anchorOperator = componentAnchorOperator;
+        }
+        expansion.relationshipVariablesByClause().forEach((clause, variables) ->
+            relVarsPerClause.computeIfAbsent(clause, ignored -> new LinkedHashSet<>()).addAll(variables));
+
+        if (rootOperator == null)
+          rootOperator = expansion.root();
+        else {
+          final double cost = CostModel.saturatingAdd(rootOperator.getEstimatedCost(),
+              expansion.root().getEstimatedCost());
+          final long cardinality = CostModel.saturatingCardinalityProduct(
+              Math.max(1, rootOperator.getEstimatedCardinality()),
+              Math.max(1, expansion.root().getEstimatedCardinality()));
+          rootOperator = new CartesianProduct(rootOperator, expansion.root(), cost, cardinality);
+        }
+      }
+
+      // Expansion operators see relationships bound earlier in their own connected chain. After a
+      // Cartesian product, enforce the same MATCH-wide rule across component boundaries as well.
+      if (components.size() > 1) {
+        final double uniquenessCost = CostModel.saturatingAdd(rootOperator.getEstimatedCost(),
+            CostModel.saturatingMultiply(rootOperator.getEstimatedCardinality(), costModel.FILTER_COST_PER_ROW));
+        rootOperator = new RelationshipUniquenessFilter(rootOperator, relVarsPerClause,
+            uniquenessCost, rootOperator.getEstimatedCardinality());
+      }
     }
 
     // 5a. Join in any disconnected single-node MATCH clause pattern via CartesianProduct (#5810).
@@ -205,9 +245,10 @@ public class CypherOptimizer {
     // and applied automatically when both endpoints are bound
 
     // 7. Push down filters
-    if (!logicalPlan.getWhereFilters().isEmpty()) {
-      rootOperator = applyFilterPushdown(logicalPlan, rootOperator, anchor.getVariable(), anchorOperator);
-    }
+    if (!logicalPlan.getWhereFilters().isEmpty())
+      rootOperator = components.size() <= 1 ?
+          applyFilterPushdown(logicalPlan, rootOperator, anchor.getVariable(), anchorOperator) :
+          applyFilterPushdown(logicalPlan, rootOperator);
 
     // 8. Fuse consecutive GAVExpandAll operators into a single GAVFusedChainOperator
     // This eliminates ALL intermediate ResultInternal/HashMap/Vertex allocations
@@ -233,8 +274,6 @@ public class CypherOptimizer {
   private PhysicalPlan optimizeMultiMatchIndependent(final LogicalPlan logicalPlan) {
     PhysicalOperator rootOperator = null;
     AnchorSelection firstAnchor = null;
-    double totalCost = 0;
-    long totalCardinality = 1;
 
     for (final LogicalNode node : logicalPlan.getNodes().values()) {
       // Create a temporary single-node plan to use the anchor selector
@@ -248,13 +287,13 @@ public class CypherOptimizer {
         rootOperator = nodeOperator;
       } else {
         // Chain with CartesianProduct
-        totalCardinality *= anchor.getEstimatedCardinality();
-        totalCost += anchor.getEstimatedCost();
-        rootOperator = new CartesianProduct(rootOperator, nodeOperator, totalCost, totalCardinality);
+        final long cardinality = CostModel.saturatingCardinalityProduct(
+            Math.max(1, rootOperator.getEstimatedCardinality()),
+            Math.max(1, nodeOperator.getEstimatedCardinality()));
+        final double cost = CostModel.saturatingAdd(rootOperator.getEstimatedCost(),
+            nodeOperator.getEstimatedCost());
+        rootOperator = new CartesianProduct(rootOperator, nodeOperator, cost, cardinality);
       }
-
-      totalCost += anchor.getEstimatedCost();
-      totalCardinality = Math.max(1, anchor.getEstimatedCardinality());
     }
 
     // Apply filters
@@ -282,8 +321,11 @@ public class CypherOptimizer {
       final AnchorSelection nodeAnchor = anchorSelector.evaluateNodeDirect(node, logicalPlan);
       final PhysicalOperator nodeOperator = createAnchorOperator(nodeAnchor);
 
-      final long cardinality = Math.max(1, rootOperator.getEstimatedCardinality()) * Math.max(1, nodeAnchor.getEstimatedCardinality());
-      final double cost = rootOperator.getEstimatedCost() + nodeAnchor.getEstimatedCost();
+      final long cardinality = CostModel.saturatingCardinalityProduct(
+          Math.max(1, rootOperator.getEstimatedCardinality()),
+          Math.max(1, nodeAnchor.getEstimatedCardinality()));
+      final double cost = CostModel.saturatingAdd(rootOperator.getEstimatedCost(),
+          nodeAnchor.getEstimatedCost());
       rootOperator = new CartesianProduct(rootOperator, nodeOperator, cost, cardinality);
     }
     return rootOperator;
@@ -304,31 +346,76 @@ public class CypherOptimizer {
 
     final Set<LogicalRelationship> needs = new HashSet<>();
     for (final List<LogicalRelationship> clauseRels : byClause.values()) {
-      if (clauseRels.size() <= 1)
-        continue;
-
-      boolean hasUntyped = false;
-      for (final LogicalRelationship rel : clauseRels)
-        if (rel.getTypes().isEmpty()) {
-          hasUntyped = true;
-          break;
-        }
-      if (hasUntyped) {
-        // Untyped hops match any edge type, so every hop in the clause may collide.
-        needs.addAll(clauseRels);
-        continue;
-      }
-
-      final Map<String, List<LogicalRelationship>> byType = new HashMap<>();
-      for (final LogicalRelationship rel : clauseRels)
-        for (final String type : rel.getTypes())
-          byType.computeIfAbsent(type, k -> new ArrayList<>()).add(rel);
-
-      for (final List<LogicalRelationship> sharingType : byType.values())
-        if (sharingType.size() > 1)
-          needs.addAll(sharingType);
+      for (int left = 0; left < clauseRels.size(); left++)
+        for (int right = left + 1; right < clauseRels.size(); right++)
+          if (relationshipTypesMayOverlap(clauseRels.get(left), clauseRels.get(right))) {
+            needs.add(clauseRels.get(left));
+            needs.add(clauseRels.get(right));
+          }
     }
     return needs;
+  }
+
+  /** Edge subtypes overlap their supertypes just as exact type names do (issue #6310). */
+  private boolean relationshipTypesMayOverlap(final LogicalRelationship left,
+      final LogicalRelationship right) {
+    if (left.getTypes().isEmpty() || right.getTypes().isEmpty())
+      return true;
+
+    for (final String leftName : left.getTypes())
+      for (final String rightName : right.getTypes()) {
+        if (leftName.equals(rightName))
+          return true;
+        final var leftType = database.getSchema().getTypeOrNull(leftName);
+        final var rightType = database.getSchema().getTypeOrNull(rightName);
+        if (leftType != null && rightType != null
+            && (leftType.instanceOf(rightName) || rightType.instanceOf(leftName)))
+          return true;
+      }
+    return false;
+  }
+
+  /** Partitions relationship patterns into deterministic node-connected components. */
+  private List<RelationshipComponent> relationshipComponents(final List<LogicalRelationship> relationships) {
+    final LinkedHashSet<LogicalRelationship> remaining = new LinkedHashSet<>(relationships);
+    final List<RelationshipComponent> components = new ArrayList<>();
+
+    while (!remaining.isEmpty()) {
+      final LogicalRelationship seed = remaining.iterator().next();
+      remaining.remove(seed);
+      final List<LogicalRelationship> componentRelationships = new ArrayList<>();
+      final Set<String> variables = new LinkedHashSet<>();
+      componentRelationships.add(seed);
+      variables.add(seed.getSourceVariable());
+      variables.add(seed.getTargetVariable());
+
+      boolean grew;
+      do {
+        grew = false;
+        final var iterator = remaining.iterator();
+        while (iterator.hasNext()) {
+          final LogicalRelationship candidate = iterator.next();
+          if (!variables.contains(candidate.getSourceVariable())
+              && !variables.contains(candidate.getTargetVariable()))
+            continue;
+          iterator.remove();
+          componentRelationships.add(candidate);
+          variables.add(candidate.getSourceVariable());
+          variables.add(candidate.getTargetVariable());
+          grew = true;
+        }
+      } while (grew);
+
+      components.add(new RelationshipComponent(componentRelationships, variables));
+    }
+    return components;
+  }
+
+  private record RelationshipComponent(List<LogicalRelationship> relationships, Set<String> variables) {
+  }
+
+  private record ExpansionPlan(PhysicalOperator root,
+                               Map<Integer, Set<String>> relationshipVariablesByClause) {
   }
 
   /**
@@ -384,18 +471,20 @@ public class CypherOptimizer {
    * kept so the planner behaves as before rather than throwing.
    */
   private AnchorSelection validateAnchorForUnidirectionalEdges(final AnchorSelection anchor,
-      final LogicalPlan logicalPlan) {
+      final LogicalPlan logicalPlan, final List<LogicalRelationship> relationships,
+      final Set<String> componentVariables) {
     // Fast path: without any unidirectional edge, every hop is reversible and any anchor is valid.
-    if (!hasUnidirectionalEdge(logicalPlan))
+    if (!hasUnidirectionalEdge(relationships))
       return anchor;
 
-    if (anchorReachesAllNodes(anchor.getVariable(), logicalPlan))
+    if (anchorReachesAllNodes(anchor.getVariable(), relationships, componentVariables))
       return anchor;
 
     AnchorSelection best = null;
     double lowestCost = Double.MAX_VALUE;
-    for (final LogicalNode node : logicalPlan.getNodes().values()) {
-      if (!anchorReachesAllNodes(node.getVariable(), logicalPlan))
+    for (final String variable : componentVariables) {
+      final LogicalNode node = logicalPlan.getPatternNode(variable);
+      if (node == null || !anchorReachesAllNodes(variable, relationships, componentVariables))
         continue;
       final AnchorSelection candidate = anchorSelector.evaluateNodeDirect(node, logicalPlan);
       if (candidate.getEstimatedCost() < lowestCost) {
@@ -409,12 +498,16 @@ public class CypherOptimizer {
   /**
    * Returns true if any relationship in the pattern uses a unidirectional (non-bidirectional) edge type.
    */
-  private boolean hasUnidirectionalEdge(final LogicalPlan logicalPlan) {
+  private boolean hasUnidirectionalEdge(final List<LogicalRelationship> relationships) {
     final var schema = database.getSchema();
-    for (final LogicalRelationship rel : logicalPlan.getRelationships())
+    for (final LogicalRelationship rel : relationships) {
+      // An untyped hop may select a unidirectional edge, so reverse traversal cannot be proven safe.
+      if (rel.getTypes().isEmpty())
+        return true;
       for (final String edgeTypeName : rel.getTypes())
         if (schema.getTypeOrNull(edgeTypeName) instanceof EdgeType et && !et.isBidirectional())
           return true;
+    }
     return false;
   }
 
@@ -423,7 +516,8 @@ public class CypherOptimizer {
    * direction for unidirectional edges (source→target only) and allowing both directions for
    * bidirectional ones. Returns true when every pattern node is reachable.
    */
-  private boolean anchorReachesAllNodes(final String anchorVar, final LogicalPlan logicalPlan) {
+  private boolean anchorReachesAllNodes(final String anchorVar,
+      final List<LogicalRelationship> relationships, final Set<String> componentVariables) {
     final var schema = database.getSchema();
     final Set<String> visited = new HashSet<>();
     final ArrayDeque<String> queue = new ArrayDeque<>();
@@ -432,12 +526,13 @@ public class CypherOptimizer {
 
     while (!queue.isEmpty()) {
       final String current = queue.poll();
-      for (final LogicalRelationship rel : logicalPlan.getRelationships()) {
+      for (final LogicalRelationship rel : relationships) {
         final String source = rel.getSourceVariable();
         final String target = rel.getTargetVariable();
         final Direction direction = rel.getDirection();
 
-        boolean bidirectional = true;
+        // Without a declared type, the matched edge set may include a unidirectional type.
+        boolean bidirectional = !rel.getTypes().isEmpty();
         for (final String edgeTypeName : rel.getTypes())
           if (schema.getTypeOrNull(edgeTypeName) instanceof EdgeType et && !et.isBidirectional()) {
             bidirectional = false;
@@ -457,7 +552,7 @@ public class CypherOptimizer {
           forwardTo = target;
         }
 
-        final boolean reverseTraversable = bidirectional || direction == Direction.BOTH;
+        final boolean reverseTraversable = bidirectional;
 
         if (current.equals(forwardFrom) && visited.add(forwardTo))
           queue.add(forwardTo);
@@ -466,7 +561,7 @@ public class CypherOptimizer {
       }
     }
 
-    return visited.containsAll(logicalPlan.getNodes().keySet());
+    return visited.containsAll(componentVariables);
   }
 
   /**
@@ -485,15 +580,19 @@ public class CypherOptimizer {
    * Builds the expansion chain by ordering relationships and creating expand operators.
    * Uses JoinOrderRule for ordering and ExpandIntoRule for optimization.
    *
-   * @param logicalPlan    the logical plan
-   * @param anchor         the selected anchor
-   * @param anchorOperator the anchor operator to build upon
+   * @param logicalPlan          the logical plan
+   * @param relationships        relationships in this connected component
+   * @param anchor               the selected anchor
+   * @param anchorOperator       the anchor operator to build upon
+   * @param needsEdgeTracking    relationships whose identity can collide in their MATCH clause
+   * @param syntheticEdgeCounter plan-wide counter for anonymous tracking bindings
    *
-   * @return root operator of the expansion chain
+   * @return root operator and relationship bindings of the expansion chain
    */
-  private PhysicalOperator buildExpansionChain(final LogicalPlan logicalPlan,
-      final AnchorSelection anchor,
-      final PhysicalOperator anchorOperator) {
+  private ExpansionPlan buildExpansionChain(final LogicalPlan logicalPlan,
+      final List<LogicalRelationship> relationships, final AnchorSelection anchor,
+      final PhysicalOperator anchorOperator, final Set<LogicalRelationship> needsEdgeTracking,
+      final int[] syntheticEdgeCounter) {
     // Get optimization rules
     final JoinOrderRule joinOrderRule = (JoinOrderRule) rules.get(3);
     final ExpandIntoRule expandIntoRule = (ExpandIntoRule) rules.get(2);
@@ -505,7 +604,7 @@ public class CypherOptimizer {
     // Order relationships by estimated cardinality
     final List<LogicalRelationship> orderedRels =
         joinOrderRule.orderRelationships(
-            logicalPlan.getRelationships(),
+            relationships,
             anchor.getVariable(),
             boundVariables,
             logicalPlan
@@ -516,9 +615,6 @@ public class CypherOptimizer {
     // clause - cross-clause edge reuse is valid Cypher and must not be blocked.
     PhysicalOperator currentOp = anchorOperator;
     final Map<Integer, Set<String>> relVarsPerClause = new HashMap<>();
-
-    final Set<LogicalRelationship> needsEdgeTracking = computeNeedsEdgeTracking(orderedRels);
-    int syntheticEdgeVarCounter = 0;
 
     for (final LogicalRelationship rel : orderedRels) {
       final Set<String> sameClausePreceding = relVarsPerClause.getOrDefault(
@@ -533,8 +629,21 @@ public class CypherOptimizer {
           && (needsEdgeTracking.contains(rel)
               || CypherVariableUsage.isEdgeVariableReferenced(statement, rel.getVariable()));
 
-      // Check if we should use ExpandInto (both endpoints bound)
-      if (expandIntoRule.shouldUseExpandInto(rel, boundVariables)) {
+      if (rel.isVariableLength()) {
+        currentOp = createVarLengthExpandOperator(rel, currentOp, boundVariables, sameClausePreceding);
+
+        if ((rel.getVariable() == null || rel.getVariable().isEmpty())
+            && needsEdgeTracking.contains(rel)
+            && currentOp instanceof VarLengthExpand expand) {
+          final String synVar = "  anon_e_" + (syntheticEdgeCounter[0]++);
+          expand.setEdgeTrackingVar(synVar);
+          relVarsPerClause
+              .computeIfAbsent(rel.getClauseIndex(), k -> new HashSet<>())
+              .add(synVar);
+        }
+
+        currentOp = addTargetLabelFilter(logicalPlan, rel, currentOp);
+      } else if (expandIntoRule.shouldUseExpandInto(rel, boundVariables)) {
         // Use ExpandInto for bounded patterns
         currentOp = createExpandIntoOperator(rel, currentOp, sameClausePreceding, needsEdgeTracking.contains(rel),
             edgeIsMaterialized);
@@ -544,7 +653,7 @@ public class CypherOptimizer {
         if ((rel.getVariable() == null || rel.getVariable().isEmpty())
             && needsEdgeTracking.contains(rel)
             && currentOp instanceof ExpandInto expandInto) {
-          final String synVar = "  anon_e_" + (syntheticEdgeVarCounter++);
+          final String synVar = "  anon_e_" + (syntheticEdgeCounter[0]++);
           expandInto.setEdgeTrackingVar(synVar);
           relVarsPerClause
               .computeIfAbsent(rel.getClauseIndex(), k -> new HashSet<>())
@@ -558,7 +667,7 @@ public class CypherOptimizer {
         if ((rel.getVariable() == null || rel.getVariable().isEmpty())
             && needsEdgeTracking.contains(rel)
             && currentOp instanceof ExpandAll expand) {
-          final String synVar = "  anon_e_" + (syntheticEdgeVarCounter++);
+          final String synVar = "  anon_e_" + (syntheticEdgeCounter[0]++);
           expand.setEdgeTrackingVar(synVar);
           relVarsPerClause
               .computeIfAbsent(rel.getClauseIndex(), k -> new HashSet<>())
@@ -573,15 +682,53 @@ public class CypherOptimizer {
       boundVariables.add(rel.getSourceVariable());
       boundVariables.add(rel.getTargetVariable());
 
-      // Track named relationship variables for subsequent hops in the same clause
-      if (rel.getVariable() != null && !rel.getVariable().isEmpty()) {
+      // Only relationships whose type domains can overlap need identity tracking. A named variable
+      // may still be materialized because the query reads it, but type-disjoint hops do not belong
+      // in the hot uniqueness checks within or across connected components.
+      if (needsEdgeTracking.contains(rel) && rel.getVariable() != null && !rel.getVariable().isEmpty()) {
         relVarsPerClause
             .computeIfAbsent(rel.getClauseIndex(), k -> new HashSet<>())
             .add(rel.getVariable());
       }
     }
 
-    return currentOp;
+    return new ExpansionPlan(currentOp, relVarsPerClause);
+  }
+
+  /** Builds a depth-first physical expansion for one ordinary variable-length relationship. */
+  private PhysicalOperator createVarLengthExpandOperator(final LogicalRelationship relationship,
+      final PhysicalOperator input, final Set<String> boundVariables,
+      final Set<String> sameClausePrecedingRelVars) {
+    String sourceVariable = relationship.getSourceVariable();
+    String targetVariable = relationship.getTargetVariable();
+    Direction direction = relationship.getDirection();
+    boolean reverseResultPath = false;
+
+    final boolean sourceIsBound = boundVariables.contains(sourceVariable);
+    final boolean targetIsBound = boundVariables.contains(targetVariable);
+    if (targetIsBound && !sourceIsBound) {
+      final String swap = sourceVariable;
+      sourceVariable = targetVariable;
+      targetVariable = swap;
+      direction = reverseDirection(direction);
+      reverseResultPath = true;
+    }
+
+    final long inputCardinality = input.getEstimatedCardinality();
+    final double avgDegree = relationship.getFirstType() != null ?
+        costModel.estimateAverageDegree(relationship.getFirstType()) : DEFAULT_AVG_DEGREE;
+    final long outputCardinality = costModel.estimateVariableLengthCardinality(inputCardinality, avgDegree,
+        relationship.getEffectiveMinHops(), relationship.getEffectiveMaxHops());
+    final double expansionCost = costModel.estimateVariableLengthExpandCost(inputCardinality, avgDegree,
+        relationship.getEffectiveMinHops(), relationship.getEffectiveMaxHops());
+    final double totalCost = CostModel.saturatingAdd(input.getEstimatedCost(), expansionCost);
+
+    final VarLengthExpand expand = new VarLengthExpand(input, sourceVariable,
+        relationship.getVariable(), targetVariable,
+        relationship.getPathVariable(), relationship.getPattern(), direction, reverseResultPath,
+        relationship.getPathMode(), totalCost, outputCardinality);
+    expand.setSameClausePrecedingRelVars(sameClausePrecedingRelVars);
+    return expand;
   }
 
   /**
@@ -1098,6 +1245,8 @@ public class CypherOptimizer {
       expandTargetVariable = ((GAVExpandAll) input).getTargetVariable();
     else if (input instanceof ExpandAll)
       expandTargetVariable = ((ExpandAll) input).getTargetVariable();
+    else if (input instanceof VarLengthExpand)
+      expandTargetVariable = ((VarLengthExpand) input).getTargetVariable();
     else
       expandTargetVariable = rel.getTargetVariable();
 
@@ -1124,6 +1273,10 @@ public class CypherOptimizer {
     }
     if (input instanceof ExpandAll) {
       ((ExpandAll) input).setTargetLabel(targetLabel);
+      return input;
+    }
+    if (input instanceof VarLengthExpand) {
+      ((VarLengthExpand) input).setTargetLabel(targetLabel);
       return input;
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -199,8 +199,10 @@ public class LogicalPlan {
           relPattern.getProperties(),
           relPattern.getMinHops(),
           relPattern.getMaxHops(),
-          null,
-          clauseIndex
+          pathPattern.getEffectivePathMode(),
+          clauseIndex,
+          relPattern,
+          pathPattern.getPathVariable()
       );
       relationships.add(logicalRel);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalRelationship.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalRelationship.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.optimizer.plan;
 
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.PathMode;
+import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 
 import java.util.Collections;
 import java.util.List;
@@ -41,6 +42,8 @@ public class LogicalRelationship {
   private final Integer maxHops;
   private final PathMode pathMode;
   private final int clauseIndex;
+  private final RelationshipPattern pattern;
+  private final String pathVariable;
 
   public LogicalRelationship(final String variable, final String sourceVariable, final String targetVariable,
                             final List<String> types, final Direction direction, final Map<String, Object> properties,
@@ -57,6 +60,14 @@ public class LogicalRelationship {
   public LogicalRelationship(final String variable, final String sourceVariable, final String targetVariable,
                             final List<String> types, final Direction direction, final Map<String, Object> properties,
                             final Integer minHops, final Integer maxHops, final PathMode pathMode, final int clauseIndex) {
+    this(variable, sourceVariable, targetVariable, types, direction, properties, minHops, maxHops,
+        pathMode, clauseIndex, null, null);
+  }
+
+  public LogicalRelationship(final String variable, final String sourceVariable, final String targetVariable,
+                            final List<String> types, final Direction direction, final Map<String, Object> properties,
+                            final Integer minHops, final Integer maxHops, final PathMode pathMode, final int clauseIndex,
+                            final RelationshipPattern pattern, final String pathVariable) {
     this.variable = variable;
     this.sourceVariable = sourceVariable;
     this.targetVariable = targetVariable;
@@ -68,6 +79,8 @@ public class LogicalRelationship {
     this.isVariableLength = minHops != null || maxHops != null;
     this.pathMode = pathMode;
     this.clauseIndex = clauseIndex;
+    this.pattern = pattern;
+    this.pathVariable = pathVariable;
   }
 
   /**
@@ -114,8 +127,29 @@ public class LogicalRelationship {
     return maxHops;
   }
 
+  public int getEffectiveMinHops() {
+    return minHops != null ? Math.max(0, minHops) : 1;
+  }
+
+  public int getEffectiveMaxHops() {
+    return maxHops != null ? maxHops : isVariableLength ? Integer.MAX_VALUE : 1;
+  }
+
   public PathMode getPathMode() {
     return pathMode;
+  }
+
+  /**
+   * Returns the parsed relationship pattern when this relationship came from the AST. The physical
+   * variable-length operator needs the original object because it owns parameterized property maps
+   * and inline WHERE evaluation, neither of which the flattened properties map can represent.
+   */
+  public RelationshipPattern getPattern() {
+    return pattern;
+  }
+
+  public String getPathVariable() {
+    return pathVariable;
   }
 
   public boolean hasTypes() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/rules/JoinOrderRule.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/rules/JoinOrderRule.java
@@ -186,6 +186,12 @@ public class JoinOrderRule implements OptimizationRule {
     // Cost depends on average degree
     final double avgDegree = estimateAverageDegree(rel, logicalPlan);
 
+    if (rel.isVariableLength())
+      return CostModel.saturatingMultiply(
+          costModel.estimateVariableLengthExpansionFactor(avgDegree,
+              rel.getEffectiveMinHops(), rel.getEffectiveMaxHops()),
+          CostModel.EXPAND_COST_PER_ROW);
+
     if (sourceIsBound) {
       // Expand from source
       return avgDegree * costModel.EXPAND_COST_PER_ROW;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/CostModel.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/CostModel.java
@@ -45,6 +45,9 @@ public class CostModel {
 
   // Default average degree for graph traversals (when statistics unavailable)
   public static final double DEFAULT_AVG_DEGREE = 10.0;
+  // An unbounded trail has no finite graph-independent estimate. Model enough levels to keep it
+  // substantially more expensive than a fixed hop without poisoning the rest of the plan with MAX_VALUE.
+  public static final int VARIABLE_LENGTH_UNBOUNDED_PLANNING_HORIZON = 8;
 
   private final StatisticsProvider statistics;
 
@@ -138,6 +141,83 @@ public class CostModel {
    */
   public double estimateExpandCost(final long inputCardinality, final double avgDegree) {
     return inputCardinality * avgDegree * EXPAND_COST_PER_ROW;
+  }
+
+  /**
+   * Estimates the number of paths emitted per input vertex for a bounded variable-length
+   * expansion. The geometric series is saturated instead of overflowing. An unbounded trail has
+   * no finite graph-independent estimate, so planning accounts for the first eight levels (or two
+   * levels beyond a larger declared minimum) rather than pretending it is a single hop.
+   */
+  public double estimateVariableLengthExpansionFactor(final double avgDegree, final int minHops,
+      final int maxHops) {
+    final int planningMaxHops;
+    if (maxHops == Integer.MAX_VALUE) {
+      final int beyondMinimum = minHops <= Integer.MAX_VALUE - 2 ? minHops + 2 : Integer.MAX_VALUE;
+      planningMaxHops = Math.max(VARIABLE_LENGTH_UNBOUNDED_PLANNING_HORIZON, beyondMinimum);
+    } else
+      planningMaxHops = maxHops;
+
+    if (planningMaxHops < minHops)
+      return 0.0;
+
+    final double degree = Math.max(0.0, avgDegree);
+    if (degree == 0.0)
+      return minHops == 0 ? 1.0 : 0.0;
+    if (degree == 1.0)
+      return (double) planningMaxHops - minHops + 1.0;
+
+    final double first = Math.pow(degree, minHops);
+    final double terms = (double) planningMaxHops - minHops + 1.0;
+    final double ratioPower = Math.pow(degree, terms);
+    final double total = degree > 1.0 ?
+        first * (ratioPower - 1.0) / (degree - 1.0) :
+        first * (1.0 - ratioPower) / (1.0 - degree);
+    return Double.isFinite(total) ? total : Double.MAX_VALUE;
+  }
+
+  public long estimateVariableLengthCardinality(final long inputCardinality, final double avgDegree,
+      final int minHops, final int maxHops) {
+    return saturatingCardinality(inputCardinality,
+        estimateVariableLengthExpansionFactor(avgDegree, minHops, maxHops));
+  }
+
+  public double estimateVariableLengthExpandCost(final long inputCardinality, final double avgDegree,
+      final int minHops, final int maxHops) {
+    return saturatingMultiply(
+        saturatingMultiply(inputCardinality,
+            estimateVariableLengthExpansionFactor(avgDegree, minHops, maxHops)),
+        EXPAND_COST_PER_ROW);
+  }
+
+  public static long saturatingCardinality(final long cardinality, final double factor) {
+    if (cardinality <= 0 || factor <= 0.0)
+      return 0;
+    if (!Double.isFinite(factor) || factor >= Long.MAX_VALUE / (double) cardinality)
+      return Long.MAX_VALUE;
+    return (long) Math.ceil(cardinality * factor);
+  }
+
+  public static long saturatingCardinalityProduct(final long left, final long right) {
+    if (left <= 0 || right <= 0)
+      return 0;
+    if (left > Long.MAX_VALUE / right)
+      return Long.MAX_VALUE;
+    return left * right;
+  }
+
+  public static double saturatingAdd(final double left, final double right) {
+    if (left == Double.MAX_VALUE || right == Double.MAX_VALUE || left > Double.MAX_VALUE - right)
+      return Double.MAX_VALUE;
+    return left + right;
+  }
+
+  public static double saturatingMultiply(final double left, final double right) {
+    if (left <= 0.0 || right <= 0.0)
+      return 0.0;
+    if (!Double.isFinite(left) || !Double.isFinite(right) || left > Double.MAX_VALUE / right)
+      return Double.MAX_VALUE;
+    return left * right;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
@@ -172,7 +172,7 @@ public class CypherExecutionPlanner {
     // Disable optimizer for queries with features not yet fully integrated:
     // - OPTIONAL MATCH (needs special handling)
     // - Complex write operations after MATCH
-    // - Variable-length paths (already work but have known issues)
+    // - Variable-length forms without a native physical capability
     // - Unlabeled nodes (optimizer requires labels for physical operators)
 
     // Collect all labeled variables across all MATCH clauses first.
@@ -190,32 +190,26 @@ public class CypherExecutionPlanner {
       if (match.isOptional())
         return false; // Not yet supported in optimizer
 
-      // Multiple path patterns in a single MATCH (e.g., MATCH (a:X)-[:E1]->(b:Y), (a)<-[:E2]-(c:Z))
-      // are supported when the patterns share variables (the optimizer handles them via join planning).
-      // Disconnected patterns with no shared variables fall through to step-by-step interpretation.
-      if (match.hasPathPatterns() && match.getPathPatterns().size() > 1) {
-        final Set<String> seenVars = new HashSet<>();
-        boolean disconnected = false;
-        for (final PathPattern path : match.getPathPatterns()) {
-          final Set<String> pathVars = new HashSet<>();
-          for (final NodePattern node : path.getNodes())
-            if (node.getVariable() != null)
-              pathVars.add(node.getVariable());
-          if (!seenVars.isEmpty() && Collections.disjoint(seenVars, pathVars)) {
-            disconnected = true;
-            break;
-          }
-          seenVars.addAll(pathVars);
-        }
-        if (disconnected)
-          return false; // Disconnected patterns in single MATCH not supported by optimizer
-      }
+      // Independently planned relationship components cannot evaluate an inline edge expression
+      // that may read a sibling component's bindings. Keep that combined shape on the ordered
+      // traditional evaluator until correlated component planning exists.
+      if (hasDisconnectedPathPatterns(match) && hasInlineRelationshipPredicates(match))
+        return false;
 
       // Check if all nodes have labels, no named path variables, and no unsupported property constraints
       if (match.hasPathPatterns()) {
         for (final PathPattern path : match.getPathPatterns()) {
-          // Named path variables not yet supported (e.g., "p = (a)-[r]->(b)")
-          if (path.hasPathVariable())
+          // shortestPath/allShortestPaths have minimum-distance semantics rather than exhaustive
+          // variable-length expansion and remain an explicit traditional-plan capability.
+          if (path instanceof ShortestPathPattern)
+            return false;
+
+          // The physical operator preserves written order for a named variable-length segment,
+          // including when a selective target makes the optimizer traverse it in reverse. Joining
+          // several independently reordered segments back into one named path is a separate
+          // capability, so retain the traditional plan for that shape.
+          if (path.hasPathVariable()
+              && (path.getRelationshipCount() != 1 || !path.getRelationship(0).isVariableLength()))
             return false;
 
           // Inline relationship property filters (e.g., [r:LINK {w: 1}]) and inline relationship
@@ -225,11 +219,18 @@ public class CypherExecutionPlanner {
           // MatchRelationshipStep applies both filters correctly. See issue #5093.
           for (int ri = 0; ri < path.getRelationshipCount(); ri++) {
             final RelationshipPattern relP = path.getRelationship(ri);
-            if (relP.hasProperties() || relP.hasWhereExpression())
+            if (relP.getPropertiesParameterName() != null)
+              return false;
+            if ((relP.hasProperties() || relP.hasWhereExpression()) && !relP.isVariableLength())
               return false;
           }
 
           for (final NodePattern node : path.getNodes()) {
+            // Dynamic labels are row expressions. The physical scans and expansion target filter
+            // currently accept only static type names, so retain the traditional evaluator.
+            if (node.hasDynamicLabels() || node.hasWhereExpression())
+              return false;
+
             // Anonymous nodes (no variable) with unidirectional edges can't be handled
             // by the optimizer's expansion chain - anchor validation can't re-anchor
             // to a node that has no variable in the LogicalPlan.
@@ -369,6 +370,36 @@ public class CypherExecutionPlanner {
     // both produce correct results regardless of edge type overlap.
 
     return true;
+  }
+
+  private static boolean hasInlineRelationshipPredicates(final MatchClause match) {
+    if (!match.hasPathPatterns())
+      return false;
+    for (final PathPattern path : match.getPathPatterns())
+      for (final RelationshipPattern relationship : path.getRelationships())
+        if (relationship.hasProperties() || relationship.hasWhereExpression())
+          return true;
+    return false;
+  }
+
+  /** Returns true when one MATCH contains path parts with no chain of shared node variables. */
+  private static boolean hasDisconnectedPathPatterns(final MatchClause match) {
+    if (!match.hasPathPatterns() || match.getPathPatterns().size() < 2)
+      return false;
+
+    final List<Set<String>> components = new ArrayList<>();
+    for (final PathPattern path : match.getPathPatterns()) {
+      final Set<String> merged = new HashSet<>();
+      for (final NodePattern node : path.getNodes())
+        if (node.getVariable() != null)
+          merged.add(node.getVariable());
+
+      for (int i = components.size() - 1; i >= 0; i--)
+        if (!Collections.disjoint(components.get(i), merged))
+          merged.addAll(components.remove(i));
+      components.add(merged);
+    }
+    return components.size() > 1;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
@@ -249,23 +249,22 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
   }
 
   /**
-   * Which plan runs a clause decides which of the two implementations its uniqueness comes from, so it is
-   * worth pinning rather than assuming. The cost-based optimizer declines every variable-length hop, comma
-   * or no comma - so there is no optimizer-side variable-length path for the guards above to be wrong on,
-   * and a test claiming to cover one would in fact be exercising the traditional plan. A comma clause of
-   * fixed-length hops IS optimized, which is what makes the rest of this class cover both implementations.
-   * <p>
-   * A tripwire, not a preference: when the optimizer does grow variable-length support, this fails, and
-   * whoever adds it is made to answer the uniqueness question on that path too.
+   * Which plan runs a clause decides which implementation supplies its uniqueness, so pin the routing
+   * rather than assuming it. Ordinary variable-length MATCH now uses {@code VarLengthExpand}; when a
+   * comma separates disconnected relationship components, the physical Cartesian product is followed by
+   * a clause-wide relationship-uniqueness filter. shortestPath remains a separate traditional capability.
    */
   @Test
-  void theOptimizerDeclinesVariableLengthHopsButNotCommas() {
+  void theOptimizerRoutesOrdinaryVariableLengthHopsButNotShortestPath() {
     assertThat(planOf("MATCH (x:C)-[*1..2]->(y:A), (p:E)-[]->(q:A) RETURN x.n AS a"))
-        .contains("Traditional Execution");
+        .contains("VarLengthExpand")
+        .contains("RelationshipUniquenessFilter")
+        .doesNotContain("Traditional Execution");
     assertThat(planOf("MATCH p1 = shortestPath((x:C)-[*1..2]->(y:A)), (p:E)-[]->(q:A) RETURN x.n AS a"))
         .contains("Traditional Execution");
     assertThat(planOf("MATCH (x:C)-[*1..2]->(y:A) RETURN x.n AS a"))
-        .contains("Traditional Execution");
+        .contains("VarLengthExpand")
+        .doesNotContain("Traditional Execution");
     assertThat(planOf("MATCH (n0:A)<-[r1]-(:E), (n3:C)-[]->(:E)-[r2]->(n0) RETURN n0.n AS a"))
         .doesNotContain("Traditional Execution");
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherMatchClauseUniquenessIssue6310Test.java
@@ -251,8 +251,10 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
   /**
    * Which plan runs a clause decides which implementation supplies its uniqueness, so pin the routing
    * rather than assuming it. Ordinary variable-length MATCH now uses {@code VarLengthExpand}; when a
-   * comma separates disconnected relationship components, the physical Cartesian product is followed by
-   * a clause-wide relationship-uniqueness filter. shortestPath remains a separate traditional capability.
+   * comma separates disconnected relationship components, the physical Cartesian product applies the
+   * clause-wide relationship-uniqueness check to each candidate pair before merging it into a row,
+   * rather than merging first and filtering afterward. shortestPath remains a separate traditional
+   * capability.
    */
   @Test
   void theOptimizerRoutesOrdinaryVariableLengthHopsButNotShortestPath() {
@@ -267,6 +269,27 @@ class CypherMatchClauseUniquenessIssue6310Test extends TestHelper {
         .doesNotContain("Traditional Execution");
     assertThat(planOf("MATCH (n0:A)<-[r1]-(:E), (n3:C)-[]->(:E)-[r2]->(n0) RETURN n0.n AS a"))
         .doesNotContain("Traditional Execution");
+  }
+
+  /**
+   * The pushdown check runs incrementally, one join at a time, so a conflict between the FIRST and
+   * THIRD of three disconnected components - never adjacent in the join chain - has to be caught by
+   * the second join carrying the first component's binding forward in its merged row, not by any
+   * single join comparing the two directly.
+   */
+  @Test
+  void uniquenessIsEnforcedAcrossThreeDisconnectedComponents() {
+    database.command("opencypher", "CREATE (:N {n:'x1'})-[:R]->(:N {n:'y1'})");
+    database.command("opencypher", "CREATE (:N {n:'x2'})-[:R]->(:N {n:'y2'})");
+    database.command("opencypher", "CREATE (:N {n:'x3'})-[:R]->(:N {n:'y3'})");
+
+    final String match = "MATCH (a1:N)-[r1:R]->(b1:N), (a2:N)-[r2:R]->(b2:N), (a3:N)-[r3:R]->(b3:N) ";
+
+    assertThat(planOf(match + "RETURN count(*) AS rows")).doesNotContain("Traditional Execution");
+
+    // 3 x 3 x 3 = 27 candidate triples, minus every triple that reuses an edge: only the 3! = 6
+    // permutations where r1, r2 and r3 are pairwise distinct edges survive.
+    assertThat(count(match + "RETURN count(*) AS rows")).isEqualTo(6);
   }
 
   private String planOf(final String query) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlannerDifferentialIssue6400Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherPlannerDifferentialIssue6400Test.java
@@ -50,12 +50,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This harness closes that gap generically. It generates a corpus of MATCH clauses combinatorially - the #6310
  * defect needed three properties to line up at once (two parts, a shared variable, and one part unable to
  * collide with itself), which is the kind of conjunction a hand-written list misses - runs each clause down both
- * planners against one fixture, and asserts the two answers are equal as multisets.
+ * planners against one fixture, and asserts the two answers are equal as multisets. Ordinary
+ * variable-length MATCH patterns are included now that the physical planner can represent them.
  * <h2>How the routing is forced, and why it is verified rather than assumed</h2>
  * The routing is forcible from the query text, so no engine hook is needed: the clause as written goes to the
  * cost-based planner and the same clause wrapped in {@code CALL { ... }} goes to the traditional one. But the
- * cost-based planner declines far more than variable-length hops - two comma-separated parts that share no
- * variable are a Cartesian product it also declines - so a corpus entry cannot be assumed to have exercised
+ * cost-based planner still declines unsupported syntax, so a corpus entry cannot be assumed to have exercised
  * both. {@code EXPLAIN} reports which planner ran, and every pair is classified by it before being compared:
  * a pair that lands on the traditional plan twice is counted as non-differential and
  * {@link #theCorpusActuallyExercisesBothPlanners()} holds the differential count to a floor, so the harness
@@ -160,6 +160,9 @@ class CypherPlannerDifferentialIssue6400Test {
   /** Inline property filters, which the cost-based planner may push into the scan and the other may not. */
   private static final String[] INLINE_FILTERS = { "", " {v: 1}" };
 
+  /** Bounded ranges including the identity path; unbounded routing is covered by the focused #5358 test. */
+  private static final String[] VLP_RANGES = { "*0..0", "*1..1", "*1..2" };
+
   /**
    * One corpus entry: the MATCH clause and the projection that reads its bindings back.
    *
@@ -206,6 +209,14 @@ class CypherPlannerDifferentialIssue6400Test {
               queries.add(new Query("MATCH " + hop("x" + label + filter, "r1" + relType, "y" + farLabel, direction),
                   "x.n AS xn, y.n AS yn"));
 
+    // Variable-length counterparts: all directions, identity/single/multi-hop ranges, and both endpoint labels.
+    for (final String direction : DIRECTIONS)
+      for (final String range : VLP_RANGES)
+        for (final String label : new String[] { ":C", ":E", ":SUBA" })
+          for (final String farLabel : FAR_LABELS)
+            queries.add(new Query("MATCH " + hop("x" + label, "r1:R" + range, "y" + farLabel, direction),
+                "x.n AS xn, y.n AS yn"));
+
     // Two-part patterns sharing a variable, which is where relationship uniqueness across the comma bites
     // (issue #6310) and also the shape the cost-based planner is willing to join.
     for (final String direction : DIRECTIONS)
@@ -221,11 +232,21 @@ class CypherPlannerDifferentialIssue6400Test {
         queries.add(new Query("MATCH " + hop("x" + label, "r1" + relType, "y:E", "->") + ", "
             + hop("p:E", "r2", "q:A", "->"), "x.n AS xn, p.n AS pn"));
 
+    // A variable-length component beside a disconnected fixed hop exercises the post-product
+    // MATCH-clause relationship-uniqueness filter introduced with VarLengthExpand.
+    for (final String range : new String[] { "*0..0", "*1..2" })
+      queries.add(new Query("MATCH " + hop("x:C", "r1:R" + range, "y:A", "->") + ", "
+          + hop("p:E", "r2:R", "q:A", "->"), "x.n AS xn, p.n AS pn"));
+
     // Anonymous hops, which the plan has to bind itself to be able to compare them at all.
     for (final String direction : DIRECTIONS)
       for (final String label : LABELS)
         queries.add(new Query("MATCH " + hop("x" + label, "", "y:E", direction) + ", " + hop("y:E", "", "z:A", "->"),
             "x.n AS xn, z.n AS zn"));
+
+    // Anonymous variable-length relationships still need internal edge tracking when another hop can collide.
+    queries.add(new Query("MATCH " + hop("x:C", ":R*1..2", "y:A", "->") + ", "
+        + hop("p:E", "", "q:A", "->"), "x.n AS xn, p.n AS pn"));
 
     // A WHERE predicate beside the pattern: what the cost-based planner may push into the scan.
     for (final String label : LABELS)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVarLengthExpandIssue5358Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVarLengthExpandIssue5358Test.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #5358: variable-length MATCH patterns are native physical operators rather than a reason
+ * for the cost-based planner to decline the whole statement.
+ */
+class CypherVarLengthExpandIssue5358Test {
+  private static final String DATABASE_PATH = "./target/databases/cypher-var-length-expand-5358";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final Map<String, MutableVertex> nodes = new HashMap<>();
+      for (final String id : List.of("a", "b", "c", "d", "hub"))
+        nodes.put(id, database.newVertex("Node").set("id", id).save());
+
+      link(nodes, "a", "b", "a-b", "ok");
+      link(nodes, "a", "c", "a-c", "bad");
+      link(nodes, "b", "d", "b-d", "ok");
+      link(nodes, "c", "d", "c-d", "ok");
+      link(nodes, "d", "hub", "d-hub", "ok");
+      link(nodes, "hub", "a", "hub-a", "ok");
+
+      for (int i = 0; i < 64; i++)
+        database.newVertex("Node").set("id", "decoy-" + i).save();
+    });
+
+    database.transaction(() -> database.getSchema().createTypeIndex(
+        Schema.INDEX_TYPE.LSM_TREE, true, "Node", "id"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void boundedUnboundedAndZeroHopPatternsUseThePhysicalOperator() {
+    for (final String range : List.of("*1..3", "*1..", "*", "*0..0"))
+      assertThat(planOf("MATCH (a:Node {id:'a'})-[:LINK" + range + "]->(b:Node) RETURN b.id AS id"))
+          .contains("VarLengthExpand")
+          .doesNotContain("Traditional Execution");
+  }
+
+  @Test
+  void reversedIndexedAnchorPreservesNamedPathAndRelationshipOrder() {
+    final String query = """
+        MATCH p = (start:Node)-[relationships:LINK*1..3]->(target:Node {id:'hub'})
+        RETURN start.id AS start,
+               [n IN nodes(p) | n.id] AS nodeIds,
+               [r IN relationships | r.step] AS steps
+        ORDER BY start, nodeIds
+        """;
+
+    assertThat(planOf(query)).contains("VarLengthExpand").contains("NodeIndexSeek");
+    assertThat(rows(query)).containsExactly(
+        "a|[a, b, d, hub]|[a-b, b-d, d-hub]",
+        "a|[a, c, d, hub]|[a-c, c-d, d-hub]",
+        "b|[b, d, hub]|[b-d, d-hub]",
+        "c|[c, d, hub]|[c-d, d-hub]",
+        "d|[d, hub]|[d-hub]");
+  }
+
+  @Test
+  void inlineRelationshipPredicatesRunInsideThePhysicalTraversal() {
+    final String query = """
+        MATCH (a:Node {id:'a'})-[relationships:LINK*1..3 WHERE relationships.tag = 'ok']->(b:Node)
+        RETURN b.id AS id
+        ORDER BY id
+        """;
+
+    assertThat(planOf(query)).contains("VarLengthExpand").doesNotContain("Traditional Execution");
+    assertThat(singleColumn(query, "id")).containsExactly("b", "d", "hub");
+  }
+
+  @Test
+  void inlineRelationshipPropertyMapsRunInsideThePhysicalTraversal() {
+    final String query = """
+        MATCH (a:Node {id:'a'})-[relationships:LINK*1..3 {tag:'ok'}]->(b:Node)
+        RETURN b.id AS id
+        ORDER BY id
+        """;
+
+    assertThat(planOf(query)).contains("VarLengthExpand").doesNotContain("Traditional Execution");
+    assertThat(singleColumn(query, "id")).containsExactly("b", "d", "hub");
+  }
+
+  @Test
+  void relationshipReuseAcrossMatchClausesRemainsValid() {
+    final String query = """
+        MATCH (a:Node {id:'a'})-[first:LINK*1..1]->(b:Node)
+        MATCH (a)-[second:LINK]->(b)
+        RETURN b.id AS id
+        ORDER BY id
+        """;
+
+    assertThat(planOf(query)).contains("VarLengthExpand").contains("ExpandInto");
+    assertThat(singleColumn(query, "id")).containsExactly("b", "c");
+  }
+
+  @Test
+  void explicitPathModesMatchTheTraditionalTraversal() {
+    for (final String mode : List.of("TRAIL", "ACYCLIC", "WALK")) {
+      final String match = "MATCH " + mode
+          + " (a:Node {id:'a'})-[relationships:LINK*1..6]->(b:Node)";
+      final String optimized = match + " RETURN b.id AS id ORDER BY id";
+      final String traditional = "CALL { " + match + " RETURN b.id AS id } RETURN id ORDER BY id";
+
+      assertThat(planOf(optimized)).contains("VarLengthExpand").doesNotContain("Traditional Execution");
+      assertThat(singleColumn(optimized, "id")).isEqualTo(singleColumn(traditional, "id"));
+    }
+  }
+
+  @Test
+  void disconnectedInlineRelationshipPredicatesRemainAnExplicitFallback() {
+    assertThat(planOf("""
+        MATCH (a:Node {id:'a'})-[r:LINK*1..2 WHERE r.tag = 'ok']->(b:Node),
+              (p:Node {id:'a'})-[:LINK]->(q:Node)
+        RETURN b.id AS id
+        """))
+        .contains("Traditional Execution")
+        .doesNotContain("VarLengthExpand");
+  }
+
+  @Test
+  void shortestPathRemainsAnExplicitTraditionalFallback() {
+    assertThat(planOf("""
+        MATCH p = shortestPath((a:Node {id:'a'})-[:LINK*1..3]->(b:Node {id:'hub'}))
+        RETURN length(p) AS hops
+        """))
+        .contains("Traditional Execution")
+        .doesNotContain("VarLengthExpand");
+  }
+
+  private void link(final Map<String, MutableVertex> nodes, final String from, final String to,
+      final String step, final String tag) {
+    nodes.get(from).newEdge("LINK", nodes.get(to), true, (Object[]) null)
+        .set("step", step)
+        .set("tag", tag)
+        .save();
+  }
+
+  private String planOf(final String query) {
+    try (final ResultSet resultSet = database.query("opencypher", "EXPLAIN " + query)) {
+      assertThat(resultSet.hasNext()).isTrue();
+      return String.valueOf(resultSet.next().<Object>getProperty("executionPlan"));
+    }
+  }
+
+  private List<String> rows(final String query) {
+    final List<String> rows = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext()) {
+        final Result row = resultSet.next();
+        rows.add(row.<Object>getProperty("start") + "|" + row.<Object>getProperty("nodeIds") + "|"
+            + row.<Object>getProperty("steps"));
+      }
+    }
+    return rows;
+  }
+
+  private List<String> singleColumn(final String query, final String column) {
+    final List<String> values = new ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        values.add(String.valueOf(resultSet.next().<Object>getProperty(column)));
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthAnchorSelectionTest.java
@@ -101,18 +101,18 @@ class CypherVariableLengthAnchorSelectionTest {
 
     assertThat(plan.getSteps()).isNotEmpty();
     assertThat(plan.getSteps().get(0).getDescription())
-        .contains("MATCH NODE (country:Area)")
-        .contains("[index: Area[id]]")
-        .contains("1 rows");
+        .contains("AnchorSelection{variable='country', useIndex=true")
+        .contains("VarLengthExpand(country)")
+        .contains("NodeIndexSeek(country:Area)");
     assertThat(plan.prettyPrint(0, 2))
-        .contains("Execution Plan (Traditional)")
-        .contains("MATCH NODE (country:Area)")
-        .doesNotContain("Execution Plan (Cost-Based Optimizer)");
+        .contains("Execution Plan (Cost-Based Optimizer)")
+        .contains("VarLengthExpand(country)")
+        .doesNotContain("Execution Plan (Traditional)");
 
     try (ResultSet resultSet = database.query("opencypher", "EXPLAIN " + sourceFirst, parameters)) {
       assertThat(resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2))
-          .contains("Using Traditional Execution (Non-Optimized)")
-          .doesNotContain("Using Cost-Based Query Optimizer");
+          .contains("Using Cost-Based Query Optimizer")
+          .doesNotContain("Using Traditional Execution (Non-Optimized)");
     }
   }
 
@@ -131,9 +131,9 @@ class CypherVariableLengthAnchorSelectionTest {
       while (resultSet.hasNext())
         resultSet.next();
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("MATCH NODE (country:Area)")
-          .contains("[index: Area[id]]")
-          .contains("1 rows");
+          .contains("AnchorSelection{variable='country', useIndex=true")
+          .contains("VarLengthExpand(country)")
+          .contains("NodeIndexSeek(country:Area)");
     }
   }
 
@@ -152,9 +152,9 @@ class CypherVariableLengthAnchorSelectionTest {
       while (resultSet.hasNext())
         resultSet.next();
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("MATCH NODE (country:Area)")
-          .contains("[index: Area[id]]")
-          .contains("1 rows");
+          .contains("AnchorSelection{variable='country', useIndex=true")
+          .contains("VarLengthExpand(country)")
+          .contains("NodeIndexSeek(country:Area)");
     }
   }
 
@@ -173,9 +173,9 @@ class CypherVariableLengthAnchorSelectionTest {
       assertThat(result.<Long>getProperty("places")).isEqualTo(3L);
       assertThat(resultSet.hasNext()).isFalse();
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("MATCH NODE (country:Area)")
-          .contains("[index: Area[id]]")
-          .contains("1 rows");
+          .contains("AnchorSelection{variable='country', useIndex=true")
+          .contains("VarLengthExpand(country)")
+          .contains("NodeIndexSeek(country:Area)");
     }
   }
 
@@ -194,9 +194,9 @@ class CypherVariableLengthAnchorSelectionTest {
       assertThat(result.<Long>getProperty("places")).isEqualTo(1L);
       assertThat(resultSet.hasNext()).isFalse();
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("MATCH NODE (country:Area)")
-          .contains("[index: Area[id]]")
-          .contains("1 rows");
+          .contains("AnchorSelection{variable='country', useIndex=true")
+          .contains("VarLengthExpand(country)")
+          .contains("NodeIndexSeek(country:Area)");
     }
   }
 
@@ -215,9 +215,9 @@ class CypherVariableLengthAnchorSelectionTest {
           .toList())
           .containsExactly("country:2", "region:1");
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("INDEX SEEK (country:Area)")
-          .contains("[index: Area[id]]")
-          .contains("2 rows");
+          .contains("AnchorSelection{variable='country', useIndex=true")
+          .contains("VarLengthExpand(country)")
+          .contains("NodeIndexSeek(country:Area)");
     }
   }
 
@@ -241,9 +241,9 @@ class CypherVariableLengthAnchorSelectionTest {
       while (resultSet.hasNext())
         resultSet.next();
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("INDEX SEEK (country:Area)")
-          .contains("[index: Area[id]]")
-          .contains("2 rows");
+          .contains("AnchorSelection{variable='country', useIndex=true")
+          .contains("VarLengthExpand(country)")
+          .contains("NodeIndexSeek(country:Area)");
     }
   }
 
@@ -267,8 +267,8 @@ class CypherVariableLengthAnchorSelectionTest {
       while (resultSet.hasNext())
         resultSet.next();
       assertThat(resultSet.getExecutionPlan().orElseThrow().prettyPrint(0, 2))
-          .contains("MATCH NODE (place:Area)")
-          .doesNotContain("INDEX SEEK (country:Area)");
+          .contains("VarLengthExpand(country)")
+          .contains("NodeIndexSeek(country:Area)");
     }
   }
 
@@ -328,8 +328,8 @@ class CypherVariableLengthAnchorSelectionTest {
     }
 
     assertThat(plan.getSteps().get(0).getDescription())
-        .contains("MATCH NODE (country:Area)")
-        .contains("[index: Area[id]]");
+        .contains("VarLengthExpand(country)")
+        .contains("NodeIndexSeek(country:Area)");
 
     final Result city = rows.stream()
         .filter(row -> "city".equals(row.<String>getProperty("id")))
@@ -357,8 +357,8 @@ class CypherVariableLengthAnchorSelectionTest {
     }
 
     assertThat(plan.getSteps().get(0).getDescription())
-        .contains("MATCH NODE (country:Area)")
-        .contains("[index: Area[id]]");
+        .contains("VarLengthExpand(country)")
+        .contains("NodeIndexSeek(country:Area)");
 
     final Result city = rows.stream()
         .filter(row -> "city".equals(row.<String>getProperty("id")))
@@ -385,8 +385,9 @@ class CypherVariableLengthAnchorSelectionTest {
       while (resultSet.hasNext())
         resultSet.next();
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("MATCH NODE (place:Area)")
-          .doesNotContain("[index:");
+          .contains("AnchorSelection{variable='place', useIndex=false")
+          .contains("VarLengthExpand(place)")
+          .contains("NodeByLabelScan(place:Area)");
     }
   }
 
@@ -405,8 +406,9 @@ class CypherVariableLengthAnchorSelectionTest {
       while (resultSet.hasNext())
         resultSet.next();
       assertThat(resultSet.getExecutionPlan().orElseThrow().getSteps().get(0).getDescription())
-          .contains("MATCH NODE (place:Area)")
-          .doesNotContain("[index:");
+          .contains("AnchorSelection{variable='place', useIndex=false")
+          .contains("VarLengthExpand(place)")
+          .contains("NodeByLabelScan(place:Area)");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthReversedAnchorSemanticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableLengthReversedAnchorSemanticsTest.java
@@ -37,8 +37,8 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Semantic parity coverage for the indexed-anchor reversal bridge used by the traditional Cypher
- * executor (PRs #5357, #5387, #5393).
+ * Semantic parity coverage for indexed-anchor reversal in variable-length Cypher traversal (PRs
+ * #5357, #5387, #5393 and the physical VarLengthExpand operator).
  * <p>
  * Every test runs the same query twice against the same graph: once anchored on the indexed
  * {@code id} property, which lets the bridge reverse the traversal, and once anchored on the
@@ -180,19 +180,18 @@ class CypherVariableLengthReversedAnchorSemanticsTest {
   }
 
   /**
-   * A named path variable still keeps the optimizer out, so no physical anchor exists and the bridge
-   * cannot engage. The query must return the correct rows through the plain source-first plan; this
-   * pins that a future eligibility change cannot silently reroute it unnoticed.
+   * A named single-segment variable-length path is represented directly by VarLengthExpand. Reversed
+   * traversal must still bind the path in written order.
    */
   @Test
-  void aNamedPathStaysIneligibleForTheBridgeAndCorrect() {
+  void aNamedPathUsesTheIndexedAnchorAndKeepsWrittenOrder() {
     final String namedPath = """
         MATCH p = (n:Node)-[:LINK*]->(hub:Node)
         WHERE hub.id = 'hub'
         RETURN [x IN nodes(p) | x.id] AS ids
         ORDER BY ids""";
 
-    assertThat(planStartsFromAnchor(namedPath)).isFalse();
+    assertThat(planStartsFromAnchor(namedPath)).isTrue();
     assertThat(rows(namedPath)).containsExactly(
         "ids=[a, b, d, hub];", "ids=[a, c, d, hub];", "ids=[b, d, hub];", "ids=[c, d, hub];",
         "ids=[d, hub];", "ids=[hub, a, b, d, hub];", "ids=[hub, a, c, d, hub];");
@@ -241,7 +240,9 @@ class CypherVariableLengthReversedAnchorSemanticsTest {
       while (resultSet.hasNext())
         resultSet.next();
       final String firstStep = resultSet.getExecutionPlan().orElseThrow().getSteps().getFirst().getDescription();
-      return firstStep.contains("(hub:Node)") && firstStep.contains("[index: Node[id]]");
+      return firstStep.contains("AnchorSelection{variable='hub', useIndex=true")
+          && firstStep.contains("VarLengthExpand(hub)")
+          && firstStep.contains("NodeIndexSeek(hub:Node)");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/optimizer/statistics/CostModelTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/optimizer/statistics/CostModelTest.java
@@ -74,6 +74,30 @@ class CostModelTest {
   }
 
   @Test
+  void estimateBoundedVariableLengthExpansionAsGeometricSeries() {
+    assertThat(costModel.estimateVariableLengthExpansionFactor(10.0, 1, 3)).isEqualTo(1110.0);
+    assertThat(costModel.estimateVariableLengthExpansionFactor(10.0, 0, 0)).isEqualTo(1.0);
+  }
+
+  @Test
+  void unboundedVariableLengthExpansionUsesAConservativeFinitePlanningHorizon() {
+    assertThat(costModel.estimateVariableLengthExpansionFactor(10.0, 1, Integer.MAX_VALUE))
+        .isEqualTo(111_111_110.0);
+    assertThat(costModel.estimateVariableLengthCardinality(100, 10.0, 1, Integer.MAX_VALUE))
+        .isEqualTo(11_111_111_000L);
+  }
+
+  @Test
+  void variableLengthCardinalityCannotOverflow() {
+    assertThat(costModel.estimateVariableLengthCardinality(Long.MAX_VALUE / 2, 10.0, 1, 3))
+        .isEqualTo(Long.MAX_VALUE);
+    assertThat(costModel.estimateVariableLengthCardinality(100, 10.0, 1, 1_000))
+        .isEqualTo(Long.MAX_VALUE);
+    assertThat(CostModel.saturatingCardinalityProduct(Long.MAX_VALUE / 2, 3))
+        .isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
   void estimateExpandIntoCost() {
     final double expandIntoCost = costModel.estimateExpandIntoCost(100);
     assertThat(expandIntoCost).isEqualTo(100.0); // Much cheaper than ExpandAll


### PR DESCRIPTION
## What does this PR do?

Adds a lazy physical `VarLengthExpand` operator and routes supported ordinary variable-length `MATCH` patterns through optimized execution instead of declining the entire query to Traditional Execution.

The physical path covers:

- bounded, unbounded, bare-star, and zero-hop expansions
- direction and relationship-type constraints
- inline relationship properties and supported inline `WHERE` predicates
- bound endpoints (`ExpandInto`) and selective reversed anchors
- named-path and relationship-list bindings with written-order semantics
- `TRAIL`, `ACYCLIC`, and `WALK` path modes
- MATCH-clause-wide relationship uniqueness across fixed-length, variable-length, and disconnected components
- conservative, saturating variable-length cost and cardinality estimates

Unsupported predicate shapes and dynamic labels retain an explicit Traditional Execution fallback. `shortestPath` and a Graph Analytical View (GAV) variable-length fast path are intentionally outside this first PR.

## Motivation

A variable-length relationship currently forces Traditional Execution even when the query has a selective indexed anchor. That discards the cost-based plan and can turn an otherwise bounded traversal into a broad scan.

In a bounded synthetic benchmark with 100,000 decoy vertices and ten measured runs, the index-anchored physical plan averaged 0.316 ms versus 126.523 ms for forced Traditional Execution (399.9x). This demonstrates the avoided scan in that workload; it is not intended as a universal speedup claim.

## Related issues

Refs #5358

Related: #6310, #6400, #6417

## Additional Notes

Focused operator, planner, path-semantics, relationship-uniqueness, differential-planner, and cost-model tests pass.

One local `./mvnw -pl engine test` run completed 8,555 tests, including all changed Cypher coverage, before the inherited `ACIDTransactionTest` stopped making progress for 27 minutes in an early asynchronous wait. The run was stopped rather than repeated.

The same run reported three unrelated results in untouched SQL tests:

- two logger-capture assertions in `BucketIteratorSkippedRecordWarningTest`; both pass in a fresh targeted run (2/2), indicating accumulated JVM state
- `ScriptExecutionTest.commitRetryMultiThreadsSQLIncrementRepeatableRead`; it reproduces immediately in isolation because this 256-CPU host requests 256 buckets while the configured maximum is 32

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
