### PR TITLE
fix(#6488): DISTINCT keys on graph elements must not depend on lazy-load state

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
+++ b/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
@@ -18,23 +18,37 @@
  */
 package com.arcadedb.function;
 
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+
 /**
- * Canonicalizes numeric values for duplicate-elimination purposes (Cypher {@code UNION},
+ * Canonicalizes values for duplicate-elimination purposes (Cypher {@code UNION},
  * {@code RETURN DISTINCT}, {@code count(DISTINCT ...)}, {@code collect(DISTINCT ...)}) so that
- * finite numeric values which compare equal under Cypher's {@code =} operator (e.g. {@code 1 = 1.0})
- * also collapse to the same key. Without this, duplicate-elimination paths that key a
- * {@link java.util.HashSet} / {@link java.util.HashMap} directly on the boxed value see
- * {@code Integer.valueOf(1)}, {@code Long.valueOf(1)} and {@code Double.valueOf(1.0)} as distinct,
- * because Java's per-type {@code equals()}/{@code hashCode()} never compares across boxed numeric
- * types. See issue #5789.
+ * values which compare equal under Cypher's {@code =} operator also collapse to the same key.
  * <p>
+ * <b>Numeric values:</b> finite numeric values which compare equal (e.g. {@code 1 = 1.0}) canonicalize
+ * to the same key. Without this, duplicate-elimination paths that key a {@link java.util.HashSet} /
+ * {@link java.util.HashMap} directly on the boxed value see {@code Integer.valueOf(1)},
+ * {@code Long.valueOf(1)} and {@code Double.valueOf(1.0)} as distinct, because Java's per-type
+ * {@code equals()}/{@code hashCode()} never compares across boxed numeric types. See issue #5789.
  * A value that is an exact-integer Java numeric type ({@link Long}, {@link Integer}, {@link Short},
  * {@link Byte}) canonicalizes to its {@code long} value, which is always exact. Any other
  * {@link Number} (typically {@link Double}, {@link Float}, or {@link java.math.BigDecimal})
  * canonicalizes to the same {@code long} value when it represents a finite integer within the range
  * a {@code double} represents integers exactly (|value| &lt;= 2^53), so it lines up with the
  * exact-integer-type canonicalization above; otherwise it canonicalizes to its {@code double} value.
- * Non-numeric values pass through unchanged.
+ * <p>
+ * <b>Graph elements:</b> a document/vertex/edge canonicalizes to its {@link RID}. Some callers build
+ * their duplicate-elimination key by calling {@code toString()} on the canonicalized value (e.g. to
+ * concatenate it into a composite string key); {@link com.arcadedb.database.BaseRecord#toString()} is
+ * RID-based and stable, but document/vertex/edge implementations that decorate it with the record's
+ * deserialized properties are not - a not-yet-loaded property buffer renders as a placeholder (e.g.
+ * {@code #1:0[?]}) instead of the actual property values, so two references to the very same record
+ * can render two different strings depending on load state alone, even though they represent one
+ * value. Canonicalizing to the identity ({@link RID}) up front, whose own {@code toString()} is just
+ * the RID text, sidesteps that instability. See issue #6488.
+ * <p>
+ * Other values pass through unchanged.
  */
 public final class DistinctNumericKey {
   /** 2^53: the largest integer magnitude a double represents exactly. */
@@ -44,9 +58,11 @@ public final class DistinctNumericKey {
   }
 
   /**
-   * Returns a canonical key for {@code value} suitable for use in a hash-based set/map so that
-   * numerically equal finite values, regardless of their boxed numeric type, hash and compare equal.
-   * Non-{@link Number} values are returned unchanged.
+   * Returns a canonical key for {@code value} suitable for use in a hash-based set/map, or to be
+   * rendered with {@code toString()} into a composite string key, so that values which are equal
+   * under Cypher's {@code =} operator collapse to the same key regardless of their Java
+   * representation or in-memory load state. Values that are neither numeric nor a graph element
+   * ({@link Identifiable}) are returned unchanged.
    */
   public static Object canonicalize(final Object value) {
     if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte)
@@ -57,6 +73,12 @@ public final class DistinctNumericKey {
       if (!Double.isNaN(d) && !Double.isInfinite(d) && d == Math.rint(d) && Math.abs(d) <= MAX_EXACT_DOUBLE_INTEGER)
         return (long) d;
       return d;
+    }
+
+    if (value instanceof Identifiable identifiable) {
+      final RID rid = identifiable.getIdentity();
+      if (rid != null)
+        return rid;
     }
 
     return value;

--- a/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
+++ b/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
@@ -21,6 +21,8 @@ package com.arcadedb.function;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 
+import java.util.function.Function;
+
 /**
  * Canonicalizes values for duplicate-elimination purposes (Cypher {@code UNION},
  * {@code RETURN DISTINCT}, {@code count(DISTINCT ...)}, {@code collect(DISTINCT ...)}) so that
@@ -82,5 +84,20 @@ public final class DistinctNumericKey {
     }
 
     return value;
+  }
+
+  /**
+   * Builds a composite string key from {@code names}, in iteration order, by rendering each name's
+   * canonicalized value as {@code name=value|}. Shared by every Cypher duplicate-elimination step
+   * (RETURN DISTINCT, WITH DISTINCT, UNION) that dedups on a set of named values, so the
+   * {@link #canonicalize(Object)} behavior - including the RID canonicalization above - only needs
+   * to be applied in one place. Callers control ordering (and hence key stability across rows) by
+   * choosing what {@code names} they pass; this method does not sort or otherwise reorder it.
+   */
+  public static String buildKey(final Iterable<String> names, final Function<String, Object> valueOf) {
+    final StringBuilder keyBuilder = new StringBuilder();
+    for (final String name : names)
+      keyBuilder.append(name).append('=').append(canonicalize(valueOf.apply(name))).append('|');
+    return keyBuilder.toString();
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
@@ -126,29 +126,19 @@ public class ProjectReturnStep extends AbstractExecutionStep {
 
             // DISTINCT: for RETURN * the single return item is the unexpanded "*", so hash on
             // the projected row's properties (sorted for stable ordering across rows) instead.
+            // Values are canonicalized via DistinctNumericKey so numerically-equal values (issue
+            // #5789) and graph-element references sharing one RID (issue #6488) collapse together.
             if (distinct) {
-              final StringBuilder keyBuilder = new StringBuilder();
+              final List<String> names;
               if (returnClause.isReturnAll()) {
                 // Distinctness is over the variables the query returns; the executor's internal
                 // bindings for anonymous pattern elements are not returned, so counting them here
                 // would keep rows that are duplicates to the caller (issue #5444).
-                for (final String name : new TreeSet<>(projectedResult.getPropertyNames())) {
-                  if (InternalVariables.isInternal(name))
-                    continue;
-                  final Object val = projectedResult.getProperty(name);
-                  // Canonicalize numeric values so DISTINCT treats e.g. INTEGER 1 and FLOAT 1.0 as
-                  // the same value, consistent with Cypher's `=` operator (issue #5789).
-                  keyBuilder.append(name).append('=').append(DistinctNumericKey.canonicalize(val)).append('|');
-                }
+                names = new TreeSet<>(projectedResult.getPropertyNames()).stream().filter(name -> !InternalVariables.isInternal(name)).toList();
               } else {
-                for (final ReturnClause.ReturnItem item : returnClause.getReturnItems()) {
-                  final String outputName = item.getOutputName();
-                  keyBuilder.append(outputName).append('=');
-                  final Object val = projectedResult.getProperty(outputName);
-                  keyBuilder.append(DistinctNumericKey.canonicalize(val)).append('|');
-                }
+                names = returnClause.getReturnItems().stream().map(ReturnClause.ReturnItem::getOutputName).toList();
               }
-              if (!seenResults.add(keyBuilder.toString()))
+              if (!seenResults.add(DistinctNumericKey.buildKey(names, projectedResult::getProperty)))
                 continue;
             }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
@@ -147,19 +147,12 @@ public class UnionStep extends AbstractExecutionStep {
       }
 
       /**
-       * Builds a key for deduplication based on result properties.
+       * Builds a key for deduplication based on result properties. Values are canonicalized via
+       * DistinctNumericKey so numerically-equal values (issue #5789) and graph-element references
+       * sharing one RID (issue #6488) collapse together.
        */
       private String buildResultKey(final Result result) {
-        final StringBuilder sb = new StringBuilder();
-        for (final String prop : result.getPropertyNames()) {
-          sb.append(prop).append("=");
-          final Object value = result.getProperty(prop);
-          // Canonicalize numeric values so UNION treats e.g. INTEGER 1 and FLOAT 1.0 as the same
-          // value, consistent with Cypher's `=` operator (issue #5789).
-          sb.append(value == null ? "null" : DistinctNumericKey.canonicalize(value));
-          sb.append("|");
-        }
-        return sb.toString();
+        return DistinctNumericKey.buildKey(result.getPropertyNames(), result::getProperty);
       }
 
       @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
@@ -188,12 +188,7 @@ public class WithStep extends AbstractExecutionStep {
               // renders as a placeholder instead of the actual values, so two references to the
               // very same record can render two different strings depending on load state alone
               // (issue #6488).
-              final StringBuilder keyBuilder = new StringBuilder();
-              for (final String name : new TreeSet<>(projectedResult.getPropertyNames())) {
-                final Object val = projectedResult.getProperty(name);
-                keyBuilder.append(name).append('=').append(DistinctNumericKey.canonicalize(val)).append('|');
-              }
-              final String resultKey = keyBuilder.toString();
+              final String resultKey = DistinctNumericKey.buildKey(new TreeSet<>(projectedResult.getPropertyNames()), projectedResult::getProperty);
               if (seenResults.contains(resultKey))
                 continue;
               seenResults.add(resultKey);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
@@ -18,6 +18,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.function.DistinctNumericKey;
 import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Execution step for WITH clause.
@@ -180,7 +182,18 @@ public class WithStep extends AbstractExecutionStep {
 
             // Apply DISTINCT
             if (withClause.isDistinct()) {
-              final String resultKey = projectedResult.toString();
+              // Build the key from the projected properties' canonicalized values rather than
+              // projectedResult.toString(): a document/vertex/edge's toString() decorates its RID
+              // with the record's deserialized properties, and a not-yet-loaded property buffer
+              // renders as a placeholder instead of the actual values, so two references to the
+              // very same record can render two different strings depending on load state alone
+              // (issue #6488).
+              final StringBuilder keyBuilder = new StringBuilder();
+              for (final String name : new TreeSet<>(projectedResult.getPropertyNames())) {
+                final Object val = projectedResult.getProperty(name);
+                keyBuilder.append(name).append('=').append(DistinctNumericKey.canonicalize(val)).append('|');
+              }
+              final String resultKey = keyBuilder.toString();
               if (seenResults.contains(resultKey))
                 continue;
               seenResults.add(resultKey);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6488DistinctHiddenPathVariableTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6488DistinctHiddenPathVariableTest.java
@@ -20,10 +20,13 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -114,6 +117,42 @@ public class Issue6488DistinctHiddenPathVariableTest {
       assertThat(rs.hasNext()).isTrue();
       rs.next();
       assertThat(rs.hasNext()).as("WITH DISTINCT must collapse the zero-length and self-loop paths into a single row").isFalse();
+    }
+  }
+
+  /**
+   * {@code UNION} (implicit DISTINCT) deduplicates through the very same
+   * {@code DistinctNumericKey.canonicalize()} utility as {@code RETURN DISTINCT}. Union the
+   * already-loaded reference from a plain match with the freshly-fetched, not-yet-deserialized
+   * reference from the self-loop traversal, and confirm they still collapse to one row.
+   */
+  @Test
+  public void unionCollapsesLoadedAndUnloadedReferencesToSameNode() {
+    try (ResultSet rs = database.query("cypher", """
+        MATCH p = WALK (n0)-[*0..1]->(n1)
+        RETURN n1 AS x
+        UNION
+        MATCH (a:A)
+        RETURN a AS x""")) {
+      assertThat(rs.hasNext()).isTrue();
+      rs.next();
+      assertThat(rs.hasNext()).as("UNION must collapse references to the same node regardless of load state").isFalse();
+    }
+  }
+
+  /**
+   * {@code collect(DISTINCT ...)} and {@code count(DISTINCT ...)} go through
+   * {@code DistinctAggregationWrapper}, which also canonicalizes via {@code DistinctNumericKey}.
+   */
+  @Test
+  public void collectAndCountDistinctCollapseSelfLoopZeroAndOneHopPaths() {
+    try (ResultSet rs = database.query("cypher", """
+        MATCH p = WALK (n0)-[*0..1]->(n1)
+        RETURN collect(DISTINCT n1) AS xs, count(DISTINCT n1) AS c""")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat((List<?>) row.getProperty("xs")).hasSize(1);
+      assertThat(row.<Number>getProperty("c").intValue()).isEqualTo(1);
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6488DistinctHiddenPathVariableTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6488DistinctHiddenPathVariableTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6488: {@code RETURN DISTINCT} (and {@code WITH DISTINCT}) must collapse
+ * rows whose projected variables are equal, even when one of the two matching rows binds its variable
+ * to a graph-element reference whose property buffer has not yet been deserialized.
+ * <p>
+ * On a single self-looping node, the quantified relationship {@code [*0..1]} enumerates two paths
+ * that both bind {@code n0} and {@code n1} to the same node: the zero-length path (whose {@code n1}
+ * reference is the already-loaded start vertex) and the one-edge self-loop path (whose {@code n1}
+ * reference is freshly obtained from the edge's endpoint and not yet deserialized). Both references
+ * carry the same RID, but {@code Document.toString()} renders a not-yet-loaded reference as a
+ * placeholder (e.g. {@code #1:0[?]}) instead of the actual property values - the root cause was
+ * DISTINCT building its deduplication key by rendering values with {@code toString()} instead of by
+ * their stable identity. {@code RETURN DISTINCT n1, n0} (and {@code WITH DISTINCT n1, n0}) must
+ * collapse the two rows to one - matching Neo4j, the openCypher reference implementation.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6488DistinctHiddenPathVariableTest {
+  private Database database;
+
+  @BeforeEach
+  public void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/issue6488");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.transaction(() -> {
+      database.command("cypher", "CREATE (a:A {name: 'a'})");
+      database.command("cypher", "MATCH (a:A {name: 'a'}) CREATE (a)-[:R]->(a)");
+    });
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  /**
+   * The reported case: an unreturned path variable {@code p} must not defeat {@code DISTINCT}.
+   */
+  @Test
+  public void distinctCollapsesSelfLoopZeroAndOneHopPaths() {
+    try (ResultSet rs = database.query("cypher", """
+        MATCH p = WALK (n0)-[*0..1]->(n1)
+        RETURN DISTINCT n1, n0""")) {
+      assertThat(rs.hasNext()).isTrue();
+      rs.next();
+      assertThat(rs.hasNext()).as("DISTINCT must collapse the zero-length and self-loop paths into a single row").isFalse();
+    }
+  }
+
+  /**
+   * Same query, but with an identity {@code CALL (*)} boundary interposed between the MATCH and the
+   * final RETURN. Both forms must agree.
+   */
+  @Test
+  public void distinctCollapsesSelfLoopPathsAcrossIdentitySubquery() {
+    try (ResultSet rs = database.query("cypher", """
+        MATCH p = WALK (n0)-[*0..1]->(n1)
+        WITH n0, n1
+        CALL (*) {
+          RETURN 0 AS marker
+        }
+        WITH n0, n1
+        RETURN DISTINCT n1, n0""")) {
+      assertThat(rs.hasNext()).isTrue();
+      rs.next();
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+
+  /**
+   * {@code WITH DISTINCT} hit the same root cause via a different code path: it built its
+   * deduplication key from the projected row's {@code toString()} instead of canonicalizing each
+   * value, so it was equally susceptible to the {@code Document.toString()} load-state instability.
+   */
+  @Test
+  public void withDistinctCollapsesSelfLoopZeroAndOneHopPaths() {
+    try (ResultSet rs = database.query("cypher", """
+        MATCH p = WALK (n0)-[*0..1]->(n1)
+        WITH DISTINCT n1, n0
+        RETURN n1, n0""")) {
+      assertThat(rs.hasNext()).isTrue();
+      rs.next();
+      assertThat(rs.hasNext()).as("WITH DISTINCT must collapse the zero-length and self-loop paths into a single row").isFalse();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6488.

`RETURN DISTINCT`, `WITH DISTINCT`, `UNION`, `collect(DISTINCT ...)` and `count(DISTINCT ...)` all build a duplicate-elimination key from the projected values. For a document/vertex/edge, that key ultimately depended on `Object.toString()`:

- `ProjectReturnStep`/`UnionStep` fed the record straight into `DistinctNumericKey.canonicalize()`, which returned it unchanged and let the caller's `StringBuilder` call `toString()` on it.
- `WithStep`'s `DISTINCT` branch called `toString()` on the whole projected row directly, bypassing `DistinctNumericKey` entirely.

`Document`/`Vertex`/`Edge` `toString()` decorates the RID with the record's deserialized properties, and a not-yet-loaded property buffer renders as a placeholder (e.g. `#1:0[?]`) instead of the actual values - so two Java references to the very same record can render two different strings depending purely on in-memory load state, even though they represent the same value.

### How the issue exposed it

`MATCH p = WALK (n0)-[*0..1]->(n1)` on a single self-looping node enumerates two paths that both bind `n0`/`n1` to the same node: the zero-length path (whose end-node reference is the already-loaded start vertex) and the one-edge self-loop path (whose end-node reference is freshly obtained from the edge's endpoint and not yet deserialized). Both carry the same RID, but rendered as different strings, so `RETURN DISTINCT n1, n0` (and `WITH DISTINCT n1, n0`) failed to collapse the two rows - even though the path variable `p` itself was never returned.

Confirmed against Neo4j 5.26 (the openCypher reference implementation): both the reported query and its `CALL (*)` workaround return a single row there.

### Fix

- `DistinctNumericKey.canonicalize()` now canonicalizes a graph element to its `RID` instead of returning it unchanged. `RID`'s own `toString()`/`equals()`/`hashCode()` are stable and identity-based, which fixes `RETURN DISTINCT`, `UNION DISTINCT` and `count`/`collect(DISTINCT ...)` at the one shared utility used by all of them - not just the reported query shape.
- `WithStep`'s `DISTINCT` branch now builds its key from each projected property's canonicalized value, the same way `ProjectReturnStep` already did for `RETURN DISTINCT`, instead of stringifying the whole row.

### Regression test

`Issue6488DistinctHiddenPathVariableTest` covers `RETURN DISTINCT`, `RETURN DISTINCT` across an identity `CALL (*)` subquery boundary (the workaround from the report), and `WITH DISTINCT`.

## Test plan

- [x] New regression test `Issue6488DistinctHiddenPathVariableTest` (3 test methods) passes
- [x] Full `com.arcadedb.query.opencypher.**` test package (8446 tests, including the openCypher TCK suite) passes with 0 failures after the fix
- [x] Reproduced the bug directly against ArcadeDB before the fix and confirmed the fix resolves it, for both `RETURN DISTINCT` and `WITH DISTINCT`
- [x] Verified expected behavior against Neo4j 5.26 (openCypher reference implementation) for both query variants from the report