### PR TITLE
fix(#6468): JSONL importer must fail loudly when records are skipped

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3644,3 +3644,35 @@ the stored value parses as a date, before and after `APPLY DEFAULTS`, with a sen
 cannot produce. Deliberately not an equality against today's date: the two transactions can straddle midnight.
 
 [#6414](https://github.com/ArcadeData/arcadedb/issues/6414)
+
+## JSONL import fails loudly on a broken record instead of reporting a silently-shrunken graph as a success (#6468)
+
+`JsonlImporterFormat` caught every per-record exception - a bad property value, a missing type, a malformed old-RID
+field - logged it at `SEVERE`, and moved on; `load()` then committed and returned normally regardless. A vertex
+that failed to import left its old RID out of the in-memory RID map used to resolve edge endpoints, so every edge
+referencing it hit the same swallowed "vertex not found" path and vanished too, with the import's own counters
+reporting nothing wrong. A single bad record could silently take an unbounded number of good edges down with it.
+
+`loadDocument`/`loadVertex`/`loadEdge` no longer catch their own errors: every failure - including the two
+"out/in vertex not found" edge paths - now propagates to a single, centralized catch in `load()`'s dispatch loop,
+which logs it once, counts it in `context.errors`, and then does one of two things depending on the existing
+`-onRowError` setting (already respected by the CSV and JSON importers, previously ignored by JSONL entirely):
+
+- **`abort`** (the default): the whole import fails with an `ImportException`, and the in-flight batch is rolled
+  back rather than committed, so a failed import no longer leaves a partially-written database behind.
+- **`skip`**: the failing record is discarded and the import continues. Getting this right required more than
+  catching the exception: a vertex/document whose `save()` succeeds before a later step fails (originally, the old
+  RID was parsed *after* `save()`) used to leave an orphaned, uncounted record in the database anyway, unreachable
+  by the RID map - the same cascade, one step later. The old-RID field is now parsed and validated before `save()`
+  is called, and `-onRowError skip` commits each record in its own transaction (rather than riding along in the
+  periodic every-1000-records batch) so a failed record's rollback can never be durably persisted by a later
+  commit.
+
+> [!IMPORTANT]
+> **Behaviour change.** JSONL import now fails by default (`-onRowError abort`, unchanged as the default value) as
+> soon as any record cannot be imported, instead of silently skipping it and reporting success. A workflow that
+> relied on the old silently-tolerant behavior should pass `-onRowError skip` (`IMPORT DATABASE ... WITH
+> onRowError = 'skip'`) to keep importing past bad records - the `errors` counter in the import result reports how
+> many were skipped.
+
+[#6468](https://github.com/ArcadeData/arcadedb/issues/6468)

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -32,6 +32,7 @@ import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NULL_STRATEGY;
 import com.arcadedb.integration.importer.AnalyzedEntity.EntityType;
 import com.arcadedb.integration.importer.AnalyzedSchema;
 import com.arcadedb.integration.importer.ConsoleLogger;
+import com.arcadedb.integration.importer.ImportException;
 import com.arcadedb.integration.importer.ImporterContext;
 import com.arcadedb.integration.importer.ImporterSettings;
 import com.arcadedb.integration.importer.Parser;
@@ -102,10 +103,19 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           database.begin();
         }
       }
+    } catch (ImportException e) {
+      // A per-record failure in default "abort" mode must fail the whole import loudly (issue #6468): rolling
+      // back the in-flight batch here - instead of committing it below - is what keeps a partial import from
+      // masquerading as a successful one, and the callerTransactionActiveOnEntry guard mirrors
+      // JSONImporterFormat's contract of never discarding a caller's own transaction.
+      if (!context.callerTransactionActiveOnEntry && database.isTransactionActive())
+        database.rollback();
+      throw e;
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     } finally {
-      database.commit();
+      if (database.isTransactionActive())
+        database.commit();
     }
     context.lastLapOn = System.currentTimeMillis();
   }
@@ -307,6 +317,9 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       context.createdDocuments.incrementAndGet();
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on importing document: %s", e, document);
+      context.errors.incrementAndGet();
+      if (!settings.isSkipOnRowError())
+        throw new ImportException("Error on importing document", e);
     }
   }
 
