### PR TITLE
fix(#6526): async executor follow-ups - in-place setParallelLevel(), DDL pool durability, boundary-commit metric

### DIFF
--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -65,13 +65,17 @@ public class Profiler {
   private static final int STAT_INDEX_COMPACTIONS = 15;
   private static final int STAT_WAL_PAGES_WRITTEN = 16;
   private static final int STAT_WAL_BYTES_WRITTEN = 17;
-  private static final int MONOTONIC_STATS        = 18;
-  private static final int STAT_WAL_TOTAL_FILES   = 18;
-  private static final int STAT_OPEN_FILES        = 19;
-  private static final int STAT_MAX_OPEN_FILES    = 20;
-  private static final int STAT_ASYNC_QUEUE       = 21;
-  private static final int STAT_ASYNC_PARALLEL    = 22;
-  private static final int STATS_COUNT            = 23;
+  // #6526: monotonic, and it belongs INSIDE the retained range - a durability-flag flipper is exactly the kind of
+  // caller (a bulk load through GraphBatch) that opens a database, does its work and closes it, so a counter that
+  // went back to zero on that close would be zero every time anybody looked at it.
+  private static final int STAT_ASYNC_BOUNDARY_COMMITS = 18;
+  private static final int MONOTONIC_STATS        = 19;
+  private static final int STAT_WAL_TOTAL_FILES   = 19;
+  private static final int STAT_OPEN_FILES        = 20;
+  private static final int STAT_MAX_OPEN_FILES    = 21;
+  private static final int STAT_ASYNC_QUEUE       = 22;
+  private static final int STAT_ASYNC_PARALLEL    = 23;
+  private static final int STATS_COUNT            = 24;
 
   /**
    * Registered database INSTANCES, compared by identity.
@@ -195,6 +199,11 @@ public class Profiler {
     final Map<String, Object> walStats = db.getTransactionManager().getStats();
     acc[STAT_WAL_PAGES_WRITTEN] += statOf(walStats, "pagesWritten");
     acc[STAT_WAL_BYTES_WRITTEN] += statOf(walStats, "bytesWritten");
+
+    // #6526: DatabaseAsyncExecutorImpl.getStats() is lock-free and documented to stay callable on a shut-down
+    // executor, which is the property this method requires of every source it reads - unregisterDatabase() calls it
+    // on a database that is already closing.
+    acc[STAT_ASYNC_BOUNDARY_COMMITS] += ((DatabaseAsyncExecutorImpl) db.async()).getStats().forcedBoundaryCommits;
     return walStats;
   }
 
@@ -220,6 +229,7 @@ public class Profiler {
     final long walTotalFiles = dbStats[STAT_WAL_TOTAL_FILES];
     final long asyncQueueLength = dbStats[STAT_ASYNC_QUEUE];
     final long asyncParallelLevel = dbStats[STAT_ASYNC_PARALLEL];
+    final long asyncForcedBoundaryCommits = dbStats[STAT_ASYNC_BOUNDARY_COMMITS];
 
     final long writeTx = dbStats[STAT_WRITE_TX];
     final long readTx = dbStats[STAT_READ_TX];
@@ -273,6 +283,10 @@ public class Profiler {
     json.put("pageFlushQueueMaxPerDatabase", new JSONObject().put("value", pStats.pageFlushQueueMaxPerDatabase));
     json.put("asyncQueueLength", new JSONObject().put("value", asyncQueueLength));
     json.put("asyncParallelLevel", new JSONObject().put("count", asyncParallelLevel));
+    // #6526: how often a durability-flag change (setTransactionUseWAL()/setTransactionSync()) cut an async worker's
+    // batch transaction short. #6511 traded the pool teardown for this extra commit; this is what makes the trade
+    // measurable instead of something to reconstruct from logs after an incident.
+    json.put("asyncForcedBoundaryCommits", new JSONObject().put("count", asyncForcedBoundaryCommits));
     json.put("pageCacheHits", new JSONObject().put("count", pageCacheHits));
     json.put("pageCacheMiss", new JSONObject().put("count", pageCacheMiss));
     json.put("totalOpenFiles", new JSONObject().put("count", totalOpenFiles));

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -76,7 +76,10 @@ public class Profiler {
   private static final int STAT_MAX_OPEN_FILES    = 21;
   private static final int STAT_ASYNC_QUEUE       = 22;
   private static final int STAT_ASYNC_PARALLEL    = 23;
-  private static final int STATS_COUNT            = 24;
+  // #6526 review round 4: instantaneous, and firmly on this side of MONOTONIC_STATS - it returns to zero as the
+  // retired workers finish, so carrying it across a close would make a gauge that only ever grows.
+  private static final int STAT_ASYNC_RETIRING    = 24;
+  private static final int STATS_COUNT            = 25;
 
   /**
    * Registered database INSTANCES, compared by identity.
@@ -182,8 +185,10 @@ public class Profiler {
       // (issue #6526 review). A database with no executor has no queue and no workers, which is what the two
       // readings below now say instead of what asking the question made true.
       final DatabaseAsyncExecutorImpl async = asyncIfExists(db);
-      acc[STAT_ASYNC_QUEUE] += async != null ? async.getStats().queueSize : 0L;
+      final DatabaseAsyncExecutorImpl.DBAsyncStats asyncStats = async != null ? async.getStats() : null;
+      acc[STAT_ASYNC_QUEUE] += asyncStats != null ? asyncStats.queueSize : 0L;
       acc[STAT_ASYNC_PARALLEL] = async != null ? async.getParallelLevel() : 0L;
+      acc[STAT_ASYNC_RETIRING] += asyncStats != null ? asyncStats.retiringWorkers : 0L;
     }
     return acc;
   }
@@ -249,6 +254,7 @@ public class Profiler {
     final long asyncQueueLength = dbStats[STAT_ASYNC_QUEUE];
     final long asyncParallelLevel = dbStats[STAT_ASYNC_PARALLEL];
     final long asyncForcedBoundaryCommits = dbStats[STAT_ASYNC_BOUNDARY_COMMITS];
+    final long asyncRetiringWorkers = dbStats[STAT_ASYNC_RETIRING];
 
     final long writeTx = dbStats[STAT_WRITE_TX];
     final long readTx = dbStats[STAT_READ_TX];
@@ -306,6 +312,9 @@ public class Profiler {
     // batch transaction short. #6511 traded the pool teardown for this extra commit; this is what makes the trade
     // measurable instead of something to reconstruct from logs after an incident.
     json.put("asyncForcedBoundaryCommits", new JSONObject().put("count", asyncForcedBoundaryCommits));
+    // #6526 review round 4: "value", not "count" - this one goes back down, so it is a gauge. Persistently non-zero
+    // is a worker a lowered parallel level retired and that never finished draining; a resize never interrupts one.
+    json.put("asyncRetiringWorkers", new JSONObject().put("value", asyncRetiringWorkers));
     json.put("pageCacheHits", new JSONObject().put("count", pageCacheHits));
     json.put("pageCacheMiss", new JSONObject().put("count", pageCacheMiss));
     json.put("totalOpenFiles", new JSONObject().put("count", totalOpenFiles));
@@ -441,6 +450,7 @@ public class Profiler {
       final long asyncQueueLength = dbStats[STAT_ASYNC_QUEUE];
       final long asyncParallelLevel = dbStats[STAT_ASYNC_PARALLEL];
       final long asyncForcedBoundaryCommits = dbStats[STAT_ASYNC_BOUNDARY_COMMITS];
+      final long asyncRetiringWorkers = dbStats[STAT_ASYNC_RETIRING];
       final long totalOpenFiles = dbStats[STAT_OPEN_FILES];
       final long maxOpenFiles = dbStats[STAT_MAX_OPEN_FILES];
       final long walPagesWritten = dbStats[STAT_WAL_PAGES_WRITTEN];
@@ -532,7 +542,8 @@ public class Profiler {
       // each flip closing whatever worker's batch sees it next. Printed here as well as in toJSON() for the same
       // reason the #6217 read-path counters are: this dump is what an operator has when there is no metrics
       // endpoint to scrape.
-      buffer.append("%n    asyncForcedBoundaryCommits=%d".formatted(asyncForcedBoundaryCommits));
+      buffer.append("%n    asyncForcedBoundaryCommits=%d asyncRetiringWorkers=%d".formatted(
+          asyncForcedBoundaryCommits, asyncRetiringWorkers));
       buffer.append(
         "%n    scanType=%d scanBucket=%d iterateType=%d iterateBucket=%d countType=%d countBucket=%d".formatted(scanType,
           scanBucket, iterateType,

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -19,6 +19,7 @@
 package com.arcadedb;
 
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
 import com.arcadedb.engine.FileManager;
 import com.arcadedb.engine.PageManager;
@@ -176,8 +177,13 @@ public class Profiler {
       acc[STAT_OPEN_FILES] += fStats.totalOpenFiles;
       acc[STAT_MAX_OPEN_FILES] += fStats.maxOpenFiles;
 
-      acc[STAT_ASYNC_QUEUE] += ((DatabaseAsyncExecutorImpl) db.async()).getStats().queueSize;
-      acc[STAT_ASYNC_PARALLEL] = db.async().getParallelLevel();
+      // asyncIfExists(), never db.async(): that accessor CREATES the executor, worker threads included, so a
+      // metrics scrape used to grow a full pool on every open database that had never touched the async API
+      // (issue #6526 review). A database with no executor has no queue and no workers, which is what the two
+      // readings below now say instead of what asking the question made true.
+      final DatabaseAsyncExecutorImpl async = asyncIfExists(db);
+      acc[STAT_ASYNC_QUEUE] += async != null ? async.getStats().queueSize : 0L;
+      acc[STAT_ASYNC_PARALLEL] = async != null ? async.getParallelLevel() : 0L;
     }
     return acc;
   }
@@ -202,9 +208,22 @@ public class Profiler {
 
     // #6526: DatabaseAsyncExecutorImpl.getStats() is lock-free and documented to stay callable on a shut-down
     // executor, which is the property this method requires of every source it reads - unregisterDatabase() calls it
-    // on a database that is already closing.
-    acc[STAT_ASYNC_BOUNDARY_COMMITS] += ((DatabaseAsyncExecutorImpl) db.async()).getStats().forcedBoundaryCommits;
+    // on a database that is already closing. And it is reached through asyncIfExists() rather than db.async() for a
+    // second reason that only this path has: this runs ON THE CLOSE, after the close has already shut down whatever
+    // executor existed, so creating one here would leave its worker threads running with nothing left to stop them.
+    final DatabaseAsyncExecutorImpl async = asyncIfExists(db);
+    if (async != null)
+      acc[STAT_ASYNC_BOUNDARY_COMMITS] += async.getStats().forcedBoundaryCommits;
     return walStats;
+  }
+
+  /**
+   * The database's asynchronous executor <b>if it already has one</b>, and {@code null} otherwise. Every database in
+   * the registry is a {@link LocalDatabase} - it is what registers itself - so the check is a formality that keeps
+   * this class honest rather than a cast that assumes.
+   */
+  private static DatabaseAsyncExecutorImpl asyncIfExists(final DatabaseInternal db) {
+    return db instanceof final LocalDatabase local ? local.getAsyncIfExists() : null;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -440,6 +440,7 @@ public class Profiler {
       final long[] dbStats = collectDatabaseStats();
       final long asyncQueueLength = dbStats[STAT_ASYNC_QUEUE];
       final long asyncParallelLevel = dbStats[STAT_ASYNC_PARALLEL];
+      final long asyncForcedBoundaryCommits = dbStats[STAT_ASYNC_BOUNDARY_COMMITS];
       final long totalOpenFiles = dbStats[STAT_OPEN_FILES];
       final long maxOpenFiles = dbStats[STAT_MAX_OPEN_FILES];
       final long walPagesWritten = dbStats[STAT_WAL_PAGES_WRITTEN];
@@ -526,6 +527,12 @@ public class Profiler {
           asyncParallelLevel, asyncQueueLength, writeTx, readTx, txRollbacks, queries, commands));
       buffer.append("%n    createRecord=%d readRecord=%d updateRecord=%d deleteRecord=%d".formatted(createRecord, readRecord,
         updateRecord, deleteRecord));
+      // #6526: read this next to asyncQueue/asyncParallelLevel above. Climbing while the async queue drains slowly
+      // is two callers flipping setTransactionUseWAL()/setTransactionSync() against each other on one database,
+      // each flip closing whatever worker's batch sees it next. Printed here as well as in toJSON() for the same
+      // reason the #6217 read-path counters are: this dump is what an operator has when there is no metrics
+      // endpoint to scrape.
+      buffer.append("%n    asyncForcedBoundaryCommits=%d".formatted(asyncForcedBoundaryCommits));
       buffer.append(
         "%n    scanType=%d scanBucket=%d iterateType=%d iterateBucket=%d countType=%d countBucket=%d".formatted(scanType,
           scanBucket, iterateType,

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -504,6 +504,25 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     return executor.quiesceWorkers();
   }
 
+  /**
+   * The asynchronous executor of this database <b>if one already exists</b>, and {@code null} otherwise - never a
+   * newly created one, unlike {@link #async()}, whose lazy creation starts a full set of worker threads.
+   * <p>
+   * The same rule {@link #waitForAsyncCompletion()} and {@link #quiesceAsync()} follow, and for the same reason,
+   * exported for the one caller that lives outside this class: {@code Profiler} reads async counters on every metrics
+   * scrape AND on every database close, and going through {@code async()} there made merely observing a database
+   * grow it a worker pool - one that the close path had already passed, so nothing was left to shut it down
+   * (issue #6526 review).
+   *
+   * @see #async()
+   */
+  public DatabaseAsyncExecutorImpl getAsyncIfExists() {
+    // The volatile field, unlocked: asyncLock serializes the lazy creation in async(), and once assigned this field
+    // is never assigned again - not even on close - so the only two values a reader can see are "no executor yet"
+    // and "the one and only executor".
+    return async;
+  }
+
   public DatabaseAsyncExecutor async() {
     if (async == null) {
       asyncLock.lock();

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -346,6 +346,11 @@ public interface DatabaseAsyncExecutor {
   /**
    * Changes the number of executor threads for asynchronous operations. It is recommended to keep this number equals or lower than the actual cores available
    * on the server.
+   * <p>
+   * Safe to call while other callers have asynchronous work in flight on the same database (issue #6526): growing
+   * only adds workers, and shrinking lets the workers it retires finish the tasks already queued on them - within a
+   * bounded wait this call makes on the caller's behalf - rather than force-exiting them. Nothing already submitted
+   * is dropped, and no unrelated producer is told the executor has shut down.
    *
    * @param parallelLevel Number of executor threads
    */

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -579,9 +579,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // halves are closed: resizeThreads() registers a retiring worker BEFORE it unpublishes the array, so it is
     // never in neither, and the identity check here drops it when it is in both. The scan is over arrays the size
     // of the pool, so it costs nothing that matters here.
-    for (final AsyncThread retiring : retiringThreads)
+    for (final AsyncThread retiring : retiringThreads) {
       if (!contains(threads, retiring))
         stats.queueSize += retiring.queue.size();
+      // #6526 review round 4: and how many of them there are. A worker retired by a shrink is normally in this set
+      // for milliseconds; one that outlived awaitRetiredThreads()'s budget stays, and until now the ONLY trace of
+      // that was the single WARNING logged at the moment the wait gave up. This is the same argument item 3 of
+      // #6526 makes for the boundary-commit counter: a condition whose only evidence is one log line is a condition
+      // somebody reconstructs after an incident instead of seeing during one. Persistently non-zero here is a
+      // wedged worker; briefly non-zero is a resize doing its job.
+      if (retiring.isAlive())
+        ++stats.retiringWorkers;
+    }
 
     stats.scheduledTasks = counterScheduledTasks.get();
     stats.forcedBoundaryCommits = forcedBoundaryCommits.get();
@@ -1613,6 +1622,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   public static class DBAsyncStats {
     public long queueSize;
     public long scheduledTasks;
+    /**
+     * Workers a shrinking {@code setParallelLevel()} retired that are still running (issue #6526 review round 4).
+     * <p>
+     * Instantaneous, not monotonic - it goes back to zero as they finish - so it must be read as a gauge and never
+     * as a counter. Zero almost always; briefly positive during a resize; PERSISTENTLY positive means a retired
+     * worker is wedged inside user code and is never going to finish, which a resize deliberately never escalates
+     * to an {@code interrupt()} the way a close does.
+     */
+    public long retiringWorkers;
     /**
      * Monotonic count of transaction boundaries forced by a durability-flag change (issue #6526, item 3). Climbing
      * while throughput drops is the signature of two callers flipping {@code setTransactionUseWAL()} /

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -572,8 +572,16 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // #6526: a worker retired by a shrinking setParallelLevel() is off the published array but is still draining
     // real tasks, so leaving it out here would report a queue that shrank the instant the pool did - which is the
     // one moment an operator is most likely to be looking at this number.
+    //
+    // Counted ONCE (#6526 review round 2, point 2): the two reads are separate and unsynchronized - deliberately,
+    // since this method must stay lock-free - so a shrink landing between them publishes the smaller array and adds
+    // the worker to retiringThreads, and a naive second loop would count that worker's queue twice. Skipping the
+    // ones the first loop already saw is exact under every interleaving: whichever of the two reads observed the
+    // worker, it contributes exactly one term. The scan is over arrays the size of the pool, so it costs nothing
+    // that matters here.
     for (final AsyncThread retiring : retiringThreads)
-      stats.queueSize += retiring.queue.size();
+      if (!contains(threads, retiring))
+        stats.queueSize += retiring.queue.size();
 
     stats.scheduledTasks = counterScheduledTasks.get();
     stats.forcedBoundaryCommits = forcedBoundaryCommits.get();
@@ -1714,14 +1722,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     if (interrupted)
       Thread.currentThread().interrupt();
 
+    // EVERY one that is still running, not just the first (#6526 review round 2, point 1). One line per worker is
+    // what an operator needs to tell "one task is slow" from "the whole pool is wedged", and this method's whole
+    // contract is that giving up is bounded and LOUD rather than silent - a break here made it loud about one.
     for (final AsyncThread worker : retired)
-      if (worker.isAlive()) {
+      if (worker.isAlive())
         LogManager.instance().log(this, Level.WARNING,
             "Asynchronous worker %s did not finish draining within %dms of the parallel level being lowered: it "
                 + "keeps running its queued tasks in the background and stays visible to waitCompletion()",
             worker.getName(), shutdownJoinTimeoutMs);
-        break;
-      }
   }
 
   private void createThreads(int parallelLevel) {
@@ -1807,6 +1816,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       Thread.currentThread().interrupt();
   }
 
+  /** Identity search over a worker array, tolerating the null a closed executor publishes. */
+  private static boolean contains(final AsyncThread[] threads, final AsyncThread worker) {
+    if (threads != null)
+      for (int i = 0; i < threads.length; ++i)
+        if (threads[i] == worker)
+          return true;
+    return false;
+  }
+
   /**
    * Concatenates the live worker array (possibly null on an already-closed executor) with the retiring ones.
    */
@@ -1839,7 +1857,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // half of it.
     final List<AsyncThread> stillRunning = new ArrayList<>(retiringThreads.size());
     for (final AsyncThread retiring : retiringThreads)
-      if (retiring.isAlive())
+      // Alive, and not already in the published array: same unsynchronized-pair window getStats() names, and the
+      // same answer. A duplicate here would only cost waitCompletion() a second marker on one worker, but there is
+      // no reason to hand it one.
+      if (retiring.isAlive() && !contains(live, retiring))
         stillRunning.add(retiring);
 
     final AsyncThread[] all = concat(live, stillRunning.toArray(new AsyncThread[0]));

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -152,8 +152,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * Reentrant, so a resize triggered from inside a resize rides on the outer one rather than deadlocking, and
    * deliberately NOT taken by {@code createThreads()}: the constructor runs before anything can race it, and
    * {@code recreateThreadsForTests()} is a test hook that means "tear it down and rebuild it".
+   * <p>
+   * FAIR (#6526 review round 6), which is the one place in this class that choice is affordable. The lock is held
+   * across a wait that can last {@code shutdownJoinTimeoutMs}, so under barging a caller could queue behind an
+   * unbounded number of other resizes; fairness turns that into first-come-first-served. The throughput fairness
+   * normally costs is irrelevant here - this is an administrative call taken once per bulk load, not a hot path -
+   * and an unbounded wait on a public API is worth more than the uncontended-acquire nanoseconds it gives up.
    */
-  private final ReentrantLock        resizeLock                    = new ReentrantLock();
+  private final ReentrantLock        resizeLock                    = new ReentrantLock(true);
 
   // #5062 review r2 (point 1): producer-side backstop for a worker wedged inside user code. After
   // this many consecutive stall windows (checkForStalledQueuesMaxDelay each, 60s with the defaults)
@@ -1555,18 +1561,38 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * There is no {@code interrupt()} on this path at all; that escalation belongs to {@code close()}, which is
    * terminal, and not to a resize, which is not.
    * <p>
-   * <b>It waits for the retired workers, within a bounded budget.</b> {@code getSlot()} maps a bucket to a worker
-   * modulo the pool size, so while a retired worker is still draining, a bucket it holds tasks for is also mapped
-   * to one of the surviving workers: returning immediately would let two workers write the same bucket's pages
-   * concurrently, which is precisely the contention {@code ThreadBucketSelectionStrategy} exists to prevent
-   * ({@code AsyncInsertTest} measures it as MVCC conflicts). The wait therefore restores the guarantee the teardown
-   * gave for free. It is bounded by {@code shutdownJoinTimeoutMs} and taken OUTSIDE {@code lifecycleLock}, so a
-   * worker wedged inside user code delays neither a concurrent {@code close()} nor the caller for ever; if the
-   * budget runs out the workers are left draining in the background, still visible to
+   * <b>It waits for the retired workers, within a bounded budget</b> - so that when this call RETURNS, the pool it
+   * reports is the pool that exists: the caller's own next {@code getSlot()} cannot land on a bucket another worker
+   * is still writing, a second resize cannot reuse a position that is still occupied, and {@code getThreadCount()}
+   * is not describing a fiction. It is bounded by {@code shutdownJoinTimeoutMs} and taken OUTSIDE
+   * {@code lifecycleLock}, so a worker wedged inside user code delays neither a concurrent {@code close()} nor the
+   * caller for ever; if the budget runs out the workers are left draining in the background, still visible to
    * {@link #waitCompletion(long)}, {@link #isProcessing()} and {@link #getStats()}, which is the honest outcome
    * rather than dropping their work to return on time.
    * <p>
-   * <b>Serialized against itself</b> by {@code resizeLock}, held across the publish AND the wait. Without that, a
+   * <b>What that wait is NOT</b> (issue #6526 review round 6), because an earlier draft of this javadoc claimed it
+   * and the claim was wrong: it does not give back the bucket exclusivity the teardown had. {@code getSlot()} maps a
+   * bucket modulo the pool size and reads {@code executorThreads} lock-free, so the moment the truncated array is
+   * published, a bucket that used to hash to a retired worker hashes to a survivor - and an UNRELATED producer,
+   * which is not holding this lock and is not waiting for anything, routes there immediately while the retired
+   * worker is still draining that same bucket's queued tasks. For the length of the drain those two workers can
+   * write one bucket's pages, which is the contention {@code ThreadBucketSelectionStrategy} exists to prevent and
+   * which {@code AsyncInsertTest} measures as MVCC conflicts. The wait bounds when the caller of THIS method
+   * observes the overlap; it cannot bound when everybody else does.
+   * <p>
+   * That residual is accepted rather than closed, and the alternatives are why. Changing the pool size changes which
+   * worker owns a bucket, so every resize has a handover, and there are only three ways to spend it: refuse the
+   * producers for its duration (the teardown's answer - the "shut down" exception of #6505), drop what the retired
+   * worker still holds (the teardown's other answer - somebody else's writes, silently), or let the two overlap
+   * while the old work finishes. Only the third loses nothing, and what it costs is bounded, self-correcting and
+   * already handled: an MVCC conflict on a migrating bucket, for the length of one drain, on a path that reports
+   * through {@code onError} and retries. Closing it properly would mean blocking a producer inside
+   * {@code scheduleTask()} until the previous owner of its bucket finished - a bounded wait on the lock-free hot
+   * path that index-compaction hooks reach after {@code writeTransactionToWAL()}, which is exactly the shape of
+   * failure #6505 was.
+   * <p>
+   * <b>Serialized against itself</b> by {@code resizeLock}, a FAIR lock held across the publish AND the wait.
+   * Without that, a
    * second caller growing the pool back would fill the array positions the shrink just vacated while the old
    * workers for those positions are still draining, and the wait would guarantee nothing for the multi-caller case
    * it exists for. The residual is what survives the wait's own budget: if a retired worker is still draining when

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1013,8 +1013,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       // method (query() goes straight to a worker), so a task that gets this far is never idempotent.
       final boolean ownTransaction = task.requiresActiveTx() && !database.isTransactionActive();
 
-      // #6526 item 2. Non-null exactly when the transaction below is OURS and therefore carries this executor's
-      // durability policy; the finally reads it back to undo the stamp.
+      // #6526 item 2. ownTx is non-null exactly when the transaction below is OURS and therefore carries this
+      // executor's durability policy; the finally reads the other two back to undo the stamp. Their initial values
+      // are never observed - the finally only runs them when ownTx is non-null, and the branch that sets ownTx sets
+      // both first - so `true` here is a compiler-mandated placeholder and not a default policy (#6526 review round
+      // 5): a primitive cannot carry the "unset" the reference next to it does.
       TransactionContext  ownTx            = null;
       boolean             previousUseWAL   = true;
       WALFile.FlushType   previousWALFlush = null;

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -573,12 +573,12 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // real tasks, so leaving it out here would report a queue that shrank the instant the pool did - which is the
     // one moment an operator is most likely to be looking at this number.
     //
-    // Counted ONCE (#6526 review round 2, point 2): the two reads are separate and unsynchronized - deliberately,
-    // since this method must stay lock-free - so a shrink landing between them publishes the smaller array and adds
-    // the worker to retiringThreads, and a naive second loop would count that worker's queue twice. Skipping the
-    // ones the first loop already saw is exact under every interleaving: whichever of the two reads observed the
-    // worker, it contributes exactly one term. The scan is over arrays the size of the pool, so it costs nothing
-    // that matters here.
+    // Counted EXACTLY ONCE (#6526 review rounds 2 and 3): the two reads are separate and unsynchronized -
+    // deliberately, since this method must stay lock-free - so a shrink landing between them could otherwise be
+    // seen twice (the worker still in the array this method read, and already in the set) or not at all. Both
+    // halves are closed: resizeThreads() registers a retiring worker BEFORE it unpublishes the array, so it is
+    // never in neither, and the identity check here drops it when it is in both. The scan is over arrays the size
+    // of the pool, so it costs nothing that matters here.
     for (final AsyncThread retiring : retiringThreads)
       if (!contains(threads, retiring))
         stats.queueSize += retiring.queue.size();
@@ -1674,14 +1674,23 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         return null;
       }
 
-      // SHRINK. Publish the survivors FIRST, so by the time the tail is asked to stop, nothing can still choose it.
+      // SHRINK, in three ordered steps that a LOCK-FREE reader has to be able to walk through at any point.
       final AsyncThread[] retired = Arrays.copyOfRange(current, newLevel, current.length);
+
+      // 1. REGISTER BEFORE UNPUBLISHING (#6526 review round 3, point 1). The reverse order - publish the smaller
+      //    array, then add - leaves a window in which a retired worker is in NEITHER collection, and a getStats()
+      //    or waitCompletion() reading the two in that window would miss its queue entirely. This way it is always
+      //    in at least one, and the identity check both readers apply makes it count for exactly one. Registering
+      //    before the stop request below matters for the same kind of reason: a worker that exits immediately must
+      //    be removed by its own run loop AFTER it was added, or it would stay in the set for ever.
+      for (final AsyncThread worker : retired)
+        retiringThreads.add(worker);
+
+      // 2. Publish the survivors, so by the time the tail is asked to stop, nothing can still choose it.
       this.executorThreads = Arrays.copyOf(current, newLevel);
 
+      // 3. Ask the tail to stop.
       for (final AsyncThread worker : retired) {
-        // Registered BEFORE the stop request, so a worker that exits immediately is removed by its own run loop
-        // after it was added rather than before - the reverse order would leave it in the set for ever.
-        retiringThreads.add(worker);
         worker.shutdown = true;
         // Best effort and NON-blocking, unlike the close path's bounded offer plus interrupt. The marker only makes
         // an IDLE worker exit at once instead of on its next 500ms poll timeout; a worker whose queue is full does
@@ -1857,9 +1866,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // half of it.
     final List<AsyncThread> stillRunning = new ArrayList<>(retiringThreads.size());
     for (final AsyncThread retiring : retiringThreads)
-      // Alive, and not already in the published array: same unsynchronized-pair window getStats() names, and the
-      // same answer. A duplicate here would only cost waitCompletion() a second marker on one worker, but there is
-      // no reason to hand it one.
+      // Alive, and not already in the published array: same unsynchronized-pair window getStats() names, closed the
+      // same way (see resizeThreads()'s ordered shrink). A duplicate here would only cost waitCompletion() a second
+      // marker on one worker, but there is no reason to hand it one.
       if (retiring.isAlive() && !contains(live, retiring))
         stillRunning.add(retiring);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -49,12 +49,15 @@ import com.arcadedb.schema.LocalTimeSeriesType;
 import com.conversantmedia.util.concurrent.DisruptorBlockingQueue;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -99,6 +102,40 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   private final AtomicInteger        commandsInFlight              = new AtomicInteger();
   /** Monitor {@link #awaitCommands} parks on; notified when the last in-flight command lands. */
   private final Object               commandsLock                  = new Object();
+
+  /**
+   * Workers a SHRINKING {@link #setParallelLevel(int)} has retired and left DRAINING (issue #6526, item 1).
+   * <p>
+   * A retired worker is unpublished from {@link #executorThreads} first - so nothing new is routed to it - and is
+   * then asked to stop the way {@code close()} asks, minus the escalation: the {@code shutdown} flag plus a
+   * best-effort {@code FORCE_EXIT} at the TAIL of its queue, never an {@code interrupt()}. Everything already
+   * queued on it therefore still runs, inside the batch transaction that worker already owns, and that batch is
+   * committed by its own run loop on the way out. That is the whole point of the change: before it,
+   * {@code setParallelLevel()} went through {@code createThreads()}, which nulls the array for the WHOLE teardown
+   * (so an unrelated concurrent producer got "Async executor has been shut down" - the #6505 failure mode) and
+   * interrupts any worker whose full queue refuses the marker within a second (so an unrelated caller's queued
+   * tasks were notified as completed WITHOUT having run).
+   * <p>
+   * They stay in this set until their run loop ends, because {@link #waitCompletion(long)}, {@link #isProcessing()}
+   * and {@link #getStats()} have to keep answering about the tasks still queued on them - a resize must not make
+   * work disappear from the executor's own accounting - and because {@code close()}/{@code kill()} must reach them
+   * too: {@code DatabaseAsyncExecutorKillTest} asserts no worker thread of the database survives a {@code kill()}.
+   * A set rather than an array: entries are added by the resizing thread and removed by each worker itself.
+   */
+  private final Set<AsyncThread>     retiringThreads               = ConcurrentHashMap.newKeySet();
+
+  /**
+   * How many times a task found the open batch transaction stamped with durability flags other than the ones now
+   * requested, and had to close it out of band (issue #6526, item 3).
+   * <p>
+   * #6511 made a durability-flag change take effect on the very next task instead of tearing down the pool, at the
+   * cost of an extra commit at the boundary: two concurrent flag-flippers sharing a worker slot can therefore drive
+   * that slot's effective batching toward {@code commitEvery=1}. That is a deliberate trade (it is strictly better
+   * than the teardown it replaced) but it was invisible - the incident that motivated #6509 was diagnosed by
+   * grepping {@code InterruptedIOException} counts out of seven hours of logs. Exported through
+   * {@link DBAsyncStats#forcedBoundaryCommits} and, from there, as {@code arcadedb.engine.async.boundary.commits}.
+   */
+  private final AtomicLong           forcedBoundaryCommits         = new AtomicLong();
 
   // #5062 review r2 (point 1): producer-side backstop for a worker wedged inside user code. After
   // this many consecutive stall windows (checkForStalledQueuesMaxDelay each, 60s with the defaults)
@@ -224,6 +261,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
     @Override
     public void run() {
+      try {
+        runLoop();
+      } finally {
+        // #6526: a worker retired by a shrinking setParallelLevel() stops being part of this executor's accounting
+        // exactly here - once its queue is drained, its batch committed and every dropped task notified. Done in a
+        // finally so an unexpected escape (an Error, an interrupt on the close path) cannot strand it in the set,
+        // where waitCompletion() would keep offering markers to a thread that is never going to run them.
+        retiringThreads.remove(this);
+      }
+    }
+
+    private void runLoop() {
       DatabaseContext.INSTANCE.init(database);
 
       DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).perThreadBucketSelection = true;
@@ -411,6 +460,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       if (activeTx.isUseWAL() == currentUseWAL && activeTx.getWALFlush() == currentSync)
         return false;
 
+      // #6526 item 3: counted BEFORE the attempt, not after it succeeds - what the metric answers is "how often is
+      // the batching of this executor being cut short by a durability-flag flip", and a boundary commit that failed
+      // cut it short just the same (the caller starts a fresh transaction either way).
+      forcedBoundaryCommits.incrementAndGet();
+
       try {
         database.commit();
       } catch (final Throwable e) {
@@ -497,7 +551,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       for (int i = 0; i < threads.length; ++i)
         stats.queueSize += threads[i].queue.size();
 
+    // #6526: a worker retired by a shrinking setParallelLevel() is off the published array but is still draining
+    // real tasks, so leaving it out here would report a queue that shrank the instant the pool did - which is the
+    // one moment an operator is most likely to be looking at this number.
+    for (final AsyncThread retiring : retiringThreads)
+      stats.queueSize += retiring.queue.size();
+
     stats.scheduledTasks = counterScheduledTasks.get();
+    stats.forcedBoundaryCommits = forcedBoundaryCommits.get();
 
     return stats;
   }
@@ -647,7 +708,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     if (!awaitCommands(beginTime, timeout))
       return false;
 
-    final AsyncThread[] threads = executorThreads;
+    // #6526: allThreads(), not executorThreads - a worker retired by a shrinking setParallelLevel() still holds
+    // the tasks it was queued before the resize, and waitCompletion() promising they are done while they are not
+    // would be the resize silently changing what this method means.
+    final AsyncThread[] threads = allThreads();
     if (threads == null)
       return true;
 
@@ -913,10 +977,45 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       // would be wrong for a query sharing a worker's batch, and cannot arise here: only command() reaches this
       // method (query() goes straight to a worker), so a task that gets this far is never idempotent.
       final boolean ownTransaction = task.requiresActiveTx() && !database.isTransactionActive();
+
+      // #6526 item 2. Non-null exactly when the transaction below is OURS and therefore carries this executor's
+      // durability policy; the finally reads it back to undo the stamp.
+      TransactionContext  ownTx            = null;
+      boolean             previousUseWAL   = true;
+      WALFile.FlushType   previousWALFlush = null;
       try {
         try {
-          if (ownTransaction)
+          if (ownTransaction) {
             database.begin();
+
+            // THE EXECUTOR'S DURABILITY POLICY APPLIES HERE TOO. Until #6526 this path - the one an HTTP
+            // POST /command with awaitResponse=false carrying DDL takes since #6303 - read neither
+            // transactionUseWAL nor transactionSync, so the command committed under whatever ambient flags the
+            // database (or, on the caller-runs fallback, the submitter's own thread) already had. A caller that
+            // set setTransactionUseWAL(false) around a bulk GraphBatch load and dispatched DDL inside that window
+            // silently got a different durability from the one it asked the executor for: a latent exception to
+            // the per-task contract #6511 established for every other task of this executor.
+            //
+            // ONLY when the transaction is ours, which is the same "touch nothing this method did not create" rule
+            // the DatabaseContext handling above follows and for a sharper reason: useWAL/walFlush are read at
+            // COMMIT time and govern the WHOLE accumulated transaction, not the individual writes, so stamping
+            // them onto a transaction the submitter opened would re-decide the durability of that caller's own
+            // work.
+            //
+            // One snapshot of each volatile, as AsyncThread.executeTask() takes: a concurrent flip landing between
+            // two reads must not stamp one field from the old policy and the other from the new one.
+            final boolean           useWAL = transactionUseWAL;
+            final WALFile.FlushType sync   = transactionSync;
+
+            ownTx = database.getTransaction();
+            // Read AFTER begin() on purpose: TransactionContext.begin()/reset() never touch these two, so this is
+            // still the value that was in force before this method ran - which is what has to go back.
+            previousUseWAL = ownTx.isUseWAL();
+            previousWALFlush = ownTx.getWALFlush();
+
+            ownTx.setUseWAL(useWAL);
+            ownTx.setWALFlush(sync);
+          }
 
           // No AsyncThread to hand it: the task never used it, and error reporting is this method's job now.
           task.execute(null, database);
@@ -938,6 +1037,17 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
             LogManager.instance().log(this, Level.SEVERE, "Error on executing asynchronous command %s", e, task);
         }
       } finally {
+        if (ownTx != null) {
+          // RESTORED, not merely set. On the caller-runs path begin() reuses the SUBMITTER'S own inactive
+          // TransactionContext rather than pushing a new one, and neither begin() nor reset() clears these two, so
+          // leaving the stamp behind would hand this executor's durability policy to the submitter's next
+          // transaction - an HTTP worker's next request - which never asked for it. On a pool thread that created
+          // its own context the restore is a no-op the removeContext() below would have covered anyway; done
+          // unconditionally so the guarantee does not depend on which of the two paths ran.
+          ownTx.setUseWAL(previousUseWAL);
+          ownTx.setWALFlush(previousWALFlush);
+        }
+
         if (contextCreated)
           DatabaseContext.INSTANCE.removeContext(database.getDatabasePath());
         else
@@ -1378,10 +1488,52 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     return parallelLevel;
   }
 
+  /**
+   * Resizes the worker pool <b>without taking the executor away from anybody else</b> (issue #6526, item 1).
+   * <p>
+   * This used to go through {@code createThreads()} - the exact full-pool teardown-and-respawn that #6511 removed
+   * from the durability setters - and it is runtime-callable public API, so it kept both of that mechanism's
+   * failure modes for an UNRELATED concurrent user of {@code database.async()} on the same database:
+   * <ul>
+   *   <li>{@code executorThreads} was nulled for the whole teardown, so a producer scheduling in that window got
+   *   {@code DatabaseOperationException("Async executor has been shut down")} - indistinguishable from a genuine
+   *   {@code close()}, and the #6505 production incident (a compaction hook crossing the WAL point of no return
+   *   and fencing the database over a scheduling hiccup that had nothing to do with it);</li>
+   *   <li>a worker whose queue was full refused the {@code FORCE_EXIT} marker within a second and was
+   *   {@code interrupt()}ed, which unwound its in-flight task loudly and notified every task still queued on it as
+   *   COMPLETED without ever running it - somebody else's writes, silently dropped.</li>
+   * </ul>
+   * Neither is inherent to changing the parallel level, and neither survives here. Growing keeps every existing
+   * worker untouched and only starts the new ones. Shrinking publishes the truncated array FIRST - so the retired
+   * workers stop receiving work while remaining perfectly able to finish what they already hold - and then retires
+   * them by DRAINING: the {@code shutdown} flag plus a {@code FORCE_EXIT} at the tail of the queue, so everything
+   * ahead of it still executes and the worker's batch transaction is committed by its own run loop on the way out.
+   * There is no {@code interrupt()} on this path at all; that escalation belongs to {@code close()}, which is
+   * terminal, and not to a resize, which is not.
+   * <p>
+   * <b>It waits for the retired workers, within a bounded budget.</b> {@code getSlot()} maps a bucket to a worker
+   * modulo the pool size, so while a retired worker is still draining, a bucket it holds tasks for is also mapped
+   * to one of the surviving workers: returning immediately would let two workers write the same bucket's pages
+   * concurrently, which is precisely the contention {@code ThreadBucketSelectionStrategy} exists to prevent
+   * ({@code AsyncInsertTest} measures it as MVCC conflicts). The wait therefore restores the guarantee the teardown
+   * gave for free. It is bounded by {@code shutdownJoinTimeoutMs} and taken OUTSIDE {@code lifecycleLock}, so a
+   * worker wedged inside user code delays neither a concurrent {@code close()} nor the caller for ever; if the
+   * budget runs out the workers are left draining in the background, still visible to
+   * {@link #waitCompletion(long)}, {@link #isProcessing()} and {@link #getStats()}, which is the honest outcome
+   * rather than dropping their work to return on time.
+   * <p>
+   * <b>What it does not do.</b> A retired worker is not parked by a {@link #quiesceWorkers()} that is already in
+   * progress - the park task would land behind the exit marker on its queue - so an index build racing a shrink can
+   * still see a draining worker write under its scan. That is the same residual {@code quiesceWorkers()} already
+   * names for workers created after its own check, it is narrower here than it was under the teardown (the wait
+   * above closes it for anything that starts after the resize returns), and closing it properly means gating the
+   * async lifecycle on the quiescence, which is a lock on a path an index build has to race a resize to reach.
+   */
   @Override
   public void setParallelLevel(final int parallelLevel) {
-    if (parallelLevel != this.parallelLevel)
-      createThreads(parallelLevel);
+    final AsyncThread[] retired = resizeThreads(parallelLevel);
+    if (retired != null)
+      awaitRetiredThreads(retired);
   }
 
   @Override
@@ -1416,6 +1568,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   public static class DBAsyncStats {
     public long queueSize;
     public long scheduledTasks;
+    /**
+     * Monotonic count of transaction boundaries forced by a durability-flag change (issue #6526, item 3). Climbing
+     * while throughput drops is the signature of two callers flipping {@code setTransactionUseWAL()} /
+     * {@code setTransactionSync()} against each other on one database: each flip closes the open batch of whatever
+     * worker sees it next, so the batching degrades toward one commit per task.
+     */
+    public long forcedBoundaryCommits;
   }
 
   // Package-private test hook (#5072 review, point 4): rebuilds the worker pool so configuration
@@ -1424,6 +1583,108 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   // removed that side effect, making this the only way to force a rebuild from a test.
   void recreateThreadsForTests() {
     createThreads(parallelLevel);
+  }
+
+  /**
+   * The pool-preserving half of {@link #setParallelLevel(int)}: publishes the resized array and hands the retired
+   * workers back to the caller to be waited for outside {@code lifecycleLock}.
+   *
+   * @return the workers this call retired, or {@code null} when nothing was retired (a grow, a no-op, or an
+   *     executor that is already shut down).
+   */
+  private AsyncThread[] resizeThreads(final int requestedLevel) {
+    final int newLevel = Math.max(1, requestedLevel);
+
+    synchronized (lifecycleLock) {
+      final AsyncThread[] current = executorThreads;
+      if (current == null) {
+        // ALREADY CLOSED. Deliberately NOT resurrecting the pool: createThreads() would have, and a set of workers
+        // brought back to life on a closed database is a worse answer than none - they would open transactions on
+        // it and no close() is coming to drain them. Recording the level keeps getParallelLevel() honest about what
+        // was asked for.
+        this.parallelLevel = newLevel;
+        return null;
+      }
+
+      if (newLevel == current.length) {
+        this.parallelLevel = newLevel;
+        return null;
+      }
+
+      // Set BEFORE constructing anything: AsyncThread's constructor sizes its queue as
+      // ASYNC_OPERATIONS_QUEUE_SIZE / parallelLevel, so a new worker must see the new level, exactly as in
+      // createThreads().
+      this.parallelLevel = newLevel;
+
+      if (newLevel > current.length) {
+        // GROW: the existing workers are carried over by reference and never touched - no marker, no flag, no join.
+        // Their queues stay whatever size they were sized at, which is the price of not disturbing them and is the
+        // right one: re-sizing a live worker's queue would mean moving its queued tasks.
+        final AsyncThread[] newThreads = Arrays.copyOf(current, newLevel);
+        for (int i = current.length; i < newLevel; ++i) {
+          newThreads[i] = new AsyncThread(database, i);
+          newThreads[i].start();
+        }
+        this.executorThreads = newThreads;
+        return null;
+      }
+
+      // SHRINK. Publish the survivors FIRST, so by the time the tail is asked to stop, nothing can still choose it.
+      final AsyncThread[] retired = Arrays.copyOfRange(current, newLevel, current.length);
+      this.executorThreads = Arrays.copyOf(current, newLevel);
+
+      for (final AsyncThread worker : retired) {
+        // Registered BEFORE the stop request, so a worker that exits immediately is removed by its own run loop
+        // after it was added rather than before - the reverse order would leave it in the set for ever.
+        retiringThreads.add(worker);
+        worker.shutdown = true;
+        // Best effort and NON-blocking, unlike the close path's bounded offer plus interrupt. The marker only makes
+        // an IDLE worker exit at once instead of on its next 500ms poll timeout; a worker whose queue is full does
+        // not need it, since the flag is what ends the loop once the queue it is busy draining runs dry. Refusing
+        // to interrupt here is the point: an interrupt would unwind the task in flight and drop the queued ones.
+        worker.queue.offer(FORCE_EXIT);
+      }
+      return retired;
+    }
+  }
+
+  /**
+   * Waits, outside {@code lifecycleLock}, for the workers a shrink retired to finish draining. Never interrupts:
+   * see {@link #setParallelLevel(int)}.
+   */
+  private void awaitRetiredThreads(final AsyncThread[] retired) {
+    final long deadline = System.currentTimeMillis() + shutdownJoinTimeoutMs;
+    boolean interrupted = false;
+
+    for (final AsyncThread worker : retired) {
+      if (worker == Thread.currentThread())
+        // A worker lowering the parallel level from inside one of its own tasks would be joining ITSELF, which never
+        // returns. Nothing in the engine does this - setParallelLevel() is an administrative call - but the method is
+        // public API and a self-join is an unrecoverable hang, not a slow path.
+        continue;
+
+      final long remaining = deadline - System.currentTimeMillis();
+      if (remaining <= 0)
+        break;
+      try {
+        worker.join(remaining);
+      } catch (final InterruptedException e) {
+        interrupted = true;
+        break;
+      }
+    }
+
+    if (interrupted)
+      Thread.currentThread().interrupt();
+
+    for (final AsyncThread worker : retired)
+      if (worker.isAlive()) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Asynchronous worker %s did not finish draining within %dms of the parallel level being lowered: it "
+                + "keeps running its queued tasks in the background and stays visible to waitCompletion()",
+            worker.getName(), shutdownJoinTimeoutMs);
+        break;
+      }
   }
 
   private void createThreads(int parallelLevel) {
@@ -1456,8 +1717,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
   // Caller must hold lifecycleLock.
   private void shutdownThreadsLocked() {
-    final AsyncThread[] toClose = executorThreads;
-    if (toClose == null)
+    final AsyncThread[] live = executorThreads;
+
+    // #6526: the workers a shrinking setParallelLevel() retired are still draining and are NOT in the published
+    // array, so closing only that array would leave them running on a database that is being torn down - and
+    // DatabaseAsyncExecutorKillTest asserts no worker thread of the database outlives a kill(). Closed together
+    // with the live ones, under the same terminal escalation: unlike a resize, a close does not have the option of
+    // letting them finish.
+    final AsyncThread[] toClose = concat(live, retiringThreads.toArray(new AsyncThread[0]));
+    if (toClose.length == 0)
       return;
 
     // Unpublish first so concurrent readers stop seeing the about-to-die threads.
@@ -1500,6 +1768,45 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     }
     if (interrupted)
       Thread.currentThread().interrupt();
+  }
+
+  /**
+   * Concatenates the live worker array (possibly null on an already-closed executor) with the retiring ones.
+   */
+  private static AsyncThread[] concat(final AsyncThread[] live, final AsyncThread[] retiring) {
+    if (live == null)
+      return retiring;
+    if (retiring.length == 0)
+      return live;
+    final AsyncThread[] all = Arrays.copyOf(live, live.length + retiring.length);
+    System.arraycopy(retiring, 0, all, live.length, retiring.length);
+    return all;
+  }
+
+  /**
+   * Every worker that can still be holding tasks of this executor: the published pool plus whatever a shrinking
+   * {@link #setParallelLevel(int)} retired and left draining (issue #6526, item 1). Returns {@code null} exactly
+   * when the executor is closed AND nothing is draining, which is the "nothing to wait for" answer the callers
+   * already knew how to handle.
+   */
+  private AsyncThread[] allThreads() {
+    final AsyncThread[] live = executorThreads;
+    if (retiringThreads.isEmpty())
+      return live;
+
+    // ONLY THE ONES STILL RUNNING. A worker removes itself from the set in its own finally, after its final queue
+    // drain, so there is a brief window in which a finished worker is still registered - and handing it to
+    // waitCompletion() would let a marker land in a queue nobody is going to poll again, which the caller pays for
+    // as its whole timeout budget. The residual race (alive here, finished by the time the marker is offered) is the
+    // same one the published array has always had, and waitCompletion()'s own isAlive() re-check covers the common
+    // half of it.
+    final List<AsyncThread> stillRunning = new ArrayList<>(retiringThreads.size());
+    for (final AsyncThread retiring : retiringThreads)
+      if (retiring.isAlive())
+        stillRunning.add(retiring);
+
+    final AsyncThread[] all = concat(live, stillRunning.toArray(new AsyncThread[0]));
+    return all.length == 0 ? null : all;
   }
 
   @Override
@@ -1545,6 +1852,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       if (threads == null)
         throw new DatabaseOperationException(
             "Async executor has been shut down; cannot schedule asynchronous task " + task);
+
+      if (slot >= threads.length)
+        // #6526: getSlot() maps its value modulo the pool size it read, and the pool can SHRINK between that read
+        // and this one - before, the array was nulled for the whole resize, so this race surfaced as the "shut
+        // down" exception above; now the array stays live and a stale slot index would be an
+        // ArrayIndexOutOfBoundsException instead. Re-mapped with the size actually in hand, which is what getSlot()
+        // would have returned had it run a moment later.
+        slot %= threads.length;
 
       final AsyncThread target = threads[slot];
       final BlockingQueue<DatabaseAsyncTask> queue = target.queue;
@@ -2002,7 +2317,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       // workers alone would report an executor with a command in flight as idle.
       return true;
 
-    final AsyncThread[] threads = executorThreads;
+    // #6526: includes the workers a shrinking setParallelLevel() left draining - they are still executing this
+    // executor's tasks, so reporting the executor idle because the pool got smaller would be wrong.
+    final AsyncThread[] threads = allThreads();
     if (threads != null)
       for (int i = 0; i < threads.length; ++i) {
         if (threads[i].isExecutingTask())

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1742,6 +1742,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       // 3. Ask the tail to stop.
       for (final AsyncThread worker : retired) {
+        // RENAMED FIRST (#6526 review round 8). A worker is named after the slot it occupies, and a grow that lands
+        // while this one is still draining past awaitRetiredThreads()'s budget starts a NEW worker on that same
+        // index - two live threads of one database with an identical name, in the one situation an operator is
+        // most likely to be reading a thread dump. The suffix keeps the prefix every existing test and log filter
+        // matches on ("AsyncExecutor-<db>-"), so kill()'s "no thread of this database survives" assertion still
+        // covers it, while saying which of the two is on its way out.
+        worker.setName(worker.getName() + "-retiring");
         worker.shutdown = true;
         // Best effort and NON-blocking, unlike the close path's bounded offer plus interrupt. The marker only makes
         // an IDLE worker exit at once instead of on its next 500ms poll timeout; a worker whose queue is full does
@@ -1786,7 +1793,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // what an operator needs to tell "one task is slow" from "the whole pool is wedged", and this method's whole
     // contract is that giving up is bounded and LOUD rather than silent - a break here made it loud about one.
     for (final AsyncThread worker : retired)
-      if (worker.isAlive())
+      // Self excluded here exactly as in the join loop (#6526 review round 8): a worker that retired its own slot
+      // from inside one of its tasks is alive BECAUSE it is still executing the call that would print this line,
+      // which is not the wedged worker this warning is about.
+      if (worker != Thread.currentThread() && worker.isAlive())
         LogManager.instance().log(this, Level.WARNING,
             "Asynchronous worker %s did not finish draining within %dms of the parallel level being lowered: it "
                 + "keeps running its queued tasks in the background and stays visible to waitCompletion()",
@@ -2343,26 +2353,51 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // the failure that got us there.
     CountDownLatch release = null;
     try {
-      final AsyncThread[] threads = executorThreads;
-      if (threads == null || threads.length == 0) {
-        // Shut down between the check above and here: nothing to park, and the lock this holds is given back by the
-        // handle like any other.
-        handedOver = true;
-        return new HeldQuiesce(null, true);
+      final CountDownLatch parked;
+
+      // ONE PARK TASK PER WORKER, which needs the pool it is sized against to be the pool the tasks are scheduled
+      // onto (#6526 review round 8). scheduleTask() re-reads executorThreads on every call, and since #6526 a slot
+      // index the pool has outgrown is re-mapped onto a live worker instead of throwing - so a shrink landing
+      // between the read that sizes the latch and the last scheduleTask() would fold several indices onto one
+      // survivor. That worker runs the first park task, counts the latch down once and blocks on `release`, so the
+      // duplicates queued behind it never run: a latch sized for the old pool that can no longer reach zero, and a
+      // caller - an index build - that waits out the whole quiesce timeout before failing. Measured: 60s and a
+      // NeedRetryException where the answer should have been immediate.
+      //
+      // So the READ AND THE LOOP ARE BOTH INSIDE resizeLock, not just the loop: a snapshot taken outside it is
+      // already stale by the time the lock is acquired, which is the same bug one window earlier.
+      //
+      // Held for that ONLY, not for the quiescence: a shrink that lands afterwards is harmless, because the park
+      // task is already ahead of the exit marker on the retired worker's queue and still runs, counts down and
+      // parks. Keeping the lock any longer would put an administrative resize behind a whole index build.
+      //
+      // Lock order is quiesceLock (held) -> resizeLock -> lifecycleLock, and nothing takes them the other way
+      // round: setParallelLevel() never touches quiesceLock, and close()/kill() take only lifecycleLock.
+      resizeLock.lock();
+      try {
+        final AsyncThread[] threads = executorThreads;
+        if (threads == null || threads.length == 0) {
+          // Shut down between the check above and here: nothing to park, and the lock this holds is given back by
+          // the handle like any other.
+          handedOver = true;
+          return new HeldQuiesce(null, true);
+        }
+
+        parked = new CountDownLatch(threads.length);
+        release = new CountDownLatch(1);
+
+        for (int i = 0; i < threads.length; i++)
+          // waitIfQueueIsFull, so a busy worker is queued behind rather than skipped: an unparked worker is exactly
+          // the hole this method exists to close, and a `false` here would be one - which is why the old call
+          // site's discarded boolean mattered. Any refusal (a worker that has shut down) throws, and the finally
+          // below releases whatever was already parked.
+          if (!scheduleTask(i, new DatabaseAsyncParkWorker(parked, release), true, 0))
+            throw new NeedRetryException(
+                "Cannot quiesce the asynchronous executor of database '" + database.getName() + "': worker " + i
+                    + " refused the park task");
+      } finally {
+        resizeLock.unlock();
       }
-
-      final CountDownLatch parked = new CountDownLatch(threads.length);
-      release = new CountDownLatch(1);
-
-      for (int i = 0; i < threads.length; i++)
-        // waitIfQueueIsFull, so a busy worker is queued behind rather than skipped: an unparked worker is exactly the
-        // hole this method exists to close, and a `false` here would be one - which is why the old call site's
-        // discarded boolean mattered. Any refusal (a worker that has shut down) throws, and the finally below
-        // releases whatever was already parked.
-        if (!scheduleTask(i, new DatabaseAsyncParkWorker(parked, release), true, 0))
-          throw new NeedRetryException(
-              "Cannot quiesce the asynchronous executor of database '" + database.getName() + "': worker " + i
-                  + " refused the park task");
 
       final long timeout = quiesceTimeoutMillis();
       try {

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -674,16 +674,20 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       // commit past the threshold schedules again - both gates are level-triggered, so no compaction is lost.
       scheduled = scheduleTask(getBestSlot(), new DatabaseAsyncIndexCompaction(index), false, 0);
     } catch (final DatabaseOperationException e) {
-      // #6505: getBestSlot()/scheduleTask throw the SAME "shut down" exception for a genuine terminal close()/
-      // kill() (#4955, the case this was written for) and for the momentary window createThreads() leaves while
-      // it tears down and respawns the whole pool for an UNRELATED caller (issue #5665 - setTransactionUseWAL()/
-      // setTransactionSync() used to trigger this on every GraphBatch open/close; #6509 removed that path, but
-      // setParallelLevel() still goes through createThreads() and leaves the same momentary window) - the pool
-      // is back within milliseconds, but this onAfterCommit hook runs AFTER writeTransactionToWAL(), so letting
-      // the exception escape crossed the WAL point of no return and fenced the entire database (#5053) over a
-      // best-effort scheduling hiccup that had nothing to do with the committing transaction's data. This finally
-      // hands the reservation back exactly like the full-queue case above: no compaction is lost, it is picked up
-      // by the next commit past the threshold.
+      // #6505: getBestSlot()/scheduleTask throw a "shut down" exception, and this onAfterCommit hook runs AFTER
+      // writeTransactionToWAL(), so letting it escape crossed the WAL point of no return and fenced the entire
+      // database (#5053) over a best-effort scheduling hiccup that had nothing to do with the committing
+      // transaction's data. This finally hands the reservation back exactly like the full-queue case above: no
+      // compaction is lost, it is picked up by the next commit past the threshold.
+      //
+      // WHAT CAN STILL THROW IT, as of #6526: a genuine terminal close()/kill() (#4955, the case this was
+      // originally written for) and nothing else. It used to be ambiguous - the same exception also came from the
+      // momentary window createThreads() left while it tore down and respawned the whole pool for an UNRELATED
+      // caller, which #5665's setTransactionUseWAL()/setTransactionSync() triggered on every GraphBatch open/close
+      // and which setParallelLevel() kept after #6509 removed that path. #6526 took setParallelLevel() off
+      // createThreads() entirely, so there is no transient window left to mistake for a close. The catch stays
+      // exactly as valuable: what it now protects against is the terminal case, where the pool is NOT coming back
+      // and an escaping exception would fence a database that is closing anyway (#6526 review round 7).
       LogManager.instance().log(this, Level.WARNING, "Could not schedule compaction of index '%s': %s", null,
           index, e.getMessage());
     } finally {
@@ -2312,13 +2316,20 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     if (executorThreads == null || executorThreads.length == 0)
       // NOTHING TO PARK, and the lock is deliberately NOT taken for it. Holding it here would make a nested
       // quiescence short-circuit on hold count and hand back another no-op - so if workers came into existence in
-      // between (a concurrent setParallelLevel on a shut-down executor is the only way), the nested call would leave
-      // them running under a scan. Not locking makes that nested call a fresh outer one that parks them properly.
+      // between, the nested call would leave them running under a scan. Not locking makes that nested call a fresh
+      // outer one that parks them properly.
       //
-      // The residual, named rather than papered over: workers created after this check are not parked by THIS
-      // quiescence either. Closing that needs the executor's creation gated on the quiescence, which is a lock on
-      // the async lifecycle path for a window an index build has to race a pool resize to reach - out of scope here,
-      // and the same window the barrier of #6281 has always had.
+      // The way that USED to happen was a concurrent setParallelLevel() on a shut-down executor, which went through
+      // createThreads() and cheerfully respawned a pool on a closed database. #6526 removed it: resizeThreads()
+      // records the requested level and returns rather than resurrecting anything, and LocalDatabase assigns its
+      // `async` field exactly once per instance, so a null-or-empty executorThreads read here is now terminal
+      // (#6526 review round 7). The defence stays because it costs nothing and the property it relies on lives in
+      // another class.
+      //
+      // The residual that is NOT closed, named rather than papered over: workers created after this check - a GROW
+      // racing the scan - are not parked by THIS quiescence either. Closing that needs the executor's creation
+      // gated on the quiescence, which is a lock on the async lifecycle path for a window an index build has to
+      // race a pool resize to reach - out of scope here, and the same window the barrier of #6281 has always had.
       return new HeldQuiesce(null, false);
 
     quiesceLock.lock();

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -137,6 +137,24 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    */
   private final AtomicLong           forcedBoundaryCommits         = new AtomicLong();
 
+  /**
+   * Serializes {@link #setParallelLevel(int)} against itself, and is held for the WHOLE resize - the publish AND
+   * the wait for whatever the publish retired (issue #6526 review, point 2).
+   * <p>
+   * The drain wait cannot be taken under {@code lifecycleLock}: that lock is what a concurrent {@code close()} or
+   * {@code kill()} needs to force the very workers being waited for, so holding it across the wait would make the
+   * wait the thing that prevents its own end. But releasing every lock leaves a second resize free to grow the pool
+   * back while the first one's workers are still draining, and a grow fills the array positions the shrink just
+   * vacated - so slot 2 would name a brand-new worker AND an old one still running slot 2's pre-shrink tasks, which
+   * is the concurrent write to one bucket's pages the wait exists to prevent. A separate lock gives the wait its
+   * meaning back without putting a resize in {@code close()}'s way.
+   * <p>
+   * Reentrant, so a resize triggered from inside a resize rides on the outer one rather than deadlocking, and
+   * deliberately NOT taken by {@code createThreads()}: the constructor runs before anything can race it, and
+   * {@code recreateThreadsForTests()} is a test hook that means "tear it down and rebuild it".
+   */
+  private final ReentrantLock        resizeLock                    = new ReentrantLock();
+
   // #5062 review r2 (point 1): producer-side backstop for a worker wedged inside user code. After
   // this many consecutive stall windows (checkForStalledQueuesMaxDelay each, 60s with the defaults)
   // in which the target worker completed NO task while its queue stayed full, offerWaiting throws
@@ -1441,8 +1459,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   public void kill() {
     final AsyncThread[] threads;
     synchronized (lifecycleLock) {
-      threads = executorThreads;
-      if (threads == null)
+      // #6526 review: the workers a shrinking setParallelLevel() retired are alive and are NOT in the published
+      // array, so reading executorThreads alone let kill() return having never touched them - and that is exactly
+      // the case this class designs for, since awaitRetiredThreads() gives up after shutdownJoinTimeoutMs and
+      // leaves whatever is still draining to finish in the background. Same treatment as shutdownThreadsLocked()
+      // gives them on the close() path, for the same reason: a kill() is terminal, so nothing of this database may
+      // still be running when it returns.
+      threads = concat(executorThreads, retiringThreads.toArray(new AsyncThread[0]));
+      if (threads.length == 0)
         return;
       // Unpublish first so concurrent callers stop targeting the about-to-die threads.
       executorThreads = null;
@@ -1522,6 +1546,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * {@link #waitCompletion(long)}, {@link #isProcessing()} and {@link #getStats()}, which is the honest outcome
    * rather than dropping their work to return on time.
    * <p>
+   * <b>Serialized against itself</b> by {@code resizeLock}, held across the publish AND the wait. Without that, a
+   * second caller growing the pool back would fill the array positions the shrink just vacated while the old
+   * workers for those positions are still draining, and the wait would guarantee nothing for the multi-caller case
+   * it exists for. The residual is what survives the wait's own budget: if a retired worker is still draining when
+   * {@code shutdownJoinTimeoutMs} runs out, the lock is released and a later grow can reuse its position while it
+   * runs on. Bounded and loud (that timeout is logged at WARNING) rather than silent, and the alternative - waiting
+   * without a bound - makes an administrative call hostage to a worker wedged in user code.
+   * <p>
    * <b>What it does not do.</b> A retired worker is not parked by a {@link #quiesceWorkers()} that is already in
    * progress - the park task would land behind the exit marker on its queue - so an index build racing a shrink can
    * still see a draining worker write under its scan. That is the same residual {@code quiesceWorkers()} already
@@ -1531,9 +1563,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    */
   @Override
   public void setParallelLevel(final int parallelLevel) {
-    final AsyncThread[] retired = resizeThreads(parallelLevel);
-    if (retired != null)
-      awaitRetiredThreads(retired);
+    resizeLock.lock();
+    try {
+      final AsyncThread[] retired = resizeThreads(parallelLevel);
+      if (retired != null)
+        awaitRetiredThreads(retired);
+    } finally {
+      resizeLock.unlock();
+    }
   }
 
   @Override
@@ -1857,8 +1894,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         // #6526: getSlot() maps its value modulo the pool size it read, and the pool can SHRINK between that read
         // and this one - before, the array was nulled for the whole resize, so this race surfaced as the "shut
         // down" exception above; now the array stays live and a stale slot index would be an
-        // ArrayIndexOutOfBoundsException instead. Re-mapped with the size actually in hand, which is what getSlot()
-        // would have returned had it run a moment later.
+        // ArrayIndexOutOfBoundsException instead.
+        //
+        // A FALLBACK, NOT A RE-DERIVATION (#6526 review, point 3): (value % oldLength) % newLength is not
+        // (value % newLength) in general - value 7 over a pool that went from 5 to 3 lands on 2 here and on 1 from
+        // a fresh getSlot(). All this owes the caller is a valid live worker instead of an exception, and the task
+        // is one whose bucket pinning was decided against a pool that no longer exists; the next task for the same
+        // bucket asks getSlot() again and gets the stable answer.
         slot %= threads.length;
 
       final AsyncThread target = threads[slot];

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -69,6 +70,8 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
    * nothing here measures elapsed time, this only has to outlive a fixed timeout in the code under test.
    */
   private static final long WORKER_HOLD_MS = 3_000;
+  // The two methods that hold a worker for it carry @Tag("slow") and run in the slow lane; the rest of the class
+  // stays in the default one, which is the per-method split CLAUDE.md asks for when only some methods are slow.
 
   /**
    * How long the gate task of the {@code kill()} test occupies its worker: long enough that only an interrupt can
@@ -84,6 +87,7 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
    * released, work silently gone.
    */
   @Test
+  @Tag("slow")
   @Timeout(60)
   void loweringTheParallelLevelRunsTheWorkStillQueuedOnTheRetiredWorkers() throws Exception {
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
@@ -262,6 +266,7 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
    * the old slot-2 worker still running its pre-shrink tasks.
    */
   @Test
+  @Tag("slow")
   @Timeout(60)
   void aConcurrentGrowCannotOvertakeAShrinkStillDraining() throws Exception {
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.WALFile;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6526, the three follow-ups the 14-round review of #6511 left explicitly out of scope.
+ * <ol>
+ *   <li><b>{@code setParallelLevel()} tore down the whole pool.</b> It was the one caller of {@code createThreads()}
+ *   left on a runtime-callable path, so it kept both failure modes #6511 removed from the durability setters: the
+ *   published worker array was nulled for the entire teardown - an unrelated concurrent producer got
+ *   {@code "Async executor has been shut down"}, the #6505 incident - and a worker whose queue was full refused the
+ *   exit marker and was interrupted, which notified somebody else's queued tasks as completed WITHOUT running
+ *   them.</li>
+ *   <li><b>The DDL dispatch path ignored the executor's durability policy.</b> A command routed to
+ *   {@code AsyncCommandPool} (an {@code awaitResponse=false} {@code CREATE INDEX}, since #6303) read neither
+ *   {@code transactionUseWAL} nor {@code transactionSync}, so it silently committed under whatever ambient flags it
+ *   found - a latent exception to the per-task contract #6511 established for every other task.</li>
+ *   <li><b>Nothing counted the boundary commits</b> #6511's fix forces when a durability flag changes under an open
+ *   batch, so the batching degrading toward {@code commitEvery=1} was invisible until somebody read seven hours of
+ *   logs.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
+
+  /**
+   * How long the gate task below occupies its worker. Longer than the one second
+   * {@code shutdownThreadsLocked()} waits for its exit marker before escalating to {@code interrupt()}, so the
+   * regression this test covers has time to happen if the teardown ever comes back. Not a latency assertion:
+   * nothing here measures elapsed time, this only has to outlive a fixed timeout in the code under test.
+   */
+  private static final long WORKER_HOLD_MS = 3_000;
+
+  /**
+   * Item 1, the half that LOSES DATA. Tasks already queued on a worker the resize retires must still run, in the
+   * batch transaction that worker already owns. Before the fix the retired worker was interrupted whenever it could
+   * not take the exit marker within a second, and its queue was drained straight into {@code completed()} - waiters
+   * released, work silently gone.
+   */
+  @Test
+  @Timeout(60)
+  void loweringTheParallelLevelRunsTheWorkStillQueuedOnTheRetiredWorkers() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(4);
+
+    final AtomicInteger executed = new AtomicInteger();
+    final AtomicInteger completed = new AtomicInteger();
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    // Worker 3 is one of the two the shrink below retires. Park it on a gate first, so the tasks queued behind the
+    // gate are provably still IN ITS QUEUE - not already run - when the resize reaches it. The gate holds for
+    // WORKER_HOLD_MS, comfortably longer than the one-second marker timeout the old teardown used before it
+    // escalated to interrupt(): that escalation is the mechanism under test, and it must have had time to fire.
+    final CountDownLatch gateEntered = new CountDownLatch(1);
+    final AtomicBoolean gateInterrupted = new AtomicBoolean();
+    assertThat(async.scheduleTask(3, new CountingTask(executed, completed) {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal db) {
+        super.execute(asyncThread, db);
+        gateEntered.countDown();
+        try {
+          Thread.sleep(WORKER_HOLD_MS);
+        } catch (final InterruptedException e) {
+          gateInterrupted.set(true);
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, true, 0)).isTrue();
+    assertThat(gateEntered.await(30, TimeUnit.SECONDS)).as("the gate task must be running on worker 3").isTrue();
+
+    // FILL worker 3's queue to the brim, which is what makes the old teardown lossy: it offered its exit marker
+    // with a one-second timeout, and a full queue refused it, so the worker was interrupt()ed - the gate task
+    // unwound and everything behind it was drained straight into completed() without ever running. Filled through
+    // the non-blocking form so the exact capacity (ASYNC_OPERATIONS_QUEUE_SIZE / parallelLevel) never has to be
+    // hardcoded here.
+    int queuedBehindTheGate = 0;
+    while (async.scheduleTask(3, new CountingTask(executed, completed), false, 0))
+      queuedBehindTheGate++;
+    assertThat(queuedBehindTheGate).as("worker 3's queue must be full before the resize").isGreaterThan(0);
+
+    // On its own thread because the resize now WAITS for the retired workers to finish draining.
+    final AtomicReference<Throwable> resizeFailure = new AtomicReference<>();
+    final Thread resizer = new Thread(() -> {
+      try {
+        async.setParallelLevel(2);
+      } catch (final Throwable e) {
+        resizeFailure.set(e);
+      }
+    }, "issue6526-resizer");
+    resizer.start();
+
+    resizer.join(60_000);
+    assertThat(resizer.isAlive()).as("the resize must not hang").isFalse();
+    assertThat(resizeFailure.get()).isNull();
+    assertThat(gateInterrupted.get())
+        .as("a resize must never interrupt a worker: that is what unwinds the task in flight").isFalse();
+
+    assertThat(async.getThreadCount()).as("the pool must actually be smaller afterwards").isEqualTo(2);
+    assertThat(executed.get())
+        .as("every task queued on the retired worker must have RUN, not merely been notified as completed")
+        .isEqualTo(queuedBehindTheGate + 1);
+    assertThat(completed.get()).isEqualTo(queuedBehindTheGate + 1);
+    assertThat(errors).as("no task may fail because the pool was resized under it").isEmpty();
+  }
+
+  /**
+   * Item 1, the half that FAILED UNRELATED CALLERS. A producer scheduling throughout a stream of resizes must never
+   * see {@code "Async executor has been shut down"}: that exception means the database is closing, and #6505 is what
+   * happens when a best-effort scheduling hook believes it - an index-compaction hook running after
+   * {@code writeTransactionToWAL()} crossed the point of no return and fenced the whole database.
+   */
+  @Test
+  @Timeout(120)
+  void resizingTheParallelLevelNeverTellsAnUnrelatedProducerTheExecutorIsShutDown() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(4);
+
+    final AtomicInteger executed = new AtomicInteger();
+    final AtomicInteger completed = new AtomicInteger();
+    final AtomicInteger scheduled = new AtomicInteger();
+    final List<Throwable> producerFailures = new CopyOnWriteArrayList<>();
+    final AtomicBoolean stop = new AtomicBoolean();
+
+    final Thread producer = new Thread(() -> {
+      while (!stop.get()) {
+        try {
+          // Slot -1 goes through getBestSlot(), which reads the published array and threw the moment
+          // createThreads() had nulled it.
+          if (async.scheduleTask(-1, new CountingTask(executed, completed), true, 0))
+            scheduled.incrementAndGet();
+        } catch (final Throwable e) {
+          producerFailures.add(e);
+        }
+      }
+    }, "issue6526-producer");
+    producer.start();
+
+    try {
+      for (int i = 0; i < 20; i++)
+        async.setParallelLevel(i % 2 == 0 ? 2 : 4);
+    } finally {
+      stop.set(true);
+      producer.join(30_000);
+    }
+    assertThat(producer.isAlive()).isFalse();
+
+    assertThat(producerFailures)
+        .as("a parallel-level change must never look like a database close to an unrelated producer")
+        .isEmpty();
+    assertThat(scheduled.get()).as("the producer must have kept working throughout the resizes").isGreaterThan(0);
+
+    assertThat(async.waitCompletion(60_000)).isTrue();
+    assertThat(executed.get())
+        .as("waitCompletion() must cover the workers still draining a shrink, so nothing is left unrun")
+        .isEqualTo(scheduled.get());
+  }
+
+  /**
+   * Item 1, growing. Raising the level must not disturb the workers that already exist: they own batch transactions
+   * and are the unit {@code ThreadBucketSelectionStrategy} pins buckets to, so respawning them is never free.
+   */
+  @Test
+  @Timeout(60)
+  void raisingTheParallelLevelLeavesTheExistingWorkersRunning() {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(2);
+
+    final Set<Long> before = asyncWorkerThreadIds();
+    assertThat(before).hasSize(2);
+
+    async.setParallelLevel(5);
+
+    assertThat(async.getThreadCount()).isEqualTo(5);
+    assertThat(asyncWorkerThreadIds()).as("growing must ADD workers, never replace the ones already running")
+        .hasSize(5).containsAll(before);
+  }
+
+  /**
+   * Item 2. A DDL command dispatched with {@code awaitResponse=false} runs on {@code AsyncCommandPool} since #6303,
+   * in a transaction that runner opens itself - and that transaction must carry the executor's durability policy,
+   * exactly as every task running on a worker does since #6511. Before this fix it carried whatever the ambient
+   * default happened to be, so a caller that had set {@code setTransactionUseWAL(false)} around a bulk load found
+   * the DDL it dispatched inside that window silently unaffected by it.
+   */
+  @Test
+  @Timeout(120)
+  void dispatchedDDLRunsUnderTheExecutorDurabilityPolicy() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+
+    async.setTransactionUseWAL(false);
+    async.setTransactionSync(WALFile.FlushType.NO);
+    final Observation withoutWAL = dispatchDDLObservingItsTransaction(db, "Issue6526A");
+    assertThat(withoutWAL.transactionActive).as("the dispatched DDL must run inside the runner's own transaction")
+        .isTrue();
+    assertThat(withoutWAL.useWAL).as("the executor's transactionUseWAL must reach the dispatched DDL").isFalse();
+    assertThat(withoutWAL.walFlush).isEqualTo(WALFile.FlushType.NO);
+
+    async.setTransactionUseWAL(true);
+    async.setTransactionSync(WALFile.FlushType.YES_NOMETADATA);
+    final Observation withWAL = dispatchDDLObservingItsTransaction(db, "Issue6526B");
+    assertThat(withWAL.useWAL).as("and so must the flip back, on the very next dispatched command").isTrue();
+    assertThat(withWAL.walFlush).isEqualTo(WALFile.FlushType.YES_NOMETADATA);
+
+    assertThat(database.getSchema().existsType("Issue6526A")).isTrue();
+    assertThat(database.getSchema().existsType("Issue6526B")).isTrue();
+
+    // The submitting thread's own transaction settings must be untouched by any of it.
+    database.transaction(() -> assertThat(db.getTransaction().isUseWAL())
+        .as("dispatching a command must not restamp the submitter's own transaction").isTrue());
+  }
+
+  /**
+   * Item 3. {@code closeTransactionBoundaryIfDurabilityPolicyChanged()} is what makes a flag flip take effect
+   * without the pool teardown, and it does so by cutting the open batch short. That is the accepted cost of the
+   * #6511 trade, and until now nothing counted it: the incident behind #6509 was reconstructed by grepping
+   * {@code InterruptedIOException}s out of seven hours of logs.
+   */
+  @Test
+  @Timeout(60)
+  void forcedBoundaryCommitsAreCounted() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(1);
+    async.setCommitEvery(1000); // ONE LONG BATCH, SO ONLY A FLAG FLIP CAN CLOSE IT
+
+    async.setTransactionUseWAL(true);
+    async.setTransactionSync(WALFile.FlushType.NO);
+    runOneTaskInATransaction(async);
+
+    final long baseline = async.getStats().forcedBoundaryCommits;
+
+    async.setTransactionUseWAL(false);
+    runOneTaskInATransaction(async);
+    assertThat(async.getStats().forcedBoundaryCommits - baseline)
+        .as("the first task after a flip must close the batch stamped with the old policy").isEqualTo(1L);
+
+    runOneTaskInATransaction(async);
+    assertThat(async.getStats().forcedBoundaryCommits - baseline)
+        .as("a task that changes nothing must not force anything").isEqualTo(1L);
+
+    async.setTransactionSync(WALFile.FlushType.YES_NOMETADATA);
+    runOneTaskInATransaction(async);
+    assertThat(async.getStats().forcedBoundaryCommits - baseline)
+        .as("the sync flag counts too, not just useWAL").isEqualTo(2L);
+  }
+
+  private record Observation(boolean transactionActive, boolean useWAL, WALFile.FlushType walFlush) {
+  }
+
+  /**
+   * Dispatches a script whose DDL half sends it to {@link AsyncCommandPool} and reads the durability flags of the
+   * transaction it is running in, from inside the command itself: {@code userCallback.onComplete} is invoked by
+   * {@code DatabaseAsyncCommand.execute()}, which the runner calls between its own {@code begin()} and
+   * {@code commit()}.
+   */
+  private Observation dispatchDDLObservingItsTransaction(final DatabaseInternal db, final String typeName)
+      throws Exception {
+    final AtomicReference<Observation> observation = new AtomicReference<>();
+    final AtomicReference<Exception> failure = new AtomicReference<>();
+    final AtomicReference<String> ranOn = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+
+    db.async().command("sqlscript", "CREATE VERTEX TYPE " + typeName + "; INSERT INTO " + typeName + " SET id = 1;",
+        new AsyncResultsetCallback() {
+          @Override
+          public void onComplete(final ResultSet rs) {
+            ranOn.set(Thread.currentThread().getName());
+            observation.set(db.isTransactionActive() ?
+                new Observation(true, db.getTransaction().isUseWAL(), db.getTransaction().getWALFlush()) :
+                new Observation(false, false, null));
+            done.countDown();
+          }
+
+          @Override
+          public void onError(final Exception exception) {
+            failure.set(exception);
+            done.countDown();
+          }
+        });
+
+    assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+    assertThat(failure.get()).isNull();
+    assertThat(ranOn.get()).as("a script carrying DDL must be dispatched to the async command pool")
+        .startsWith("ArcadeDB-AsyncCommand-");
+    db.async().waitCompletion();
+    return observation.get();
+  }
+
+  private static void runOneTaskInATransaction(final DatabaseAsyncExecutorImpl async) throws Exception {
+    final CountDownLatch done = new CountDownLatch(1);
+    assertThat(async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // The task only has to exist: what is under test is the boundary check that runs BEFORE it.
+      }
+
+      @Override
+      public void completed() {
+        done.countDown();
+      }
+    }, true, 0)).isTrue();
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+  }
+
+  private Set<Long> asyncWorkerThreadIds() {
+    final String prefix = "AsyncExecutor-" + database.getName() + "-";
+    final Set<Long> ids = new HashSet<>();
+    for (final Thread t : Thread.getAllStackTraces().keySet())
+      if (t.getName().startsWith(prefix) && t.isAlive())
+        ids.add(t.threadId());
+    return ids;
+  }
+
+  /** Counts executions and completions separately: a dropped task is completed WITHOUT ever being executed. */
+  private static class CountingTask implements DatabaseAsyncTask {
+    private final AtomicInteger executed;
+    private final AtomicInteger completed;
+
+    private CountingTask(final AtomicInteger executed, final AtomicInteger completed) {
+      this.executed = executed;
+      this.completed = completed;
+    }
+
+    @Override
+    public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+      executed.incrementAndGet();
+    }
+
+    @Override
+    public void completed() {
+      completed.incrementAndGet();
+    }
+
+    @Override
+    public boolean requiresActiveTx() {
+      return false;
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
@@ -371,6 +371,70 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
   }
 
   /**
+   * Item 1, the boundary the drain wait actually holds (#6526 review round 6). A producer pinned to ONE bucket -
+   * the case round-robin scheduling cannot reach, and the case where a shrink migrates that bucket from a retiring
+   * worker to a survivor - must keep working across the resize: every task it schedules runs, and it is never
+   * refused.
+   * <p>
+   * What this deliberately does NOT assert is that the two workers never touch the bucket's pages at the same time,
+   * because they can: the moment the truncated array is published, {@code getSlot()} sends the producer to the
+   * survivor while the retired worker is still draining that bucket's queued tasks. That overlap is the accepted
+   * residual documented on {@link DatabaseAsyncExecutorImpl#setParallelLevel(int)} - bounded by the drain, costing
+   * an MVCC conflict the async path already reports and retries - and a test claiming otherwise would be pinning a
+   * guarantee the code does not make. What it pins instead is the guarantee it does: nothing is lost, nobody is
+   * refused.
+   */
+  @Test
+  @Timeout(60)
+  void aProducerPinnedToOneBucketKeepsWorkingAcrossAShrink() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(4);
+
+    final AtomicInteger executed = new AtomicInteger();
+    final AtomicInteger completed = new AtomicInteger();
+    final AtomicInteger scheduled = new AtomicInteger();
+    final List<Throwable> producerFailures = new CopyOnWriteArrayList<>();
+    final List<Throwable> taskErrors = new CopyOnWriteArrayList<>();
+    async.onError(taskErrors::add);
+
+    // BUCKET 3 is the one that migrates: 3 % 4 = 3, a worker the shrink below retires, and 3 % 2 = 1, one that
+    // survives. Routed through getSlot() on every iteration exactly as the engine's own createRecord() does, so the
+    // producer follows the mapping across the resize instead of pinning to a slot number.
+    final AtomicBoolean stop = new AtomicBoolean();
+    final Thread producer = new Thread(() -> {
+      while (!stop.get()) {
+        try {
+          if (async.scheduleTask(async.getSlot(3), new CountingTask(executed, completed), true, 0))
+            scheduled.incrementAndGet();
+        } catch (final Throwable e) {
+          producerFailures.add(e);
+        }
+      }
+    }, "issue6526-bucket-producer");
+    producer.start();
+
+    try {
+      async.setParallelLevel(2);
+      async.setParallelLevel(4);
+      async.setParallelLevel(2);
+    } finally {
+      stop.set(true);
+      producer.join(30_000);
+    }
+    assertThat(producer.isAlive()).isFalse();
+
+    assertThat(producerFailures)
+        .as("a producer pinned to a migrating bucket must never be refused by a resize").isEmpty();
+    assertThat(scheduled.get()).as("the producer must have kept working throughout").isGreaterThan(0);
+
+    assertThat(async.waitCompletion(60_000)).isTrue();
+    assertThat(executed.get())
+        .as("and every task it scheduled must have run, on whichever worker owned the bucket at the time")
+        .isEqualTo(scheduled.get());
+    assertThat(taskErrors).as("no task may fail because its bucket changed owner").isEmpty();
+  }
+
+  /**
    * Item 1, growing. Raising the level must not disturb the workers that already exist: they own batch transactions
    * and are the unit {@code ThreadBucketSelectionStrategy} pins buckets to, so respawning them is never free.
    */

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
@@ -18,8 +18,11 @@
  */
 package com.arcadedb.database.async;
 
+import com.arcadedb.Profiler;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -66,6 +69,13 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
    * nothing here measures elapsed time, this only has to outlive a fixed timeout in the code under test.
    */
   private static final long WORKER_HOLD_MS = 3_000;
+
+  /**
+   * How long the gate task of the {@code kill()} test occupies its worker: long enough that only an interrupt can
+   * end it, so the test cannot pass by the worker simply finishing on its own. Never actually waited for - a
+   * {@code kill()} that does its job cuts it short in milliseconds.
+   */
+  private static final long UNTIL_INTERRUPTED_MS = 120_000;
 
   /**
    * Item 1, the half that LOSES DATA. Tasks already queued on a worker the resize retires must still run, in the
@@ -193,6 +203,122 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
   }
 
   /**
+   * Item 1, the terminal path (#6526 review, finding 1). {@code kill()} read only the published array, so a worker
+   * left draining by a shrink whose wait had expired was never force-shut-down, never interrupted and never joined:
+   * {@code kill()} returned while a thread of this database kept running against a database it had just stopped.
+   * The shrink here is made to outlive its own drain budget - {@code shutdownJoinTimeoutMs} is dropped to a few
+   * milliseconds - which is precisely the case the design leaves running in the background.
+   */
+  @Test
+  @Timeout(60)
+  void killReachesTheWorkersAShrinkLeftDraining() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(4);
+
+    final AtomicInteger executed = new AtomicInteger();
+    final AtomicInteger completed = new AtomicInteger();
+
+    final CountDownLatch gateEntered = new CountDownLatch(1);
+    assertThat(async.scheduleTask(3, new CountingTask(executed, completed) {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal ignored) {
+        super.execute(asyncThread, ignored);
+        gateEntered.countDown();
+        try {
+          Thread.sleep(UNTIL_INTERRUPTED_MS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, true, 0)).isTrue();
+    assertThat(gateEntered.await(30, TimeUnit.SECONDS)).isTrue();
+
+    // Make the shrink give up on the drain almost immediately, so worker 3 is provably still alive and still
+    // registered as retiring when kill() runs.
+    final long previousJoinTimeout = async.shutdownJoinTimeoutMs;
+    async.shutdownJoinTimeoutMs = 10;
+    final DatabaseAsyncExecutorImpl.AsyncThread retiredWorker = workerNamed(3);
+    assertThat(retiredWorker).isNotNull();
+    try {
+      async.setParallelLevel(2);
+      assertThat(retiredWorker.isAlive()).as("the drain budget must have expired with the worker still running")
+          .isTrue();
+
+      async.kill();
+
+      retiredWorker.join(10_000);
+      assertThat(retiredWorker.isAlive()).as("kill() must not leave a retired worker of this database running")
+          .isFalse();
+    } finally {
+      async.shutdownJoinTimeoutMs = previousJoinTimeout;
+    }
+  }
+
+  /**
+   * Item 1, concurrent resizes (#6526 review, finding 2). The drain wait is what keeps two workers off one bucket's
+   * pages while a shrink finishes, and it only means that if a second caller cannot grow the pool back through the
+   * middle of it: a grow refills the array positions the shrink vacated, so slot 2 would name a fresh worker AND
+   * the old slot-2 worker still running its pre-shrink tasks.
+   */
+  @Test
+  @Timeout(60)
+  void aConcurrentGrowCannotOvertakeAShrinkStillDraining() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(4);
+
+    final AtomicInteger executed = new AtomicInteger();
+    final AtomicInteger completed = new AtomicInteger();
+
+    final CountDownLatch gateEntered = new CountDownLatch(1);
+    assertThat(async.scheduleTask(3, new CountingTask(executed, completed) {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal db) {
+        super.execute(asyncThread, db);
+        gateEntered.countDown();
+        try {
+          Thread.sleep(WORKER_HOLD_MS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, true, 0)).isTrue();
+    assertThat(gateEntered.await(30, TimeUnit.SECONDS)).isTrue();
+
+    final DatabaseAsyncExecutorImpl.AsyncThread retiredWorker = workerNamed(3);
+    assertThat(retiredWorker).isNotNull();
+
+    final Thread shrinker = new Thread(() -> async.setParallelLevel(2), "issue6526-shrinker");
+    shrinker.start();
+
+    // Spin until the shrink has published its smaller pool, so the grow below provably starts while the retired
+    // worker is still draining rather than before the shrink got anywhere.
+    // Sleeping rather than spinning: a tight onSpinWait() loop on this thread starves the shrinker of the CPU it
+    // needs to get anywhere, which turned a three-second test into a fifty-second one on a loaded fork.
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (async.getThreadCount() != 2 && System.currentTimeMillis() < deadline)
+      Thread.sleep(2);
+    assertThat(async.getThreadCount()).as("the shrink must have published before the grow starts").isEqualTo(2);
+
+    final AtomicBoolean oldWorkerStillAliveAtGrow = new AtomicBoolean();
+    final Thread grower = new Thread(() -> {
+      async.setParallelLevel(4);
+      oldWorkerStillAliveAtGrow.set(retiredWorker.isAlive());
+    }, "issue6526-grower");
+    grower.start();
+
+    grower.join(45_000);
+    shrinker.join(45_000);
+    assertThat(grower.isAlive()).isFalse();
+    assertThat(shrinker.isAlive()).isFalse();
+
+    assertThat(oldWorkerStillAliveAtGrow.get())
+        .as("a grow must not republish a slot while the worker the shrink retired for it is still running")
+        .isFalse();
+    assertThat(async.getThreadCount()).isEqualTo(4);
+  }
+
+  /**
    * Item 1, growing. Raising the level must not disturb the workers that already exist: they own batch transactions
    * and are the unit {@code ThreadBucketSelectionStrategy} pins buckets to, so respawning them is never free.
    */
@@ -281,6 +407,42 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
         .as("the sync flag counts too, not just useWAL").isEqualTo(2L);
   }
 
+  /**
+   * Item 3, the part that must cost nothing (#6526 review round 1, found by the regression it caused). The counter
+   * is folded into {@code Profiler} on every metrics scrape AND on every database close, and reaching it through
+   * {@code db.async()} rather than the field made merely OBSERVING a database grow it a full set of worker threads.
+   * On the close path that is a leak with no owner: the close has already shut down whatever executor existed, so
+   * the pool created behind it has nothing left to stop it. {@code waitForAsyncCompletion()} and
+   * {@code quiesceAsync()} both carry the same rule in their comments; this pins it for the profiler too.
+   */
+  @Test
+  @Timeout(60)
+  void readingTheProfilerCountersNeverCreatesAnAsyncExecutor() throws Exception {
+    final String dbName = "Issue6526NoAsyncProfiler";
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/" + dbName);
+    if (factory.exists())
+      factory.open().drop();
+
+    final LocalDatabase db = (LocalDatabase) factory.create();
+    try {
+      // A database that has never touched the async API. Nothing below may change that.
+      assertThat(db.getAsyncIfExists()).as("a fresh database must have no asynchronous executor").isNull();
+
+      Profiler.INSTANCE.toJSON();
+      assertThat(db.getAsyncIfExists())
+          .as("a metrics scrape must not start a worker pool on a database that never used async").isNull();
+    } finally {
+      db.drop();
+    }
+
+    // The close path folds the same counters in through unregisterDatabase(), where a pool created behind the close
+    // would never be shut down at all: no worker thread of this database may be alive now.
+    final String prefix = "AsyncExecutor-" + dbName + "-";
+    for (final Thread t : Thread.getAllStackTraces().keySet())
+      assertThat(t.getName().startsWith(prefix) && t.isAlive())
+          .as("closing a database must not leave (or start) async worker threads: %s", t.getName()).isFalse();
+  }
+
   private record Observation(boolean transactionActive, boolean useWAL, WALFile.FlushType walFlush) {
   }
 
@@ -337,6 +499,15 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
       }
     }, true, 0)).isTrue();
     assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+  }
+
+  /** The live worker of this database occupying the given slot, by the name {@code AsyncThread} gives itself. */
+  private DatabaseAsyncExecutorImpl.AsyncThread workerNamed(final int slot) {
+    final String name = "AsyncExecutor-" + database.getName() + "-" + slot;
+    for (final Thread t : Thread.getAllStackTraces().keySet())
+      if (t instanceof final DatabaseAsyncExecutorImpl.AsyncThread worker && name.equals(t.getName()) && t.isAlive())
+        return worker;
+    return null;
   }
 
   private Set<Long> asyncWorkerThreadIds() {

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
@@ -249,11 +249,21 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
       assertThat(retiredWorker.isAlive()).as("the drain budget must have expired with the worker still running")
           .isTrue();
 
+      // #6526 review round 4: a worker abandoned past its drain budget has to be VISIBLE, not just logged once at
+      // the moment the wait gave up. This is the only state in which the gauge is non-zero for longer than a
+      // resize takes, and it is the state an operator needs to be able to see.
+      assertThat(async.getStats().retiringWorkers)
+          .as("a worker still draining past the resize budget must be reported").isEqualTo(1L);
+      assertThat(Profiler.INSTANCE.toJSON().getJSONObject("asyncRetiringWorkers").getLong("value", -1L))
+          .as("and must reach the profiler, as a gauge rather than a counter").isGreaterThanOrEqualTo(1L);
+
       async.kill();
 
       retiredWorker.join(10_000);
       assertThat(retiredWorker.isAlive()).as("kill() must not leave a retired worker of this database running")
           .isFalse();
+      assertThat(async.getStats().retiringWorkers)
+          .as("and the gauge must come back down once nothing is draining").isZero();
     } finally {
       async.shutdownJoinTimeoutMs = previousJoinTimeout;
     }

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
@@ -435,6 +435,50 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
   }
 
   /**
+   * Item 1 against the barrier (#6526 review round 8). {@code quiesceWorkers()} snapshots the pool once and then
+   * schedules one park task per slot, but {@code scheduleTask()} re-reads the published array on every call - and
+   * since this PR a slot the pool has outgrown is re-mapped onto a live worker rather than refused. A shrink
+   * landing inside that loop therefore used to fold several park tasks onto one survivor, which runs the first,
+   * counts the latch down once and blocks: the duplicates behind it never run, the latch never reaches zero, and
+   * the caller - an index build - waits out the whole quiesce timeout before failing.
+   * <p>
+   * Driven from the worst end: the resize runs in a tight loop while the quiescence is repeatedly established and
+   * released, so the two interleave many times rather than once by luck.
+   */
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void quiescingWhileTheParallelLevelChangesStillParksEveryWorker() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(5);
+
+    final AtomicBoolean stop = new AtomicBoolean();
+    final List<Throwable> resizeFailures = new CopyOnWriteArrayList<>();
+    final Thread resizer = new Thread(() -> {
+      for (int i = 0; !stop.get(); i++)
+        try {
+          async.setParallelLevel(i % 2 == 0 ? 2 : 5);
+        } catch (final Throwable e) {
+          resizeFailures.add(e);
+        }
+    }, "issue6526-quiesce-resizer");
+    resizer.start();
+
+    try {
+      // Each quiescence must complete promptly. Before the fix a collapsed park loop could not reach its latch and
+      // only unblocked when quiesceTimeoutMillis() (60s) expired, so a run that finishes at all finishes fast.
+      for (int i = 0; i < 40; i++)
+        async.quiesceWorkers().close();
+    } finally {
+      stop.set(true);
+      resizer.join(30_000);
+    }
+
+    assertThat(resizer.isAlive()).isFalse();
+    assertThat(resizeFailures).as("a resize must not fail because a quiescence was running").isEmpty();
+  }
+
+  /**
    * Item 1, growing. Raising the level must not disturb the workers that already exist: they own batch transactions
    * and are the unit {@code ThreadBucketSelectionStrategy} pins buckets to, so respawning them is never free.
    */

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java
@@ -334,6 +334,43 @@ class Issue6526AsyncExecutorFollowUpsTest extends TestHelper {
   }
 
   /**
+   * Item 1, the stale-slot fallback in {@code scheduleTask()} (#6526 review round 5), pinned directly rather than
+   * left to be hit by chance. {@code getSlot()} maps a bucket modulo the pool size it read, and the pool can shrink
+   * before the caller reaches {@code scheduleTask()} - a window that did not exist while a resize nulled the array
+   * for its whole duration, because the caller got the "shut down" exception instead. The index is re-mapped rather
+   * than thrown on, so the task still runs.
+   * <p>
+   * Deterministic, and does not need a race to be: an index obtained from an eight-worker pool is simply carried
+   * across the shrink by hand, which is precisely the value the racing caller would be holding.
+   */
+  @Test
+  @Timeout(60)
+  void aSlotIndexLeftStaleByAShrinkStillReachesALiveWorker() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(8);
+
+    final int staleSlot = async.getSlot(7);
+    assertThat(staleSlot).as("the bucket must map into the upper half of the pool it was read against").isEqualTo(7);
+
+    async.setParallelLevel(2);
+    assertThat(staleSlot)
+        .as("the slot must now be out of bounds for the published pool, or the fallback is not being exercised")
+        .isGreaterThanOrEqualTo(async.getThreadCount());
+
+    final AtomicInteger executed = new AtomicInteger();
+    final AtomicInteger completed = new AtomicInteger();
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    assertThat(async.scheduleTask(staleSlot, new CountingTask(executed, completed), true, 0))
+        .as("a stale slot must be re-mapped onto a live worker, not thrown on").isTrue();
+    assertThat(async.waitCompletion(30_000)).isTrue();
+
+    assertThat(executed.get()).as("and the task must actually run there").isEqualTo(1);
+    assertThat(errors).isEmpty();
+  }
+
+  /**
    * Item 1, growing. Raising the level must not disturb the workers that already exist: they own batch transactions
    * and are the unit {@code ThreadBucketSelectionStrategy} pins buckets to, so respawning them is never free.
    */

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -104,6 +104,12 @@ public final class EngineMetricsBinder implements MeterBinder {
         "Chunked reads that completed after a page they walked had moved", "chunkChainReadRevalidations");
     counter(registry, "arcadedb.engine.record.chunked.read.retries",
         "Chunked reads restarted because the record changed under them", "chunkChainReadRetries");
+    // #6526: the cost side of #6511's fix. A durability-flag change no longer tears the async pool down, it closes
+    // the affected worker's open batch transaction instead - so this climbing while async throughput falls is two
+    // callers flipping setTransactionUseWAL()/setTransactionSync() against each other on one database, and the
+    // batching collapsing toward one commit per task.
+    counter(registry, "arcadedb.engine.async.boundary.commits",
+        "Async batch transactions closed early by a durability-flag change", "asyncForcedBoundaryCommits");
     counter(registry, "arcadedb.engine.tx.write", "Write transactions", "writeTx");
     counter(registry, "arcadedb.engine.tx.read", "Read transactions", "readTx");
     counter(registry, "arcadedb.engine.tx.rollbacks", "Transaction rollbacks", "txRollbacks");

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -179,6 +179,13 @@ public final class EngineMetricsBinder implements MeterBinder {
     // PageManager.getDeferredRAMBytesOf.
     gauge(registry, "arcadedb.engine.flush.deferred.bytes", "Dirty page bytes deferred by a flush suspension",
         "deferredRAM");
+
+    // #6526: workers a lowered parallel level retired that are still finishing the tasks queued on them. Zero almost
+    // always, briefly positive during a resize - and PERSISTENTLY positive is the alertable one: a resize never
+    // interrupts a worker the way a close does, so one wedged inside user code drains for ever, and before this the
+    // only trace of it was a single WARNING at the moment the resize gave up waiting.
+    gauge(registry, "arcadedb.engine.async.workers.retiring",
+        "Async workers retired by a parallel-level change and still draining", "asyncRetiringWorkers");
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
@@ -93,7 +93,10 @@ class EngineMetricsBinderTest {
         // #6125: a high-water mark. Monotonic, but a rate() over it would be meaningless, so it is the one
         // never-decreasing reading here that is deliberately a gauge
         "arcadedb.engine.snapshot.barrier.max.seconds",
-        "arcadedb.engine.flush.deferred.bytes" }) {
+        "arcadedb.engine.flush.deferred.bytes",
+        // #6526: workers a lowered parallel level retired and that are still draining - it comes back down, so it
+        // is a gauge
+        "arcadedb.engine.async.workers.retiring" }) {
       final Gauge gauge = registry.find(name).gauge();
       assertThat(gauge).as(name).isNotNull();
       assertThat(Double.isNaN(gauge.value())).as(name).isFalse();

--- a/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
@@ -67,7 +67,9 @@ class EngineMetricsBinderTest {
         "arcadedb.engine.snapshot.barrier.count", "arcadedb.engine.snapshot.barrier.seconds",
         "arcadedb.engine.snapshot.barrier.inexact",
         // #6217: the read-path twin of the page merges above
-        "arcadedb.engine.record.chunked.read.revalidations", "arcadedb.engine.record.chunked.read.retries" }) {
+        "arcadedb.engine.record.chunked.read.revalidations", "arcadedb.engine.record.chunked.read.retries",
+        // #6526: async batch transactions cut short by a durability-flag change
+        "arcadedb.engine.async.boundary.commits" }) {
       final FunctionCounter counter = registry.find(name).functionCounter();
       assertThat(counter).as(name).isNotNull();
       assertThat(Double.isNaN(counter.count())).as(name).isFalse();


### PR DESCRIPTION
Closes #6526.

The three follow-ups the 14-round review of #6511 left explicitly out of scope.

## 1. `setParallelLevel()` no longer tears down the whole pool

It was the last runtime-callable caller of `createThreads()`, the exact full teardown-and-respawn #6511 removed from the durability setters, so it kept both of that mechanism's failure modes for an **unrelated** concurrent user of `database.async()` on the same database:

- `executorThreads` was nulled for the entire teardown, so a producer scheduling in that window got `DatabaseOperationException("Async executor has been shut down")` - indistinguishable from a genuine `close()`. That is the #6505 incident: an index-compaction `onAfterCommit` hook running after `writeTransactionToWAL()` believed it and fenced the whole database over a scheduling hiccup that had nothing to do with the committing transaction.
- a worker whose queue was full refused the `FORCE_EXIT` marker within a second and was `interrupt()`ed, which unwound its in-flight task loudly and notified every task still queued on it as **completed without ever running it**.

Neither is inherent to changing the parallel level:

- **Growing** carries every existing worker over by reference and only starts the new ones. No marker, no flag, no join, no bucket-pinning disturbed.
- **Shrinking** publishes the truncated array *first* (nothing new can choose the retiring tail), then retires that tail by **draining** it: the `shutdown` flag plus a best-effort `FORCE_EXIT` at the **tail** of its queue, and *never* an `interrupt()`. Everything already queued still executes, inside the batch transaction that worker already owns, and that batch is committed by its own run loop on the way out.
- The retired workers are then **waited for**, outside `lifecycleLock` and bounded by `shutdownJoinTimeoutMs`. `getSlot()` maps a bucket to a worker modulo the pool size, so returning while a retired worker still drains would let two workers write one bucket's pages concurrently - the contention `ThreadBucketSelectionStrategy` exists to prevent. If the budget runs out they keep draining in the background and stay visible to `waitCompletion()`, `isProcessing()`, `getStats()` and `close()`/`kill()`, rather than having their work dropped to return on time.

`scheduleTask()` also re-maps a slot index a concurrent shrink has made stale: the array used to be null for the whole resize, so that race surfaced as the \"shut down\" exception above rather than as an `ArrayIndexOutOfBoundsException`.

The issue suggested \"soften the teardown, or document that a parallel-level change should only be done when nothing else is using `database.async()`\". Documenting it would have left the API with a footgun that only shows up under production concurrency; draining removes the footgun instead, which is why this PR takes that route.

## 2. The DDL dispatch path now carries the executor's durability policy

A command routed to `AsyncCommandPool` (an `awaitResponse=false` `CREATE INDEX`, since #6303) read neither `transactionUseWAL` nor `transactionSync`, so it committed under whatever ambient flags it found. A caller that set `setTransactionUseWAL(false)` around a bulk `GraphBatch` load and dispatched DDL inside that window silently got a durability it had not asked for.

`runCommand()` now stamps the executor's policy on the transaction it opens itself - and **only** on that one. On the caller-runs fallback the transaction may be the submitter's own, and `useWAL`/`walFlush` are read at *commit* time and govern the whole accumulated transaction, so stamping there would re-decide the durability of that caller's work. The stamp is restored afterwards, since `TransactionContext.begin()`/`reset()` never clear it and on that path the context belongs to a submitting HTTP worker that has its next request to serve.

## 3. Forced boundary commits are counted

`closeTransactionBoundaryIfDurabilityPolicyChanged()` is what lets a flag flip take effect without the pool teardown, at the cost of cutting the open batch short - so two concurrent flag-flippers sharing a worker slot can degrade that slot toward `commitEvery=1`. Nothing counted it; the incident behind #6509 was reconstructed by grepping `InterruptedIOException` counts out of a seven-hour log window.

Now exported as:
- `DatabaseAsyncExecutorImpl.DBAsyncStats.forcedBoundaryCommits`
- `Profiler` key `asyncForcedBoundaryCommits` (monotonic, inside the range retained across a database close - a bulk loader opens, loads and closes, so a counter reset on close would read zero every time anybody looked)
- Micrometer `arcadedb.engine.async.boundary.commits`

## Tests

`Issue6526AsyncExecutorFollowUpsTest`, five cases, each verified to FAIL with the corresponding fix reverted:

| test | reverted behaviour |
|---|---|
| `loweringTheParallelLevelRunsTheWorkStillQueuedOnTheRetiredWorkers` | the retired worker is `interrupt()`ed |
| `resizingTheParallelLevelNeverTellsAnUnrelatedProducerTheExecutorIsShutDown` | producer collects `"Async executor has been shut down"` |
| `raisingTheParallelLevelLeavesTheExistingWorkersRunning` | every worker respawned on a grow |
| `dispatchedDDLRunsUnderTheExecutorDurabilityPolicy` | dispatched DDL ignores `setTransactionUseWAL(false)` |
| `forcedBoundaryCommitsAreCounted` | counter stays at zero |

Green locally: 79 tests across `com.arcadedb.database.async.*`, `Issue6303*`, `Issue5665GraphBatchAsyncPoolChurnTest`, `MVCCTest`, `AsyncTest`; plus `EngineMetricsBinderTest`, `DefaultServerMetricsTest`, `AsyncInsertTest` in `server`.

## Files changed

- `engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java`
- `engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java`
- `engine/src/main/java/com/arcadedb/Profiler.java`
- `server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java`
- `server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java`
- `engine/src/test/java/com/arcadedb/database/async/Issue6526AsyncExecutorFollowUpsTest.java` (new)