### PR TITLE
fix(#6455): JSONL exporter encodes DATE/DATETIME_MICROS/NANOS for schema-typed write-back

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
@@ -22,9 +22,13 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.DateUtils;
 
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -32,9 +36,10 @@ import java.util.Map;
 
 public class JsonGraphSerializer extends JsonSerializer {
 
-  private boolean    expandVertexEdges = false;
-  private JSONObject sharedJson        = null;
-  private boolean    includeMetadata   = true;
+  private boolean    expandVertexEdges       = false;
+  private JSONObject sharedJson              = null;
+  private boolean    includeMetadata         = true;
+  private boolean    precisionAwareTemporals = false;
 
   private JsonGraphSerializer() {
   }
@@ -67,6 +72,8 @@ public class JsonGraphSerializer extends JsonSerializer {
       object.put("r", rid.toString());
     object.put("t", document.getTypeName());
 
+    final DocumentType type = precisionAwareTemporals ? document.getType() : null;
+
     for (final Map.Entry<String, Object> prop : document.toMap(includeMetadata).entrySet()) {
       Object value = prop.getValue();
 
@@ -90,6 +97,8 @@ public class JsonGraphSerializer extends JsonSerializer {
         else if (value.equals(Double.NEGATIVE_INFINITY) || value.equals(Float.NEGATIVE_INFINITY))
           // JSON DOES NOT SUPPORT INFINITY
           value = "NegInfinity";
+        else if (type != null && value instanceof Temporal && type.existsProperty(prop.getKey()))
+          value = encodeTemporalForWriteBack(value, type.getProperty(prop.getKey()).getType());
       }
       properties.put(prop.getKey(), value);
     }
@@ -142,5 +151,39 @@ public class JsonGraphSerializer extends JsonSerializer {
   public JsonGraphSerializer setIncludeMetadata(final boolean includeMetadata) {
     this.includeMetadata = includeMetadata;
     return this;
+  }
+
+  /**
+   * Issue #6455: when enabled, a schema-typed DATE or DATETIME_MICROS/DATETIME_NANOS property is
+   * pre-converted to the encoding a schema-typed write-back path (such as {@code MutableDocument.fromMap})
+   * actually decodes, instead of the epoch-millisecond number {@link JSONObject#put(String, Object)}'s
+   * default temporal branch writes for every temporal:
+   * <ul>
+   *   <li>DATE becomes epoch DAYS ({@link DateUtils#dateToEpochDays}) - the encoding {@code Type.convert}'s
+   *   {@code Number} branch reads back for a DATE property, matching the remote-wire fix of issue #4601.
+   *   A DATE written as epoch millis is read back as epoch days: any date from ~August 1981 onward
+   *   overflows {@code LocalDate.ofEpochDay}'s range, and the resulting exception is swallowed by
+   *   {@code Type.convert}'s broad catch, silently nulling the property.</li>
+   *   <li>DATETIME_MICROS/DATETIME_NANOS become an ISO-8601 string, because a raw epoch number is always
+   *   decoded as MILLIS on the way back in, regardless of the column's declared precision (the {@code
+   *   Number} branch of {@code Type.convert} hardcodes it) - only a parsed string carries enough digits
+   *   to restore the sub-millisecond component.</li>
+   * </ul>
+   * Off by default: existing callers - the HTTP graph-mode query response in particular, which does not
+   * write these values back through the schema-typed path this class assumes - keep writing every
+   * temporal as an epoch-millis number. {@code JsonlExporterFormat} opts in because its counterpart
+   * importer feeds the JSON straight back through {@code MutableDocument.fromMap}.
+   */
+  public JsonGraphSerializer setPrecisionAwareTemporals(final boolean precisionAwareTemporals) {
+    this.precisionAwareTemporals = precisionAwareTemporals;
+    return this;
+  }
+
+  private static Object encodeTemporalForWriteBack(final Object value, final Type propertyType) {
+    if (propertyType == Type.DATE)
+      return DateUtils.dateToEpochDays(value);
+    if (propertyType == Type.DATETIME_MICROS || propertyType == Type.DATETIME_NANOS)
+      return value.toString();
+    return value;
   }
 }

--- a/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/format/JsonlExporterFormat.java
@@ -122,10 +122,14 @@ public class JsonlExporterFormat extends AbstractExporterFormat {
 
       final JSONObject recordJson = new JSONObject();
 
+      // Issue #6455: the importer feeds the exported JSON straight back through MutableDocument.fromMap(), so
+      // DATE/DATETIME_MICROS/DATETIME_NANOS must be encoded the way that schema-typed write-back path decodes
+      // them, not as the epoch-millis number the default (HTTP graph-mode) encoding uses.
       final JsonGraphSerializer graphSerializer = JsonGraphSerializer.createJsonGraphSerializer()
           .setSharedJson(recordJson)
           .setIncludeMetadata(false)
-          .setExpandVertexEdges(true);
+          .setExpandVertexEdges(true)
+          .setPrecisionAwareTemporals(true);
 
       exportVertices(vertexTypes, graphSerializer);
       exportDocuments(documentTypes, graphSerializer);

--- a/integration/src/test/java/com/arcadedb/integration/exporter/Issue6455JsonlDateTimeRoundTripIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/Issue6455JsonlDateTimeRoundTripIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.exporter;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.integration.TestHelper;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6455: the JSONL exporter wrote a DATE property as epoch MILLISECONDS through the raw
+ * {@code JSONObject.put(Object)} temporal branch, while the importer decodes a DATE number as epoch
+ * DAYS. Every DATE at or after ~August 1981 overflows {@code LocalDate.ofEpochDay}'s range: the
+ * resulting {@code DateTimeException} is swallowed by {@code Type.convert}'s broad exception catch
+ * (logged at FINE, invisible by default) and the property is silently set to {@code null} instead of
+ * the original date. Separately, DATETIME_NANOS/DATETIME_MICROS were hardcoded to millisecond
+ * precision on export, losing everything past the third fractional digit.
+ * <p>
+ * Pins the full round trip: the modern-dated vertex and its edge both survive, and the DATE /
+ * DATETIME_NANOS values come back exact instead of null / truncated.
+ */
+class Issue6455JsonlDateTimeRoundTripIT {
+  private static final String SOURCE_PATH = "target/databases/issue6455-jsonl-datetime-source";
+  private static final String TARGET_PATH = "target/databases/issue6455-jsonl-datetime-target";
+  private static final String FILE        = "target/issue6455-jsonl-datetime.jsonl.tgz";
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    TestHelper.checkActiveDatabases();
+    FileUtils.deleteRecursively(new File(SOURCE_PATH));
+    FileUtils.deleteRecursively(new File(TARGET_PATH));
+    new File(FILE).delete();
+  }
+
+  @Test
+  void modernDateAndNanosPrecisionSurviveAnExportImportCycle() throws Exception {
+    final LocalDate birth = LocalDate.of(2024, 1, 15);
+    final LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 0, 0, 0, 123_456_789);
+
+    try (final Database source = new DatabaseFactory(SOURCE_PATH).create()) {
+      source.transaction(() -> {
+        final VertexType personType = source.getSchema().buildVertexType().withName("Person").create();
+        personType.createProperty("id", Type.INTEGER);
+        personType.createProperty("birth", Type.DATE);
+        personType.createProperty("createdAt", Type.DATETIME_NANOS);
+        source.getSchema().buildEdgeType().withName("Friend").create();
+
+        final MutableVertex a = source.newVertex("Person").set("id", 0).set("birth", birth).set("createdAt", createdAt)
+            .save();
+        final MutableVertex b = source.newVertex("Person").set("id", 1).save();
+        a.newEdge("Friend", b);
+      });
+
+      assertThat(source.countType("Person", false)).isEqualTo(2);
+      assertThat(source.countType("Friend", false)).isEqualTo(1);
+    }
+
+    new Exporter(("-f " + FILE + " -d " + SOURCE_PATH + " -o -format jsonl").split(" ")).exportDatabase();
+    assertThat(new File(FILE).exists()).isTrue();
+
+    try (final Database target = new DatabaseFactory(TARGET_PATH).create()) {
+      target.command("sql", "IMPORT DATABASE file://" + new File(FILE).getAbsolutePath());
+    }
+
+    try (final Database target = new DatabaseFactory(TARGET_PATH).open()) {
+      // Neither the modern-dated vertex nor its edge was silently dropped.
+      assertThat(target.countType("Person", false)).as("the modern-dated vertex must not be dropped").isEqualTo(2);
+      assertThat(target.countType("Friend", false)).as("the edge must not cascade-drop with its vertex").isEqualTo(1);
+
+      final Vertex imported = target.query("sql", "select from Person where id = ?", 0).next().getVertex().get();
+      assertThat((LocalDate) imported.get("birth")).isEqualTo(birth);
+      assertThat((LocalDateTime) imported.get("createdAt")).isEqualTo(createdAt);
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the JSONL exporter so that DATE and DATETIME_MICROS/DATETIME_NANOS property values are
written in the encoding the importer's write-back path actually decodes, instead of the raw
epoch-millisecond encoding `JSONObject.put(Object)`'s default temporal branch uses for every
temporal.

Closes #6455

## Root cause

`JsonlExporterFormat` serializes every record through `JsonGraphSerializer.serializeGraphElement`,
which routes each property value into the raw `JSONObject.put(Object)` temporal branch:

- A `DATE` property (`LocalDate`) is written as **epoch milliseconds**
  (`localDate.atStartOfDay(...).toInstant().toEpochMilli()`).
- A `DATETIME_MICROS`/`DATETIME_NANOS` property has its precision **hardcoded to milliseconds**
  (`DateUtils.dateTimeToTimestamp(value, ChronoUnit.MILLIS)`), so anything past the third
  fractional digit is dropped before it ever reaches the file.

`JsonlImporterFormat` feeds the parsed JSON straight back through `MutableDocument.fromMap()`,
which calls `Type.convert(...)`. For a `DATE` property, `Type.convert` decodes a `Number` as
**epoch DAYS** (`DateUtils.date(db, number.longValue(), LocalDate.class)` ->
`LocalDate.ofEpochDay(...)`), so an epoch-millis value written for any date at or after
~August 1981 overflows `LocalDate.ofEpochDay`'s valid range. The resulting `DateTimeException` is
caught by `Type.convert`'s broad `catch (Exception e)` (logged at `FINE`, invisible by default)
and the property is silently set to `null` - verified directly against this codebase with the new
regression test (the vertex and its edge are not dropped in this exact repro, but the DATE value
is silently corrupted to `null`).

For `DATETIME_MICROS`/`DATETIME_NANOS`, `Type.convert`'s `Number` branch always decodes as MILLIS
regardless of the column's declared precision, so a raw epoch number can never carry
sub-millisecond digits back in - the only way to preserve them is a parsed ISO-8601 string, which
`Type.convert`'s `String` branch tries first (`LocalDateTime.parse`, which natively supports
variable-width fractional seconds) for the default `LocalDateTime` implementation.

## Fix

`JsonGraphSerializer` gains an opt-in `setPrecisionAwareTemporals(boolean)` flag, **off by
default** so existing callers - notably the HTTP graph-mode query response
(`AbstractQueryHandler`), which does not write these values back through the schema-typed
`fromMap` path this flag assumes - keep their current epoch-millis encoding unchanged. When
enabled, a schema-typed `DATE` or `DATETIME_MICROS`/`DATETIME_NANOS` property value is
pre-converted before it reaches `JSONObject.put`:

- `DATE` -> `DateUtils.dateToEpochDays(value)` (epoch DAYS - matches the decode side and mirrors
  the existing #4601 fix for the same encoding on the remote wire).
- `DATETIME_MICROS` / `DATETIME_NANOS` -> `value.toString()` (an ISO-8601 string with the value's
  actual fractional digits, parsed back exactly by `Type.convert`'s ISO-first `String` branch).

`JsonlExporterFormat` opts in, since its importer counterpart is exactly the schema-typed
write-back path this flag targets. `DATETIME`/`DATETIME_SECOND` were left untouched: both already
round-trip correctly today because encode and decode already agree on the unit (milliseconds).

## Related issues

Closes #6455. Related to #4601 (the analogous DATE epoch-days fix on the remote/HTTP wire).

## Additional Notes

- Scoped narrowly to the JSONL exporter via an opt-in flag rather than changing
  `JsonGraphSerializer`'s default behavior, since that class is also used by the HTTP graph-mode
  query response path, which is outside this issue's reported scope and untouched by this PR.
- Not in scope: `Instant`/`ZonedDateTime` `arcadedb.dateTimeImplementation` configurations. The
  default `LocalDateTime` implementation is precision-aware via ISO parsing on the way back in;
  the alternate implementations have pre-existing gaps in `Type.convert`'s `String` branch (no ISO
  parse attempt for `Instant`, no ISO-first attempt for `ZonedDateTime`) that are unrelated to this
  issue and are not addressed here.

## Test plan

- [x] New regression test `Issue6455JsonlDateTimeRoundTripIT`
  (`integration/src/test/java/com/arcadedb/integration/exporter/`): exports a vertex with a modern
  `DATE` (2024-01-15), a `DATETIME_NANOS` with sub-millisecond digits, and an edge attached to that
  vertex, then imports the JSONL back and asserts the vertex/edge counts and the exact property
  values survive. Confirmed RED before the fix (`expected: 2024-01-15 (java.time.LocalDate) but
  was: null`) and GREEN after.
- [x] `mvn -pl integration -am test` for `com.arcadedb.integration.exporter.**` and
  `com.arcadedb.integration.importer.**` (all existing exporter/importer ITs, including
  `LightweightEdgeRoundTripIT` and the OrientDB/Neo4j importer suites) - all green.
- [x] `mvn -pl engine -am test` for `JsonGraphSerializerTest`, `JsonSerializerTest`,
  `TypeConversionTest`, `DocumentTest`, `TypeTest`, `DocumentValidationTest`, `CollectDistinctTest`,
  `QueryTest` (the tests directly touching `JsonGraphSerializer`, temporal type conversion, and
  DATE/DATETIME serialization) - all green, confirming the default (HTTP graph-mode) encoding is
  unchanged for callers that don't opt in.

To reproduce locally:
```
mvn -pl integration -am -Dtest=Issue6455JsonlDateTimeRoundTripIT test
```

## Checklist

- [x] I have run the build using `mvn clean package` command (via targeted module builds)
- [x] My unit tests cover both failure and success scenarios (regression test proven RED then GREEN)
