### PR TITLE
fix(#6489): a build's own orphans made every close rebuild the graph

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2452,8 +2452,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
       }
       if (!unreachableEntries.isEmpty())
         LogManager.instance().log(this, Level.WARNING,
-            "Graph build left %d of %d vectors unreachable for index %s: serving them from the delta scan until the "
-                + "next rebuild", unreachableEntries.size(), finalActiveVectorIds.length, indexName);
+            "Graph build left %d of %d vectors unreachable for index %s: serving them from the delta scan. A later "
+                + "rebuild does not repair this - a Vamana build orphans a fresh set - so the count does not "
+                + "converge downwards", unreachableEntries.size(), finalActiveVectorIds.length, indexName);
 
       // Reacquire write lock to update graph state
       lock.writeLock().lock();
@@ -2470,6 +2471,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
           if (e.vectorId >= deltaSnapshotId)
             remaining.add(e);
 
+        // Entries inserted DURING the rebuild are genuinely pending: a later rebuild incorporates them, so they
+        // must keep the index MUTABLE. Nodes this build left unreachable are not pending work. They are already
+        // in the graph file, the delta scan already serves them, and a rebuild does not remove them - a Vamana
+        // build simply orphans a fresh set, so the count does not converge downwards. Deriving graphState from
+        // both collapses "has unflushed writes" into "has orphans", and flush() - which tests graphState alone,
+        // unlike rebuildGraphBeforeSearch() - then rebuilds the whole graph when a session that built or wrote
+        // closes, with nothing to flush. The mutation counter is already guarded against this same loop above
+        // ("would rebuild itself forever"); the state flag was not.
+        final boolean hasPendingWrites = !remaining.isEmpty();
+
         remaining.addAll(unreachableEntries);
 
         this.deltaVectors = remaining;
@@ -2481,8 +2492,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
         if (mutationsSinceSerialize.get() <= 0)
           cancelInactivityRebuildTimer();
 
-        // Only transition to IMMUTABLE if no new mutations arrived during rebuild
-        this.graphState = remaining.isEmpty() ? GraphState.IMMUTABLE : GraphState.MUTABLE;
+        // Only transition to IMMUTABLE if no new mutations arrived during rebuild. Nodes this build orphaned are
+        // deliberately not consulted here - see hasPendingWrites above.
+        this.graphState = hasPendingWrites ? GraphState.MUTABLE : GraphState.IMMUTABLE;
       } finally {
         lock.writeLock().unlock();
       }

