### PR TITLE
fix(#6374): enforce label/inline-property constraints on a correlated pattern-comprehension start node

### DIFF
--- a/docs/6374-pattern-comprehension-bound-node-label-check.md
+++ b/docs/6374-pattern-comprehension-bound-node-label-check.md
@@ -9,9 +9,7 @@ returns that vertex directly, so the method never routes through `traverseUncorr
 (which is where labels/inline properties are enforced for an *unbound* start). The only check
 applied to a *correlated* start node was the inline `WHERE` predicate
 (`matchesNodeWhereExpression`); `Labels.matches(...)` and `InlineProperties.matches(...)` were
-never called on it. Worse, that WHERE-only check lived inside the multi-hop branch, past the
-`hopIndex >= pathPattern.getRelationshipCount()` terminal check - so a zero-relationship pattern
-comprehension (a single node, no arrows) skipped node-pattern validation entirely, WHERE included.
+never called on it.
 
 The sibling construct `exists(...)` / `PatternPredicateExpression.matchesNodePattern` already
 enforces labels + inline properties + WHERE on a bound start vertex (fixed for issue #5095), so
@@ -20,23 +18,34 @@ the two constructs disagreed.
 ## Fix
 
 In `engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java`,
-`traversePattern` now resolves the leading node's vertex and validates it (labels, inline
-properties, inline WHERE) via a new `matchesStartNodePattern` helper **before** the
-zero-relationship terminal check, not just before the mid-pattern edge expansion. This closes both
-gaps described in the issue: the label/property omission on a correlated bound start, and the
-zero-relationship terminal branch that bypassed the check altogether.
-
-The old separate inline-WHERE-only check further down was removed - it's now subsumed by
+`traversePattern` now validates the leading node's constraints (labels, inline properties, inline
+WHERE) via a new `matchesStartNodePattern` helper at the same site the old WHERE-only check lived
+(`hopIndex == 0 && knownStartVertex == null`, just before the mid-pattern edge expansion). The old
+separate inline-WHERE-only check at that site was removed - it's now subsumed by
 `matchesStartNodePattern`.
+
+The `hopIndex >= pathPattern.getRelationshipCount()` terminal check ("all hops matched") is
+unconditionally the first statement in `traversePattern` and stays there; `matchesStartNodePattern`
+does not run ahead of it. This is not a gap in practice: the grammar's `pathPatternNonEmpty` rule
+(`nodePattern (relationshipPattern nodePattern)+`) requires at least one relationship, so a parsed
+`PatternComprehensionExpression` never has `getRelationshipCount() == 0` and the terminal branch is
+never reached at `hopIndex == 0` without first passing through the new check. The issue's suggested
+fix mentioned guarding "the zero-relationship terminal branch" too; that branch is unreachable from
+any query the parser accepts, so no change was made there. (An earlier draft of this doc claimed the
+check had been moved ahead of the terminal branch - that was inaccurate, caught in PR review, and is
+corrected here.)
 
 ## Test
 
 `engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionBoundStartLabelIssue6374Test.java`
 reproduces the issue's exact repro (label + inline property on a correlated leading node,
-contrasted against `exists(...)` and the zero-relationship single-node case) and asserts the
-comprehension and `exists(...)` agree.
+contrasted against `exists(...)`), plus a case pinning the pre-existing inline-WHERE behavior so the
+refactor into `matchesStartNodePattern` doesn't regress it.
 
 ## Verification
 
-- `mvn -o -pl engine -am test -Dtest=CypherComprehensionBoundStartLabelIssue6374Test -Dmaven.repo.local=...`
-- Full opencypher package regression: `mvn -o -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**' ...` (see PR for exact command/coverage run)
+- `mvn -pl engine -am test -Dtest=CypherComprehensionBoundStartLabelIssue6374Test` - green.
+- Full `engine` module suite (8789 tests, includes the openCypher TCK): `mvn -pl engine -am test` -
+  green except one pre-existing, unrelated failure
+  (`Issue6302AlgoGraphDrivenWorkGuardTest.apspObservesTheDeadlineInsideTheTripleLoop`, a timing-based
+  APSP deadline test) that reproduces identically on an unmodified `main` checkout.

--- a/docs/6374-pattern-comprehension-bound-node-label-check.md
+++ b/docs/6374-pattern-comprehension-bound-node-label-check.md
@@ -49,3 +49,27 @@ refactor into `matchesStartNodePattern` doesn't regress it.
   green except one pre-existing, unrelated failure
   (`Issue6302AlgoGraphDrivenWorkGuardTest.apspObservesTheDeadlineInsideTheTripleLoop`, a timing-based
   APSP deadline test) that reproduces identically on an unmodified `main` checkout.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6485
+
+## Review cycles
+
+- **Cycle 1** - head `bf0cc12e`. Claude review (posted as an issue comment, not a formal PR review):
+  fix logic and test coverage called "solid, well-scoped," nothing blocking, but flagged one
+  doc-accuracy issue - this tracking doc claimed the leading-node check had been moved ahead of the
+  zero-relationship terminal check, which the code does not actually do (the terminal check is still
+  unconditionally first; the branch is simply unreachable per the grammar). Addressed: corrected the
+  "Fix" section above to state the actual code ordering and why the terminal branch needs no guard.
+  Committed as `7c3f825` ("address review: fix tracking-doc claim about the terminal-check
+  ordering") and pushed.
+- **Cycle 2** - head `7c3f825a`. No bot response within the 15-minute per-iteration timeout. Per
+  [reference_review_bot_can_time_out_before_posting], the review bot can time out before ever
+  posting for a given push; this is a detection/infra gap, not evidence the fix itself is wrong.
+
+## Final state
+
+`timeout` - cycle 2 got no bot response within 15 minutes. The PR is left open for the developer;
+merge is the developer's responsibility. All functional review feedback that did arrive (cycle 1)
+was addressed and pushed.

--- a/docs/6374-pattern-comprehension-bound-node-label-check.md
+++ b/docs/6374-pattern-comprehension-bound-node-label-check.md
@@ -1,0 +1,42 @@
+# Issue #6374: Pattern comprehension ignores label/inline-property constraints on a correlated (outer-bound) leading node
+
+## Root cause
+
+`PatternComprehensionExpression.traversePattern` is the engine's evaluator for pattern
+comprehensions like `[(p:Company)-->(x) | x.name]`. When the leading node of the pattern reuses
+a variable already bound in the outer scope (e.g. `p` from an enclosing `MATCH`), `resolveVertex`
+returns that vertex directly, so the method never routes through `traverseUncorrelatedStart`
+(which is where labels/inline properties are enforced for an *unbound* start). The only check
+applied to a *correlated* start node was the inline `WHERE` predicate
+(`matchesNodeWhereExpression`); `Labels.matches(...)` and `InlineProperties.matches(...)` were
+never called on it. Worse, that WHERE-only check lived inside the multi-hop branch, past the
+`hopIndex >= pathPattern.getRelationshipCount()` terminal check - so a zero-relationship pattern
+comprehension (a single node, no arrows) skipped node-pattern validation entirely, WHERE included.
+
+The sibling construct `exists(...)` / `PatternPredicateExpression.matchesNodePattern` already
+enforces labels + inline properties + WHERE on a bound start vertex (fixed for issue #5095), so
+the two constructs disagreed.
+
+## Fix
+
+In `engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java`,
+`traversePattern` now resolves the leading node's vertex and validates it (labels, inline
+properties, inline WHERE) via a new `matchesStartNodePattern` helper **before** the
+zero-relationship terminal check, not just before the mid-pattern edge expansion. This closes both
+gaps described in the issue: the label/property omission on a correlated bound start, and the
+zero-relationship terminal branch that bypassed the check altogether.
+
+The old separate inline-WHERE-only check further down was removed - it's now subsumed by
+`matchesStartNodePattern`.
+
+## Test
+
+`engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionBoundStartLabelIssue6374Test.java`
+reproduces the issue's exact repro (label + inline property on a correlated leading node,
+contrasted against `exists(...)` and the zero-relationship single-node case) and asserts the
+comprehension and `exists(...)` agree.
+
+## Verification
+
+- `mvn -o -pl engine -am test -Dtest=CypherComprehensionBoundStartLabelIssue6374Test -Dmaven.repo.local=...`
+- Full opencypher package regression: `mvn -o -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**' ...` (see PR for exact command/coverage run)

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -119,12 +119,15 @@ public class PatternComprehensionExpression implements Expression {
       return;
     }
 
-    // Inline WHERE predicate on the leading node, e.g. [(a WHERE a.v = 1)-[:E]->(x) | x]. Only the
-    // first hop needs the check here: every later hop starts from the previous hop's end node, which
-    // matchesEndPattern already validated, and an uncorrelated start is validated while iterating
-    // candidates in traverseUncorrelatedStart.
-    if (hopIndex == 0 && knownStartVertex == null
-        && !matchesNodeWhereExpression(startVertex, startNodePattern, inlineWhereRow(startNodePattern, currentResult), context))
+    // Label, inline-property and inline-WHERE constraints on the leading node, e.g.
+    // [(a:Company WHERE a.v = 1)-[:E]->(x) | x]. Only the first hop needs the check here: every
+    // later hop starts from the previous hop's end node, which matchesEndPattern already validated,
+    // and an uncorrelated start is validated while iterating candidates in traverseUncorrelatedStart.
+    // A correlated start (the leading node reuses an outer-bound variable) used to skip the label and
+    // inline-property checks entirely and enforce only the WHERE predicate, so a comprehension and
+    // the sibling exists(...) pattern predicate - which enforces all three on a bound start vertex
+    // (issue #5095) - disagreed on the same pattern (issue #6374).
+    if (hopIndex == 0 && knownStartVertex == null && !matchesStartNodePattern(startVertex, startNodePattern, currentResult, context))
       return;
 
     // Add start vertex to path at first hop
@@ -219,6 +222,23 @@ public class PatternComprehensionExpression implements Expression {
     if (!InlineProperties.matches(vertex, startNodePattern.getProperties(), bindings, context))
       return false;
     return matchesNodeWhereExpression(vertex, startNodePattern, whereEvalRow, context);
+  }
+
+  /**
+   * Returns true if a <b>correlated</b> start vertex - the leading node of the pattern reusing a
+   * variable already bound in the outer scope - satisfies the start node pattern's labels, inline
+   * properties and inline {@code WHERE} predicate. Unlike {@link #matchesStartPattern}, the labels
+   * are checked here: the vertex did not come from a label-filtered candidate scan, it is whatever
+   * the outer scope already bound (issue #6374, mirroring {@code PatternPredicateExpression}'s
+   * enforcement of the same rule for {@code exists(...)}, issue #5095).
+   */
+  private boolean matchesStartNodePattern(final Vertex vertex, final NodePattern startNodePattern, final Result bindings,
+      final CommandContext context) {
+    if (!Labels.matches(vertex, startNodePattern.getLabels(), startNodePattern.isLabelDisjunction()))
+      return false;
+    if (!InlineProperties.matches(vertex, startNodePattern.getProperties(), bindings, context))
+      return false;
+    return matchesNodeWhereExpression(vertex, startNodePattern, inlineWhereRow(startNodePattern, bindings), context);
   }
 
   private void traverseVariableLength(final Result baseResult, final CommandContext context,

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionBoundStartLabelIssue6374Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherComprehensionBoundStartLabelIssue6374Test.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6374: a pattern comprehension whose leading node reuses an
+ * outer-bound variable ignored any label or inline-property constraint declared on that leading
+ * node, expanding the bound vertex's edges regardless. The sibling {@code exists(...)} pattern
+ * predicate already enforces the same constraint on a bound start vertex (issue #5095), so the two
+ * constructs disagreed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherComprehensionBoundStartLabelIssue6374Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-comprehension-bound-start-6374");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.transaction(() -> database.command("opencypher", "CREATE (p:Person {name:'P'})-[:KNOWS]->(:Person {name:'F'})"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void aLabelConstraintOnACorrelatedBoundStartIsEnforced() {
+    // p is a Person, not a Company: the :Company constraint on the bound p must fail the whole
+    // comprehension, matching what exists(...) already answers for the same pattern.
+    assertThat(listOf("MATCH (p:Person {name:'P'}) RETURN [(p:Company)-[:KNOWS]->(x) | x.name] AS r")).isEmpty();
+    assertThat(booleanOf("MATCH (p:Person {name:'P'}) RETURN exists((p:Company)-[:KNOWS]->()) AS r")).isFalse();
+  }
+
+  @Test
+  void anInlinePropertyConstraintOnACorrelatedBoundStartIsEnforced() {
+    assertThat(listOf("MATCH (p:Person {name:'P'}) RETURN [(p {name:'WRONG'})-[:KNOWS]->(x) | x.name] AS r")).isEmpty();
+    assertThat(booleanOf("MATCH (p:Person {name:'P'}) RETURN exists((p {name:'WRONG'})-[:KNOWS]->()) AS r")).isFalse();
+  }
+
+  @Test
+  void aMatchingLabelOnACorrelatedBoundStartStillWorks() {
+    assertThat(listOf("MATCH (p:Person {name:'P'}) RETURN [(p:Person)-[:KNOWS]->(x) | x.name] AS r"))
+        .containsExactly("F");
+  }
+
+  @Test
+  void anInlineWhereOnACorrelatedBoundStartIsStillEnforced() {
+    // The inline-WHERE check was already correct before the fix; pinned here so the restructuring
+    // that folds it together with the label/property checks does not regress it.
+    assertThat(listOf("MATCH (p:Person {name:'P'}) RETURN [(p WHERE p.name = 'WRONG')-[:KNOWS]->(x) | x.name] AS r")).isEmpty();
+    assertThat(listOf("MATCH (p:Person {name:'P'}) RETURN [(p WHERE p.name = 'P')-[:KNOWS]->(x) | x.name] AS r"))
+        .containsExactly("F");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object> listOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return (List<Object>) rs.next().getProperty("r");
+    }
+  }
+
+  private boolean booleanOf(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return (Boolean) rs.next().getProperty("r");
+    }
+  }
+}


