### PR TITLE
fix(#6502): add a pre-filter plan for selective RID allow-lists in vector search

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1060,6 +1060,19 @@ public enum GlobalConfiguration {
       searcher per query.""",
       Integer.class, 0),
 
+  VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY("arcadedb.vectorIndex.prefilterMaxSelectivity", SCOPE.DATABASE,
+      """
+      Maximum fraction of the index's live vectors that a query's RID allow-list may cover and still take the \
+      pre-filter plan instead of the HNSW graph walk (issue #6502). The graph's Bits filter only rejects a node \
+      once it is popped from the beam - it cannot make the walk itself shrink with a narrower filter - so a \
+      selective allow-list makes the beam admit almost nothing and the walk keeps expanding trying to fill k, \
+      the search space growing smaller in principle and larger in practice: at the limit, 5 candidates cost more \
+      than 20,000. Below this fraction the query instead resolves the allow-list to its ordinals and scores them \
+      directly, which is O(allow-list) and exact by construction. Above it the allow-list barely narrows the \
+      search, the graph walk is already cheap, and resolving every allowed RID up front would cost more than the \
+      walk it replaces. Set to 0 to disable the pre-filter plan and always use the graph walk.""",
+      Float.class, 0.2f),
+
   VECTOR_INDEX_GRAPH_BUILD_PARALLELISM("arcadedb.vectorIndex.graphBuildParallelism", SCOPE.DATABASE,
       """
       Number of threads in the dedicated pool that builds the HNSW graph of a vector index. Graph construction \

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4145,6 +4145,27 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
         final RandomAccessVectorValues vectors = searchVectorValues(ordinalMap);
 
+        // Issue #6502: a RID allow-list narrow enough relative to the index is cheaper to answer directly than to
+        // walk the HNSW graph under it. The graph's Bits filter only rejects a node once it is popped from the
+        // beam - it cannot make the walk itself shrink with a narrower filter - so a selective allow-list makes the
+        // beam admit almost nothing and the walk keeps expanding trying to fill k: the search space gets smaller in
+        // principle and larger in practice. Scoring the allowed ordinals directly is O(allow-list) and exact by
+        // construction, matching the 1.0000 recall already measured at the selective end. collectAllowedOrdinals,
+        // scoreOrdinal and bruteForceScan already do exactly this walk for the issue #3722 shortfall fallback, so
+        // it is reused here as the primary plan rather than duplicated.
+        if (allowedRIDs != null && !allowedRIDs.isEmpty()) {
+          final float maxSelectivity = getDatabase().getConfiguration()
+              .getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY);
+          final int availableVectors = Math.min(ordinalMap.length, vectorIndex.size());
+          if (maxSelectivity > 0f && allowedRIDs.size() <= availableVectors * maxSelectivity) {
+            metrics.incrementPreFilterSearches();
+            final List<Pair<RID, Float>> results = new ArrayList<>(k);
+            mergeWithDeltaScan(queryVectorFloat, k, allowedRIDs, results);
+            bruteForceScan(queryVectorFloat, k, allowedRIDs, results, vectors, ordinalMap);
+            return results;
+          }
+        }
+
         // Only live vectors may enter the result heap. Accepting tombstones lets a query aimed at a deleted
         // neighbourhood fill its beam with them and stop, which is what returned an empty list (issue #5558).
         final Bits bitsFilter = new LiveVectorBitsFilter(allowedRIDs, ordinalMap, vectorIndex);
@@ -4253,12 +4274,26 @@ public class LSMVectorIndex implements Index, IndexInternal {
         final int availableVectors = Math.min(ordinalMap.length, vectorIndex.size());
         final int expectedResults = Math.min(k, availableVectors);
         if (results.size() < expectedResults) {
-          LogManager.instance()
-              .log(this, Level.WARNING,
-                  """
-                  Graph search returned only %d results (expected %d, available %d) for index %s - \
-                  falling back to brute-force scan (graph may need rebuilding)""",
-                  results.size(), expectedResults, availableVectors, indexName);
+          // Issue #6502: an allow-list narrower than k can never be filled from the graph - that is a property of
+          // the filter, not a sign the graph needs attention, and the pre-filter plan above already answers the
+          // common case of this directly without reaching here at all. What still lands here is either no allow-list
+          // at all (the original issue #3722 degraded-graph case) or one wide enough to skip the pre-filter plan
+          // yet still narrower than k, so the two are told apart rather than both blamed on the graph.
+          if (allowedRIDs != null && !allowedRIDs.isEmpty() && allowedRIDs.size() < expectedResults)
+            LogManager.instance()
+                .log(this, Level.FINE,
+                    """
+                    Graph search returned only %d results (expected %d, available %d) for index %s - the RID \
+                    allow-list has only %d entries, which is fewer than requested, so completing the answer with a \
+                    brute-force scan of the allow-list is expected, not a sign the graph needs rebuilding""",
+                    results.size(), expectedResults, availableVectors, indexName, allowedRIDs.size());
+          else
+            LogManager.instance()
+                .log(this, Level.WARNING,
+                    """
+                    Graph search returned only %d results (expected %d, available %d) for index %s - \
+                    falling back to brute-force scan (graph may need rebuilding)""",
+                    results.size(), expectedResults, availableVectors, indexName);
           metrics.incrementBruteForceScans();
           bruteForceScan(queryVectorFloat, k, allowedRIDs, results, vectors, ordinalMap);
         }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4279,7 +4279,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // common case of this directly without reaching here at all. What still lands here is either no allow-list
           // at all (the original issue #3722 degraded-graph case) or one wide enough to skip the pre-filter plan
           // yet still narrower than k, so the two are told apart rather than both blamed on the graph.
-          if (allowedRIDs != null && !allowedRIDs.isEmpty() && allowedRIDs.size() < expectedResults)
+          if (shortfallIsAllowListDriven(allowedRIDs, expectedResults))
             LogManager.instance()
                 .log(this, Level.FINE,
                     """
@@ -4317,6 +4317,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final long elapsed = System.currentTimeMillis() - startTime;
       metrics.addSearchLatency(elapsed);
     }
+  }
+
+  /**
+   * Issue #6502: tells apart the two reasons the issue #3722 shortfall fallback can fire, so the log line does not
+   * blame the graph for a shortfall the allow-list itself made unavoidable. An allow-list narrower than
+   * {@code expectedResults} can never be filled from the graph regardless of graph quality - that is a property of
+   * the filter, and expected. Anything else reaching the fallback (no allow-list, or one wide enough to skip the
+   * pre-filter plan and still come up short) is a genuine sign the graph search underperformed.
+   * <p>
+   * Extracted to a pure, testable predicate rather than left inline: a logic inversion here would silently swap
+   * which condition gets the (rare, expected) FINE line and which keeps the WARNING an operator watches for.
+   */
+  static boolean shortfallIsAllowListDriven(final Set<RID> allowedRIDs, final int expectedResults) {
+    return allowedRIDs != null && !allowedRIDs.isEmpty() && allowedRIDs.size() < expectedResults;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4145,14 +4145,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
         final RandomAccessVectorValues vectors = searchVectorValues(ordinalMap);
 
-        // Issue #6502: a RID allow-list narrow enough relative to the index is cheaper to answer directly than to
-        // walk the HNSW graph under it. The graph's Bits filter only rejects a node once it is popped from the
-        // beam - it cannot make the walk itself shrink with a narrower filter - so a selective allow-list makes the
-        // beam admit almost nothing and the walk keeps expanding trying to fill k: the search space gets smaller in
-        // principle and larger in practice. Scoring the allowed ordinals directly is O(allow-list) and exact by
-        // construction, matching the 1.0000 recall already measured at the selective end. collectAllowedOrdinals,
-        // scoreOrdinal and bruteForceScan already do exactly this walk for the issue #3722 shortfall fallback, so
-        // it is reused here as the primary plan rather than duplicated.
+        // Issue #6502 pre-filter plan: below VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY (see its javadoc for why the
+        // graph walk gets more expensive, not less, as the allow-list narrows), score the allow-list directly via
+        // collectAllowedOrdinals/scoreOrdinal/bruteForceScan - the same walk the issue #3722 shortfall fallback
+        // already uses - instead of duplicating it.
         if (allowedRIDs != null && !allowedRIDs.isEmpty()) {
           final float maxSelectivity = getDatabase().getConfiguration()
               .getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY);
@@ -4274,11 +4270,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         final int availableVectors = Math.min(ordinalMap.length, vectorIndex.size());
         final int expectedResults = Math.min(k, availableVectors);
         if (results.size() < expectedResults) {
-          // Issue #6502: an allow-list narrower than k can never be filled from the graph - that is a property of
-          // the filter, not a sign the graph needs attention, and the pre-filter plan above already answers the
-          // common case of this directly without reaching here at all. What still lands here is either no allow-list
-          // at all (the original issue #3722 degraded-graph case) or one wide enough to skip the pre-filter plan
-          // yet still narrower than k, so the two are told apart rather than both blamed on the graph.
+          // Issue #6502: see shortfallIsAllowListDriven's javadoc for why this is split.
           if (shortfallIsAllowListDriven(allowedRIDs, expectedResults))
             LogManager.instance()
                 .log(this, Level.FINE,

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4150,8 +4150,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // collectAllowedOrdinals/scoreOrdinal/bruteForceScan - the same walk the issue #3722 shortfall fallback
         // already uses - instead of duplicating it.
         if (allowedRIDs != null && !allowedRIDs.isEmpty()) {
-          final float maxSelectivity = getDatabase().getConfiguration()
-              .getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY);
+          // Clamped to 1.0: the setting is documented as a fraction of the index, and an operator-supplied value
+          // above that would route every allow-list query - however wide - through the ordinal-resolution walk
+          // instead of the graph, which is exactly the pathology this plan exists to avoid on the OTHER side of
+          // the crossover.
+          final float maxSelectivity = Math.min(1f, getDatabase().getConfiguration()
+              .getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY));
           final int availableVectors = Math.min(ordinalMap.length, vectorIndex.size());
           if (maxSelectivity > 0f && allowedRIDs.size() <= availableVectors * maxSelectivity) {
             metrics.incrementPreFilterSearches();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4156,6 +4156,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // the crossover.
           final float maxSelectivity = Math.min(1f, getDatabase().getConfiguration()
               .getValueAsFloat(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY));
+          // Persisted/graph vectors only, same as the shortfall-budget calculation below - the delta buffer is not
+          // in this count. Under a large buffer relative to the graph this can overstate the allow-list's
+          // selectivity against the true live set and bias toward the graph walk; per the shortfall calculation's
+          // own comment, that only ever costs a missed optimization, never a wrong answer.
           final int availableVectors = Math.min(ordinalMap.length, vectorIndex.size());
           if (maxSelectivity > 0f && allowedRIDs.size() <= availableVectors * maxSelectivity) {
             metrics.incrementPreFilterSearches();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
@@ -41,6 +41,10 @@ class LSMVectorIndexMetrics {
   // expensive thing this index does, and until now it was only a log line (issue #5558). Counts the plain k-NN path
   // only, which is the only one with a fallback to count: the grouped and PQ paths deliberately have none.
   private final AtomicLong bruteForceScans = new AtomicLong(0);
+  // Queries answered by the pre-filter plan (issue #6502): the RID allow-list was narrow enough that scoring it
+  // directly was chosen up front, in place of the HNSW graph walk. Unlike bruteForceScans this is not a fallback -
+  // it is the cheaper of two exact plans, picked before any graph traversal ran.
+  private final AtomicLong preFilterSearches = new AtomicLong(0);
   // Grouped searches (vector.neighbors with groupBy) that ran out of candidate budget before they could open `limit`
   // distinct groups, so the caller got a correct but short answer. Finding the limit-th nearest group costs however
   // many candidates the data puts between it and the query, which no fixed budget can guarantee (issue #5761), so
@@ -85,6 +89,10 @@ class LSMVectorIndexMetrics {
 
   void incrementBruteForceScans() {
     bruteForceScans.incrementAndGet();
+  }
+
+  void incrementPreFilterSearches() {
+    preFilterSearches.incrementAndGet();
   }
 
   void incrementGroupedSearchesShortOfLimit() {
@@ -141,6 +149,10 @@ class LSMVectorIndexMetrics {
     return bruteForceScans.get();
   }
 
+  long getPreFilterSearches() {
+    return preFilterSearches.get();
+  }
+
   long getGroupedSearchesShortOfLimit() {
     return groupedSearchesShortOfLimit.get();
   }
@@ -189,6 +201,7 @@ class LSMVectorIndexMetrics {
     stats.put("insertOperations", insertOperations.get());
     stats.put("graphRebuildCount", graphRebuildCount.get());
     stats.put("bruteForceScans", bruteForceScans.get());
+    stats.put("preFilterSearches", preFilterSearches.get());
     stats.put("groupedSearchesShortOfLimit", groupedSearchesShortOfLimit.get());
     stats.put("unverifiedGraphReuses", unverifiedGraphReuses.get());
     stats.put("compactionCount", compactionCount.get());
@@ -209,6 +222,7 @@ class LSMVectorIndexMetrics {
     insertOperations.set(0);
     graphRebuildCount.set(0);
     bruteForceScans.set(0);
+    preFilterSearches.set(0);
     groupedSearchesShortOfLimit.set(0);
     unverifiedGraphReuses.set(0);
     compactionCount.set(0);

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6502PrefilterLatencyBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6502PrefilterLatencyBenchmark.java
@@ -99,7 +99,10 @@ class Issue6502PrefilterLatencyBenchmark {
         System.out.printf("Vectors: %,d | Dimensions: %d | K: %d%n%n", NUM_VECTORS, DIMENSIONS, K);
 
         measure(index, "unfiltered", queries, null);
-        for (final int allowedCount : new int[] { NUM_VECTORS / 10, NUM_VECTORS / 100, NUM_VECTORS / 1000, 5 }) {
+        // 25% and 15% straddle the default VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY (20%) on either side, so the
+        // crossover is a measured point rather than an unverified round-number guess (per code review on #6512).
+        for (final int allowedCount : new int[] { NUM_VECTORS / 4, NUM_VECTORS / 5, (NUM_VECTORS * 3) / 20,
+            NUM_VECTORS / 10, NUM_VECTORS / 100, NUM_VECTORS / 1000, 5 }) {
           final Set<RID> allowed = randomSubset(rids, allowedCount, rng);
           measure(index, allowedCount + " RIDs (" + (100.0 * allowedCount / NUM_VECTORS) + "%)", queries, allowed);
         }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6502PrefilterLatencyBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6502PrefilterLatencyBenchmark.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.Pair;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Reproduces the measurement from issue #6502: a RID allow-list narrower than the graph's own admission behaviour
+ * used to make {@code findNeighborsFromVector} monotonically <em>slower</em> the more selective the allow-list got,
+ * because the HNSW walk's Bits filter only rejects a node once it is popped from the beam and cannot make the walk
+ * itself shrink. Same shape as the issue: 20,000 x 128, EUCLIDEAN, k=10, maxConnections=32, beamWidth=100.
+ * <p>
+ * Usage: {@code mvn test -pl engine -Dtest=Issue6502PrefilterLatencyBenchmark -DfailIfNoTests=false}
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class Issue6502PrefilterLatencyBenchmark {
+  private static final String DB_PATH    = "target/test-databases/Issue6502PrefilterLatencyBenchmark";
+  private static final int    NUM_VECTORS = Integer.getInteger("vector.bench.numVectors", 20_000);
+  private static final int    DIMENSIONS  = Integer.getInteger("vector.bench.dimensions", 128);
+  private static final int    K           = 10;
+  private static final int    NUM_QUERIES = 200;
+  private static final int    WARMUP      = 20;
+  private static final long   SEED        = 42L;
+
+  @Test
+  void measurePrefilterVsGraphWalk() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    GlobalConfiguration.PROFILE.setValue("high-performance");
+
+    final Random rng = new Random(SEED);
+    final float[][] vectors = randomVectors(NUM_VECTORS, DIMENSIONS, rng);
+
+    final RID[] rids = new RID[NUM_VECTORS];
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      try (final Database db = factory.create()) {
+        db.transaction(() -> {
+          final var type = db.getSchema().createDocumentType("Vec");
+          type.createProperty("v", Type.ARRAY_OF_FLOATS);
+          db.command("sql",
+              "CREATE INDEX ON Vec (v) LSM_VECTOR METADATA "
+                  + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", "
+                  + "\"maxConnections\": 32, \"beamWidth\": 100 }");
+        });
+        db.begin();
+        for (int i = 0; i < NUM_VECTORS; i++) {
+          rids[i] = db.newDocument("Vec").set("v", vectors[i]).save().getIdentity();
+          if ((i + 1) % 5_000 == 0) {
+            db.commit();
+            db.begin();
+          }
+        }
+        if (db.isTransactionActive())
+          db.commit();
+      }
+
+      try (final Database db = factory.open()) {
+        final LSMVectorIndex index = (LSMVectorIndex) db.getSchema().getType("Vec")
+            .getPolymorphicIndexByProperties("v").getIndexesOnBuckets()[0];
+        // Force the graph build up front so it is not attributed to the first measurement below.
+        index.findNeighborsFromVector(vectors[0], K, 100);
+
+        final float[][] queries = randomVectors(NUM_QUERIES, DIMENSIONS, rng);
+
+        System.out.println("=== Issue #6502: RID allow-list pre-filter plan ===");
+        System.out.printf("Vectors: %,d | Dimensions: %d | K: %d%n%n", NUM_VECTORS, DIMENSIONS, K);
+
+        measure(index, "unfiltered", queries, null);
+        for (final int allowedCount : new int[] { NUM_VECTORS / 10, NUM_VECTORS / 100, NUM_VECTORS / 1000, 5 }) {
+          final Set<RID> allowed = randomSubset(rids, allowedCount, rng);
+          measure(index, allowedCount + " RIDs (" + (100.0 * allowedCount / NUM_VECTORS) + "%)", queries, allowed);
+        }
+      }
+    }
+  }
+
+  private void measure(final LSMVectorIndex index, final String label, final float[][] queries, final Set<RID> allowed) {
+    for (int i = 0; i < WARMUP; i++)
+      index.findNeighborsFromVector(queries[i % queries.length], K, 100, allowed);
+
+    final long[] latenciesNs = new long[NUM_QUERIES];
+    for (int q = 0; q < NUM_QUERIES; q++) {
+      final long start = System.nanoTime();
+      final List<Pair<RID, Float>> results = index.findNeighborsFromVector(queries[q], K, 100, allowed);
+      latenciesNs[q] = System.nanoTime() - start;
+      if (results.isEmpty())
+        throw new IllegalStateException("fixture produced no results for " + label);
+    }
+
+    Arrays.sort(latenciesNs);
+    final double p50Ms = latenciesNs[latenciesNs.length / 2] / 1e6;
+    final double p95Ms = latenciesNs[(int) (latenciesNs.length * 0.95)] / 1e6;
+    System.out.printf("[%-28s] p50=%8.3f ms  p95=%8.3f ms%n", label, p50Ms, p95Ms);
+  }
+
+  private Set<RID> randomSubset(final RID[] rids, final int count, final Random rng) {
+    final Set<RID> subset = new LinkedHashSet<>();
+    while (subset.size() < count)
+      subset.add(rids[rng.nextInt(rids.length)]);
+    return subset;
+  }
+
+  private float[][] randomVectors(final int count, final int dims, final Random rng) {
+    final float[][] vectors = new float[count][dims];
+    for (int i = 0; i < count; i++)
+      for (int d = 0; d < dims; d++)
+        vectors[i][d] = (float) rng.nextGaussian();
+    return vectors;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6502VectorPrefilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6502VectorPrefilterTest.java
@@ -22,6 +22,8 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.log.Logger;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
 import com.arcadedb.utility.Pair;
@@ -33,6 +35,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +63,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       not also trip the issue #3722 shortfall fallback it happens to reuse the scan of.</li>
  *   <li>{@link #thePreFilterPlanSeesVectorsStillInTheDeltaBuffer} - an allowed RID ingested after the last graph
  *       build is only in the delta buffer, and the plan has to merge it in like the graph path does.</li>
+ *   <li>{@link #shortfallIsAllowListDrivenClassifiesBothDirections} - direct coverage of the predicate that decides
+ *       whether the issue #3722 shortfall log line is the expected FINE case or the WARNING one, since a logic
+ *       inversion there would otherwise pass the rest of the suite silently.</li>
+ *   <li>{@link #aNarrowAllowListWithThePlanDisabledLogsAtFineNotWarning} - the end-to-end path into that predicate:
+ *       selectivity 0 forces a narrow allow-list past the pre-filter plan and into the shortfall log, which must
+ *       come out at FINE, not the graph-degradation WARNING.</li>
  * </ul>
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -176,6 +186,68 @@ class Issue6502VectorPrefilterTest extends TestHelper {
         .contains(inDelta);
   }
 
+  /**
+   * Direct coverage of {@link LSMVectorIndex#shortfallIsAllowListDriven}, the predicate that decides whether the
+   * issue #3722 shortfall log line comes out at FINE (the allow-list itself made the shortfall unavoidable) or
+   * WARNING (the graph may genuinely need attention). Exercised without a real degraded-graph fixture: JVector's
+   * graph builder is not guaranteed to produce the same structure run to run, so pinning a specific log level on a
+   * "real shortfall" fixture would risk flaking. The predicate is pure and takes no graph state, so testing it
+   * directly is both simpler and deterministic - and it is exactly what would catch a logic inversion silently
+   * swapping the two branches.
+   */
+  @Test
+  void shortfallIsAllowListDrivenClassifiesBothDirections() {
+    final RID a = new RID(1, 0);
+    final RID b = new RID(1, 1);
+    final RID c = new RID(1, 2);
+
+    assertThat(LSMVectorIndex.shortfallIsAllowListDriven(Set.of(a, b), 5))
+        .as("an allow-list narrower than expectedResults is what the pre-filter plan could not fully answer")
+        .isTrue();
+    assertThat(LSMVectorIndex.shortfallIsAllowListDriven(null, 5))
+        .as("no allow-list at all is the original issue #3722 degraded-graph case").isFalse();
+    assertThat(LSMVectorIndex.shortfallIsAllowListDriven(Set.of(), 5))
+        .as("an empty allow-list means \"no filter\", not \"filter to nothing\"").isFalse();
+    assertThat(LSMVectorIndex.shortfallIsAllowListDriven(Set.of(a, b, c), 3))
+        .as("an allow-list at least as wide as expectedResults did not force the shortfall by itself").isFalse();
+    assertThat(LSMVectorIndex.shortfallIsAllowListDriven(Set.of(a, b, c), 2))
+        .as("wider than expectedResults is the same case, comfortably so").isFalse();
+  }
+
+  /**
+   * End-to-end path into the predicate above: disabling the pre-filter plan is the only way to make a narrow
+   * allow-list reach the shortfall log at all (the plan would otherwise answer it directly first), so this pins
+   * that the log level it lands on is FINE, and that the graph-degradation WARNING text does not also fire.
+   */
+  @Test
+  void aNarrowAllowListWithThePlanDisabledLogsAtFineNotWarning() {
+    createSchemaAndData();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY, 0f);
+
+    final LSMVectorIndex index = vectorIndex();
+    final float[] query = embedding(7);
+    final Set<RID> allowed = ridsOf(3, 42, 91); // 3 of 100, narrower than K=5
+
+    final List<String> captured = new CopyOnWriteArrayList<>();
+    final Logger originalLogger = LogManager.instance().getLogger();
+    LogManager.instance().setLogger(new LevelInclusiveCapturingLogger(captured, originalLogger));
+    try {
+      final List<Pair<RID, Float>> results = index.findNeighborsFromVector(query, K, -1, allowed);
+
+      assertThat(results).hasSize(3);
+      assertThat(captured)
+          .as("a shortfall forced purely by allow-list width must log at FINE, saying so")
+          .anyMatch(m -> m != null && m.contains("allow-list has only 3 entries"));
+      assertThat(captured)
+          .as("and must NOT also log the graph-degradation WARNING - only one of the two may fire")
+          .noneMatch(m -> m != null && m.contains("graph may need rebuilding"));
+    } finally {
+      LogManager.instance().setLogger(originalLogger);
+      database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY,
+          GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY.getDefValue());
+    }
+  }
+
   // ------------------------------------------------------------------------------------------------- helpers
 
   private void createSchemaAndData() {
@@ -241,5 +313,57 @@ class Issue6502VectorPrefilterTest extends TestHelper {
     for (int j = 0; j < DIMENSIONS; j++)
       vector[j] = (float) Math.sin(i * 0.37 + j * 0.91) + 2.0f + i * 0.013f;
     return vector;
+  }
+
+  /**
+   * Captures every message regardless of level while still forwarding to the production logger, unlike
+   * {@code LSMVectorIndexBruteForceScanTest}'s {@code CapturingLogger}, which drops anything below WARNING and so
+   * cannot observe the FINE-level branch of the issue #6502 shortfall log.
+   */
+  private static final class LevelInclusiveCapturingLogger implements Logger {
+    private final List<String> captured;
+    private final Logger       delegate;
+
+    LevelInclusiveCapturingLogger(final List<String> captured, final Logger delegate) {
+      this.captured = captured;
+      this.delegate = delegate;
+    }
+
+    private void capture(final String message, final Object... args) {
+      if (message == null)
+        return;
+      String formatted = message;
+      if (args != null && args.length > 0) {
+        try {
+          formatted = message.formatted(args);
+        } catch (final Exception ignored) {
+          // Fall back to the raw template; good enough for substring matching.
+        }
+      }
+      captured.add(formatted);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+        final Object arg6, final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11,
+        final Object arg12, final Object arg13, final Object arg14, final Object arg15, final Object arg16, final Object arg17) {
+      capture(message, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16,
+          arg17);
+      delegate.log(requester, level, message, exception, context, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10,
+          arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    @Override
+    public void log(final Object requester, final Level level, final String message, final Throwable exception,
+        final String context, final Object... args) {
+      capture(message, args);
+      delegate.log(requester, level, message, exception, context, args);
+    }
+
+    @Override
+    public void flush() {
+      delegate.flush();
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6502VectorPrefilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6502VectorPrefilterTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
+import com.arcadedb.utility.Pair;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6502: a RID allow-list was applied only as an admission test inside the HNSW traversal, plus a post-filter
+ * on the output. There was no pre-filter plan, so a query got monotonically <em>slower</em> the more selective its
+ * filter was - at the limit, asking for the 5 nearest among 5 candidates cost more than asking for the 10 nearest
+ * among 20,000, because the Bits filter only rejects a node once the walk has already popped it from the beam and
+ * cannot make the walk itself shrink.
+ * <p>
+ * The fix resolves a narrow allow-list to its ordinals and scores them directly - the same walk
+ * {@code collectAllowedOrdinals}/{@code scoreOrdinal}/{@code bruteForceScan} already used as the issue #3722
+ * shortfall fallback - as the primary plan, whenever the allow-list covers no more than
+ * {@link GlobalConfiguration#VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY} of the index's live vectors. The tests below
+ * pin:
+ * <ul>
+ *   <li>{@link #aNarrowAllowListTakesThePreFilterPlanAndMatchesTheGraphAnswer} - the plan switches on below the
+ *       threshold, and its answer is identical to what the graph walk (forced by disabling the plan) returns.</li>
+ *   <li>{@link #aWideAllowListStaysOnTheGraphWalk} - above the threshold the graph walk is still used, since
+ *       resolving a wide allow-list up front would cost more than the walk it would replace.</li>
+ *   <li>{@link #disablingThePlanViaZeroSelectivityAlwaysUsesTheGraphWalk} - the escape hatch: selectivity 0 restores
+ *       the pre-issue-#6502 behaviour exactly.</li>
+ *   <li>{@link #thePreFilterPlanNeverTriggersTheShortfallWarningOrItsScan} - the plan answers directly, so it must
+ *       not also trip the issue #3722 shortfall fallback it happens to reuse the scan of.</li>
+ *   <li>{@link #thePreFilterPlanSeesVectorsStillInTheDeltaBuffer} - an allowed RID ingested after the last graph
+ *       build is only in the delta buffer, and the plan has to merge it in like the graph path does.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6502VectorPrefilterTest extends TestHelper {
+
+  private static final int DIMENSIONS = 8;
+  private static final int VERTICES   = 100;
+  private static final int K          = 5;
+
+  @Test
+  void aNarrowAllowListTakesThePreFilterPlanAndMatchesTheGraphAnswer() {
+    createSchemaAndData();
+
+    final LSMVectorIndex index = vectorIndex();
+    final float[] query = embedding(7);
+    // 3 of 100 is 3%, well under the 20% default threshold.
+    final Set<RID> allowed = ridsOf(3, 42, 91);
+
+    final long preFilterBefore = index.getStats().getOrDefault("preFilterSearches", 0L);
+    final List<Pair<RID, Float>> preFiltered = index.findNeighborsFromVector(query, K, -1, allowed);
+    assertThat(index.getStats().get("preFilterSearches")).as("the narrow allow-list must take the pre-filter plan")
+        .isEqualTo(preFilterBefore + 1);
+
+    // Force the graph walk for the same query by disabling the plan, and compare answers.
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY, 0f);
+    try {
+      final List<Pair<RID, Float>> graphWalked = index.findNeighborsFromVector(query, K, -1, allowed);
+      assertThat(ridsIn(preFiltered)).as("the pre-filter plan must answer exactly what the graph walk answers")
+          .isEqualTo(ridsIn(graphWalked));
+      assertThat(distancesIn(preFiltered)).isEqualTo(distancesIn(graphWalked));
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY,
+          GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY.getDefValue());
+    }
+  }
+
+  @Test
+  void aWideAllowListStaysOnTheGraphWalk() {
+    createSchemaAndData();
+
+    final LSMVectorIndex index = vectorIndex();
+    final float[] query = embedding(7);
+
+    // 80 of 100 is 80%, well over the 20% default threshold.
+    final Set<RID> allowed = new HashSet<>();
+    for (int i = 0; i < 80; i++)
+      allowed.add(ridOf("doc" + i));
+
+    final long preFilterBefore = index.getStats().getOrDefault("preFilterSearches", 0L);
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVector(query, K, -1, allowed);
+    assertThat(index.getStats().get("preFilterSearches"))
+        .as("a wide allow-list must not take the pre-filter plan").isEqualTo(preFilterBefore);
+    assertThat(results).as("the graph walk must still answer the query").hasSize(K);
+    for (final Pair<RID, Float> r : results)
+      assertThat(allowed).as("and every result must respect the allow-list").contains(r.getFirst());
+  }
+
+  @Test
+  void disablingThePlanViaZeroSelectivityAlwaysUsesTheGraphWalk() {
+    createSchemaAndData();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY, 0f);
+    try {
+      final LSMVectorIndex index = vectorIndex();
+      final float[] query = embedding(7);
+      final Set<RID> allowed = ridsOf(3, 42, 91);
+
+      final long preFilterBefore = index.getStats().getOrDefault("preFilterSearches", 0L);
+      final List<Pair<RID, Float>> results = index.findNeighborsFromVector(query, K, -1, allowed);
+      assertThat(index.getStats().get("preFilterSearches"))
+          .as("selectivity 0 must disable the pre-filter plan even for a very narrow allow-list")
+          .isEqualTo(preFilterBefore);
+      assertThat(results).hasSize(3);
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY,
+          GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY.getDefValue());
+    }
+  }
+
+  @Test
+  void thePreFilterPlanNeverTriggersTheShortfallWarningOrItsScan() {
+    createSchemaAndData();
+
+    final LSMVectorIndex index = vectorIndex();
+    final float[] query = embedding(7);
+    final Set<RID> allowed = ridsOf(3, 42, 91);
+
+    final Map<String, Long> before = index.getStats();
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVector(query, K, -1, allowed);
+    final Map<String, Long> after = index.getStats();
+
+    assertThat(results).as("the query is still answered").hasSize(3);
+    assertThat(after.get("preFilterSearches")).isEqualTo(before.getOrDefault("preFilterSearches", 0L) + 1);
+    assertThat(after.get("bruteForceScans"))
+        .as("the pre-filter plan answers directly and must not also trip the issue #3722 shortfall fallback")
+        .isEqualTo(before.getOrDefault("bruteForceScans", 0L));
+  }
+
+  @Test
+  void thePreFilterPlanSeesVectorsStillInTheDeltaBuffer() {
+    createSchemaAndData();
+
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "afterTheBuild",
+        embedding(500)));
+    final RID inDelta = ridOf("afterTheBuild");
+
+    final LSMVectorIndex index = vectorIndex();
+    final float[] query = embedding(500);
+    final Set<RID> allowed = new HashSet<>();
+    allowed.add(inDelta);
+    allowed.add(ridOf("doc3"));
+
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVector(query, K, -1, allowed);
+    assertThat(ridsIn(results)).as("the pre-filter plan must merge in a delta-buffered allowed vector too")
+        .contains(inDelta);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private void createSchemaAndData() {
+    // No rebuild may run mid-test, or ordinal/live counts used by the selectivity check would move under the test.
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, 1_000_000);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, -1);
+
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON Doc (id) UNIQUE");
+
+      final TypeLSMVectorIndexBuilder builder = (TypeLSMVectorIndexBuilder) database.getSchema()
+          .buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType();
+      builder.withDimensions(DIMENSIONS).withQuantization(VectorQuantizationType.NONE).withSimilarity("EUCLIDEAN")
+          .create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < VERTICES; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "doc" + i, embedding(i));
+    });
+
+    vectorIndex().buildVectorGraphNow();
+  }
+
+  private Set<RID> ridsOf(final int... ids) {
+    final Set<RID> rids = new HashSet<>();
+    for (final int id : ids)
+      rids.add(ridOf("doc" + id));
+    return rids;
+  }
+
+  private RID ridOf(final String id) {
+    try (final ResultSet rs = database.query("sql", "SELECT FROM Doc WHERE id = ?", id)) {
+      return rs.next().getIdentity().orElseThrow();
+    }
+  }
+
+  private static List<RID> ridsIn(final List<Pair<RID, Float>> results) {
+    final List<RID> rids = new ArrayList<>(results.size());
+    for (final Pair<RID, Float> r : results)
+      rids.add(r.getFirst());
+    return rids;
+  }
+
+  private static List<Float> distancesIn(final List<Pair<RID, Float>> results) {
+    final List<Float> distances = new ArrayList<>(results.size());
+    for (final Pair<RID, Float> r : results)
+      distances.add(r.getSecond());
+    return distances;
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[embedding]");
+    return (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+  }
+
+  /** Deterministic, distinct, non-zero vectors, well spread so no two of them tie on distance. */
+  private static float[] embedding(final int i) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int j = 0; j < DIMENSIONS; j++)
+      vector[j] = (float) Math.sin(i * 0.37 + j * 0.91) + 2.0f + i * 0.013f;
+    return vector;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6502VectorPrefilterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6502VectorPrefilterTest.java
@@ -187,6 +187,91 @@ class Issue6502VectorPrefilterTest extends TestHelper {
   }
 
   /**
+   * The union-and-truncate case flagged in code review: {@code mergeWithDeltaScan} runs first against an empty
+   * {@code results}, then {@code bruteForceScan} adds the persisted candidates and re-sorts the combined list before
+   * trimming to {@code k}. With an allow-list wider than {@code k}, split across both the delta buffer and the
+   * persisted graph, the closest {@code k} overall - not the closest {@code k} of either source considered alone -
+   * has to survive the truncation, regardless of which side of that split they came from.
+   */
+  @Test
+  void thePreFilterPlanTruncatesToKAcrossBothDeltaAndPersistedCandidates() {
+    createSchemaAndData();
+
+    // Five more documents landing in the delta buffer (inserted after the graph build), interleaved with five
+    // already-persisted ones so the allow-list straddles both sources.
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++)
+        database.command("sql", "INSERT INTO Doc SET id = ?, embedding = ?", "delta" + i, embedding(200 + i));
+    });
+
+    final LSMVectorIndex index = vectorIndex();
+    final float[] query = embedding(202); // near the middle of the delta cluster
+
+    final Set<RID> allowed = new HashSet<>();
+    for (int i = 0; i < 5; i++)
+      allowed.add(ridOf("delta" + i));
+    for (final int i : new int[] { 10, 25, 40, 60, 80 }) // persisted, spread across the index
+      allowed.add(ridOf("doc" + i));
+    assertThat(allowed).hasSize(10);
+
+    final int k = 3;
+    final List<Pair<RID, Float>> preFiltered = index.findNeighborsFromVector(query, k, -1, allowed);
+    assertThat(preFiltered).hasSize(k);
+
+    // Reference: an unfiltered search wide enough to rank the whole live set (persisted + delta), then keep only
+    // the allowed RIDs and truncate by hand - the same reference-by-construction approach used elsewhere in this
+    // suite, extended to a query the delta buffer also has to answer through.
+    final List<Pair<RID, Float>> everything = index.findNeighborsFromVector(query, VERTICES + 10, -1, null);
+    final List<Pair<RID, Float>> reference = new ArrayList<>();
+    for (final Pair<RID, Float> candidate : everything)
+      if (allowed.contains(candidate.getFirst()) && reference.size() < k)
+        reference.add(candidate);
+
+    assertThat(reference).as("the fixture has to leave something for the comparison to be about").hasSize(k);
+    assertThat(ridsIn(preFiltered))
+        .as("the closest k overall must survive truncation, not the closest k of either source alone")
+        .isEqualTo(ridsIn(reference));
+    assertThat(distancesIn(preFiltered)).isEqualTo(distancesIn(reference));
+  }
+
+  /**
+   * An operator-supplied selectivity above 1.0 is nonsensical (the setting is documented as a fraction of the
+   * index) but not rejected outright; it must not be taken literally either, or a value like {@code 5.0} would
+   * route every allow-list query - however wide - through the ordinal-resolution walk instead of the graph, which
+   * is the same pathology this plan exists to fix on the other side of the crossover.
+   */
+  @Test
+  void aSelectivityAboveOneIsClampedNotTakenLiterally() {
+    createSchemaAndData();
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY, 5.0f);
+    try {
+      final LSMVectorIndex index = vectorIndex();
+      final float[] query = embedding(7);
+
+      // Every real RID (100% of the index) plus enough RIDs from a bucket this index knows nothing about to push
+      // the allow-list past availableVectors (100) but comfortably under an unclamped 5.0x threshold (500). Only a
+      // literal (unclamped) selectivity would route this to the pre-filter plan.
+      final Set<RID> allWithExtra = new HashSet<>();
+      for (int i = 0; i < VERTICES; i++)
+        allWithExtra.add(ridOf("doc" + i));
+      for (int i = 0; i < 50; i++)
+        allWithExtra.add(new RID(9999, i));
+      assertThat(allWithExtra.size()).as("must exceed availableVectors to distinguish clamped from unclamped")
+          .isGreaterThan(VERTICES);
+
+      final long preFilterBefore = index.getStats().getOrDefault("preFilterSearches", 0L);
+      final List<Pair<RID, Float>> results = index.findNeighborsFromVector(query, K, -1, allWithExtra);
+      assertThat(index.getStats().get("preFilterSearches"))
+          .as("a selectivity above 1.0 must be clamped to 1.0, not taken as \"prefer the pre-filter plan always\"")
+          .isEqualTo(preFilterBefore);
+      assertThat(results).hasSize(K);
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY,
+          GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY.getDefValue());
+    }
+  }
+
+  /**
    * Direct coverage of {@link LSMVectorIndex#shortfallIsAllowListDriven}, the predicate that decides whether the
    * issue #3722 shortfall log line comes out at FINE (the allow-list itself made the shortfall unavoidable) or
    * WARNING (the graph may genuinely need attention). Exercised without a real degraded-graph fixture: JVector's

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBruteForceScanTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexBruteForceScanTest.java
@@ -187,13 +187,16 @@ class LSMVectorIndexBruteForceScanTest extends TestHelper {
   }
 
   /**
-   * The end-to-end route into the brute-force fallback that survives #5873, so the "a real query reaches the scan
+   * The end-to-end route into {@code bruteForceScan} that survives #5873, so the "a real query reaches the scan
    * and the scan pairs each RID with its own score" claim keeps a test.
    * <p>
    * An allow-list narrower than {@code k} is the case: the graph can only ever answer with the allowed rows, which
-   * is fewer than the {@code k} the caller asked for, so {@code expectedResults} stays above what the search returns
-   * and the fallback fires every time (issue #5748). Unlike the stale-graph fixture above, that shortfall is real -
-   * the answer genuinely cannot be filled from the graph - so the scan has something to do.
+   * is fewer than the {@code k} the caller asked for. Before issue #6502 that shortfall was only discovered after
+   * a full graph walk, which is what drove this fixture's size (a large, stale-free graph the walk had to pay for
+   * on every query). Since #6502 an allow-list this narrow is resolved by the pre-filter plan up front - same
+   * {@code bruteForceScan} call, reached without ever asking the graph - so the graph walk and its shortfall
+   * WARNING are now the thing this fixture proves does NOT run, while the RID/score pairing claim is proven the
+   * same way it always was.
    */
   @Test
   void aNarrowAllowListStillReachesTheFallbackEndToEnd() {
@@ -235,13 +238,19 @@ class LSMVectorIndexBruteForceScanTest extends TestHelper {
     final Logger originalLogger = LogManager.instance().getLogger();
     LogManager.instance().setLogger(new CapturingLogger(captured, originalLogger));
     try {
+      final long preFilterBefore = index.getStats().getOrDefault("preFilterSearches", 0L);
+
       // Probe with one whitelisted vertex's own vector: it has to rank first at ~0 distance, which is exactly the
       // RID-to-score pairing issue #4581 was about, now observed through a real query rather than by reflection.
       final int probe = total / allowed;
       final List<Pair<RID, Float>> results = index.findNeighborsFromVector(vectorByIndex[probe], 10, whitelist);
 
-      assertThat(captured).as("an allow-list narrower than k cannot be filled from the graph, so the scan must run")
-          .anyMatch(m -> m != null && m.contains("falling back to brute-force scan"));
+      assertThat(index.getStats().get("preFilterSearches"))
+          .as("3 of 1200 is well under the default pre-filter threshold, so the plan must answer this directly")
+          .isEqualTo(preFilterBefore + 1);
+      assertThat(captured)
+          .as("the pre-filter plan answers before the graph is ever walked, so its shortfall WARNING must not fire")
+          .noneMatch(m -> m != null && m.contains("falling back to brute-force scan"));
       assertThat(results).as("and it answers with the whitelisted rows, and only those").hasSize(allowed);
       for (final Pair<RID, Float> r : results)
         assertThat(whitelist).as("a row outside the allow-list must not survive the scan").contains(


### PR DESCRIPTION
## Summary

Fixes #6502. A RID allow-list passed to `findNeighborsFromVector` was applied only as an admission test inside the HNSW graph walk plus a post-filter on the output. JVector's `Bits` filter only rejects a node once the walk has already popped it from the beam - it cannot make the walk itself shrink with a narrower filter - so a selective allow-list made the beam admit almost nothing and the walk kept expanding trying to fill `k`. At the limit, asking for 5 candidates among 5 allowed RIDs cost more than asking for 10 among 20,000.

- `findNeighborsFromVector` now resolves a narrow allow-list to its ordinals and scores them directly, skipping the graph walk entirely, whenever the allow-list covers no more than `arcadedb.vectorIndex.prefilterMaxSelectivity` (new setting, default 20%, clamped to 1.0) of the index's live vectors. This reuses `collectAllowedOrdinals`/`scoreOrdinal`/`bruteForceScan`, the same walk issue #3722's shortfall fallback already used, as the primary plan instead of a last resort - exact by construction, matching the 1.0000 recall the issue already measured at the selective end. Set the new config to `0` to disable and always take the graph walk (restores the pre-#6502 behavior exactly).
- Added a `preFilterSearches` counter to `getStats()` alongside the existing `bruteForceScans`, since this is a deliberately chosen cheaper plan, not a fallback.
- The shortfall WARNING that still fires past the pre-filter threshold (e.g. selectivity disabled, or a wide-but-still-narrower-than-`k` allow-list) now distinguishes an allow-list-driven shortfall (expected, not a graph problem) from a real degraded-graph shortfall, addressing tae898's follow-up comment on the issue about the log line being misleading. The classification (`LSMVectorIndex.shortfallIsAllowListDriven`) is a pure, directly unit-tested predicate rather than untestable inline logic.

**Scope**: this targets `findNeighborsFromVector`, which is what the issue measured and what SQL/Cypher's `vectorNeighbors()` calls into. The grouped (`groupBy`) and PQ-approximate search paths have the same shape of problem but different internals (group accounting, PQ scoring) and are left as a follow-up: tracked in #6514.

## Known limitation

The selectivity check (and the FINE/WARNING shortfall classification) compares against the allow-list's **raw size**, not the count of RIDs actually resolvable in *this* index, and `availableVectors` counts persisted/graph vectors only (not the delta buffer). A caller-supplied allow-list built from a broader/polymorphic query, or a large delta buffer relative to the persisted graph, can therefore make the effective selectivity look narrower or wider than it truly is against the live set. This is a deliberate trade-off: resolving the true count up front would mean paying the O(allow-list · log index) ordinal-resolution walk just to decide whether to pay for it, which is circular. It never produces a wrong answer - only a possibly-missed fast path (falls back to the already-correct graph walk) or a log severity that's more cautious than strictly necessary. Flagging explicitly here since it's the kind of thing a future "why didn't my narrow filter take the fast path" report would otherwise have to be re-derived from the code.

## Measured

Local benchmark reproducing the issue's scenario (20,000 x 128, EUCLIDEAN, k=10):

| allow-list | before (issue's numbers) | after (this PR) | plan taken |
|---|---|---|---|
| unfiltered | 2.020 ms | 0.352 ms | - |
| 25% (5,000 RIDs) | - | 0.851 ms | graph walk |
| 20% (4,000 RIDs) | - | 0.865 ms | pre-filter (at the `<=` boundary) |
| 15% (3,000 RIDs) | - | 0.551 ms | pre-filter |
| 10% (2,000 RIDs) | 6.281 ms | 0.327-0.369 ms | pre-filter |
| 1% (200 RIDs) | 20.614 ms | 0.024-0.026 ms | pre-filter |
| 0.1% (20 RIDs) | 27.937 ms | 0.002 ms | pre-filter |
| 5 RIDs | 30.145 ms | 0.001 ms | pre-filter |

(Different hardware than the issue's own measurement, so treat the "before" column as directional, not a same-machine comparison; the "after" column was measured on this branch, `Issue6502PrefilterLatencyBenchmark`.) The 15-25% points straddle the default threshold on both sides: the two plans cost about the same right at the boundary (0.851 vs 0.865 ms), so the default isn't sensitive to being off by a few points - the pre-filter plan's win is already decisive well before it.

## Test plan

- [x] `Issue6502VectorPrefilterTest`: narrow allow-list takes the pre-filter plan and matches the graph-walk answer exactly (forced via selectivity=0); wide allow-list stays on the graph walk; selectivity=0 disables the plan; the plan does not trip the issue #3722 shortfall WARNING/scan; the plan merges allowed vectors still in the delta buffer; the delta+persisted candidate union truncates to `k` by overall distance, not per-source; a selectivity above 1.0 is clamped, not taken literally; the FINE/WARNING shortfall predicate is unit-tested in both directions plus end-to-end (verified against a deliberately inverted predicate before trusting it).
- [x] Updated `LSMVectorIndexBruteForceScanTest.aNarrowAllowListStillReachesTheFallbackEndToEnd`, whose premise (a narrow allow-list must reach the graph's shortfall fallback) is exactly what this PR optimizes away; it now asserts the pre-filter plan is taken and the shortfall path is *not* reached, while keeping its original RID/score-pairing (#4581) assertions.
- [x] `Issue6502PrefilterLatencyBenchmark` (`@Tag("benchmark")`, excluded from CI) reproducing the issue's exact scenario, extended with data points straddling the default threshold.
- [x] Full `com.arcadedb.index.vector.**` package (242 tests), plus `vectorNeighbors()` SQL/Cypher integration tests (`SQLFunctionVectorNeighborsTest`, `PartitionPruningVectorNeighborsTest`, `CypherCallVectorNeighborsTest`, `SQLVectorDatabaseFunctionsTest`) and `GlobalConfigurationTest` all pass.

https://claude.ai/code/session_016yjKJXMNMQeLPKdCno7cFX
