### PR TITLE
fix(#6494): efSearch: 100 was read as "unset" and silently replaced by the adaptive beam

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4175,7 +4175,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             // Explicit efSearch: use fixed beam width (per-query or index default override)
             final int effectiveEfSearch = Math.max(k, efSearch);
             searchResult = searcher.search(ssp, k, effectiveEfSearch, 0.0f, 0.0f, bitsFilter);
-          } else if (metadata.efSearch != 100) {
+          } else if (metadata.efSearchConfigured) {
             // User configured efSearch in index metadata: use their value
             final int effectiveEfSearch = Math.max(k, metadata.efSearch);
             searchResult = searcher.search(ssp, k, effectiveEfSearch, 0.0f, 0.0f, bitsFilter);
@@ -4414,7 +4414,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           final int effectiveEfSearch;
           if (efSearch > 0)
             effectiveEfSearch = Math.max(maxRows, efSearch);
-          else if (metadata.efSearch != 100)
+          else if (metadata.efSearchConfigured)
             effectiveEfSearch = Math.max(maxRows, metadata.efSearch);
           else
             // The doubling is the second multiplication issue #6066 covers. maxRows is already clamped to the
@@ -5604,6 +5604,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // the next restart is barely better than one that was dropped at creation (issue #5639). LSMVectorIndexMetadata
     // reads each of these back, and a value equal to its default round-trips as itself.
     json.put("efSearch", metadata.efSearch);
+    json.put("efSearchConfigured", metadata.efSearchConfigured);
     json.put("neighborOverflowFactor", metadata.neighborOverflowFactor);
     json.put("alphaDiversityRelaxation", metadata.alphaDiversityRelaxation);
     json.put("locationCacheSize", metadata.locationCacheSize);

--- a/engine/src/main/java/com/arcadedb/schema/LSMVectorIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/LSMVectorIndexMetadata.java
@@ -408,9 +408,7 @@ public class LSMVectorIndexMetadata extends IndexMetadata {
       this.efSearch = metadata.getInt("efSearch");
       // A schema written before efSearchConfigured existed cannot say whether the value was chosen or defaulted,
       // so fall back to the old inference for it. That keeps existing databases behaving exactly as they do now.
-      this.efSearchConfigured = metadata.has("efSearchConfigured")
-          ? metadata.getBoolean("efSearchConfigured")
-          : this.efSearch != 100;
+      this.efSearchConfigured = metadata.getBoolean("efSearchConfigured", this.efSearch != 100);
     }
 
     // metadataFloat, not a cast to Number: the cast raised ClassCastException on a quoted value, which for a

--- a/engine/src/main/java/com/arcadedb/schema/LSMVectorIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/LSMVectorIndexMetadata.java
@@ -77,6 +77,13 @@ public class LSMVectorIndexMetadata extends IndexMetadata {
   public int                      maxConnections           = 32;
   public int                      beamWidth                = 100;
   public int                      efSearch                 = 100;  // Search beam width (higher = better recall but slower)
+  /**
+   * Whether {@link #efSearch} was actually configured, as opposed to sitting at its default. The search path used
+   * to infer this by testing {@code efSearch != 100}, which made 100 the one value a user could not ask for: an
+   * index created with {@code "efSearch": 100} was treated as unconfigured and silently given the adaptive beam
+   * instead (issue #6494).
+   */
+  public boolean                  efSearchConfigured       = false;
   public float                    neighborOverflowFactor   = 1.2f;
   public float                    alphaDiversityRelaxation = 1.2f;
   public String                   idPropertyName           = "id";
@@ -119,6 +126,7 @@ public class LSMVectorIndexMetadata extends IndexMetadata {
     copy.maxConnections = maxConnections;
     copy.beamWidth = beamWidth;
     copy.efSearch = efSearch;
+    copy.efSearchConfigured = efSearchConfigured;
     copy.neighborOverflowFactor = neighborOverflowFactor;
     copy.alphaDiversityRelaxation = alphaDiversityRelaxation;
     copy.idPropertyName = idPropertyName;
@@ -320,6 +328,7 @@ public class LSMVectorIndexMetadata extends IndexMetadata {
     if (efSearch < 1)
       throw new IllegalArgumentException("efSearch must be at least 1");
     this.efSearch = efSearch;
+    this.efSearchConfigured = true;
   }
 
   /** Sets the neighbor overflow factor used while building the graph. Typical range 1.0-1.5. */
@@ -395,8 +404,14 @@ public class LSMVectorIndexMetadata extends IndexMetadata {
     if (metadata.has("beamWidth"))
       this.beamWidth = metadata.getInt("beamWidth");
 
-    if (metadata.has("efSearch"))
+    if (metadata.has("efSearch")) {
       this.efSearch = metadata.getInt("efSearch");
+      // A schema written before efSearchConfigured existed cannot say whether the value was chosen or defaulted,
+      // so fall back to the old inference for it. That keeps existing databases behaving exactly as they do now.
+      this.efSearchConfigured = metadata.has("efSearchConfigured")
+          ? metadata.getBoolean("efSearchConfigured")
+          : this.efSearch != 100;
+    }
 
     // metadataFloat, not a cast to Number: the cast raised ClassCastException on a quoted value, which for a
     // hand-edited or hand-restored schema.json meant a failure while OPENING the database. The integer keys above

--- a/engine/src/test/java/com/arcadedb/index/vector/EfSearch100IsRequestableTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/EfSearch100IsRequestableTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code efSearch: 100} must mean what it says.
+ * <p>
+ * The search path used to decide whether the user had configured a beam by testing
+ * {@code metadata.efSearch != 100}. Since 100 is also the default, that made 100 the one value the knob could
+ * not express: an index created with {@code "efSearch": 100} was treated as unconfigured and given the
+ * adaptive beam instead, which above 10,000 nodes is {@code max(k * 2, 20)}.
+ * <p>
+ * The assertion below fails on main, where the configured 100 is discarded and the adaptive beam is used.
+ */
+@Tag("vector")
+class EfSearch100IsRequestableTest extends TestHelper {
+  private static final int DIMENSIONS  = 64;
+  // Above the adaptive path's 10,000-node branch, so an unconfigured index would take the narrow beam.
+  private static final int NUM_VECTORS = 12_000;
+  private static final int K           = 10;
+
+  @Test
+  void efSearch100IsHonouredRatherThanReadAsUnset() {
+    final Random rng = new Random(7);
+    final List<float[]> vectors = new ArrayList<>(NUM_VECTORS);
+
+    database.transaction(() -> {
+      final DocumentType t = database.getSchema().createDocumentType("Doc");
+      t.createProperty("id", Type.INTEGER);
+      t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      for (int i = 0; i < NUM_VECTORS; i++) {
+        final float[] v = randomVector(rng);
+        vectors.add(v);
+        database.newDocument("Doc").set("id", i).set("embedding", v).save();
+      }
+    });
+
+    database.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+        + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", \"maxConnections\": 32, "
+        + "\"efSearch\": 100 }");
+
+    final TypeIndex idx = (TypeIndex) database.getSchema().getIndexByName("Doc[embedding]");
+    final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+    for (int i = 0; i < 900 && lsm.getStats().get("graphNodeCount") == 0L; i++)
+      try { Thread.sleep(100); } catch (final InterruptedException ignored) { break; }
+
+    // Asserted through BEHAVIOUR, not through the new field: a test that references the fix does not compile
+    // against unpatched code, so it cannot demonstrate the defect it exists to pin. This compiles on main and
+    // fails there.
+    database.transaction(() -> {
+      for (int q = 0; q < 20; q++) {
+        final float[] query = vectors.get(q * 137 % NUM_VECTORS);
+        final List<com.arcadedb.database.RID> fromMetadata = rids(lsm.findNeighborsFromVector(query, K, -1));
+        final List<com.arcadedb.database.RID> fromExplicit = rids(lsm.findNeighborsFromVector(query, K, 100));
+        assertThat(fromMetadata)
+            .as("query %d: the configured efSearch=100 must give the same result as asking for 100 per query", q)
+            .isEqualTo(fromExplicit);
+      }
+    });
+  }
+
+  private static List<com.arcadedb.database.RID> rids(
+      final List<com.arcadedb.utility.Pair<com.arcadedb.database.RID, Float>> hits) {
+    final List<com.arcadedb.database.RID> out = new ArrayList<>(hits.size());
+    for (final com.arcadedb.utility.Pair<com.arcadedb.database.RID, Float> h : hits)
+      out.add(h.getFirst());
+    return out;
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/EfSearch100IsRequestableTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/EfSearch100IsRequestableTest.java
@@ -19,9 +19,11 @@
 package com.arcadedb.index.vector;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
+import com.arcadedb.utility.Pair;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -80,8 +82,8 @@ class EfSearch100IsRequestableTest extends TestHelper {
     database.transaction(() -> {
       for (int q = 0; q < 20; q++) {
         final float[] query = vectors.get(q * 137 % NUM_VECTORS);
-        final List<com.arcadedb.database.RID> fromMetadata = rids(lsm.findNeighborsFromVector(query, K, -1));
-        final List<com.arcadedb.database.RID> fromExplicit = rids(lsm.findNeighborsFromVector(query, K, 100));
+        final List<RID> fromMetadata = rids(lsm.findNeighborsFromVector(query, K, -1));
+        final List<RID> fromExplicit = rids(lsm.findNeighborsFromVector(query, K, 100));
         assertThat(fromMetadata)
             .as("query %d: the configured efSearch=100 must give the same result as asking for 100 per query", q)
             .isEqualTo(fromExplicit);
@@ -89,10 +91,10 @@ class EfSearch100IsRequestableTest extends TestHelper {
     });
   }
 
-  private static List<com.arcadedb.database.RID> rids(
-      final List<com.arcadedb.utility.Pair<com.arcadedb.database.RID, Float>> hits) {
-    final List<com.arcadedb.database.RID> out = new ArrayList<>(hits.size());
-    for (final com.arcadedb.utility.Pair<com.arcadedb.database.RID, Float> h : hits)
+  private static List<RID> rids(
+      final List<Pair<RID, Float>> hits) {
+    final List<RID> out = new ArrayList<>(hits.size());
+    for (final Pair<RID, Float> h : hits)
       out.add(h.getFirst());
     return out;
   }


### PR DESCRIPTION
Fixes #6494 (the sentinel half)

## What

`LSMVectorIndex` decided whether the user had configured a search beam by testing `metadata.efSearch != 100`. Since 100 is also the documented default, **100 is the one value the knob cannot express**: an index created with `"efSearch": 100` was treated as unconfigured and given the adaptive beam instead, which above 10,000 nodes is `max(k * 2, 20)`.

## Measured

50,000 x 128, `maxConnections=32`, k=10, EUCLIDEAN, 200 queries against exact ground truth, on `main` at `8e89f2b9b2`:

| `metadata.efSearch` | recall@10 on the default path |
|---|---|
| unset | 0.3745 |
| **100 (explicitly set)** | **0.3745** — the value is discarded |
| 101 | 0.7260 |

Asking for 101 works. Asking for the documented default silently does nothing.

## The change

An explicit `efSearchConfigured` flag, set by `setEfSearch()` so the DDL `METADATA` path records it, copied by `copy()`, and persisted next to the value.

**Existing databases are unaffected.** A schema written before this flag existed cannot say whether its value was chosen or defaulted, so the reload falls back to the old `efSearch != 100` inference for those. Only newly written schemas record the distinction.

## What this deliberately does not do

It does not touch the adaptive beam's shape. That the beam *narrows* as the graph grows (100 below 10,000 nodes, `max(k*2, 20)` above) is the other half of #6494, and it is a tuning policy rather than a defect, so it is yours to decide. I asked in the issue whether that branch was meant to read the other way round.

## Test

`EfSearch100IsRequestableTest` asserts behaviour, not the new field: a test that references the fix would not compile against unpatched code and so could not demonstrate the defect. This one compiles on `main` and fails there with

```
query 1: the configured efSearch=100 must give the same result as asking for 100 per query
```

and passes with the change. 12,000 vectors, so the adaptive path would otherwise take the narrow branch.

Full `com.arcadedb.index.vector` suite with the patch: **342 tests, 0 failures**. Tagged `@Tag("vector")` per `CLAUDE.md`'s partition rule.

## Environment

`main` at `8e89f2b9b2`, jvector 4.0.0-rc.9, JDK 25, Linux.
