### PR TITLE
fix(#6495): compacted vector graph must reuse under its new name, not just avoid leaking

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2593,9 +2593,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // rebuild issue #6495's fix otherwise still leaves behind. Dropping the reference here, immediately
       // before it is read, makes the persist step below register a fresh file under the CURRENT name instead,
       // so the very next open finds it - zero rebuilds, zero orphans - exactly like the mutable/compacted
-      // components a compaction replaces just above: the stale file is torn down only once its replacement
-      // (gf) actually exists, and outside any lock, because a reader that already captured it must be able to
-      // finish (see dropReplacedComponent()).
+      // components a compaction replaces just above. Unlike those two, the stale file is NOT torn down here:
+      // it stays the only usable persisted graph until the replacement is CERTIFIED (graphCertified, set once
+      // writeGraphManifest() has vouched for committed pages), not merely once getOrCreateGraphFile() hands
+      // back an empty file object. A write or commit failure in between restores this reference instead (see
+      // the catch block below and the graphCertified check further down), so a failed persist still leaves
+      // something usable on disk rather than nothing.
       final LSMVectorIndexGraphFile staleGraphFileFromCompaction = locationIndexAlreadyPublished ? graphFile : null;
       if (staleGraphFileFromCompaction != null)
         graphFile = null;
@@ -2603,15 +2606,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // Persist graph to disk IMMEDIATELY in its own transaction
       // This ensures the graph is available on next database open (fast restart)
       final LSMVectorIndexGraphFile gf = getOrCreateGraphFile();
-      if (staleGraphFileFromCompaction != null) {
-        if (gf != null)
-          dropReplacedComponent(staleGraphFileFromCompaction);
-        else
-          // getOrCreateGraphFile() could not create a replacement: keep serving this session from the stale,
-          // pre-compaction file rather than losing the graph outright. It stays orphaned under its old name,
-          // exactly as before this change, and is picked up again the next time something finds graphFile null.
-          this.graphFile = staleGraphFileFromCompaction;
-      }
+      if (gf == null && staleGraphFileFromCompaction != null)
+        // getOrCreateGraphFile() could not create a replacement at all: keep serving this session from the
+        // stale, pre-compaction file rather than losing the graph outright. It stays orphaned under its old
+        // name, exactly as before this change, and is picked up again the next time something finds graphFile
+        // null.
+        this.graphFile = staleGraphFileFromCompaction;
       if (gf != null) {
         final int totalNodes = graphIndex.getIdUpperBound();
         LogManager.instance().log(this, Level.FINE, "Writing vector graph to disk for index: %s (nodes=%d)",
@@ -2675,6 +2675,13 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // thing able to certify a graph nobody built.
           writeGraphManifest(gf, finalActiveVectorIds);
           graphCertified = true;
+
+          // The replacement is certified now, so the stale pre-compaction file it supersedes is safe to drop -
+          // outside any lock, because a reader that already captured it must be able to finish (see
+          // dropReplacedComponent()). Doing this only now, rather than as soon as gf existed, is what keeps a
+          // write or commit failure above from deleting the one persisted graph the index still has.
+          if (staleGraphFileFromCompaction != null)
+            dropReplacedComponent(staleGraphFileFromCompaction);
 
           // When storeVectorsInGraph is enabled, reload the graph as OnDiskGraphIndex so the
           // current session benefits from inline vector storage immediately. This is safe because
@@ -2740,8 +2747,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
           //
           // writeGraph() marks its own failures the same way before rethrowing, so this repeats that one small
           // write when the failure came from in there. Cheap, and on a path already logged as SEVERE.
-          if (!graphCertified)
+          if (!graphCertified) {
             gf.getManifest().markUnusable("graph persist failed: " + e);
+            // The replacement never got certified, so it was never dropped above either: restore the stale
+            // file as the active graph rather than leaving the index with no usable persisted graph at all.
+            // gf itself is now unreachable from any field - drop it here (outside any lock, same reasoning as
+            // dropReplacedComponent()'s other callers) rather than leaving an uncertified, unusable file behind
+            // as a second orphan alongside the very one this whole rebuild was trying to eliminate. The stale
+            // file stays orphaned under its old (pre-compaction) name; the next build attempt finds graphFile
+            // null again and retries under the current one.
+            if (staleGraphFileFromCompaction != null) {
+              this.graphFile = staleGraphFileFromCompaction;
+              dropReplacedComponent(gf);
+            }
+          }
           LogManager.instance().log(this, Level.SEVERE,
               "PERSIST: Failed to persist graph for %s (nodes=%d, storeVectorsInGraph=%b, txStatus=%s): %s - %s",
               indexName,

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1286,7 +1286,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     try {
       final DatabaseInternal db = getDatabase();
       final String graphFileName = indexName + "_" + LSMVectorIndexGraphFile.FILE_EXT;
-      final String graphFilePath = mutable.getFilePath() + "_" + LSMVectorIndexGraphFile.FILE_EXT;
+      // Derive from the BARE index path, exactly as the creating constructor does. mutable.getFilePath()
+      // already carries the ".<fileId>.<pageSize>.v<version>.lsmvecidx" suffix, and ComponentFile derives a
+      // component's registered name from its path, so appending here produced the name
+      // "<index>.<fileId>.<pageSize>.v<version>.lsmvecidx_vecgraph". discoverAndLoadGraphFile() looks for
+      // "<mutable.getName()>_vecgraph", which that can never match, so the file was written, never found
+      // again, and re-created on every open.
+      final String graphFilePath =
+          db.getDatabasePath() + File.separator + indexName + "_" + LSMVectorIndexGraphFile.FILE_EXT;
       this.graphFile = new LSMVectorIndexGraphFile(db, graphFileName, graphFilePath,
           db.getMode(), mutable.getPageSize());
       this.graphFile.setMainIndex(this);

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2586,9 +2586,32 @@ public class LSMVectorIndex implements Index, IndexInternal {
         lock.writeLock().unlock();
       }
 
+      // COMPACT INDEX just renamed this index above (rewriteDataFileWithLiveEntries sets indexName to the new
+      // mutable's name), but getOrCreateGraphFile() only derives a fresh path when graphFile is null: left
+      // alone, it would silently overwrite the pre-compaction graph file in place, still registered under a
+      // name discoverAndLoadGraphFile() can no longer find on the next open - the one orphan and one avoidable
+      // rebuild issue #6495's fix otherwise still leaves behind. Dropping the reference here, immediately
+      // before it is read, makes the persist step below register a fresh file under the CURRENT name instead,
+      // so the very next open finds it - zero rebuilds, zero orphans - exactly like the mutable/compacted
+      // components a compaction replaces just above: the stale file is torn down only once its replacement
+      // (gf) actually exists, and outside any lock, because a reader that already captured it must be able to
+      // finish (see dropReplacedComponent()).
+      final LSMVectorIndexGraphFile staleGraphFileFromCompaction = locationIndexAlreadyPublished ? graphFile : null;
+      if (staleGraphFileFromCompaction != null)
+        graphFile = null;
+
       // Persist graph to disk IMMEDIATELY in its own transaction
       // This ensures the graph is available on next database open (fast restart)
       final LSMVectorIndexGraphFile gf = getOrCreateGraphFile();
+      if (staleGraphFileFromCompaction != null) {
+        if (gf != null)
+          dropReplacedComponent(staleGraphFileFromCompaction);
+        else
+          // getOrCreateGraphFile() could not create a replacement: keep serving this session from the stale,
+          // pre-compaction file rather than losing the graph outright. It stays orphaned under its old name,
+          // exactly as before this change, and is picked up again the next time something finds graphFile null.
+          this.graphFile = staleGraphFileFromCompaction;
+      }
       if (gf != null) {
         final int totalNodes = graphIndex.getIdUpperBound();
         LogManager.instance().log(this, Level.FINE, "Writing vector graph to disk for index: %s (nodes=%d)",

--- a/engine/src/test/java/com/arcadedb/index/vector/CompactIndexGraphPersistFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/CompactIndexGraphPersistFailureTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * A {@code COMPACT INDEX} whose graph persist fails partway through must not lose the pre-compaction graph.
+ * <p>
+ * {@code buildGraphFromScratchExclusively()} drops the stale, pre-compaction graph file only after the
+ * replacement is certified (committed pages plus a manifest that vouches for them), and restores it as the
+ * active {@code graphFile} if the persist fails first - mirroring the same {@code Throwable} guard issue #6503
+ * added around this block. This test injects a failure at the same point that one does (right after the graph
+ * pages are written, before the transaction commits), but through a {@code compactDataFile=true} rebuild, which
+ * is the path {@code COMPACT INDEX} takes and the one where a stale reference exists to restore.
+ * <p>
+ * Two things must hold after the injected failure: the index keeps exactly one usable {@code .vecgraph} file
+ * (the stale one, restored) rather than either losing the graph outright or leaking the broken replacement
+ * alongside it, and the failure itself must not escape - the persist block already swallows it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("vector")
+class CompactIndexGraphPersistFailureTest {
+  private static final int    DIMENSIONS  = 24;
+  private static final int    NUM_VECTORS = 300;
+  private static final String DB_PATH     = "./target/databases/CompactIndexGraphPersistFailureTest";
+
+  @AfterEach
+  void cleanUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void failedPersistAfterCompactionRestoresTheStaleGraphInsteadOfLosingIt() throws Exception {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    final Random rng = new Random(11);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+      try {
+        db.transaction(() -> {
+          final DocumentType t = db.getSchema().createDocumentType("Doc");
+          t.createProperty("id", Type.INTEGER);
+          t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+          for (int i = 0; i < NUM_VECTORS; i++)
+            db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
+        });
+        db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+            + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", \"maxConnections\": 32 }");
+        final LSMVectorIndex lsm = vectorIndex(db);
+        waitForGraph(lsm);
+
+        final LSMVectorIndexGraphFile graphFileBeforeCompaction = graphFileField(lsm);
+        assertThat(graphFileBeforeCompaction)
+            .as("the index must have a persisted graph before compaction, or this test proves nothing")
+            .isNotNull();
+
+        // Drive the exact rebuild COMPACT INDEX triggers (buildGraphFromScratch(null, true), private and always
+        // callback-less on the public compact() path), but with a callback that fails persistence right after
+        // the graph pages are written - the same injection point Issue6503GraphPersistOutOfMemoryTest uses -
+        // so the data file rename has already happened but the replacement graph never gets certified.
+        assertThatCode(() -> buildGraphFromScratchWithRetry(lsm,
+            (phase, processedNodes, totalNodes, vectorAccesses) -> {
+              if ("persisting".equals(phase) && processedNodes > 0 && processedNodes == totalNodes)
+                throw new RuntimeException("simulated graph persist failure after compaction");
+            }, true))
+            .as("the persist block must swallow this failure the same way it swallows an OOM there (issue #6503)")
+            .doesNotThrowAnyException();
+
+        final LSMVectorIndexGraphFile graphFileAfterFailure = graphFileField(lsm);
+        assertThat(graphFileAfterFailure)
+            .as("a persist failure must restore the stale, pre-compaction graph as the active one rather than "
+                + "leaving the index with no usable persisted graph at all")
+            .isNotNull();
+        assertThat(graphFileAfterFailure.hasPersistedGraph())
+            .as("the restored graph must still be the valid, already-persisted one from before compaction")
+            .isTrue();
+
+        assertThat(countGraphFiles())
+            .as("the broken, uncertified replacement must be dropped, not leaked alongside the restored stale "
+                + "file - exactly the class of orphan this whole fix exists to prevent")
+            .isEqualTo(1);
+
+        // The index must still be able to search and to accept further writes: nothing is left wedged by the
+        // aborted persist.
+        assertThat(lsm.findNeighborsFromVector(randomVector(new Random(99)), 5, 64)).hasSize(5);
+        db.transaction(() -> db.newDocument("Doc").set("id", NUM_VECTORS).set("embedding", randomVector(rng)).save());
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  /** Invokes the private {@code buildGraphFromScratchWithRetry(GraphBuildCallback, boolean, boolean)}. */
+  private static void buildGraphFromScratchWithRetry(final LSMVectorIndex index,
+      final LSMVectorIndex.GraphBuildCallback callback, final boolean compactDataFile) throws Exception {
+    final Method method = LSMVectorIndex.class.getDeclaredMethod("buildGraphFromScratchWithRetry",
+        LSMVectorIndex.GraphBuildCallback.class, boolean.class, boolean.class);
+    method.setAccessible(true);
+    try {
+      method.invoke(index, callback, compactDataFile, false);
+    } catch (final java.lang.reflect.InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException re)
+        throw re;
+      if (e.getCause() instanceof Error err)
+        throw err;
+      throw e;
+    }
+  }
+
+  private static LSMVectorIndexGraphFile graphFileField(final LSMVectorIndex index) throws Exception {
+    final Field field = LSMVectorIndex.class.getDeclaredField("graphFile");
+    field.setAccessible(true);
+    return (LSMVectorIndexGraphFile) field.get(index);
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+    return (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+  }
+
+  private static void waitForGraph(final LSMVectorIndex lsm) {
+    for (int i = 0; i < 600 && lsm.getStats().get("graphNodeCount") == 0L; i++)
+      try { Thread.sleep(50); } catch (final InterruptedException ignored) { break; }
+  }
+
+  private static int countGraphFiles() {
+    final File[] files = new File(DB_PATH).listFiles((d, n) -> n.endsWith("." + LSMVectorIndexGraphFile.FILE_EXT));
+    return files == null ? 0 : files.length;
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/CompactIndexKeepsGraphReusableTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/CompactIndexKeepsGraphReusableTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A persisted vector graph must survive {@code COMPACT INDEX} and stay reusable across reopens.
+ * <p>
+ * {@code getOrCreateGraphFile()} built the graph file's path from {@code mutable.getFilePath()}, which already
+ * carries the {@code .<fileId>.<pageSize>.v<version>.lsmvecidx} suffix. {@code ComponentFile} derives a
+ * component's registered name from its path, so the graph registered as
+ * {@code <index>.<fileId>.<pageSize>.v<version>.lsmvecidx_vecgraph} while
+ * {@code discoverAndLoadGraphFile()} looks for {@code <mutable.getName()>_vecgraph}. The two can never match,
+ * so every open failed to find a graph, rebuilt from scratch, and wrote one more file that would never be
+ * found either.
+ * <p>
+ * Compaction is what exposes it: {@code rewriteDataFileWithLiveEntries()} renames the index, so the graph
+ * registered under the pre-compaction name stops matching and the lazy path takes over from there on.
+ * <p>
+ * Before the fix the file count grows without bound and every reopen rebuilds. This test pins what the path
+ * fix achieves: the graph written on the FIRST open after compaction is found again by every later open, so
+ * the count stabilises and no further rebuild happens.
+ * <p>
+ * One orphan remains, the graph registered under the pre-compaction name. Removing it needs the compaction
+ * path to re-register the component under the new name, which sits inside a critical section documented as
+ * needing its statements kept adjacent, so it is left as a follow-up rather than attempted here.
+ */
+@Tag("vector")
+class CompactIndexKeepsGraphReusableTest {
+  private static final int    DIMENSIONS  = 32;
+  private static final int    NUM_VECTORS = 2_000;
+  private static final int    REOPENS     = 3;
+  private static final String DB_PATH     = "./target/databases/CompactIndexKeepsGraphReusableTest";
+
+  @AfterEach
+  void cleanUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void compactionMustNotOrphanTheGraphOrForceARebuildOnEveryOpen() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    final Random rng = new Random(7);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+      db.transaction(() -> {
+        final DocumentType t = db.getSchema().createDocumentType("Doc");
+        t.createProperty("id", Type.INTEGER);
+        t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+        for (int i = 0; i < NUM_VECTORS; i++)
+          db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
+      });
+      db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+          + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", \"maxConnections\": 32 }");
+      waitForGraph(db);
+      db.command("sql", "COMPACT INDEX `Doc[embedding]`");
+      db.close();
+    }
+
+    int settledFileCount = -1;
+
+    for (int open = 1; open <= REOPENS; open++) {
+      try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+        final Database db = factory.open();
+        final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+        final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+        waitForGraph(db, lsm);
+
+        if (open > 1)
+          assertThat(lsm.getStats().get("graphRebuildCount"))
+              .as("open %d rebuilt the graph; the one written on the first open after compaction should have "
+                  + "been found and reused", open)
+              .isEqualTo(0L);
+        db.close();
+      }
+
+      final int now = countGraphFiles();
+      if (open == 1)
+        settledFileCount = now;
+      else
+        assertThat(now)
+            .as("open %d left another .vecgraph behind; after the first open the count must not grow", open)
+            .isEqualTo(settledFileCount);
+    }
+  }
+
+  private static void waitForGraph(final Database db) {
+    final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+    waitForGraph(db, (LSMVectorIndex) idx.getIndexesOnBuckets()[0]);
+  }
+
+  private static void waitForGraph(final Database db, final LSMVectorIndex lsm) {
+    for (int i = 0; i < 600 && lsm.getStats().get("graphNodeCount") == 0L; i++)
+      try { Thread.sleep(50); } catch (final InterruptedException ignored) { break; }
+  }
+
+  private static int countGraphFiles() {
+    final File[] files = new File(DB_PATH).listFiles((d, n) -> n.endsWith("." + LSMVectorIndexGraphFile.FILE_EXT));
+    return files == null ? 0 : files.length;
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/CompactIndexKeepsGraphReusableTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/CompactIndexKeepsGraphReusableTest.java
@@ -35,26 +35,28 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * A persisted vector graph must survive {@code COMPACT INDEX} and stay reusable across reopens.
+ * A persisted vector graph must survive {@code COMPACT INDEX} and stay reusable across reopens, with no
+ * rebuild and no orphaned file left behind by the compaction itself.
  * <p>
- * {@code getOrCreateGraphFile()} built the graph file's path from {@code mutable.getFilePath()}, which already
- * carries the {@code .<fileId>.<pageSize>.v<version>.lsmvecidx} suffix. {@code ComponentFile} derives a
- * component's registered name from its path, so the graph registered as
+ * Two defects compounded here (issue #6495). First, {@code getOrCreateGraphFile()} built the graph file's
+ * path from {@code mutable.getFilePath()}, which already carries the
+ * {@code .<fileId>.<pageSize>.v<version>.lsmvecidx} suffix. {@code ComponentFile} derives a component's
+ * registered name from its path, so the graph registered as
  * {@code <index>.<fileId>.<pageSize>.v<version>.lsmvecidx_vecgraph} while
- * {@code discoverAndLoadGraphFile()} looks for {@code <mutable.getName()>_vecgraph}. The two can never match,
- * so every open failed to find a graph, rebuilt from scratch, and wrote one more file that would never be
- * found either.
+ * {@code discoverAndLoadGraphFile()} looks for {@code <mutable.getName()>_vecgraph}. The two could never
+ * match, so every open failed to find a graph, rebuilt from scratch, and wrote one more file that would
+ * never be found either - unbounded growth on every reopen.
  * <p>
- * Compaction is what exposes it: {@code rewriteDataFileWithLiveEntries()} renames the index, so the graph
- * registered under the pre-compaction name stops matching and the lazy path takes over from there on.
+ * Second, even with that path fixed, compaction itself ({@code rewriteDataFileWithLiveEntries()}) renames
+ * the index but leaves the in-memory {@code graphFile} reference pointing at the file registered under the
+ * pre-compaction name, so the graph the compaction rebuilds gets persisted back into that same
+ * now-unreachable file: correct content, unreachable name. The persist step now drops that stale reference
+ * before it is read, letting {@code getOrCreateGraphFile()} register a fresh file under the CURRENT name -
+ * the one {@code discoverAndLoadGraphFile()} will actually look for - and drops the superseded file the same
+ * way compaction already drops the mutable/compacted components it replaces.
  * <p>
- * Before the fix the file count grows without bound and every reopen rebuilds. This test pins what the path
- * fix achieves: the graph written on the FIRST open after compaction is found again by every later open, so
- * the count stabilises and no further rebuild happens.
- * <p>
- * One orphan remains, the graph registered under the pre-compaction name. Removing it needs the compaction
- * path to re-register the component under the new name, which sits inside a critical section documented as
- * needing its statements kept adjacent, so it is left as a follow-up rather than attempted here.
+ * This test pins the fully closed loop: after {@code COMPACT INDEX}, not even the first reopen has to
+ * rebuild, and the {@code .vecgraph} file count never grows past the one file compaction leaves behind.
  */
 @Tag("vector")
 class CompactIndexKeepsGraphReusableTest {
@@ -89,7 +91,12 @@ class CompactIndexKeepsGraphReusableTest {
       db.close();
     }
 
-    int settledFileCount = -1;
+    // Compaction itself already persists the graph under a name the next open can find: nothing between here
+    // and the first reopen should add or remove a single .vecgraph file.
+    final int settledFileCount = countGraphFiles();
+    assertThat(settledFileCount)
+        .as("COMPACT INDEX must leave exactly one .vecgraph file behind, not one orphan plus a replacement")
+        .isEqualTo(1);
 
     for (int open = 1; open <= REOPENS; open++) {
       try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
@@ -98,21 +105,16 @@ class CompactIndexKeepsGraphReusableTest {
         final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
         waitForGraph(db, lsm);
 
-        if (open > 1)
-          assertThat(lsm.getStats().get("graphRebuildCount"))
-              .as("open %d rebuilt the graph; the one written on the first open after compaction should have "
-                  + "been found and reused", open)
-              .isEqualTo(0L);
+        assertThat(lsm.getStats().get("graphRebuildCount"))
+            .as("open %d rebuilt the graph; the one compaction persisted should have been found and reused",
+                open)
+            .isEqualTo(0L);
         db.close();
       }
 
-      final int now = countGraphFiles();
-      if (open == 1)
-        settledFileCount = now;
-      else
-        assertThat(now)
-            .as("open %d left another .vecgraph behind; after the first open the count must not grow", open)
-            .isEqualTo(settledFileCount);
+      assertThat(countGraphFiles())
+          .as("open %d left another .vecgraph behind; the count must never grow past the settled one", open)
+          .isEqualTo(settledFileCount);
     }
   }
 


### PR DESCRIPTION
## What

Builds on #6504 (thank you @tae898 for the diagnosis and the first fix - both commits from that PR are included here unmodified) to close the remaining gap it deliberately scoped out.

#6504 fixed `getOrCreateGraphFile()` deriving the graph file's path from the already-suffixed `mutable.getFilePath()` instead of the bare index path, which made every lazily-created graph file undiscoverable and caused unbounded growth on every reopen after a `COMPACT INDEX`. That fix is necessary and correct on its own.

It also left one gap on purpose, noted in its own description: `rewriteDataFileWithLiveEntries()` renames the index during compaction, but the in-memory `graphFile` reference still points at the file registered under the pre-compaction name. `getOrCreateGraphFile()` only derives a fresh path when `graphFile` is `null`, so the graph rebuilt by the same compaction gets persisted right back into that same now-unreachable file - correct content, unreachable name. Net effect even with #6504 applied: one orphaned `.vecgraph` file per compaction, and one avoidable full rebuild on the very next open.

## Fix

Right before the post-compaction rebuild persists its graph, drop the stale `graphFile` reference (only when compaction actually renamed the index - `locationIndexAlreadyPublished`) so `getOrCreateGraphFile()` registers a fresh file under the CURRENT name. This mirrors exactly how compaction already replaces the mutable/compacted components: a new file registered under the new identity, the old one dropped outside any lock once its replacement exists (`dropReplacedComponent`). If persistence itself fails, the stale reference is restored instead of losing the graph outright.

No change to the sensitive critical section that keeps the rename and the schema re-keying adjacent (the `indexName = ...` / `indexRenamed(...)` pair) - this only touches the persist step later in the same method, gated on the boolean that section already produces.

## Test

Extended `CompactIndexKeepsGraphReusableTest` (from #6504) to assert the fully closed loop instead of just the bounded-damage version:
- exactly one `.vecgraph` file survives immediately after `COMPACT INDEX` (no orphan)
- `graphRebuildCount == 0` on every reopen, including the first one (previously only opens 2+ were checked)

Verified by reverting each fix independently: reverting #6504's path fix reproduces its original failure; reverting this PR's addition on top of #6504's fix reproduces `graphRebuildCount == 1` on the first reopen and 2 `.vecgraph` files on disk instead of 1.

Full `com.arcadedb.index.vector` suite: 342 tests, 0 failures.

## Test plan

- [x] `mvn -o -pl engine -am compile`
- [x] `CompactIndexKeepsGraphReusableTest` passes
- [x] Full `com.arcadedb.index.vector` package: 342/342 passing