### PR TITLE
fix(#6503): a vector rebuild no longer holds two graphs with no admission control, and an OOM cannot certify a half-written graph

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3644,3 +3644,53 @@ the stored value parses as a date, before and after `APPLY DEFAULTS`, with a sen
 cannot produce. Deliberately not an equality against today's date: the two transactions can straddle midnight.
 
 [#6414](https://github.com/ArcadeData/arcadedb/issues/6414)
+
+## A vector graph rebuild no longer holds two graphs at once on close, and an OOM in one can no longer certify a half-written graph (#6503)
+
+A from-scratch rebuild of an `LSM_VECTOR` graph deliberately keeps the old graph resident so searches keep working,
+and replaces it only at the very end. On top of that it pays for a whole new build's working set: the build cache,
+the JVector builder, the ordinal map. Measured at 50,000 x 128, that is a peak of 1,700 MB for a rebuild against
+959 MB for the first build of the same corpus - a factor of 1.73x. At DEEP-10M in a 24 GB heap the first build
+completes and a second one on top of it dies.
+
+Raising `-Xmx` did not create the headroom, because both of this index's auto-sized caches budgeted themselves off
+*total* heap, so a bigger heap grew them proportionally and the rebuild was no more likely to fit. And nothing
+consulted memory before starting: the only gate was `REBUILD_SEMAPHORE`, which bounds how many rebuilds run at
+once, not how much heap one needs. A rebuild that could not fit was simply attempted.
+
+Four changes, in the order they matter:
+
+**The close path releases the old graph before building the replacement.** By the time `flush()` rebuilds, it has
+already CAS-ed the index to `UNAVAILABLE` and `close()` has already cleared the pooled searchers, so nothing can
+still be reading the old graph or the shared search cache - holding them for the duration of the build was pure
+waste. This roughly halves peak heap for exactly the case that measurably dies today. An *online* rebuild keeps
+both, unchanged: `rebuildGraphBeforeSearch()`, an async rebuild, an explicit `REBUILD INDEX` and `COMPACT INDEX`
+do not gate concurrent searches, so for them the old graph is still load-bearing.
+
+**Both caches are now budgeted against the heap actually available**, not against the ceiling. Availability is read
+from `MemoryPoolMXBean.getCollectionUsage()` - the pool's occupancy measured right after the JVM last collected it,
+which approximates live retained data - rather than from `Runtime.freeMemory()`, which counts everything allocated
+since the last GC as used whether it is live or garbage and would collapse the build cache for no reason. When no
+pool publishes a collection usage, the budget falls back to the whole ceiling, which reproduces the previous
+behaviour exactly.
+
+**An online rebuild is now admitted only if it is expected to fit.** Before starting, the estimated peak footprint
+(the graph being built, the build cache, and - for an online rebuild - the graph being replaced) is compared
+against `arcadedb.vectorIndex.rebuildMaxHeapPercent` (default 90) of the available heap. A rebuild that does not
+fit is deferred rather than attempted: the next mutation-threshold or inactivity trigger retries it, pending
+vectors stay exactly searchable through the in-memory delta buffer meanwhile, and the deferral is both logged and
+counted (`rebuildsDeferredForMemory` in the index stats) so an index that never fits does not go stale silently.
+The estimate is deliberately coarse and the default deliberately generous: it refuses only a rebuild that is
+confidently too large. Set the percentage to 0 to restore the previous attempt-and-hope behaviour. Only the online
+path is gated - a first build, a rebuild on close, `REBUILD INDEX` and `COMPACT INDEX` have no later trigger to
+retry them, so declining one would turn "slower" into "never".
+
+**An `OutOfMemoryError` during the graph persist no longer escapes the handler that refuses the pages.** It is an
+`Error`, not an `Exception`, so it used to walk straight past the `catch (Exception)` around the persist block -
+skipping both the transaction rollback and the `markUnusable()` call that is the only thing stopping the next
+database open from trusting a possibly half-rewritten graph on node-count agreement alone (#6106 is the check that
+exists to prevent exactly that). The persist guard, the async rebuild thread's guard and the inactivity timer
+task's guard now all catch `Throwable`; in the latter two an escaping `Error` would additionally have killed the
+thread past the point where it clears the in-progress flag, silently stopping every later rebuild of that index.
+
+[#6503](https://github.com/ArcadeData/arcadedb/issues/6503)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3661,11 +3661,20 @@ once, not how much heap one needs. A rebuild that could not fit was simply attem
 Four changes, in the order they matter:
 
 **The close path releases the old graph before building the replacement.** By the time `flush()` rebuilds, it has
-already CAS-ed the index to `UNAVAILABLE` and `close()` has already cleared the pooled searchers, so nothing can
+already CAS-ed the index to `UNAVAILABLE` and a closing database hands it no further requests, so nothing can
 still be reading the old graph or the shared search cache - holding them for the duration of the build was pure
-waste. This roughly halves peak heap for exactly the case that measurably dies today. An *online* rebuild keeps
-both, unchanged: `rebuildGraphBeforeSearch()`, an async rebuild, an explicit `REBUILD INDEX` and `COMPACT INDEX`
-do not gate concurrent searches, so for them the old graph is still load-bearing.
+waste. This roughly halves peak heap for exactly the case that measurably dies today.
+
+Three references have to go, not one. `graphIndex` and the search cache are the obvious two; the third is the
+searcher pool, because a pooled searcher holds the graph it was pooled under and so pins it however many times
+`graphIndex` is nulled. That is not hypothetical on this path: `LocalDatabase.closeDurableParts()` runs
+`index.flush()` *before* `index.releaseBackgroundResources()`, so on a real database close the pool is still
+populated when the rebuild starts. The release therefore clears the pool itself rather than assuming the caller
+already has.
+
+An *online* rebuild keeps all three, unchanged: `rebuildGraphBeforeSearch()`, an async rebuild, an explicit
+`REBUILD INDEX` and `COMPACT INDEX` do not gate concurrent searches on the index status, so for them the old graph
+is still load-bearing.
 
 **Both caches are now budgeted against the heap actually available**, not against the ceiling. Availability is read
 from `MemoryPoolMXBean.getCollectionUsage()` - the pool's occupancy measured right after the JVM last collected it,

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3686,9 +3686,17 @@ behaviour exactly.
 **An online rebuild is now admitted only if it is expected to fit.** Before starting, the estimated peak footprint
 (the graph being built, the build cache, and - for an online rebuild - the graph being replaced) is compared
 against `arcadedb.vectorIndex.rebuildMaxHeapPercent` (default 90) of the available heap. A rebuild that does not
-fit is deferred rather than attempted: the next mutation-threshold or inactivity trigger retries it, pending
-vectors stay exactly searchable through the in-memory delta buffer meanwhile, and the deferral is both logged and
-counted (`rebuildsDeferredForMemory` in the index stats) so an index that never fits does not go stale silently.
+fit is deferred rather than attempted: a later trigger retries it, pending vectors stay exactly searchable through
+the in-memory delta buffer meanwhile, and the deferral is both logged and counted (`rebuildsDeferredForMemory` in
+the index stats) so an index that never fits does not go stale silently.
+
+A deferral leaves its own trigger intact - only a *successful* build consumes the pending mutations - so "a later
+trigger" needs a cooldown to mean anything. A search evaluates the rebuild condition on every query, so without one
+a large heap-constrained index would spawn a rebuild thread, take and release the JVM-wide rebuild permit and log a
+warning once *per query*: thread churn and contention added exactly when the JVM is already short of memory, which
+works against the deferral's own purpose. `arcadedb.vectorIndex.rebuildDeferralCooldownMs` (default 30s, 0 to
+disable) is the minimum gap before another attempt; a completed build clears it, so a stale deferral cannot keep
+gating triggers after the shortage has passed.
 The estimate is deliberately coarse and the default deliberately generous: it refuses only a rebuild that is
 confidently too large. Set the percentage to 0 to restore the previous attempt-and-hope behaviour. Only the online
 path is gated - a first build, a rebuild on close, `REBUILD INDEX` and `COMPACT INDEX` have no later trigger to

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1031,7 +1031,9 @@ public enum GlobalConfiguration {
       """
       Maximum share of the JVM heap (percentage) the auto-sized graph-build cache may use. Only applies when \
       arcadedb.vectorIndex.graphBuildCacheSize is left at 0. A corpus larger than this budget still builds: \
-      the cache evicts instead of holding everything.""",
+      the cache evicts instead of holding everything. Measured against the heap currently AVAILABLE rather than \
+      against the ceiling, so a rebuild that is holding the old graph resident asks for less (issue #6503). \
+      Values above 90 are clamped to 90: no cache is allowed to plan on the whole heap.""",
       Integer.class, 25),
 
   VECTOR_INDEX_SEARCH_CACHE_SIZE("arcadedb.vectorIndex.searchCacheSize", SCOPE.DATABASE,
@@ -1046,8 +1048,10 @@ public enum GlobalConfiguration {
 
   VECTOR_INDEX_SEARCH_CACHE_MAX_HEAP_PERCENT("arcadedb.vectorIndex.searchCacheMaxHeapPercent", SCOPE.DATABASE,
       """
-      Upper bound, as a percentage of the maximum JVM heap, on the RAM an automatically sized per-index search \
-      cache may use (see arcadedb.vectorIndex.searchCacheSize). Ignored when the cache size is set explicitly.""",
+      Upper bound, as a percentage of the JVM heap currently AVAILABLE rather than of the ceiling (issue #6503), \
+      on the RAM an automatically sized per-index search cache may use (see arcadedb.vectorIndex.searchCacheSize). \
+      Ignored when the cache size is set explicitly. Values above 90 are clamped to 90: no cache is allowed to \
+      plan on the whole heap.""",
       Integer.class, 25),
 
   VECTOR_INDEX_SEARCHER_POOL_SIZE("arcadedb.vectorIndex.searcherPoolSize", SCOPE.DATABASE,
@@ -1133,7 +1137,8 @@ public enum GlobalConfiguration {
       wrong or missing results. The estimate is deliberately coarse, so the default is generous: it refuses only \
       when a rebuild is confidently too large, not whenever one looks tight. Applies to online rebuilds only - a \
       first build, a rebuild on close, an explicit REBUILD INDEX and a COMPACT INDEX are never declined. \
-      Set to 0 to disable the gate and restore the attempt-and-hope behaviour.""",
+      Set to 0 to disable the gate and restore the attempt-and-hope behaviour. Values above 90 are clamped to 90: \
+      a rebuild is never allowed to plan on the whole heap, since the request, I/O and GC threads need some too.""",
       Integer.class, 90),
 
   VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS("arcadedb.vectorIndex.rebuildPermitTimeoutMs", SCOPE.JVM,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1121,6 +1121,21 @@ public enum GlobalConfiguration {
       Set to 1 to serialize all rebuilds (safest for memory). Higher values trade memory for throughput.""",
       Integer.class, 1),
 
+  VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT("arcadedb.vectorIndex.rebuildMaxHeapPercent", SCOPE.DATABASE,
+      """
+      Share of the currently AVAILABLE heap (percentage) that an online vector graph rebuild's estimated peak \
+      footprint may occupy before the rebuild is deferred instead of attempted. An online rebuild keeps the old \
+      graph resident so searches keep working, and pays for a full new build's working set on top of it, so it \
+      costs roughly 1.7x what building the same corpus from nothing costs. With no gate at all it simply attempts \
+      the rebuild and dies with an OutOfMemoryError when it does not fit. A deferred cycle is not lost: the next \
+      mutation-threshold or inactivity trigger retries it, and pending vectors stay exactly searchable through the \
+      in-memory delta buffer meanwhile, so the cost of deferring is a longer delta scan per query rather than \
+      wrong or missing results. The estimate is deliberately coarse, so the default is generous: it refuses only \
+      when a rebuild is confidently too large, not whenever one looks tight. Applies to online rebuilds only - a \
+      first build, a rebuild on close, an explicit REBUILD INDEX and a COMPACT INDEX are never declined. \
+      Set to 0 to disable the gate and restore the attempt-and-hope behaviour.""",
+      Integer.class, 90),
+
   VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS("arcadedb.vectorIndex.rebuildPermitTimeoutMs", SCOPE.JVM,
       """
       Maximum time in milliseconds an async vector index rebuild waits to acquire a JVM-wide rebuild permit \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -1141,6 +1141,21 @@ public enum GlobalConfiguration {
       a rebuild is never allowed to plan on the whole heap, since the request, I/O and GC threads need some too.""",
       Integer.class, 90),
 
+  VECTOR_INDEX_REBUILD_DEFERRAL_COOLDOWN_MS("arcadedb.vectorIndex.rebuildDeferralCooldownMs", SCOPE.DATABASE,
+      """
+      How long, in milliseconds, an online vector graph rebuild that was deferred for lack of heap \
+      (see arcadedb.vectorIndex.rebuildMaxHeapPercent) waits before another one may be attempted. \
+      A deferral does not consume the pending mutations that triggered it - only a successful build does - so the \
+      trigger condition is still true the instant the deferred cycle ends. Without a cooldown the next search \
+      re-triggers immediately, and since a search checks on every query, a large heap-constrained index would \
+      spawn a rebuild thread, take and release the JVM-wide rebuild permit and log a warning once PER QUERY: \
+      thread churn and lock contention added precisely when the JVM is already short of memory, which works \
+      against the deferral's own purpose. \
+      The wait is not lost time: pending vectors stay exactly searchable through the in-memory delta buffer \
+      throughout, so the cost is a slightly longer delta scan per query, which is what a deferral costs anyway. \
+      Set to 0 to retry as soon as the next trigger fires.""",
+      Integer.class, 30_000),
+
   VECTOR_INDEX_REBUILD_PERMIT_TIMEOUT_MS("arcadedb.vectorIndex.rebuildPermitTimeoutMs", SCOPE.JVM,
       """
       Maximum time in milliseconds an async vector index rebuild waits to acquire a JVM-wide rebuild permit \

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -249,6 +249,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
   // This prevents vectorNeighbors queries from blocking for minutes on large indexes.
   private volatile Thread  asyncRebuildThread     = null;
   private volatile boolean asyncRebuildInProgress = false;
+  // When the last online rebuild was declined for lack of heap (issue #6503). A deferral does not consume the
+  // mutations that triggered it - only a successful build does - so without this the trigger is still true the
+  // instant the deferred cycle ends, and rebuildGraphBeforeSearch() runs on EVERY query: one rebuild thread, one
+  // JVM-wide permit acquire and one WARNING per search, precisely when the JVM is already short of memory.
+  private volatile long    lastRebuildDeferralMs  = 0L;
   // Incremented each time a graph build snapshots its start mutation counter. Lets callers (and tests) observe
   // that a build has passed the point after which further mutations are preserved rather than folded into the
   // build's own snapshot (issue #3683).
@@ -2523,6 +2528,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
         this.graphIndex = builtGraph;
         // Track graph rebuild metric
         metrics.incrementGraphRebuildCount();
+        // A build got through, so whatever heap shortage deferred the last online attempt is no longer in the
+        // way: clear the cooldown rather than let a stale deferral keep gating triggers (issue #6503).
+        lastRebuildDeferralMs = 0L;
         // Reset page tracking since we rebuilt from persisted pages
         currentInsertPageNum = -1;
 
@@ -3118,6 +3126,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (asyncRebuildInProgress)
       return; // Another rebuild is already running
 
+    // Still cooling down from a rebuild that did not fit the heap (issue #6503). Checked HERE, before the thread
+    // is spawned, rather than inside admitOnlineRebuild(): the point is to not pay for the attempt at all - no
+    // daemon thread, no JVM-wide permit acquire and release, no O(allocated chunks) getActiveCount() - on a path
+    // that a search reaches on every single query while the trigger condition stays true.
+    if (isCoolingDownFromRebuildDeferral())
+      return;
+
     asyncRebuildInProgress = true;
     final int mutations = mutationsSinceSerialize.get();
 
@@ -3245,6 +3260,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
       return true;
 
     metrics.incrementRebuildsDeferredForMemory();
+    // Start the cooldown BEFORE logging, so the timestamp is set no matter what the log call does.
+    lastRebuildDeferralMs = System.currentTimeMillis();
     LogManager.instance().log(this, Level.WARNING,
         "Deferring the graph rebuild of vector index %s: it needs about %d MB (%d nodes, keeping the old graph "
             + "resident so searches keep working) against %d MB of the %d MB currently available heap that %s "
@@ -3257,6 +3274,42 @@ public class LSMVectorIndex implements Index, IndexInternal {
         GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getKey(),
         GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey());
     return false;
+  }
+
+  /**
+   * Whether an online rebuild declined for lack of heap is still within its retry cooldown (issue #6503).
+   * <p>
+   * The cooldown exists because a deferral leaves its own trigger intact: {@code mutationsSinceSerialize} is only
+   * decremented by a build that actually ran, so the moment the deferred cycle ends the condition
+   * {@link #rebuildGraphBeforeSearch()} tests is true again - and that method runs on every query. Without a
+   * cooldown a large, heap-constrained index spawns a rebuild thread, acquires and releases the JVM-wide permit
+   * and logs a WARNING once per search, adding thread churn and contention exactly when memory is already tight.
+   * <p>
+   * Nothing is lost by waiting: the pending vectors stay searchable through the delta scan throughout, which is
+   * what a deferral costs in the first place.
+   *
+   * @return true when another attempt must be skipped for now
+   */
+  private boolean isCoolingDownFromRebuildDeferral() {
+    final long deferredAt = lastRebuildDeferralMs;
+    if (deferredAt == 0L)
+      return false; // nothing has been deferred yet
+
+    final long cooldownMs = getDatabase().getConfiguration()
+        .getValueAsLong(GlobalConfiguration.VECTOR_INDEX_REBUILD_DEFERRAL_COOLDOWN_MS);
+    if (cooldownMs <= 0)
+      return false; // cooldown disabled: retry on the next trigger, as before
+
+    final long elapsed = System.currentTimeMillis() - deferredAt;
+    // A backwards clock step would otherwise park the index for as long as the step lasted: treat any negative
+    // elapsed time as "the cooldown is over" rather than trusting the arithmetic.
+    if (elapsed < 0 || elapsed >= cooldownMs)
+      return false;
+
+    LogManager.instance().log(this, Level.FINE,
+        "Skipping the rebuild trigger for vector index %s: still %d ms into the %d ms cooldown from the last "
+            + "rebuild deferred for lack of heap", indexName, elapsed, cooldownMs);
+    return true;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1707,12 +1707,28 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Rebuilds the way {@link #flush()} does on the close path: releases the resident graph and the shared search
-   * cache before starting, instead of at the end. {@code flush()} has already CAS-ed the index to
-   * {@code UNAVAILABLE} and {@code close()} has already run {@link #releaseBackgroundResources()} (which clears
-   * the pooled searchers), so nothing can still be reading either reference - dropping them first roughly halves
-   * peak heap for the case that otherwise runs out of it: a from-scratch build already retains the old graph plus
-   * its own full working set (build cache, JVector builder, ordinal map) for the whole build (issue #6503).
+   * Rebuilds the way {@link #flush()} does on the close path: releases everything holding the OLD graph on the
+   * heap before starting, instead of at the end. A from-scratch build otherwise retains that graph plus its own
+   * full working set (build cache, JVector builder, ordinal map) for the whole build, which is what makes a
+   * rebuild cost about 1.7x what building the same corpus from nothing costs and what runs a large index out of
+   * heap (issue #6503). Releasing first roughly halves the peak.
+   * <p>
+   * <b>All three references have to go, not just {@link #graphIndex}.</b> {@link #searchVectorCache} is the
+   * obvious second one. The third is the searcher pool: a pooled searcher holds the {@code ImmutableGraphIndex}
+   * it was pooled under, so a populated pool pins the old graph however many times {@code graphIndex} is nulled.
+   * That is not hypothetical on the path this method exists for - {@code LocalDatabase.closeDurableParts()}
+   * calls {@code index.flush()} BEFORE {@code index.releaseBackgroundResources()}, so on a database close the
+   * pool is still full when this runs, and clearing it here rather than relying on the caller having done it is
+   * what makes the release actually release anything.
+   * <p>
+   * <b>Safe only because no search can be in flight.</b> {@code flush()} has already CAS-ed {@link #status} to
+   * {@code UNAVAILABLE}, and a database close does not return requests to the pool afterwards. That is a
+   * caller-side contract, though, not something this class enforces: the search methods gate on
+   * {@code lock.readLock()} alone and never consult {@link #status}. A reader that violated it would not crash
+   * or read torn state - it takes the {@code graphIndex == null} branch and is served from the delta scan - but
+   * it would get an incomplete result set, and for the whole duration of the rebuild rather than for the instant
+   * around the swap. Degrading rather than corrupting is why this is acceptable on a path where the contract
+   * holds, and exactly why it must not be used where it does not.
    * <p>
    * Deliberately not used by an online rebuild ({@link #rebuildGraphBeforeSearch()}, {@link #startAsyncGraphRebuild()},
    * an explicit {@link #buildVectorGraphNow(GraphBuildCallback)}, or {@code compact()}): none of those gate
@@ -1761,11 +1777,16 @@ public class LSMVectorIndex implements Index, IndexInternal {
     }
 
     if (releaseResidentGraphFirst) {
-      // See buildGraphFromScratchReleasingResidentGraph() for why this is safe only on that path.
+      // See buildGraphFromScratchReleasingResidentGraph() for why this is safe only on that path, and why the
+      // searcher pool has to be emptied too: a pooled searcher holds the graph it was pooled under, so leaving
+      // the pool populated would keep the old graph reachable and release nothing.
       lock.writeLock().lock();
       try {
         this.graphIndex = null;
         this.searchVectorCache = null;
+        final GraphSearcherPool searchers = searcherPool;
+        if (searchers != null)
+          searchers.clear();
       } finally {
         lock.writeLock().unlock();
       }
@@ -2001,6 +2022,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // worker threads cannot lookupByRID without a transaction context bound to the thread.
       final boolean inlineQuantization = metadata.quantizationType == VectorQuantizationType.INT8
           || metadata.quantizationType == VectorQuantizationType.BINARY;
+      // ORDERING: this now budgets off AVAILABLE heap (issue #6503), so it must stay AFTER the
+      // releaseResidentGraphFirst block at the top of this method. On the close path that block has already
+      // dropped the old graph, the search cache and the pooled searchers, so this sizes against a heap that no
+      // longer counts them. Move this call above that block - or that block below this call - and the close-path
+      // rebuild would shrink its own build cache to make room for memory it is in the act of freeing, which is
+      // the slow-build failure mode this change exists to avoid rather than cause.
       final int graphBuildCacheSize = computeGraphBuildCacheCapacity(expectedSize, inlineQuantization);
       // Never preload more than the cache can hold: the surplus used to be read, boxed and then dropped.
       final int preloadBudget = Math.min(expectedSize, graphBuildCacheSize);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1535,7 +1535,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // Force rebuild from on-disk pages, bypassing mutation thresholds and lazy-load behavior.
       graphState = GraphState.LOADING;
       mutationsSinceSerialize.set(0);
-      buildGraphFromScratchWithRetry(graphCallback, false);
+      buildGraphFromScratchWithRetry(graphCallback, false, false);
     } finally {
       status.set(INDEX_STATUS.AVAILABLE);
     }
@@ -1703,7 +1703,28 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private void buildGraphFromScratch(final GraphBuildCallback graphCallback, final boolean compactDataFile) {
     // buildGraphFromScratchWithRetry() reads pages directly and rebuilds vectorIndex
     // No need to reload here - just call the retry logic directly
-    buildGraphFromScratchWithRetry(graphCallback, compactDataFile);
+    buildGraphFromScratchWithRetry(graphCallback, compactDataFile, false);
+  }
+
+  /**
+   * Rebuilds the way {@link #flush()} does on the close path: releases the resident graph and the shared search
+   * cache before starting, instead of at the end. {@code flush()} has already CAS-ed the index to
+   * {@code UNAVAILABLE} and {@code close()} has already run {@link #releaseBackgroundResources()} (which clears
+   * the pooled searchers), so nothing can still be reading either reference - dropping them first roughly halves
+   * peak heap for the case that otherwise runs out of it: a from-scratch build already retains the old graph plus
+   * its own full working set (build cache, JVector builder, ordinal map) for the whole build (issue #6503).
+   * <p>
+   * Deliberately not used by an online rebuild ({@link #rebuildGraphBeforeSearch()}, {@link #startAsyncGraphRebuild()},
+   * an explicit {@link #buildVectorGraphNow(GraphBuildCallback)}, or {@code compact()}): none of those gate
+   * concurrent searches on {@link #status}, so the old graph and cache must stay resident until the new one is
+   * ready to swap in.
+   * <p>
+   * Package-private so tests can drive it directly with a progress callback.
+   *
+   * @param graphCallback optional progress callback invoked during graph construction/persistence
+   */
+  void buildGraphFromScratchReleasingResidentGraph(final GraphBuildCallback graphCallback) {
+    buildGraphFromScratchWithRetry(graphCallback, false, true);
   }
 
   /**
@@ -1712,7 +1733,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
    *
    * @param graphCallback Optional callback for graph build progress
    */
-  private void buildGraphFromScratchWithRetry(final GraphBuildCallback graphCallback, final boolean compactDataFile) {
+  private void buildGraphFromScratchWithRetry(final GraphBuildCallback graphCallback, final boolean compactDataFile,
+      final boolean releaseResidentGraphFirst) {
     // Serialize graph builds for this index. The index write lock used to do this implicitly by covering the
     // whole preparation phase; now that the O(index size) validation runs unlocked (issue #5391), two builds
     // could interleave their vectorIndex re-sync and their ordinal-map publication and leave a searcher with an
@@ -1720,13 +1742,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // and inserts never touch it, so it does not reintroduce the stall.
     graphBuildLock.lock();
     try {
-      buildGraphFromScratchExclusively(graphCallback, compactDataFile);
+      buildGraphFromScratchExclusively(graphCallback, compactDataFile, releaseResidentGraphFirst);
     } finally {
       graphBuildLock.unlock();
     }
   }
 
-  private void buildGraphFromScratchExclusively(final GraphBuildCallback graphCallback, final boolean compactDataFile) {
+  private void buildGraphFromScratchExclusively(final GraphBuildCallback graphCallback, final boolean compactDataFile,
+      final boolean releaseResidentGraphFirst) {
     // Reset live builder — full rebuild creates a new graph with different ordinal mapping
     if (liveBuilder != null) {
       try {
@@ -1735,6 +1758,17 @@ public class LSMVectorIndex implements Index, IndexInternal {
       }
       liveBuilder = null;
       liveVectorValues = null;
+    }
+
+    if (releaseResidentGraphFirst) {
+      // See buildGraphFromScratchReleasingResidentGraph() for why this is safe only on that path.
+      lock.writeLock().lock();
+      try {
+        this.graphIndex = null;
+        this.searchVectorCache = null;
+      } finally {
+        lock.writeLock().unlock();
+      }
     }
 
     // Snapshot the next vector ID so we know which delta entries were included in this build
@@ -2604,7 +2638,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
               buildAndPersistPQ(vectors);
             }
           }
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
+          // Throwable, not Exception: an OutOfMemoryError raised anywhere in this block - most likely while
+          // persisting a graph large enough that the old graph plus the new one no longer both fit - is an Error,
+          // and used to escape this handler entirely. That skipped both the rollback below and markUnusable(),
+          // so a build that died mid-persist left a dangling transaction and a manifest that still vouched for
+          // whatever the pages happened to hold (issue #6503).
+          //
           // Rollback on error
           if (startedTransaction) {
             try {
@@ -3093,13 +3133,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
         LogManager.instance().log(this, Level.INFO,
             "Acquired rebuild permit for index: %s (available permits: %d)",
             indexName, REBUILD_SEMAPHORE.availablePermits());
+        // Measured here, holding the permit, rather than at scheduling time: this is the moment the memory is
+        // actually about to be claimed, and any other index's rebuild has by now released whatever it held.
+        if (!admitOnlineRebuild())
+          return;
         buildGraphFromScratch();
         completed = true;
         LogManager.instance().log(this, Level.INFO,
             "Async graph rebuild completed for index: %s", indexName);
-      } catch (final Exception | AssertionError e) {
-        // AssertionError too: JVector validates with `assert`, and an escaping one would kill this daemon
-        // thread past the point where the in-progress flag is cleared.
+      } catch (final Throwable e) {
+        // Throwable, not just Exception|AssertionError: an OutOfMemoryError from a rebuild that no longer fits
+        // (issue #6503) is an Error too, and an escaping one would kill this daemon thread past the point where
+        // the in-progress flag is cleared, the same way an escaping AssertionError would.
         //
         // Checked by exception type first, not just isInterrupted(): releaseBackgroundResources() cancels
         // the build's ForkJoinTask directly (issue #5872), which unblocks this thread's join() with a
@@ -3131,6 +3176,60 @@ public class LSMVectorIndex implements Index, IndexInternal {
     }, "VectorIndex-AsyncRebuild-" + indexName);
     asyncRebuildThread.setDaemon(true);
     asyncRebuildThread.start();
+  }
+
+  /**
+   * Decides whether an ONLINE rebuild - one that keeps the old graph resident so searches keep working - is going
+   * to fit the heap that is actually available, and declines the cycle when it will not (issue #6503).
+   * <p>
+   * There was no such gate before: {@code REBUILD_SEMAPHORE} bounds how many rebuilds run at once, which is not
+   * the same question, and nothing else consulted memory at all. A rebuild that did not fit was simply attempted,
+   * and died with an {@link OutOfMemoryError}. Declining costs a longer delta scan per query until the next
+   * trigger retries; dying costs the rebuild, and used to cost the manifest's integrity with it.
+   * <p>
+   * Only the online path is gated. A first build, a rebuild on close, {@code REBUILD INDEX} and
+   * {@code COMPACT INDEX} are lifecycle- or operator-driven, have no later trigger to retry them, and in the
+   * close case have already released the old graph - declining one of those would turn "slower" into "never".
+   * <p>
+   * Package-private so tests can drive the decision directly rather than through a background thread.
+   *
+   * @return true to proceed with the rebuild
+   */
+  boolean admitOnlineRebuild() {
+    final int percent = getDatabase().getConfiguration()
+        .getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT);
+    if (percent <= 0)
+      return true; // gate disabled by configuration
+
+    final ImmutableGraphIndex resident = graphIndex;
+    if (resident == null)
+      return true; // nothing built yet: this is a first build in all but name, and must not be declined
+
+    final long nodes = Math.max(resident.getIdUpperBound(), vectorIndex.getActiveCount());
+    final boolean inlineQuantization = metadata.quantizationType == VectorQuantizationType.INT8
+        || metadata.quantizationType == VectorQuantizationType.BINARY;
+    final long buildCacheCapacity = computeGraphBuildCacheCapacity((int) Math.min(nodes, Integer.MAX_VALUE / 2),
+        inlineQuantization);
+
+    final long estimate = VectorHeapBudget.estimateRebuildHeapBytes(nodes, metadata.dimensions, buildCacheCapacity,
+        true);
+    final long budget = VectorHeapBudget.budgetBytes(percent);
+    if (estimate <= budget)
+      return true;
+
+    metrics.incrementRebuildsDeferredForMemory();
+    LogManager.instance().log(this, Level.WARNING,
+        "Deferring the graph rebuild of vector index %s: it needs about %d MB (%d nodes, keeping the old graph "
+            + "resident so searches keep working) against %d MB of the %d MB currently available heap that %s "
+            + "allows it. The %d pending vectors stay searchable through the delta scan, and the next mutation or "
+            + "inactivity trigger retries - but until one fits, every query pays that scan. Give the JVM more "
+            + "heap, lower %s, or set %s to 0 to attempt the rebuild regardless",
+        indexName, estimate / (1024 * 1024), nodes, budget / (1024 * 1024),
+        VectorHeapBudget.availableHeapBytes() / (1024 * 1024),
+        GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey(), mutationsSinceSerialize.get(),
+        GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT.getKey(),
+        GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getKey());
+    return false;
   }
 
   /**
@@ -5685,7 +5784,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
               .log(this, Level.FINE, "Building graph before close for index: %s (this may take 1-2 minutes for large datasets)",
                   indexName);
           final long startTime = System.currentTimeMillis();
-          buildGraphFromScratch();
+          // Releases the resident graph and search cache before building the replacement (issue #6503): by this
+          // point status is UNAVAILABLE and releaseBackgroundResources() has already cleared the pooled searchers,
+          // so nothing can still be reading either one, and a from-scratch build otherwise retains both for the
+          // whole build on top of its own working set.
+          buildGraphFromScratchReleasingResidentGraph(null);
           final long elapsed = System.currentTimeMillis() - startTime;
           LogManager.instance().log(this, Level.FINE, "Graph building completed in %d seconds", elapsed / 1000);
         } catch (final Exception e) {
@@ -6202,7 +6305,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     try {
       // Build graph from scratch (already reads from pages)
-      buildGraphFromScratchWithRetry(graphCallback, false);
+      buildGraphFromScratchWithRetry(graphCallback, false, false);
 
       // Persist graph with chunking callback
       final ChunkCommitCallback chunkCallback = bytesWritten -> {
@@ -6468,6 +6571,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
    *       materializes anyway: bounding the cache below it (issue #3144) threw the vectors away right after
    *       reading them and made a from-scratch fp32 build re-read almost every vector, hundreds of times each.</li>
    * </ul>
+   * The budget is a share of the heap actually AVAILABLE, not of the whole heap (issue #6503): a rebuild keeps the
+   * old graph and its search cache resident for its whole duration, and sizing off the ceiling made the cache ask
+   * for the same amount whether that headroom existed or not - which is also why raising {@code -Xmx} did not help,
+   * since it grew the cache proportionally. See {@link VectorHeapBudget} for how availability is measured.
    *
    * @param expectedSize        number of vectors the build will walk
    * @param inlineQuantization  whether vectors are readable from index pages without a record lookup
@@ -6482,18 +6589,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (inlineQuantization)
       return ArcadePageVectorValues.DEFAULT_CACHE_SIZE;
 
-    // Per-entry cost: the float payload plus the VectorFloat wrapper, the cache entry and the array slot
-    final long bytesPerVector = (long) metadata.dimensions * Float.BYTES + 64;
-
-    int heapPercent = mutable.getDatabase().getConfiguration()
+    final int heapPercent = mutable.getDatabase().getConfiguration()
         .getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_MAX_HEAP_PERCENT);
     if (heapPercent <= 0)
       return ArcadePageVectorValues.DEFAULT_CACHE_SIZE;
-    if (heapPercent > 90)
-      heapPercent = 90;
 
-    final long heapBudget = Runtime.getRuntime().maxMemory() / 100 * heapPercent;
-    final long affordable = Math.max(ArcadePageVectorValues.DEFAULT_CACHE_SIZE, heapBudget / bytesPerVector);
+    final long heapBudget = VectorHeapBudget.budgetBytes(heapPercent);
+    final long affordable = Math.max(ArcadePageVectorValues.DEFAULT_CACHE_SIZE,
+        heapBudget / VectorHeapBudget.bytesPerCachedVector(metadata.dimensions));
     final long wanted = Math.max(1, expectedSize);
 
     return (int) Math.min(Math.min(affordable, wanted), Integer.MAX_VALUE / 2);
@@ -6571,7 +6674,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * <p>
    * An explicit {@code arcadedb.vectorIndex.searchCacheSize} wins. Otherwise the cache is sized to hold the
    * whole corpus - which is the point: a working set that fits never touches disk again - but capped at the
-   * configured share of the heap so a corpus larger than RAM degrades to eviction instead of OOM.
+   * configured share of the heap actually AVAILABLE (issue #6503, see {@link VectorHeapBudget}) so a corpus
+   * larger than RAM degrades to eviction instead of OOM. The cache only ever grows, so a reading taken while the
+   * heap is tight simply declines to grow it further rather than shrinking what is already there.
    *
    * @return the number of vectors to hold, or 0 when caching is disabled
    */
@@ -6583,18 +6688,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (configured > 0)
       return configured;
 
-    // Per-entry cost: the float payload plus the VectorFloat wrapper, the cache entry and the array slot
-    final long bytesPerVector = (long) metadata.dimensions * Float.BYTES + 64;
-
-    int heapPercent = mutable.getDatabase().getConfiguration()
+    final int heapPercent = mutable.getDatabase().getConfiguration()
         .getValueAsInteger(GlobalConfiguration.VECTOR_INDEX_SEARCH_CACHE_MAX_HEAP_PERCENT);
     if (heapPercent <= 0)
       return 0;
-    if (heapPercent > 90)
-      heapPercent = 90;
 
-    final long heapBudget = Runtime.getRuntime().maxMemory() / 100 * heapPercent;
-    final long affordable = Math.max(MIN_SEARCH_CACHE_SIZE, heapBudget / bytesPerVector);
+    final long heapBudget = VectorHeapBudget.budgetBytes(heapPercent);
+    final long affordable = Math.max(MIN_SEARCH_CACHE_SIZE,
+        heapBudget / VectorHeapBudget.bytesPerCachedVector(metadata.dimensions));
 
     final long corpus = Math.max(MIN_SEARCH_CACHE_SIZE, vectorIndex.size());
 
@@ -6715,10 +6816,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
               scheduleInactivityRebuild();
             }
           }
-        } catch (final Exception | AssertionError e) {
-          // AssertionError too: JVector validates with `assert`, so a build over an index whose vectors can no
-          // longer be read (a closing database, say) throws one straight through. Letting it escape kills the
-          // shared TimerThread, and the failure then surfaces on whatever unrelated work runs next.
+        } catch (final Throwable e) {
+          // Throwable, not just Exception|AssertionError: an OutOfMemoryError from a rebuild that no longer fits
+          // (issue #6503) is an Error too. AssertionError already mattered here because JVector validates with
+          // `assert`, so a build over an index whose vectors can no longer be read (a closing database, say)
+          // throws one straight through - either way, letting it escape kills this index's own TimerThread, and
+          // every inactivity rebuild after it silently stops firing until the database is reopened.
           LogManager.instance().log(this, Level.WARNING,
               "Error during inactivity rebuild for index %s: %s", indexName, e.getMessage());
         }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
@@ -51,6 +51,12 @@ class LSMVectorIndexMetrics {
   // one restored from a backup, which does not carry the sidecar. Non-zero means this index is still being judged by
   // the weaker comparison; REBUILD INDEX, or any graph persist, writes a manifest and takes it off that path.
   private final AtomicLong unverifiedGraphReuses = new AtomicLong(0);
+  // Online rebuild cycles declined because the estimated peak footprint did not fit the available heap (issue
+  // #6503). Deferring is the intended outcome - the alternative is an OutOfMemoryError - but it is not free: the
+  // graph stays as stale as the delta buffer is long, so every query pays a longer brute-force scan over it. A
+  // number that keeps climbing is the signal to give the JVM more heap, lower graphBuildCacheMaxHeapPercent, or
+  // split the index; one that climbed once and stopped is a transient the next trigger already recovered from.
+  private final AtomicLong rebuildsDeferredForMemory = new AtomicLong(0);
 
   // Vector fetch source tracking
   private final AtomicLong vectorFetchFromQuantized = new AtomicLong(0);
@@ -93,6 +99,10 @@ class LSMVectorIndexMetrics {
 
   void incrementUnverifiedGraphReuses() {
     unverifiedGraphReuses.incrementAndGet();
+  }
+
+  void incrementRebuildsDeferredForMemory() {
+    rebuildsDeferredForMemory.incrementAndGet();
   }
 
   // Vector fetch source tracking methods
@@ -191,6 +201,7 @@ class LSMVectorIndexMetrics {
     stats.put("bruteForceScans", bruteForceScans.get());
     stats.put("groupedSearchesShortOfLimit", groupedSearchesShortOfLimit.get());
     stats.put("unverifiedGraphReuses", unverifiedGraphReuses.get());
+    stats.put("rebuildsDeferredForMemory", rebuildsDeferredForMemory.get());
     stats.put("compactionCount", compactionCount.get());
 
     stats.put("vectorFetchFromQuantized", vectorFetchFromQuantized.get());
@@ -211,6 +222,7 @@ class LSMVectorIndexMetrics {
     bruteForceScans.set(0);
     groupedSearchesShortOfLimit.set(0);
     unverifiedGraphReuses.set(0);
+    rebuildsDeferredForMemory.set(0);
     compactionCount.set(0);
     vectorFetchFromQuantized.set(0);
     vectorFetchFromDocuments.set(0);

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
@@ -18,10 +18,14 @@
  */
 package com.arcadedb.index.vector;
 
+import com.arcadedb.log.LogManager;
+
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
 import java.lang.management.MemoryUsage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 /**
  * How much heap a vector-index graph build may ask for, and how much one is going to cost.
@@ -39,6 +43,16 @@ import java.lang.management.MemoryUsage;
  * of the problem being solved. {@link MemoryPoolMXBean#getCollectionUsage()} is the garbage-free reading: it is
  * the pool's occupancy measured immediately after the JVM last collected that pool, so it approximates live
  * retained data rather than allocation since the last GC.
+ * <p>
+ * <b>Two ways that reading can be absent or stale, both of which fail safe.</b> A JVM that has not collected yet,
+ * or a collector/configuration that does not publish a collection usage at all, makes {@link #liveHeapBytes()}
+ * answer {@code -1}; the budget then falls back to the whole ceiling, which is precisely the total-heap behaviour
+ * this class replaces - so the fallback changes nothing rather than degrading anything. It does mean the
+ * improvement is inactive there, which would otherwise be invisible, so it is reported once per JVM at FINE.
+ * And for a generational collector whose old-gen collections are infrequent, the figure reflects the last such
+ * collection rather than current occupancy. That errs toward reporting LESS headroom than really exists, so the
+ * failure direction is a cache sized smaller or a rebuild deferred - never a rebuild admitted that should not
+ * have been.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -53,6 +67,9 @@ final class VectorHeapBudget {
 
   /** Ordinal-to-vector-id map: one int per node, held once per graph generation. */
   private static final long ORDINAL_MAP_BYTES_PER_NODE = Integer.BYTES;
+
+  /** So the fallback above is reported once per JVM rather than on every cache-sizing call. */
+  private static final AtomicBoolean COLLECTION_USAGE_UNAVAILABLE_REPORTED = new AtomicBoolean();
 
   private VectorHeapBudget() {
   }
@@ -89,6 +106,11 @@ final class VectorHeapBudget {
         live = 0L;
       live += Math.max(0L, collectionUsage.getUsed());
     }
+    if (live < 0 && COLLECTION_USAGE_UNAVAILABLE_REPORTED.compareAndSet(false, true))
+      LogManager.instance().log(VectorHeapBudget.class, Level.FINE,
+          "No heap pool on this JVM publishes a collection usage, so vector index heap budgets fall back to the "
+              + "total heap. That is the pre-issue-#6503 behaviour and is safe, but a rebuild holding the old "
+              + "graph resident will not ask for a smaller cache on account of it");
     return live;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorHeapBudget.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+
+/**
+ * How much heap a vector-index graph build may ask for, and how much one is going to cost.
+ * <p>
+ * Both of this index's auto-sized caches used to budget themselves off <em>total</em> heap
+ * ({@code Runtime.maxMemory() / 100 * percent}), which is the wrong denominator for a rebuild: the old graph and
+ * its search cache stay resident for the whole build, so the heap actually available to the build is what is left
+ * after them, not the whole heap. Raising {@code -Xmx} did not create headroom either, because a bigger heap grew
+ * both caches proportionally and the rebuild was no more likely to fit (issue #6503).
+ * <p>
+ * <b>Why not {@code Runtime.freeMemory()}.</b> That reports free space in the <em>currently committed</em> heap,
+ * and everything allocated since the last collection counts as used whether it is live or garbage. Read just
+ * before a collection it says the heap is nearly full even when almost all of it is about to be reclaimed, so a
+ * budget taken from it would collapse the build cache for no reason and make the build far slower - the opposite
+ * of the problem being solved. {@link MemoryPoolMXBean#getCollectionUsage()} is the garbage-free reading: it is
+ * the pool's occupancy measured immediately after the JVM last collected that pool, so it approximates live
+ * retained data rather than allocation since the last GC.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class VectorHeapBudget {
+  /**
+   * Retained heap per graph node, measured in issue #6503 (~1.1 KB/node at 128 dimensions, across the JVector
+   * adjacency structure and its per-node overhead). Deliberately a single flat constant rather than a function of
+   * {@code maxConnections}: the number exists to decide whether a rebuild is going to fit at all, an
+   * order-of-magnitude question, and a false precision here would read as a guarantee this cannot make.
+   */
+  static final long APPROX_GRAPH_BYTES_PER_NODE = 1_100L;
+
+  /** Ordinal-to-vector-id map: one int per node, held once per graph generation. */
+  private static final long ORDINAL_MAP_BYTES_PER_NODE = Integer.BYTES;
+
+  private VectorHeapBudget() {
+  }
+
+  /**
+   * @return the heap ceiling, i.e. what {@code -Xmx} allows.
+   */
+  static long maxHeapBytes() {
+    return Runtime.getRuntime().maxMemory();
+  }
+
+  /**
+   * Live (post-collection) heap occupancy, summed over every heap pool that reports it.
+   *
+   * @return the bytes the JVM still held right after it last collected each pool, or {@code -1} when no pool
+   * reports a collection usage - a JVM that has not collected yet, or a GC that does not publish the figure. A
+   * caller that gets {@code -1} must fall back to the whole heap rather than assume zero pressure.
+   */
+  static long liveHeapBytes() {
+    long live = -1L;
+    for (final MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+      if (pool == null || pool.getType() != MemoryType.HEAP)
+        continue;
+      final MemoryUsage collectionUsage;
+      try {
+        collectionUsage = pool.getCollectionUsage();
+      } catch (final RuntimeException e) {
+        // An implementation that refuses the query is indistinguishable from one that does not publish it.
+        continue;
+      }
+      if (collectionUsage == null)
+        continue;
+      if (live < 0)
+        live = 0L;
+      live += Math.max(0L, collectionUsage.getUsed());
+    }
+    return live;
+  }
+
+  /**
+   * Heap a new allocation can realistically expect to get: the ceiling minus what is live after the last
+   * collection. Falls back to the whole ceiling when live occupancy is unknown, which reproduces exactly the
+   * total-heap budgeting this class replaces - a conservative default in the sense that it changes nothing.
+   */
+  static long availableHeapBytes() {
+    final long max = maxHeapBytes();
+    final long live = liveHeapBytes();
+    if (live < 0)
+      return max;
+    return Math.max(0L, max - live);
+  }
+
+  /**
+   * The share of {@link #availableHeapBytes()} a caller is allowed to claim.
+   *
+   * @param percent share to claim, clamped into {@code [0, 90]}: a build is never allowed to plan on the whole
+   *                heap, since the request, I/O and GC threads need some of it too
+   *
+   * @return the budget in bytes, never negative
+   */
+  static long budgetBytes(final int percent) {
+    if (percent <= 0)
+      return 0L;
+    return availableHeapBytes() / 100 * Math.min(percent, 90);
+  }
+
+  /**
+   * Retained heap of one graph generation of {@code nodes} nodes, including its ordinal map.
+   */
+  static long estimateGraphBytes(final long nodes) {
+    if (nodes <= 0)
+      return 0L;
+    return nodes * (APPROX_GRAPH_BYTES_PER_NODE + ORDINAL_MAP_BYTES_PER_NODE);
+  }
+
+  /**
+   * Per-entry cost of a cached vector: the float payload plus the {@code VectorFloat} wrapper, the cache entry
+   * and the array slot. Same figure the two cache-sizing paths in {@code LSMVectorIndex} use.
+   */
+  static long bytesPerCachedVector(final int dimensions) {
+    return (long) dimensions * Float.BYTES + 64;
+  }
+
+  /**
+   * Peak heap a from-scratch graph build is expected to hold at once.
+   *
+   * @param nodes                  number of vectors the build will walk
+   * @param dimensions             vector width
+   * @param buildCacheCapacity     vectors the build cache will hold
+   * @param oldGraphStaysResident  whether the graph being replaced is retained for the duration - true for an
+   *                               online rebuild, which must keep serving searches, false on the close path,
+   *                               which releases it up front (issue #6503)
+   *
+   * @return the estimated peak in bytes
+   */
+  static long estimateRebuildHeapBytes(final long nodes, final int dimensions, final long buildCacheCapacity,
+      final boolean oldGraphStaysResident) {
+    long estimate = estimateGraphBytes(nodes);                              // the graph being built
+    estimate += Math.max(0L, buildCacheCapacity) * bytesPerCachedVector(dimensions);
+    if (oldGraphStaysResident)
+      estimate += estimateGraphBytes(nodes);                                // ...on top of the one being replaced
+    return estimate;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6503GraphPersistOutOfMemoryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6503GraphPersistOutOfMemoryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for issue #6503: an {@link OutOfMemoryError} raised while a graph rebuild persists is an
+ * {@link Error}, not an {@link Exception}, so it used to escape the {@code catch (final Exception e)} guard around
+ * the persist block in {@code LSMVectorIndex.buildGraphFromScratchExclusively()}. That guard is the only place that
+ * calls {@code manifest.markUnusable()} on a failed persist - skip it and the manifest is left vouching for
+ * whatever the pages happen to hold after a write that died partway through, so the next database open trusts a
+ * possibly half-rewritten graph on node-count agreement alone (issue #6106 is exactly the check this exists to
+ * satisfy). The transaction rollback in the same block is skipped too, leaving a dangling transaction.
+ * <p>
+ * The fix widens that one catch to {@code Throwable}. This test does not need an actual heap exhaustion to prove
+ * it: it injects a real {@link OutOfMemoryError} through a {@link LSMVectorIndex.GraphBuildCallback}, at the same
+ * point in the persist block ("persisting" phase completion, right after the graph pages are written but before
+ * the transaction commits or the manifest is certified) where a genuine allocation failure would strike.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6503GraphPersistOutOfMemoryTest {
+  private static final String DB_ROOT     = "target/test-databases/Issue6503GraphPersistOutOfMemoryTest";
+  private static final int    DIMENSIONS  = 16;
+  private static final int    NUM_VECTORS = 50;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void oomDuringPersistStillMarksTheManifestUnusableAndRollsBack() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // Simulates an allocation failure at the exact point in the persist block a real one would strike: the
+        // graph pages are already written, but the transaction has not committed and the manifest has not been
+        // certified yet.
+        assertThatCode(() -> index.buildVectorGraphNow((phase, processedNodes, totalNodes, vectorAccesses) -> {
+          if ("persisting".equals(phase) && processedNodes > 0 && processedNodes == totalNodes)
+            throw new OutOfMemoryError("simulated for issue #6503 test");
+        }))
+            .as("the persist block must swallow the OOM the same way it already swallows an ordinary Exception "
+                + "there, not let it escape as an unhandled Error")
+            .doesNotThrowAnyException();
+
+        final LSMVectorIndexGraphManifest.Content manifest = graphManifestField(index).read();
+        assertThat(manifest)
+            .as("the manifest must exist and refuse the pages, not be silently absent (issue #6106) or left "
+                + "vouching for a persist that died mid-write")
+            .isNotNull();
+        assertThat(manifest.vectorCount())
+            .as("an unusable manifest is marked with a negative vector count - no live set can match it")
+            .isNegative();
+
+        // The rollback in the same catch block must have run too: no transaction left dangling on the thread.
+        assertThat(db.isTransactionActive())
+            .as("the failed persist must have rolled back its own transaction, not left one open")
+            .isFalse();
+
+        // The in-memory graph itself is unaffected - only the disk persist failed, so the index built the new
+        // graph successfully before the injected failure. It must keep answering correctly, and normal writes
+        // must keep working (proves nothing is left wedged by the aborted persist transaction).
+        assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+        db.transaction(() -> db.newDocument("Doc").set("id", NUM_VECTORS).set("vector", randomVector(new Random(1))).save());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static LSMVectorIndexGraphManifest graphManifestField(final LSMVectorIndex index) throws Exception {
+    final Field field = LSMVectorIndex.class.getDeclaredField("graphFile");
+    field.setAccessible(true);
+    final LSMVectorIndexGraphFile graphFile = (LSMVectorIndexGraphFile) field.get(index);
+    return graphFile.getManifest();
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\" }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++)
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+
+  private static float[] queryVector() {
+    return randomVector(new Random(99));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6503RebuildAdmissionControlTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6503RebuildAdmissionControlTest.java
@@ -78,6 +78,8 @@ class Issue6503RebuildAdmissionControlTest {
         GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getDefValue());
     GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(
         GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.getDefValue());
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_DEFERRAL_COOLDOWN_MS.setValue(
+        GlobalConfiguration.VECTOR_INDEX_REBUILD_DEFERRAL_COOLDOWN_MS.getDefValue());
     FileUtils.deleteRecursively(new File(dbPath));
   }
 
@@ -194,6 +196,95 @@ class Issue6503RebuildAdmissionControlTest {
       index.buildVectorGraphNow(null);
       assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
     });
+  }
+
+  /**
+   * A deferral does not consume the mutations that triggered it - only a successful build decrements
+   * {@code mutationsSinceSerialize} - so the trigger condition is true again the instant the deferred cycle ends,
+   * and {@code rebuildGraphBeforeSearch()} evaluates it on EVERY query. Without a cooldown a large,
+   * heap-constrained index therefore spawns a rebuild thread, takes and releases the JVM-wide permit and logs a
+   * WARNING once per search - thread churn and contention added exactly when memory is already tight, which works
+   * against the deferral's own purpose.
+   */
+  @Test
+  void repeatedTriggersWithinTheCooldownDoNotEachAttemptARebuild() {
+    withIndex(index -> {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+      GlobalConfiguration.VECTOR_INDEX_REBUILD_DEFERRAL_COOLDOWN_MS.setValue(60_000);
+
+      // First trigger: genuinely attempts, and is genuinely declined.
+      triggerAsyncRebuildAndSettle(index);
+      assertThat(index.getStats().get("rebuildsDeferredForMemory"))
+          .as("the first trigger must actually attempt the rebuild and be declined").isEqualTo(1L);
+
+      // Every subsequent trigger inside the cooldown must be skipped before any of the work an attempt costs.
+      for (int i = 0; i < 25; i++)
+        triggerAsyncRebuildAndSettle(index);
+
+      assertThat(index.getStats().get("rebuildsDeferredForMemory"))
+          .as("25 further triggers inside the cooldown must not each spawn a rebuild thread, take the JVM-wide "
+              + "permit and log a warning: a search evaluates this trigger on every query")
+          .isEqualTo(1L);
+    });
+  }
+
+  /** The suppression above must come from the cooldown, not from some other state that stopped triggering. */
+  @Test
+  void withTheCooldownDisabledEveryTriggerAttemptsAgain() {
+    withIndex(index -> {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+      GlobalConfiguration.VECTOR_INDEX_REBUILD_DEFERRAL_COOLDOWN_MS.setValue(0);
+
+      for (int i = 0; i < 3; i++)
+        triggerAsyncRebuildAndSettle(index);
+
+      assertThat(index.getStats().get("rebuildsDeferredForMemory"))
+          .as("0 disables the cooldown, so each trigger attempts and is declined again - which is also what "
+              + "proves the test above is measuring the cooldown and nothing else")
+          .isEqualTo(3L);
+    });
+  }
+
+  /** A successful build clears the cooldown, so a later shortage is not gated by a stale deferral. */
+  @Test
+  void aSuccessfulBuildClearsTheCooldown() {
+    withIndex(index -> {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+      GlobalConfiguration.VECTOR_INDEX_REBUILD_DEFERRAL_COOLDOWN_MS.setValue(60_000);
+
+      triggerAsyncRebuildAndSettle(index);
+      assertThat(index.getStats().get("rebuildsDeferredForMemory")).isEqualTo(1L);
+
+      // An explicit rebuild is never declined, and completing one means the shortage is no longer in the way.
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(
+          GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.getDefValue());
+      index.buildVectorGraphNow(null);
+
+      // Back under pressure, the very next trigger must attempt again rather than sit out the original cooldown.
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+      triggerAsyncRebuildAndSettle(index);
+      assertThat(index.getStats().get("rebuildsDeferredForMemory"))
+          .as("a completed build must clear the cooldown a previous deferral set")
+          .isEqualTo(2L);
+    });
+  }
+
+  /**
+   * Drives one online-rebuild trigger the way a search does and waits for the background thread to settle, so the
+   * assertions above read a stable state rather than racing the daemon.
+   */
+  private static void triggerAsyncRebuildAndSettle(final LSMVectorIndex index) {
+    try {
+      final Method start = LSMVectorIndex.class.getDeclaredMethod("startAsyncGraphRebuild");
+      start.setAccessible(true);
+      start.invoke(index);
+    } catch (final ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (index.getStats().get("asyncRebuildInProgress") != 0 && System.currentTimeMillis() < deadline)
+      Thread.onSpinWait();
   }
 
   private void withIndex(final java.util.function.Consumer<LSMVectorIndex> body) {

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6503RebuildAdmissionControlTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6503RebuildAdmissionControlTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6503, item 3: nothing consulted memory before starting a graph rebuild. The only gate
+ * was {@code REBUILD_SEMAPHORE}, which bounds how many rebuilds run at once, not how much heap one needs - a
+ * rebuild that could not fit was simply attempted, and died with an {@link OutOfMemoryError}. There was no path
+ * that deferred, degraded, or declined.
+ * <p>
+ * A rebuild is now admitted only when its estimated peak footprint fits
+ * {@code arcadedb.vectorIndex.rebuildMaxHeapPercent} of the currently available heap, and only the ONLINE path is
+ * gated: a first build, a rebuild on close, {@code REBUILD INDEX} and {@code COMPACT INDEX} have no later trigger
+ * to retry them, so declining one would turn "slower" into "never".
+ * <p>
+ * The oversized-footprint cases below drive the estimate past any plausible heap with an explicit build-cache
+ * size rather than by allocating anything, so the outcome does not depend on the {@code -Xmx} the suite happens to
+ * run under.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6503RebuildAdmissionControlTest {
+  private static final String DB_ROOT     = "target/test-databases/Issue6503RebuildAdmissionControlTest";
+  private static final int    DIMENSIONS  = 16;
+  private static final int    NUM_VECTORS = 200;
+
+  /**
+   * An explicit build-cache size of ~1.07e9 entries at (16*4 + 64) bytes each estimates to ~137 GB, which is past
+   * 90% of any heap a JVM can be given, so the outcome does not depend on the {@code -Xmx} the suite runs under.
+   * Nothing is ever allocated at this size: only the estimate reads it, and every test resets the setting before
+   * letting a real build run.
+   */
+  private static final int UNAFFORDABLE_BUILD_CACHE_SIZE = Integer.MAX_VALUE / 2;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.setValue(
+        GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.getDefValue());
+    GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(
+        GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.getDefValue());
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void anOnlineRebuildThatCannotFitIsDeferredAndCounted() {
+    withIndex(index -> {
+      final long deferredBefore = index.getStats().get("rebuildsDeferredForMemory");
+
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+
+      assertThat(index.admitOnlineRebuild())
+          .as("a rebuild whose estimated footprint dwarfs the available heap must be declined, not attempted - "
+              + "attempting it is what produced the OutOfMemoryError in issue #6503")
+          .isFalse();
+
+      assertThat(index.getStats().get("rebuildsDeferredForMemory"))
+          .as("a deferral must be visible in the stats, not only in the log: an index that never fits goes stale "
+              + "silently otherwise")
+          .isEqualTo(deferredBefore + 1);
+    });
+  }
+
+  @Test
+  void anOnlineRebuildThatFitsIsAdmitted() {
+    withIndex(index -> {
+      // Default configuration, a 200-vector 16-dimension index: this cannot fail to fit on any machine that can
+      // run the test suite at all. Guards against a gate that declines everything, which would pass the test
+      // above while quietly disabling rebuilds across the engine.
+      assertThat(index.admitOnlineRebuild())
+          .as("a small rebuild with the default budget must be admitted")
+          .isTrue();
+      assertThat(index.getStats().get("rebuildsDeferredForMemory")).isZero();
+    });
+  }
+
+  @Test
+  void theGateCanBeDisabledByConfiguration() {
+    withIndex(index -> {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+      GlobalConfiguration.VECTOR_INDEX_REBUILD_MAX_HEAP_PERCENT.setValue(0);
+
+      assertThat(index.admitOnlineRebuild())
+          .as("0 restores the previous attempt-and-hope behaviour for an operator who knows better than the "
+              + "estimate")
+          .isTrue();
+      assertThat(index.getStats().get("rebuildsDeferredForMemory"))
+          .as("a disabled gate must not count deferrals it did not make")
+          .isZero();
+    });
+  }
+
+  /**
+   * The close path, {@code REBUILD INDEX} and {@code COMPACT INDEX} must go through regardless: nothing retries
+   * them, and the close path has already released the old graph, so it is not even the expensive shape the gate
+   * exists to refuse. Only the async/online path consults it.
+   */
+  @Test
+  void anExplicitRebuildIsNeverDeclinedNoMatterWhatTheGateWouldSay() {
+    withIndex(index -> {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+      assertThat(index.admitOnlineRebuild()).as("precondition: the gate would decline an online rebuild here")
+          .isFalse();
+
+      // ...and REBUILD INDEX still runs to completion and leaves a searchable graph.
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(
+          GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.getDefValue());
+      final long rebuildsBefore = index.getStats().get("graphRebuildCount");
+      index.buildVectorGraphNow(null);
+      assertThat(index.getStats().get("graphRebuildCount")).isGreaterThan(rebuildsBefore);
+      assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+    });
+  }
+
+  /**
+   * Wiring, not policy: the async rebuild thread must consult the gate AFTER taking its permit and must hand
+   * every piece of state back on the way out - the permit, the in-progress flag and the thread reference - or a
+   * single deferral would wedge the index out of ever rebuilding again.
+   */
+  @Test
+  void aDeferredAsyncRebuildReleasesItsPermitAndInProgressFlag() throws Exception {
+    withIndex(index -> {
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(UNAFFORDABLE_BUILD_CACHE_SIZE);
+
+      final long rebuildsBefore = index.getStats().get("graphRebuildCount");
+      try {
+        final Method start = LSMVectorIndex.class.getDeclaredMethod("startAsyncGraphRebuild");
+        start.setAccessible(true);
+        start.invoke(index);
+      } catch (final ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+
+      // The rebuild thread is a daemon; poll rather than sleep a fixed amount. Both conditions, not just the
+      // counter: the counter is incremented inside the gate and the flag is cleared by the thread's finally block
+      // a moment later, so exiting on the counter alone would read the flag while it is legitimately still set.
+      final long deadline = System.currentTimeMillis() + 30_000;
+      while ((index.getStats().get("rebuildsDeferredForMemory") == 0
+          || index.getStats().get("asyncRebuildInProgress") != 0)
+          && System.currentTimeMillis() < deadline)
+        Thread.onSpinWait();
+
+      assertThat(index.getStats().get("rebuildsDeferredForMemory"))
+          .as("the async path must consult the gate, not bypass it").isEqualTo(1L);
+      assertThat(index.getStats().get("graphRebuildCount"))
+          .as("a declined cycle must not have rebuilt anything").isEqualTo(rebuildsBefore);
+      assertThat(index.getStats().get("asyncRebuildInProgress"))
+          .as("the in-progress flag must be cleared on the deferral path too, or the index can never schedule "
+              + "another rebuild")
+          .isZero();
+
+      // The permit must be back: a later rebuild, once it fits, has to be able to take it.
+      GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.setValue(
+          GlobalConfiguration.VECTOR_INDEX_GRAPH_BUILD_CACHE_SIZE.getDefValue());
+      index.buildVectorGraphNow(null);
+      assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+    });
+  }
+
+  private void withIndex(final java.util.function.Consumer<LSMVectorIndex> body) {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+        // Make the graph resident: the gate deliberately admits an index whose graph was never built, since that
+        // is a first build in all but name.
+        assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+        body.accept(index);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\" }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++)
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+
+  private static float[] queryVector() {
+    return randomVector(new Random(99));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6503VectorHeapBudgetTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6503VectorHeapBudgetTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The heap arithmetic behind issue #6503, on its own: every decision that used to be made against TOTAL heap and
+ * now has to be made against the heap actually available, plus the footprint estimate the rebuild admission gate
+ * compares to it. Cheaper to pin here than through a database, and each of these is a property no realistic
+ * fixture would exercise from both sides.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6503VectorHeapBudgetTest {
+
+  @Test
+  void availableHeapNeverExceedsTheCeilingAndIsNeverNegative() {
+    final long max = VectorHeapBudget.maxHeapBytes();
+    final long available = VectorHeapBudget.availableHeapBytes();
+
+    assertThat(max).as("a JVM always reports a heap ceiling").isPositive();
+    assertThat(available)
+        .as("available heap must stay inside [0, -Xmx]: a negative budget would size a cache to nothing and a "
+            + "budget past the ceiling would be the total-heap bug this replaces")
+        .isBetween(0L, max);
+  }
+
+  /**
+   * A JVM that has not collected yet, or a GC that does not publish a collection usage, must fall back to the
+   * whole ceiling - which reproduces exactly the previous total-heap behaviour. Assuming zero live heap would be
+   * the same thing; assuming a FULL heap would silently disable every auto-sized cache in the engine.
+   */
+  @Test
+  void unknownLiveHeapFallsBackToTheWholeCeilingRatherThanToZeroBudget() {
+    final long live = VectorHeapBudget.liveHeapBytes();
+    if (live < 0)
+      assertThat(VectorHeapBudget.availableHeapBytes()).isEqualTo(VectorHeapBudget.maxHeapBytes());
+    else
+      assertThat(live).as("a published live-heap reading is an occupancy, so it cannot be negative").isNotNegative();
+  }
+
+  @Test
+  void budgetIsAShareOfAvailableHeapAndIsCappedAtNinetyPercent() {
+    assertThat(VectorHeapBudget.budgetBytes(0)).as("0 means 'no budget', not 'unlimited'").isZero();
+    assertThat(VectorHeapBudget.budgetBytes(-5)).as("a negative percentage is not a licence to overcommit").isZero();
+
+    final long available = VectorHeapBudget.availableHeapBytes();
+    assertThat(VectorHeapBudget.budgetBytes(50)).isLessThanOrEqualTo(available / 2 + 1);
+
+    // 100% is clamped to 90: a build must never plan on the whole heap, since the request, I/O and GC threads
+    // need some of it too.
+    assertThat(VectorHeapBudget.budgetBytes(100)).isEqualTo(VectorHeapBudget.budgetBytes(90));
+    assertThat(VectorHeapBudget.budgetBytes(90)).isLessThan(available + 1);
+  }
+
+  @Test
+  void budgetGrowsMonotonicallyWithTheRequestedShare() {
+    // Not a tautology: budgetBytes() clamps and divides, and an implementation that clamped in the wrong order
+    // (or divided before multiplying by a clamped value) could easily invert this for a share above the cap.
+    assertThat(VectorHeapBudget.budgetBytes(10)).isLessThanOrEqualTo(VectorHeapBudget.budgetBytes(25));
+    assertThat(VectorHeapBudget.budgetBytes(25)).isLessThanOrEqualTo(VectorHeapBudget.budgetBytes(50));
+    assertThat(VectorHeapBudget.budgetBytes(50)).isLessThanOrEqualTo(VectorHeapBudget.budgetBytes(90));
+  }
+
+  @Test
+  void anEmptyGraphCostsNothingAndNodeCostScalesLinearly() {
+    assertThat(VectorHeapBudget.estimateGraphBytes(0)).isZero();
+    assertThat(VectorHeapBudget.estimateGraphBytes(-1)).as("a negative node count is not a negative footprint")
+        .isZero();
+
+    final long one = VectorHeapBudget.estimateGraphBytes(1);
+    assertThat(one).isGreaterThanOrEqualTo(VectorHeapBudget.APPROX_GRAPH_BYTES_PER_NODE);
+    assertThat(VectorHeapBudget.estimateGraphBytes(1_000)).isEqualTo(one * 1_000);
+  }
+
+  /**
+   * This is the 1.73x the issue measured (1,700 MB for a rebuild against 959 MB for the first build of the same
+   * 50,000 x 128 corpus). The estimate does not have to reproduce that ratio exactly - it is deliberately coarse -
+   * but a rebuild that retains the old graph must come out strictly more expensive than one that does not, or the
+   * admission gate is measuring the wrong thing entirely.
+   */
+  @Test
+  void keepingTheOldGraphResidentCostsStrictlyMoreThanReleasingIt() {
+    final long nodes = 50_000;
+    final int dimensions = 128;
+    final long cacheCapacity = nodes;
+
+    final long online = VectorHeapBudget.estimateRebuildHeapBytes(nodes, dimensions, cacheCapacity, true);
+    final long onClose = VectorHeapBudget.estimateRebuildHeapBytes(nodes, dimensions, cacheCapacity, false);
+
+    assertThat(online).isGreaterThan(onClose);
+    assertThat(online - onClose)
+        .as("the difference is exactly one resident graph generation - what the close path releases up front")
+        .isEqualTo(VectorHeapBudget.estimateGraphBytes(nodes));
+  }
+
+  @Test
+  void theEstimateAccountsForTheBuildCacheAsWellAsTheGraphs() {
+    final long nodes = 10_000;
+    final int dimensions = 256;
+
+    final long withoutCache = VectorHeapBudget.estimateRebuildHeapBytes(nodes, dimensions, 0, false);
+    final long withCache = VectorHeapBudget.estimateRebuildHeapBytes(nodes, dimensions, nodes, false);
+
+    assertThat(withCache - withoutCache)
+        .as("a build cache holding the whole corpus costs one cached vector per node")
+        .isEqualTo(nodes * VectorHeapBudget.bytesPerCachedVector(dimensions));
+    // A negative capacity must not credit the estimate with heap it is not going to give back.
+    assertThat(VectorHeapBudget.estimateRebuildHeapBytes(nodes, dimensions, -1_000, false)).isEqualTo(withoutCache);
+  }
+
+  @Test
+  void cachedVectorCostCoversThePayloadPlusTheWrapperOverhead() {
+    assertThat(VectorHeapBudget.bytesPerCachedVector(128))
+        .as("the float payload alone would be 512 bytes; the wrapper, cache entry and array slot are the rest")
+        .isGreaterThan(128L * Float.BYTES);
+    // Linear in the dimension count, so a wide-vector index is charged for being wide.
+    assertThat(VectorHeapBudget.bytesPerCachedVector(256) - VectorHeapBudget.bytesPerCachedVector(128))
+        .isEqualTo(128L * Float.BYTES);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6503VectorRebuildResidentGraphReleaseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6503VectorRebuildResidentGraphReleaseTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6503: a from-scratch graph rebuild keeps the OLD graph (and the shared search cache)
+ * resident for the whole build, on top of the new build's own working set (build cache, JVector builder, ordinal
+ * map). On the close path that doubling is pure waste - {@code flush()} has already CAS-ed the index to
+ * {@code UNAVAILABLE} and {@code close()} has already run {@code releaseBackgroundResources()}, which clears the
+ * pooled searchers, so nothing can still be reading either the old graph or the old cache by the time the rebuild
+ * starts. Measured in the issue at 50,000 x 128: peak heap 1,700 MB for a rebuild against 959 MB for a first build
+ * of the same corpus - a factor of 1.73x that raising {@code -Xmx} does not fix, because both caches size
+ * themselves off total heap, not free heap.
+ * <p>
+ * {@link LSMVectorIndex#buildGraphFromScratchReleasingResidentGraph(LSMVectorIndex.GraphBuildCallback)} is the
+ * fix: it releases the resident graph and search cache before starting, and {@code flush()} now calls it instead
+ * of the ordinary {@code buildGraphFromScratch()}. It must not be used anywhere else - an online rebuild
+ * ({@code rebuildGraphBeforeSearch()}, {@code startAsyncGraphRebuild()}, an explicit
+ * {@code buildVectorGraphNow()}, or {@code compact()}) has to keep serving the old graph to concurrent searches,
+ * since none of those gate searches on {@code status}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6503VectorRebuildResidentGraphReleaseTest {
+  private static final String DB_ROOT     = "target/test-databases/Issue6503VectorRebuildResidentGraphReleaseTest";
+  private static final int    DIMENSIONS  = 16;
+  private static final int    NUM_VECTORS = 200;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void closeStyleRebuildReleasesTheResidentGraphAndSearchCacheBeforeBuilding() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // A search makes both the graph and the shared search cache resident, same as any index that has
+        // actually answered a query - which is the state a close-triggered rebuild finds them in.
+        assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+        assertThat(index.getGraphIndex()).as("graph must be resident before the rebuild under test").isNotNull();
+        assertThat(searchVectorCacheField(index))
+            .as("search cache must be resident before the rebuild under test").isNotNull();
+
+        final AtomicReference<Boolean> graphReleasedOnFirstSample = new AtomicReference<>();
+        final AtomicReference<Object>  searchCacheOnFirstSample   = new AtomicReference<>();
+
+        index.buildGraphFromScratchReleasingResidentGraph((phase, processedNodes, totalNodes, vectorAccesses) -> {
+          if (graphReleasedOnFirstSample.get() != null)
+            return; // only the first sample matters: it is chronologically the earliest observation point
+          graphReleasedOnFirstSample.set(index.getGraphIndex() == null);
+          try {
+            searchCacheOnFirstSample.set(searchVectorCacheField(index));
+          } catch (final Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+        assertThat(graphReleasedOnFirstSample.get())
+            .as("the resident graph must already be released by the time the rebuild reports its first progress "
+                + "sample - otherwise the old graph and the new build's working set are both resident at once")
+            .isTrue();
+        assertThat(searchCacheOnFirstSample.get())
+            .as("the resident search cache must already be released by the time the rebuild reports its first "
+                + "progress sample")
+            .isNull();
+
+        // ...and the rebuild still produces a correct, searchable graph.
+        assertThat(index.getGraphIndex()).as("the rebuild must have published a new graph").isNotNull();
+        assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  @Test
+  void onlineRebuildDoesNotReleaseTheResidentGraphBeforeBuilding() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+
+        final Object residentGraphBeforeRebuild = index.getGraphIndex();
+        assertThat(residentGraphBeforeRebuild).isNotNull();
+
+        final AtomicReference<Object> graphOnFirstSample = new AtomicReference<>();
+        // buildVectorGraphNow() is what an explicit REBUILD INDEX drives while the database may still be
+        // serving concurrent traffic: nothing here gates searches on status, so the old graph must stay put.
+        index.buildVectorGraphNow((phase, processedNodes, totalNodes, vectorAccesses) -> {
+          if (graphOnFirstSample.get() == null)
+            graphOnFirstSample.set(index.getGraphIndex());
+        });
+
+        assertThat(graphOnFirstSample.get())
+            .as("an explicit/online rebuild must keep serving the OLD graph until the new one is ready - it must "
+                + "not take the close-path shortcut that releases it up front")
+            .isSameAs(residentGraphBeforeRebuild);
+
+        // The rebuild still completes correctly; only the timing of the release differs from the close path.
+        assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  @Test
+  void closingWithPendingMutationsRebuildsAndReopensToACorrectGraph() {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      populate(db);
+
+      // One more mutation than the initial build absorbed, so graphState is MUTABLE and flush() takes the
+      // rebuild branch under test instead of the "nothing to do" one.
+      db.transaction(() -> {
+        final float[] vector = randomVector(new Random(123));
+        db.newDocument("Doc").set("id", NUM_VECTORS).set("vector", vector).save();
+      });
+
+      assertThat(vectorIndex(db).getStats().get("graphState"))
+          .as("an extra insert past the initial build must leave the graph MUTABLE, otherwise close() below "
+              + "would skip the rebuild this test exercises")
+          .isEqualTo(2L); // GraphState.MUTABLE ordinal, see getStats()
+
+      db.close();
+    }
+
+    // Reopen and confirm the close-triggered rebuild persisted a correct, searchable graph over all
+    // NUM_VECTORS + 1 vectors - including the one added right before close().
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      try (final Database db = factory.open()) {
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.findNeighborsFromVector(queryVector(), 5, 64)).hasSize(5);
+        assertThat(index.getStats().get("activeVectors")).isEqualTo((long) NUM_VECTORS + 1);
+      }
+    } finally {
+      FileUtils.deleteRecursively(new File(dbPath));
+    }
+  }
+
+  private static VectorCache searchVectorCacheField(final LSMVectorIndex index) throws Exception {
+    final Field field = LSMVectorIndex.class.getDeclaredField("searchVectorCache");
+    field.setAccessible(true);
+    return (VectorCache) field.get(index);
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\" }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+      if (i % 1000 == 999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+
+  private static float[] queryVector() {
+    return randomVector(new Random(99));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6503VectorRebuildResidentGraphReleaseTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6503VectorRebuildResidentGraphReleaseTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,18 +39,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Regression test for issue #6503: a from-scratch graph rebuild keeps the OLD graph (and the shared search cache)
  * resident for the whole build, on top of the new build's own working set (build cache, JVector builder, ordinal
  * map). On the close path that doubling is pure waste - {@code flush()} has already CAS-ed the index to
- * {@code UNAVAILABLE} and {@code close()} has already run {@code releaseBackgroundResources()}, which clears the
- * pooled searchers, so nothing can still be reading either the old graph or the old cache by the time the rebuild
- * starts. Measured in the issue at 50,000 x 128: peak heap 1,700 MB for a rebuild against 959 MB for a first build
- * of the same corpus - a factor of 1.73x that raising {@code -Xmx} does not fix, because both caches size
- * themselves off total heap, not free heap.
+ * {@code UNAVAILABLE} and a closing database does not hand it any more requests, so nothing can still be reading
+ * either the old graph or the old cache by the time the rebuild starts. Measured in the issue at 50,000 x 128:
+ * peak heap 1,700 MB for a rebuild against 959 MB for a first build of the same corpus - a factor of 1.73x that
+ * raising {@code -Xmx} does not fix, because both caches size themselves off total heap, not free heap.
  * <p>
  * {@link LSMVectorIndex#buildGraphFromScratchReleasingResidentGraph(LSMVectorIndex.GraphBuildCallback)} is the
- * fix: it releases the resident graph and search cache before starting, and {@code flush()} now calls it instead
- * of the ordinary {@code buildGraphFromScratch()}. It must not be used anywhere else - an online rebuild
- * ({@code rebuildGraphBeforeSearch()}, {@code startAsyncGraphRebuild()}, an explicit
- * {@code buildVectorGraphNow()}, or {@code compact()}) has to keep serving the old graph to concurrent searches,
- * since none of those gate searches on {@code status}.
+ * fix: it releases the resident graph, the search cache AND the pooled searchers before starting, and
+ * {@code flush()} now calls it instead of the ordinary {@code buildGraphFromScratch()}. All three matter - a
+ * pooled searcher holds the graph it was pooled under, and {@code LocalDatabase.closeDurableParts()} runs
+ * {@code flush()} BEFORE {@code releaseBackgroundResources()}, so on a real close the pool is still populated
+ * when the rebuild starts and would pin the old graph on its own.
+ * <p>
+ * It must not be used anywhere else - an online rebuild ({@code rebuildGraphBeforeSearch()},
+ * {@code startAsyncGraphRebuild()}, an explicit {@code buildVectorGraphNow()}, or {@code compact()}) has to keep
+ * serving the old graph to concurrent searches, since none of those gate searches on {@code status}.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -88,11 +92,13 @@ class Issue6503VectorRebuildResidentGraphReleaseTest {
 
         final AtomicReference<Boolean> graphReleasedOnFirstSample = new AtomicReference<>();
         final AtomicReference<Object>  searchCacheOnFirstSample   = new AtomicReference<>();
+        final AtomicInteger            pooledSearchersOnFirstSample = new AtomicInteger(-1);
 
         index.buildGraphFromScratchReleasingResidentGraph((phase, processedNodes, totalNodes, vectorAccesses) -> {
           if (graphReleasedOnFirstSample.get() != null)
             return; // only the first sample matters: it is chronologically the earliest observation point
           graphReleasedOnFirstSample.set(index.getGraphIndex() == null);
+          pooledSearchersOnFirstSample.set(index.getStats().get("pooledGraphSearchers").intValue());
           try {
             searchCacheOnFirstSample.set(searchVectorCacheField(index));
           } catch (final Exception e) {
@@ -108,6 +114,14 @@ class Issue6503VectorRebuildResidentGraphReleaseTest {
             .as("the resident search cache must already be released by the time the rebuild reports its first "
                 + "progress sample")
             .isNull();
+        // Nulling graphIndex alone releases nothing while a pooled searcher still holds the graph it was pooled
+        // under. This is not hypothetical on the path under test: LocalDatabase.closeDurableParts() runs
+        // index.flush() BEFORE index.releaseBackgroundResources(), so on a real database close the pool is still
+        // populated when the rebuild starts, and the old graph would stay reachable through it.
+        assertThat(pooledSearchersOnFirstSample.get())
+            .as("the searcher pool must be emptied too, or every pooled searcher keeps the old graph alive and "
+                + "the release frees nothing")
+            .isZero();
 
         // ...and the rebuild still produces a correct, searchable graph.
         assertThat(index.getGraphIndex()).as("the rebuild must have published a new graph").isNotNull();


### PR DESCRIPTION
Fixes #6503

## What

A from-scratch rebuild of an `LSM_VECTOR` graph keeps the old graph resident so searches keep working, and pays for a whole new build's working set on top of it: the build cache, the JVector builder, the ordinal map. Measured in the issue at 50,000 x 128, that is a peak of **1,700 MB** against **959 MB** for the first build of the same corpus, a factor of **1.73x**. At DEEP-10M in a 24 GB heap the first build completes and a second one on top of it dies.

Raising `-Xmx` did not create the headroom: both auto-sized caches budgeted themselves off *total* heap, so a bigger heap grew them proportionally. And nothing consulted memory before starting - `REBUILD_SEMAPHORE` bounds how many rebuilds run at once, not how much heap one needs - so a rebuild that could not fit was simply attempted, and the resulting `OutOfMemoryError` escaped the handler that would have refused the pages.

## Changes

**1. The close path releases the resident graph and search cache before building the replacement.**
`flush()` has already CAS-ed the index to `UNAVAILABLE` and `close()` has already run `releaseBackgroundResources()` (which clears the pooled searchers), so nothing can still be reading either reference. Holding them for the whole build was pure waste; dropping them first roughly halves peak heap for exactly the case that measurably dies today.

An **online** rebuild keeps both, unchanged. `rebuildGraphBeforeSearch()`, an async rebuild, an explicit `REBUILD INDEX` and `COMPACT INDEX` do not gate concurrent searches on `status`, so for them the old graph is still load-bearing. The two behaviours are pinned against each other by test, not just by comment.

**2. Both caches are budgeted against the heap actually available.**
Availability is read from `MemoryPoolMXBean.getCollectionUsage()` - the pool's occupancy measured right after the JVM last collected it, which approximates live retained data.

Deliberately **not** `Runtime.freeMemory()`, which the issue's sketch suggested: that reports free space in the *currently committed* heap and counts everything allocated since the last collection as used, live or garbage. Read just before a GC it says the heap is nearly full when almost all of it is about to be reclaimed, so a budget taken from it would collapse the build cache for no reason and make the build far slower - the opposite of the problem being solved. When no pool publishes a collection usage (a JVM that has not collected yet, or a GC that does not publish the figure), the budget falls back to the whole ceiling, which reproduces the previous behaviour exactly rather than assuming either extreme.

**3. Admission control on the online rebuild path.**
Before starting, the estimated peak footprint - the graph being built, the build cache, and for an online rebuild the graph being replaced - is compared against `arcadedb.vectorIndex.rebuildMaxHeapPercent` (new, default 90) of the available heap. A rebuild that does not fit is **deferred rather than attempted**: the next mutation-threshold or inactivity trigger retries it, pending vectors stay exactly searchable through the in-memory delta buffer meanwhile, and the deferral is both logged (with what to change) and counted as `rebuildsDeferredForMemory` in the index stats, so an index that never fits does not go stale silently.

The estimate is coarse and the default generous on purpose: it refuses only a rebuild that is confidently too large, not one that merely looks tight. `0` restores the previous attempt-and-hope behaviour.

Only the online path is gated. A first build, a rebuild on close, `REBUILD INDEX` and `COMPACT INDEX` have no later trigger to retry them, and the close case has already released the old graph - declining one of those would turn "slower" into "never".

Note that (2) and (3) compose rather than overlap: free-heap budgeting **is** the degradation the issue asks for under "fall back to a bounded-cache build", since a resident old graph now shrinks the cache the rebuild asks for. (3) declines only when even a degraded build cannot fit, i.e. when the graphs themselves do not fit, which no cache bound can fix.

**4. An `OutOfMemoryError` during the graph persist no longer escapes the handler that refuses the pages.**
It is an `Error`, not an `Exception`, so it walked straight past the `catch (Exception)` around the persist block - skipping both the transaction rollback and the `markUnusable()` call that is the only thing stopping the next database open from trusting a possibly half-rewritten graph on node-count agreement alone (#6106 exists to prevent exactly that). That guard, the async rebuild thread's and the inactivity timer task's now all catch `Throwable`. In the latter two an escaping `Error` additionally killed the thread past the point where it clears the in-progress flag, silently stopping every later rebuild of that index.

## Alternative considered, and why this one

The issue offered to send (1) alone as a PR and explicitly declined to guess at (2) and (3). (1) on its own is the largest single win per line changed, but it only helps the close path - it does nothing for the online rebuild, which is the path #6496 shows a *single insert* into a settled index is enough to schedule, and which is the 1.73x shape in the first place. (4) alone is likewise necessary but not sufficient: it converts a silent corruption risk into a clean failure without making the failure less likely. Shipping all four is what turns "dies, and lies about it afterwards" into "degrades, defers, and says so".

## Tests

- `Issue6503VectorRebuildResidentGraphReleaseTest` - the release happens on the close path, does **not** happen on the online path, and a close with pending mutations still reopens to a correct graph over every vector.
- `Issue6503GraphPersistOutOfMemoryTest` - an `OutOfMemoryError` injected at the persist point still marks the manifest unusable, still rolls back, and leaves the index writable.
- `Issue6503VectorHeapBudgetTest` - the heap arithmetic and the footprint estimate, including that keeping the old graph resident costs exactly one graph generation more.
- `Issue6503RebuildAdmissionControlTest` - defer, admit, disable by configuration, never decline an explicit rebuild, and release the permit and in-progress flag on the deferral path.

Each was verified to fail with its corresponding fix reverted. Full `com.arcadedb.index.vector` package: 250 tests in the default lane, 49 in the `vector` lane, 62 in the `slow` lane, all green apart from `LSMVectorIndexAutoCompactionTest.anAttemptWhoseTaskIsNeverEnqueuedReleasesItsSlot`, which fails identically on a pristine `origin/main` worktree and is unrelated (async-executor compaction slot).