### PR TITLE
fix(#6495): the lazily created graph file registered under a name discovery cannot match

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1281,7 +1281,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     try {
       final DatabaseInternal db = getDatabase();
       final String graphFileName = indexName + "_" + LSMVectorIndexGraphFile.FILE_EXT;
-      final String graphFilePath = mutable.getFilePath() + "_" + LSMVectorIndexGraphFile.FILE_EXT;
+      // Derive from the BARE index path, exactly as the creating constructor does. mutable.getFilePath()
+      // already carries the ".<fileId>.<pageSize>.v<version>.lsmvecidx" suffix, and ComponentFile derives a
+      // component's registered name from its path, so appending here produced the name
+      // "<index>.<fileId>.<pageSize>.v<version>.lsmvecidx_vecgraph". discoverAndLoadGraphFile() looks for
+      // "<mutable.getName()>_vecgraph", which that can never match, so the file was written, never found
+      // again, and re-created on every open.
+      final String graphFilePath =
+          db.getDatabasePath() + File.separator + indexName + "_" + LSMVectorIndexGraphFile.FILE_EXT;
       this.graphFile = new LSMVectorIndexGraphFile(db, graphFileName, graphFilePath,
           db.getMode(), mutable.getPageSize());
       this.graphFile.setMainIndex(this);

--- a/engine/src/test/java/com/arcadedb/index/vector/CompactIndexKeepsGraphReusableTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/CompactIndexKeepsGraphReusableTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A persisted vector graph must survive {@code COMPACT INDEX} and stay reusable across reopens.
+ * <p>
+ * {@code getOrCreateGraphFile()} built the graph file's path from {@code mutable.getFilePath()}, which already
+ * carries the {@code .<fileId>.<pageSize>.v<version>.lsmvecidx} suffix. {@code ComponentFile} derives a
+ * component's registered name from its path, so the graph registered as
+ * {@code <index>.<fileId>.<pageSize>.v<version>.lsmvecidx_vecgraph} while
+ * {@code discoverAndLoadGraphFile()} looks for {@code <mutable.getName()>_vecgraph}. The two can never match,
+ * so every open failed to find a graph, rebuilt from scratch, and wrote one more file that would never be
+ * found either.
+ * <p>
+ * Compaction is what exposes it: {@code rewriteDataFileWithLiveEntries()} renames the index, so the graph
+ * registered under the pre-compaction name stops matching and the lazy path takes over from there on.
+ * <p>
+ * Before the fix the file count grows without bound and every reopen rebuilds. This test pins what the path
+ * fix achieves: the graph written on the FIRST open after compaction is found again by every later open, so
+ * the count stabilises and no further rebuild happens.
+ * <p>
+ * One orphan remains, the graph registered under the pre-compaction name. Removing it needs the compaction
+ * path to re-register the component under the new name, which sits inside a critical section documented as
+ * needing its statements kept adjacent, so it is left as a follow-up rather than attempted here.
+ */
+@Tag("vector")
+class CompactIndexKeepsGraphReusableTest {
+  private static final int    DIMENSIONS  = 32;
+  private static final int    NUM_VECTORS = 2_000;
+  private static final int    REOPENS     = 3;
+  private static final String DB_PATH     = "./target/databases/CompactIndexKeepsGraphReusableTest";
+
+  @AfterEach
+  void cleanUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void compactionMustNotOrphanTheGraphOrForceARebuildOnEveryOpen() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    final Random rng = new Random(7);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+      db.transaction(() -> {
+        final DocumentType t = db.getSchema().createDocumentType("Doc");
+        t.createProperty("id", Type.INTEGER);
+        t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+        for (int i = 0; i < NUM_VECTORS; i++)
+          db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
+      });
+      db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+          + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", \"maxConnections\": 32 }");
+      waitForGraph(db);
+      db.command("sql", "COMPACT INDEX `Doc[embedding]`");
+      db.close();
+    }
+
+    int settledFileCount = -1;
+
+    for (int open = 1; open <= REOPENS; open++) {
+      try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+        final Database db = factory.open();
+        final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+        final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+        waitForGraph(db, lsm);
+
+        if (open > 1)
+          assertThat(lsm.getStats().get("graphRebuildCount"))
+              .as("open %d rebuilt the graph; the one written on the first open after compaction should have "
+                  + "been found and reused", open)
+              .isEqualTo(0L);
+        db.close();
+      }
+
+      final int now = countGraphFiles();
+      if (open == 1)
+        settledFileCount = now;
+      else
+        assertThat(now)
+            .as("open %d left another .vecgraph behind; after the first open the count must not grow", open)
+            .isEqualTo(settledFileCount);
+    }
+  }
+
+  private static void waitForGraph(final Database db) {
+    final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+    waitForGraph(db, (LSMVectorIndex) idx.getIndexesOnBuckets()[0]);
+  }
+
+  private static void waitForGraph(final Database db, final LSMVectorIndex lsm) {
+    for (int i = 0; i < 600 && lsm.getStats().get("graphNodeCount") == 0L; i++)
+      try { Thread.sleep(50); } catch (final InterruptedException ignored) { break; }
+  }
+
+  private static int countGraphFiles() {
+    final File[] files = new File(DB_PATH).listFiles((d, n) -> n.endsWith("." + LSMVectorIndexGraphFile.FILE_EXT));
+    return files == null ? 0 : files.length;
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}


