### PR TITLE
fix(#6509): apply async executor durability flags per task instead of tearing down the pool

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3737,4 +3737,14 @@ are now plain volatile writes with no `createThreads()` call at all, so a change
 whichever worker runs the next task - and by the commit that follows it - without any thread ever being torn down,
 and without disturbing whatever unrelated work is queued on the rest of the pool.
 
+Re-stamping the flags onto an already-open transaction is not, by itself, enough: `useWAL`/`walFlush` are read only
+at commit time and then govern the *whole* accumulated transaction, which can span up to `ASYNC_TX_BATCH_SIZE`
+(10,240 by default) tasks from unrelated callers sharing the same worker slot. Without a further guard, a flag flip
+landing mid-transaction would silently carry earlier tasks - queued under the old policy - into a commit governed by
+the new one, downgrading (or upgrading) their durability without anyone asking for it. The pool-teardown this PR
+removes had incidentally prevented that: a flag flip forced every worker's pending transaction to commit under its
+original flags before the new thread began a fresh one. `executeTask()` now preserves that "a flag change always
+starts a fresh transaction" property explicitly - closing out the currently open transaction, under its own
+unmodified flags, before applying a changed policy to a new one - instead of relying on thread teardown for it.
+
 [#6509](https://github.com/ArcadeData/arcadedb/issues/6509)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3747,4 +3747,12 @@ original flags before the new thread began a fresh one. `executeTask()` now pres
 starts a fresh transaction" property explicitly - closing out the currently open transaction, under its own
 unmodified flags, before applying a changed policy to a new one - instead of relying on thread teardown for it.
 
+That boundary-forcing commit closes out *earlier* tasks' work, not the task whose flag check triggered it - so its
+failure (a genuine `ConcurrentModificationException`, say, under the exact multi-writer contention this fix targets)
+must not be attributed to that task, which has not run yet. Left unguarded, the failure would propagate to
+`executeTask()`'s own catch block, and the triggering task would still reach `completed()` having never reached
+`execute()` - a task silently marked done without ever running. The boundary commit's failure is now caught
+separately, reported through the executor's `onError`, and the triggering task still gets its own attempt on a
+freshly begun transaction.
+
 [#6509](https://github.com/ArcadeData/arcadedb/issues/6509)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3711,3 +3711,30 @@ task's guard now all catch `Throwable`; in the latter two an escaping `Error` wo
 thread past the point where it clears the in-progress flag, silently stopping every later rebuild of that index.
 
 [#6503](https://github.com/ArcadeData/arcadedb/issues/6503)
+
+## The async executor no longer tears down and respawns its whole worker pool to flip a durability flag (#6509)
+
+`DatabaseAsyncExecutorImpl.setTransactionUseWAL()`/`setTransactionSync()` unconditionally called `createThreads()`,
+which shuts down and respawns every worker thread of the database's async pool - not just the caller's. `GraphBatch`
+calls both setters once per batch session to relax and then restore durability for a bulk load, so opening or
+closing a batch churned the entire pool. Any *other* concurrent user of `database.async()` - another `GraphBatch`,
+an async insert, an index compaction - had its in-flight and queued tasks force-exited mid-flight, surfacing as
+`"Async executor has been shut down"` for callers that had nothing to do with the batch.
+
+#5665 diagnosed this and shipped a cheap interim mitigation (GraphBatch toggling the flags once per batch instead of
+once per flush), explicitly deferring the real fix: `AsyncThread.run()` applied both flags only once, at thread
+start, so respawning the thread was the only way a change could ever become visible to it. A production log (#6505)
+showed the interim mitigation is not enough under real multi-writer concurrency: six threads on one database,
+including a `GraphBatch` import running alongside a `DELETE ... BATCH` loop, produced 2,183 `InterruptedIOException`s
+over about seven hours from the pool teardown interrupting unrelated in-progress LSM compactions, and one of those
+races escalated into fencing the entire database when a commit's `onAfterCommit()` hook tried to schedule a
+compaction at the exact moment the pool was mid-recreate (fixed separately by #6505 hardening the compaction
+scheduler against that specific escalation).
+
+The proper fix, per #5665's own diagnosis: `AsyncThread.executeTask()` now re-applies `transactionUseWAL`/
+`transactionSync` to the worker's transaction before every task, instead of `run()` applying them once. The setters
+are now plain volatile writes with no `createThreads()` call at all, so a changed durability policy is picked up by
+whichever worker runs the next task - and by the commit that follows it - without any thread ever being torn down,
+and without disturbing whatever unrelated work is queued on the rest of the pool.
+
+[#6509](https://github.com/ArcadeData/arcadedb/issues/6509)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3742,4 +3742,11 @@ the about-to-be-stale value (skipping the boundary commit) while the stamp went 
 reintroducing the same durability-mixing failure through a race instead of a guaranteed ordering. Both reads now
 share one snapshot taken at the top of `executeTask()`, so the check and the stamp always agree.
 
+Worth knowing when tuning `parallelLevel`/queue sizing around concurrent bulk loads: the boundary-forcing commit is
+paid per worker slot, not per database, so two `GraphBatch` sessions (or a batch and a direct caller) that land on
+the *same* slot and keep flipping the durability policy in opposite directions can degrade that slot toward
+`commitEvery=1` - each task forcing its own boundary. Correctness over batching is the right trade, and it is still
+strictly better than the pre-fix full pool teardown, but a workload that provokes this is a sign the workers sharing
+that slot would benefit from more parallelism (raising `parallelLevel`) rather than sharing one.
+
 [#6509](https://github.com/ArcadeData/arcadedb/issues/6509)

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -302,6 +302,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         // runs inside (#5062 review, point 1) - the helping path defers polled tasks back to the run loop
         // instead of nesting, so `nested` is always false today; every `!nested` guard in this method is
         // defense-in-depth should a re-entrant call path ever be reintroduced.
+        //
+        // Deliberately does not touch `count`: a flag-triggered boundary commit here closes a transaction
+        // out of band from the commitEvery cadence, so the NEXT periodic boundary below can land anywhere
+        // from immediately (if `count % commitEvery` was already due) to up to `commitEvery` tasks later -
+        // it is measuring "how many tasks since the last periodic check", not "how many since the
+        // transaction last committed". Harmless: it can only make the next real commit arrive sooner or
+        // later than the nominal cadence, never mix data across a durability-policy boundary (that is what
+        // this whole method exists to prevent) or lose a task.
         final boolean forceFreshTransactionAfterBoundaryFailure =
             !nested && closeTransactionBoundaryIfDurabilityPolicyChanged(currentUseWAL, currentSync);
 
@@ -380,6 +388,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
      * IOException), leaving the transaction in a half-cleaned, unknown state; a caller that trusted
      * {@code isTransactionActive()} at that point would skip beginning a fresh transaction and run the next
      * task against that leftover state instead.
+     * <p>
+     * In that double-failure case the caller's {@code begin()} pushes a new nested {@code TransactionContext}
+     * (see {@code executeTask()}'s caller-side comment) and the poisoned one this method leaves behind stays
+     * on the per-thread transaction stack underneath it - nothing pops a non-top entry. It is not a permanent
+     * leak: {@code DatabaseContext}'s dead-thread sweep (and a normal database close) rolls back and clears
+     * every entry on the stack, not just the top, once this worker thread eventually ends. Until then it sits
+     * inert (only the stack top is ever read or written by later tasks) at the cost of one small object.
      */
     private boolean closeTransactionBoundaryIfDurabilityPolicyChanged(final boolean currentUseWAL,
         final WALFile.FlushType currentSync) {

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -330,8 +330,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
               // that guarantee. Made unconditional here rather than relying on it: without this, a
               // still-active transaction would skip begin() below and the stamp would land on the same
               // stale, mismatched transaction the boundary commit was trying to close out.
-              if (database.isTransactionActive())
-                database.rollback();
+              try {
+                if (database.isTransactionActive())
+                  database.rollback();
+              } catch (final Throwable rollbackError) {
+                // #6509 review: a failure HERE must not escape to the outer catch either - that would
+                // repeat the exact bug this whole block exists to close, just one level deeper: `message`
+                // would still reach completed() in the outer finally having never reached execute().
+                // Logged and swallowed instead; `message` still gets its own begin()/execute() attempt
+                // below regardless of whether the transaction ends up active or not.
+                LogManager.instance().log(this, Level.WARNING,
+                    "Error rolling back the transaction after a failed durability-boundary commit", rollbackError);
+              }
             }
           }
         }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -377,6 +377,16 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         // silently re-stamp the still-open transaction of the outer, suspended task it is nested inside -
         // bypassing the boundary-commit guard entirely rather than merely skipping the commitEvery boundary
         // the way the existing !nested guards below document.
+        //
+        // #6509 review: when forceFreshTransactionAfterBoundaryFailure is set but `message` does not
+        // require an active tx, begin() above is skipped (message does not need it) and this still stamps
+        // the snapshot onto the poisoned transaction from the double-failure branch - `database.getTransaction()`
+        // is that same still-active, half-cleaned one, not the fresh nested one begin() would have created.
+        // Accepted: a task with requiresActiveTx()==false never writes through it, and the stamp simply
+        // means the NEXT task's boundary check sees this poisoned transaction's flags already matching the
+        // current snapshot and does not re-trigger a boundary commit on it - it is left exactly as
+        // untouched-by-writes as it already was, for whatever later commitEvery boundary or begin() call
+        // eventually deals with it.
         if (!nested) {
           database.getTransaction().setUseWAL(currentUseWAL);
           database.setWALFlush(currentSync);

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -227,10 +227,16 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       DatabaseContext.INSTANCE.init(database);
 
       DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).perThreadBucketSelection = true;
-      // Seeds the transaction this thread is about to begin; executeTask() re-applies both on every
-      // task afterwards (#6509), so a later change is picked up without needing this thread respawned.
-      database.getTransaction().setUseWAL(transactionUseWAL);
-      database.setWALFlush(transactionSync);
+      // Seeds the transaction this thread is about to begin; executeTask() re-applies both on every task
+      // afterwards (#6509), so a later change is picked up without needing this thread respawned. Snapshotted
+      // into locals first, same as executeTask(), so a concurrent setTransactionUseWAL()/setTransactionSync()
+      // flip landing between the two reads can't seed one field from the old policy and the other from the
+      // new one - benign here either way (the first task's own boundary check reconciles it), but consistent
+      // with the same reasoning applied there.
+      final boolean           initialUseWAL = transactionUseWAL;
+      final WALFile.FlushType initialSync   = transactionSync;
+      database.getTransaction().setUseWAL(initialUseWAL);
+      database.setWALFlush(initialSync);
       database.getTransaction().begin(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED); // FORCE THE LOWEST LEVEL
       // OF ISOLATION
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -300,8 +300,20 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         // task's partial writes.
         if (!nested && database.isTransactionActive()) {
           final TransactionContext activeTx = database.getTransaction();
-          if (activeTx.isUseWAL() != transactionUseWAL || activeTx.getWALFlush() != transactionSync)
-            database.commit();
+          if (activeTx.isUseWAL() != transactionUseWAL || activeTx.getWALFlush() != transactionSync) {
+            try {
+              database.commit();
+            } catch (final Throwable e) {
+              // #6509 review: this commit closes out EARLIER tasks' accumulated work, not `message` -
+              // which has not run yet - so its failure must not be attributed to `message`. Left to the
+              // outer catch below, it would be: `message` would reach completed() in the finally block
+              // there having never reached execute(), which silently discards it instead of running it.
+              // Report the failure and fall through to begin a fresh transaction for `message` instead:
+              // if the failure left the database unusable, the begin()/execute() below will fail too,
+              // for a reason that legitimately belongs to `message`.
+              onError(e);
+            }
+          }
         }
 
         if (message.requiresActiveTx() && !database.isTransactionActive())

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -391,10 +391,16 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
      * <p>
      * In that double-failure case the caller's {@code begin()} pushes a new nested {@code TransactionContext}
      * (see {@code executeTask()}'s caller-side comment) and the poisoned one this method leaves behind stays
-     * on the per-thread transaction stack underneath it - nothing pops a non-top entry. It is not a permanent
-     * leak: {@code DatabaseContext}'s dead-thread sweep (and a normal database close) rolls back and clears
-     * every entry on the stack, not just the top, once this worker thread eventually ends. Until then it sits
-     * inert (only the stack top is ever read or written by later tasks) at the cost of one small object.
+     * on the per-thread transaction stack underneath it - nothing pops a non-top entry. Not a permanent leak
+     * in the common case: {@code DatabaseContext}'s dead-thread sweep (and a normal database close) rolls
+     * back and clears every entry on the stack, not just the top, once this worker thread eventually ends.
+     * Until then it sits inert (only the stack top is ever read or written by later tasks) at the cost of one
+     * small object. That reclaim itself calls {@code rollback()} again, though, so if the original rollback
+     * failure was persistent (e.g. a disk genuinely full, a corrupted schema dictionary that keeps throwing)
+     * rather than transient, the sweep's own attempt can fail the same way - its own contract is a logged
+     * warning and moving on, not a guarantee, and its own comment already documents that failure mode as
+     * held file locks. A double failure on top of the double failure that got here is out of scope for this
+     * class to solve.
      */
     private boolean closeTransactionBoundaryIfDurabilityPolicyChanged(final boolean currentUseWAL,
         final WALFile.FlushType currentSync) {

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -309,6 +309,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         // (unmodified) flags before this task touches anything, then let the check below open a new one
         // that picks up the new flags cleanly. Guarded by !nested for the same reason as the commitEvery
         // boundary below: a nested commit would commit an enclosing task's partial writes.
+        // #6509 review: set only when BOTH the boundary commit AND its rollback fallback fail (e.g.
+        // TransactionContext.rollback() can itself throw - and return without reaching its own reset()
+        // call - on a schema-dictionary reload IOException, line ~439). In that double-failure case
+        // database.isTransactionActive() can still read true over a transaction left in a half-cleaned,
+        // unknown state, and the begin() guard below would then wrongly skip beginning a fresh one for
+        // `message`, running it against that leftover state instead. Forces begin() regardless of the
+        // active-flag reading below when set - see the guard's comment for why that is safe.
+        boolean forceFreshTransactionAfterBoundaryFailure = false;
+
         if (!nested && database.isTransactionActive()) {
           final TransactionContext activeTx = database.getTransaction();
           if (activeTx.isUseWAL() != currentUseWAL || activeTx.getWALFlush() != currentSync) {
@@ -338,15 +347,24 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
                 // repeat the exact bug this whole block exists to close, just one level deeper: `message`
                 // would still reach completed() in the outer finally having never reached execute().
                 // Logged and swallowed instead; `message` still gets its own begin()/execute() attempt
-                // below regardless of whether the transaction ends up active or not.
+                // below regardless of whether the transaction ends up active or not - forced past the
+                // stale still-active read via the flag above, rather than trusted to it.
                 LogManager.instance().log(this, Level.WARNING,
                     "Error rolling back the transaction after a failed durability-boundary commit", rollbackError);
+                forceFreshTransactionAfterBoundaryFailure = database.isTransactionActive();
               }
             }
           }
         }
 
-        if (message.requiresActiveTx() && !database.isTransactionActive())
+        if (message.requiresActiveTx() && (forceFreshTransactionAfterBoundaryFailure || !database.isTransactionActive()))
+          // #6509 review: LocalDatabase.begin() checks isActive() on the CURRENT TransactionContext itself -
+          // when forceFreshTransactionAfterBoundaryFailure is set that reads true (the double-failure case
+          // above), so this deliberately takes the "already active" branch and pushes a NEW nested context
+          // for `message` rather than reusing the poisoned one, exactly as it would for any other caller
+          // that begins a transaction while one is already open. The poisoned transaction is left on the
+          // stack underneath, still there for whatever the next commitEvery boundary or flag flip does with
+          // it, but `message` itself runs isolated from its unknown state either way.
           database.begin();
 
         // Applied per task, not once at thread start (see run()): setTransactionUseWAL()/

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -72,7 +72,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   private volatile AsyncThread[]     executorThreads;
   private final Object               lifecycleLock                 = new Object();
   // #4961: these settings are written by user threads and read by the worker threads, so they must
-  // be volatile or a change applied after createThreads() may never become visible to the workers.
+  // be volatile or a change may never become visible to the workers. parallelLevel only ever changes
+  // via createThreads() (setParallelLevel), which visibility naturally piggybacks on; transactionUseWAL
+  // and transactionSync are read directly by AsyncThread.executeTask() on every task instead (#6509).
   private volatile int               parallelLevel                 = 1;
   private volatile int               commitEvery;
   private volatile int               backPressurePercentage        = 0;
@@ -224,6 +226,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       DatabaseContext.INSTANCE.init(database);
 
       DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).perThreadBucketSelection = true;
+      // Seeds the transaction this thread is about to begin; executeTask() re-applies both on every
+      // task afterwards (#6509), so a later change is picked up without needing this thread respawned.
       database.getTransaction().setUseWAL(transactionUseWAL);
       database.setWALFlush(transactionSync);
       database.getTransaction().begin(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED); // FORCE THE LOWEST LEVEL
@@ -282,6 +286,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
         if (message.requiresActiveTx() && !database.isTransactionActive())
           database.begin();
+
+        // #6509: applied per task, not once at thread start (see run()). setTransactionUseWAL()/
+        // setTransactionSync() are plain volatile writes now, so the latest requested durability
+        // policy is picked up here on the very next task and carried into whichever commit follows -
+        // the commitEvery boundary below or the final commit in run() - instead of requiring the
+        // whole pool to be torn down and respawned for the change to become visible.
+        database.getTransaction().setUseWAL(transactionUseWAL);
+        database.setWALFlush(transactionSync);
 
         message.execute(this, database);
 
@@ -375,8 +387,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
   @Override
   public void setTransactionUseWAL(final boolean transactionUseWAL) {
+    // #6509: a plain volatile write. AsyncThread.executeTask() re-applies this to the worker's
+    // TransactionContext before every task, so the new value takes effect on the very next task
+    // without tearing down and respawning the whole pool (the #5665 mechanism this replaces).
     this.transactionUseWAL = transactionUseWAL;
-    createThreads(parallelLevel);
   }
 
   @Override
@@ -391,8 +405,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
   @Override
   public void setTransactionSync(final WALFile.FlushType transactionSync) {
+    // #6509: see setTransactionUseWAL() above - same plain-volatile-write treatment.
     this.transactionSync = transactionSync;
-    createThreads(parallelLevel);
   }
 
   public long getCheckForStalledQueuesMaxDelay() {
@@ -442,13 +456,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       scheduled = scheduleTask(getBestSlot(), new DatabaseAsyncIndexCompaction(index), false, 0);
     } catch (final DatabaseOperationException e) {
       // #6505: getBestSlot()/scheduleTask throw the SAME "shut down" exception for a genuine terminal close()/
-      // kill() (#4955, the case this was written for) and for the momentary window setTransactionUseWAL()/
-      // setTransactionSync() leaves while createThreads() tears down and respawns the whole pool for an
-      // UNRELATED caller (issue #5665) - the pool is back within milliseconds, but this onAfterCommit hook runs
-      // AFTER writeTransactionToWAL(), so letting the exception escape crossed the WAL point of no return and
-      // fenced the entire database (#5053) over a best-effort scheduling hiccup that had nothing to do with the
-      // committing transaction's data. This finally hands the reservation back exactly like the full-queue case
-      // above: no compaction is lost, it is picked up by the next commit past the threshold.
+      // kill() (#4955, the case this was written for) and for the momentary window createThreads() leaves while
+      // it tears down and respawns the whole pool for an UNRELATED caller (issue #5665 - setTransactionUseWAL()/
+      // setTransactionSync() used to trigger this on every GraphBatch open/close; #6509 removed that path, but
+      // setParallelLevel() still goes through createThreads() and leaves the same momentary window) - the pool
+      // is back within milliseconds, but this onAfterCommit hook runs AFTER writeTransactionToWAL(), so letting
+      // the exception escape crossed the WAL point of no return and fenced the entire database (#5053) over a
+      // best-effort scheduling hiccup that had nothing to do with the committing transaction's data. This finally
+      // hands the reservation back exactly like the full-queue case above: no compaction is lost, it is picked up
+      // by the next commit past the threshold.
       LogManager.instance().log(this, Level.WARNING, "Could not schedule compaction of index '%s': %s", null,
           index, e.getMessage());
     } finally {
@@ -1286,8 +1302,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   }
 
   // Package-private test hook (#5072 review, point 4): rebuilds the worker pool so configuration
-  // changes (e.g. ASYNC_OPERATIONS_QUEUE_SIZE) are picked up deterministically, instead of the
-  // tests relying on setTransactionUseWAL()'s createThreads() side effect.
+  // changes (e.g. ASYNC_OPERATIONS_QUEUE_SIZE) are picked up deterministically. Originally an
+  // alternative to tests relying on setTransactionUseWAL()'s createThreads() side effect; #6509
+  // removed that side effect, making this the only way to force a rebuild from a test.
   void recreateThreadsForTests() {
     createThreads(parallelLevel);
   }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -28,6 +28,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.ErrorRecordCallback;
 import com.arcadedb.engine.WALFile;
@@ -284,14 +285,33 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
             .log(this, Level.FINE, "Received async message %s (threadId=%d)", message,
                 Thread.currentThread().threadId());
 
+        // #6509 review: useWAL/walFlush are read only at commit time and then govern the WHOLE
+        // accumulated transaction (TransactionContext.commit1stPhase/commit2ndPhase), not per write - so
+        // an already-open transaction that straddles a flag change would silently commit EARLIER tasks
+        // (queued by a caller unrelated to whoever changed the flag) under a durability policy they
+        // never asked for. Before #6509 this could not happen: a flag flip tore down and respawned the
+        // whole pool, and each worker's shutdown path committed its pending transaction under the STILL
+        // original flags before the new thread began a fresh one with the new flags. That "a flag change
+        // always starts a fresh transaction" guarantee is preserved here explicitly instead: if a
+        // transaction is already open and was last stamped with different flags than are current now,
+        // close it out under its own (unmodified) flags before this task touches anything, then let the
+        // check below open a new one that picks up the new flags cleanly. Guarded by !nested for the
+        // same reason as the commitEvery boundary below: a nested commit would commit an enclosing
+        // task's partial writes.
+        if (!nested && database.isTransactionActive()) {
+          final TransactionContext activeTx = database.getTransaction();
+          if (activeTx.isUseWAL() != transactionUseWAL || activeTx.getWALFlush() != transactionSync)
+            database.commit();
+        }
+
         if (message.requiresActiveTx() && !database.isTransactionActive())
           database.begin();
 
-        // #6509: applied per task, not once at thread start (see run()). setTransactionUseWAL()/
-        // setTransactionSync() are plain volatile writes now, so the latest requested durability
-        // policy is picked up here on the very next task and carried into whichever commit follows -
-        // the commitEvery boundary below or the final commit in run() - instead of requiring the
-        // whole pool to be torn down and respawned for the change to become visible.
+        // Applied per task, not once at thread start (see run()): setTransactionUseWAL()/
+        // setTransactionSync() are plain volatile writes now, so the latest requested durability policy
+        // is picked up here - on a transaction that, by the guard above, either just began or was
+        // already running under this same policy - instead of requiring the whole pool to be torn down
+        // and respawned for the change to become visible.
         database.getTransaction().setUseWAL(transactionUseWAL);
         database.setWALFlush(transactionSync);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -285,22 +285,33 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
             .log(this, Level.FINE, "Received async message %s (threadId=%d)", message,
                 Thread.currentThread().threadId());
 
-        // #6509 review: useWAL/walFlush are read only at commit time and then govern the WHOLE
-        // accumulated transaction (TransactionContext.commit1stPhase/commit2ndPhase), not per write - so
-        // an already-open transaction that straddles a flag change would silently commit EARLIER tasks
-        // (queued by a caller unrelated to whoever changed the flag) under a durability policy they
-        // never asked for. Before #6509 this could not happen: a flag flip tore down and respawned the
-        // whole pool, and each worker's shutdown path committed its pending transaction under the STILL
-        // original flags before the new thread began a fresh one with the new flags. That "a flag change
-        // always starts a fresh transaction" guarantee is preserved here explicitly instead: if a
-        // transaction is already open and was last stamped with different flags than are current now,
-        // close it out under its own (unmodified) flags before this task touches anything, then let the
-        // check below open a new one that picks up the new flags cleanly. Guarded by !nested for the
-        // same reason as the commitEvery boundary below: a nested commit would commit an enclosing
-        // task's partial writes.
+        // #6509 review: transactionUseWAL/transactionSync are volatile and can be changed concurrently by
+        // ANY other thread calling setTransactionUseWAL()/setTransactionSync() (another GraphBatch
+        // open/close, a direct caller) - exactly the multi-writer scenario this fix is about. Reading them
+        // twice below (once for the boundary check, once for the stamp) would let a flip land in between:
+        // the check would see the transaction's flags still matching the about-to-be-stale value and skip
+        // the boundary commit, then the stamp would apply the NEW value anyway - silently committing
+        // earlier tasks' writes under a policy they never asked for the same way an unguarded flip would,
+        // just through a narrow race instead of a guaranteed ordering. One snapshot, reused for both,
+        // makes the two agree by construction.
+        final boolean           currentUseWAL = transactionUseWAL;
+        final WALFile.FlushType currentSync   = transactionSync;
+
+        // useWAL/walFlush are read only at commit time and then govern the WHOLE accumulated transaction
+        // (TransactionContext.commit1stPhase/commit2ndPhase), not per write - so an already-open
+        // transaction that straddles a flag change would silently commit EARLIER tasks (queued by a caller
+        // unrelated to whoever changed the flag) under a durability policy they never asked for. Before
+        // #6509 this could not happen: a flag flip tore down and respawned the whole pool, and each
+        // worker's shutdown path committed its pending transaction under the STILL original flags before
+        // the new thread began a fresh one with the new flags. That "a flag change always starts a fresh
+        // transaction" guarantee is preserved here explicitly instead: if a transaction is already open and
+        // was last stamped with different flags than the snapshot above, close it out under its own
+        // (unmodified) flags before this task touches anything, then let the check below open a new one
+        // that picks up the new flags cleanly. Guarded by !nested for the same reason as the commitEvery
+        // boundary below: a nested commit would commit an enclosing task's partial writes.
         if (!nested && database.isTransactionActive()) {
           final TransactionContext activeTx = database.getTransaction();
-          if (activeTx.isUseWAL() != transactionUseWAL || activeTx.getWALFlush() != transactionSync) {
+          if (activeTx.isUseWAL() != currentUseWAL || activeTx.getWALFlush() != currentSync) {
             try {
               database.commit();
             } catch (final Throwable e) {
@@ -312,6 +323,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
               // if the failure left the database unusable, the begin()/execute() below will fail too,
               // for a reason that legitimately belongs to `message`.
               onError(e);
+              // #6509 review: TransactionContext.commit()'s own failure paths always leave the
+              // transaction inactive (rollback()/reset() run in every catch/finally there), but
+              // LocalDatabase.commit() wraps the call in executeInReadLock(...), so a failure originating
+              // outside TransactionContext (e.g. the read-lock acquisition) is not provably covered by
+              // that guarantee. Made unconditional here rather than relying on it: without this, a
+              // still-active transaction would skip begin() below and the stamp would land on the same
+              // stale, mismatched transaction the boundary commit was trying to close out.
+              if (database.isTransactionActive())
+                database.rollback();
             }
           }
         }
@@ -321,11 +341,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
         // Applied per task, not once at thread start (see run()): setTransactionUseWAL()/
         // setTransactionSync() are plain volatile writes now, so the latest requested durability policy
-        // is picked up here - on a transaction that, by the guard above, either just began or was
-        // already running under this same policy - instead of requiring the whole pool to be torn down
-        // and respawned for the change to become visible.
-        database.getTransaction().setUseWAL(transactionUseWAL);
-        database.setWALFlush(transactionSync);
+        // is picked up here - on a transaction that, by the guard above, either just began or was already
+        // running under this same (snapshotted) policy - instead of requiring the whole pool to be torn
+        // down and respawned for the change to become visible. Guarded by !nested for the same reason as
+        // the boundary-commit check above: today `nested` is always false (the helping path defers instead
+        // of nesting), but restamping here unconditionally would, if that ever changed, let a nested task
+        // silently re-stamp the still-open transaction of the outer, suspended task it is nested inside -
+        // bypassing the boundary-commit guard entirely rather than merely skipping the commitEvery boundary
+        // the way the existing !nested guards below document.
+        if (!nested) {
+          database.getTransaction().setUseWAL(currentUseWAL);
+          database.setWALFlush(currentSync);
+        }
 
         message.execute(this, database);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -285,108 +285,38 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
             .log(this, Level.FINE, "Received async message %s (threadId=%d)", message,
                 Thread.currentThread().threadId());
 
-        // #6509 review: transactionUseWAL/transactionSync are volatile and can be changed concurrently by
-        // ANY other thread calling setTransactionUseWAL()/setTransactionSync() (another GraphBatch
-        // open/close, a direct caller) - exactly the multi-writer scenario this fix is about. Reading them
-        // twice below (once for the boundary check, once for the stamp) would let a flip land in between:
-        // the check would see the transaction's flags still matching the about-to-be-stale value and skip
-        // the boundary commit, then the stamp would apply the NEW value anyway - silently committing
-        // earlier tasks' writes under a policy they never asked for the same way an unguarded flip would,
-        // just through a narrow race instead of a guaranteed ordering. One snapshot, reused for both,
-        // makes the two agree by construction.
+        // One snapshot, reused everywhere below: transactionUseWAL/transactionSync are independent
+        // volatiles that any other thread can flip concurrently (another GraphBatch open/close, a direct
+        // caller), so reading them more than once per task would let a flip land in between reads and
+        // desynchronize the boundary check from the stamp (#6509 review).
         final boolean           currentUseWAL = transactionUseWAL;
         final WALFile.FlushType currentSync   = transactionSync;
 
-        // useWAL/walFlush are read only at commit time and then govern the WHOLE accumulated transaction
-        // (TransactionContext.commit1stPhase/commit2ndPhase), not per write - so an already-open
-        // transaction that straddles a flag change would silently commit EARLIER tasks (queued by a caller
-        // unrelated to whoever changed the flag) under a durability policy they never asked for. Before
-        // #6509 this could not happen: a flag flip tore down and respawned the whole pool, and each
-        // worker's shutdown path committed its pending transaction under the STILL original flags before
-        // the new thread began a fresh one with the new flags. That "a flag change always starts a fresh
-        // transaction" guarantee is preserved here explicitly instead: if a transaction is already open and
-        // was last stamped with different flags than the snapshot above, close it out under its own
-        // (unmodified) flags before this task touches anything, then let the check below open a new one
-        // that picks up the new flags cleanly. Guarded by !nested for the same reason as the commitEvery
-        // boundary below: a nested commit would commit an enclosing task's partial writes.
-        // #6509 review: set only when BOTH the boundary commit AND its rollback fallback fail (e.g.
-        // TransactionContext.rollback() can itself throw - and return without reaching its own reset()
-        // call - on a schema-dictionary reload IOException, line ~439). In that double-failure case
-        // database.isTransactionActive() can still read true over a transaction left in a half-cleaned,
-        // unknown state, and the begin() guard below would then wrongly skip beginning a fresh one for
-        // `message`, running it against that leftover state instead. Forces begin() regardless of the
-        // active-flag reading below when set - see the guard's comment for why that is safe.
-        boolean forceFreshTransactionAfterBoundaryFailure = false;
-
-        if (!nested && database.isTransactionActive()) {
-          final TransactionContext activeTx = database.getTransaction();
-          if (activeTx.isUseWAL() != currentUseWAL || activeTx.getWALFlush() != currentSync) {
-            try {
-              database.commit();
-            } catch (final Throwable e) {
-              // #6509 review: this commit closes out EARLIER tasks' accumulated work, not `message` -
-              // which has not run yet - so its failure must not be attributed to `message`. Left to the
-              // outer catch below, it would be: `message` would reach completed() in the finally block
-              // there having never reached execute(), which silently discards it instead of running it.
-              // Report the failure and fall through to begin a fresh transaction for `message` instead:
-              // if the failure left the database unusable, the begin()/execute() below will fail too,
-              // for a reason that legitimately belongs to `message`.
-              onError(e);
-              // #6509 review: TransactionContext.commit()'s own failure paths always leave the
-              // transaction inactive (rollback()/reset() run in every catch/finally there), but
-              // LocalDatabase.commit() wraps the call in executeInReadLock(...), so a failure originating
-              // outside TransactionContext (e.g. the read-lock acquisition) is not provably covered by
-              // that guarantee. Made unconditional here rather than relying on it: without this, a
-              // still-active transaction would skip begin() below and the stamp would land on the same
-              // stale, mismatched transaction the boundary commit was trying to close out.
-              try {
-                if (database.isTransactionActive())
-                  database.rollback();
-              } catch (final Throwable rollbackError) {
-                // #6509 review: a failure HERE must not escape to the outer catch either - that would
-                // repeat the exact bug this whole block exists to close, just one level deeper: `message`
-                // would still reach completed() in the outer finally having never reached execute().
-                // Logged and swallowed instead; `message` still gets its own begin()/execute() attempt
-                // below regardless of whether the transaction ends up active or not - forced past the
-                // stale still-active read via the flag above, rather than trusted to it.
-                LogManager.instance().log(this, Level.WARNING,
-                    "Error rolling back the transaction after a failed durability-boundary commit", rollbackError);
-                forceFreshTransactionAfterBoundaryFailure = database.isTransactionActive();
-              }
-            }
-          }
-        }
+        // A nested execution must never touch the transaction boundary of the outer, suspended task it
+        // runs inside (#5062 review, point 1) - the helping path defers polled tasks back to the run loop
+        // instead of nesting, so `nested` is always false today; every `!nested` guard in this method is
+        // defense-in-depth should a re-entrant call path ever be reintroduced.
+        final boolean forceFreshTransactionAfterBoundaryFailure =
+            !nested && closeTransactionBoundaryIfDurabilityPolicyChanged(currentUseWAL, currentSync);
 
         if (message.requiresActiveTx() && (forceFreshTransactionAfterBoundaryFailure || !database.isTransactionActive()))
-          // #6509 review: LocalDatabase.begin() checks isActive() on the CURRENT TransactionContext itself -
-          // when forceFreshTransactionAfterBoundaryFailure is set that reads true (the double-failure case
-          // above), so this deliberately takes the "already active" branch and pushes a NEW nested context
-          // for `message` rather than reusing the poisoned one, exactly as it would for any other caller
-          // that begins a transaction while one is already open. The poisoned transaction is left on the
-          // stack underneath, still there for whatever the next commitEvery boundary or flag flip does with
-          // it, but `message` itself runs isolated from its unknown state either way.
+          // LocalDatabase.begin() checks isActive() on the CURRENT TransactionContext itself - when
+          // forceFreshTransactionAfterBoundaryFailure is set that reads true, so this deliberately takes
+          // the "already active" branch and pushes a NEW nested context for `message` rather than reusing
+          // the poisoned one left behind by closeTransactionBoundaryIfDurabilityPolicyChanged(), exactly as
+          // it would for any other caller that begins a transaction while one is already open.
           database.begin();
 
         // Applied per task, not once at thread start (see run()): setTransactionUseWAL()/
-        // setTransactionSync() are plain volatile writes now, so the latest requested durability policy
-        // is picked up here - on a transaction that, by the guard above, either just began or was already
-        // running under this same (snapshotted) policy - instead of requiring the whole pool to be torn
-        // down and respawned for the change to become visible. Guarded by !nested for the same reason as
-        // the boundary-commit check above: today `nested` is always false (the helping path defers instead
-        // of nesting), but restamping here unconditionally would, if that ever changed, let a nested task
-        // silently re-stamp the still-open transaction of the outer, suspended task it is nested inside -
-        // bypassing the boundary-commit guard entirely rather than merely skipping the commitEvery boundary
-        // the way the existing !nested guards below document.
-        //
-        // #6509 review: when forceFreshTransactionAfterBoundaryFailure is set but `message` does not
-        // require an active tx, begin() above is skipped (message does not need it) and this still stamps
-        // the snapshot onto the poisoned transaction from the double-failure branch - `database.getTransaction()`
-        // is that same still-active, half-cleaned one, not the fresh nested one begin() would have created.
-        // Accepted: a task with requiresActiveTx()==false never writes through it, and the stamp simply
-        // means the NEXT task's boundary check sees this poisoned transaction's flags already matching the
-        // current snapshot and does not re-trigger a boundary commit on it - it is left exactly as
-        // untouched-by-writes as it already was, for whatever later commitEvery boundary or begin() call
-        // eventually deals with it.
+        // setTransactionSync() are plain volatile writes now, so the latest requested durability policy is
+        // picked up here - on a transaction that, by the call above, either just began fresh or was
+        // already running under this same snapshotted policy - instead of requiring the whole pool to be
+        // torn down and respawned for the change to become visible. Skipped when `forceFreshTransactionAfterBoundaryFailure`
+        // is set but `message` does not require an active tx (begin() above was skipped too): the stamp
+        // then lands on the still-active, poisoned transaction rather than a fresh one, which is accepted
+        // since a task that never writes through it does not need it clean - it only means the NEXT task's
+        // boundary check sees this poisoned transaction's flags already matching and leaves it for a later
+        // commitEvery boundary or begin() call to deal with, exactly as untouched as it already was.
         if (!nested) {
           database.getTransaction().setUseWAL(currentUseWAL);
           database.setWALFlush(currentSync);
@@ -394,17 +324,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
         message.execute(this, database);
 
-        // #5062 review (point 1): the commit-every-N boundary must never fire from a nested
-        // execution while an enclosing task is suspended mid-execute(), or it would commit that
-        // task's partial writes. The helping path defers tasks instead of nesting (see
-        // offerHelping), so today `nested` is always false here; the guard is defense-in-depth
-        // should a re-entrant call path ever be reintroduced.
         if (!nested) {
           count++;
 
           if (database.isTransactionActive() && count % commitEvery == 0) {
             database.commit();
             database.begin();
+            // TransactionContext.begin()/reset() never reset useWAL/walFlush, so the stamp above would
+            // "happen to" survive this cycle via object reuse even without this - re-applied explicitly
+            // anyway so the guarantee does not depend on that staying true in a different class (#6509
+            // review round 9).
+            database.getTransaction().setUseWAL(currentUseWAL);
+            database.setWALFlush(currentSync);
           }
         }
       } catch (final Throwable e) {
@@ -420,6 +351,68 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
           executingTask.set(nested);
         }
       }
+    }
+
+    /**
+     * If a transaction is already open and was last stamped with different durability flags than
+     * {@code currentUseWAL}/{@code currentSync}, commits it under its own (unmodified) flags before the
+     * caller applies the new ones to anything - a no-op otherwise.
+     * <p>
+     * {@code useWAL}/{@code walFlush} are read only at commit time and then govern the WHOLE accumulated
+     * transaction (see {@code TransactionContext.commit1stPhase}/{@code commit2ndPhase}), not per write, so
+     * re-stamping them onto an already-open transaction without first closing it would silently commit
+     * earlier tasks - queued under the OLD policy by a caller unrelated to whoever changed it - under the
+     * NEW one instead. Before #6509 this could not happen: a flag flip tore down and respawned the whole
+     * pool, and each worker's shutdown path committed its pending transaction under the still-original
+     * flags before the new thread began a fresh one. This restores that "a flag change always starts a
+     * fresh transaction" guarantee explicitly, without the pool teardown.
+     *
+     * @return true if the transaction must be treated as active by the caller's own {@code begin()} guard
+     * even though {@link Database#isTransactionActive()} may still (wrongly) report true afterward - set
+     * only when BOTH the commit above and its rollback fallback fail. {@code TransactionContext.rollback()}
+     * can itself throw before reaching its own {@code reset()} (e.g. a schema-dictionary reload
+     * IOException), leaving the transaction in a half-cleaned, unknown state; a caller that trusted
+     * {@code isTransactionActive()} at that point would skip beginning a fresh transaction and run the next
+     * task against that leftover state instead.
+     */
+    private boolean closeTransactionBoundaryIfDurabilityPolicyChanged(final boolean currentUseWAL,
+        final WALFile.FlushType currentSync) {
+      if (!database.isTransactionActive())
+        return false;
+
+      final TransactionContext activeTx = database.getTransaction();
+      if (activeTx.isUseWAL() == currentUseWAL && activeTx.getWALFlush() == currentSync)
+        return false;
+
+      try {
+        database.commit();
+      } catch (final Throwable e) {
+        // This commit closes out EARLIER tasks' accumulated work, not the task that triggered this check -
+        // which has not run yet - so the failure must not be attributed to it: left uncaught, the caller's
+        // task would still reach completed() without ever reaching execute(), silently discarding it
+        // instead of running it. Reported here instead, and the caller still gets its own begin()/execute()
+        // attempt on a transaction this method leaves inactive (see below) - if the failure left the
+        // database unusable, that attempt fails too, for a reason that legitimately belongs to it.
+        onError(e);
+        try {
+          // TransactionContext.commit()'s own failure paths always leave the transaction inactive
+          // (rollback()/reset() run in every catch/finally there), but LocalDatabase.commit() wraps the
+          // call in executeInReadLock(...), so a failure originating outside TransactionContext (e.g. the
+          // read-lock acquisition) is not provably covered by that guarantee - made unconditional here
+          // instead of relying on it.
+          if (database.isTransactionActive())
+            database.rollback();
+        } catch (final Throwable rollbackError) {
+          // A failure HERE must not escape either, for the same reason as the commit failure above: it
+          // would repeat the exact bug this method exists to close, one level deeper. Logged and swallowed;
+          // the true/false returned tells the caller whether it can still trust isTransactionActive() or
+          // must force a fresh transaction regardless of what that reads.
+          LogManager.instance().log(this, Level.WARNING,
+              "Error rolling back the transaction after a failed durability-boundary commit", rollbackError);
+          return database.isTransactionActive();
+        }
+      }
+      return false;
     }
 
     private void drainQueueNotifyingWaiters() {

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -377,12 +377,13 @@ public class GraphBatch implements AutoCloseable {
   private final boolean savedUseWAL;
   private final WALFile.FlushType savedWALFlush;
   // Async executor WAL policy, relaxed/restored ONCE for the whole batch instead of once per flush
-  // (issue #5665): DatabaseAsyncExecutorImpl tears down and respawns its entire worker pool on every
-  // setTransactionUseWAL()/setTransactionSync() call, so applying the relaxed policy around every
-  // flush's parallel connect phase recreated every async worker thread on every flush - killing any
-  // concurrent async work on this database (an unrelated caller's in-flight/queued tasks force-exited
-  // with "Async executor has been shut down") and, on a large multi-flush bulk load, doing so tens of
-  // thousands of times. Meaningful only when parallelFlush is true; unused (false/null) otherwise.
+  // (issue #5665): applying the relaxed policy around every flush's parallel connect phase toggled the
+  // shared, database-wide policy that many times, needlessly forcing a transaction boundary on every
+  // OTHER concurrent user of database.async() sharing a worker slot with this batch (#6509 - before
+  // that fix, each toggle instead tore down and respawned the entire async worker pool, which was far
+  // more disruptive: any concurrent caller's in-flight/queued tasks were force-exited with "Async
+  // executor has been shut down"). Meaningful only when parallelFlush is true; unused (false/null)
+  // otherwise.
   private final boolean            savedAsyncUseWAL;
   private final WALFile.FlushType  savedAsyncWALFlush;
 
@@ -472,7 +473,8 @@ public class GraphBatch implements AutoCloseable {
 
     // Relax the shared async executor's WAL policy once, here, instead of once per flush (issue
     // #5665; see the field javadoc on savedAsyncUseWAL). Guarded on an actual change because the
-    // setters below are not - each unconditionally tears down and respawns the worker pool.
+    // setters below are not: an unconditional call would still needlessly force a transaction boundary
+    // on any other concurrent caller sharing a worker slot with this batch (#6509) for a no-op change.
     if (parallelFlush) {
       final DatabaseAsyncExecutor asyncExecutor = database.async();
       final boolean           priorAsyncUseWAL   = asyncExecutor.isTransactionUseWAL();
@@ -1445,9 +1447,10 @@ public class GraphBatch implements AutoCloseable {
   /**
    * Puts back the async executor's WAL policy relaxed once at construction for {@code parallelFlush}
    * (issue #5665). Guarded on an actual change for the same reason as the constructor: the setters are
-   * not, so calling them unconditionally would tear down and respawn the worker pool for nothing. A
-   * no-op when {@code parallelFlush} is false (the policy was never touched) or when called twice
-   * (idempotent: {@link #abandon()} and {@link #close()} can both reach this).
+   * not, so calling them unconditionally would needlessly force a transaction boundary on any other
+   * concurrent caller sharing a worker slot with this batch (#6509) for a no-op change. A no-op when
+   * {@code parallelFlush} is false (the policy was never touched) or when called twice (idempotent:
+   * {@link #abandon()} and {@link #close()} can both reach this).
    */
   private void restoreAsyncSettings() {
     if (!parallelFlush)

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncCrossSlotSchedulingDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncCrossSlotSchedulingDeadlockTest.java
@@ -48,8 +48,8 @@ class AsyncCrossSlotSchedulingDeadlockTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // 1 PER WORKER
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(2);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
     async.setCheckForStalledQueuesMaxDelay(100);
 
     final List<Throwable> errors = new CopyOnWriteArrayList<>();

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingAtomicityTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingAtomicityTest.java
@@ -49,8 +49,8 @@ class AsyncHelpingAtomicityTest extends TestHelper {
 
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(2);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
     async.setCommitEvery(1); // EVERY TASK BOUNDARY COMMITS: A NESTED EXECUTION WOULD COMMIT IMMEDIATELY
 
     final List<Throwable> errors = new CopyOnWriteArrayList<>();

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
@@ -46,8 +46,8 @@ class AsyncShutdownDrainTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 4);
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(1);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
 
     final CountDownLatch blockerStarted = new CountDownLatch(1);
     async.scheduleTask(0, blockerTask(blockerStarted, 10_000), true, 0);
@@ -71,8 +71,8 @@ class AsyncShutdownDrainTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(1);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
 
     final CountDownLatch blockerStarted = new CountDownLatch(1);
     async.scheduleTask(0, blockerTask(blockerStarted, 15_000), true, 0);
@@ -123,8 +123,8 @@ class AsyncShutdownDrainTest extends TestHelper {
       // #5105 review: pin the join timeout small so the <15s bound is self-contained (not coupled to the
       // 10s shutdownJoinTimeoutMs default) - the force-shutdown here is offer -> join -> interrupt -> join.
       async.shutdownJoinTimeoutMs = 2_000;
-      // Force thread re-creation so the parallel level above is picked up.
-      async.setTransactionUseWAL(true);
+      // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the parallel level above is picked up.
+      async.recreateThreadsForTests();
 
       final CountDownLatch blockerStarted = new CountDownLatch(1);
       // Wedged far longer than the 1s close timeout and than the bound below: pre-fix, the unbounded
@@ -173,7 +173,7 @@ class AsyncShutdownDrainTest extends TestHelper {
       async.setParallelLevel(1);
       // #5105 review: pin the join timeout small so the assertion is not coupled to the 10s default.
       async.shutdownJoinTimeoutMs = 2_000;
-      async.setTransactionUseWAL(true);
+      async.recreateThreadsForTests();
 
       final CountDownLatch blockerStarted = new CountDownLatch(1);
       // Signals iff the worker actually receives an interrupt: on the pre-fix code the caller's set flag

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownEscalationTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownEscalationTest.java
@@ -49,8 +49,8 @@ class AsyncShutdownEscalationTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 4); // 2 PER WORKER
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(2);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
     // Shrink the shutdown grace period so the escalation (not the wedge ceiling) decides the timing.
     async.shutdownJoinTimeoutMs = 500;
 

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncSlowPeerNoFalseStallTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncSlowPeerNoFalseStallTest.java
@@ -50,8 +50,8 @@ class AsyncSlowPeerNoFalseStallTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // CAPACITY 1 PER WORKER
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(2);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
     // 500ms window: the old code threw after ONE flat window (~500ms), the fixed code needs three
     // (1.5s); the slow peer is released after ~700ms, comfortably between the two bounds.
     async.setCheckForStalledQueuesMaxDelay(500);

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncStallDetectorFalsePositiveTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncStallDetectorFalsePositiveTest.java
@@ -43,8 +43,8 @@ class AsyncStallDetectorFalsePositiveTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(1);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
     // 300ms window: the 1.2s head task is 4x the old 2-window false-positive bound, while staying
     // well below the wedged-worker backstop (STALLED_NO_PROGRESS_WINDOWS x 300ms = 3.6s), which
     // must not fire for a single legitimately slow task.

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncWaitCompletionTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncWaitCompletionTimeoutTest.java
@@ -47,8 +47,8 @@ class AsyncWaitCompletionTimeoutTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(1);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
 
     final CountDownLatch blockerStarted = new CountDownLatch(1);
     final CountDownLatch release = new CountDownLatch(1);

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
@@ -54,8 +54,8 @@ class AsyncWedgedWorkerStallTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(1);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Force thread re-creation (#6509: setTransactionUseWAL() no longer does this) so the queue size above is picked up regardless of the previous level.
+    async.recreateThreadsForTests();
     async.setCheckForStalledQueuesMaxDelay(50);
 
     final CountDownLatch wedgeStarted = new CountDownLatch(1);

--- a/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorLifecycleRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorLifecycleRaceTest.java
@@ -34,10 +34,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   SEVER [PostBatchHandler] Cannot assign field "shutdown" because "this.executorThreads[i]" is null
  *   SEVER [PostBatchHandler] Cannot store to object array because "this.executorThreads" is null
  * </pre>
- * The cause was a race between two callers of {@code createThreads}/{@code shutdownThreads} (e.g.
- * concurrent {@code setTransactionUseWAL(true)} during GraphBatch close). Each call read
- * {@code executorThreads}, the other thread nulled it, and the first thread NPE'd on the dangling
- * reference. This test exercises that race directly.
+ * The cause was a race between two callers of {@code createThreads}/{@code shutdownThreads} (concurrent
+ * {@code setTransactionUseWAL(true)} during GraphBatch close, back when that setter still tore down and
+ * respawned the pool). Each call read {@code executorThreads}, the other thread nulled it, and the first
+ * thread NPE'd on the dangling reference. This test exercises concurrent flag flips directly.
+ * <p>
+ * #6509 turned {@code setTransactionUseWAL()}/{@code setTransactionSync()} into plain volatile writes
+ * that no longer call {@code createThreads()} at all, so this exact race is no longer reachable through
+ * them - the assertions below stay valid (concurrent flips still must not throw) as a standing guard
+ * against the mechanism being reintroduced.
  */
 class DatabaseAsyncExecutorLifecycleRaceTest extends TestHelper {
 
@@ -54,10 +59,8 @@ class DatabaseAsyncExecutorLifecycleRaceTest extends TestHelper {
       workers[t] = CompletableFuture.runAsync(() -> {
         try {
           for (int i = 0; i < iterations; i++) {
-            // Every flip of WAL or sync triggers an internal createThreads() -> shutdownThreads()
-            // cycle on the shared async executor. Multiple threads racing on this is the exact
-            // workload the customer hit (one GraphBatch per ingest worker thread, all on the same
-            // database).
+            // #6509: plain volatile writes now, no createThreads()/shutdownThreads() cycle. Kept as a
+            // concurrent-flip regression guard for the mechanism this test was written against.
             async.setTransactionUseWAL((seed + i) % 2 == 0);
             async.setTransactionSync((seed + i) % 2 == 0
                 ? WALFile.FlushType.NO

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6509AsyncExecutorPerTaskDurabilityFlagsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6509AsyncExecutorPerTaskDurabilityFlagsTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -110,6 +111,86 @@ class Issue6509AsyncExecutorPerTaskDurabilityFlagsTest extends TestHelper {
     assertThat(asyncWorkerThreadIds())
         .as("the durability change must take effect without the worker thread being respawned")
         .isEqualTo(threadIdsBefore);
+  }
+
+  /**
+   * Regression test for the code-review finding on this fix: {@code useWAL}/{@code walFlush} are read only
+   * at COMMIT time and then govern the WHOLE accumulated transaction ({@code TransactionContext}'s
+   * {@code commit1stPhase}/{@code commit2ndPhase}), not per write - so re-stamping them onto an
+   * already-open transaction is not enough by itself. Without also forcing a transaction boundary on a
+   * flag change, a worker's open transaction could straddle a flip: writes queued while {@code useWAL}
+   * was {@code true} would sit in the SAME transaction as later writes queued after a caller (e.g. a
+   * concurrent GraphBatch) flipped it to {@code false}, and the eventual commit - whether the periodic
+   * {@code commitEvery} boundary or a later flag-triggered one - would apply whichever value happened to
+   * be current at that moment to ALL of them, silently downgrading the durability the earlier caller
+   * asked for.
+   * <p>
+   * {@code AsyncThread.executeTask()} closes this by forcing a commit (under the transaction's own,
+   * unmodified flags) whenever it finds an open transaction whose applied flags differ from the current
+   * ones, before running the next task - restoring the "a flag change always starts a fresh transaction"
+   * property the pre-#6509 pool-teardown gave for free.
+   */
+  @Test
+  void durabilityFlagFlipMidTransactionForcesABoundaryInsteadOfMixingDurability() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    database.getSchema().createDocumentType("MixTest");
+
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    async.recreateThreadsForTests();
+    // High enough that the natural commitEvery boundary never fires before the 3rd task below - only the
+    // flag-flip boundary (or, pre-fix, nothing at all) can close a transaction early in this test.
+    async.setCommitEvery(3);
+
+    final AtomicInteger walWrites = new AtomicInteger();
+    db.registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, () -> {
+      walWrites.incrementAndGet();
+      return null;
+    });
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    // Task A: written while useWAL=true. Must end up in a WAL-protected commit of its own.
+    async.setTransactionUseWAL(true);
+    createDocumentAndWait(async, "MixTest");
+
+    // Task B: the flip. Forces task A's still-open transaction to commit (under useWAL=true, the value it
+    // was opened/stamped with) BEFORE B runs, then starts a fresh transaction stamped useWAL=false.
+    async.setTransactionUseWAL(false);
+    createDocumentAndWait(async, "MixTest");
+    assertThat(walWrites.get())
+        .as("task A's write must be committed under WAL as soon as the flag changes, not carried silently "
+            + "into a later no-WAL commit")
+        .isEqualTo(1);
+
+    // Task C: no flip, same useWAL=false transaction as B. This is the 3rd task on the worker, so it hits
+    // the natural commitEvery(3) boundary - committing {B, C} together, correctly WITHOUT WAL.
+    createDocumentAndWait(async, "MixTest");
+    assertThat(walWrites.get())
+        .as("B and C must commit together without WAL: the periodic boundary must not retroactively gain "
+            + "a WAL write, and must not be the moment A's write finally commits")
+        .isEqualTo(1);
+
+    assertThat(errors).as("no task may fail").isEmpty();
+  }
+
+  /** Schedules a task that creates one document of the given type and waits for it to run (not commit). */
+  private static void createDocumentAndWait(final DatabaseAsyncExecutorImpl async, final String typeName)
+      throws Exception {
+    final CountDownLatch done = new CountDownLatch(1);
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        database.newDocument(typeName).save();
+      }
+
+      @Override
+      public void completed() {
+        done.countDown();
+      }
+    }, true, 0);
+    assertThat(done.await(5, TimeUnit.SECONDS)).as("document-creation task must complete").isTrue();
   }
 
   /** Schedules a task on worker 0 that captures the transaction's current useWAL flag, and waits for it. */

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6509AsyncExecutorPerTaskDurabilityFlagsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6509AsyncExecutorPerTaskDurabilityFlagsTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -173,6 +174,75 @@ class Issue6509AsyncExecutorPerTaskDurabilityFlagsTest extends TestHelper {
         .isEqualTo(1);
 
     assertThat(errors).as("no task may fail").isEmpty();
+  }
+
+  /**
+   * Regression test for a second code-review finding: the boundary-forcing commit added above closes out
+   * EARLIER tasks' work, not the task about to run. If that commit fails (e.g. a genuine
+   * {@code ConcurrentModificationException} under the exact multi-writer contention this fix is about), the
+   * failure must not be attributed to the task that triggered the flag check - which has not executed yet.
+   * Left unguarded, the failure would propagate to {@code executeTask()}'s outer catch, and the task would
+   * still reach {@code completed()} in the {@code finally} there having never reached {@code execute()}:
+   * silent task loss dressed up as success. The fix catches the boundary commit's failure separately,
+   * reports it via {@code onError}, and still attempts the triggering task on a freshly begun transaction.
+   */
+  @Test
+  void failedBoundaryCommitDoesNotSilentlyDropTheTriggeringTask() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    database.getSchema().createDocumentType("BoundaryFailTest");
+
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    async.recreateThreadsForTests();
+    async.setCommitEvery(1000); // NEVER FIRES NATURALLY IN THIS TEST
+
+    // Fires exactly once, on the FIRST WAL-protected commit only: the boundary commit this test targets.
+    // Any later commit (this test's own cleanup included) must go through unharmed.
+    final AtomicBoolean armed = new AtomicBoolean(true);
+    db.registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, () -> {
+      if (armed.compareAndSet(true, false))
+        throw new RuntimeException("injected boundary-commit failure");
+      return null;
+    });
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    // Task A: useWAL=true, left uncommitted (commitEvery is huge).
+    async.setTransactionUseWAL(true);
+    createDocumentAndWait(async, "BoundaryFailTest");
+
+    // Task B: the flip. Forces a boundary commit of A's transaction, which the injected callback fails.
+    async.setTransactionUseWAL(false);
+    final AtomicBoolean bExecuted = new AtomicBoolean(false);
+    final CountDownLatch bDone = new CountDownLatch(1);
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        bExecuted.set(true);
+        database.newDocument("BoundaryFailTest").save();
+      }
+
+      @Override
+      public void completed() {
+        bDone.countDown();
+      }
+    }, true, 0);
+    assertThat(bDone.await(5, TimeUnit.SECONDS)).as("task B must reach completed()").isTrue();
+
+    assertThat(errors)
+        .as("the boundary commit's failure must be reported")
+        .hasSize(1);
+    assertThat(bExecuted.get())
+        .as("task B must actually run - not be silently marked completed for a failure that belongs to "
+            + "task A's boundary commit, not to B")
+        .isTrue();
+
+    // Confirm B's write is really there (not just that execute() set a flag): commit it for real and count.
+    async.waitCompletion();
+    assertThat(database.countType("BoundaryFailTest", false))
+        .as("task B's document must actually be persisted")
+        .isEqualTo(1L);
   }
 
   /** Schedules a task that creates one document of the given type and waits for it to run (not commit). */

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6509AsyncExecutorPerTaskDurabilityFlagsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6509AsyncExecutorPerTaskDurabilityFlagsTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.WALFile;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6509: {@code DatabaseAsyncExecutorImpl.setTransactionUseWAL()}/
+ * {@code setTransactionSync()} used to apply the new value by tearing down and respawning the
+ * ENTIRE worker pool ({@code createThreads()}), because {@code AsyncThread.run()} only ever applied
+ * the durability flags once, at thread start. Issue #5665 diagnosed this and shipped a cheap interim
+ * mitigation (GraphBatch toggling the flags once per batch instead of once per flush), but explicitly
+ * deferred the real fix, and a production incident (#6505) showed the interim mitigation is not
+ * sufficient under real multi-writer concurrency: any concurrent user of {@code database.async()} still
+ * has its in-flight/queued tasks force-exited whenever the pool churns.
+ * <p>
+ * The fix moves {@code transactionUseWAL}/{@code transactionSync} off "applied once at thread start"
+ * and onto "applied per task" ({@code AsyncThread.executeTask()}), so the setters become plain volatile
+ * writes and {@code createThreads()} drops out of the path entirely - exactly as #5665 originally
+ * proposed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6509AsyncExecutorPerTaskDurabilityFlagsTest extends TestHelper {
+
+  @Test
+  void directDurabilityFlagFlipsDoNotRecreateAsyncThreads() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(3);
+    async.recreateThreadsForTests();
+
+    final Set<Long> threadIdsBefore = asyncWorkerThreadIds();
+    assertThat(threadIdsBefore).as("async worker pool must exist before the flips").hasSize(3);
+    final int threadCountBefore = async.getThreadCount();
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    // Repeatedly flip both flags directly on the executor - the exact pattern GraphBatch used to
+    // trigger on every open/close (and, pre-#5665, on every flush) - interleaving a real scheduled and
+    // awaited task between flips so any respawn would have to race live work rather than an idle pool.
+    for (int i = 0; i < 25; i++) {
+      async.setTransactionUseWAL(i % 2 == 0);
+      async.setTransactionSync(i % 2 == 0 ? WALFile.FlushType.NO : WALFile.FlushType.YES_NOMETADATA);
+
+      final CountDownLatch done = new CountDownLatch(1);
+      assertThat(async.scheduleTask(i % 3, countingTask(done), true, 0)).isTrue();
+      assertThat(done.await(5, TimeUnit.SECONDS)).as("task %d must complete", i).isTrue();
+    }
+
+    assertThat(errors).as("no unrelated task may fail while the flags are flipped").isEmpty();
+    assertThat(async.getThreadCount())
+        .as("thread count must be unchanged by flag flips")
+        .isEqualTo(threadCountBefore);
+    assertThat(asyncWorkerThreadIds())
+        .as("the same worker threads must survive every flag flip: no createThreads() teardown")
+        .isEqualTo(threadIdsBefore);
+  }
+
+  @Test
+  void durabilityFlagChangeTakesEffectOnNextTaskWithoutThreadRespawn() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    async.recreateThreadsForTests();
+    async.setCommitEvery(1); // COMMIT AFTER EVERY TASK
+
+    final Set<Long> threadIdsBefore = asyncWorkerThreadIds();
+
+    async.setTransactionUseWAL(false);
+    async.setTransactionSync(WALFile.FlushType.NO);
+    assertThat(observeUseWALOnWorker(async)).as("task must observe the flag in effect when it runs").isFalse();
+
+    // Flip WITHOUT recreating the pool: the next task, on the SAME already-running worker, must
+    // observe the new value.
+    async.setTransactionUseWAL(true);
+    async.setTransactionSync(WALFile.FlushType.YES_NOMETADATA);
+    assertThat(observeUseWALOnWorker(async)).as("the flip must be visible to the very next task").isTrue();
+
+    assertThat(asyncWorkerThreadIds())
+        .as("the durability change must take effect without the worker thread being respawned")
+        .isEqualTo(threadIdsBefore);
+  }
+
+  /** Schedules a task on worker 0 that captures the transaction's current useWAL flag, and waits for it. */
+  private static boolean observeUseWALOnWorker(final DatabaseAsyncExecutorImpl async) throws Exception {
+    final AtomicReference<Boolean> observedUseWAL = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        observedUseWAL.set(database.getTransaction().isUseWAL());
+      }
+
+      @Override
+      public void completed() {
+        done.countDown();
+      }
+    }, true, 0);
+    assertThat(done.await(5, TimeUnit.SECONDS)).as("observation task must complete").isTrue();
+    return observedUseWAL.get();
+  }
+
+  private static DatabaseAsyncTask countingTask(final CountDownLatch latch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public void completed() {
+        latch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private Set<Long> asyncWorkerThreadIds() {
+    final String prefix = "AsyncExecutor-" + database.getName() + "-";
+    final Set<Long> ids = new HashSet<>();
+    for (final Thread t : Thread.getAllStackTraces().keySet())
+      if (t.getName().startsWith(prefix))
+        ids.add(t.threadId());
+    return ids;
+  }
+}


### PR DESCRIPTION
## Summary

`DatabaseAsyncExecutorImpl.setTransactionUseWAL()`/`setTransactionSync()` unconditionally called `createThreads()`, which shuts down and respawns the **entire** async worker pool of a database, not scoped to the caller. `GraphBatch` calls both setters once per batch session to relax/restore durability for a bulk load, so opening or closing a batch churned the whole pool and force-exited the in-flight/queued tasks of any *other* concurrent user of `database.async()` - surfacing as `"Async executor has been shut down"` for callers that had nothing to do with the batch.

This was diagnosed in #5665, which shipped only a cheap interim mitigation (GraphBatch toggling the flags once per batch instead of once per flush) and explicitly deferred the real fix. A production incident (#6505) traced 2,183 `InterruptedIOException`s over ~7 hours, and one database-fencing escalation, to this exact mechanism, showing the interim mitigation is not sufficient under real multi-writer concurrency.

### The fix

`AsyncThread.run()` applied `transactionUseWAL`/`transactionSync` only once, at thread start - so respawning the thread was the only way a change ever became visible to it. `AsyncThread.executeTask()` now re-applies both flags to the worker's transaction **before every task**, so the setters become plain volatile writes and `createThreads()` drops out of the path entirely, exactly as #5665's own diagnosis proposed.

### Test/doc cleanup

- Eight async executor tests used `setTransactionUseWAL(true)` purely as a "force thread re-creation" hack to make a queue-size/parallel-level config change take effect deterministically. Switched them to the existing (previously underused) `recreateThreadsForTests()` package-private test hook, since the side effect they relied on is exactly what this fix removes.
- Updated stale comments/Javadoc that described the old `createThreads()`-on-every-flip behavior (in `DatabaseAsyncExecutorImpl`, the `compact()` shutdown-race comment, and `DatabaseAsyncExecutorLifecycleRaceTest`).

## Test plan

- [x] New regression test `Issue6509AsyncExecutorPerTaskDurabilityFlagsTest`:
  - `directDurabilityFlagFlipsDoNotRecreateAsyncThreads` - 25 direct flips of both flags interleaved with real scheduled/awaited tasks; asserts worker thread identities are unchanged.
  - `durabilityFlagChangeTakesEffectOnNextTaskWithoutThreadRespawn` - flips a flag, observes it from inside a task running on the same (unrespawned) worker, flips again, observes the new value on the very next task.
  - Verified both tests **fail** against the pre-fix code (thread identities differ after flips) and **pass** with the fix.
- [x] Full `com.arcadedb.database.async.*` package + `Issue5665GraphBatchAsyncPoolChurnTest` + `Issue5666ConcurrentGraphBatchTest` + `Issue5667GraphBatchSuperNodeResumeTest` + `GraphBatchCommitRetryTest`/`GraphBatchBoundedStateTest`/`GraphBatchUniqueIndexTest`/`GraphBatchWALRestoreTest` + `ConcurrentCompactionTest` + `LSMTreeIndexCompactionTest` + `Issue6303AsyncQuiesceTest`: 84 tests, 0 failures.
- [x] `mvn -o -pl engine -am compile` and `test-compile` both clean.