--- a/engine/src/test/java/com/arcadedb/index/vector/VectorIndexRebuildsOnEveryCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/VectorIndexRebuildsOnEveryCloseTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Closing a database rebuilds a vector graph that is already complete and already on disk.
+ * <p>
+ * A Vamana build leaves a few nodes unreachable from the entry point; jvector ships no connectivity
+ * repair pass, so the engine records them and serves them from the delta scan. But
+ * {@code buildGraphFromScratchExclusively()} folds them into the pending-mutation list before it
+ * derives the graph state:
+ * <pre>
+ *   remaining.addAll(unreachableEntries);                          // LSMVectorIndex:2424
+ *   this.graphState = remaining.isEmpty() ? IMMUTABLE : MUTABLE;   // LSMVectorIndex:2436
+ * </pre>
+ * so "this build orphaned a few nodes" and "this index has unflushed writes" collapse into one bit.
+ * After a bulk load the index therefore reports {@code graphState=MUTABLE} with
+ * {@code mutationsSinceRebuild=0} and a complete graph - a state this test asserts directly.
+ * <p>
+ * The two consumers of that bit then disagree. {@code rebuildGraphBeforeSearch()} requires
+ * {@code mutationsSinceSerialize > 0} before it will rebuild (:2902), so searches correctly do
+ * nothing. {@code flush()}, which {@code close()} calls via {@code LocalDatabase.closeDurableParts},
+ * tests {@code graphState} alone (:5518) and rebuilds the whole graph. The rebuild orphans nodes
+ * again, so it cannot clear the condition that triggered it.
+ * <p>
+ * The state does not outlive the process - a quiesced index reopens {@code IMMUTABLE} off the
+ * persisted graph and closes in milliseconds - so the cost falls on every session that builds or
+ * writes, not on every close. At DEEP-10M that is a ~5,500 s rebuild appended to a ~5,500 s build,
+ * and it is what pushes the tier past a heap ceiling the build alone fits comfortably.
+ * <p>
+ * The mutation counter was already guarded against exactly this loop ("would rebuild itself
+ * forever", :2372-2377). The state flag was not.
+ */
+class VectorIndexRebuildsOnEveryCloseTest {
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 50_000;
+  private static final int    MAX_CONNECTIONS = 32;   // the engine default
+  private static final int    BEAM_WIDTH      = 100;
+  private static final String DB_PATH         = "./target/databases/VectorIndexRebuildsOnEveryCloseTest";
+
+  @AfterEach
+  void cleanUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void closingMustNotRebuildAGraphThatIsAlreadyCompleteAndPersisted() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+
+    final long buildMs;
+    final long closeMs;
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+
+      // Bulk-load first, then index. This is the shape a vector bulk load takes, and it leaves the
+      // index with no pending writes of its own - which is what makes the rebuild below indefensible.
+      final Random rng = new Random(7);
+      db.transaction(() -> {
+        final DocumentType docType = db.getSchema().createDocumentType("Doc");
+        docType.createProperty("id", Type.INTEGER);
+        docType.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+        for (int i = 0; i < NUM_VECTORS; i++)
+          db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
+      });
+
+      final long t0 = System.currentTimeMillis();
+      db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+          + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", "
+          + "\"maxConnections\": " + MAX_CONNECTIONS + ", \"beamWidth\": " + BEAM_WIDTH + ", "
+          + "\"storeVectorsInGraph\": false, \"addHierarchy\": true }");
+
+      final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+      final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+      for (int i = 0; i < 900 && lsm.getStats().get("graphNodeCount") == 0L; i++)
+        try { Thread.sleep(100); } catch (final InterruptedException ignored) { break; }
+      buildMs = System.currentTimeMillis() - t0;
+
+      final Map<String, Long> afterBuild = lsm.getStats();
+
+      assertThat(afterBuild.get("graphNodeCount"))
+          .as("the graph was built over every loaded vector").isEqualTo((long) NUM_VECTORS);
+      assertThat(afterBuild.get("mutationsSinceRebuild"))
+          .as("a completed build leaves nothing pending to flush").isEqualTo(0L);
+      assertThat(afterBuild.get("graphState"))
+          .as("THE DEFECT: a complete, persisted graph with zero pending mutations is still marked "
+              + "MUTABLE(2), because the build's own orphaned nodes were added to the pending list")
+          .isEqualTo(1L); // IMMUTABLE
+
+      final long t1 = System.currentTimeMillis();
+      db.close();
+      closeMs = System.currentTimeMillis() - t1;
+    }
+
+    assertThat(closeMs)
+        .as("closing rebuilt the whole graph (build was %d ms, close took %d ms); the rebuild "
+            + "re-orphans nodes, so this repeats on every open/close cycle", buildMs, closeMs)
+        .isLessThan(buildMs / 4);
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/VectorIndexRebuildsOnEveryCloseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/VectorIndexRebuildsOnEveryCloseTest.java
@@ -24,8 +24,10 @@ import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -63,12 +65,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The mutation counter was already guarded against exactly this loop ("would rebuild itself
  * forever", :2372-2377). The state flag was not.
  */
+@Tag("vector")
 class VectorIndexRebuildsOnEveryCloseTest {
   private static final int    DIMENSIONS      = 128;
   private static final int    NUM_VECTORS     = 50_000;
   private static final int    MAX_CONNECTIONS = 32;   // the engine default
   private static final int    BEAM_WIDTH      = 100;
   private static final String DB_PATH         = "./target/databases/VectorIndexRebuildsOnEveryCloseTest";
+  /**
+   * Tripwire, not a latency budget. Close doing nothing measured 0.07 s; the rebuild it must not do measured
+   * 10.8 s at this size. 5 s sits well clear of both, and per CLAUDE.md a wider bound cannot turn a passing
+   * run red.
+   */
+  private static final long   CLOSE_TRIPWIRE_MS = 5_000;
 
   @AfterEach
   void cleanUp() {
@@ -78,9 +87,6 @@ class VectorIndexRebuildsOnEveryCloseTest {
   @Test
   void closingMustNotRebuildAGraphThatIsAlreadyCompleteAndPersisted() {
     FileUtils.deleteRecursively(new File(DB_PATH));
-
-    final long buildMs;
-    final long closeMs;
 
     try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
       final Database db = factory.create();
@@ -96,7 +102,6 @@ class VectorIndexRebuildsOnEveryCloseTest {
           db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
       });
 
-      final long t0 = System.currentTimeMillis();
       db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
           + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", "
           + "\"maxConnections\": " + MAX_CONNECTIONS + ", \"beamWidth\": " + BEAM_WIDTH + ", "
@@ -106,7 +111,6 @@ class VectorIndexRebuildsOnEveryCloseTest {
       final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
       for (int i = 0; i < 900 && lsm.getStats().get("graphNodeCount") == 0L; i++)
         try { Thread.sleep(100); } catch (final InterruptedException ignored) { break; }
-      buildMs = System.currentTimeMillis() - t0;
 
       final Map<String, Long> afterBuild = lsm.getStats();
 
@@ -119,15 +123,14 @@ class VectorIndexRebuildsOnEveryCloseTest {
               + "MUTABLE(2), because the build's own orphaned nodes were added to the pending list")
           .isEqualTo(1L); // IMMUTABLE
 
-      final long t1 = System.currentTimeMillis();
+      // StallAwareStopwatch, not System.currentTimeMillis(): a full-suite run shares one JVM and a
+      // stop-the-world pause inside the measured window would otherwise flake this independently of any
+      // regression (CLAUDE.md, issue #6260).
+      final StallAwareStopwatch closing = StallAwareStopwatch.start();
       db.close();
-      closeMs = System.currentTimeMillis() - t1;
+      closing.assertGaveUpWithin(CLOSE_TRIPWIRE_MS,
+          "a close that persists an already-persisted graph from one that rebuilds it from scratch");
     }
-
-    assertThat(closeMs)
-        .as("closing rebuilt the whole graph (build was %d ms, close took %d ms); the rebuild "
-            + "re-orphans nodes, so this repeats on every open/close cycle", buildMs, closeMs)
-        .isLessThan(buildMs / 4);
   }
 
   private static float[] randomVector(final Random rng) {


### PR DESCRIPTION
Fixes #6489

## What

A graph build that leaves any node unreachable marks the index `MUTABLE` even when the build succeeded, persisted, and has zero pending mutations. `flush()` tests `graphState` alone, so `close()` rebuilds the whole graph, and the rebuild cannot repair what triggered it because a Vamana build orphans a fresh set.

`buildGraphFromScratchExclusively()` merged the build's own orphans into the pending-mutation list before deriving the state:

```java
remaining.addAll(unreachableEntries);
this.graphState = remaining.isEmpty() ? GraphState.IMMUTABLE : GraphState.MUTABLE;
```

so "this build orphaned a node" and "this index has unflushed writes" became one bit. The two consumers then disagree: `rebuildGraphBeforeSearch()` requires `MUTABLE && mutationsSinceSerialize > 0` and correctly does nothing, while `flush()` tests `graphState` alone.

The mutation counter is already guarded against this same loop a few lines above ("counting it would let an index whose last build orphaned a node rebuild itself forever"). The state flag was not.

## Change

Compute the pending-writes flag before the orphans are merged. Orphans still go into `deltaVectors`, so `mergeWithDeltaScan` serves them exactly as before; they simply stop claiming the index is stale.

Also corrects the WARNING text, which said the orphans are served "until the next rebuild" and so stated the assumption that produced the defect. Measured across three consecutive runs, the close-time rebuild reported more orphans than the build it replaced (323 to 338, 289 to 333, 302 to 346).

## Test

`VectorIndexRebuildsOnEveryCloseTest` bulk-loads 50,000 vectors, creates the index, and asserts the post-build state directly. On `main` it fails with `graphState` expected `IMMUTABLE(1)` but `MUTABLE(2)`, alongside `graphNodeCount=50000` and `mutationsSinceRebuild=0`. It then asserts that `close()` costs a fraction of the build.

## Measurements

50,000 x 128 random gaussian, `maxConnections=32`, `beamWidth=100`, EUCLIDEAN, `storeVectorsInGraph=false`. N=3, medians:

| | build_s | close_s | recall@10 |
|---|---|---|---|
| before | 10.86 | 10.80 | 0.7115 |
| after | 10.75 | 0.07 | 0.7180 |

Recall and build time are unaffected. The observed recall spread across all runs was 0.7080 to 0.7325, so the difference above is run-to-run noise.

At DEEP-10M (9,990,000 x 128, `maxConnections=32`, 24 GB heap in a 36 GB container) the build orphans 1148 vectors, 0.0115%, which is enough to trigger the rebuild. Before the change the second build died with `OutOfMemoryError` at 24,554 / 24,576 MB, after the first had peaked at 21,851 MB and completed. After the change: one build, peak 22,664 MB, `close_s = 0.158`, recall@10 = 0.9506, exit 0.

## Verification

* The new test fails on `main` (704325c100) and passes with this change.
* The full `com.arcadedb.index.vector` suite passes: `Tests run: 341, Failures: 0, Errors: 0, Skipped: 0`
* Verified end to end through the Python bindings at DEEP-10M on a 20-thread i9-12900HK, JDK 25.

## Notes

* Related to #6067, which is a different defect in the same method (that one is about `flush()` re-running a build that `releaseBackgroundResources()` just cancelled). Worth noting for its analysis: it states `graphState` only advances past `MUTABLE`/`LOADING` on a successful build, but a successful build also leaves `MUTABLE` whenever it orphans a node.
* Related to #5747, which closed the `LOADING` path. This is the `MUTABLE` path.
* The orphans themselves are a jvector property, not a defect here: `cleanup()`'s final `enforceDegree` pass removes edges with no in-degree bookkeeping, and `reconnectOrphanedNodes()` was removed in jvector PR #402 with no replacement. This change does not try to reduce the orphan count, only to stop it from being mistaken for pending work.