### PR DESCRIPTION
Fixes #6495

## What

`getOrCreateGraphFile()` built the graph file's path from `mutable.getFilePath()`, which already carries the `.<fileId>.<pageSize>.v<version>.lsmvecidx` suffix. `ComponentFile` derives a component's registered name from its path, so the graph registered as

```
<index>.<fileId>.<pageSize>.v<version>.lsmvecidx_vecgraph
```

while `discoverAndLoadGraphFile()` looks for `<mutable.getName()>_vecgraph`. Those can never match, so the file was written, never found again, and re-created on the next open, without bound.

The creating constructor at `:928` already derives from the bare index path. This makes the lazy path do the same.

Compaction is what exposes it: `rewriteDataFileWithLiveEntries()` renames the index, so the graph registered under the pre-compaction name stops matching and every later open falls to the lazy path.

## Measured before the change

10,000 x 64 INT8. Control with no compaction: the graph is reused on all four reopens, 12 files, 6,885,031 bytes, first search 242 ms.

After one `COMPACT INDEX`, five reopens, each logging `Created graph file on demand` then `Building JVector graph index with 10000 vectors`:

| open | files |
|---|---|
| after compact | 14 |
| 1 | 16 |
| 2 | 18 |
| 3 | 20 |
| 4 | 22 |

16,322,731 bytes against the control's 6,885,031 (2.37x) on identical data, and first search 2,033 ms against 242 ms, never improving.

## Scope, stated plainly

This caps the damage rather than removing it. **One orphan remains** (the graph registered under the pre-compaction name) and the first open after a compaction still rebuilds. What it removes is the unbounded part: one more file and one more full rebuild on every open, forever.

Removing the residual needs the compaction path to re-register the graph component under the new name. That sits inside the critical section whose own comment asks that the rename and the schema re-keying stay adjacent, with a documented history of a bug caused by separating them, so I did not attempt it in a file I do not own. Two options if you want it done, and I am happy to send it:

1. rename the registered `ComponentFile` alongside `indexRenamed(...)`, or
2. drop it via `dropReplacedComponent()` and let the lazy path recreate it under the now-correct name.

## Test

`CompactIndexKeepsGraphReusableTest` pins exactly what this achieves: the graph written on the first open after a compaction is found by every later open, so the file count stabilises and no further rebuild happens.

* On `main` it fails: `open 2 left another .vecgraph behind; expected: 2 but was: 3`.
* With this change it passes.
* Full `com.arcadedb.index.vector` suite with the patch: **342 tests, 0 failures**.

Tagged `@Tag("vector")` only, per `CLAUDE.md`'s note that the tags are a partition, matching `LSMVectorIndexRebuildTest`.

## Environment

`main` at `8e89f2b9b2`, jvector 4.0.0-rc.9, JDK 25, Linux.
