### PR TITLE
fix(#6427): claim every CONTAINSTEXT condition on a full-text property, not just the first

### DIFF
--- a/docs/6427-containstext-two-conditions-same-property.md
+++ b/docs/6427-containstext-two-conditions-same-property.md
@@ -44,3 +44,53 @@ with the rest via the existing `intersectPerProperty`.
 ## Verification
 
 - `mvn -o -pl engine -am test -Dtest=Issue6427ContainsTextSamePropertyTwiceTest,Issue6414ContainsTextMultiPropertyIndexTest,Issue6382ContainsTextColonTest,Issue6438ContainsTextNonStringArgumentTest -DexcludedGroups=benchmark,vector`
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6523
+
+## Review cycles
+
+Ran the full `--max-cycles=4` budget; every cycle's `claude` review carried genuine, minor
+feedback that was addressed with a follow-up commit (no cycle reached a clean approval).
+
+- **Cycle 1** (head `1c33ce82`): review flagged one doc-precision nit - a `{@link}` in
+  `FetchFromIndexStep.processFullTextBlock`'s Javadoc pointed at `LSMTreeFullTextIndex#get(Object[],
+  int)` for the list-slot expansion, when the expansion actually happens in `splitPositionalKey`.
+  Fixed in `d1902efe`.
+- **Cycle 2** (head `d1902efe`): review raised an edge case - a property indexed under two modifiers
+  sharing one base name (e.g. `m by key`, `m by value`) with two repeated `CONTAINSTEXT` conditions on
+  that base name resolves both conditions to the FIRST matching index property only; the other modifier
+  is never queried. Confirmed (via a throwaway experiment, not committed) that this pre-dates #6427 -
+  even a single such condition already only ever queried the first modifier - and that two repeated
+  conditions used to bail to the generic path entirely pre-fix, so this is a net improvement, not a
+  regression. Documented the limitation in a Javadoc/comment (the reviewer's "either a test or a doc
+  note" option) rather than a test, since correctly pinning that interaction needs deeper investigation
+  into MAP `BY KEY`/`BY VALUE` full-text indexing that is out of scope for this bug fix. Also applied
+  the review's mechanical nit, `@SuppressWarnings("unchecked")` on the accumulator cast. Fixed in `0550c622`.
+- **Cycle 3** (head `0550c622`): review confirmed the dual-modifier analysis independently (same
+  conclusion: net improvement, not a regression) and had one style nit - scope
+  `@SuppressWarnings("unchecked")` to the single cast rather than the whole method. Fixed in `1177c751`.
+- **Cycle 4** (head `1177c751`): review was positive overall, with one optional, non-blocking test-
+  coverage suggestion - no test combined a repeated same-property condition with a null-valued repeated
+  condition on that same property. Added
+  `Issue6427ContainsTextSamePropertyTwiceTest.aNullValuedRepeatedConditionOnTheSamePropertyMatchesNothing`.
+  Fixed in `0ab777b3`.
+
+Max-cycles (4) reached after the cycle-4 push; the loop stops there per the skill's constraints rather
+than polling a 5th time. `0ab777b3` (the final head at the time this doc was written) had not yet been
+reviewed when the loop ended.
+
+## Deferred / left to the developer
+
+- Cycle 2's review suggested (optionally) filing a tracking GitHub issue for the dual-modifier
+  (`BY KEY`/`BY VALUE` sharing a base property name) position-resolution limitation, "if you want it
+  discoverable later." Not filed by this automated run - filing new issues is a developer judgment call,
+  and the limitation is already recorded in `FetchFromIndexStep.processFullTextBlock`'s Javadoc. Left for
+  the developer to file if they want a tracking issue.
+
+## Final state
+
+`max-cycles-reached` - every review cycle's feedback was addressed with a commit; none were a clean
+approval outright, and the 4-cycle budget was exhausted before one arrived. Merge remains the developer's
+call.

--- a/docs/6427-containstext-two-conditions-same-property.md
+++ b/docs/6427-containstext-two-conditions-same-property.md
@@ -1,0 +1,46 @@
+# Issue #6427: CONTAINSTEXT - two conditions on the same property, only one reaches the full-text index
+
+## Root cause
+
+Two independent single-condition-per-property limits combined to create the bug:
+
+1. `SelectExecutionPlanner.buildIndexSearchDescriptorForFulltext` matched at most ONE `CONTAINSTEXT`
+   condition per indexed property (`break` right after the first match). A second condition on an
+   already-claimed property was left in the residual filter, where `ContainsTextCondition.evaluate`
+   answers it with a case-sensitive `String.contains` instead of the index's analyzer-token semantics.
+2. Even if the planner claimed both, `FetchFromIndexStep.processFullTextBlock` built a POSITIONAL key
+   with exactly one slot per indexed property (`Object[] keys`, sized `properties.size()`), so a second
+   condition on the same property had nowhere to go (`keys[position] != null` bailed to the generic,
+   non-full-text path).
+
+`LSMTreeFullTextIndex.intersectPerProperty` already ANDs an arbitrary list of per-property lookups; it
+was driven by a key with one slot per property rather than one per condition.
+
+## Fix
+
+1. `buildIndexSearchDescriptorForFulltext`: removed the `break`, so every `CONTAINSTEXT` condition on an
+   indexed property is claimed, not just the first.
+2. `FetchFromIndexStep.processFullTextBlock`: when a property's slot is already filled, accumulate the
+   values into a `List` instead of bailing out.
+3. `LSMTreeFullTextIndex.splitPositionalKey`: now also triggers the positional/intersecting path for a
+   SINGLE-property index when a slot holds a `List` (previously it only triggered for indexes with 2+
+   properties), and expands a `List` slot into one entry per element. A single-property index does not
+   store field-qualified tokens (`put()`), so entries built from a single-property key stay unqualified.
+
+The conjunction now comes from the number of `CONTAINSTEXT` conditions in the query, not from how the
+index happened to be declared: a third condition on the same property costs one more lookup, intersected
+with the rest via the existing `intersectPerProperty`.
+
+## Tests
+
+- `engine/src/test/java/com/arcadedb/index/fulltext/Issue6427ContainsTextSamePropertyTwiceTest.java` (new):
+  covers single- and multi-property indexes, BM25 similarity, 3+ conditions on the same property, a
+  condition alongside a non-fulltext filter, and a mix of same-property + different-property conditions.
+- `Issue6414ContainsTextMultiPropertyIndexTest.aSecondConditionOnTheSamePropertyIsStillAnsweredByTheRowFilter`
+  (existing, pre-existing test explicitly documents in its own Javadoc/comments that its third assertion
+  is "the one #6427 will flip" - updated to assert the new, corrected behavior now that the fix lands. No
+  other assertion in that test changed.
+
+## Verification
+
+- `mvn -o -pl engine -am test -Dtest=Issue6427ContainsTextSamePropertyTwiceTest,Issue6414ContainsTextMultiPropertyIndexTest,Issue6382ContainsTextColonTest,Issue6438ContainsTextNonStringArgumentTest -DexcludedGroups=benchmark,vector`

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -225,9 +225,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * Decomposes a POSITIONAL key over a multi-property index into one field-qualified single-text query per constrained
-   * property, or answers {@code null} when the key is not positional and must keep its historical "text to find anywhere"
-   * meaning.
+   * Decomposes a POSITIONAL key into one single-text query per constrained property PER CONDITION, or answers
+   * {@code null} when the key is not positional and must keep its historical "text to find anywhere" meaning.
    * <p>
    * A multi-property full-text index stores each token twice - once qualified as {@code field:token} and once unprefixed
    * (see {@link #put}) - so a per-property lookup is exact rather than a filter over a superset. Before issue #6414 nothing
@@ -239,21 +238,55 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * {@link #parseQueryTerms} works at: qualifying only the head would leave every following word matching any property.
    * The qualifier is the property's BASE name ({@code obj.hd}, not the index's {@code obj.hd by item}): the modified
    * spelling carries spaces, which the whitespace split would tear apart before anything could recognise it.
+   * <p>
+   * A slot holding a {@code List} - two or more {@code CONTAINSTEXT} conditions claimed for the same property - expands
+   * into one entry PER ELEMENT rather than one entry for the whole property, so {@code intersectPerProperty} ANDs them
+   * exactly as it already ANDs conditions on different properties (issue #6427). This is also what lets a
+   * SINGLE-property index take this path: without a list in a one-property key there is nothing to intersect, and the
+   * key keeps meaning "one query text, its words OR-ed by the historical coordination scoring" - which is why the
+   * property-count guard alone is not enough to decide whether this is a positional key any more. A single-property
+   * index never field-qualifies its tokens ({@link #put}, {@code getPropertyCount() == 1} branch), so entries built from
+   * a one-property key are left unqualified too.
    *
    * @param propertyNames the indexed property names, in index order
    * @param keys          the lookup key
    *
-   * @return one single-element key per constrained property, or {@code null} if {@code keys} is not a positional key
+   * @return one single-element key per constrained property per condition, or {@code null} if {@code keys} is not a
+   * positional key
    */
   static List<Object[]> splitPositionalKey(final List<String> propertyNames, final Object[] keys) {
-    if (propertyNames == null || propertyNames.size() < 2 || keys == null || keys.length != propertyNames.size())
+    if (propertyNames == null || keys == null || keys.length != propertyNames.size())
+      return null;
+
+    final boolean multiProperty = propertyNames.size() > 1;
+
+    boolean positional = multiProperty;
+    if (!positional)
+      for (final Object key : keys)
+        if (key instanceof Collection) {
+          positional = true;
+          break;
+        }
+
+    if (!positional)
+      // Single property, single text: keep the historical "anywhere" meaning untouched.
       return null;
 
     final List<Object[]> result = new ArrayList<>(keys.length);
     for (int i = 0; i < keys.length; i++) {
       if (keys[i] == null)
         continue;
-      result.add(new Object[] { qualifyEveryPart(keys[i].toString(), Index.basePropertyName(propertyNames.get(i))) });
+      final String baseField = Index.basePropertyName(propertyNames.get(i));
+      if (keys[i] instanceof Collection<?> values) {
+        for (final Object value : values) {
+          if (value == null)
+            continue;
+          result.add(new Object[] { multiProperty ? qualifyEveryPart(value.toString(), baseField) : value.toString() });
+        }
+      } else {
+        result.add(
+            new Object[] { multiProperty ? qualifyEveryPart(keys[i].toString(), baseField) : keys[i].toString() });
+      }
     }
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -378,7 +378,20 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * it. That is what {@link ContainsTextCondition#evaluate} does off the index (a {@code null} value is never a match),
    * what a single-property index already did (an empty query text finds no term), and now what a multi-property one
    * does too.
+   * <p>
+   * The position-resolution loop below matches a condition's field name to an index property by its BASE name only, so
+   * two index properties that share one base name but differ in modifier ({@code m by key} and {@code m by value})
+   * are indistinguishable to it - a condition on {@code m} always resolves to whichever of the two comes FIRST in
+   * {@code properties}. This was already true for a single such condition before issue #6427 (it silently searched only
+   * the first modifier's tokens, never the second); what changes here is that a SECOND {@code m} condition, which used
+   * to make the whole block bail to the generic path, now lands in the same slot as the first and is intersected
+   * against it. Both conditions therefore query the same one modifier property - the other is never consulted - rather
+   * than one condition per modifier. Resolving that would need the position lookup to track which specific index
+   * property the planner associated each claimed condition with, rather than re-deriving it from the field name alone;
+   * that is a distinct, narrower problem than #6427, whose fix is deliberately confined to the same-property,
+   * same-modifier case the issue describes.
    */
+  @SuppressWarnings("unchecked")
   private boolean processFullTextBlock() {
     if (index.getType() != Schema.INDEX_TYPE.FULL_TEXT || additionalRangeCondition != null)
       return false;
@@ -421,6 +434,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       if (existing == null) {
         keys[position] = value;
       } else if (existing instanceof List<?> existingList) {
+        // Safe: the only producer of this list is the `else` branch below, freshly allocated as List<Object>.
         ((List<Object>) existingList).add(value);
       } else {
         final List<Object> values = new ArrayList<>(2);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -368,8 +368,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * A property's slot can be filled more than once - two (or more) {@code CONTAINSTEXT} conditions on the same property,
    * which the planner now claims all of, or one document property indexed twice under different modifiers
    * ({@code (m by key, m by value)}). Rather than keeping one value, the slot then holds a {@code List} of them, and
-   * {@link com.arcadedb.index.fulltext.LSMTreeFullTextIndex#get(Object[], int)} expands each list slot into one lookup per
-   * element, intersecting them exactly as it already intersects one lookup per property (issue #6427).
+   * {@link com.arcadedb.index.fulltext.LSMTreeFullTextIndex#splitPositionalKey(java.util.List, Object[])} expands each
+   * list slot into one lookup per element, which {@link com.arcadedb.index.fulltext.LSMTreeFullTextIndex#get(Object[],
+   * int)} intersects exactly as it already intersects one lookup per property (issue #6427).
    * <p>
    * A condition whose right side evaluates to {@code null} makes the whole block match NOTHING rather than leaving its
    * property unconstrained. The two readings share one slot - a {@code null} slot is exactly how the key says "this property

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -391,7 +391,6 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * that is a distinct, narrower problem than #6427, whose fix is deliberately confined to the same-property,
    * same-modifier case the issue describes.
    */
-  @SuppressWarnings("unchecked")
   private boolean processFullTextBlock() {
     if (index.getType() != Schema.INDEX_TYPE.FULL_TEXT || additionalRangeCondition != null)
       return false;
@@ -434,8 +433,11 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       if (existing == null) {
         keys[position] = value;
       } else if (existing instanceof List<?> existingList) {
-        // Safe: the only producer of this list is the `else` branch below, freshly allocated as List<Object>.
-        ((List<Object>) existingList).add(value);
+        // Safe: the only producer of this list is the `else` branch below, freshly allocated as List<Object>. The
+        // suppression is scoped to this one cast rather than the whole method.
+        @SuppressWarnings("unchecked")
+        final List<Object> objectList = (List<Object>) existingList;
+        objectList.add(value);
       } else {
         final List<Object> values = new ArrayList<>(2);
         values.add(existing);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -362,13 +362,14 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * condition on the second property alone is a perfectly good key and must not be shifted into the first slot.
    * <p>
    * Answers false, leaving the generic path to run, whenever the block is not exactly that: another index type, a range
-   * condition alongside, anything but {@code CONTAINSTEXT}, a property this index does not cover, a multi-value key, or two
-   * conditions on the same property. A single-property index takes this path too and produces the same one-element key it
-   * always did (issue #6414, item 2).
+   * condition alongside, anything but {@code CONTAINSTEXT}, a property this index does not cover, or a multi-value key. A
+   * single-property index takes this path too and produces the same one-element key it always did (issue #6414, item 2).
    * <p>
-   * The already-filled-slot case is reachable only when one document property is indexed twice under different modifiers
-   * ({@code (m by key, m by value)}), since the planner claims at most one condition per index property; two conditions on
-   * one property leave the second in the residual filter instead, with the semantics gap that is issue #6427.
+   * A property's slot can be filled more than once - two (or more) {@code CONTAINSTEXT} conditions on the same property,
+   * which the planner now claims all of, or one document property indexed twice under different modifiers
+   * ({@code (m by key, m by value)}). Rather than keeping one value, the slot then holds a {@code List} of them, and
+   * {@link com.arcadedb.index.fulltext.LSMTreeFullTextIndex#get(Object[], int)} expands each list slot into one lookup per
+   * element, intersecting them exactly as it already intersects one lookup per property (issue #6427).
    * <p>
    * A condition whose right side evaluates to {@code null} makes the whole block match NOTHING rather than leaving its
    * property unconstrained. The two readings share one slot - a {@code null} slot is exactly how the key says "this property
@@ -402,7 +403,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
           break;
         }
 
-      if (position < 0 || keys[position] != null)
+      if (position < 0)
         return false;
 
       final Object value = textCondition.getRight().execute((Result) null, context);
@@ -415,7 +416,17 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       if (!(value instanceof Identifiable) && MultiValue.isMultiValue(value))
         return false;
 
-      keys[position] = value;
+      final Object existing = keys[position];
+      if (existing == null) {
+        keys[position] = value;
+      } else if (existing instanceof List<?> existingList) {
+        ((List<Object>) existingList).add(value);
+      } else {
+        final List<Object> values = new ArrayList<>(2);
+        values.add(existing);
+        values.add(value);
+        keys[position] = values;
+      }
     }
 
     cursor = index.get(keys);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -3915,11 +3915,12 @@ public class SelectExecutionPlanner {
    * second dropped from the filter as well (issue #6414, item 2). {@link FetchFromIndexStep} turns the claimed conditions
    * into the positional key the index expects.
    * <p>
-   * At most ONE condition per index property is claimed - the inner loop breaks after the first match - so a second
-   * condition on the same property stays in the residual filter and is answered by {@code String.contains} rather than by
-   * the index's analyzer. The positional key has one slot per property and cannot express two texts for one: within a
-   * property the terms of a single query text are OR-ed, while the {@code AND} between two conditions wants both. Serving
-   * it means one lookup per CONDITION rather than per property, which is issue #6427.
+   * EVERY condition on an index property is claimed, not just the first - the inner loop used to {@code break} after the
+   * first match, which left a second condition on an already-claimed property in the residual filter, answered by
+   * {@code String.contains} rather than by the index's analyzer (issue #6427). {@link FetchFromIndexStep} accumulates the
+   * conditions claimed for one property into a list and turns them into one lookup per condition rather than one per
+   * property, intersecting them via {@code LSMTreeFullTextIndex.intersectPerProperty}: the conjunction then comes from the
+   * number of conditions in the query, not from the shape of the index.
    *
    * @param context
    * @param index
@@ -3953,7 +3954,8 @@ public class SelectExecutionPlanner {
             condition.setRight(textCondition.getRight().copy());
             indexKeyValue.getSubBlocks().add(condition);
             blockIterator.remove();
-            break;
+            // No break: a second (or third...) CONTAINSTEXT on this same property is claimed too, not left for the
+            // residual filter to answer with different (case-sensitive, non-tokenized) semantics.
           }
         }
       }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6414ContainsTextMultiPropertyIndexTest.java
@@ -147,29 +147,29 @@ class Issue6414ContainsTextMultiPropertyIndexTest extends TestHelper {
   }
 
   /**
-   * Pins what a SECOND condition on an already-claimed property does today, which issue #6427 exists to change. The
-   * planner claims one condition per index property, so this one is answered by the index and that one by the residual
-   * {@code String.contains} - the last place where the same operator still means two things in one query. The
-   * assertions are a record of the current answer, not an endorsement of it: the third is the one #6427 will flip.
+   * Pins what a SECOND condition on an already-claimed property does now that issue #6427 is fixed: the planner claims
+   * every {@code CONTAINSTEXT} condition on an index property, not just the first, so both reach the index instead of
+   * one being answered by the residual {@code String.contains}.
    */
   @Test
-  void aSecondConditionOnTheSamePropertyIsStillAnsweredByTheRowFilter() {
+  void aSecondConditionOnTheSamePropertyIsAlsoAnsweredByTheIndex() {
     createArticles("CREATE INDEX ON Article6414 (title, content) FULL_TEXT");
     database.transaction(() -> database.command("sql",
         "INSERT INTO Article6414 SET id = 'e', title = 'java concurrency', content = 'threads'"));
 
     database.transaction(() -> {
-      // The index answers 'java'; the row filter answers 'concurrency' as a substring, and agrees here.
       assertThat(idsMatching(
           "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'concurrency'"))
           .containsExactly("e");
-      // A second condition that matches nothing still empties the result: it is checked, just not by the index.
+      // A second condition that matches nothing still empties the result.
       assertThat(idsMatching(
           "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'zzz'")).isEmpty();
-      // #6427: the index is case-insensitive and the row filter is not, so the two conditions disagree about the same
-      // word. Once a second condition reaches the index this becomes 'e'.
+      // Issue #6427: the index is case-insensitive, so the two conditions now agree about the same word regardless of
+      // case - this used to answer empty, when the second condition was still evaluated by the residual, case-sensitive
+      // String.contains.
       assertThat(idsMatching(
-          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'CONCURRENCY'")).isEmpty();
+          "SELECT id FROM Article6414 WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'CONCURRENCY'"))
+          .containsExactly("e");
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6427ContainsTextSamePropertyTwiceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6427ContainsTextSamePropertyTwiceTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Two {@code CONTAINSTEXT} conditions on the SAME property used to reach the full-text index only once: the
+ * planner claimed at most one condition per indexed property, so the second stayed in the residual filter and
+ * was evaluated by {@link com.arcadedb.query.sql.parser.ContainsTextCondition#evaluate} - a case-sensitive
+ * {@code String.contains} - instead of the index's analyzer-token, case-insensitive matching. Same operator,
+ * same query, two different meanings decided only by which condition happened to be claimed first (issue #6427).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6427ContainsTextSamePropertyTwiceTest extends TestHelper {
+
+  @Test
+  void twoConditionsOnASinglePropertyIndexAreBothPushedToTheIndex() {
+    final String type = "Article6427";
+    createArticles(type, "CREATE INDEX ON " + type + " (title) FULL_TEXT");
+
+    database.transaction(() -> {
+      assertThat(explain("SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'concurrency'"))
+          .contains("FETCH FROM INDEX " + type + "[title]");
+
+      // The index is analyzer-token and case-insensitive: a residual String.contains would answer this empty,
+      // because the stored word is 'concurrency' and the row filter comparison used to be case-sensitive.
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'CONCURRENCY'"))
+          .containsExactly("e");
+
+      // Both conditions still have to hold: a second condition matching nothing empties the result.
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'zzz'")).isEmpty();
+
+      // Sanity: the two conditions really are ANDed together, not just the first one answered.
+      assertThat(idsMatching("SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java'"))
+          .containsExactlyInAnyOrder("a", "c", "e");
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'concurrency'"))
+          .containsExactly("e");
+    });
+  }
+
+  @Test
+  void threeConditionsOnTheSamePropertyAreAllIntersected() {
+    final String type = "Article6427c";
+    createArticles(type, "CREATE INDEX ON " + type + " (title) FULL_TEXT");
+
+    database.transaction(() -> {
+      assertThat(idsMatching("SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT "
+          + "'concurrency' AND title CONTAINSTEXT 'threads'")).isEmpty();
+
+      database.command("sql",
+          "INSERT INTO " + type + " SET id = 'f', title = 'java concurrency threads', content = 'more'");
+    });
+
+    database.transaction(() -> assertThat(idsMatching("SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' "
+        + "AND title CONTAINSTEXT 'concurrency' AND title CONTAINSTEXT 'threads'")).containsExactly("f"));
+  }
+
+  @Test
+  void twoConditionsOnTheSamePropertyOfAMultiPropertyIndexAreBothPushedToTheIndex() {
+    final String type = "Article6427m";
+    createArticles(type, "CREATE INDEX ON " + type + " (title, content) FULL_TEXT");
+
+    database.transaction(() -> {
+      assertThat(explain(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'concurrency'"))
+          .contains("FETCH FROM INDEX " + type + "[title,content]");
+
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'CONCURRENCY'"))
+          .containsExactly("e");
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'zzz'")).isEmpty();
+
+      // A word that only lives in 'content' must not satisfy a second condition on 'title', even though the
+      // multi-property index also stores it unqualified.
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'databases'"))
+          .isEmpty();
+    });
+  }
+
+  @Test
+  void aRepeatedConditionOnOnePropertyCombinesWithAConditionOnAnotherProperty() {
+    final String type = "Article6427m2";
+    createArticles(type, "CREATE INDEX ON " + type + " (title, content) FULL_TEXT");
+
+    database.transaction(() -> assertThat(idsMatching("SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' "
+        + "AND title CONTAINSTEXT 'concurrency' AND content CONTAINSTEXT 'threads'")).containsExactly("e"));
+  }
+
+  @Test
+  void aNonFulltextConditionAlongsideARepeatedConditionStillFilters() {
+    final String type = "Article6427nf";
+    createArticles(type, "CREATE INDEX ON " + type + " (title) FULL_TEXT");
+
+    database.transaction(() -> {
+      assertThat(idsMatching("SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' "
+          + "AND title CONTAINSTEXT 'concurrency' AND id = 'e'")).containsExactly("e");
+      assertThat(idsMatching("SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' "
+          + "AND title CONTAINSTEXT 'concurrency' AND id = 'a'")).isEmpty();
+    });
+  }
+
+  @Test
+  void theSameHoldsForABM25Index() {
+    final String type = "Article6427bm";
+    createArticles(type, "CREATE INDEX ON " + type + " (title) FULL_TEXT METADATA {\"similarity\": \"BM25\"}");
+
+    database.transaction(() -> {
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'CONCURRENCY'"))
+          .containsExactly("e");
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'zzz'")).isEmpty();
+    });
+  }
+
+  private void createArticles(final String typeName, final String indexCommand) {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE " + typeName);
+      database.command("sql", "CREATE PROPERTY " + typeName + ".title STRING");
+      database.command("sql", "CREATE PROPERTY " + typeName + ".content STRING");
+      database.command("sql", indexCommand);
+
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'a', title = 'java', content = 'databases'");
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'b', title = 'python', content = 'java bindings'");
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'c', title = 'JAVA rocks', content = 'other'");
+      database.command("sql", "INSERT INTO " + typeName + " SET id = 'd', title = 'cooking notes', content = 'pasta'");
+      database.command("sql",
+          "INSERT INTO " + typeName + " SET id = 'e', title = 'java concurrency', content = 'threads'");
+    });
+  }
+
+  private Set<String> idsMatching(final String query) {
+    final Set<String> ids = new LinkedHashSet<>();
+    try (final ResultSet rs = database.query("sql", query, Map.of())) {
+      while (rs.hasNext())
+        ids.add(rs.next().getProperty("id"));
+    }
+    return ids;
+  }
+
+  private String explain(final String query) {
+    try (final ResultSet rs = database.query("sql", "EXPLAIN " + query)) {
+      return rs.next().toJSON().toString();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/Issue6427ContainsTextSamePropertyTwiceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/Issue6427ContainsTextSamePropertyTwiceTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -130,6 +131,35 @@ class Issue6427ContainsTextSamePropertyTwiceTest extends TestHelper {
     });
   }
 
+  /**
+   * A {@code null}-valued condition makes the whole block unsatisfiable (issue #6414) even when it is the SECOND
+   * condition on a property whose slot already accumulated a value from the first. The null check in
+   * {@code FetchFromIndexStep.processFullTextBlock} runs before the slot-accumulation logic, so a null cannot be
+   * silently folded into (or lost behind) an already-partial {@code List} slot.
+   */
+  @Test
+  void aNullValuedRepeatedConditionOnTheSamePropertyMatchesNothing() {
+    final String type = "Article6427null";
+    createArticles(type, "CREATE INDEX ON " + type + " (title) FULL_TEXT");
+
+    final Map<String, Object> noValue = new HashMap<>();
+    noValue.put("missing", null);
+
+    database.transaction(() -> {
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT :missing", noValue))
+          .isEmpty();
+      // Order does not matter: the null-valued condition short-circuits whether it is claimed first or second.
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT :missing AND title CONTAINSTEXT 'java'", noValue))
+          .isEmpty();
+      // Sanity: without the null-valued condition, the same two-condition-on-one-property query still matches.
+      assertThat(idsMatching(
+          "SELECT id FROM " + type + " WHERE title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'concurrency'"))
+          .containsExactly("e");
+    });
+  }
+
   @Test
   void theSameHoldsForABM25Index() {
     final String type = "Article6427bm";
@@ -161,8 +191,12 @@ class Issue6427ContainsTextSamePropertyTwiceTest extends TestHelper {
   }
 
   private Set<String> idsMatching(final String query) {
+    return idsMatching(query, Map.of());
+  }
+
+  private Set<String> idsMatching(final String query, final Map<String, Object> parameters) {
     final Set<String> ids = new LinkedHashSet<>();
-    try (final ResultSet rs = database.query("sql", query, Map.of())) {
+    try (final ResultSet rs = database.query("sql", query, parameters)) {
       while (rs.hasNext())
         ids.add(rs.next().getProperty("id"));
     }


### PR DESCRIPTION
## What does this PR do?

Fixes `CONTAINSTEXT`: when a query has two conditions on the SAME property (e.g. `title CONTAINSTEXT 'java' AND title CONTAINSTEXT 'concurrency'`), both conditions now reach the full-text index and are ANDed together via `LSMTreeFullTextIndex.intersectPerProperty`. Before this fix, the planner claimed at most one `CONTAINSTEXT` condition per indexed property, so a second condition on an already-claimed property was left in the residual, row-level filter and evaluated by `ContainsTextCondition.evaluate` - a case-sensitive `String.contains` - instead of the index's analyzer-token, case-insensitive matching. The same operator, in the same query, meant two different things depending only on which condition happened to be claimed first.

### Root cause

Two independent single-condition-per-property limits combined to create the bug:

1. `SelectExecutionPlanner.buildIndexSearchDescriptorForFulltext` matched at most ONE `CONTAINSTEXT` condition per indexed property (it `break`s right after the first match). A second condition on an already-claimed property was left in the residual filter.
2. Even if the planner claimed both, `FetchFromIndexStep.processFullTextBlock` built a POSITIONAL key with exactly one slot per indexed property, so a second condition on the same property had nowhere to go (`keys[position] != null` bailed to the generic, non-full-text path).

`LSMTreeFullTextIndex.intersectPerProperty` already ANDs an arbitrary list of per-property lookups; it was just driven by a key with one slot per property rather than one per condition.

### Fix

1. `buildIndexSearchDescriptorForFulltext`: removed the `break`, so every `CONTAINSTEXT` condition on an indexed property is claimed, not just the first.
2. `FetchFromIndexStep.processFullTextBlock`: when a property's slot is already filled, the value is now accumulated into a `List` instead of bailing out.
3. `LSMTreeFullTextIndex.splitPositionalKey`: now also triggers the positional/intersecting path for a SINGLE-property index when a slot holds a `List` (previously it only triggered for indexes with 2+ properties), and expands a `List` slot into one lookup entry per element. A single-property index does not store field-qualified tokens (see `put()`), so entries built from a single-property key stay unqualified, matching what is actually stored.

The conjunction now comes from the number of `CONTAINSTEXT` conditions in the query, not from how the index happened to be declared: a third condition on the same property costs one more lookup, intersected with the rest via the existing `intersectPerProperty`.

## Motivation

Reported in #6427, spotted while reviewing the #6421/#6414 follow-up batch. Left out of #6421's scope deliberately, filed as its own issue.

## Related issues

Closes #6427

Builds on the positional-key work from #6414 (multi-property `CONTAINSTEXT` pushdown) and reuses its `intersectPerProperty` helper unchanged.

## Additional Notes

- One pre-existing test, `Issue6414ContainsTextMultiPropertyIndexTest`, had a test explicitly documenting the pre-fix behavior in its own Javadoc/comments ("the assertions are a record of the current answer, not an endorsement of it: the third is the one #6427 will flip"). That assertion (and the test name/Javadoc) is updated to assert the new, corrected behavior now that the fix lands - no other assertion in that test changed, and no other existing test was touched.
- A new regression test class, `Issue6427ContainsTextSamePropertyTwiceTest`, covers: a single-property index, a multi-property index (repeated condition on one property + a condition on the other), a BM25-similarity index, three conditions on the same property, and a repeated `CONTAINSTEXT` condition alongside a non-full-text filter.

## Test plan

- [x] New test: `mvn -pl engine -am test -Dtest=Issue6427ContainsTextSamePropertyTwiceTest`
- [x] Updated test + arity regression suite: `mvn -pl engine -am test -Dtest=Issue6414ContainsTextMultiPropertyIndexTest,Issue6382ContainsTextColonTest,Issue6438ContainsTextNonStringArgumentTest`
- [x] Wider full-text / `CONTAINSTEXT` / index-selection regression sweep (34 classes): `ContainsTextIndexUsageTest`, `ContainsTextWithArrayTest`, `ContainsTextWithFullTextIndexTest`, `FullTextAnalyzerConfigTest`, `FullTextBackwardCompatibilityTest`, `FullTextBM25CompactionTest`, `FullTextBM25Test`, `FullTextBuildOverChurnedDataTest`, `FullTextEdgeCasesTest`, `FullTextListByItemTest`, `FullTextMultiPropertyByItemTest`, `FullTextMultiPropertyTest`, `FullTextNestedListByItemTest`, `FullTextPersistenceTest`, `FullTextPolymorphicScoreTest`, `FullTextQueryExecutorTest`, `FullTextQuerySyntaxTest`, `FullTextRebuildOverExistingTest`, `FullTextScoreTest`, `FullTextSearchTest`, `FullTextWildcardSearchTest`, `Issue6436Bm25ConjunctionSharedCorpusScanTest`, `LSMTreeFullTextIndexMLTTest`, `LSMTreeFullTextIndexTest`, `SQLFunctionSearchBareCallTest`, `SQLFunctionSearchFieldsMoreTest`, `SQLFunctionSearchFieldsTest`, `SQLFunctionSearchIndexMoreTest`, `SQLFunctionSearchIndexTest`, `CompositeIndexPartialKeySelectTest`, `FetchFromIndexedFunctionStepTest`, `LSMTreeIndexTest`, `LSMTreeIndexPolymorphicTest`, `MatchInheritanceTest`, `PolymorphicIndexConflictTest`, `SQLFunctionSearchIndexFuzzyStressTest` - all pass
- [x] Full `com.arcadedb.query.sql.executor.**` package (planner + step regression coverage) - all pass
- [x] `mvn -pl engine -am compile` - clean

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
