### PR TITLE
fix: align Document values() with keys() — use getPropertyNames() instead of toMap()

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
@@ -48,11 +48,18 @@ public class SQLMethodValues extends AbstractSQLMethod {
 
     if (value instanceof Map map)
       return map.values();
-    else if (value instanceof Document document)
-      return new ArrayList<>(document.toMap().values());
-    else if (value instanceof Result result)
-      return result.toMap().values();
-    else if (value instanceof Collection<?> collection) {
+    else if (value instanceof Document document) {
+      // Use getPropertyNames() to align with keys() — same order, same set of properties
+      final List<Object> result = new ArrayList<>();
+      for (final String prop : document.getPropertyNames())
+        result.add(document.get(prop));
+      return result;
+    } else if (value instanceof Result result) {
+      final List<Object> result2 = new ArrayList<>();
+      for (final String prop : result.getPropertyNames())
+        result2.add(result.getProperty(prop));
+      return result2;
+    } else if (value instanceof Collection<?> collection) {
       final List<Object> result = new ArrayList<>();
       for (final Object o : collection) {
         if (o instanceof Map || o instanceof Document || o instanceof Result || o instanceof Collection) {


### PR DESCRIPTION
## Problem

`SQLMethodValues` uses `document.toMap().values()` which returns `@rid`, `@type`, and `@cat` metadata fields alongside the declared properties. `SQLMethodKeys` uses `document.getPropertyNames()` which returns only declared property names. This causes:

- `keys().size() != values().size()` for the same document
- The two lists are not index-aligned — `keys()[i]` does not correspond to `values()[i]`

## Fix

Changed `SQLMethodValues` to iterate `document.getPropertyNames()` and look up each property via `get(prop)`, matching the same property set used by `SQLMethodKeys`. Applied the same approach to the `Result` branch for consistency.

## Verification

With this fix, for any Document:
- `keys().size() == values().size()`
- `keys().get(i)` corresponds to `values().get(i)`

Fixes #6472