### PR TITLE
fix: align Document values() with keys() — use toMap(false) to exclude metadata fields

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/MutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/MutableDocument.java
@@ -129,8 +129,10 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
   @Override
   public Map<String, Object> toMap(final boolean includeMetadata) {
     checkForLazyLoadingProperties();
-    // Optimized: add extra capacity for metadata fields (@rid, @type, @cat)
-    final Map<String, Object> result = new HashMap<>(map.size() + (includeMetadata ? 3 : 0));
+    // LinkedHashMap (not HashMap) so iteration order matches getPropertyNames()/map's own
+    // insertion order — SQL methods keys()/values() rely on this to stay index-aligned, and
+    // ImmutableDocument.toMap() already gives this ordering guarantee (#6472).
+    final Map<String, Object> result = new LinkedHashMap<>(map.size() + (includeMetadata ? 3 : 0));
     result.putAll(map);
     if (includeMetadata) {
       result.put(CAT_PROPERTY, "d");

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
@@ -49,7 +49,9 @@ public class SQLMethodValues extends AbstractSQLMethod {
     if (value instanceof Map map)
       return map.values();
     else if (value instanceof Document document)
-      return new ArrayList<>(document.toMap().values());
+      // Use toMap(false) to exclude metadata fields (@rid, @type, @cat) — matches keys()'s
+      // getPropertyNames() which returns only declared property names (issue #6472).
+      return new ArrayList<>(document.toMap(false).values());
     else if (value instanceof Result result)
       return result.toMap().values();
     else if (value instanceof Collection<?> collection) {

--- a/engine/src/test/java/com/arcadedb/DocumentTest.java
+++ b/engine/src/test/java/com/arcadedb/DocumentTest.java
@@ -110,4 +110,44 @@ public class DocumentTest extends TestHelper {
       assertThat(detached.getString("lastname")).isNull();
     });
   }
+
+  // Regression test for issue #6472: MutableDocument.toMap(false) used to copy the properties
+  // into a plain HashMap, whose iteration order (hash-bucket order) can differ from
+  // getPropertyNames()'s insertion order (the properties LinkedHashMap's keySet()). That made
+  // toMap().values() misaligned with getPropertyNames() for any document with enough properties
+  // to land in different buckets, which is what made doc.keys()[i]/doc.values()[i] disagree.
+  @Test
+  void toMapPreservesPropertyInsertionOrder() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("OrderPerson");
+      type.createProperty("name", Type.STRING);
+      type.createProperty("age", Type.INTEGER);
+      type.createProperty("city", Type.STRING);
+      type.createProperty("country", Type.STRING);
+      type.createProperty("email", Type.STRING);
+
+      final MutableDocument doc = database.newDocument("OrderPerson");
+      doc.set("name", "Alice");
+      doc.set("age", 30);
+      doc.set("city", "Rome");
+      doc.set("country", "Italy");
+      doc.set("email", "alice@example.com");
+      doc.save();
+
+      final List<String> propertyNames = new ArrayList<>(doc.getPropertyNames());
+      final List<Object> mapValuesNoMetadata = new ArrayList<>(doc.toMap(false).values());
+      final List<String> mapKeysNoMetadata = new ArrayList<>(doc.toMap(false).keySet());
+
+      // toMap(false)'s key order must match getPropertyNames()'s order...
+      assertThat(mapKeysNoMetadata).isEqualTo(propertyNames);
+      // ...and therefore values() at index i must be the value of keys()/propertyNames() at index i.
+      for (int i = 0; i < propertyNames.size(); i++)
+        assertThat(mapValuesNoMetadata.get(i)).isEqualTo(doc.get(propertyNames.get(i)));
+
+      // With metadata included, the declared properties keep their relative order and the
+      // @cat/@type/@rid fields are appended after them.
+      final List<String> mapKeysWithMetadata = new ArrayList<>(doc.toMap(true).keySet());
+      assertThat(mapKeysWithMetadata.subList(0, propertyNames.size())).isEqualTo(propertyNames);
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
@@ -90,11 +90,11 @@ class SQLMethodValuesTest extends TestHelper {
 
       Object result = function.execute(doc, null, null, null);
 
-      // Flat collection of the document's property values (toMap() also carries the internal
-      // fields RID, type marker "d", type name), not wrapped in an extra one-element list.
+      // Flat collection of the document's declared property values. toMap(false) excludes the
+      // internal fields (RID, type marker "d", type name), so values() aligns with keys().
       assertThat(result).isInstanceOf(Collection.class);
       final Collection<Object> values = (Collection<Object>) result;
-      assertThat(values).containsExactlyInAnyOrder("Alice", 30, doc.getIdentity().toString(), "d", "Person");
+      assertThat(values).containsExactlyInAnyOrder("Alice", 30);
     });
   }
 
