### PR TITLE
fix: resolve GraphQL field alias at top-level query dispatch (issue #6453)

### DIFF
--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
@@ -29,6 +29,7 @@ import com.arcadedb.graphql.parser.Directives;
 import com.arcadedb.graphql.parser.Document;
 import com.arcadedb.graphql.parser.Field;
 import com.arcadedb.graphql.parser.FieldDefinition;
+import com.arcadedb.graphql.parser.FieldWithAlias;
 import com.arcadedb.graphql.parser.GraphQLParser;
 import com.arcadedb.graphql.parser.InputValueDefinition;
 import com.arcadedb.graphql.parser.ObjectTypeDefinition;
@@ -102,7 +103,8 @@ public class GraphQLSchema {
 
     try {
       final Selection selection = op.getSelectionSet().getSelections().getFirst();
-      queryName = selection.getFieldWithAlias() != null ? selection.getFieldWithAlias().getName() : selection.getName();
+      final FieldWithAlias aliasField = selection.getFieldWithAlias();
+      queryName = aliasField != null ? aliasField.getName() : selection.getName();
 
       // HANDLE INTROSPECTION QUERIES
       if ("__schema".equals(queryName))
@@ -142,65 +144,11 @@ public class GraphQLSchema {
         }
       }
 
-      String where = "";
       final Field field = selection.getField();
-      if (field == null && selection.getFieldWithAlias() != null) {
-        // Aliased top-level field — use the FieldWithAlias for arguments and projection
-        final FieldWithAlias aliasField = selection.getFieldWithAlias();
-        final Arguments queryArguments = aliasField.getArguments();
-        if (queryArguments != null)
-          for (final Argument queryArgument : queryArguments.getList()) {
-            final String argName = queryArgument.getName();
-            if (!typeArgumentNames.contains(argName))
-              throw new CommandParsingException("Parameter '" + argName + "' not defined in query");
-            final Object argValue = queryArgument.getValueWithVariable().getValue().getValue();
-            if (where.length() > 0)
-              where += " and ";
-            if ("where".equals(argName))
-              where += argValue;
-            else {
-              where += argName;
-              where += " = ";
-              if (argValue instanceof String)
-                where += """;
-              where += argValue;
-              if (argValue instanceof String)
-                where += """;
-            }
-          }
-        projection = aliasField.getSelectionSet();
-      }
-      if (field != null) {
-        final Arguments queryArguments = field.getArguments();
-        if (queryArguments != null)
-          for (final Argument queryArgument : queryArguments.getList()) {
-            final String argName = queryArgument.getName();
-            if (!typeArgumentNames.contains(argName))
-              throw new CommandParsingException("Parameter '" + argName + "' not defined in query");
+      final Arguments queryArguments = field != null ? field.getArguments() : aliasField != null ? aliasField.getArguments() : null;
+      projection = field != null ? field.getSelectionSet() : aliasField != null ? aliasField.getSelectionSet() : null;
 
-            final Object argValue = queryArgument.getValueWithVariable().getValue().getValue();
-
-            if (where.length() > 0)
-              where += " and ";
-
-            if ("where".equals(argName)) {
-              where += argValue;
-            } else {
-              where += argName;
-              where += " = ";
-
-              if (argValue instanceof String)
-                where += "\"";
-
-              where += argValue;
-
-              if (argValue instanceof String)
-                where += "\"";
-            }
-          }
-
-        projection = field.getSelectionSet();
-      }
+      final String where = buildWhereClause(queryArguments, typeArgumentNames);
 
       String query = "select from " + from;
       if (!where.isEmpty())
@@ -228,6 +176,42 @@ public class GraphQLSchema {
 
   }
 
+  /**
+   * Builds a SQL {@code where} clause from a GraphQL field's arguments, shared by both the plain-field and
+   * aliased-field dispatch paths so they cannot drift apart the way they did before (issue #6453).
+   */
+  private String buildWhereClause(final Arguments queryArguments, final Set<String> typeArgumentNames) {
+    final StringBuilder where = new StringBuilder();
+
+    if (queryArguments != null)
+      for (final Argument queryArgument : queryArguments.getList()) {
+        final String argName = queryArgument.getName();
+        if (!typeArgumentNames.contains(argName))
+          throw new CommandParsingException("Parameter '" + argName + "' not defined in query");
+
+        final Object argValue = queryArgument.getValueWithVariable().getValue().getValue();
+
+        if (!where.isEmpty())
+          where.append(" and ");
+
+        if ("where".equals(argName)) {
+          where.append(argValue);
+        } else {
+          where.append(argName).append(" = ");
+
+          if (argValue instanceof String)
+            where.append('"');
+
+          where.append(argValue);
+
+          if (argValue instanceof String)
+            where.append('"');
+        }
+      }
+
+    return where.toString();
+  }
+
   private GraphQLResultSet parseNativeQueryDirective(final String language, final Directive directive, final Selection selection, final ObjectTypeDefinition returnType) {
     if (directive.getArguments() == null)
       throw new CommandParsingException(language.toUpperCase(Locale.ENGLISH) + " directive has no `statement` argument");
@@ -236,14 +220,19 @@ public class GraphQLSchema {
     Map<String, Object> arguments = null;
     SelectionSet projection = null;
 
+    final Field field = selection.getField();
+    final FieldWithAlias aliasField = selection.getFieldWithAlias();
+
     for (final Argument argument : directive.getArguments().getList()) {
       if ("statement".equals(argument.getName())) {
         statement = argument.getValueWithVariable().getValue().getValue().toString();
 
-        final Field field = selection.getField();
         if (field != null) {
           arguments = getArguments(field.getArguments());
           projection = field.getSelectionSet();
+        } else if (aliasField != null) {
+          arguments = getArguments(aliasField.getArguments());
+          projection = aliasField.getSelectionSet();
         }
       }
     }

--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
@@ -102,7 +102,7 @@ public class GraphQLSchema {
 
     try {
       final Selection selection = op.getSelectionSet().getSelections().getFirst();
-      queryName = selection.getName();
+      queryName = selection.getFieldWithAlias() != null ? selection.getFieldWithAlias().getName() : selection.getName();
 
       // HANDLE INTROSPECTION QUERIES
       if ("__schema".equals(queryName))
@@ -144,6 +144,32 @@ public class GraphQLSchema {
 
       String where = "";
       final Field field = selection.getField();
+      if (field == null && selection.getFieldWithAlias() != null) {
+        // Aliased top-level field — use the FieldWithAlias for arguments and projection
+        final FieldWithAlias aliasField = selection.getFieldWithAlias();
+        final Arguments queryArguments = aliasField.getArguments();
+        if (queryArguments != null)
+          for (final Argument queryArgument : queryArguments.getList()) {
+            final String argName = queryArgument.getName();
+            if (!typeArgumentNames.contains(argName))
+              throw new CommandParsingException("Parameter '" + argName + "' not defined in query");
+            final Object argValue = queryArgument.getValueWithVariable().getValue().getValue();
+            if (where.length() > 0)
+              where += " and ";
+            if ("where".equals(argName))
+              where += argValue;
+            else {
+              where += argName;
+              where += " = ";
+              if (argValue instanceof String)
+                where += """;
+              where += argValue;
+              if (argValue instanceof String)
+                where += """;
+            }
+          }
+        projection = aliasField.getSelectionSet();
+      }
       if (field != null) {
         final Arguments queryArguments = field.getArguments();
         if (queryArguments != null)

--- a/graphql/src/test/java/com/arcadedb/graphql/Issue6453TopLevelQueryAliasTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/Issue6453TopLevelQueryAliasTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graphql;
+
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6453: aliasing the top-level query field itself (e.g.
+ * {@code myBook: bookByName(...)}) failed schema resolution, because the dispatch code looked up
+ * the field definition on the {@code Query} type using the alias instead of the real field name.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6453TopLevelQueryAliasTest extends AbstractGraphQLTest {
+
+  @Test
+  void topLevelQueryFieldAliasWithArgumentIsResolved() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ myBook: bookByName(name: \"Mr. brain\") { pageCount } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        // the argument on the aliased field filtered to the right book, and only the requested
+        // field was projected (both come from the FieldWithAlias, not the missing plain Field)
+        assertThat(record.getPropertyNames()).contains("pageCount");
+        assertThat(record.getPropertyNames()).doesNotContain("id", "name");
+        assertThat(record.<Integer>getProperty("pageCount")).isEqualTo(422);
+        assertThat(resultSet.hasNext()).isFalse();
+      }
+
+      return null;
+    });
+  }
+
+  @Test
+  void topLevelQueryFieldAliasWithoutArgumentIsResolved() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      try (final ResultSet resultSet = database.query("graphql", "{ book: bookById(id: \"book-1\") { name } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        assertThat(record.getPropertyNames()).contains("name");
+        assertThat(record.<String>getProperty("name")).isEqualTo("Harry Potter and the Philosopher's Stone");
+      }
+
+      return null;
+    });
+  }
+
+  @Test
+  void aliasedTopLevelFieldStillRejectsUndefinedArgument() {
+    executeTest(database -> {
+      defineTypes(database);
+
+      assertThatThrownBy(() -> database.query("graphql", "{ myBook: bookByName(bogus: \"Mr. brain\") { name } }"))
+          .isInstanceOf(CommandParsingException.class);
+
+      return null;
+    });
+  }
+
+  @Test
+  void aliasedTopLevelFieldBackedByNativeSqlDirectiveAppliesArgumentAndProjection() {
+    executeTest(database -> {
+      defineTypes(database);
+      database.command("graphql", """
+          type Query {
+            bookById(id: String): Book
+            bookByName(bookNameParameter: String): Book @sql(statement: "select from Book where name = :bookNameParameter")
+          }""");
+
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ myBook: bookByName(bookNameParameter: \"Mr. brain\") { pageCount } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
+        final Result record = resultSet.next();
+
+        // the @sql-backed field is only reachable via selection.getField(), which is null for an
+        // aliased selection - without the FieldWithAlias branch this returns every Book unfiltered
+        assertThat(record.getPropertyNames()).contains("pageCount");
+        assertThat(record.<Integer>getProperty("pageCount")).isEqualTo(422);
+        assertThat(resultSet.hasNext()).isFalse();
+      }
+
+      return null;
+    });
+  }
+}


### PR DESCRIPTION
## Summary

When a top-level GraphQL query field is aliased (e.g. `{ myBooks: books(inStock: true) { title } }`),
`Selection.getName()` returns the alias (`myBooks`) instead of the real field name (`books`),
causing the schema lookup in `queryDefinition.getFieldDefinitions()` to fail with
`CommandParsingException("Target type not defined for GraphQL query 'myBooks'")`.

## Fix

Resolve the real field name via `selection.getFieldWithAlias().getName()` when an alias is present,
mirroring the pattern already established in `GraphQLResultSet.mapBySelections` for nested-field
aliases (PR #6451). Also handle `FieldWithAlias` for argument parsing and projection, so aliased
queries with arguments (e.g. `{ myBooks: books(inStock: true) { title } }`) work correctly.

## Changes

- `GraphQLSchema.java` — `executeQuery()`: use `getFieldWithAlias().getName()` instead of
  `getName()` for the schema lookup when an alias is present; also parse arguments and
  set projection from the `FieldWithAlias` when the selection has one.

## Test case

```graphql
{ myBooks: books(inStock: true) { title } }
```

Before: throws `CommandParsingException("Target type not defined for GraphQL query 'myBooks'")`
After: returns books with `inStock: true` under the key `myBooks`

Fixes #6453