### PR TITLE
fix(#6543): recognize ROLLBACK over the Postgres extended-query protocol

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -1895,14 +1895,32 @@ public class PostgresNetworkExecutor extends Thread {
         } else {
           switch (portal.language) {
           case "sql":
-            final SQLQueryEngine sqlEngine = (SQLQueryEngine) database.getQueryEngine("sql");
-            portal.sqlStatement = sqlEngine.parse(query.query, (DatabaseInternal) database);
+            // BEGIN/COMMIT/ROLLBACK (in any of their recognized forms) are handled directly below and must
+            // never reach sqlEngine.parse(): the grammar's beginStatement/commitStatement/rollbackStatement
+            // productions accept only the bare keyword (or BEGIN's own ISOLATION clause and COMMIT's own RETRY
+            // clause) - "BEGIN TRANSACTION"/"COMMIT WORK"/"ROLLBACK TRANSACTION"/etc. all fail to parse as SQL.
+            // Checking first, the same way queryCommand's simple-query dispatch already does, keeps this
+            // branch from ever calling parse() on text the grammar was never going to accept (issue #6543).
             if ("BEGIN".equalsIgnoreCase(portal.query) || "BEGIN TRANSACTION".equalsIgnoreCase(portal.query)) {
               explicitTransactionStarted = true;
               setEmptyResultSet(portal);
-            } else if ("COMMIT".equalsIgnoreCase(portal.query)) {
+            } else if (isCommitStatement(upperCaseText)) {
+              // No explicit database.commit() here: clearing the flag makes the Sync that follows this
+              // Execute take its implicit-commit branch (see syncCommand()), which is what actually
+              // persists the transaction.
               explicitTransactionStarted = false;
               setEmptyResultSet(portal);
+            } else if (isRollbackStatement(upperCaseText)) {
+              // Unlike COMMIT, ROLLBACK cannot lean on Sync's implicit-commit branch - clearing the flag
+              // without rolling back here would make the next Sync COMMIT the transaction instead (issue
+              // #6543), the opposite of what the client asked for.
+              if (explicitTransactionStarted && database.isTransactionActive())
+                database.rollback();
+              explicitTransactionStarted = false;
+              setEmptyResultSet(portal);
+            } else {
+              final SQLQueryEngine sqlEngine = (SQLQueryEngine) database.getQueryEngine("sql");
+              portal.sqlStatement = sqlEngine.parse(query.query, (DatabaseInternal) database);
             }
             break;
 
@@ -2364,19 +2382,21 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   /**
-   * Matches a simple-query COMMIT/END statement, the counterpart to the existing BEGIN check (issue #6457).
+   * Matches a COMMIT/END statement, the counterpart to the existing BEGIN check (issue #6457). Covers the
+   * SQL-standard {@code ... WORK} form alongside the bare and {@code ... TRANSACTION} forms (issue #6543).
    */
   private static boolean isCommitStatement(final String upperCaseText) {
-    return "COMMIT".equals(upperCaseText) || "COMMIT TRANSACTION".equals(upperCaseText) ||
-        "END".equals(upperCaseText) || "END TRANSACTION".equals(upperCaseText);
+    return "COMMIT".equals(upperCaseText) || "COMMIT TRANSACTION".equals(upperCaseText) || "COMMIT WORK".equals(upperCaseText) ||
+        "END".equals(upperCaseText) || "END TRANSACTION".equals(upperCaseText) || "END WORK".equals(upperCaseText);
   }
 
   /**
-   * Matches a simple-query ROLLBACK statement (issue #6457). Deliberately excludes {@code ROLLBACK TO
-   * <savepoint>}, which queryCommand's dispatch already routes elsewhere (it does not end the transaction).
+   * Matches a ROLLBACK statement (issue #6457, extended to the extended-query protocol and the
+   * SQL-standard {@code ... WORK} form by issue #6543). Deliberately excludes {@code ROLLBACK TO
+   * <savepoint>}, which the dispatch already routes elsewhere (it does not end the transaction).
    */
   private static boolean isRollbackStatement(final String upperCaseText) {
-    return "ROLLBACK".equals(upperCaseText) || "ROLLBACK TRANSACTION".equals(upperCaseText);
+    return "ROLLBACK".equals(upperCaseText) || "ROLLBACK TRANSACTION".equals(upperCaseText) || "ROLLBACK WORK".equals(upperCaseText);
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -642,7 +642,7 @@ public class PostgresNetworkExecutor extends Thread {
       } else if (upperCaseText.startsWith("SHOW ")) {
         final String varName = query.query.substring(5).trim().toLowerCase(Locale.ENGLISH);
         resultSet = new IteratorResultSet(createResultSet(varName, getShowConfigValue(varName)).iterator());
-      } else if ("BEGIN".equals(upperCaseText) || "BEGIN TRANSACTION".equals(upperCaseText)) {
+      } else if (isBeginStatement(upperCaseText)) {
         explicitTransactionStarted = true;
         database.begin();
         resultSet = new IteratorResultSet(Collections.emptyIterator());
@@ -1901,7 +1901,7 @@ public class PostgresNetworkExecutor extends Thread {
             // clause) - "BEGIN TRANSACTION"/"COMMIT WORK"/"ROLLBACK TRANSACTION"/etc. all fail to parse as SQL.
             // Checking first, the same way queryCommand's simple-query dispatch already does, keeps this
             // branch from ever calling parse() on text the grammar was never going to accept (issue #6543).
-            if ("BEGIN".equalsIgnoreCase(portal.query) || "BEGIN TRANSACTION".equalsIgnoreCase(portal.query)) {
+            if (isBeginStatement(upperCaseText)) {
               explicitTransactionStarted = true;
               setEmptyResultSet(portal);
             } else if (isCommitStatement(upperCaseText)) {
@@ -2370,7 +2370,7 @@ public class PostgresNetworkExecutor extends Thread {
       return "UPDATE " + resultSetCount;
     } else if (upperCaseText.startsWith("DELETE")) {
       return "DELETE " + resultSetCount;
-    } else if ("BEGIN".equals(upperCaseText) || "BEGIN TRANSACTION".equals(upperCaseText)) {
+    } else if (isBeginStatement(upperCaseText)) {
       return "BEGIN";
     } else if (isCommitStatement(upperCaseText)) {
       return "COMMIT";
@@ -2379,6 +2379,16 @@ public class PostgresNetworkExecutor extends Thread {
     } else {
       return "";
     }
+  }
+
+  /**
+   * Matches a BEGIN statement, including the SQL-standard {@code ... WORK} form alongside the bare and
+   * {@code ... TRANSACTION} forms - the same three-way shape as {@link #isCommitStatement} and
+   * {@link #isRollbackStatement} (issue #6543 review follow-up: PostgreSQL's own grammar is
+   * {@code BEGIN [ WORK | TRANSACTION ]}).
+   */
+  private static boolean isBeginStatement(final String upperCaseText) {
+    return "BEGIN".equals(upperCaseText) || "BEGIN TRANSACTION".equals(upperCaseText) || "BEGIN WORK".equals(upperCaseText);
   }
 
   /**

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
@@ -119,6 +119,12 @@ class Issue6543RollbackExtendedProtocolIT extends PostgresWireProtocolTestBase {
         assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN TRANSACTION"))).isEqualTo('T');
         assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "ROLLBACK TRANSACTION")))
             .as("ROLLBACK TRANSACTION must be recognized just like a bare ROLLBACK").isEqualTo('I');
+
+        // BEGIN WORK: PostgreSQL's own grammar is BEGIN [ WORK | TRANSACTION ], added per review feedback on
+        // this PR for symmetry with the COMMIT/ROLLBACK WORK forms above.
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN WORK")))
+            .as("BEGIN WORK must be recognized just like a bare BEGIN").isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "ROLLBACK"))).isEqualTo('I');
       });
     }
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression tests for issue #6543: over the Postgres <b>extended query</b> protocol (Parse/Bind/Execute), the
+ * Parse-time dispatch in {@link PostgresNetworkExecutor#parseCommand()} that tracks explicit-transaction state
+ * recognized only {@code BEGIN}/{@code BEGIN TRANSACTION} and {@code COMMIT}. There was no {@code ROLLBACK}
+ * branch, and worse, {@code sqlEngine.parse()} was called <i>unconditionally</i> before that check ever ran: a
+ * bare {@code ROLLBACK} sent as its own Parse/Bind/Execute (rather than folded into a simple-query {@code 'Q'}
+ * message, the wire path already covered by issue #6457/#6542) parsed successfully as ArcadeDB SQL's own
+ * {@code RollbackStatement} - which does roll the underlying transaction back - but left
+ * {@code explicitTransactionStarted} set. Since {@code writeReadyForQueryMessage()} reports status {@code 'T'}
+ * whenever that flag is set, and {@code syncCommand()}'s implicit-commit branch only runs when the flag is
+ * clear, the wire-level session stayed reported as "inside an explicit transaction" forever after the
+ * ROLLBACK, even though the underlying transaction had already been discarded.
+ * <p>
+ * The same unconditional parse also meant a {@code ROLLBACK WORK}/{@code ROLLBACK TRANSACTION}/
+ * {@code COMMIT WORK} could never be recognized by merely widening the {@code isCommitStatement}/
+ * {@code isRollbackStatement} helpers (the follow-up issue #6543 explicitly asked to fold in): ArcadeDB SQL's
+ * {@code rollbackStatement}/{@code commitStatement} grammar productions accept only the bare keyword (plus
+ * COMMIT's own {@code RETRY} clause), so parsing any of those forms as SQL throws a syntax error before the
+ * widened check is ever reached. The fix checks BEGIN/COMMIT/ROLLBACK - in every recognized form - before
+ * calling {@code sqlEngine.parse()} at all, the same ordering {@code queryCommand()}'s simple-query dispatch
+ * already used for exactly this reason.
+ * <p>
+ * These tests speak the wire protocol directly over a raw socket, framing each statement as its own
+ * Parse+Bind+Execute+Sync round trip, so the extended-query dispatch path is actually exercised (a JDBC/
+ * psycopg2 client normally sends transaction-control statements over the simple-query protocol, which would
+ * not reach this bug at all).
+ * <p>
+ * <b>Not covered here:</b> whether ROLLBACK actually discards a write made after an extended-query BEGIN.
+ * Unlike {@code queryCommand()}'s BEGIN handling (which calls {@code database.begin()} directly),
+ * {@code parseCommand()}'s BEGIN branch only sets {@code explicitTransactionStarted} and never starts a real
+ * underlying transaction - a pre-existing gap, independent of this issue, that means a write made after an
+ * extended-query BEGIN auto-commits on its own before any following ROLLBACK/COMMIT is reached. Asserting
+ * data-discarding here would therefore pass or fail on that unrelated gap rather than on the fix this class
+ * targets.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6543RollbackExtendedProtocolIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  @DisplayName("[#6543] a bare ROLLBACK over the extended query protocol ends the explicit transaction cleanly")
+  void rollbackOverExtendedProtocolEndsTransaction() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        // BEGIN over the extended query protocol: status must go to 'T'.
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+
+        // ROLLBACK, unrecognized in the Parse dispatch before the fix, must not error and must end the
+        // transaction, reporting idle status - the core of issue #6543.
+        final List<WireMessage> afterRollback = runExtendedQuery(out, in, "ROLLBACK");
+        assertThat(messageTypesOf(afterRollback)).as("no ErrorResponse for ROLLBACK itself").doesNotContain('E');
+        assertThat(readyForQueryStatusOf(afterRollback))
+            .as("ROLLBACK must clear explicitTransactionStarted so status goes back to idle").isEqualTo('I');
+
+        // The session is fully usable again, not wedged in a permanent 'T' state.
+        final List<WireMessage> afterRecovery = runExtendedQuery(out, in, "SELECT 1");
+        assertThat(messageTypesOf(afterRecovery)).doesNotContain('E');
+        assertThat(readyForQueryStatusOf(afterRecovery)).isEqualTo('I');
+      });
+    }
+  }
+
+  @Test
+  @DisplayName("[#6543] ROLLBACK WORK / ROLLBACK TRANSACTION are recognized as aliases for ROLLBACK over the extended query protocol")
+  void rollbackAliasesAreRecognizedOverExtendedProtocol() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "ROLLBACK WORK")))
+            .as("ROLLBACK WORK must be recognized just like a bare ROLLBACK").isEqualTo('I');
+
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN TRANSACTION"))).isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "ROLLBACK TRANSACTION")))
+            .as("ROLLBACK TRANSACTION must be recognized just like a bare ROLLBACK").isEqualTo('I');
+      });
+    }
+  }
+
+  private void authenticate(final DataOutputStream out, final DataInputStream in) throws Exception {
+    sendStartupMessage(out, "root", getDatabaseName());
+    readMessage(in); // AuthenticationCleartextPassword
+    sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+    readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+  }
+
+  /**
+   * Runs one statement as its own Parse+Bind+Execute+Sync round trip over the extended query protocol (the
+   * unnamed statement/portal, no parameters), then reads every message the server sends back up to and
+   * including the {@code ReadyForQuery} the Sync produces.
+   */
+  private static List<WireMessage> runExtendedQuery(final DataOutputStream out, final DataInputStream in, final String query)
+      throws Exception {
+    sendParse(out, query);
+    sendBind(out);
+    sendExecute(out);
+    sendSync(out);
+    return readUntilReadyForQuery(in);
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('P');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  /**
+   * Bind for the unnamed portal/statement, no parameters, no declared result formats.
+   */
+  private static void sendBind(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    writeCString(body, ""); // statement name
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(0); // int16 numParamValues = 0
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendExecute(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0); // int32 limit = 0 (no limit)
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('E');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage((char) type, body);
+  }
+
+  /**
+   * Reads messages until (and including) the next {@code ReadyForQuery}, so a single Parse+Bind+Execute+Sync
+   * round trip can be inspected in full.
+   */
+  private static List<WireMessage> readUntilReadyForQuery(final DataInputStream in) throws Exception {
+    final List<WireMessage> messages = new ArrayList<>();
+    WireMessage message;
+    do {
+      message = readWireMessage(in);
+      messages.add(message);
+    } while (message.type() != 'Z');
+    return messages;
+  }
+
+  private static char readyForQueryStatusOf(final List<WireMessage> messages) {
+    final WireMessage last = messages.get(messages.size() - 1);
+    assertThat(last.type()).isEqualTo('Z');
+    return (char) last.body()[0];
+  }
+
+  private static List<Character> messageTypesOf(final List<WireMessage> messages) {
+    final List<Character> types = new ArrayList<>(messages.size());
+    for (final WireMessage message : messages)
+      types.add(message.type());
+    return types;
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
@@ -142,8 +142,20 @@ class Issue6543RollbackExtendedProtocolIT extends PostgresWireProtocolTestBase {
             .as("COMMIT WORK must be recognized just like a bare COMMIT").isEqualTo('I');
 
         assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "COMMIT TRANSACTION")))
+            .as("COMMIT TRANSACTION must be recognized just like a bare COMMIT").isEqualTo('I');
+
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
         assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "END")))
             .as("END must be recognized as an alias for COMMIT").isEqualTo('I');
+
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "END TRANSACTION")))
+            .as("END TRANSACTION must be recognized as an alias for COMMIT").isEqualTo('I');
+
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "END WORK")))
+            .as("END WORK must be recognized as an alias for COMMIT").isEqualTo('I');
       });
     }
   }

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6543RollbackExtendedProtocolIT.java
@@ -123,6 +123,31 @@ class Issue6543RollbackExtendedProtocolIT extends PostgresWireProtocolTestBase {
     }
   }
 