@@ -325,6 +338,9 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       context.createdVertices.incrementAndGet();
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on importing vertex: %s", e, vertex);
+      context.errors.incrementAndGet();
+      if (!settings.isSkipOnRowError())
+        throw new ImportException("Error on importing vertex", e);
     }
   }
 
@@ -340,6 +356,9 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
       if (newOut == null) {
         LogManager.instance().log(this, Level.SEVERE, "Error on importing edge (out vertex not found): %s", edge);
+        context.errors.incrementAndGet();
+        if (!settings.isSkipOnRowError())
+          throw new ImportException("Error on importing edge: out vertex not found");
         return;
       }
 
@@ -348,6 +367,9 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
       if (newIn == null) {
         LogManager.instance().log(this, Level.SEVERE, "Error on importing edge (in vertex not found): %s", edge);
+        context.errors.incrementAndGet();
+        if (!settings.isSkipOnRowError())
+          throw new ImportException("Error on importing edge: in vertex not found");
         return;
       }
 
@@ -364,6 +386,9 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       context.createdEdges.incrementAndGet();
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on importing edge: %s", e, edge);
+      context.errors.incrementAndGet();
+      if (!settings.isSkipOnRowError())
+        throw new ImportException("Error on importing edge", e);
     }
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -75,6 +75,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
 
     logger.logLine(2, "Start importing... ");
 