### PR DESCRIPTION
Closes #6374

## What does this PR do?

A pattern comprehension whose leading node reuses an outer-bound variable and carries a label or
inline-property constraint - e.g. `[(p:Company)-->(x) | x.name]` where `p` is already bound in the
outer scope - ignored that constraint and expanded the bound vertex's edges regardless, producing
over-inclusive results. Only the inline `WHERE` predicate was enforced on the bound start vertex;
`Labels.matches(...)` and `InlineProperties.matches(...)` were never called on it.

The sibling construct `exists(...)` (`PatternPredicateExpression.matchesNodePattern`) already
enforces labels + inline properties + WHERE on a bound start vertex, fixed for issue #5095 with the
explicit rationale "these constraints must hold on the bound variable itself, not only on the
traversal target." `PatternComprehensionExpression` disagreed with that sibling on the exact same
pattern.

### Root cause

`PatternComprehensionExpression.traversePattern`, at `hopIndex == 0 && knownStartVertex == null`
(the correlated-start case), called only `matchesNodeWhereExpression(...)`. The label/property
checks that exist elsewhere in the file (`matchesEndPattern` for expanded nodes,
`matchesStartPattern` for an *uncorrelated* candidate scan) were never applied to a vertex the outer
scope had already bound.

### Fix

Added `matchesStartNodePattern`, which checks labels, inline properties and the inline `WHERE`
predicate together, and call it at the correlated-start site instead of the WHERE-only check. This
mirrors `PatternPredicateExpression#matchesNodePattern`.

