### PR TITLE
docs(#6497): maxPendingMutations does not bound the delta buffer

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1094,9 +1094,14 @@ public enum GlobalConfiguration {
 
   VECTOR_INDEX_MAX_PENDING_MUTATIONS("arcadedb.vectorIndex.maxPendingMutations", SCOPE.DATABASE,
       """
-      Hard ceiling on the rebuild threshold computed from rebuildGraphRatio. Pending vectors are held in an \
-      in-memory delta buffer until the next rebuild, so this bounds that buffer's footprint \
-      (RAM = pendingMutations * dimensions * 4 bytes). Set to 0 for no ceiling.""",
+      Hard ceiling on the rebuild threshold computed from rebuildGraphRatio. Set to 0 for no ceiling. \
+      This caps the RATIO-DERIVED term only, and it is read where a rebuild is decided, not where the delta \
+      buffer grows, so it does NOT bound that buffer: writes keep appending between rebuilds regardless, and \
+      rebuilds are asynchronous, so sustained ingest outruns them. Measured with this set to 500, the buffer \
+      reached 45,000 entries, and 42,504 even with the rebuild trigger firing continuously. Note also that \
+      mutationsBeforeRebuild is applied as a floor afterwards, so an explicit value above this ceiling wins. \
+      Size the buffer with mutationsBeforeRebuild and rebuildGraphRatio, and treat its footprint as a \
+      consequence of ingest rate rather than something this setting guarantees.""",
       Integer.class, 50_000),
 
   VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS("arcadedb.vectorIndex.inactivityRebuildTimeoutMs", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1100,8 +1100,8 @@ public enum GlobalConfiguration {
       rebuilds are asynchronous, so sustained ingest outruns them. Measured with this set to 500, the buffer \
       reached 45,000 entries, and 42,504 even with the rebuild trigger firing continuously. Note also that \
       mutationsBeforeRebuild is applied as a floor afterwards, so an explicit value above this ceiling wins. \
-      Size the buffer with mutationsBeforeRebuild and rebuildGraphRatio, and treat its footprint as a \
-      consequence of ingest rate rather than something this setting guarantees.""",
+      Nothing here bounds the buffer. mutationsBeforeRebuild and rebuildGraphRatio only change how OFTEN a \
+      rebuild drains it, so its peak follows from how much is written between rebuilds.""",
       Integer.class, 50_000),
 
   VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS("arcadedb.vectorIndex.inactivityRebuildTimeoutMs", SCOPE.DATABASE,


### PR DESCRIPTION
Fixes #6497 (the documentation half)

## What

`arcadedb.vectorIndex.maxPendingMutations` documented itself as bounding the in-memory delta buffer, with a RAM formula following from that:

> Pending vectors are held in an in-memory delta buffer until the next rebuild, so this bounds that buffer's footprint (RAM = pendingMutations * dimensions * 4 bytes).

Neither part holds. The setting caps the ratio-derived rebuild threshold, and it is read where a rebuild is *decided*, not where the buffer *grows*.

## Measured

128 dimensions, a 5,000-vector graph, then 45,000 streamed in:

| configuration | peak `deltaVectorsCount` | vs ceiling |
|---|---|---|
| `maxPendingMutations=500` | 45,000 | **90x** |
| `maxPendingMutations=500`, plus a search every 2,500 inserts so the rebuild trigger fires continuously | 42,504 | **85x** |

The second row is the one that matters: even with rebuilds firing throughout, ingestion outruns them, so firing the trigger does not bound the buffer either.

At 128 dimensions the formula predicts 500 x 128 x 4 = 256 KB where the buffer actually held about 23 MB.

Separately, `mutationsBeforeRebuild` is applied as a floor *after* the cap (`Math.max(absolute, capped)`), so an explicit value above the ceiling wins: `mutationsBeforeRebuild=200000` with the default `maxPendingMutations=50000` gives an effective threshold of 200,000.

## Scope

**Documentation only.** Whether the buffer *should* be bounded, and how, is the open question in #6497. Enforcing it at the write path would change ingest behaviour under load, and the measurement above suggests it would need backpressure to bound anything at all, so I have not presumed an answer.

No test: there is no behaviour change to pin, and a test asserting the current unbounded growth would be encoding the thing under discussion.

## Environment

`main` at `8e89f2b9b2`, jvector 4.0.0-rc.9, JDK 25, Linux.