@@ -122,9 +122,9 @@ class SQLMethodValuesTest extends TestHelper {
 
     assertThat(result).isInstanceOf(List.class);
     List<?> flattenedValues = (List<?>) result;
-    // Each document contributes its own (unwrapped) toMap() values: name, age plus the 3
-    // internal fields (RID, type marker, type name) = 5 values per document.
-    assertThat(flattenedValues).hasSize(10);
+    // Each document contributes its own (unwrapped) declared-property values: name, age = 2
+    // values per document (metadata fields excluded via toMap(false)).
+    assertThat(flattenedValues).hasSize(4);
     assertThat((List<Object>) flattenedValues).contains("Alice", 30, "Bob", 25);
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
@@ -128,6 +128,70 @@ class SQLMethodValuesTest extends TestHelper {
     assertThat((List<Object>) flattenedValues).contains("Alice", 30, "Bob", 25);
   }
 
+  // Regression tests for issue #6472: keys()/values() must be index-aligned, not just same-sized
+
+  @Test
+  void keysAndValuesAreIndexAlignedForDocumentWithSeveralProperties() {
+    database.transaction(() ->
+      database.getSchema().createDocumentType("OrderPerson"));
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("OrderPerson");
+      doc.set("name", "Alice");
+      doc.set("age", 30);
+      doc.set("city", "Rome");
+      doc.set("country", "Italy");
+      doc.set("email", "alice@example.com");
+      doc.save();
+
+      final SQLMethod keysFunction = new SQLMethodKeys();
+
+      final List<String> keys = (List<String>) keysFunction.execute(doc, null, null, null);
+      final List<Object> values = (List<Object>) function.execute(doc, null, null, null);
+
+      assertThat(keys).hasSameSizeAs(values);
+      for (int i = 0; i < keys.size(); i++)
+        assertThat(values.get(i)).as("value at index %d for key '%s'", i, keys.get(i)).isEqualTo(doc.get(keys.get(i)));
+    });
+  }
+
+  @Test
+  void keysAndValuesAreIndexAlignedViaSQLOnStoredDocument() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("OrderPerson");
+
+      final MutableDocument doc = database.newDocument("OrderPerson");
+      doc.set("name", "Alice");
+      doc.set("age", 30);
+      doc.set("city", "Rome");
+      doc.set("country", "Italy");
+      doc.set("email", "alice@example.com");
+      doc.save();
+    });
+
+    // Reproduces the SQL scenario from issue #6472, on a document reloaded from storage
+    // (an ImmutableDocument), not the in-memory MutableDocument used right after save().
+    try (ResultSet resultSet = database.query("sql",
+        "SELECT @this.keys() AS k, @this.values() AS v FROM OrderPerson LIMIT 1")) {
+      final Result row = resultSet.next();
+      final List<String> keys = row.getProperty("k");
+      final List<Object> values = row.getProperty("v");
+
+      assertThat(keys).hasSameSizeAs(values);
+      for (int i = 0; i < keys.size(); i++) {
+        final Object expected = switch (keys.get(i)) {
+          case "name" -> "Alice";
+          case "age" -> 30;
+          case "city" -> "Rome";
+          case "country" -> "Italy";
+          case "email" -> "alice@example.com";
+          default -> throw new AssertionError("Unexpected key: " + keys.get(i));
+        };
+        assertThat(values.get(i)).as("value at index %d for key '%s'", i, keys.get(i)).isEqualTo(expected);
+      }
+    }
+  }
+
   // NEW TESTS - Result object handling
 
   @Test


### PR DESCRIPTION
## Problem

`SQLMethodValues` handles the `Document` branch asymmetrically compared to `SQLMethodKeys`:

- `keys()` → `document.getPropertyNames()` — declared properties only
- `values()` → `document.toMap().values()` — declared properties **plus** internal metadata `@rid`, `@type`, `@cat` (because `toMap()` defaults to `toMap(true)`)

For the same document, `doc.keys().size() != doc.values().size()` and the two lists are not index-aligned.

## Fix

`values()` now uses `document.toMap(false)` which excludes the metadata fields, matching the property set returned by `getPropertyNames()`. This is the direction suggested in the issue as "more consistent with user expectations of keys()/values() as a matched pair".

```java
// Before: metadata fields included
return new ArrayList<>(document.toMap().values());

// After: declared properties only
return new ArrayList<>(document.toMap(false).values());
```

The `Result` branch already operates on a map without metadata fields, so it was left unchanged.

## Tests

Updated `SQLMethodValuesTest`:
- `withDocument()`: now asserts only the 2 declared property values (`Alice`, `30`) instead of 5 (declared + metadata)
- `withCollectionOfDocuments()`: now asserts 4 flat values (2 per document) instead of 10

## Verification

After the fix, for any Document:
- `keys().size() == values().size()`
- Both operate on the same property set

Fixes #6472