### PR TITLE
fix(#6444): checkpoint CSR-adjacency budget on entries-seen, not just node count

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AbstractAlgoProcedure.java
@@ -265,6 +265,25 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
    */
   protected static final long MATRIX_ROW_OVERHEAD_BYTES = 32L;
 
+  /**
+   * Entry-count checkpoint interval for the CSR-adjacency fallback branch of {@link GraphData#adjacency}, taken
+   * when a {@link com.arcadedb.graph.GraphTraversalProvider} has no {@link com.arcadedb.graph.NeighborView} to
+   * size the copy from up front.
+   * <p>
+   * That branch used to checkpoint the budget every 1024 <em>nodes</em>, a count with no relationship to how much
+   * heap those nodes actually cost: a single supernode's neighbour list is fully materialised by one
+   * {@code getNeighborIds()} call, so a node-count interval left the budget unable to refuse it until up to 1023
+   * more (possibly tiny) rows had also been expanded. Checkpointing on entries-seen-so-far as well closes that -
+   * the supernode's own row already crosses this threshold, so the very next checkpoint (right after that one
+   * row) has a chance to refuse the call, rather than the one up to 1023 nodes later (issue #6444, following up
+   * on the #6417 code review that first named this gap).
+   * <p>
+   * 1 Mi entries is 4 MB of {@code int[]} at {@link #INT_BYTES} each - generous enough that an ordinary,
+   * moderate-degree graph still checkpoints on the node-count interval as before, while capping how much of a
+   * single oversized row's cost can go unpriced past the previous checkpoint.
+   */
+  protected static final long ADJACENCY_CHECKPOINT_ENTRIES = 1_048_576L;
+
   /** Heap cost of one {@code boolean} array element, which the JVM stores as a byte. */
   protected static final long BOOLEAN_BYTES = 1L;
 
@@ -706,20 +725,21 @@ public abstract class AbstractAlgoProcedure implements CypherProcedure {
           }
           return adj;
         }
