### PR TITLE
fix(#6456): UPDATE ... REMOVE ... RETURN BEFORE returns post-removal snapshot

### DIFF
--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
@@ -774,6 +774,40 @@ public class UpdateStatementExecutionTest extends TestHelper {
   }
 
   @Test
+  void returnBeforeWithNestedListInsideMapRemoveIsNotMutatedByTheRemoval() {
+    // Issue #6456 review follow-up: pin down the recursive branch of the deep copy, not just a top-level
+    // List/Map, by mutating a List nested inside a Map value.
+    final String className = "overridden" + this.className;
+    database.getSchema().createDocumentType(className);
+
+    final MutableDocument doc = database.newDocument(className);
+    final Map<String, Object> nestedMap = new HashMap<>();
+    final List<String> nestedList = new ArrayList<>();
+    nestedList.add("foo");
+    nestedList.add("bar");
+    nestedList.add("baz");
+    nestedMap.put("list", nestedList);
+    doc.set("nestedMap", nestedMap);
+    doc.save();
+
+    final ResultSet result = database.command("sql",
+        "update " + className + " remove nestedMap[\"list\"] = 'bar' RETURN BEFORE");
+    assertThat(result.hasNext()).isTrue();
+    final Result item = result.next();
+    assertThat(item).isNotNull();
+    final Map<String, Object> before = item.getProperty("nestedMap");
+    assertThat((List<String>) before.get("list")).containsExactly("foo", "bar", "baz");
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    final ResultSet persisted = database.query("sql", "SELECT nestedMap FROM " + className);
+    assertThat(persisted.hasNext()).isTrue();
+    final Map<String, Object> after = persisted.next().getProperty("nestedMap");
+    assertThat((List<String>) after.get("list")).containsExactly("foo", "baz");
+    persisted.close();
+  }
+
+  @Test
   void returnBeforeWithMapKeyRemoveIsNotMutatedByTheRemoval() {
     // Issue #6456: same shallow-copy bug for nested `REMOVE map[key]` on the map value.
     final ResultSet result = database.command("sql",

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
@@ -753,6 +753,47 @@ public class UpdateStatementExecutionTest extends TestHelper {
   }
 
   @Test
+  void returnBeforeWithListRemoveIsNotMutatedByTheRemoval() {
+    // Issue #6456: UPDATE ... REMOVE <collection value> ... RETURN BEFORE must snapshot the collection
+    // BEFORE the in-place removal, not share the live list reference with it.
+    final ResultSet result = database.command("sql",
+        "update " + className + " remove tagsList = 'bar' RETURN BEFORE where name = 'name1'");
+    assertThat(result.hasNext()).isTrue();
+    final Result item = result.next();
+    assertThat(item).isNotNull();
+    final List<String> before = item.getProperty("tagsList");
+    assertThat(before).containsExactly("foo", "bar", "baz");
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    final ResultSet persisted = database.query("sql", "SELECT tagsList FROM " + className + " WHERE name = 'name1'");
+    assertThat(persisted.hasNext()).isTrue();
+    final List<String> after = persisted.next().getProperty("tagsList");
+    assertThat(after).containsExactly("foo", "baz");
+    persisted.close();
+  }
+
+  @Test
+  void returnBeforeWithMapKeyRemoveIsNotMutatedByTheRemoval() {
+    // Issue #6456: same shallow-copy bug for nested `REMOVE map[key]` on the map value.
+    final ResultSet result = database.command("sql",
+        "update " + className + " remove tagsMap[\"bar\"] RETURN BEFORE where name = 'name1'");
+    assertThat(result.hasNext()).isTrue();
+    final Result item = result.next();
+    assertThat(item).isNotNull();
+    final Map<String, String> before = item.getProperty("tagsMap");
+    assertThat(before).containsEntry("bar", "bar").hasSize(3);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    final ResultSet persisted = database.query("sql", "SELECT tagsMap FROM " + className + " WHERE name = 'name1'");
+    assertThat(persisted.hasNext()).isTrue();
+    final Map<String, String> after = persisted.next().getProperty("tagsMap");
+    assertThat(after).doesNotContainKey("bar").hasSize(2);
+    persisted.close();
+  }
+
+  @Test
   void localDateTimeUpsertWithIndexMicros() throws Exception {
     database.transaction(() -> {
       if (database.getSchema().existsType("Product"))


### PR DESCRIPTION
Closes #6456

## What does this PR do?

Fixes `UPDATE ... REMOVE <collection/map value> ... RETURN BEFORE`, which returned the **post**-removal snapshot as
the BEFORE image instead of the pre-removal one.

`CopyRecordContentBeforeUpdateStep` built the BEFORE snapshot by copying each property value with a plain
`prevValue.setProperty(propName, result.getProperty(propName))`. For `List`/`Set`/`Map` properties this stores the
same live reference the record holds, not a copy. `UpdateRemoveItem.applyUpdate` then mutates that structure in
place (`MultiValue.remove()` → `Collection.remove(...)`, or a nested `applyRemove` on a map/list element) and marks
the owner dirty so the change persists correctly. Because the BEFORE snapshot shared the same object, the later
in-place removal was visible through it too, so the RETURN BEFORE result showed the record **after** the removal
instead of before it. The persisted record was always correct; only the returned BEFORE projection was wrong.

The fix deep-copies `List`/`Set`/`Map` values (recursively, so nested collections/maps are covered too) when
building the snapshot in `CopyRecordContentBeforeUpdateStep`, so a later in-place mutation of the live property
can no longer leak into the already-returned BEFORE image. Scalars, RIDs, and arrays are left untouched:
`MultiValue.remove()` already replaces an array with a fresh copy rather than mutating it, so arrays never shared
state with the live value in the first place.

## Motivation

Reported in #6456 with a traced root cause and repro. `UPDATE ... REMOVE tags = 'b' RETURN BEFORE` on
`tags = ['a','b','c']` returned BEFORE `{tags:['a','c']}` instead of the expected `{tags:['a','b','c']}`.

## Related issues

Closes #6456

## Additional Notes

- Scope: this only affects `UPDATE ... RETURN BEFORE` whose REMOVE operation mutates an embedded
  `List`/`Set`/`Map` in place (`REMOVE listProp = value`, `REMOVE map[k]`, `REMOVE list[i]`). Scalar `SET` and
  top-level replacement were already unaffected, since those replace the property reference rather than mutating it.
- No behavior change to the persisted record in any case; only the BEFORE projection returned by the statement.

## Test plan

- [x] New regression test `UpdateStatementExecutionTest#returnBeforeWithListRemoveIsNotMutatedByTheRemoval`:
      `UPDATE ... REMOVE tagsList = 'bar' RETURN BEFORE` returns the original 3-element list as BEFORE, while the
      persisted record correctly ends up with 2 elements.
- [x] New regression test `UpdateStatementExecutionTest#returnBeforeWithMapKeyRemoveIsNotMutatedByTheRemoval`:
      `UPDATE ... REMOVE tagsMap["bar"] RETURN BEFORE` returns the original 3-entry map as BEFORE, while the
      persisted record correctly ends up with 2 entries.
- [x] Both new tests fail against pre-fix code (confirmed) and pass after the fix.
- [x] `UpdateStatementExecutionTest` (40 tests) and `UpdateStatementTest` (12 tests) pass.
- [x] `MultiValueTest`, `SQLExecutorLowCoverageTest`, `SQLExecutorAdditionalCoverageTest`,
      `SQLMethodRemoveTest`, `SQLMethodRemoveAllTest` pass (114 tests total), confirming the existing
      copy-on-write remove/removeAll semantics (#4730) are unaffected.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
