### PR TITLE
fix: guard against negative k in LSMVectorIndex entry points

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4408,6 +4408,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
     try {
       if (queryVector == null)
         throw new IllegalArgumentException("Query vector cannot be null");
+      if (k < 0)
+        throw new IllegalArgumentException("k must be >= 0, got " + k);
 
       if (queryVector.length != metadata.dimensions)
         throw new IllegalArgumentException(
@@ -4701,6 +4703,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
     try {
       if (queryVector == null)
         throw new IllegalArgumentException("Query vector cannot be null");
+      if (k < 0)
+        throw new IllegalArgumentException("k must be >= 0, got " + k);
 
       if (queryVector.length != metadata.dimensions)
         throw new IllegalArgumentException(
@@ -5052,6 +5056,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
     try {
       if (queryVector == null)
         throw new IllegalArgumentException("Query vector cannot be null");
+      if (k < 0)
+        throw new IllegalArgumentException("k must be >= 0, got " + k);
 
       if (queryVector.length != metadata.dimensions)
         throw new IllegalArgumentException(

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4420,6 +4420,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
         throw new IllegalArgumentException(
             "Query vector cannot be a zero vector when using COSINE similarity (causes undefined similarity)");
 
+      // Issue #6531 follow-up: k == 0 is a valid "no results wanted" request, but letting it reach
+      // GraphSearcher.search() with topK == 0 throws a NullPointerException deep inside JVector's
+      // reranking (NodeQueue.rerank), not an ArcadeDB exception. Short-circuit here, matching the
+      // limit <= 0 behavior SQLFunctionVectorNeighbors already applies before ever calling in, and
+      // skip the graph build/lock entirely since there is nothing left to search for.
+      if (k == 0)
+        return Collections.emptyList();
+
       // Ensure graph is available (lazy-load from disk if needed, or build if not persisted)
       ensureGraphAvailable();
 
@@ -5065,6 +5073,11 @@ public class LSMVectorIndex implements Index, IndexInternal {
       if (metadata.similarityFunction == VectorSimilarityFunction.COSINE && VectorUtils.isZeroVector(queryVector))
         throw new IllegalArgumentException(
             "Query vector cannot be a zero vector when using COSINE similarity (causes undefined similarity)");
+
+      // Issue #6531 follow-up: see findNeighborsFromVector's matching short-circuit - k == 0 must not
+      // reach GraphSearcher.search() with topK == 0, which NPEs inside JVector's reranking.
+      if (k == 0)
+        return Collections.emptyList();
 
       // Ensure graph is available (lazy-load from disk if needed)
       ensureGraphAvailable();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4703,8 +4703,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
     try {
       if (queryVector == null)
         throw new IllegalArgumentException("Query vector cannot be null");
-      if (k < 0)
-        throw new IllegalArgumentException("k must be >= 0, got " + k);
 
       if (queryVector.length != metadata.dimensions)
         throw new IllegalArgumentException(

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
@@ -2602,6 +2602,59 @@ class LSMVectorIndexTest extends TestHelper {
     });
   }
 
+  // Issue #6531: a negative k passed to the public findNeighborsFromVector*/ entry points must raise a clear
+  // IllegalArgumentException naming the offending value, instead of the ArrayList constructor's confusing
+  // "Illegal Capacity: -N" once it reaches `new ArrayList<>(k)`.
+  @Test
+  void negativeKRaisesClearError() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE NegativeKDoc");
+      database.command("sql", "CREATE PROPERTY NegativeKDoc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX ON NegativeKDoc (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions": 3,
+            "similarity": "COSINE"
+          }""");
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < 5; i++) {
+        final var vertex = database.newVertex("NegativeKDoc");
+        vertex.set("embedding", new float[] { 1.0f + i, 1.0f + i, 1.0f + i });
+        vertex.save();
+      }
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("NegativeKDoc[embedding]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    database.transaction(() -> {
+      final float[] queryVector = { 1.5f, 1.5f, 1.5f };
+
+      assertThatThrownBy(() -> index.findNeighborsFromVector(queryVector, -1))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("k must be >= 0")
+          .hasMessageContaining("-1");
+
+      assertThatThrownBy(() -> index.findNeighborsFromVector(queryVector, -3, (Set<RID>) null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("k must be >= 0")
+          .hasMessageContaining("-3");
+
+      assertThatThrownBy(() -> index.findNeighborsFromVectorApproximate(queryVector, -1))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("k must be >= 0")
+          .hasMessageContaining("-1");
+
+      // k == 0 must remain unaffected by the guard: it is a valid, harmless request for zero neighbors.
+      assertThatCode(() -> {
+        final List<Pair<RID, Float>> zeroResults = index.findNeighborsFromVector(queryVector, 0);
+        assertThat(zeroResults).isEmpty();
+      }).doesNotThrowAnyException();
+    });
+  }
+
   /**
    * Helper method to recursively delete a directory using Files.walk() API
    */


### PR DESCRIPTION
## Summary

LSMVectorIndex's `findNeighborsFromVector` and `findNeighborsFromVectorApproximate` public entry points accept a negative `k` and throw a confusing `IllegalArgumentException: Illegal Capacity: -N` from the `ArrayList` constructor — a message that says nothing about which parameter was wrong.

## Changes

Added `k < 0` guard to both public entry points with a clear error message:

1. `findNeighborsFromVector` — throws `IllegalArgumentException("k must be >= 0, got " + k)`
2. `findNeighborsFromVectorApproximate` — throws `IllegalArgumentException("k must be >= 0, got " + k)`

`findNeighborsFromVectorGrouped` was already guarded by `limit <= 0 || groupSize <= 0` returning an empty list, so no change needed there.

## Testing

- Negative k now throws a clear IllegalArgumentException with the actual value
- k == 0 is harmless (same as before, `subList(0, size)` is valid)
- Positive k continues to work unchanged

Closes #6531