### PR TITLE
fix(#6517): deep-copy embedded Document values in UPDATE ... RETURN BEFORE snapshot

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CopyRecordContentBeforeUpdateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CopyRecordContentBeforeUpdateStep.java
@@ -1,4 +1,21 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
@@ -22,7 +39,7 @@ import static com.arcadedb.schema.Property.TYPE_PROPERTY;
  * <p>This is mainly used from statements that need to copy of the original data before modifying it,
  * eg. UPDATE ... RETURN BEFORE</p>
  *
- * @author Luigi Dell Aquila (luigi.dellaquila-(at)-gmail.com)
+ * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
  */
 public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
 
@@ -75,10 +92,12 @@ public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
   }
 
   /**
-   * Returns a deep copy of {@code value} when it is a {@link List}/{@link Set}/{@link Map} or
-   * {@link Document}/{@link com.arcadedb.database.EmbeddedDocument} (or nests them), so a later in-place
-   * mutation of the live property (e.g. {@code REMOVE coll = val} / {@code REMOVE map[k]} / {@code REMOVE emb.field})
-   * cannot leak into this snapshot (issues #6456, #6517). Scalars, RIDs, and arrays are returned unchanged.
+   * Returns a deep copy of {@code value} when it is a {@link List}/{@link Set}/{@link Map}, an embedded
+   * {@link Document}/{@link com.arcadedb.database.EmbeddedDocument}, or any nesting of them, so a later in-place
+   * mutation of the live property (e.g. {@code REMOVE coll = val}, {@code REMOVE map[k]}, {@code REMOVE emb.field})
+   * cannot leak into this BEFORE snapshot (issues #6456 and #6517). Scalars, RIDs, and arrays are returned unchanged:
+   * {@code MultiValue.remove()} already replaces arrays with a fresh copy rather than mutating them, so they never
+   * share state with the live value.
    */
   private static Object deepCopyMultiValue(final Object value) {
     if (value instanceof Map<?, ?> map) {
@@ -100,8 +119,9 @@ public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
       return copy;
     }
     if (value instanceof Document document) {
-      // Deep-copy the embedded document via toMap + recursive deep copy so a later in-place field removal
-      // (e.g. REMOVE emb.field) cannot leak into the BEFORE snapshot (issue #6517)
+      // Issue #6517: an embedded Document is shared (not copied) by the BEFORE snapshot, and REMOVE emb.field
+      // mutates it in place via MutableDocument.modify(). Snapshot via toMap() + recursive deep copy so the
+      // BEFORE image keeps the pre-removal state.
       final Map<String, Object> map = document.toMap(false);
       final Map<String, Object> copy = new LinkedHashMap<>(map.size());
       for (final Map.Entry<String, Object> entry : map.entrySet())

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CopyRecordContentBeforeUpdateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CopyRecordContentBeforeUpdateStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
+import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
@@ -92,12 +93,15 @@ public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
   }
 
   /**
-   * Returns a deep copy of {@code value} when it is a {@link List}/{@link Set}/{@link Map}, an embedded
-   * {@link Document}/{@link com.arcadedb.database.EmbeddedDocument}, or any nesting of them, so a later in-place
-   * mutation of the live property (e.g. {@code REMOVE coll = val}, {@code REMOVE map[k]}, {@code REMOVE emb.field})
-   * cannot leak into this BEFORE snapshot (issues #6456 and #6517). Scalars, RIDs, and arrays are returned unchanged:
-   * {@code MultiValue.remove()} already replaces arrays with a fresh copy rather than mutating them, so they never
-   * share state with the live value.
+   * Returns a deep copy of {@code value} when it is a {@link List}/{@link Set}/{@link Map}, an
+   * {@link EmbeddedDocument}, or any nesting of them, so a later in-place mutation of the live property (e.g.
+   * {@code REMOVE coll = val}, {@code REMOVE map[k]}, {@code REMOVE emb.field}) cannot leak into this BEFORE
+   * snapshot (issues #6456 and #6517). Scalars, RIDs, and arrays are returned unchanged: {@code MultiValue.remove()}
+   * already replaces arrays with a fresh copy rather than mutating them, so they never share state with the live
+   * value. Deliberately checks {@link EmbeddedDocument} rather than the broader {@link Document}: a top-level
+   * {@code Vertex}/{@code Edge} is never itself a property value (graph references are stored by RID), but should
+   * one turn up here it must be returned as-is rather than flattened into a plain {@link Map}, which would strip
+   * its identity and type.
    */
   private static Object deepCopyMultiValue(final Object value) {
     if (value instanceof Map<?, ?> map) {
@@ -118,8 +122,8 @@ public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
         copy.add(deepCopyMultiValue(o));
       return copy;
     }
-    if (value instanceof Document document) {
-      // Issue #6517: an embedded Document is shared (not copied) by the BEFORE snapshot, and REMOVE emb.field
+    if (value instanceof EmbeddedDocument document) {
+      // Issue #6517: an embedded document is shared (not copied) by the BEFORE snapshot, and REMOVE emb.field
       // mutates it in place via MutableDocument.modify(). Snapshot via toMap() + recursive deep copy so the
       // BEFORE image keeps the pre-removal state.
       final Map<String, Object> map = document.toMap(false);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CopyRecordContentBeforeUpdateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CopyRecordContentBeforeUpdateStep.java
@@ -1,27 +1,17 @@
-/*
- * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
- * SPDX-License-Identifier: Apache-2.0
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
 import static com.arcadedb.schema.Property.TYPE_PROPERTY;
@@ -32,7 +22,7 @@ import static com.arcadedb.schema.Property.TYPE_PROPERTY;
  * <p>This is mainly used from statements that need to copy of the original data before modifying it,
  * eg. UPDATE ... RETURN BEFORE</p>
  *
- * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
+ * @author Luigi Dell Aquila (luigi.dellaquila-(at)-gmail.com)
  */
 public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
 
@@ -63,7 +53,7 @@ public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
               prevValue.setProperty(TYPE_PROPERTY, document.getTypeName());
 
             for (final String propName : result.getPropertyNames())
-              prevValue.setProperty(propName, result.getProperty(propName));
+              prevValue.setProperty(propName, deepCopyMultiValue(result.getProperty(propName)));
 
             updatableResult.previousValue = prevValue;
           } else {
@@ -82,6 +72,43 @@ public class CopyRecordContentBeforeUpdateStep extends AbstractExecutionStep {
         lastFetched.close();
       }
     };
+  }
+
+  /**
+   * Returns a deep copy of {@code value} when it is a {@link List}/{@link Set}/{@link Map} or
+   * {@link Document}/{@link com.arcadedb.database.EmbeddedDocument} (or nests them), so a later in-place
+   * mutation of the live property (e.g. {@code REMOVE coll = val} / {@code REMOVE map[k]} / {@code REMOVE emb.field})
+   * cannot leak into this snapshot (issues #6456, #6517). Scalars, RIDs, and arrays are returned unchanged.
+   */
+  private static Object deepCopyMultiValue(final Object value) {
+    if (value instanceof Map<?, ?> map) {
+      final Map<Object, Object> copy = new LinkedHashMap<>(map.size());
+      for (final Map.Entry<?, ?> entry : map.entrySet())
+        copy.put(entry.getKey(), deepCopyMultiValue(entry.getValue()));
+      return copy;
+    }
+    if (value instanceof Set<?> set) {
+      final Set<Object> copy = new LinkedHashSet<>(set.size());
+      for (final Object o : set)
+        copy.add(deepCopyMultiValue(o));
+      return copy;
+    }
+    if (value instanceof List<?> list) {
+      final List<Object> copy = new ArrayList<>(list.size());
+      for (final Object o : list)
+        copy.add(deepCopyMultiValue(o));
+      return copy;
+    }
+    if (value instanceof Document document) {
+      // Deep-copy the embedded document via toMap + recursive deep copy so a later in-place field removal
+      // (e.g. REMOVE emb.field) cannot leak into the BEFORE snapshot (issue #6517)
+      final Map<String, Object> map = document.toMap(false);
+      final Map<String, Object> copy = new LinkedHashMap<>(map.size());
+      for (final Map.Entry<String, Object> entry : map.entrySet())
+        copy.put(entry.getKey(), deepCopyMultiValue(entry.getValue()));
+      return copy;
+    }
+    return value;
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
@@ -721,6 +721,37 @@ public class UpdateStatementExecutionTest extends TestHelper {
   }
 
   @Test
+  void returnBeforeWithEmbeddedDocRemoveIsNotMutatedByTheRemoval() {
+    // Issue #6517: UPDATE ... REMOVE <embeddedDoc>.<field> ... RETURN BEFORE must snapshot the embedded
+    // document BEFORE the in-place field removal, not share the live reference with it.
+    final String className = "overridden" + this.className;
+    database.getSchema().createDocumentType(className);
+
+    final MutableDocument doc = database.newDocument(className);
+    final MutableEmbeddedDocument emb = doc.newEmbeddedDocument("emb", "emb");
+    emb.set("sub", "foo").set("aaa", "bar");
+    doc.save();
+
+    final ResultSet result = database.command("sql",
+        "update " + className + " remove emb.sub RETURN BEFORE");
+    assertThat(result.hasNext()).isTrue();
+    final Result item = result.next();
+    assertThat(item).isNotNull();
+    final Map<String, Object> before = item.getProperty("emb");
+    assertThat((String) before.get("sub")).isEqualTo("foo");
+    assertThat((String) before.get("aaa")).isEqualTo("bar");
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    final ResultSet persisted = database.query("sql", "SELECT emb FROM " + className);
+    assertThat(persisted.hasNext()).isTrue();
+    final Map<String, Object> after = persisted.next().getProperty("emb");
+    assertThat(after.containsKey("sub")).isFalse();
+    assertThat((String) after.get("aaa")).isEqualTo("bar");
+    persisted.close();
+  }
+
+  @Test
   void localDateTimeUpsertWithIndexMicros() throws Exception {
     database.transaction(() -> {
       if (database.getSchema().existsType("Product"))

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
@@ -725,10 +725,11 @@ public class UpdateStatementExecutionTest extends TestHelper {
     // Issue #6517: UPDATE ... REMOVE <embeddedDoc>.<field> ... RETURN BEFORE must snapshot the embedded
     // document BEFORE the in-place field removal, not share the live reference with it.
     final String className = "overridden" + this.className;
-    database.getSchema().createDocumentType(className);
+    final DocumentType clazz = database.getSchema().createDocumentType(className);
+    clazz.createProperty("emb", Type.EMBEDDED);
 
     final MutableDocument doc = database.newDocument(className);
-    final MutableEmbeddedDocument emb = doc.newEmbeddedDocument("emb", "emb");
+    final MutableEmbeddedDocument emb = doc.newEmbeddedDocument(className, "emb");
     emb.set("sub", "foo").set("aaa", "bar");
     doc.save();
 
@@ -745,9 +746,9 @@ public class UpdateStatementExecutionTest extends TestHelper {
 
     final ResultSet persisted = database.query("sql", "SELECT emb FROM " + className);
     assertThat(persisted.hasNext()).isTrue();
-    final Map<String, Object> after = persisted.next().getProperty("emb");
-    assertThat(after.containsKey("sub")).isFalse();
-    assertThat((String) after.get("aaa")).isEqualTo("bar");
+    final EmbeddedDocument after = persisted.next().getProperty("emb");
+    assertThat(after.getPropertyNames().contains("sub")).isFalse();
+    assertThat(after.getString("aaa")).isEqualTo("bar");
     persisted.close();
   }
 


### PR DESCRIPTION
Fixes #6517

## Problem

`UPDATE ... REMOVE <embeddedDoc>.<field> ... RETURN BEFORE` returns the **post**-removal snapshot as the BEFORE image.

The BEFORE snapshot shares the live `EmbeddedDocument` reference with the record: `SuffixIdentifier.applyRemove` calls `document.modify()` (which returns `this` for a mutable embedded document) and mutates it in place, so the snapshot built by `CopyRecordContentBeforeUpdateStep` leaks the removal.

## Root cause

`CopyRecordContentBeforeUpdateStep.deepCopyMultiValue` deep-copies `List`/`Set`/`Map` values (as of #6515 for #6456) but explicitly leaves `Document`/`EmbeddedDocument` values unchanged — a documented scope boundary that #6517 now closes.

## Fix

Adds a `Document` branch to `deepCopyMultiValue`: embedded documents are snapshotted via `toMap(false)` + recursive deep copy, matching the #6456/#6515 treatment of collections, so a later in-place field removal (e.g. `REMOVE emb.field`) cannot leak into the BEFORE image.

## Repro

```sql
CREATE VERTEX V SET emb = {sub:'foo', aaa:'bar'};
UPDATE #x:y REMOVE emb.sub RETURN BEFORE;
```

**Before fix:** BEFORE = `{emb:{aaa:'bar'}}` (the `sub` key is already gone)
**After fix:**  BEFORE = `{emb:{sub:'foo', aaa:'bar'}}`

## Tests

Adds `returnBeforeWithEmbeddedDocRemoveIsNotMutatedByTheRemoval` to `UpdateStatementExecutionTest`:
- Creates a record with an embedded document (`sub`/`aaa` properties)
- `REMOVE emb.sub RETURN BEFORE` — asserts BEFORE still contains `sub`
- Asserts the persisted record correctly lacks `sub` after the removal
