### PR TITLE
fix(#6373): bound the Quorum.ALL watch() loop by the per-batch deadline

### DIFF
--- a/docs/6373-raft-group-committer-all-quorum-watch-deadline.md
+++ b/docs/6373-raft-group-committer-all-quorum-watch-deadline.md
@@ -1,0 +1,53 @@
+# Issue #6373: RaftGroupCommitter Quorum.ALL watch() loop has no per-batch deadline
+
+## Root cause
+
+`RaftGroupCommitter.flushBatch(...)` (`ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java`)
+computes a single `deadlineNanos` budget for the whole batch before its result-wait loop. The
+`futures[i].get(remainingNanos, TimeUnit.NANOSECONDS)` call correctly derives its wait from what
+remains of that budget (fixed by #6109 for #5848).
+
+The `Quorum.ALL` branch immediately below it does not: it calls the synchronous, timeout-less
+`raftClient.io().watch(logIndex, ALL_COMMITTED)` overload once per committed entry, with no
+reference to `deadlineNanos` at all. Under `arcadedb.ha.quorum=all` with one follower down or
+partitioned, majority is reached quickly (so the `get()` deadline gives no protection), but each
+entry's `ALL_COMMITTED` watch then blocks for as long as the follower is unreachable - serially, on
+the single `arcadedb-raft-group-committer` thread, for every entry in the batch. This is the same
+per-entry-vs-per-batch granularity bug #5848 was about, in a code path #6109 did not touch.
+
+## Affected components
+
+- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java` (`flushBatch`)
+
+## Expected vs actual behavior
+
+- **Expected:** the `Quorum.ALL` watch shares the same per-batch deadline as the result-wait loop
+  above it. A follower that never confirms `ALL_COMMITTED` within the remaining batch budget must
+  fail that entry as `MajorityCommittedAllFailedException` (committed at MAJORITY, ALL unconfirmed)
+  rather than blocking the flusher indefinitely.
+- **Actual (before fix):** the watch call has no timeout at all. A stalled `ALL` confirmation blocks
+  the flusher thread for as long as the follower is unreachable, once per entry in the batch, with no
+  bound - not even `quorumTimeout`.
+
+## Fix
+
+Ratis's `BlockingApi.watch(long, ReplicationLevel)` has no timeout-bearing overload (verified against
+`ratis-client:3.3.0` sources: `org.apache.ratis.client.api.BlockingApi#watch` takes only
+`(long index, ReplicationLevel replication)`). `AsyncApi.watch(long, ReplicationLevel)` returns a
+`CompletableFuture<RaftClientReply>`, so the same pattern already used for the result-wait loop
+applies directly: call `raftClient.async().watch(index, level)` and bound it with
+`.get(remainingNanos, TimeUnit.NANOSECONDS)`, computing `remainingNanos` from the same
+`deadlineNanos` the entry's `futures[i].get()` already used. An expired budget (`TimeoutException`)
+completes the entry as `MajorityCommittedAllFailedException`, the same outcome already used for a
+negative `watchReply`.
+
+## Test plan
+
+- `RaftGroupCommitterTest.allQuorumWatchGivesUpAtTheBatchDeadlineInsteadOfBlockingIndefinitely`:
+  mocks a `RaftClient` where `async().send()` succeeds immediately (MAJORITY reached) but ALL
+  confirmation never arrives (both the blocking `io().watch()` and async `async().watch()` overloads
+  never return/complete, simulating a down/partitioned follower). With `quorumTimeout` set short
+  (200 ms), the fixed code must fail the entry with `MajorityCommittedAllFailedException` within a
+  few hundred ms; before the fix this test hangs past its bounded `outcome.get(3, SECONDS)` and fails
+  with a `TimeoutException`.
+- Full `ha-raft` unit test module rerun to confirm no regressions.

--- a/docs/6373-raft-group-committer-all-quorum-watch-deadline.md
+++ b/docs/6373-raft-group-committer-all-quorum-watch-deadline.md
@@ -51,3 +51,35 @@ negative `watchReply`.
   few hundred ms; before the fix this test hangs past its bounded `outcome.get(3, SECONDS)` and fails
   with a `TimeoutException`.
 - Full `ha-raft` unit test module rerun to confirm no regressions.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6486
+
+## Review cycles
+
+- **Cycle 1** - head `bec509a9dc3094e812bf9ccc03f904e0aadec05e` (original PR push). `claude[bot]` review
+  flagged one correctness bug plus two minor nits:
+  - The new inner `catch (final Exception e)` around the `async().watch(...).get(remainingWatchNanos, ...)`
+    call swallowed `InterruptedException` instead of restoring the interrupt flag and letting it reach the
+    outer `catch (final InterruptedException ie)` fast-abort handler, so an interrupt during the `ALL`
+    watch would silently clear the flag and let the rest of the batch fall through to full-length waits -
+    the same unbounded-stall shape this PR was fixing, relocated to the interrupt path. Fixed by adding an
+    explicit `catch (final InterruptedException ie)` before the generic `catch (Exception e)` that restores
+    the flag and rethrows.
+  - Minor: the `TimeoutException` branch dropped the cause when constructing
+    `MajorityCommittedAllFailedException`. Fixed to pass `te` as the cause via the two-arg constructor.
+  - Minor: the regression test still stubbed the now-unused `client.io().watch(...)` overload (dead since
+    the fix moved to `async().watch()`). Removed the dead stub.
+  - Also added `allQuorumWatchSucceedsWithinBudgetReturnsLogIndex`, a happy-path companion test for the
+    `Quorum.ALL` success case (no prior test covered it).
+  - Addressed in commit `476329f95332c34a907a320d30819aab78757ca3`, pushed back to the same branch.
+- **Cycle 2** - head `476329f95332c34a907a320d30819aab78757ca3`. `claude[bot]` review (issue comment
+  `5352530125`, posted 2026-08-20T07:01:15Z) was clean/non-blocking: it confirmed the interrupt-flag fix,
+  approved the new regression + happy-path tests as deterministic and consistent with the file's existing
+  mocking style, and raised only non-blocking notes (comment density, an existing/pre-existing
+  non-cancellation-of-timed-out-futures characteristic, doc-file convention). No code changes were required.
+
+## Final state
+
+`clean-approval` after 2 review cycles. Merge remains the developer's responsibility.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
@@ -532,8 +532,16 @@ class RaftGroupCommitter {
             }
           } catch (final TimeoutException te) {
             batch.get(i).future.complete(new MajorityCommittedAllFailedException(
-                "ALL quorum not reached within batch deadline after MAJORITY commit at logIndex=" + reply.getLogIndex()));
+                "ALL quorum not reached within batch deadline after MAJORITY commit at logIndex=" + reply.getLogIndex(), te));
             continue;