## Motivation

Correctness: a query author writing `[(p:Company)-->(x) | x.name]` expects the `:Company`
constraint on `p` to be honored, exactly as `exists((p:Company)-->(x))` already honors it. Silent
over-inclusion of results is a correctness bug with no error or warning to the user.

## Related issues

Closes #6374. References #5095 (the `exists(...)` fix this change brings the sibling construct in
line with).

## Additional Notes

- The issue also suggested applying the same guard to a "zero-relationship terminal branch." That
  branch is unreachable from the parser: the grammar's `pathPatternNonEmpty` requires
  `nodePattern (relationshipPattern nodePattern)+`, i.e. at least one relationship, so a
  `PatternComprehensionExpression` never has `getRelationshipCount() == 0`. No code change was
  needed there; noted in the tracking doc for the record.
- Ran the full `engine` module test suite (`mvn -pl engine -am test`, 8789 tests): one pre-existing,
  unrelated failure (`Issue6302AlgoGraphDrivenWorkGuardTest.apspObservesTheDeadlineInsideTheTripleLoop`,
  a timing-based APSP deadline test) reproduces identically on an unmodified `main` checkout, so it
  predates this change.

## Test plan

- [x] New regression test `CypherComprehensionBoundStartLabelIssue6374Test` reproduces the issue's
      exact repro (label + inline-property constraint on a correlated bound leading node), confirmed
      failing before the fix and passing after, and cross-checks against `exists(...)` for the same
      pattern.
- [x] `mvn -pl engine -am test -Dtest=CypherComprehensionBoundStartLabelIssue6374Test` - green.
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**'` (8789 tests, includes the
      full openCypher TCK suite) - green except the pre-existing unrelated failure noted above.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios