### PR TITLE
fix(#6450): reject a concluding CALL ... YIELD with no consuming clause

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -93,6 +93,7 @@ public class CypherSemanticValidator {
     v.validateExpressionAliases(statement);
     v.validateReturnStar(statement);
     v.validateFunctionArgumentTypes(statement);
+    v.validateCallYieldConclusion(statement);
     v.validateNestedStatements(statement);
   }
 
@@ -2096,6 +2097,44 @@ public class CypherSemanticValidator {
     }
   }
 
+  // ================================================
+  // Phase 10b: CALL ... YIELD Conclusion Validation
+  // ================================================
+
+  /**
+   * Rejects a {@code CALL ... YIELD} that concludes the statement (or a subquery body, since this also runs through
+   * {@link #validateBodyPhases}) without a {@code RETURN} or some other clause consuming the yielded columns -
+   * mirroring Neo4j's {@code "Query cannot conclude with CALL together with YIELD"} compile-time error.
+   * <p>
+   * A <b>standalone</b> {@code CALL ... YIELD} - the statement's only clause - is deliberately exempt: it owns its
+   * own projection (issue #6446/#6448, {@code CypherExecutionPlan}'s {@code bareCallOwnsProjection}) and needs no
+   * trailing {@code RETURN}, exactly as real Neo4j allows {@code CALL db.labels() YIELD label} to stand alone. What
+   * this rejects is the narrower gap #6448 left open on purpose: a {@code CALL ... YIELD} chained after (or before)
+   * other clauses, that is still the LAST clause of the statement, with nothing left to project its yielded
+   * columns. Before this check, {@code CypherExecutionPlan.execute()}'s write branch silently treated "no RETURN"
+   * as "side effects only" for that shape too, so {@code WITH 1 AS x CALL math.add(x, 1) YIELD value} parsed fine
+   * and quietly returned zero rows - a worse failure mode than an error, since the shape looks like it should
+   * produce rows. A {@code CALL} with no {@code YIELD} at all chained the same way is untouched: that is the
+   * ordinary "side effects only" terminal write clause, and Neo4j accepts it without a trailing {@code RETURN}.
+   */
+  private static void validateCallYieldConclusion(final CypherStatement statement) {
+    final List<ClauseEntry> clauses = statement.getClausesInOrder();
+    // A CALL that is the statement's only clause is the standalone/bare-CALL exception - not this check's business.
+    if (clauses == null || clauses.size() < 2)
+      return;
+
+    final ClauseEntry last = clauses.get(clauses.size() - 1);
+    if (last.getType() != ClauseEntry.ClauseType.CALL)
+      return;
+
+    final CallClause callClause = last.getTypedClause();
+    if (callClause.hasYield())
+      throw new CommandParsingException(
+          "QueryCannotConcludeWithCallYield: Query cannot conclude with CALL together with YIELD - add a RETURN "
+              + "(or another clause that consumes the yielded columns), or drop the YIELD to call it as a "
+              + "side-effect-only statement");
+  }
+
   // ==================================================
   // Phase 11: Every phase above, applied to each body
   // ==================================================
