### PR TITLE
fix: DetachedDocument.toMap() must also preserve property insertion order

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DetachedDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/DetachedDocument.java
@@ -22,7 +22,6 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.serializer.JsonSerializer;
 import com.arcadedb.serializer.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +89,9 @@ public class DetachedDocument extends BaseDocument {
 
   @Override
   public synchronized Map<String, Object> toMap(final boolean includeMetadata) {
-    final Map<String, Object> result = new HashMap<>(map);
+    // LinkedHashMap (not HashMap) so iteration order matches getPropertyNames() (this same
+    // LinkedHashMap-backed map's keySet()) — see MutableDocument.toMap() for the same fix (#6472).
+    final Map<String, Object> result = new LinkedHashMap<>(map);
     if (includeMetadata) {
       result.put(Property.CAT_PROPERTY, "d");
       result.put(Property.TYPE_PROPERTY, type.getName());

--- a/engine/src/test/java/com/arcadedb/DocumentTest.java
+++ b/engine/src/test/java/com/arcadedb/DocumentTest.java
@@ -150,4 +150,41 @@ public class DocumentTest extends TestHelper {
       assertThat(mapKeysWithMetadata.subList(0, propertyNames.size())).isEqualTo(propertyNames);
     });
   }
+
+  // Regression test for issue #6472: DetachedDocument.toMap(false) had the same bug as
+  // MutableDocument.toMap() (copied into a plain HashMap instead of a LinkedHashMap), so it was
+  // left unfixed by PR #6500. Document.detach() is a common pattern for handing documents outside
+  // a transaction, so this covers that path too.
+  @Test
+  void detachedDocumentToMapPreservesPropertyInsertionOrder() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("OrderPersonDetached");
+      type.createProperty("name", Type.STRING);
+      type.createProperty("age", Type.INTEGER);
+      type.createProperty("city", Type.STRING);
+      type.createProperty("country", Type.STRING);
+      type.createProperty("email", Type.STRING);
+
+      final MutableDocument doc = database.newDocument("OrderPersonDetached");
+      doc.set("name", "Alice");
+      doc.set("age", 30);
+      doc.set("city", "Rome");
+      doc.set("country", "Italy");
+      doc.set("email", "alice@example.com");
+      doc.save();
+
+      final DetachedDocument detached = doc.detach();
+
+      final List<String> propertyNames = new ArrayList<>(detached.getPropertyNames());
+      final List<String> mapKeysNoMetadata = new ArrayList<>(detached.toMap(false).keySet());
+      final List<Object> mapValuesNoMetadata = new ArrayList<>(detached.toMap(false).values());
+
+      assertThat(mapKeysNoMetadata).isEqualTo(propertyNames);
+      for (int i = 0; i < propertyNames.size(); i++)
+        assertThat(mapValuesNoMetadata.get(i)).isEqualTo(detached.get(propertyNames.get(i)));
+
+      final List<String> mapKeysWithMetadata = new ArrayList<>(detached.toMap(true).keySet());
+      assertThat(mapKeysWithMetadata.subList(0, propertyNames.size())).isEqualTo(propertyNames);
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.method.collection;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DetachedDocument;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.query.sql.executor.Result;
@@ -190,6 +191,32 @@ class SQLMethodValuesTest extends TestHelper {
         assertThat(values.get(i)).as("value at index %d for key '%s'", i, keys.get(i)).isEqualTo(expected);
       }
     }
+  }
+
+  @Test
+  void keysAndValuesAreIndexAlignedOnDetachedDocument() {
+    database.transaction(() ->
+      database.getSchema().createDocumentType("OrderPerson"));
+
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument("OrderPerson");
+      doc.set("name", "Alice");
+      doc.set("age", 30);
+      doc.set("city", "Rome");
+      doc.set("country", "Italy");
+      doc.set("email", "alice@example.com");
+      doc.save();
+
+      final DetachedDocument detached = doc.detach();
+
+      final SQLMethod keysFunction = new SQLMethodKeys();
+      final List<String> keys = (List<String>) keysFunction.execute(detached, null, null, null);
+      final List<Object> values = (List<Object>) function.execute(detached, null, null, null);
+
+      assertThat(keys).hasSameSizeAs(values);
+      for (int i = 0; i < keys.size(); i++)
+        assertThat(values.get(i)).as("value at index %d for key '%s'", i, keys.get(i)).isEqualTo(detached.get(keys.get(i)));
+    });
   }
 
   // NEW TESTS - Result object handling


### PR DESCRIPTION
## Problem

PR #6500 (issue #6472) fixed `keys()`/`values()` index-misalignment for `Document` by:
1. Making `SQLMethodValues` use `document.toMap(false)` instead of `toMap()`.
2. Switching `MutableDocument.toMap(boolean)` from a plain `HashMap` to a `LinkedHashMap`, so its iteration order matches `getPropertyNames()` (both derived from the same insertion-ordered `map` field).

The [post-merge review](https://github.com/ArcadeData/arcadedb/pull/6500#issuecomment-5364241918) caught that `DetachedDocument` has the exact same bug and was left unfixed:

```java
// DetachedDocument.java
public synchronized Map<String, Object> toMap(final boolean includeMetadata) {
  final Map<String, Object> result = new HashMap<>(map);   // bucket order
  ...
}

public synchronized Set<String> getPropertyNames() {
  return map.keySet();                                      // insertion order (map is a LinkedHashMap)
}
```

`Document.detach()` is a common pattern for handing documents outside a transaction, so `detached.keys()`/`detached.values()` (or plain `toMap(false)`) could still disagree by index for a detached document with 3+ properties.

## Fix

Switch `DetachedDocument.toMap(boolean)` to build a `LinkedHashMap`, matching `MutableDocument` and `ImmutableDocument` (which already used `LinkedHashMap`).

## Tests

- `DocumentTest.detachedDocumentToMapPreservesPropertyInsertionOrder`: asserts `toMap(false)` key/value order matches `getPropertyNames()` on a detached document with 5 properties.
- `SQLMethodValuesTest.keysAndValuesAreIndexAlignedOnDetachedDocument`: asserts `keys()[i]`/`values()[i]` correspondence via the SQL methods, on a detached document.

Confirmed both new tests fail against the pre-fix code (property order came back scrambled, e.g. `[name, country, city, age, email]` instead of insertion order `[name, age, city, country, email]`) and pass with the fix.

Fixes the remaining part of #6472 not covered by #6500.