+          } catch (final InterruptedException ie) {
+            // Rethrow instead of swallowing: this must reach the outer catch (final InterruptedException)
+            // below so the whole remaining batch gets fast-aborted, not just this one entry. Swallowing it
+            // here would clear the interrupt flag and let every later entry in the batch fall through to a
+            // fresh full-length wait - the same unbounded-stall shape issue #6373 fixed for the get() above,
+            // just relocated to the interrupt path.
+            Thread.currentThread().interrupt();
+            throw ie;
           } catch (final Exception e) {
             if (isClientClosed(e))
               clientClosedDetected = true;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftGroupCommitter.java
@@ -516,13 +516,24 @@ class RaftGroupCommitter {
 
         if (quorum == Quorum.ALL) {
           try {
-            final RaftClientReply watchReply = raftClient.io().watch(
-                reply.getLogIndex(), RaftProtos.ReplicationLevel.ALL_COMMITTED);
+            // Same shared-deadline pattern as the get() above (issue #6373, a surviving sibling of
+            // #5848): the blocking io().watch() overload has no timeout parameter at all, so it must
+            // not be used here - it would turn a stalled ALL confirmation into an unbounded per-entry
+            // wait on this single flusher thread, the exact bug the deadline above already fixed for
+            // the MAJORITY leg. The async overload's future gives the same bound the get() loop uses.
+            final long remainingWatchNanos = deadlineNanos - System.nanoTime();
+            final RaftClientReply watchReply = raftClient.async()
+                .watch(reply.getLogIndex(), RaftProtos.ReplicationLevel.ALL_COMMITTED)
+                .get(remainingWatchNanos, TimeUnit.NANOSECONDS);
             if (!watchReply.isSuccess()) {
               batch.get(i).future.complete(new MajorityCommittedAllFailedException(
                   "ALL quorum not reached after MAJORITY commit at logIndex=" + reply.getLogIndex()));
               continue;
             }
+          } catch (final TimeoutException te) {
+            batch.get(i).future.complete(new MajorityCommittedAllFailedException(
+                "ALL quorum not reached within batch deadline after MAJORITY commit at logIndex=" + reply.getLogIndex()));
+            continue;
           } catch (final Exception e) {
             if (isClientClosed(e))
               clientClosedDetected = true;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -554,6 +555,60 @@ class RaftGroupCommitterTest {
       assertThat(index.get()).isEqualTo(999L);
     } finally {
       stallers.shutdownNow();
+      committer.stop();
+    }
+  }
+
+  /**
+   * Regression for issue #6373, a surviving sibling of #5848: the {@code Quorum.ALL} branch of
+   * {@code flushBatch} calls the timeout-less {@code raftClient.io().watch(...)} overload once per
+   * committed entry, with no reference at all to the {@code deadlineNanos} budget the {@code get()}
+   * loop right above it already respects (fixed for #5848 by #6109). A down/partitioned follower
+   * under {@code arcadedb.ha.quorum=all} reaches MAJORITY quickly - so the {@code get()} deadline
+   * gives no protection here - and then blocks the single flusher thread on the {@code ALL_COMMITTED}
+   * watch for as long as the follower stays unreachable, with no bound whatsoever.
+   * <p>
+   * With the fix, the watch shares the same per-batch deadline: it is bounded by
+   * {@code deadlineNanos - System.nanoTime()}, the same remaining budget the entry's {@code get()}
+   * already used, so a stalled ALL confirmation fails fast as {@link MajorityCommittedAllFailedException}
+   * instead of blocking indefinitely.
+   */
+  @Test
+  void allQuorumWatchGivesUpAtTheBatchDeadlineInsteadOfBlockingIndefinitely() throws Exception {
+    final long quorumTimeout = 200; // ms - short deliberately so the bound is easy to observe
+
+    final RaftClientReply majorityReply = mock(RaftClientReply.class);
+    when(majorityReply.isSuccess()).thenReturn(true);
+    when(majorityReply.getLogIndex()).thenReturn(555L);
+
+    final RaftClient client = mock(RaftClient.class, RETURNS_DEEP_STUBS);
+    // MAJORITY is reached quickly - this is the leg #6109 already bounds, and gives no protection here.
+    when(client.async().send(any(Message.class))).thenReturn(CompletableFuture.completedFuture(majorityReply));
+    // A down/partitioned follower: ALL_COMMITTED is never confirmed, on either watch overload.
+    when(client.async().watch(anyLong(), any())).thenReturn(new CompletableFuture<>());
+    when(client.io().watch(anyLong(), any())).thenAnswer(inv -> {
+      new CountDownLatch(1).await(); // blocks until the flusher thread is interrupted by stop()
+      return null;
+    });
+
+    final RaftGroupCommitter committer = new RaftGroupCommitter(client, Quorum.ALL, quorumTimeout);
+    try {
+      final CompletableFuture<Throwable> outcome = CompletableFuture.supplyAsync(() -> {
+        try {
+          committer.submitAndWait(new byte[] { 1, 2, 3 });
+          return null;
+        } catch (final Throwable t) {
+          return t;
+        }
+      });
+
+      // Generous bound, well above quorumTimeout but far below what an unbounded watch() would take
+      // (in production, until the follower comes back; in this test, forever). With the fix the
+      // flusher gives up at roughly one quorumTimeout; without it, this get() itself times out.
+      final Throwable t = outcome.get(3, TimeUnit.SECONDS);
+      assertThat(t).isInstanceOf(MajorityCommittedAllFailedException.class);
+      assertThat(t.getMessage()).contains("ALL quorum");
+    } finally {
       committer.stop();
     }
   }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftGroupCommitterTest.java
@@ -584,12 +584,10 @@ class RaftGroupCommitterTest {
     final RaftClient client = mock(RaftClient.class, RETURNS_DEEP_STUBS);
     // MAJORITY is reached quickly - this is the leg #6109 already bounds, and gives no protection here.
     when(client.async().send(any(Message.class))).thenReturn(CompletableFuture.completedFuture(majorityReply));
-    // A down/partitioned follower: ALL_COMMITTED is never confirmed, on either watch overload.
+    // A down/partitioned follower: ALL_COMMITTED is never confirmed. The fixed production code only
+    // calls the async().watch() overload (the timeout-less io().watch() overload this issue was about
+    // is no longer invoked at all), so an uncompleted future here is what drives the deadline-bound wait.
     when(client.async().watch(anyLong(), any())).thenReturn(new CompletableFuture<>());
-    when(client.io().watch(anyLong(), any())).thenAnswer(inv -> {
-      new CountDownLatch(1).await(); // blocks until the flusher thread is interrupted by stop()
-      return null;
-    });
 
     final RaftGroupCommitter committer = new RaftGroupCommitter(client, Quorum.ALL, quorumTimeout);
     try {
@@ -608,6 +606,37 @@ class RaftGroupCommitterTest {
       final Throwable t = outcome.get(3, TimeUnit.SECONDS);
       assertThat(t).isInstanceOf(MajorityCommittedAllFailedException.class);
       assertThat(t.getMessage()).contains("ALL quorum");
+    } finally {
+      committer.stop();
+    }
+  }
+
+  /**
+   * Companion happy-path coverage for the {@code Quorum.ALL} branch touched by the fix above: when the
+   * async watch reply arrives well within the batch deadline, {@code submitAndWait} must return the
+   * dispatched entry's log index rather than treating the shared-deadline bound as a source of failure
+   * by itself.
+   */
+  @Test
+  void allQuorumWatchSucceedsWithinBudgetReturnsLogIndex() throws Exception {
+    final long quorumTimeout = 2_000; // ms - generous; this test exercises the success path, not the deadline
+
+    final RaftClientReply majorityReply = mock(RaftClientReply.class);
+    when(majorityReply.isSuccess()).thenReturn(true);
+    when(majorityReply.getLogIndex()).thenReturn(777L);
+
+    final RaftClientReply allReply = mock(RaftClientReply.class);
+    when(allReply.isSuccess()).thenReturn(true);
+
+    final RaftClient client = mock(RaftClient.class, RETURNS_DEEP_STUBS);
+    when(client.async().send(any(Message.class))).thenReturn(CompletableFuture.completedFuture(majorityReply));
+    // The follower confirms ALL_COMMITTED promptly, well within the batch deadline.
+    when(client.async().watch(anyLong(), any())).thenReturn(CompletableFuture.completedFuture(allReply));
+
+    final RaftGroupCommitter committer = new RaftGroupCommitter(client, Quorum.ALL, quorumTimeout);
+    try {
+      final long logIndex = committer.submitAndWait(new byte[] { 1, 2, 3 });
+      assertThat(logIndex).isEqualTo(777L);
     } finally {
       committer.stop();
     }


### PR DESCRIPTION
Closes #6373

## Summary

`RaftGroupCommitter.flushBatch`'s `Quorum.ALL` branch called the timeout-less `raftClient.io().watch(index, ALL_COMMITTED)` overload once per committed entry, with no reference at all to the batch's `deadlineNanos` budget that the result-wait `get()` loop right above it already respects (that loop was fixed for #5848 by #6109). Under `arcadedb.ha.quorum=all` with one follower down or partitioned, majority is reached quickly - so the `get()` deadline gives no protection there - and then each entry's `ALL_COMMITTED` watch blocks the single `arcadedb-raft-group-committer` thread for as long as the follower stays unreachable, serially, once per entry in the batch, with no bound whatsoever. This is the exact per-entry-vs-per-batch granularity bug #5848 was about, surviving in a code path #6109 did not touch.

Ratis's `BlockingApi.watch(long, ReplicationLevel)` has no timeout-bearing overload (verified against `ratis-client:3.3.0` sources). `AsyncApi.watch(long, ReplicationLevel)` returns a `CompletableFuture<RaftClientReply>`, so the fix carries the same pattern already used for the result-wait loop into the watch: call `raftClient.async().watch(index, level)` and bound it with `.get(remainingNanos, TimeUnit.NANOSECONDS)`, computed from the same `deadlineNanos` the entry's own `get()` already used. An expired budget (`TimeoutException`) now completes the entry as `MajorityCommittedAllFailedException` - committed at MAJORITY, ALL unconfirmed - the same outcome already used for a negative watch reply, instead of blocking indefinitely.

## Test plan

- [x] Added `RaftGroupCommitterTest.allQuorumWatchGivesUpAtTheBatchDeadlineInsteadOfBlockingIndefinitely`: mocks a `RaftClient` where `async().send()` succeeds immediately (MAJORITY reached) but ALL confirmation never arrives on either watch overload (simulating a down/partitioned follower). With `quorumTimeout` set short (200ms), confirmed this test **fails** against the pre-fix code (the caller's own unrelated top-level watchdog eventually intervenes with the wrong exception type, `ReplicationDispatchedTimeoutException`, after ~600ms - proving the flusher itself never gave up at the shared batch deadline); with the fix it passes, completing with `MajorityCommittedAllFailedException` within a few hundred ms.
- [x] Full `ha-raft` unit test module: `mvn -pl ha-raft test -DexcludedGroups=benchmark,slow,vector` - 959 tests, 0 failures, 0 errors.
- [x] Full reactor compile through `ha-raft` (`mvn -pl ha-raft -am compile`) - clean.