-        // No view to size the copy from, so the rows are priced as they arrive, 1024 nodes at a time. That
-        // interval is a node count, not a byte count: a single supernode's neighbour list is fully materialised
-        // by getNeighborIds() before the next checkpoint has a chance to refuse it, unlike the NeighborView
-        // branch above and the OLTP buildAdjacencyList below, both of which know the exact entry count before
-        // allocating a single row. Narrow in practice - it takes one enormous row rather than many average ones
-        // to matter - and left as a known limitation rather than checkpointed per-row, which would cost a
-        // reservation call per node on every CSR-backed call that lacks a NeighborView (code review, issue #6317).
+        // No view to size the copy from, so the rows are priced as they arrive. Unlike the NeighborView branch
+        // above and the OLTP buildAdjacencyList below - both of which know the exact entry count before
+        // allocating a single row - this loop cannot know a row's size before calling getNeighborIds(), so that
+        // one call is unavoidably unpriced. What is avoidable is how long a checkpoint can then be postponed:
+        // checkpointing on entries-seen-so-far as well as on the node-count interval means a single oversized
+        // row (a supernode) crosses ADJACENCY_CHECKPOINT_ENTRIES by itself and gets checkpointed - and can be
+        // refused - right after that one row, rather than only after another 1023 nodes reach the next
+        // node-count boundary (issue #6444, following up on the #6317 code review that first named this gap).
         reserveAdjacency(nodeCount, 0);
         final int[][] adj = new int[nodeCount][];
         long entries = 0;
         for (int i = 0; i < nodeCount; i++) {
           adj[i] = provider.getNeighborIds(i, dir, relTypes);
           entries += adj[i].length;
-          if ((i & 1023) == 1023) {
+          if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
             reserveAdjacency(0, entries);
             entries = 0;
           }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6444AlgoAdjacencyEntryCheckpointTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/Issue6444AlgoAdjacencyEntryCheckpointTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6444 (follow-up from #6417/#6317): {@code AbstractAlgoProcedure.GraphData.adjacency()}'s CSR fallback
+ * branch - taken when a {@link GraphTraversalProvider} has no {@link com.arcadedb.graph.NeighborView} to size the
+ * copy from - used to checkpoint the budget every 1024 <em>nodes</em>. A single supernode's neighbour list is
+ * fully materialised by {@code getNeighborIds()} in one call, so a node-count interval gives the budget no chance
+ * to refuse the call until up to 1023 more nodes have also been expanded, even though the supernode alone already
+ * blew the budget.
+ * <p>
+ * The fix checkpoints on entries-seen-so-far as well as nodes-seen-so-far, so a single oversized row is priced
+ * (and can be refused) the moment it lands, rather than only after the next node-count boundary.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6444AlgoAdjacencyEntryCheckpointTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/test-issue-6444-adjacency-entry-checkpoint");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void teardown() {
+    if (database != null) {
+      database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY,
+          GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY.getDefValue());
+      GraphTraversalProviderRegistry.clearAll(database);
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void aSupernodeRowIsCheckpointedRightAwayRatherThanAfter1024Nodes() {
+    // 5000 nodes so the old 1024-node interval has room to fire at least once before the loop ends, node 0 is a
+    // supernode whose row alone costs far more than the budget, and every other node is empty - so an entries-
+    // based checkpoint refuses right after node 0, while a nodes-based one only refuses at node 1023.
+    final int nodeCount = 5000;
+    final int supernodeDegree = 2_000_000;
+    final SupernodeProvider provider = new SupernodeProvider(nodeCount, supernodeDegree);
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    // Admits the upfront row-header reservation (5000 * 32 = 160,000 bytes) but not the supernode row on top of
+    // it (2,000,000 entries * 4 bytes = 8,000,000 bytes).
+    database.getConfiguration().setValue(GlobalConfiguration.CYPHER_ALGO_MAX_WORKING_MEMORY, 500_000L);
+
+    assertThatThrownBy(() -> drain("CALL algo.wcc() YIELD node, componentId RETURN node"))
+        .as("the supernode row alone must be enough to refuse the call")
+        .hasStackTraceContaining("the adjacency list would need");
+
+    assertThat(provider.calls.get())
+        .as("a checkpoint keyed on entries-seen-so-far refuses right after the oversized row, "
+            + "not after another 1023 nodes were expanded to reach the next node-count boundary")
+        .isLessThan(10);
+  }
+
+  @Test
+  void aBudgetThatFitsTheSupernodeLetsTheCallThrough() {
+    // The counterweight: a budget generous enough for the supernode must not be refused by the new checkpoint.
+    final int nodeCount = 50;
+    final int supernodeDegree = 100;
+    final SupernodeProvider provider = new SupernodeProvider(nodeCount, supernodeDegree);
+    GraphTraversalProviderRegistry.register(database, provider);
+
+    assertThat(drain("CALL algo.wcc() YIELD node, componentId RETURN node")).hasSize(nodeCount);
+    assertThat(provider.calls.get()).isEqualTo(nodeCount);
+  }
+
+  private java.util.List<Object> drain(final String query) {
+    final java.util.List<Object> rows = new java.util.ArrayList<>();
+    try (final ResultSet resultSet = database.query("opencypher", query)) {
+      while (resultSet.hasNext())
+        rows.add(resultSet.next());
+    }
+    return rows;
+  }
+
+  /**
+   * A minimal {@link GraphTraversalProvider} test double: no {@link com.arcadedb.graph.NeighborView}
+   * (so {@code adjacency()} takes the fallback branch under test), node 0 returns an oversized neighbour
+   * array and every other node returns an empty one.
+   */
+  private static final class SupernodeProvider implements GraphTraversalProvider {
+    private final int nodeCount;
+    private final int supernodeDegree;
+    final AtomicInteger calls = new AtomicInteger();
+
+    SupernodeProvider(final int nodeCount, final int supernodeDegree) {
+      this.nodeCount = nodeCount;
+      this.supernodeDegree = supernodeDegree;
+    }
+
+    @Override
+    public int getNodeCount() {
+      return nodeCount;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "test-supernode-provider";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return new RID(0, nodeId);
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      calls.incrementAndGet();
+      return new int[nodeId == 0 ? supernodeDegree : 0];
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return nodeId == 0 ? supernodeDegree : 0;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Closes #6444

## Summary

`AbstractAlgoProcedure.GraphData.adjacency()`'s CSR fallback branch (taken when a `GraphTraversalProvider` has no `NeighborView` to size the copy from up front) checkpointed the `arcadedb.cypher.algoMaxWorkingMemory` budget every 1024 *nodes*. A single supernode's neighbour list is fully materialised by one `getNeighborIds()` call, so the node-count interval left the budget unable to refuse the call until up to 1023 more (possibly tiny) rows had also been expanded, even though the supernode alone had already blown the budget. This was called out as a narrow, non-blocking edge case in the #6417 code review and filed as a follow-up in #6444.

**Note on scope:** #6444 bundled two additional release-notes-only follow-ups from the same review (a `labels()` sentinel-type upgrade note and an `algoMaxWorkingMemory` scope-widening note). Both are documentation-only and, per the issue text, were already applied in `arcadedb-docs` (`reference/cypher/cypher-expressions.adoc` and `reference/graph-algorithms/notes.adoc` / `reference/settings.adoc`). There is no release-notes file in this repo to update, so this PR addresses only the code fix (item 1, the budget-checkpoint granularity gap).

## Root cause

```java
reserveAdjacency(nodeCount, 0);
final int[][] adj = new int[nodeCount][];
long entries = 0;
for (int i = 0; i < nodeCount; i++) {
  adj[i] = provider.getNeighborIds(i, dir, relTypes);
  entries += adj[i].length;
  if ((i & 1023) == 1023) {
    reserveAdjacency(0, entries);
    entries = 0;
  }
}
reserveAdjacency(0, entries);
```

The checkpoint fired purely on node count. A graph with node 0 as a supernode and thousands of otherwise-small nodes would materialise node 0's entire oversized row, then keep calling `getNeighborIds()` for up to 1023 more nodes before the first `reserveAdjacency` call had a chance to refuse the call.

## Fix

Checkpoint on entries-seen-so-far as well as on the node-count interval:

```java
if (entries >= ADJACENCY_CHECKPOINT_ENTRIES || (i & 1023) == 1023) {
  reserveAdjacency(0, entries);
  entries = 0;
}
```

`ADJACENCY_CHECKPOINT_ENTRIES` is `1_048_576` (1 Mi entries, 4 MB of `int[]`), generous enough that an ordinary, moderate-degree graph still checkpoints on the node-count interval exactly as before, while a single oversized row now crosses the threshold by itself and is checkpointed - and can be refused - right after that one row, instead of after up to 1023 more nodes.

The single `getNeighborIds()` call materialising the oversized row itself is unavoidable (this branch exists precisely because the provider cannot report a row's size before returning it), but the fix bounds how much *further* unpriced allocation can happen after that row before the budget gets a chance to react.

## Test plan

- [x] New regression test `Issue6444AlgoAdjacencyEntryCheckpointTest`:
  - `aSupernodeRowIsCheckpointedRightAwayRatherThanAfter1024Nodes` registers a test `GraphTraversalProvider` (5000 nodes, node 0 returns a 2,000,000-entry row, every other node returns an empty one, no `NeighborView`) with a budget that admits the row-header reservation but not the supernode row. Asserts the call is refused **and** that `getNeighborIds()` was called only once or twice, confirming the checkpoint fires right after the supernode row rather than after 1024 nodes have been expanded. Written first against the unfixed code: it failed with `getNeighborIds()` called exactly 1024 times before refusal, confirming the reproduction.
  - `aBudgetThatFitsTheSupernodeLetsTheCallThrough` is the counterweight: a budget generous enough for a small supernode must not be refused, and the call must complete normally.
- [x] `mvn -pl engine -am test -Dtest=Issue6444AlgoAdjacencyEntryCheckpointTest` - both tests pass against the fix.
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.query.opencypher.procedures.algo.*Test'` - 494 tests, 1 pre-existing failure unrelated to this change (`Issue6302AlgoGraphDrivenWorkGuardTest.apspObservesTheDeadlineInsideTheTripleLoop`, a `COMMAND_TIMEOUT`-based timing test on the OLTP Floyd-Warshall path, which does not touch the CSR-provider code changed here); it passed in isolation, consistent with timing flakiness under concurrent build load rather than a regression from this change.

## Impact

No behavior change for the common case (graphs without a single node whose adjacency row exceeds 1 Mi entries): the node-count checkpoint still fires exactly as before. For a graph with a supernode row larger than that, a call now gets checkpointed (and can be refused, or can continue) right after the supernode's own row instead of only after up to 1023 additional rows - reducing the worst-case unpriced-allocation window, not changing whether an in-budget call succeeds.