@@ -2172,6 +2211,7 @@ public class CypherSemanticValidator {
     validateColumnNames(body);
     validateExpressionAliases(body);
     validateReturnStar(body);
+    validateCallYieldConclusion(body);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherUnionCallProfileTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for UNION, CALL, and PROFILE features.
@@ -405,6 +407,86 @@ class OpenCypherUnionCallProfileTest {
     final ResultSet check = database.query("opencypher", "MATCH (n:NoReturnNode) RETURN n.name AS name");
     assertThat(check.hasNext()).isTrue();
     assertThat((Object) check.next().getProperty("name")).isEqualTo("x");
+  }
+
+  // ============================================================
+  // Issue #6450: CALL ... YIELD that concludes the statement (not
+  // standalone, no trailing RETURN/consuming clause) must be a
+  // compile-time error, matching Neo4j's "Query cannot conclude
+  // with CALL together with YIELD", instead of silently returning
+  // zero rows.
+  // ============================================================
+
+  @Test
+  void callYieldConcludingAWriteClassifiedStatementIsRejected() {
+    // Exact repro from the issue: math.add is a custom DEFINE FUNCTION, so it is write-classified
+    // per #6418's conservative classification. Before the fix this parsed fine and silently
+    // returned zero rows instead of erroring like Neo4j does.
+    database.command("sql", "DEFINE FUNCTION math.add \"SELECT :a + :b AS result\" PARAMETERS [a,b] LANGUAGE sql");
+
+    assertThatThrownBy(() -> database.command("opencypher", "WITH 1 AS x CALL math.add(x, 1) YIELD value"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("Query cannot conclude with CALL together with YIELD");
+  }
+
+  @Test
+  void callYieldConcludingAReadClassifiedStatementIsRejected() {
+    // Same shape, but the CALL target is a registered read-only procedure: the rule is about clause
+    // composition, not the write/read classification, so this must be rejected too.
+    assertThatThrownBy(() -> database.command("opencypher", "WITH 1 AS x CALL db.labels() YIELD label"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("Query cannot conclude with CALL together with YIELD");
+  }
+
+  @Test
+  void callYieldConcludingAfterMatchIsRejected() {
+    database.getSchema().createVertexType("CallYieldConclude");
+    database.command("opencypher", "CREATE (n:CallYieldConclude {name: 'a'})");
+
+    assertThatThrownBy(() -> database.command("opencypher",
+        "MATCH (n:CallYieldConclude) WITH n CALL db.labels() YIELD label"))
+        .isInstanceOf(CommandParsingException.class)
+        .hasMessageContaining("Query cannot conclude with CALL together with YIELD");
+  }
+
+  @Test
+  void callYieldFollowedByReturnIsStillAccepted() {
+    // The existing, already-working shape: CALL ... YIELD followed by RETURN must keep working
+    // exactly as before - this check must not reject a query that already has its consuming clause.
+    final ResultSet result = database.command("opencypher", "WITH 1 AS x CALL db.labels() YIELD label RETURN label");
+    // No rows expected (empty database), but the statement itself must parse and execute without error.
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  void callYieldFollowedByWithThenReturnIsStillAccepted() {
+    // CALL ... YIELD followed by WITH (which consumes the yielded column) and eventually a RETURN
+    // must still be accepted: the YIELD is not the statement's final clause here.
+    final ResultSet result = database.command("opencypher", "CALL db.labels() YIELD label WITH label RETURN label");
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  void bareCallYieldAsTheSoleClauseIsStillAccepted() {
+    // The standalone-CALL exception (issue #6446/#6448) must be untouched by this check: a CALL ...
+    // YIELD that is the statement's ONLY clause owns its own projection and needs no RETURN.
+    database.command("sql", "DEFINE FUNCTION math.add \"SELECT :a + :b AS result\" PARAMETERS [a,b] LANGUAGE sql");
+
+    final ResultSet result = database.command("opencypher", "CALL math.add(3, 5) YIELD value");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(((Number) result.next().getProperty("value")).intValue()).isEqualTo(8);
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  void callWithNoYieldChainedAfterWithIsStillAccepted() {
+    // A CALL with no YIELD at all, chained after another clause, is a legal side-effect-only
+    // terminal statement in Neo4j (existing "no RETURN -> side effects only" behavior) and must
+    // not be caught by this YIELD-specific check.
+    database.command("sql", "DEFINE FUNCTION math.add \"SELECT :a + :b AS result\" PARAMETERS [a,b] LANGUAGE sql");
+
+    final ResultSet result = database.command("opencypher", "WITH 1 AS x CALL math.add(x, 1)");
+    assertThat(result.hasNext()).isFalse();
   }
 
   // ============================================================


### PR DESCRIPTION
Closes #6450

## What does this PR do?

A `CALL ... YIELD` that is not the sole clause of an openCypher statement, and is not followed by a `RETURN` (or any other clause consuming its yielded columns), used to parse successfully and silently return **zero rows**:

```cypher
WITH 1 AS x CALL math.add(x, 1) YIELD value
```

`CypherSemanticValidator` now rejects that shape at parse time with a `CommandParsingException`, mirroring Neo4j's `"Query cannot conclude with CALL together with YIELD"` compile-time error, instead of silently swallowing the output.

## Motivation

Spun out of code review on #6448 (fix for #6446 item 1). Root cause: `CypherExecutionPlan.execute()`'s write branch treats "no RETURN clause" as "side effects only" for any write-classified statement, which is correct for `CREATE`/`SET`/`DELETE`/`MERGE`/`REMOVE` and for a genuinely bare/standalone `CALL` (the sole clause of the statement, `#6446`/`#6448`'s own exception), but wrong for a `CALL ... YIELD` that is chained after or before other clauses: its yielded columns are dropped with no diagnostic, which is a worse failure mode than an error since the query text looks like it should produce rows.

The fix adds a new semantic-validation phase (`validateCallYieldConclusion`) rather than widening the executor's exception - the error needs to surface before any side effect runs, not after.

**Scope deliberately preserved:**
- A standalone `CALL ... YIELD` (the statement's only clause) still owns its own projection and needs no trailing `RETURN` - `#6446`/`#6448`'s fix is untouched.
- A `CALL` with **no** `YIELD` at all, chained after other clauses, is still the ordinary, legal side-effect-only terminal write clause and is not rejected - it's the `YIELD` that has to go somewhere, not the `CALL`.
- The check also runs against subquery bodies (`CALL { ... }`), through the existing `validateBodyPhases` walk that closes the same class of gap for the other structural checks (issue #5656).

## Related issues

- Closes #6450
- Related to #6446 / #6448 (bare-CALL output swallowing, the narrower sibling bug this PR was deliberately scoped out of)

## Test plan

- [x] `bin/` n/a - engine-level change
- [x] New tests in `OpenCypherUnionCallProfileTest`:
  - `callYieldConcludingAWriteClassifiedStatementIsRejected` - exact repro from the issue (write-classified custom function)
  - `callYieldConcludingAReadClassifiedStatementIsRejected` - same shape with a registered read-only procedure (`db.labels()`), confirming the rule is about clause composition, not write/read classification
  - `callYieldConcludingAfterMatchIsRejected` - `MATCH ... WITH ... CALL ... YIELD` with no trailing `RETURN`
  - `callYieldFollowedByReturnIsStillAccepted` / `callYieldFollowedByWithThenReturnIsStillAccepted` - already-working shapes must keep working
  - `bareCallYieldAsTheSoleClauseIsStillAccepted` - the standalone-CALL exception from #6446/#6448 must be untouched
  - `callWithNoYieldChainedAfterWithIsStillAccepted` - a `CALL` with no `YIELD` chained after `WITH` must still return empty (side effects only), not error
- [x] Full `com.arcadedb.query.opencypher.**` package (including the openCypher TCK suite) run green with the change, confirming no regressions across the existing CALL/YIELD/subquery test surface
- [x] Manually confirmed the exact issue repro now throws `CommandParsingException: QueryCannotConcludeWithCallYield: Query cannot conclude with CALL together with YIELD ...` instead of silently returning zero rows

## Additional Notes

Scanned the rest of the repo (bolt, server, engine `algo.*` procedure tests, graph/olap analytics tests) for any other test relying on the old silent-empty behavior for a concluding `CALL ... YIELD`; found none - every other `CALL ... YIELD` usage in the test suite is either standalone or already followed by a consuming clause.

## Checklist

- [x] I have run the build using `mvn clean package` command (`mvn test -pl engine -am` for the affected module, plus the full `opencypher` package suite)
- [x] My unit tests cover both failure and success scenarios