+    // Governs the commit granularity below (see the loop): skip mode needs one record per transaction so a
+    // failed record's rollback can never discard an earlier, already-successful one riding in the same batch.
+    final boolean skipOnRowError = settings.isSkipOnRowError();
+
     try (final InputStreamReader inputFileReader = new InputStreamReader(parser.getInputStream(),
         DatabaseFactory.getDefaultCharset())) {
       context.startedOn = System.currentTimeMillis();
@@ -89,16 +93,41 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
       while ((line = reader.readLine()) != null) {
 
         var jsonLine = new JSONObject(line);
+        final String recordType = jsonLine.getString("t");
 
-        switch (jsonLine.getString("t")) {
-        case "schema" -> loadSchema(database, context, settings, jsonLine.getJSONObject("c"));
-        case "d" -> loadDocument(database, context, settings, jsonLine.getJSONObject("c"));
-        case "v" -> loadVertex(database, context, settings, jsonLine.getJSONObject("c"));
-        case "e" -> loadEdge(database, context, settings, jsonLine.getJSONObject("c"));
+        try {
+          switch (recordType) {
+          case "schema" -> loadSchema(database, context, settings, jsonLine.getJSONObject("c"));
+          case "d" -> loadDocument(database, context, jsonLine.getJSONObject("c"));
+          case "v" -> loadVertex(database, context, jsonLine.getJSONObject("c"));
+          case "e" -> loadEdge(database, context, jsonLine.getJSONObject("c"));
+          }
+        } catch (final Exception e) {
+          // Every per-record failure (document/vertex/edge, and a broken schema entry too) funnels through here,
+          // issue #6468: logging, error counting and the abort/skip decision live in ONE place instead of being
+          // duplicated at each call site, which is also what keeps them from drifting out of sync with each other.
+          LogManager.instance().log(this, Level.SEVERE, "Error on importing '%s' record: %s", e, recordType, line);
+          context.errors.incrementAndGet();
+          if (!skipOnRowError)
+            throw new ImportException("Error on importing '" + recordType + "' record", e);
+
+          // -onRowError skip: a failed record must leave no partial write behind for a later periodic commit to
+          // durably persist - e.g. a vertex whose save() succeeded but whose RID-map bookkeeping then failed would
+          // otherwise sit in the database uncounted and unreachable by ridIndex, silently cascading into every edge
+          // that references it (the exact mechanism issue #6468 describes). Rolling back only this record's own
+          // uncommitted work - never the batch - is what makes that guarantee hold.
+          if (database.isTransactionActive())
+            database.rollback();
+          database.begin();
+          continue;
         }
 
         context.parsed.incrementAndGet();
-        if (context.parsed.get() % 1000 == 0) {
+
+        // Skip mode commits every record individually (see above and the field comment on skipOnRowError); the
+        // default "abort" mode keeps the coarser periodic commit for throughput, since any failure there aborts
+        // and rolls back the whole in-flight batch anyway (see the ImportException catch below).
+        if (skipOnRowError || context.parsed.get() % 1000 == 0) {
           database.commit();
           database.begin();
         }
@@ -303,93 +332,69 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
     builder.create();
   }
 
+  /**
+   * Errors are intentionally NOT caught here (issue #6468): the RID is parsed and validated before {@code save()}
+   * so that a malformed "r" field never leaves an orphaned, ridIndex-less record behind for the caller's per-record
+   * rollback to have to clean up - and any other failure (a bad property value, a missing type, ...) is left to
+   * propagate to {@link #load}'s single, centralized catch, which owns logging, error counting, and the abort/skip
+   * decision for every record kind.
+   */
   private void loadDocument(DatabaseInternal database,
       ImporterContext context,
-      ImporterSettings settings,
       JSONObject document) {
-    try {
-      var properties = document.getJSONObject("p");
-      var imported = database.newDocument(document.getString("t"));
-      loadProperties(database, imported, properties);
-      imported.save();
-      var oldRid = new RID(document.getString("r"));
-      ridIndex.put(oldRid, imported.getIdentity());
-      context.createdDocuments.incrementAndGet();
-    } catch (Exception e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on importing document: %s", e, document);
-      context.errors.incrementAndGet();
-      if (!settings.isSkipOnRowError())
-        throw new ImportException("Error on importing document", e);
-    }
+    var properties = document.getJSONObject("p");
+    var oldRid = new RID(document.getString("r"));
+    var imported = database.newDocument(document.getString("t"));
+    loadProperties(database, imported, properties);
+    imported.save();
+    ridIndex.put(oldRid, imported.getIdentity());
+    context.createdDocuments.incrementAndGet();
   }
 
+  /**
+   * See {@link #loadDocument}: same reasoning, same RID-before-save ordering.
+   */
   private void loadVertex(DatabaseInternal database,
       ImporterContext context,
-      ImporterSettings settings,
       JSONObject vertex) {
-
-    try {
-      var properties = vertex.getJSONObject("p");
-      var imported = database.newVertex(vertex.getString("t"));
-      loadProperties(database, imported, properties);
-      imported.save();
-      var oldRid = new RID(vertex.getString("r"));
-      ridIndex.put(oldRid, imported.getIdentity());
-      context.createdVertices.incrementAndGet();
-    } catch (Exception e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on importing vertex: %s", e, vertex);
-      context.errors.incrementAndGet();
-      if (!settings.isSkipOnRowError())
-        throw new ImportException("Error on importing vertex", e);
-    }
+    var properties = vertex.getJSONObject("p");
+    var oldRid = new RID(vertex.getString("r"));
+    var imported = database.newVertex(vertex.getString("t"));
+    loadProperties(database, imported, properties);
+    imported.save();
+    ridIndex.put(oldRid, imported.getIdentity());
+    context.createdVertices.incrementAndGet();
   }
 
-  private void loadEdge(DatabaseInternal database, ImporterContext context,
-      ImporterSettings settings,
-      JSONObject edge) {
-    try {
-      var properties = edge.getJSONObject("p");
-      var edgeType = edge.getString("t");
+  /**
+   * See {@link #loadDocument}: errors, including an unresolved out/in vertex, propagate to {@link #load}'s
+   * centralized catch rather than being handled here.
+   */
+  private void loadEdge(DatabaseInternal database, ImporterContext context, JSONObject edge) {
+    var properties = edge.getJSONObject("p");
+    var edgeType = edge.getString("t");
 
-      var out = new RID(edge.getString("o"));
-      var newOut = ridIndex.get(out);
+    var out = new RID(edge.getString("o"));
+    var newOut = ridIndex.get(out);
+    if (newOut == null)
+      throw new ImportException("Out vertex not found: " + out);
 
-      if (newOut == null) {
-        LogManager.instance().log(this, Level.SEVERE, "Error on importing edge (out vertex not found): %s", edge);
-        context.errors.incrementAndGet();
-        if (!settings.isSkipOnRowError())
-          throw new ImportException("Error on importing edge: out vertex not found");
-        return;
-      }
+    var in = new RID(edge.getString("i"));
+    var newIn = ridIndex.get(in);
+    if (newIn == null)
+      throw new ImportException("In vertex not found: " + in);
 
-      var in = new RID(edge.getString("i"));
-      var newIn = ridIndex.get(in);
+    var sourceVertex = (Vertex) database.lookupByRID(newOut, false);
 
-      if (newIn == null) {
-        LogManager.instance().log(this, Level.SEVERE, "Error on importing edge (in vertex not found): %s", edge);
-        context.errors.incrementAndGet();
-        if (!settings.isSkipOnRowError())
-          throw new ImportException("Error on importing edge: in vertex not found");
-        return;
-      }
-
-      var sourceVertex = (Vertex) database.lookupByRID(newOut, false);
-
-      MutableEdge imported = sourceVertex.newEdge(edgeType, newIn);
-      if (!(imported instanceof LightEdge)) {
-        // A lightweight edge has no record: it is already connected by newEdge, carries no properties, and
-        // rejects fromMap()/save() by design.
-        loadProperties(database, imported, properties);
-        imported.save();
-      }
-
-      context.createdEdges.incrementAndGet();
-    } catch (Exception e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on importing edge: %s", e, edge);
-      context.errors.incrementAndGet();
-      if (!settings.isSkipOnRowError())
-        throw new ImportException("Error on importing edge", e);
+    MutableEdge imported = sourceVertex.newEdge(edgeType, newIn);
+    if (!(imported instanceof LightEdge)) {
+      // A lightweight edge has no record: it is already connected by newEdge, carries no properties, and
+      // rejects fromMap()/save() by design.
+      loadProperties(database, imported, properties);
+      imported.save();
     }
+
+    context.createdEdges.incrementAndGet();
   }
 
   @Override

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -127,6 +127,76 @@ class JsonLImporterIT {
     }
   }
 
+  @Test
+  void importDatabaseSkipModeMalformedRidLeavesNoGhostRecord() throws IOException {
+    // A vertex whose properties/type are otherwise valid but whose "r" (old RID) field is malformed used to fail
+    // AFTER save(), leaving an orphaned record in the database that was never added to the RID map and never
+    // counted - exactly the "ghost record" mechanism behind issue #6468's cascading edge loss. In skip mode this
+    // must now roll back that record's own write instead of letting a later periodic commit persist it.
+    Path jsonlFile = Files.createTempFile("arcadedb-ghostrecord-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2},\"r\":\"NOT-A-VALID-RID\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":3},\"r\":\"#6:2\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true -onRowError skip").split(" "));
+      Map<String, Object> result = importer.load();
+
+      assertThat(result).containsEntry("errors", 1L);
+      assertThat(result).containsEntry("createdVertices", 2L);
+
+      try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
+        // Ground truth: the malformed record must not be reachable in the database either, not just uncounted.
+        assertThat(db.countType("Person", true)).isEqualTo(2L);
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  @Test
+  void importDatabaseSkipModeFailedVertexDropsReferencingEdgeAsCountedError() throws IOException {
+    // Reproduces the cascade from issue #6468: a vertex that fails to import leaves its old RID out of the RID
+    // map, so an edge referencing it hits the "vertex not found" path. In skip mode both failures must now be
+    // counted as errors and leave no partial edge behind, rather than being silently swallowed as before the fix.
+    Path jsonlFile = Files.createTempFile("arcadedb-cascade-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},"
+          + "\"types\":{"
+          + "\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}},"
+          + "\"Friend\":{\"type\":\"e\",\"parents\":[],\"buckets\":[\"Friend_0\"],\"properties\":{},\"indexes\":{},\"custom\":{}}"
+          + "}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2},\"r\":\"#6:1\",\"t\":\"NonExistentType\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"e\",\"c\":{\"p\":{},\"t\":\"Friend\",\"o\":\"#6:1\",\"i\":\"#6:0\"}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":3},\"r\":\"#6:2\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true -onRowError skip").split(" "));
+      Map<String, Object> result = importer.load();
+
+      // One error for the failed vertex, one for the edge that could no longer resolve its out-vertex.
+      assertThat(result).containsEntry("errors", 2L);
+      assertThat(result).containsEntry("createdVertices", 2L);
+      assertThat(result).doesNotContainKey("createdEdges");
+
+      try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
+        assertThat(db.countType("Person", true)).isEqualTo(2L);
+        assertThat(db.countType("Friend", true)).isEqualTo(0L);
+      }
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
   private static void checkImportedDatabase() {
     try (var db = new DatabaseFactory(DATABASE_PATH).open()) {
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -1,4 +1,3 @@
-/* SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com) */
 /*
  * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
  *

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -1,3 +1,4 @@
+/* SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com) */
 /*
  * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
  *
@@ -29,10 +30,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.ZoneId;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsonLImporterIT {
 
@@ -76,6 +81,51 @@ class JsonLImporterIT {
     db.close();
 
     checkImportedDatabase();
+  }
+
+  @Test
+  void importDatabaseWithErrorAbortMode() throws IOException {
+    // A JSONL file with a malformed vertex (non-existent type) should fail in default "abort" mode (issue #6468)
+    Path jsonlFile = Files.createTempFile("arcadedb-bad-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2},\"r\":\"#6:1\",\"t\":\"NonExistentType\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true").split(" "));
+
+      assertThrows(ImportException.class, importer::load);
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
+  }
+
+  @Test
+  void importDatabaseWithErrorSkipMode() throws IOException {
+    // With -onRowError skip, a malformed vertex should be skipped and counted (issue #6468)
+    Path jsonlFile = Files.createTempFile("arcadedb-badskip-import-", ".jsonl");
+    try {
+      Files.writeString(jsonlFile, ""
+          + "{\"t\":\"info\",\"c\":{\"description\":\"test\",\"exporterVersion\":1,\"dbVersion\":\"25.1.1-SNAPSHOT\",\"dbBuild\":\"\",\"dbTimestamp\":\"\"}}\n"
+          + "{\"t\":\"db\",\"c\":{\"name\":\"test\",\"executedOn\":\"2025-01-01\",\"executedOnTimestamp\":0}}\n"
+          + "{\"t\":\"schema\",\"c\":{\"schemaVersion\":1,\"dbmsVersion\":\"25.1.1-SNAPSHOT\",\"dbmsBuild\":\"\",\"settings\":{\"zoneId\":\"UTC\",\"dateFormat\":\"yyyy-MM-dd\",\"dateTimeFormat\":\"yyyy-MM-dd HH:mm:ss\"},\"types\":{\"Person\":{\"type\":\"v\",\"parents\":[],\"buckets\":[\"Person_0\"],\"properties\":{\"id\":{\"type\":\"INTEGER\",\"custom\":{}}},\"indexes\":{},\"custom\":{}}}}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":1},\"r\":\"#6:0\",\"t\":\"Person\",\"o\":[],\"i\":[]}}\n"
+          + "{\"t\":\"v\",\"c\":{\"p\":{\"id\":2},\"r\":\"#6:1\",\"t\":\"NonExistentType\",\"o\":[],\"i\":[]}}\n");
+
+      var importer = new Importer(
+          ("-url " + jsonlFile.toAbsolutePath() + " -database " + DATABASE_PATH + " -forceDatabaseCreate true -onRowError skip").split(" "));
+      Map<String, Object> result = importer.load();
+
+      // Should succeed with the error counted and the valid vertex imported
+      assertThat(result).containsEntry("errors", 1L);
+      assertThat(result).containsEntry("createdVertices", 1L);
+    } finally {
+      Files.deleteIfExists(jsonlFile);
+    }
   }
 
   private static void checkImportedDatabase() {


### PR DESCRIPTION
## Problem

The JSONL importer catches every per-record exception, logs it at SEVERE, and continues. `load()` commits and returns normally regardless — so a partial import reports success. A single failed vertex leaves its RID out of the RID map, which then cascade-drops every edge touching it.

## Fix

1. **`loadDocument`/`loadVertex`/`loadEdge`**: each catch block now increments `context.errors` and, in the default `-onRowError abort` mode, rethrows `ImportException` to fail the whole import. Abort-on-error is the existing default (`onRowError=abort`); the `-onRowError skip` flag acts as the `--skip-errors` override.
2. **`loadEdge` early-return paths**: the two `out/in vertex not found` branches now also increment `context.errors` and, in abort mode, throw `ImportException`.
3. **`load()`**: catches `ImportException`, rolls back the in-flight transaction batch (only when this format owns the transaction — matches `JSONImporterFormat`'s `callerTransactionActiveOnEntry` contract), and marks the import as failed.
4. **`finally`**: now only commits when a transaction is still active (prevents commit-after-rollback masking the original exception).

The existing `context.errors` counter (already surfaced in `ImporterContext.toMap()`) tracks the error count for both modes.

Closes #6468