### PR TITLE
fix(#6536): capture LSMVectorIndex.graphFile once per read site to close TOCTOU NPE

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -411,9 +411,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
     final long vectorIndexBytes = safeFileSize(
         mutable != null && mutable.getComponentFile() != null ? Path.of(mutable.getComponentFile().getFilePath()) :
             null);
+    final LSMVectorIndexGraphFile gf = graphFile;
     final long graphFileBytes = safeFileSize(
-        graphFile != null && graphFile.getComponentFile() != null ?
-            Path.of(graphFile.getComponentFile().getFilePath()) : null);
+        gf != null && gf.getComponentFile() != null ?
+            Path.of(gf.getComponentFile().getFilePath()) : null);
     final long pqFileBytes = safeFileSize(pqFile != null ? pqFile.getFilePath() : null);
     final long compactedFileBytes = safeFileSize(
         compactedSubIndex != null && compactedSubIndex.getComponentFile() != null ?
@@ -1285,8 +1286,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * eagerly in the loading constructor.
    */
   private LSMVectorIndexGraphFile getOrCreateGraphFile() {
-    if (graphFile != null)
-      return graphFile;
+    final LSMVectorIndexGraphFile existing = graphFile;
+    if (existing != null)
+      return existing;
 
     try {
       final DatabaseInternal db = getDatabase();
@@ -1321,7 +1323,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // For loaded indexes, graph will be lazy-loaded on first search via ensureGraphAvailable()
     if (vectorIndex.size() > 0 && graphState == GraphState.LOADING) {
       // Check if we can lazy-load from persisted graph
-      if (graphFile != null && graphFile.hasPersistedGraph()) {
+      final LSMVectorIndexGraphFile gf = graphFile;
+      if (gf != null && gf.hasPersistedGraph()) {
         LogManager.instance().log(this, Level.INFO, "Graph will be lazy-loaded from disk for index: %s", indexName);
         return;
       }
@@ -1376,9 +1379,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
             indexName);
       }
 
-      if (graphFile != null && graphFile.hasPersistedGraph() && !needsGraphRebuildForPQ && !hasDeletedVectors) {
+      final LSMVectorIndexGraphFile gf = graphFile;
+      if (gf != null && gf.hasPersistedGraph() && !needsGraphRebuildForPQ && !hasDeletedVectors) {
         try {
-          final var loadedGraph = graphFile.loadGraph();
+          final var loadedGraph = gf.loadGraph();
 
           // Rebuild ordinalToVectorId from vectorIndex
           // IMPORTANT: Must match the validation logic used during graph building
@@ -1444,7 +1448,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           // densely [0, N), so two generations holding different records routinely produce arrays of identical
           // length. The manifest written next to the graph records the correspondence itself, and comparing
           // against it is what makes the reuse safe rather than merely plausible.
-          final LSMVectorIndexGraphManifest.Content persistedManifest = graphFile.getManifest().read();
+          final LSMVectorIndexGraphManifest.Content persistedManifest = gf.getManifest().read();
 
           final String staleReason;
           if (persistedManifest == null) {
@@ -2871,8 +2875,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * @param cause what went wrong; recorded in the manifest for a human, nothing reads it back
    */
   private void markGraphManifestUnusable(final Exception cause) {
-    if (graphFile != null)
-      graphFile.getManifest().markUnusable("index build failed: " + cause);
+    final LSMVectorIndexGraphFile gf = graphFile;
+    if (gf != null)
+      gf.getManifest().markUnusable("index build failed: " + cause);
   }
 
   /**
@@ -5767,8 +5772,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
   public List<Integer> getFileIds() {
     // #4937: the companion graph file receives page writes during the transaction too - it must be part of
     // the commit lock set, or its pages pass the version checks without their file lock held.
-    if (graphFile != null)
-      return List.of(mutable.getFileId(), graphFile.getFileId());
+    final LSMVectorIndexGraphFile gf = graphFile;
+    if (gf != null)
+      return List.of(mutable.getFileId(), gf.getFileId());
     return Collections.singletonList(mutable.getFileId());
   }
 
@@ -6141,7 +6147,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
       // graph is already on disk, and rebuilding then only reproduces a file
       // that already exists. initializeGraphIndex() already draws exactly this
       // distinction with the same predicate.
-      final boolean graphAlreadyOnDisk = graphFile != null && graphFile.hasPersistedGraph();
+      final LSMVectorIndexGraphFile gf = graphFile;
+      final boolean graphAlreadyOnDisk = gf != null && gf.hasPersistedGraph();
       final boolean needsBuild = vectorIndex.size() > 0 && (graphState == GraphState.MUTABLE
           || (graphState == GraphState.LOADING && !graphAlreadyOnDisk));
 
@@ -6346,13 +6353,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
       }
 
       // Delete graph file if it exists
-      if (graphFile != null) {
-        final File graphIndexFile = graphFile.getOSFile();
+      final LSMVectorIndexGraphFile gf = graphFile;
+      if (gf != null) {
+        final File graphIndexFile = gf.getOSFile();
         if (graphIndexFile.exists())
           graphIndexFile.delete();
         // And the sidecar that describes it: left behind, it would be read as vouching for whatever graph file a
         // later index happened to create under the same name (issue #6106).
-        graphFile.getManifest().invalidate();
+        gf.getManifest().invalidate();
       }
 
       // NOTE: Metadata is now embedded in the schema JSON via toJSON() and is automatically

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -6545,6 +6545,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
             // buildGraphWithChunking() rewrites the graph pages inside this transaction, which drops the manifest;
             // only here, past the commit, is there a persisted graph to vouch for again (issue #6106).
+            // Single read, not a check-then-use, and this runs on the thread that owns the initial build while
+            // the index is UNAVAILABLE (no concurrent COMPACT INDEX possible) - intentionally left out of #6536's
+            // local-capture sweep.
             writeGraphManifest(graphFile, ordinalToVectorId);
 
             persistBuildState(BUILD_STATE.READY);
@@ -6730,6 +6733,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
           vectorProp,
           vectorIndex, ordinalToVectorId, this, getSearchVectorCache());
 
+      // Single read, not a check-then-use, and this runs on the thread that owns the initial build while the
+      // index is UNAVAILABLE (no concurrent COMPACT INDEX possible) - intentionally left out of #6536's
+      // local-capture sweep.
       graphFile.writeGraph(graphIndex, vectors, chunkSizeMB, chunkCallback);
 
       // Final commit for graph

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphFileToctouTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphFileToctouTest.java
@@ -78,8 +78,8 @@ class LSMVectorIndexGraphFileToctouTest {
     FileUtils.deleteRecursively(new File(DB_PATH));
     final Random rng = new Random(7);
 
-    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
-      final Database db = factory.create();
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+         final Database db = factory.create()) {
       db.transaction(() -> {
         final DocumentType t = db.getSchema().createDocumentType("Doc");
         t.createProperty("id", Type.INTEGER);
@@ -131,8 +131,6 @@ class LSMVectorIndexGraphFileToctouTest {
               + "dereferencing it; reading it twice lets a concurrent writer null it out in between and turns the "
               + "null-check-then-use into a live NullPointerException (issue #6536)")
           .isNull();
-
-      db.close();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphFileToctouTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphFileToctouTest.java
@@ -125,6 +125,7 @@ class LSMVectorIndexGraphFileToctouTest {
         reader.join(10_000);
       }
 
+      assertThat(reader.isAlive()).as("reader thread must have terminated, not hung, within the join timeout").isFalse();
       assertThat(readerFailure.get())
           .as("getFileIds() must take a single local snapshot of the volatile graphFile field before checking and "
               + "dereferencing it; reading it twice lets a concurrent writer null it out in between and turns the "

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphFileToctouTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexGraphFileToctouTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6536 (follow-up from #6527/#6528): making {@code LSMVectorIndex.graphFile} {@code volatile} fixed the
+ * cross-thread <em>visibility</em> gap #6527 was about, but every read site still does a {@code graphFile != null}
+ * check followed by one or more <em>separate</em> reads of the same field to dereference it, e.g.
+ * {@link Index#getFileIds()}:
+ * <pre>
+ *   if (graphFile != null)
+ *     return List.of(mutable.getFileId(), graphFile.getFileId());
+ * </pre>
+ * During {@code COMPACT INDEX}, the graph-builder thread briefly sets {@code graphFile = null} before registering
+ * the fresh post-compaction file, guarded by {@code graphBuildLock} on the writer side only - a reader taking no
+ * lock at all can have its null-check pass just before that write and its dereference land just after, throwing an
+ * NPE instead of returning a torn-but-non-null answer. Making the field {@code volatile} in #6528 made this window
+ * reliably <em>visible</em> across threads for the first time, so the TOCTOU race is more likely to manifest as a
+ * live NPE now than it was pre-#6528 (a plain field's CPU-local caching used to incidentally hide the window).
+ * <p>
+ * This test reproduces the race deterministically rather than relying on real {@code COMPACT INDEX} timing (that
+ * null window is only a handful of statements wide - far too narrow to hit reliably by chance): a background thread
+ * hammers {@link Index#getFileIds()} while the field is toggled null/non-null many times via reflection, exactly
+ * mirroring the two states {@code buildGraphFromScratchExclusively()} puts it through around the persist step. Pinned
+ * against pre-fix code (a bare double read of {@code graphFile}), this fails with an NPE almost immediately; against
+ * the fix (a single local snapshot taken once per read site), it must never fail.
+ */
+@Tag("vector")
+class LSMVectorIndexGraphFileToctouTest {
+  private static final int    DIMENSIONS        = 16;
+  private static final int    NUM_VECTORS       = 50;
+  private static final String DB_PATH           = "./target/databases/LSMVectorIndexGraphFileToctouTest";
+  private static final int    TOGGLE_ITERATIONS = 50_000;
+
+  @AfterEach
+  void cleanUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void getFileIdsMustNotNpeWhileGraphFileIsBrieflyNulledOnAnotherThread() throws Exception {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    final Random rng = new Random(7);
+
+    try (final DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      final Database db = factory.create();
+      db.transaction(() -> {
+        final DocumentType t = db.getSchema().createDocumentType("Doc");
+        t.createProperty("id", Type.INTEGER);
+        t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+        for (int i = 0; i < NUM_VECTORS; i++)
+          db.newDocument("Doc").set("id", i).set("embedding", randomVector(rng)).save();
+      });
+      db.command("sql", "CREATE INDEX ON Doc (embedding) LSM_VECTOR METADATA "
+          + "{ \"dimensions\": " + DIMENSIONS + ", \"similarity\": \"EUCLIDEAN\", \"maxConnections\": 16 }");
+      waitForGraph(db);
+
+      final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+      final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+
+      final Field field = LSMVectorIndex.class.getDeclaredField("graphFile");
+      field.setAccessible(true);
+      final Object originalGraphFile = field.get(lsm);
+      assertThat(originalGraphFile)
+          .as("index must already have registered a graph file for the null/non-null toggle below to be meaningful")
+          .isNotNull();
+
+      final AtomicBoolean         stop          = new AtomicBoolean(false);
+      final AtomicReference<Throwable> readerFailure = new AtomicReference<>();
+      final Thread reader = new Thread(() -> {
+        while (!stop.get()) {
+          try {
+            lsm.getFileIds();
+          } catch (final Throwable t) {
+            readerFailure.compareAndSet(null, t);
+            return;
+          }
+        }
+      }, "graphFile-toctou-reader");
+      reader.start();
+
+      try {
+        for (int i = 0; i < TOGGLE_ITERATIONS && readerFailure.get() == null; i++) {
+          field.set(lsm, null);
+          field.set(lsm, originalGraphFile);
+        }
+      } finally {
+        stop.set(true);
+        reader.join(10_000);
+      }
+
+      assertThat(readerFailure.get())
+          .as("getFileIds() must take a single local snapshot of the volatile graphFile field before checking and "
+              + "dereferencing it; reading it twice lets a concurrent writer null it out in between and turns the "
+              + "null-check-then-use into a live NullPointerException (issue #6536)")
+          .isNull();
+
+      db.close();
+    }
+  }
+
+  private static void waitForGraph(final Database db) {
+    final TypeIndex idx = (TypeIndex) db.getSchema().getIndexByName("Doc[embedding]");
+    final LSMVectorIndex lsm = (LSMVectorIndex) idx.getIndexesOnBuckets()[0];
+    for (int i = 0; i < 600 && lsm.getStats().get("graphNodeCount") == 0L; i++)
+      try { Thread.sleep(50); } catch (final InterruptedException ignored) { break; }
+  }
+
+  private static float[] randomVector(final Random rng) {
+    final float[] v = new float[DIMENSIONS];
+    for (int i = 0; i < DIMENSIONS; i++)
+      v[i] = (float) rng.nextGaussian();
+    return v;
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up from #6527 (fixed by #6528). Making `LSMVectorIndex.graphFile` `volatile` fixed the cross-thread *visibility* gap #6527 was about, but every read site still did a `graphFile != null` check followed by one or more **separate** reads of the same volatile field to dereference it, e.g. `getFileIds()`:

```java
if (graphFile != null)
  return List.of(mutable.getFileId(), graphFile.getFileId());
```

During `COMPACT INDEX`, the graph-builder thread briefly sets `graphFile = null` before registering the fresh post-compaction file, guarded by `graphBuildLock` on the writer side only. A reader taking no lock at all (`getFileIds()` in particular, which runs on every transaction's commit-lock computation per #4937) can have its null-check pass just before that write and its dereference land just after, throwing an NPE instead of returning a torn-but-non-null answer.

This is arguably a regression *introduced* by #6528, not merely carried forward: before that fix, a reader had no visibility guarantee at all and would typically keep serving a stale-but-non-null cached reference throughout the whole compaction, incidentally hiding the null window behind CPU-local caching. Now that the field is `volatile`, readers reliably observe every write - including the transient `null` - so the TOCTOU race is more likely to actually manifest as a live NPE.

## Fix

Capture `graphFile` into a local variable once at the top of each read site, per the issue's own suggested fix - the standard pattern for consuming a `volatile` reference field safely, with no new locking since each site only ever needed a single consistent snapshot, not synchronization with the writer:

- `getFileIds()` (the most consequential instance - runs on the tx commit-lock path)
- `initializeGraphIndex()` and `ensureGraphAvailable()` (lazy-load-from-disk checks)
- `getOrCreateGraphFile()`
- `markGraphManifestUnusable()`
- `flush()`
- `drop()`
- `captureGraphBuildDiagnostics()`

The compaction/persist path itself (`buildGraphFromScratchExclusively()`) already captured `graphFile` into locals correctly before this change - it runs on a single thread under `graphBuildLock`, so it was never a read site with this issue.

## Test plan

- Added `LSMVectorIndexGraphFileToctouTest`: builds a real vector index with a persisted graph, then races a background thread hammering `getFileIds()` against 50,000 reflection-driven null/non-null toggles of `graphFile` on the main thread - reproducing the exact interleaving `COMPACT INDEX` creates, deterministically rather than relying on the real (far too narrow) timing window.
  - Verified the test fails reliably with the pre-fix NPE (`Cannot invoke "LSMVectorIndexGraphFile.getFileId()" because "this.graphFile" is null`) when `getFileIds()`'s double-read is temporarily restored, and passes with the fix.
- Full `com.arcadedb.index.vector` suite (392 tests, including the pre-existing `LSMVectorIndexGraphFileVisibilityTest` from #6527/#6528): all green.

Closes #6536

https://claude.ai/code/session_01Ho2s8oThF2cuitxbMsuD86