### PR TITLE
fix(vector): merge the delta buffer into grouped vector search (#6501)

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -207,6 +207,12 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
    * whose nearest group is denser than its candidate budget returns fewer groups and counts the query in
    * {@code groupedSearchesShortOfLimit}, which is the signal to raise the index's {@code efSearch}.
    * <p>
+   * Adding {@code groupBy} to a query changes how its rows are capped and nothing else about what the index can see:
+   * both branches below are answered from the graph <em>and</em> the delta buffer of vectors written since it was
+   * built. That is worth stating because it was not true until issue #6501 - the grouped branch skipped the buffer,
+   * so the same query, index and instant returned recent writes without {@code groupBy} and hid them with it. Any
+   * future divergence between the two branches on what is visible is a defect, not a tradeoff of grouping.
+   * <p>
    * <b>Parameter sprawl</b> (8 positional args). Each new option that lands here adds another
    * parameter. The next addition should refactor to a {@code VectorSearchOptions} record - keeping
    * it positional for now to minimise the blast radius of the maxDistance / Tier 4 follow-ups.

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4675,12 +4675,27 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * cap returns fewer than {@code limit} groups and increments {@code groupedSearchesShortOfLimit} in
    * {@link #getStats()}. Raise {@code efSearch} when that counter moves.
    * <p>
-   * <b>Delta scan and brute-force fallback are skipped.</b> The two augmentations would re-admit
-   * candidates outside the per-group cap; the delta path because it scores newly-inserted vectors
-   * not yet visible to HNSW (no Bits filter applied), the brute-force path because it walks every
-   * vector when the graph search returned too few hits. Skipping them is correct for the grouped
-   * contract; callers that depend on either should use {@link #findNeighborsFromVector} and apply
-   * the group admission post-filter at the SQL layer.
+   * <b>The delta buffer is merged into the stream, not appended to the answer</b> (issue #6501). Every
+   * vector written since the graph was last built lives in the delta buffer and is invisible to the
+   * walk above, so a grouped query that ignored it answered from the corpus as of the last rebuild -
+   * a full, exception-free, plausible answer over stale data, while the same query without
+   * {@code groupBy} returned the newer rows. On stock knobs that window is up to
+   * {@code min(rebuildGraphRatio * graphSize, maxPendingMutations)} rows wide and stays open for as
+   * long as writes keep arriving, so it is the steady state under ingestion rather than a corner case.
+   * <p>
+   * Merging is the only way to add them: {@link GroupAdmissionState} hands out its slots
+   * first-come-first-served, so a delta row offered after the walk would take a group its distance
+   * never earned, and one offered before it would lock the walk out of groups it should have won. The
+   * buffer is therefore scored once into a {@link ScoredCandidateCursor} and drained into the same
+   * rank-ordered stream the walk feeds: before each graph candidate, every delta candidate at least as
+   * near as it. A row offered by both sides - a vector left unreachable by a rebuild is re-queued into
+   * the buffer while its graph node survives - is admitted once.
+   * <p>
+   * <b>The issue #3722 brute-force fallback is still skipped.</b> That one walks every vector in the
+   * index whenever the graph search came up short, which for a grouped search is not evidence of a
+   * degraded graph at all - it is the ordinary outcome of a cap that stops admitting. Callers that
+   * want it should use {@link #findNeighborsFromVector} and apply the group admission post-filter at
+   * the SQL layer.
    *
    * @param queryVector      query embedding
    * @param limit            max number of distinct groups to return; must be {@code > 0}
@@ -4738,10 +4753,25 @@ public class LSMVectorIndex implements Index, IndexInternal {
       lock.readLock().lock();
       readLockHeld = true;
       try {
-        if (graphIndex == null || vectorIndex.size() == 0)
-          return Collections.emptyList();
-
         final VectorFloat<?> queryVectorFloat = vts.createFloatVector(queryVector);
+
+        // Volatile read pinned for the whole query, taken under the read lock because writers mutate this list in
+        // place under the write lock. Every candidate the cursor built below points back into it by position.
+        final List<DeltaVectorEntry> deltaSnapshot = deltaVectors;
+
+        if (graphIndex == null || vectorIndex.size() == 0) {
+          // No graph to walk yet - but the delta buffer can still answer, which is the same courtesy
+          // findNeighborsFromVector extends. Before issue #6501 this returned an empty list even when every vector
+          // in the index was sitting in the buffer.
+          final GroupedSearchState deltaOnly = new GroupedSearchState(limit, groupSize, maxRows, allowedRIDs,
+              groupKeyResolver, queryVectorFloat, deltaSnapshot);
+          if (!deltaOnly.mergesDelta())
+            return Collections.emptyList();
+          deltaOnly.drainDelta();
+          if (deltaOnly.mergedFromDelta() > 0)
+            metrics.incrementGroupedSearchesMergingDelta();
+          return deltaOnly.finish();
+        }
 
         // Snapshotted once and reused for the prefilter check, the vectors accessor and the Bits filter below, for
         // the same issue #4581 reason findNeighborsFromVector snapshots it: a concurrent rebuild must not pair an
@@ -4756,7 +4786,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             && allowListQualifiesForPreFilter(allowedRIDs, ordinalMap, GlobalConfiguration.VECTOR_INDEX_PREFILTER_MAX_SELECTIVITY)) {
           metrics.incrementPreFilterSearches();
           return preFilterGrouped(queryVectorFloat, limit, groupSize, maxRows, allowedRIDs, groupKeyResolver, vectors,
-              ordinalMap);
+              ordinalMap, deltaSnapshot);
         }
 
         // Liveness-only Bits filter. Unlike the first grouped implementation, we do NOT apply
@@ -4765,9 +4795,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // (issue #5761). The group cap is applied to the score-ordered output below instead.
         final Bits bitsFilter = new LiveVectorBitsFilter(allowedRIDs, ordinalMap, vectorIndex);
 
-        final List<Pair<RID, Float>> results = new ArrayList<>(maxRows);
-        final GroupAdmissionState groups = new GroupAdmissionState(limit, groupSize);
-        final GroupedSearchTally tally = new GroupedSearchTally();
+        final GroupedSearchState state = new GroupedSearchState(limit, groupSize, maxRows, allowedRIDs,
+            groupKeyResolver, queryVectorFloat, deltaSnapshot);
 
         final GraphSearcherPool pool = getSearcherPool();
         final long poolEpoch = searcherPoolEpoch();
@@ -4807,10 +4836,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
           while (true) {
             final int returned = searchResult.getNodes().length;
             examined += returned;
-            admitGroupedCandidates(searchResult, ordinalMap, allowedRIDs, groupKeyResolver, groups, results,
-                tally);
+            admitGroupedCandidates(searchResult, ordinalMap, state);
 
-            if (groups.isFull())
+            if (state.isFull())
               break;
             // A pass that could not fill its beam ran the candidate queue dry: the reachable graph is
             // exhausted and no further pass can add anything. This is also what makes the loop terminate -
@@ -4829,29 +4857,32 @@ public class LSMVectorIndex implements Index, IndexInternal {
           pool.release(searcher, pooledGraph, poolEpoch);
         }
 
-        // Each pass is score-ordered and starts below where the previous one stopped, so the rows are collected in
-        // rank order - with one exception: a resumed pass expands nodes the previous one left on the frontier, and a
-        // neighbour of a mediocre node can outrank the worst row already admitted. That is the same greedy-stop
-        // approximation the ungrouped path lives with, and it is far too rare to justify buffering every candidate
-        // and sorting before the cap; but the return contract says "ascending by distance", so make it true. At most
-        // limit * groupSize entries, so the sort is free.
-        results.sort(Comparator.comparing(Pair::getSecond));
+        // The walk is over - the groups filled, the reachable graph ran out, or the candidate budget did. Whatever
+        // is left in the cursor is further from the query than every graph candidate examined, so it is exactly what
+        // a merged stream would offer next, and it takes whatever the cap still has free (issue #6501).
+        state.drainDelta();
+        if (state.mergedFromDelta() > 0)
+          metrics.incrementGroupedSearchesMergingDelta();
 
-        if (groups.distinctGroups() < limit) {
+        final List<Pair<RID, Float>> results = state.finish();
+
+        if (state.distinctGroups() < limit) {
           metrics.incrementGroupedSearchesShortOfLimit();
           LogManager.instance()
               .log(this, Level.FINE,
                   "Vector grouped search on index %s filled only %d of %d groups after %d pass(es) - raise efSearch for wider group coverage",
-                  indexName, groups.distinctGroups(), limit, passes);
+                  indexName, state.distinctGroups(), limit, passes);
         }
 
         LogManager.instance()
             .log(this, Level.FINE,
                 """
                 Vector grouped search returned %d results in %d group(s) over %d pass(es) (graphSize=%d, limit=%d, \
-                groupSize=%d, skipped: %d out of bounds, %d deleted/null, %d group full, %d unresolved group)""",
-                results.size(), groups.distinctGroups(), passes, graphSize, limit, groupSize, tally.outOfBounds,
-                tally.deletedOrNull, tally.groupFull, tally.unresolvedGroup);
+                groupSize=%d, %d row(s) merged from a %d-entry delta buffer, skipped: %d out of bounds, \
+                %d deleted/null, %d group full, %d unresolved group, %d duplicate)""",
+                results.size(), state.distinctGroups(), passes, graphSize, limit, groupSize, state.mergedFromDelta(),
+                deltaSnapshot.size(), state.outOfBounds, state.deletedOrNull, state.groupFull, state.unresolvedGroup,
+                state.duplicates);
         return results;
 
       } catch (final Exception e) {
@@ -4868,64 +4899,41 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Offers one pass of {@link #findNeighborsFromVectorGrouped}'s search output to the group cap. The nodes arrive in
-   * descending score order and every pass is strictly worse than the one before it, so feeding successive passes into
-   * the same {@link GroupAdmissionState} keeps the whole walk in rank order: the {@code groupSize} members admitted
-   * for a group really are its best, and the {@code limit} groups admitted really are the nearest.
+   * Offers one pass of {@link #findNeighborsFromVectorGrouped}'s search output to the group cap, interleaved with
+   * whatever the delta buffer has that is at least as near (issue #6501). The nodes arrive in descending score order
+   * and every pass is strictly worse than the one before it, so feeding successive passes into the same
+   * {@link GroupedSearchState} keeps the whole walk in rank order: the {@code groupSize} members admitted for a group
+   * really are its best, and the {@code limit} groups admitted really are the nearest.
    */
   private void admitGroupedCandidates(final SearchResult searchResult, final int[] ordinalToVectorId,
-      final Set<RID> allowedRIDs, final Function<RID, Object> groupKeyResolver, final GroupAdmissionState groups,
-      final List<Pair<RID, Float>> results, final GroupedSearchTally tally) {
+      final GroupedSearchState state) {
     for (final SearchResult.NodeScore nodeScore : searchResult.getNodes()) {
-      if (groups.isFull())
+      if (state.isFull())
         return;
       final int ordinal = nodeScore.node;
       if (ordinal < 0 || ordinal >= ordinalToVectorId.length) {
-        tally.outOfBounds++;
+        state.outOfBounds++;
         continue;
       }
       final int vectorId = ordinalToVectorId[ordinal];
       final RID rid = vectorIndex.getRid(vectorId);
       if (rid == null) {
-        tally.deletedOrNull++;
+        state.deletedOrNull++;
         continue;
       }
+      final float distance = scoreToDistance(metadata.similarityFunction, nodeScore.score);
+
+      // Everything in the delta buffer at least as near as this graph candidate outranks it, so it goes first. Ties
+      // go to the buffer, which is also what makes the duplicate check inside admit() see the pair adjacently.
+      state.drainDeltaUpTo(distance);
+      if (state.isFull())
+        return;
+
       // Defensive post-filter: JVector may include the entry node despite Bits, and the LiveVectorBitsFilter has
       // already enforced the liveness + RID-whitelist contract, so we only need to re-check the RID whitelist here
       // for parity with findNeighborsFromVector.
-      admitGroupedCandidate(rid, scoreToDistance(metadata.similarityFunction, nodeScore.score), allowedRIDs,
-          groupKeyResolver, groups, results, tally);
+      state.admit(rid, distance);
     }
-  }
-
-  /**
-   * The per-candidate half of {@link #admitGroupedCandidates}, factored out so {@link #preFilterGrouped} (issue
-   * #6514) can feed it already-resolved, already-scored candidates instead of a JVector {@link SearchResult}. Both
-   * callers must agree on what "admit" means - the RID-whitelist re-check, the group-key resolution and its failure
-   * handling, and the cap itself - or the graph-walk and pre-filter plans could answer the same grouped query
-   * differently depending only on which one a narrow allow-list happened to route to.
-   */
-  private void admitGroupedCandidate(final RID rid, final float distance, final Set<RID> allowedRIDs,
-      final Function<RID, Object> groupKeyResolver, final GroupAdmissionState groups,
-      final List<Pair<RID, Float>> results, final GroupedSearchTally tally) {
-    if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(rid))
-      return;
-
-    final Object groupKey;
-    try {
-      groupKey = groupKeyResolver.apply(rid);
-    } catch (final RuntimeException e) {
-      // Same verdict the traversal-integrated filter gave an unresolvable candidate: drop it. Counted apart from
-      // the cap hits so the log does not read a resolver fault as a full group.
-      tally.unresolvedGroup++;
-      return;
-    }
-    if (!groups.admit(groupKey)) {
-      tally.groupFull++;
-      return;
-    }
-
-    results.add(new Pair<>(bindRid(rid), distance));
   }
 
   /**
@@ -4938,17 +4946,18 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * {@code k} before the caller ever sees which group a row belongs to, which is exactly the information the group
    * cap needs. So every allow-listed candidate is scored and dedup'd through {@link #scoreOrdinal} (unbounded, no
    * {@code k} truncation), sorted once, and then walked in rank order through the same
-   * {@link #admitGroupedCandidate} bookkeeping {@link #admitGroupedCandidates} applies to graph-walk output - the
+   * {@link GroupedSearchState#admit} bookkeeping {@link #admitGroupedCandidates} applies to graph-walk output - the
    * two plans can therefore never disagree about which candidates the group cap keeps.
    * <p>
-   * Like the graph-walk path, this never touches the delta buffer or the issue #3722 brute-force fallback: both
-   * would re-admit candidates outside the per-group cap, which {@link #findNeighborsFromVectorGrouped}'s own javadoc
-   * already rules out for the graph-walk path, and a query whose allow-list is narrow enough to reach this plan
-   * inherits the same contract.
+   * Like the graph-walk path it merges the delta buffer into the same rank-ordered stream (issue #6501) and skips
+   * the issue #3722 brute-force fallback; see {@link #findNeighborsFromVectorGrouped}'s javadoc for why the two are
+   * decided differently. Merging matters more here, not less: an allow-list is usually a set of records the caller
+   * just wrote, so "narrow enough to reach this plan" and "still in the delta buffer" are the same query, and this
+   * plan used to answer it empty.
    */
   private List<Pair<RID, Float>> preFilterGrouped(final VectorFloat<?> queryVectorFloat, final int limit, final int groupSize,
       final int maxRows, final Set<RID> allowedRIDs, final Function<RID, Object> groupKeyResolver,
-      final RandomAccessVectorValues vectors, final int[] ordinalMap) {
+      final RandomAccessVectorValues vectors, final int[] ordinalMap, final List<DeltaVectorEntry> deltaSnapshot) {
     final int[] candidates = collectAllowedOrdinals(allowedRIDs, ordinalMap);
     final ArcadePageVectorValues pageValues = vectors instanceof final ArcadePageVectorValues p ? p : null;
     final RidHashSet seenRIDs = new RidHashSet(candidates.length);
@@ -4957,51 +4966,239 @@ public class LSMVectorIndex implements Index, IndexInternal {
       scoreOrdinal(ordinal, queryVectorFloat, allowedRIDs, scored, vectors, ordinalMap, seenRIDs, pageValues);
     scored.sort(Comparator.comparing(Pair::getSecond));
 
-    final GroupAdmissionState groups = new GroupAdmissionState(limit, groupSize);
-    final GroupedSearchTally tally = new GroupedSearchTally();
-    // maxRows, not limit * groupSize: the caller has already clamped that product in long and to what the index can
-    // address (issue #6066) - recomputing it here in int would reopen the same overflow the caller closed.
-    final List<Pair<RID, Float>> results = new ArrayList<>(Math.min(scored.size(), maxRows));
+    final GroupedSearchState state = new GroupedSearchState(limit, groupSize, maxRows, allowedRIDs, groupKeyResolver,
+        queryVectorFloat, deltaSnapshot);
     for (final Pair<RID, Float> candidate : scored) {
-      if (groups.isFull())
+      if (state.isFull())
         break;
-      // allowedRIDs is not re-checked here: scoreOrdinal already enforced membership when it built `scored`.
-      admitGroupedCandidate(candidate.getFirst(), candidate.getSecond(), null, groupKeyResolver, groups, results, tally);
+      state.drainDeltaUpTo(candidate.getSecond());
+      if (state.isFull())
+        break;
+      state.admit(candidate.getFirst(), candidate.getSecond());
     }
+    // Whatever the allow-list still has in the delta buffer is further away than every ordinal scored above, so it
+    // comes last - the same place the graph-walk plan puts it.
+    state.drainDelta();
+    if (state.mergedFromDelta() > 0)
+      metrics.incrementGroupedSearchesMergingDelta();
 
-    if (groups.distinctGroups() < limit) {
+    if (state.distinctGroups() < limit) {
       metrics.incrementGroupedSearchesShortOfLimit();
-      // Deliberately not claiming this is "expected": that is only true when scored.size() itself is under limit.
+      // Deliberately not claiming this is "expected": that is only true when the scored set itself is under limit.
       // An allow-list wide enough to clear limit can still land here if its candidates cluster into fewer than
-      // limit distinct groups, or enough of them hit tally.unresolvedGroup - the summary log line below breaks out
-      // scored.size() against groupFull/unresolvedGroup, which is what actually tells the two apart.
+      // limit distinct groups, or enough of them fail group-key resolution - the summary log line below breaks the
+      // candidate count out against groupFull/unresolvedGroup, which is what actually tells the two apart.
       LogManager.instance()
           .log(this, Level.FINE,
               """
               Vector grouped pre-filter search on index %s filled only %d of %d groups from %d allow-listed \
-              candidate(s) - either the allow-list itself is narrower than %d distinct groups, or its candidates \
-              cluster into fewer than %d groups; see the result summary below for which""",
-              indexName, groups.distinctGroups(), limit, scored.size(), limit, limit);
+              candidate(s) (%d scored from the graph, %d from the delta buffer) - either the allow-list itself is \
+              narrower than %d distinct groups, or its candidates cluster into fewer than %d groups; see the result \
+              summary below for which""",
+              indexName, state.distinctGroups(), limit, scored.size() + state.deltaCandidates(), scored.size(),
+              state.deltaCandidates(), limit, limit);
     }
 
     LogManager.instance()
         .log(this, Level.FINE,
             """
-            Vector grouped pre-filter search returned %d results in %d group(s) over %d allow-listed candidate(s) \
-            (limit=%d, groupSize=%d, skipped: %d group full, %d unresolved group)""",
-            results.size(), groups.distinctGroups(), scored.size(), limit, groupSize, tally.groupFull, tally.unresolvedGroup);
-    return results;
+            Vector grouped pre-filter search returned %d results in %d group(s) over %d graph candidate(s) and \
+            %d delta candidate(s) (limit=%d, groupSize=%d, %d row(s) merged from the delta buffer, skipped: \
+            %d group full, %d unresolved group, %d duplicate)""",
+            state.results().size(), state.distinctGroups(), scored.size(), state.deltaCandidates(), limit, groupSize,
+            state.mergedFromDelta(), state.groupFull, state.unresolvedGroup, state.duplicates);
+    return state.finish();
   }
 
   /**
-   * Per-query skip counters for the grouped search, kept in one object so the multi-pass loop can accumulate them
-   * across passes without four parameters travelling by reference. Query-scoped, never shared, never thread-safe.
+   * Everything one grouped query accumulates: the per-group cap, the rows admitted so far, the delta buffer merged
+   * into the candidate stream (issue #6501), and the per-query skip counters.
+   * <p>
+   * One object rather than eight parameters because the two plans that can answer a grouped query - the graph walk
+   * of {@link #findNeighborsFromVectorGrouped} and the narrow-allow-list plan of {@link #preFilterGrouped} - have to
+   * agree on every one of them, and while they travelled positionally the two call sites could drift apart in
+   * silence. The only thing a plan now chooses is the order it offers candidates in; what "admit" means is here, and
+   * is the same for both.
+   * <p>
+   * Candidates must be offered in ascending distance order, for the reason {@link GroupAdmissionState} documents:
+   * the cap is first-come-first-served, so only a rank-ordered stream makes "first" mean "nearest".
+   * <p>
+   * Query-scoped, never shared, never thread-safe.
    */
-  private static final class GroupedSearchTally {
+  private final class GroupedSearchState {
+    private final Set<RID>               allowedRIDs;
+    private final Function<RID, Object>  groupKeyResolver;
+    private final GroupAdmissionState    groups;
+    private final List<Pair<RID, Float>> results;
+
+    // The delta buffer, scored once and drained in rank order. The cursor's payloads are positions in the snapshot,
+    // which is pinned for the life of the query. Null when the buffer held nothing this query could use.
+    private final List<DeltaVectorEntry> deltaSnapshot;
+    private final ScoredCandidateCursor  deltaCursor;
+    private final int                    deltaCandidates;
+
+    // Only allocated when a delta merge is actually running. The merge is the one thing that can offer the same RID
+    // twice - a vector left unreachable by a rebuild is re-queued into the buffer while its graph node survives (see
+    // buildGraphFromScratch) - and a query with nothing to merge should not pay for a set that can never fire.
+    private final RidHashSet admitted;
+
     private int outOfBounds;
     private int deletedOrNull;
     private int groupFull;
     private int unresolvedGroup;
+    private int duplicates;
+    private int fromDelta;
+
+    private GroupedSearchState(final int limit, final int groupSize, final int maxRows, final Set<RID> allowedRIDs,
+        final Function<RID, Object> groupKeyResolver, final VectorFloat<?> queryVectorFloat,
+        final List<DeltaVectorEntry> deltaSnapshot) {
+      this.allowedRIDs = allowedRIDs;
+      this.groupKeyResolver = groupKeyResolver;
+      this.groups = new GroupAdmissionState(limit, groupSize);
+      // maxRows, not limit * groupSize: the caller has already clamped that product in long and to what the index
+      // can address (issue #6066) - recomputing it here in int would reopen the same overflow the caller closed.
+      this.results = new ArrayList<>(maxRows);
+      this.deltaSnapshot = deltaSnapshot;
+      this.deltaCursor = scoreDeltaCandidates(queryVectorFloat, allowedRIDs, deltaSnapshot);
+      this.deltaCandidates = deltaCursor == null ? 0 : deltaCursor.size();
+      this.admitted = deltaCursor == null ? null : new RidHashSet(maxRows);
+    }
+
+    private boolean isFull() {
+      return groups.isFull();
+    }
+
+    private int distinctGroups() {
+      return groups.distinctGroups();
+    }
+
+    private boolean mergesDelta() {
+      return deltaCursor != null;
+    }
+
+    /** Delta candidates this query could have used, before the cap decided how many of them it actually wanted. */
+    private int deltaCandidates() {
+      return deltaCandidates;
+    }
+
+    /** Rows of the answer that came out of the delta buffer rather than the graph. */
+    private int mergedFromDelta() {
+      return fromDelta;
+    }
+
+    private List<Pair<RID, Float>> results() {
+      return results;
+    }
+
+    /**
+     * Offers one candidate to the cap. Both plans reach the cap through here - the RID-whitelist re-check, the
+     * duplicate check, the group-key resolution and its failure handling, and the cap itself - so the graph-walk and
+     * pre-filter plans cannot answer the same grouped query differently depending only on which one a narrow
+     * allow-list happened to route to.
+     */
+    private void admit(final RID rid, final float distance) {
+      if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(rid))
+        return;
+
+      // Caught before the cap sees it, so a row offered by both sides of the merge never spends two group slots. A
+      // candidate the cap REJECTED is deliberately not remembered: the cap only ever gets fuller, so a second offer
+      // of it is rejected again anyway, and remembering it would cost a set entry per skipped row.
+      if (admitted != null && admitted.contains(rid)) {
+        duplicates++;
+        return;
+      }
+
+      final Object groupKey;
+      try {
+        groupKey = groupKeyResolver.apply(rid);
+      } catch (final RuntimeException e) {
+        // Same verdict the traversal-integrated filter gave an unresolvable candidate: drop it. Counted apart from
+        // the cap hits so the log does not read a resolver fault as a full group.
+        unresolvedGroup++;
+        return;
+      }
+      if (!groups.admit(groupKey)) {
+        groupFull++;
+        return;
+      }
+
+      if (admitted != null)
+        admitted.add(rid);
+      results.add(new Pair<>(bindRid(rid), distance));
+    }
+
+    /**
+     * Offers every delta candidate at least as near as {@code distance} to the cap, in rank order. Called just
+     * before each graph candidate, so the two streams interleave by distance rather than one being appended to the
+     * other - which is the whole point: the cap is first-come-first-served, so appending in either direction hands
+     * a group slot to a row that did not earn it.
+     */
+    private void drainDeltaUpTo(final float distance) {
+      if (deltaCursor == null)
+        return;
+      while (!deltaCursor.isEmpty() && deltaCursor.peekDistance() <= distance) {
+        if (groups.isFull())
+          return;
+        final float candidateDistance = deltaCursor.peekDistance();
+        final int before = results.size();
+        admit(deltaSnapshot.get(deltaCursor.poll()).rid, candidateDistance);
+        if (results.size() > before)
+          fromDelta++;
+      }
+    }
+
+    /** Drains the rest of the buffer, for the point at which no graph candidate can outrank what is left. */
+    private void drainDelta() {
+      drainDeltaUpTo(Float.POSITIVE_INFINITY);
+    }
+
+    /**
+     * Sorts the admitted rows and hands them over. The passes of a resumed walk are each score-ordered and start
+     * below where the previous one stopped, so the rows are collected in rank order already - with one exception: a
+     * resumed pass expands nodes the previous one left on the frontier, and a neighbour of a mediocre node can
+     * outrank the worst row already admitted. That is the same greedy-stop approximation the ungrouped path lives
+     * with, and it is far too rare to justify buffering every candidate and sorting before the cap; but the return
+     * contract says "ascending by distance", so make it true. At most {@code limit * groupSize} entries, so the sort
+     * is free.
+     */
+    private List<Pair<RID, Float>> finish() {
+      results.sort(Comparator.comparing(Pair::getSecond));
+      return results;
+    }
+  }
+
+  /**
+   * Scores the delta buffer for one grouped query and returns it as a rank-ordered cursor, or {@code null} when
+   * there is nothing in it this query can use (issue #6501).
+   * <p>
+   * The whole buffer is scored, not a top-k slice of it: see {@link ScoredCandidateCursor}'s javadoc for why the
+   * group cap makes a bounded heap lose rows the answer needs. Scoring allocates nothing - delta entries are stored
+   * already converted to {@link VectorFloat} for exactly this reason (issue #5391) - and the two arrays handed to
+   * the cursor are the only per-query allocation, at 8 bytes per buffered vector.
+   */
+  private ScoredCandidateCursor scoreDeltaCandidates(final VectorFloat<?> queryVectorFloat, final Set<RID> allowedRIDs,
+      final List<DeltaVectorEntry> deltaSnapshot) {
+    final int buffered = deltaSnapshot.size();
+    if (buffered == 0)
+      return null;
+
+    final float[] distances = new float[buffered];
+    final int[] positions = new int[buffered];
+    int kept = 0;
+    for (int i = 0; i < buffered; i++) {
+      final DeltaVectorEntry entry = deltaSnapshot.get(i);
+      if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(entry.rid))
+        continue;
+      // The same tombstone check mergeWithDeltaScan applies, asked of the tombstone set for the same reason - see
+      // its javadoc for why a resident location cannot answer it and why it stays despite being unreachable today.
+      if (vectorIndex.isDeleted(entry.vectorId))
+        continue;
+      distances[kept] = scoreToDistance(metadata.similarityFunction,
+          metadata.similarityFunction.compare(queryVectorFloat, entry.vector));
+      positions[kept] = i;
+      kept++;
+    }
+    return kept == 0 ? null : new ScoredCandidateCursor(distances, positions, kept);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4099,6 +4099,43 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * Visible for tests: re-queues a graph ordinal's vector into the delta buffer, exactly as
+   * {@link #buildGraphFromScratch()} does for a vector its build left unreachable - same vector id, same RID, same
+   * {@link VectorFloat} - while the node itself stays in the graph.
+   * <p>
+   * That state is the only one in which the grouped search's cap is offered the same RID twice, once by the graph
+   * walk and once by the delta merge, and it is what {@code GroupedSearchState}'s dedup set exists for (issue
+   * #6501). There is no way to reach it from the public API on demand: it takes a build that happens to orphan a
+   * node, which the data and JVector's own diversity heuristic decide between them. So a test that wants to pin the
+   * dedup - rather than have it hold by accident because no fixture ever produced an overlap - has to put the index
+   * into the state directly.
+   *
+   * @param rid the record to re-queue; it must already be in the graph
+   *
+   * @return the graph ordinal that was re-queued, or {@code -1} if the RID carries no live graph node
+   */
+  int requeueIntoDeltaBufferForTest(final RID rid) {
+    lock.writeLock().lock();
+    try {
+      final int[] ordinalMap = ordinalToVectorId;
+      final RandomAccessVectorValues values = searchVectorValues(ordinalMap);
+      for (int ordinal = 0; ordinal < ordinalMap.length; ordinal++) {
+        final int vectorId = ordinalMap[ordinal];
+        if (!rid.equals(vectorIndex.getRid(vectorId)))
+          continue;
+        final VectorFloat<?> vector = values.getVector(ordinal);
+        if (vector == null)
+          return -1;
+        deltaVectors.add(new DeltaVectorEntry(vectorId, rid, vector));
+        return ordinal;
+      }
+      return -1;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  /**
    * Visible for tests: the similarity a search would compute for one graph ordinal, through the same vector values and
    * the same score function the query path builds. Lets a test assert what a node whose vector cannot be read scores,
    * which end-to-end search results cannot show - the {@link LiveVectorBitsFilter} keeps such a node out of the answer
@@ -5097,6 +5134,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
      * allow-list happened to route to.
      */
     private void admit(final RID rid, final float distance) {
+      // Redundant for two of the three sources - scoreDeltaCandidates filters the cursor on the way in, and
+      // preFilterGrouped's scoreOrdinal filtered before it sorted - and kept anyway, at one hash lookup per
+      // candidate. Making it conditional on where the candidate came from is how the whitelist ends up enforced on
+      // some paths and not others, which is the class of divergence this whole object exists to prevent.
       if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(rid))
         return;
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndexMetrics.java
@@ -52,6 +52,14 @@ class LSMVectorIndexMetrics {
   // many candidates the data puts between it and the query, which no fixed budget can guarantee (issue #5761), so
   // this is the signal to raise efSearch on the index or the query.
   private final AtomicLong groupedSearchesShortOfLimit = new AtomicLong(0);
+  // Grouped searches that merged at least one row out of the delta buffer into their answer (issue #6501). Before
+  // that issue the grouped path skipped the buffer outright, so a groupBy query silently answered from the corpus as
+  // of the last graph rebuild while the same query without groupBy returned the newer rows; the merge is what closed
+  // that, and this counter is what makes it visible. A number that tracks the query rate means the graph is
+  // persistently behind the write rate and every grouped query is paying a linear scan of the buffer for it -
+  // deltaVectorsCount says how long that scan is, and a lower vectorIndex.mutationsBeforeRebuild or
+  // rebuildGraphRatio is what shortens it.
+  private final AtomicLong groupedSearchesMergingDelta = new AtomicLong(0);
   // Times a persisted graph was reused on the strength of its node count alone, because it carries no manifest
   // saying which records it was built over (issue #6106) - a graph written by a version older than the manifest, or
   // one restored from a backup, which does not carry the sidecar. Non-zero means this index is still being judged by
@@ -105,6 +113,10 @@ class LSMVectorIndexMetrics {
 
   void incrementGroupedSearchesShortOfLimit() {
     groupedSearchesShortOfLimit.incrementAndGet();
+  }
+
+  void incrementGroupedSearchesMergingDelta() {
+    groupedSearchesMergingDelta.incrementAndGet();
   }
 
   void incrementUnverifiedGraphReuses() {
@@ -169,6 +181,10 @@ class LSMVectorIndexMetrics {
     return groupedSearchesShortOfLimit.get();
   }
 
+  long getGroupedSearchesMergingDelta() {
+    return groupedSearchesMergingDelta.get();
+  }
+
   long getVectorFetchFromQuantized() {
     return vectorFetchFromQuantized.get();
   }
@@ -215,6 +231,7 @@ class LSMVectorIndexMetrics {
     stats.put("bruteForceScans", bruteForceScans.get());
     stats.put("preFilterSearches", preFilterSearches.get());
     stats.put("groupedSearchesShortOfLimit", groupedSearchesShortOfLimit.get());
+    stats.put("groupedSearchesMergingDelta", groupedSearchesMergingDelta.get());
     stats.put("unverifiedGraphReuses", unverifiedGraphReuses.get());
     stats.put("rebuildsDeferredForMemory", rebuildsDeferredForMemory.get());
     stats.put("compactionCount", compactionCount.get());
@@ -237,6 +254,7 @@ class LSMVectorIndexMetrics {
     bruteForceScans.set(0);
     preFilterSearches.set(0);
     groupedSearchesShortOfLimit.set(0);
+    groupedSearchesMergingDelta.set(0);
     unverifiedGraphReuses.set(0);
     rebuildsDeferredForMemory.set(0);
     compactionCount.set(0);

--- a/engine/src/main/java/com/arcadedb/index/vector/ScoredCandidateCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ScoredCandidateCursor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Ascending-distance cursor over a fixed set of already-scored candidates, used to merge the delta buffer into the
+ * grouped vector search's candidate stream (issue #6501).
+ * <p>
+ * <b>Why a cursor and not a top-k heap.</b> {@code findNeighborsFromVector}'s delta scan keeps only the k best
+ * candidates, which is exact because its only consumer takes the k nearest rows and nothing else. The grouped search
+ * cannot bound the set that way: {@link GroupAdmissionState} rejects a row whose group is already full, so an
+ * arbitrary number of near candidates can be skipped before a far one is admitted. With {@code limit=2},
+ * {@code groupSize=1} and a thousand delta rows in one group, the row that fills the second group is the
+ * thousand-and-first by rank - a top-{@code limit * groupSize} heap would have thrown it away. So the whole set stays
+ * addressable, and the cap decides how far into it the query actually walks.
+ * <p>
+ * <b>Why a heap and not a sort.</b> Ordering the whole set costs {@code O(n log n)} up front, of which a query that
+ * fills its groups from the first handful of candidates uses almost nothing. Heapifying is {@code O(n)} and each
+ * {@link #poll()} is {@code O(log n)}, so the common case - a few candidates drained out of a large delta buffer -
+ * pays for what it takes, and the pathological case is no worse than the sort would have been.
+ * <p>
+ * The two parallel arrays are heapsorted in place and owned by the cursor from construction on: the caller must not
+ * read or write them afterwards. Primitive arrays rather than a {@code PriorityQueue} of pairs because the delta
+ * buffer routinely runs to tens of thousands of entries, and boxing every one of them per query is exactly the
+ * garbage the delta path was already tuned to avoid (issue #5391).
+ * <p>
+ * Lifetime is one query. Not thread-safe.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class ScoredCandidateCursor {
+  private final float[] distance;
+  private final int[]   payload;
+  private       int     size;
+
+  /**
+   * Takes ownership of both arrays and arranges the first {@code size} entries as a min-heap on {@code distance}.
+   * Entries past {@code size} are ignored, so the caller can over-allocate and compact as it scores.
+   *
+   * @param distance distance of each candidate; reordered in place
+   * @param payload  caller-defined id of each candidate, moved in lockstep with its distance
+   * @param size     number of live entries at the head of both arrays
+   */
+  ScoredCandidateCursor(final float[] distance, final int[] payload, final int size) {
+    if (size < 0 || size > distance.length || size > payload.length)
+      throw new IllegalArgumentException(
+          "size " + size + " is not addressable in arrays of " + distance.length + "/" + payload.length);
+    this.distance = distance;
+    this.payload = payload;
+    this.size = size;
+    for (int i = (size >>> 1) - 1; i >= 0; i--)
+      siftDown(i);
+  }
+
+  boolean isEmpty() {
+    return size == 0;
+  }
+
+  int size() {
+    return size;
+  }
+
+  /**
+   * Distance of the nearest candidate not yet polled. O(1).
+   */
+  float peekDistance() {
+    if (size == 0)
+      throw new NoSuchElementException("Scored candidate cursor is exhausted");
+    return distance[0];
+  }
+
+  /**
+   * Removes the nearest candidate and returns its payload. O(log n).
+   */
+  int poll() {
+    if (size == 0)
+      throw new NoSuchElementException("Scored candidate cursor is exhausted");
+    final int head = payload[0];
+    if (--size > 0) {
+      distance[0] = distance[size];
+      payload[0] = payload[size];
+      siftDown(0);
+    }
+    return head;
+  }
+
+  /**
+   * Standard binary-heap sift-down, hoisting the displaced entry rather than swapping at every level: one write per
+   * level instead of three.
+   */
+  private void siftDown(int slot) {
+    final float movedDistance = distance[slot];
+    final int movedPayload = payload[slot];
+    final int firstLeaf = size >>> 1;
+    while (slot < firstLeaf) {
+      int child = (slot << 1) + 1;
+      final int right = child + 1;
+      if (right < size && distance[right] < distance[child])
+        child = right;
+      if (distance[child] >= movedDistance)
+        break;
+      distance[slot] = distance[child];
+      payload[slot] = payload[child];
+      slot = child;
+    }
+    distance[slot] = movedDistance;
+    payload[slot] = movedPayload;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6501GroupedDeltaMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6501GroupedDeltaMergeTest.java
@@ -249,6 +249,38 @@ class Issue6501GroupedDeltaMergeTest extends TestHelper {
   }
 
   /**
+   * The one row that can reach the cap from both sides of the merge. A graph build occasionally leaves a vector with
+   * a full out-degree and no in-edges and re-queues it into the delta buffer while its node stays in the graph, so
+   * the walk and the cursor both offer the same RID. Admitting it twice would put one record in the answer twice and
+   * charge its group two of its {@code groupSize} slots, evicting a record that earned one.
+   * <p>
+   * Driven through {@code requeueIntoDeltaBufferForTest} rather than by producing a real orphan: whether a build
+   * orphans a node is decided by the data and JVector's diversity heuristic, so a fixture cannot ask for one. The
+   * row re-queued is the nearest record to the query, so it is certain to reach the cap from the graph side too -
+   * re-queueing an arbitrary one of 1,200 proves nothing, since the answer holds twelve. {@code groupSize} is 2 on
+   * purpose: at 1 the cap would reject the second copy on its own and the test would pass with the dedup deleted.
+   */
+  @Test
+  void aRowOfferedByBothTheGraphAndTheDeltaBufferIsAdmittedOnce() {
+    createSchema();
+    insertBaseVertices();
+
+    final RID shared = vectorIndex().findNeighborsFromVector(query(), 1).getFirst().getFirst();
+    assertThat(vectorIndex().requeueIntoDeltaBufferForTest(shared))
+        .as("the nearest record has to be in the graph for this to be an overlap at all").isNotNegative();
+    assertThat(deltaCount()).as("and in the delta buffer as well, which is the whole point").isPositive();
+
+    final int sharedCluster = ((Document) database.lookupByRID(shared, true)).getInteger("cluster");
+    final List<Pair<RID, Float>> grouped = grouped(CLUSTERS, 2);
+
+    assertThat(ridsOf(grouped)).as("the row is in the graph and in the delta buffer; it belongs to the answer once")
+        .filteredOn(shared::equals).hasSize(1);
+    assertThat(clustersOf(grouped)).as("and its group must not have spent two slots on one record")
+        .filteredOn(cluster -> cluster == sharedCluster).hasSizeLessThanOrEqualTo(2);
+    assertWellFormed(grouped);
+  }
+
+  /**
    * Nothing about the merge may change a query that has nothing to merge: with no rows written since the graph was
    * built, the grouped answer has to be exactly what it always was. The buffer is not necessarily empty even here -
    * a rebuild re-queues any vector it left unreachable, so the same row can sit in the graph and the buffer at once -

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6501GroupedDeltaMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6501GroupedDeltaMergeTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
+import com.arcadedb.utility.Pair;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6501: a {@code groupBy} vector search could not see anything ingested since the last graph rebuild.
+ * <p>
+ * {@code findNeighborsFromVectorGrouped} answered purely from the HNSW graph, and the delta buffer - which holds
+ * every vector written since that graph was built - was documented as deliberately out of scope. The result was a
+ * full, plausible, exception-free answer computed over a stale corpus: the same index, the same query vector and the
+ * same instant returned the newly written rows without {@code groupBy} and hid them with it. On stock knobs the
+ * invisible window is up to {@code min(rebuildGraphRatio * graphSize, 50000)} rows wide and stays open for as long
+ * as writes keep arriving, so this is the steady state under ingestion rather than a corner case.
+ * <p>
+ * The delta candidates are now merged into the candidate stream <em>before</em> the group cap sees it, in ascending
+ * distance order, which is the only place they can go: {@link GroupAdmissionState} is first-come-first-served, so
+ * appending them after the graph walk would let a far delta row take a group slot from a nearer graph row. These
+ * tests pin both halves - the rows are visible, and the cap they arrive through is still the one the caller asked
+ * for.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6501GroupedDeltaMergeTest extends TestHelper {
+
+  private static final int    DIMENSIONS  = 16;
+  private static final int    CLUSTERS    = 6;
+  // 200 per cluster, so the graph clears ASYNC_REBUILD_MIN_GRAPH_SIZE. Below 1,000 nodes rebuildGraphBeforeSearch()
+  // rebuilds synchronously on EVERY query with no threshold gate, which drains the delta buffer before the search
+  // under test can look at it - a small fixture would be green whatever the grouped path does, for the wrong reason.
+  private static final int    PER_CLUSTER = 200;
+  private static final int    VERTICES    = CLUSTERS * PER_CLUSTER;
+  private static final double CLUSTER_GAP = 0.12;
+  private static final double JITTER      = 0.0001;
+
+  /**
+   * Angle of the query: a quarter of a cluster gap past cluster 1's centre. Far enough off the base grid that the
+   * nearest base vertex sits at a distance floats can tell from zero, which is what lets a delta row a thousandth of
+   * a radian away be provably nearer rather than a tie the index breaks however it likes.
+   */
+  private static final double QUERY_THETA = theta(centerOf(1)) + CLUSTER_GAP / 4;
+
+  /** Angular step between consecutive delta rows: far inside the query's gap to the base grid, and above float noise. */
+  private static final double DELTA_STEP  = 0.001;
+
+  @BeforeEach
+  void freezeTheGraph() {
+    // The whole defect only exists while the delta buffer is non-empty, so the fixture has to keep it that way:
+    // no mutation-count rebuild, no ratio rebuild, no inactivity-timer rebuild.
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.setValue(1_000_000);
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.setValue(0f);
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.setValue(0);
+  }
+
+  @AfterEach
+  void thawTheGraph() {
+    GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD.reset();
+    GlobalConfiguration.VECTOR_INDEX_REBUILD_GRAPH_RATIO.reset();
+    GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS.reset();
+  }
+
+  /**
+   * The issue as filed. Three rows written after the graph was built are the three nearest vectors in the index by a
+   * wide margin; the ungrouped query returns exactly those three, and the grouped query used to return the best the
+   * <em>stale</em> graph had instead - ten rows, no exception, no warning, and a nearest distance three orders of
+   * magnitude worse.
+   */
+  @Test
+  void aGroupedSearchSeesVectorsWrittenSinceTheLastGraphRebuild() {
+    createSchema();
+    insertBaseVertices();
+
+    final long baseline = deltaCount();
+    final List<RID> fresh = insertDeltaVertices(3);
+    assertThat(deltaCount()).as("the fixture is only a regression test while the rows are still in the delta buffer")
+        .isEqualTo(baseline + 3);
+
+    final List<Pair<RID, Float>> ungrouped = vectorIndex().findNeighborsFromVector(query(), 3);
+    assertThat(ridsOf(ungrouped)).as("control: without groupBy the delta rows are the answer")
+        .containsExactlyInAnyOrderElementsOf(fresh);
+
+    final long mergesBefore = stat("groupedSearchesMergingDelta");
+
+    final List<Pair<RID, Float>> grouped = grouped(3, 1);
+    assertThat(ridsOf(grouped)).as("the same index, vector and instant must not answer a groupBy query from a stale corpus")
+        .containsExactlyInAnyOrderElementsOf(fresh);
+    assertThat(grouped.getFirst().getSecond()).as("and the nearest row must be the nearest row")
+        .isEqualTo(ungrouped.getFirst().getSecond());
+    assertWellFormed(grouped);
+
+    assertThat(stat("groupedSearchesMergingDelta"))
+        .as("a grouped query paying for a delta scan has to be visible in the stats, which is what issue #6501 asked "
+            + "for before it asked for the merge - groupedSearchesShortOfLimit means something else entirely")
+        .isGreaterThan(mergesBefore);
+  }
+
+  /**
+   * The surface the issue was actually filed against. {@code vector.neighbors} routes to the grouped index method on
+   * the presence of {@code groupBy} alone, so a user bucketing an existing query by a field was opting into a stale
+   * corpus without a syntax, a doc page or a log line saying so. Same query, same instant, with and without the
+   * option.
+   */
+  @Test
+  void theSqlSurfaceSeesTheDeltaBufferWithAndWithoutGroupBy() {
+    createSchema();
+    insertBaseVertices();
+
+    final List<RID> fresh = insertDeltaVertices(3);
+
+    final List<RID> plain = ridsFromSql("SELECT expand(`vector.neighbors`(?, ?, ?))");
+    assertThat(plain).as("control: the ungrouped SQL query returns the rows written since the rebuild")
+        .containsExactlyInAnyOrderElementsOf(fresh);
+
+    final List<RID> byCluster = ridsFromSql(
+        "SELECT expand(`vector.neighbors`(?, ?, ?, { groupBy: 'cluster', groupSize: 1 }))");
+    assertThat(byCluster).as("adding groupBy buckets the rows - it does not change which rows exist")
+        .containsExactlyInAnyOrderElementsOf(fresh);
+  }
+
+  /**
+   * Merging is not appending: {@link GroupAdmissionState} hands out slots first-come-first-served, so a delta row
+   * offered after the graph walk would take a group its distance never earned. Here the delta rows sit in one brand
+   * new group and are nearer than everything else, so a correct merge spends exactly {@code groupSize} of them and
+   * fills the remaining groups from the graph.
+   */
+  @Test
+  void theGroupCapStillHoldsOverTheMergedDeltaRows() {
+    createSchema();
+    insertBaseVertices();
+
+    final long baseline = deltaCount();
+    insertDeltaVerticesInOneGroup(5, 99);
+    assertThat(deltaCount()).as("the rows have to still be in the delta buffer for this to test anything")
+        .isEqualTo(baseline + 5);
+
+    final List<Pair<RID, Float>> grouped = grouped(3, 2);
+
+    assertThat(grouped).as("three groups of two rows each").hasSize(6);
+    assertThat(clustersOf(grouped)).as("the delta rows are nearest, but the cap is still two per group")
+        .filteredOn(cluster -> cluster == 99).hasSize(2);
+    assertThat(new HashSet<>(clustersOf(grouped))).as("and still three distinct groups").hasSize(3);
+    assertWellFormed(grouped);
+  }
+
+  /**
+   * A delta row must be ranked, not just appended: with one row per group the answer is the {@code limit} nearest
+   * distinct groups, and the merged stream has to interleave delta and graph rows by distance to produce it. The
+   * delta rows here straddle the base clusters - two nearer than anything indexed, one deliberately further away
+   * than the nearest base cluster - so appending in either direction gives a different (wrong) answer.
+   */
+  @Test
+  void deltaRowsAreRankedAgainstGraphRowsRatherThanAppended() {
+    createSchema();
+    insertBaseVertices();
+
+    final RID nearest = insertDeltaVertex(QUERY_THETA + DELTA_STEP, 90);
+    final RID second = insertDeltaVertex(QUERY_THETA + 2 * DELTA_STEP, 91);
+    final RID far = insertDeltaVertex(theta(centerOf(4)), 92);
+
+    final List<Pair<RID, Float>> grouped = grouped(4, 1);
+
+    assertThat(grouped).hasSize(4);
+    assertThat(grouped.get(0).getFirst()).as("the nearest delta row leads the answer").isEqualTo(nearest);
+    assertThat(grouped.get(1).getFirst()).as("followed by the second delta row").isEqualTo(second);
+    assertThat(ridsOf(grouped)).as("a delta row further away than four base clusters has not earned a slot")
+        .doesNotContain(far);
+    assertWellFormed(grouped);
+  }
+
+  /**
+   * The narrow-allow-list plan (issue #6514) is a second entry point into the same grouped contract, and it skipped
+   * the delta buffer for the same reason. An allow-list made only of rows that are still in the delta buffer is the
+   * sharpest form of the bug: every candidate the caller asked about was invisible, so the answer was empty.
+   */
+  @Test
+  void theGroupedPreFilterPlanSeesTheDeltaBufferToo() {
+    createSchema();
+    insertBaseVertices();
+
+    final List<RID> fresh = insertDeltaVertices(3);
+    final Set<RID> allowed = new LinkedHashSet<>(fresh);
+
+    final List<Pair<RID, Float>> grouped = vectorIndex().findNeighborsFromVectorGrouped(query(), 3, 1, -1, allowed,
+        groupKeyResolver());
+
+    assertThat(ridsOf(grouped)).as("an allow-list of delta-only rows must not answer empty")
+        .containsExactlyInAnyOrderElementsOf(fresh);
+    assertWellFormed(grouped);
+  }
+
+  /**
+   * An allow-list that mixes graph rows and delta rows has to be answered from both, and in rank order across the
+   * two: the delta rows are nearer, so they lead.
+   */
+  @Test
+  void theGroupedPreFilterPlanRanksDeltaAndGraphRowsTogether() {
+    createSchema();
+    final List<RID> base = insertBaseVertices();
+
+    final List<RID> fresh = insertDeltaVertices(2);
+    final Set<RID> allowed = new LinkedHashSet<>(fresh);
+    allowed.add(base.get(centerOf(3)));
+    allowed.add(base.get(centerOf(5)));
+
+    final List<Pair<RID, Float>> grouped = vectorIndex().findNeighborsFromVectorGrouped(query(), 4, 1, -1, allowed,
+        groupKeyResolver());
+
+    assertThat(grouped).hasSize(4);
+    assertThat(ridsOf(grouped).subList(0, 2)).as("the delta rows are the nearest two of the allow-list")
+        .containsExactlyInAnyOrderElementsOf(fresh);
+    assertWellFormed(grouped);
+  }
+
+  /**
+   * Nothing about the merge may change a query that has nothing to merge: with no rows written since the graph was
+   * built, the grouped answer has to be exactly what it always was. The buffer is not necessarily empty even here -
+   * a rebuild re-queues any vector it left unreachable, so the same row can sit in the graph and the buffer at once -
+   * which is precisely the case the merge has to admit once rather than twice.
+   */
+  @Test
+  void aQueryWithNothingNewToSeeIsUnchanged() {
+    createSchema();
+    insertBaseVertices();
+
+    final List<Pair<RID, Float>> grouped = grouped(3, 2);
+
+    assertThat(grouped).hasSize(6);
+    assertThat(new HashSet<>(clustersOf(grouped))).hasSize(3);
+    assertThat(clustersOf(grouped)).as("the group the query sits in cannot be absent from its own answer").contains(1);
+    assertWellFormed(grouped);
+  }
+
+  // ------------------------------------------------------------------------------------------------- helpers
+
+  private void assertWellFormed(final List<Pair<RID, Float>> neighbors) {
+    assertThat(ridsOf(neighbors)).as("the same row must not be admitted twice, from either side of the merge")
+        .doesNotHaveDuplicates();
+    for (int i = 1; i < neighbors.size(); i++)
+      assertThat(neighbors.get(i).getSecond()).as("row %d is nearer than row %d, so the answer is not sorted", i, i - 1)
+          .isGreaterThanOrEqualTo(neighbors.get(i - 1).getSecond());
+  }
+
+  private List<RID> ridsFromSql(final String query) {
+    final List<RID> rids = new ArrayList<>();
+    try (final ResultSet rs = database.query("sql", query, "Doc[embedding]", query(), 3)) {
+      while (rs.hasNext())
+        rids.add(rs.next().getIdentity().get());
+    }
+    return rids;
+  }
+
+  private List<RID> ridsOf(final List<Pair<RID, Float>> neighbors) {
+    final List<RID> rids = new ArrayList<>(neighbors.size());
+    for (final Pair<RID, Float> neighbor : neighbors)
+      rids.add(neighbor.getFirst());
+    return rids;
+  }
+
+  private List<Integer> clustersOf(final List<Pair<RID, Float>> neighbors) {
+    final List<Integer> clusters = new ArrayList<>(neighbors.size());
+    for (final Pair<RID, Float> neighbor : neighbors)
+      clusters.add(((Document) database.lookupByRID(neighbor.getFirst(), true)).getInteger("cluster"));
+    return clusters;
+  }
+
+  private Function<RID, Object> groupKeyResolver() {
+    return rid -> ((Document) database.lookupByRID(rid, true)).getInteger("cluster");
+  }
+
+  private List<Pair<RID, Float>> grouped(final int limit, final int groupSize) {
+    return vectorIndex().findNeighborsFromVectorGrouped(query(), limit, groupSize, -1, null, groupKeyResolver());
+  }
+
+  private long deltaCount() {
+    return stat("deltaVectorsCount");
+  }
+
+  private long stat(final String name) {
+    return vectorIndex().getStats().getOrDefault(name, 0L);
+  }
+
+  private LSMVectorIndex vectorIndex() {
+    return (LSMVectorIndex) ((TypeIndex) database.getSchema().getIndexByName("Doc[embedding]")).getIndexesOnBuckets()[0];
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.id STRING");
+      database.command("sql", "CREATE PROPERTY Doc.cluster INTEGER");
+      database.command("sql", "CREATE PROPERTY Doc.embedding ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON Doc (id) UNIQUE");
+
+      final TypeLSMVectorIndexBuilder builder = (TypeLSMVectorIndexBuilder) database.getSchema()
+          .buildTypeIndex("Doc", new String[] { "embedding" }).withLSMVectorType();
+      builder.withDimensions(DIMENSIONS).withQuantization(VectorQuantizationType.NONE).withSimilarity("COSINE")
+          .create();
+    });
+  }
+
+  private List<RID> insertBaseVertices() {
+    final List<RID> rids = new ArrayList<>(VERTICES);
+    database.transaction(() -> {
+      for (int i = 0; i < VERTICES; i++)
+        rids.add(insert("doc" + i, i / PER_CLUSTER, embeddingAt(theta(i))));
+    });
+    // Force the first graph build outside the assertions: everything inserted above is now in the graph, and the
+    // delta buffer is empty again.
+    vectorIndex().findNeighborsFromVector(query(), 1);
+    return rids;
+  }
+
+  /** {@code count} rows nearer to the query than every base vertex, each in a group of its own. */
+  private List<RID> insertDeltaVertices(final int count) {
+    final List<RID> rids = new ArrayList<>(count);
+    for (int i = 0; i < count; i++)
+      rids.add(insertDeltaVertex(QUERY_THETA + (i + 1) * DELTA_STEP, 90 + i));
+    return rids;
+  }
+
+  /** {@code count} rows nearer to the query than every base vertex, all sharing one group. */
+  private void insertDeltaVerticesInOneGroup(final int count, final int cluster) {
+    for (int i = 0; i < count; i++)
+      insertDeltaVertex(QUERY_THETA + (i + 1) * DELTA_STEP, cluster);
+  }
+
+  private RID insertDeltaVertex(final double atTheta, final int cluster) {
+    final RID[] rid = new RID[1];
+    database.transaction(() -> rid[0] = insert("delta-" + atTheta + "-" + cluster, cluster, embeddingAt(atTheta)));
+    return rid[0];
+  }
+
+  private RID insert(final String id, final int cluster, final float[] embedding) {
+    return ((Document) database.command("sql", "INSERT INTO Doc SET id = ?, cluster = ?, embedding = ?", id, cluster,
+        embedding).next().getRecord().get()).getIdentity();
+  }
+
+  private static int centerOf(final int cluster) {
+    return cluster * PER_CLUSTER + PER_CLUSTER / 2;
+  }
+
+  private static double theta(final int vertex) {
+    return (vertex / PER_CLUSTER) * CLUSTER_GAP + (vertex % PER_CLUSTER - PER_CLUSTER / 2.0) * JITTER;
+  }
+
+  private float[] query() {
+    return embeddingAt(QUERY_THETA);
+  }
+
+  /**
+   * Points on an arc, embedded with damped harmonics so cosine similarity decreases strictly with the angular gap -
+   * the same construction as {@code Issue5761GroupedSearchGroupChoiceTest}, so which row is nearest is decidable on
+   * paper rather than an artefact of the index.
+   */
+  private static float[] embeddingAt(final double angle) {
+    final float[] v = new float[DIMENSIONS];
+    for (int m = 1; m <= DIMENSIONS / 2; m++) {
+      v[(m - 1) * 2] = (float) (Math.cos(m * angle) / m);
+      v[(m - 1) * 2 + 1] = (float) (Math.sin(m * angle) / m);
+    }
+    return v;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/vector/ScoredCandidateCursorTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/ScoredCandidateCursorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the ordering device the issue #6501 delta merge rests on. The grouped search reads correctness off
+ * this class alone: {@link GroupAdmissionState} is first-come-first-served, so a cursor that returns candidates even
+ * slightly out of rank order hands a group slot to a row that did not earn it, and the answer is wrong in a way no
+ * exception marks. Worth pinning here rather than only through a search, where the graph walk's own approximation
+ * would blur what failed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ScoredCandidateCursorTest {
+
+  @Test
+  void anEmptyCursorIsExhaustedFromTheStart() {
+    final ScoredCandidateCursor cursor = new ScoredCandidateCursor(new float[0], new int[0], 0);
+
+    assertThat(cursor.isEmpty()).isTrue();
+    assertThat(cursor.size()).isZero();
+    assertThatThrownBy(cursor::peekDistance).isInstanceOf(NoSuchElementException.class);
+    assertThatThrownBy(cursor::poll).isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  void aSingleCandidateComesBackOnceAndThenTheCursorIsDone() {
+    final ScoredCandidateCursor cursor = new ScoredCandidateCursor(new float[] { 0.5f }, new int[] { 7 }, 1);
+
+    assertThat(cursor.peekDistance()).isEqualTo(0.5f);
+    assertThat(cursor.poll()).isEqualTo(7);
+    assertThat(cursor.isEmpty()).isTrue();
+  }
+
+  /**
+   * The payload has to travel with its own distance through every sift, not just end up in the same multiset - the
+   * caller looks its candidate up by payload, so a pair that comes apart returns one row's identity at another
+   * row's distance.
+   */
+  @Test
+  void payloadsStayPairedWithTheirDistances() {
+    final float[] distances = { 9f, 1f, 7f, 3f, 5f };
+    final int[] payloads = { 90, 10, 70, 30, 50 };
+
+    final ScoredCandidateCursor cursor = new ScoredCandidateCursor(distances, payloads, distances.length);
+
+    final List<Integer> drained = new ArrayList<>();
+    while (!cursor.isEmpty()) {
+      final float distance = cursor.peekDistance();
+      final int payload = cursor.poll();
+      assertThat(payload).as("payload %d does not belong to distance %s", payload, distance)
+          .isEqualTo(Math.round(distance * 10));
+      drained.add(payload);
+    }
+    assertThat(drained).containsExactly(10, 30, 50, 70, 90);
+  }
+
+  /**
+   * The caller scores into over-allocated arrays and compacts as it filters, so everything past {@code size} is
+   * whatever the previous entry left there. It must never surface.
+   */
+  @Test
+  void entriesPastTheDeclaredSizeAreInvisible() {
+    final float[] distances = { 4f, 2f, 6f, -1f, -1f };
+    final int[] payloads = { 40, 20, 60, 999, 999 };
+
+    final ScoredCandidateCursor cursor = new ScoredCandidateCursor(distances, payloads, 3);
+
+    assertThat(cursor.size()).isEqualTo(3);
+    final List<Integer> drained = new ArrayList<>();
+    while (!cursor.isEmpty())
+      drained.add(cursor.poll());
+    assertThat(drained).as("a candidate the caller filtered out must not reappear").containsExactly(20, 40, 60);
+  }
+
+  @Test
+  void aSizeTheArraysCannotHoldIsRejected() {
+    assertThatThrownBy(() -> new ScoredCandidateCursor(new float[2], new int[2], 3))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new ScoredCandidateCursor(new float[4], new int[2], 3))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new ScoredCandidateCursor(new float[2], new int[2], -1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * Duplicate distances are the norm, not the exception - a delta buffer full of copies of one vector scores them
+   * all identically - and a comparison that mishandles ties either loses candidates or spins.
+   */
+  @Test
+  void tiedDistancesAllComeBack() {
+    final float[] distances = new float[64];
+    final int[] payloads = new int[64];
+    for (int i = 0; i < 64; i++) {
+      distances[i] = 0.25f;
+      payloads[i] = i;
+    }
+
+    final ScoredCandidateCursor cursor = new ScoredCandidateCursor(distances, payloads, 64);
+
+    final List<Integer> drained = new ArrayList<>();
+    while (!cursor.isEmpty()) {
+      assertThat(cursor.peekDistance()).isEqualTo(0.25f);
+      drained.add(cursor.poll());
+    }
+    assertThat(drained).hasSize(64).doesNotHaveDuplicates();
+  }
+
+  /**
+   * Randomised, against the answer a sort gives, over sizes that straddle every shape of the heap - odd and even
+   * node counts, a last level that is full and one that is not, a single-child parent.
+   */
+  @Test
+  void anyInputDrainsInAscendingOrder() {
+    final Random random = new Random(6501);
+    for (int size = 0; size <= 200; size++) {
+      final float[] distances = new float[size];
+      final int[] payloads = new int[size];
+      final float[] expected = new float[size];
+      for (int i = 0; i < size; i++) {
+        distances[i] = random.nextFloat() * 100f;
+        expected[i] = distances[i];
+        payloads[i] = i;
+      }
+      Arrays.sort(expected);
+
+      final ScoredCandidateCursor cursor = new ScoredCandidateCursor(distances, payloads, size);
+
+      for (int i = 0; i < size; i++) {
+        assertThat(cursor.size()).as("size after %d of %d polls", i, size).isEqualTo(size - i);
+        final float distance = cursor.peekDistance();
+        cursor.poll();
+        assertThat(distance).as("candidate %d of %d is out of rank order", i, size).isEqualTo(expected[i]);
+      }
+      assertThat(cursor.isEmpty()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
Closes #6501.

## The defect

`vector.neighbors(..., {groupBy: ...})` routes to `findNeighborsFromVectorGrouped` on the presence of `groupBy` alone. That method answered purely from the HNSW graph, and every vector written since the graph was last built lives in the delta buffer - so a grouped query returned a full, plausible, exception-free answer computed over a **stale corpus**, while the same query, on the same index, with the same vector, at the same instant, returned the newer rows without `groupBy`.

Nothing at the SQL surface said so. No exception, no `WARNING`, and `groupedSearchesShortOfLimit` stayed at `0` because it counts something else. On stock knobs the invisible window is up to `min(rebuildGraphRatio * graphSize, maxPendingMutations)` rows wide and stays open for as long as writes keep arriving, so it is the steady state under ingestion rather than a corner case.

The reporter's measurement, reproduced by `Issue6501GroupedDeltaMergeTest`:

| query | rows from delta | best distance |
|---|---|---|
| ungrouped | 10 | 0.00002 |
| grouped | 0 | 249.42732 |

## What was done, and why not the simpler options

The issue offered three options in increasing order of effort - (1) a counter, (2) a line in the syntax help, (3) actually merging. This implements **(3)**, and folds (1) and (2) in on top, because (1) and (2) only make a wrong answer easier to notice.

The skip was deliberate and documented, on the grounds that a delta candidate would be "re-admitted outside the per-group cap". The issue's reading is right that since #5761 the cap is applied to score-ordered output, so a delta candidate is just another scored `(RID, distance)` pair - **but only if it enters the stream in rank order.** `GroupAdmissionState` hands out its slots first-come-first-served:

- appending the buffer *after* the walk lets a far delta row take a group slot from a nearer graph row;
- prepending it locks the walk out of groups it should have won.

Both are wrong in a way that returns rows rather than an error, which is the same failure mode the issue is about. So the buffer is scored once into a new `ScoredCandidateCursor` and **drained into the same rank-ordered stream the walk feeds**: before each graph candidate, every delta candidate at least as near as it; after the walk, whatever is left. `deltaRowsAreRankedAgainstGraphRowsRatherThanAppended` pins exactly this - its delta rows straddle the base clusters, so appending in either direction gives a different, wrong answer.

Both plans that can answer a grouped query get the merge: the graph walk, and the #6514 narrow-allow-list pre-filter - where it matters **more**, not less, since an allow-list is usually a set of records the caller just wrote, so "narrow enough to reach that plan" and "still in the delta buffer" are the same query, and it used to answer it empty.

### Why a cursor and not a top-k heap

`findNeighborsFromVector`'s delta scan keeps only the k best candidates, which is exact because its consumer takes the k nearest rows and nothing else. The grouped search cannot bound the set that way: the cap rejects a row whose group is already full, so an unbounded run of near candidates can be skipped before a far one is admitted. With `limit=2`, `groupSize=1` and a thousand delta rows in one group, the row that opens the second group is the thousand-and-first by rank - a top-`limit * groupSize` heap throws it away.

So the whole set stays addressable and the cap decides how far into it the query walks. `ScoredCandidateCursor` heapifies two parallel primitive arrays in place, so a query that fills its groups from the first handful pays `O(n)` plus a few `O(log n)` pops rather than sorting everything, and the pathological case is no worse than the sort would have been. Scoring allocates nothing (delta entries are already stored as `VectorFloat` for this reason, #5391); the two arrays are 8 bytes per buffered vector.

## Also in this PR

- The grouped path's bookkeeping - the cap, the admitted rows, the merge, the skip counters - collapses into one `GroupedSearchState`, so the graph-walk and pre-filter plans can no longer drift apart on what "admit" means (they were eight positional parameters). A row offered by **both** sides of the merge - a vector re-queued into the buffer as an orphan while its graph node survives - is admitted once.
- A `groupedSearchesMergingDelta` statistic, plus the delta counts in the FINE summary lines: the issue's item (1), repurposed from "your answer may be stale" to "this query is paying for a linear scan of an N-entry buffer, and here is how many rows it bought".
- `vector.neighbors`' javadoc now states the parity between the grouped and ungrouped branches, so a future change cannot reintroduce the divergence quietly.
- The issue's item (2) is addressed in the docs repo rather than the syntax help: `groupBy`, `groupSize` and `maxDistance` had no page at all (`grep` over the docs tree returns nothing, as the issue notes). A commit adding all three to the options table, with two grouped examples, is staged locally in `arcadedb-docs` and not pushed.

## Tests

- `Issue6501GroupedDeltaMergeTest` - 6 of its 7 tests fail on `main` and pass here, covering the index API, the `vector.neighbors` SQL surface the issue was filed against, the group cap holding over merged rows, rank-order interleaving, and both pre-filter paths. The seventh is the no-regression control.
- `ScoredCandidateCursorTest` - the ordering device on its own, including ties, over-allocated arrays, and a randomised sweep across every heap shape from 0 to 200 entries.

The fixture holds 1,200 base vectors deliberately: below `ASYNC_REBUILD_MIN_GRAPH_SIZE` every search rebuilds the graph synchronously and drains the buffer, so a small fixture would be green whatever the grouped path does.

`mvn -o -pl engine test` over `com/arcadedb/index/vector/**` and `com/arcadedb/function/sql/vector/**`, including the `slow` and `vector` lanes: **709 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4rxAnQ2dXPyQeHHtXZahz