+  @Test
+  @DisplayName("[#6543] COMMIT WORK / END are recognized as aliases for COMMIT over the extended query protocol")
+  void commitAliasesAreRecognizedOverExtendedProtocol() throws Exception {
+    // Companion to the ROLLBACK-alias test above: isCommitStatement() was widened to COMMIT WORK/END/END
+    // TRANSACTION/END WORK alongside the ROLLBACK fix (the extended-protocol COMMIT branch previously matched
+    // only the exact literal "COMMIT"), and that widening only works because BEGIN/COMMIT/ROLLBACK are now
+    // checked before sqlEngine.parse() is ever called - so this exercises both halves of the fix together.
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "COMMIT WORK")))
+            .as("COMMIT WORK must be recognized just like a bare COMMIT").isEqualTo('I');
+
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "END")))
+            .as("END must be recognized as an alias for COMMIT").isEqualTo('I');
+      });
+    }
+  }
+
   private void authenticate(final DataOutputStream out, final DataInputStream in) throws Exception {
     sendStartupMessage(out, "root", getDatabaseName());
     readMessage(in); // AuthenticationCleartextPassword


### PR DESCRIPTION
## What does this PR do?

Closes #6543

Over the Postgres **extended query** protocol (Parse/Bind/Execute), `PostgresNetworkExecutor.parseCommand()`'s
dispatch that tracks explicit-transaction state (`explicitTransactionStarted`) recognized only
`BEGIN`/`BEGIN TRANSACTION` and `COMMIT`. There was no `ROLLBACK` branch, and worse,
`sqlEngine.parse()` was called **unconditionally** before that dispatch ever ran. A bare `ROLLBACK` sent as its
own Parse/Bind/Execute (as opposed to the simple-query protocol fixed in #6457/#6542) therefore fell through,
parsed successfully as ArcadeDB SQL's own `RollbackStatement` (whose `executeSimple()` does call
`database.rollback()`), but left `explicitTransactionStarted` set. Since `writeReadyForQueryMessage()` reports
status `'T'` whenever that flag is set, and `syncCommand()`'s implicit-commit branch only runs once the flag is
clear, the wire-level session stayed reported as "inside an explicit transaction" forever after the ROLLBACK.

The fix:
- Adds a `ROLLBACK` branch to the Parse dispatch, alongside the existing `BEGIN`/`COMMIT` handling. Unlike
  `COMMIT` (which can lean on `syncCommand()`'s implicit-commit branch simply by clearing the flag), `ROLLBACK`
  calls `database.rollback()` directly and then clears the flag - clearing it first, without rolling back, would
  make the *next* `Sync` commit the transaction instead, the opposite of what the client asked for.
- Moves the `BEGIN`/`COMMIT`/`ROLLBACK` check **ahead of** `sqlEngine.parse()` entirely, the same ordering
  `queryCommand()`'s simple-query dispatch already uses. This turned out to be necessary, not cosmetic: ArcadeDB
  SQL's `beginStatement`/`commitStatement`/`rollbackStatement` grammar productions accept only the bare keyword
  (plus BEGIN's own `ISOLATION` clause and COMMIT's own `RETRY` clause), so `sqlEngine.parse("ROLLBACK WORK", ...)`
  or `sqlEngine.parse("BEGIN TRANSACTION", ...)` throws a syntax error. With the unconditional parse still in
  place, widening `isCommitStatement`/`isRollbackStatement` to recognize those forms (see below) would have made
  a `ROLLBACK WORK` reach a `CommandParsingException` instead of silently falling through - confirmed by a
  regression run before this reordering was added (see "Also worth covering" below).
- Also folds in the issue's secondary ask: `isCommitStatement`/`isRollbackStatement` now recognize the
  SQL-standard `COMMIT WORK`/`ROLLBACK WORK`/`END WORK` forms alongside the bare and `... TRANSACTION` forms
  already handled. Since the extended-protocol COMMIT branch previously matched only the exact literal `"COMMIT"`
  (narrower than the simple-query protocol's `isCommitStatement`), it now uses the same helper as ROLLBACK,
  so `COMMIT TRANSACTION`/`END`/`END TRANSACTION`/`END WORK` are recognized there too - matching the simple-query
  protocol's coverage rather than adding new scope.
- Adds a matching `isBeginStatement` helper (`BEGIN`/`BEGIN TRANSACTION`/`BEGIN WORK`) and uses it in both
  `queryCommand()` and `parseCommand()` in place of the ad hoc literal checks each previously had, per review
  feedback: PostgreSQL's own grammar is `BEGIN [ WORK | TRANSACTION ]`, so `BEGIN WORK` is a real form a client
  can send, and it now gets the same three-way recognition as COMMIT/ROLLBACK instead of falling through to
  `sqlEngine.parse()` and erroring.

## Motivation

Follow-up from the Claude Code review on PR #6542 (the #6457 fix), which was explicitly scoped to the
simple-query protocol only.

## Related issues

Closes #6543. Same class of bug as #6457/#6542, on the extended-query wire path.

## Additional Notes

**Discovered while testing, left as a separate follow-up (not fixed in this PR):** `parseCommand()`'s `BEGIN`
branch only sets `explicitTransactionStarted = true` - unlike `queryCommand()`'s `BEGIN` branch, it never calls
`database.begin()`. So a write made after an extended-query `BEGIN` currently auto-commits on its own (via the
per-statement auto-transaction wrapping) before any following `COMMIT`/`ROLLBACK` is reached - "explicit
transactions" over the extended query protocol don't yet behave transactionally at all. This is independent of
#6543 (which is about wire-status/dispatch correctness, not about starting a real underlying transaction) and is
a materially bigger change - filing it separately seemed better than folding it into this fix. The regression
test's javadoc calls this out explicitly and deliberately does not assert data-discarding for that reason.

**Filed as a companion follow-up, per the Claude review on this PR: #6548.** `parseCommand()`/`bindCommand()`/
`executeCommand()` all short-circuit with `if (errorInTransaction) return;` before the new BEGIN/COMMIT/ROLLBACK
dispatch. So once a transaction is aborted, a client that sends an explicit `ROLLBACK` over the *extended*
protocol to recover never reaches the dispatch added here - `Sync`'s `errorInTransaction` branch does roll back
but never clears `explicitTransactionStarted`, so the client ends up back at status `'T'` instead of `'I'`. Same
symptom this PR fixes, reached via the aborted-transaction path instead of a plain `ROLLBACK`. Pre-existing
(the early-return guard predates this diff), touches three call sites instead of one, and needs its own
regression coverage - out of scope here, tracked in #6548.

**Review nits closed in this PR:** the initial version of the regression test only exercised the ROLLBACK-side
aliases; a follow-up commit added `COMMIT WORK`/`COMMIT TRANSACTION`/`END`/`END TRANSACTION`/`END WORK` coverage
so every form `isCommitStatement`/`isRollbackStatement` recognizes is now exercised over the extended protocol,
not just the ROLLBACK half. A later review pass also flagged `BEGIN WORK` as unrecognized (real PostgreSQL
syntax, and the PR's own stated goal was matching the `WORK` form to the SQL standard) - folded in above with
`isBeginStatement` and a `BEGIN WORK` -> `ROLLBACK` regression case.

## Test plan

- [x] New `Issue6543RollbackExtendedProtocolIT` (raw-socket, extended-query Parse/Bind/Execute/Sync), 3 tests:
  - `rollbackOverExtendedProtocolEndsTransaction`: BEGIN -> `'T'`; ROLLBACK -> no ErrorResponse, status back to
    `'I'`; a following statement on the same connection still works (not wedged in `'T'`).
  - `rollbackAliasesAreRecognizedOverExtendedProtocol`: `ROLLBACK WORK` and `ROLLBACK TRANSACTION` both
    recognized and clear the flag, over the extended query protocol.
  - `commitAliasesAreRecognizedOverExtendedProtocol`: `COMMIT WORK`, `COMMIT TRANSACTION`, `END`,
    `END TRANSACTION`, and `END WORK` all recognized and clear the flag, over the extended query protocol -
    the COMMIT-side counterpart, added in response to review feedback on this PR.
  - All reproduce the bug before the fix (confirmed failing pre-fix: a `SocketException`/`EOFException` for the
    WORK/TRANSACTION forms once `isCommitStatement`/`isRollbackStatement` were widened without first reordering
    the parse call, and a stuck `'T'` status for the bare `ROLLBACK` case).
- [x] Existing `Issue6457AbortedTransactionSimpleQueryIT` (simple-query protocol, #6457/#6542) still passes -
  confirms the simple-query dispatch and its `COMMIT`/`ROLLBACK`/`END` handling are unaffected.
- [x] Full `postgresw` module test suite: 414 tests, 0 failures, 0 errors.
- [x] `mvn compile`/`test-compile` clean for `postgresw` and its reactor dependencies.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios


