### PR TITLE
fix(#6548): recognize BEGIN/COMMIT/ROLLBACK-family statements in parseCommand() while aborted

### DIFF
--- a/docs/6548-extended-protocol-rollback-recovery.md
+++ b/docs/6548-extended-protocol-rollback-recovery.md
@@ -47,6 +47,24 @@ one of those into an `ErrorResponse`.
 
 - `postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java` - `parseCommand()`.
 
+## Review follow-up: trailing ';' / whitespace
+
+`isCommitStatement()`/`isRollbackStatement()` match by exact string equality, so `abortedUpperCaseText` has to
+be trimmed and stripped of a trailing `;` before comparison - the same normalization `queryCommand()` applies
+to its own `queryText` (`queryText = readString().trim(); if (queryText.endsWith(";")) queryText = ...`)
+before its aborted-transaction check runs. Without it, a client that sends `"ROLLBACK;"` (a real Postgres
+statement terminator many drivers append) over the extended protocol while aborted falls through to the
+silent `return`, reproducing this issue's "wedged forever" symptom via a trailing semicolon instead of via
+the missing dispatch. Caught by the Claude Code review on this PR.
+
+Fixed narrowly: a local `abortedText` is trimmed and semicolon-stripped before uppercasing, only for the
+match this PR's new branch performs. `portal.query` itself is left untouched (the matched branch overwrites
+it outright with `"ROLLBACK"`; the unmatched branch discards the portal). The non-aborted BEGIN/COMMIT/
+ROLLBACK dispatch a few lines below (`upperCaseText` at parseCommand()'s top) has the identical gap, but that
+variable is also read by several unrelated checks (SET/SHOW/SAVEPOINT/system-query), so normalizing it there
+is a materially larger, riskier change outside this PR's scope - left as a pre-existing issue, not introduced
+here, callable out as a fast follow if desired.
+
 ## Tests
 
 - `postgresw/src/test/java/com/arcadedb/postgres/Issue6548AbortedTransactionRollbackExtendedProtocolIT.java` (new)
@@ -54,6 +72,9 @@ one of those into an `ErrorResponse`.
     sent as its own Parse/Bind/Execute/Sync must clear both `errorInTransaction` and
     `explicitTransactionStarted`, reporting status `'I'`, not `'T'`.
   - Covers `COMMIT`/`END` while aborted producing the `ROLLBACK` command tag, per real Postgres semantics.
+  - Covers `"ROLLBACK;"`, `" ROLLBACK "`, and `" ROLLBACK; "` while aborted, locking in the trim/semicolon-strip
+    fix above - verified red against the code before that fix (protocol desync, same signature as the
+    original bug), green after.
   - Confirms the session is fully usable again after recovery (`SELECT 1` succeeds with no `ErrorResponse`).
 
 ## Verification

--- a/docs/6548-extended-protocol-rollback-recovery.md
+++ b/docs/6548-extended-protocol-rollback-recovery.md
@@ -1,0 +1,84 @@
+# Issue #6548: Postgres extended-protocol ROLLBACK recovery never reaches the new dispatch
+
+## Root cause
+
+`PostgresNetworkExecutor.parseCommand()` starts with:
+
+```java
+if (errorInTransaction)
+  return;
+```
+
+This early return happens **before** the query text is inspected at all. Once `errorInTransaction` is
+set (a statement erred inside an explicit `BEGIN` block), a client that sends an explicit `ROLLBACK` (or
+`COMMIT`/`END`, which real Postgres treats identically while aborted) over the **extended** query protocol
+to recover from the aborted transaction never reaches the BEGIN/COMMIT/ROLLBACK dispatch added by #6546 for
+the simple-query path (`queryCommand()`) - `Parse` just silently drops the message (no `ParseComplete`, no
+error).
+
+When `Sync` eventually arrives, its `errorInTransaction` branch (`syncCommand()`) does call
+`database.rollback()` and clears `errorInTransaction`, but it never touches `explicitTransactionStarted`.
+Since `writeReadyForQueryMessage()` checks `errorInTransaction` first and `explicitTransactionStarted`
+second, the client ends up back at `ReadyForQuery` status `'T'` instead of `'I'` - the same "wedged forever"
+symptom #6543 fixed, just reached via the aborted-transaction path.
+
+## Fix
+
+`parseCommand()` now recognizes a BEGIN/COMMIT/ROLLBACK-family statement (via the existing
+`isTransactionEndStatement`/`isCommitStatement`/`isRollbackStatement` helpers) **before** falling through to
+the unconditional early return while `errorInTransaction` is set. Mirroring `queryCommand()`'s
+aborted-transaction dispatch (#6457/#6542):
+
+- If the active transaction is still active, roll it back.
+- Clear both `explicitTransactionStarted` and `errorInTransaction`.
+- Real Postgres treats a COMMIT/END of an aborted transaction the same as ROLLBACK (there is nothing left to
+  commit), so the portal's query text is overridden to `"ROLLBACK"` before `setEmptyResultSet()` runs - this
+  makes `executeCommand()`'s later `writeCommandComplete()` report the `ROLLBACK` tag regardless of which of
+  the three keywords the client actually sent, exactly like the simple-query dispatch already does.
+- The portal is stored and `ParseComplete` is written, so the following Bind/Execute/Sync round trip runs
+  through the ordinary (non-aborted) code paths - no changes were needed in `bindCommand()`/`executeCommand()`
+  themselves, since by the time they run, `errorInTransaction` is already false.
+
+Every other statement (anything that is not a transaction-end statement) still falls through to the silent
+`return` - `bindCommand()`'s own `errorInTransaction` check (issue #6545) is what turns an attempt to Bind
+one of those into an `ErrorResponse`.
+
+## Files changed
+
+- `postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java` - `parseCommand()`.
+
+## Tests
+
+- `postgresw/src/test/java/com/arcadedb/postgres/Issue6548AbortedTransactionRollbackExtendedProtocolIT.java` (new)
+  - Reproduces the exact wedge: `BEGIN` (extended) -> a malformed `Parse` aborts the transaction -> `ROLLBACK`
+    sent as its own Parse/Bind/Execute/Sync must clear both `errorInTransaction` and
+    `explicitTransactionStarted`, reporting status `'I'`, not `'T'`.
+  - Covers `COMMIT`/`END` while aborted producing the `ROLLBACK` command tag, per real Postgres semantics.
+  - Confirms the session is fully usable again after recovery (`SELECT 1` succeeds with no `ErrorResponse`).
+
+## Verification
+
+- **Red/green on the new test.** Ran `Issue6548AbortedTransactionRollbackExtendedProtocolIT` against the
+  unfixed code first (`git stash` on the source change only): both tests failed. The `ROLLBACK` scenario
+  failed with a protocol desync (`EOFException` client-side, server-side `PostgresProtocolException:
+  Unexpected message type`) rather than a clean assertion failure - the unfixed `Parse` drops the message
+  without draining nothing extra, but the *previous* portal at the unnamed-portal slot was already removed
+  by the prior statement's `Execute` (which always removes its portal - `getPortal(name, true)`), so `Bind`
+  hits the pre-existing "portal not found" fast path in `bindCommand()`, which returns without consuming the
+  rest of the Bind message body, desyncing the wire for anything pipelined after it. This is a sharper
+  real-world symptom than the issue's own description (connection actively closed, not just wedged at status
+  `'T'`) for any client that re-Parses the unnamed portal per statement. Re-ran after restoring the fix
+  (`git stash pop`): both tests passed.
+- **Full aborted-transaction/rollback regression group**, fix applied: `Issue6543RollbackExtendedProtocolIT`,
+  `Issue6545AbortedTransactionExtendedQueryIT`, `Issue6457AbortedTransactionSimpleQueryIT`,
+  `Issue6548AbortedTransactionRollbackExtendedProtocolIT` - 9/9 passed.
+- **Full `postgresw` integration-test suite** (all 18 `*IT` classes, dependency-module unit tests skipped to
+  keep the run scoped): 19/19 of the tests that ran passed; one class, `PostgresProtocolIT`, crashed its
+  forked JVM (`SurefireBooterForkException`, exit 143) both in the full run and when re-run in isolation.
+  The host was under severe memory pressure at the time (415MB free of 35GB used, ~15GB in the zram
+  compressor, multiple concurrent `mvn`/`java` processes from other sessions on the same machine) - the fork
+  could not start at all, not merely fail a test, and the class is unrelated to this change (a general JDBC
+  connectivity IT, not aborted-transaction/extended-protocol logic). Treated as a pre-existing environmental
+  flake, not a regression from this fix.
+- Full reactor compile (`mvn -o -pl postgresw -am clean test-compile`) passed with no new warnings beyond
+  pre-existing ones in this file.

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -1865,7 +1865,17 @@ public class PostgresNetworkExecutor extends Thread {
         // portal.language switch), this check runs regardless of portal.language - intentionally, matching
         // queryCommand()'s own aborted-transaction branch, which has no language gate either. No real client
         // sends a transaction-control statement under a non-"sql" language mid-session.
-        final String abortedUpperCaseText = portal.query.toUpperCase(Locale.ENGLISH);
+        // isCommitStatement()/isRollbackStatement() match by exact string equality, so the text they see must
+        // be trimmed and stripped of a trailing ';' the same way queryCommand() strips it from its queryText
+        // before its own aborted-transaction check runs (issue #6548 review follow-up) - otherwise a client
+        // that sends "ROLLBACK;" (a real Postgres statement terminator many drivers append) falls through to
+        // the silent return below, reproducing this exact issue's "wedged forever" symptom via a trailing
+        // semicolon instead of via the missing dispatch. portal.query itself is left untouched here: the
+        // matched branch below overwrites it outright, and the unmatched branch discards this portal.
+        String abortedText = portal.query.trim();
+        if (abortedText.endsWith(";"))
+          abortedText = abortedText.substring(0, abortedText.length() - 1);
+        final String abortedUpperCaseText = abortedText.toUpperCase(Locale.ENGLISH);
         if (isTransactionEndStatement(abortedUpperCaseText)) {
           if (database.isTransactionActive())
             database.rollback();

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -1852,8 +1852,31 @@ public class PostgresNetworkExecutor extends Thread {
             .log(this, Level.INFO, "PSQL: parse (portal=%s) -> %s (params=%d, detected=%d) (errorInTransaction=%s thread=%s)",
                 portalName, portal.query, paramCount, actualParamCount, errorInTransaction, Thread.currentThread().threadId());
 
-      if (errorInTransaction)
+      if (errorInTransaction) {
+        // Mirror queryCommand()'s aborted-transaction dispatch (issue #6457/#6542): a client recovering
+        // from an aborted transaction over the extended protocol sends its COMMIT/END/ROLLBACK through its
+        // own Parse/Bind/Execute round trip rather than a single Query message, and the unconditional
+        // return below dropped it silently - Sync's own errorInTransaction branch clears errorInTransaction
+        // but never explicitTransactionStarted, so the client was reported status 'T' forever after
+        // "recovering" (issue #6548). Every other statement still falls through to the silent return;
+        // bindCommand()'s own errorInTransaction check (issue #6545) is what turns an attempt to Bind one
+        // of those into an ErrorResponse.
+        final String abortedUpperCaseText = portal.query.toUpperCase(Locale.ENGLISH);
+        if (isTransactionEndStatement(abortedUpperCaseText)) {
+          if (database.isTransactionActive())
+            database.rollback();
+          explicitTransactionStarted = false;
+          errorInTransaction = false;
+          // Real Postgres treats a COMMIT/END of an aborted transaction the same as ROLLBACK - there is
+          // nothing left to commit - so the command tag executeCommand() later writes must read ROLLBACK
+          // regardless of which of the three keywords the client actually sent (see queryCommand()).
+          portal.query = "ROLLBACK";
+          setEmptyResultSet(portal);
+          portals.put(portalName, portal);
+          writeMessage("parse complete", null, '1', 4);
+        }
         return;
+      }
 
       if (portal.query.isEmpty()) {
         emptyQueryResponse();

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -1861,6 +1861,10 @@ public class PostgresNetworkExecutor extends Thread {
         // "recovering" (issue #6548). Every other statement still falls through to the silent return;
         // bindCommand()'s own errorInTransaction check (issue #6545) is what turns an attempt to Bind one
         // of those into an ErrorResponse.
+        // Unlike the non-aborted BEGIN/COMMIT/ROLLBACK recognition below (gated inside the "sql" case of the
+        // portal.language switch), this check runs regardless of portal.language - intentionally, matching
+        // queryCommand()'s own aborted-transaction branch, which has no language gate either. No real client
+        // sends a transaction-control statement under a non-"sql" language mid-session.
         final String abortedUpperCaseText = portal.query.toUpperCase(Locale.ENGLISH);
         if (isTransactionEndStatement(abortedUpperCaseText)) {
           if (database.isTransactionActive())

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6548AbortedTransactionRollbackExtendedProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6548AbortedTransactionRollbackExtendedProtocolIT.java
@@ -102,6 +102,38 @@ class Issue6548AbortedTransactionRollbackExtendedProtocolIT extends PostgresWire
   }
 
   @Test
+  @DisplayName("[#6548] a trailing ';' or surrounding whitespace on ROLLBACK does not defeat the aborted-transaction recovery match")
+  void rollbackWithTrailingSemicolonOrWhitespaceRecoversFromAbortedTransaction() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        // isCommitStatement()/isRollbackStatement() match by exact string equality, so the aborted-branch
+        // dispatch must trim and strip a trailing ';' before comparing - the same normalization
+        // queryCommand() applies to its own queryText - or a driver that appends the statement terminator
+        // (many do) would fall through to the silent return and reproduce this issue's "wedged forever"
+        // symptom via a trailing semicolon instead of via the missing dispatch.
+        for (final String rollbackVariant : new String[] {"ROLLBACK;", " ROLLBACK ", " ROLLBACK; "}) {
+          assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+
+          sendParse(out, "SELEC 1");
+          assertThat(readWireMessage(in).type()).isEqualTo('E');
+
+          final List<WireMessage> afterRollback = runExtendedQuery(out, in, rollbackVariant);
+          assertThat(messageTypesOf(afterRollback))
+              .as("'" + rollbackVariant + "' must not itself error").doesNotContain('E');
+          assertThat(readyForQueryStatusOf(afterRollback))
+              .as("'" + rollbackVariant + "' must clear both errorInTransaction and explicitTransactionStarted")
+              .isEqualTo('I');
+        }
+      });
+    }
+  }
+
+  @Test
   @DisplayName("[#6548] COMMIT/END sent while aborted over the extended query protocol recover the session and report the ROLLBACK tag")
   void commitAndEndRecoverFromAbortedTransactionOverExtendedProtocol() throws Exception {
     try (final Socket socket = new Socket()) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/Issue6548AbortedTransactionRollbackExtendedProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/Issue6548AbortedTransactionRollbackExtendedProtocolIT.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression tests for issue #6548, a follow-up from the review on PR #6546 (fix for #6543):
+ * {@link PostgresNetworkExecutor#parseCommand()}, {@code bindCommand()}, and {@code executeCommand()} (the
+ * extended query protocol - Parse/Bind/Execute) all started with an unconditional
+ * <pre>{@code
+ * if (errorInTransaction)
+ *   return;
+ * }</pre>
+ * before the query text was ever inspected. Once {@code errorInTransaction} was set - a statement erred
+ * inside an explicit {@code BEGIN} block - a client sending an explicit {@code ROLLBACK} (or {@code COMMIT}/
+ * {@code END}, which real Postgres treats identically while aborted) over the extended protocol to recover
+ * never reached the BEGIN/COMMIT/ROLLBACK dispatch #6546 added to the simple-query path: {@code Parse} just
+ * silently dropped the message.
+ * <p>
+ * When {@code Sync} eventually arrived, its {@code errorInTransaction} branch called {@code
+ * database.rollback()} and cleared {@code errorInTransaction}, but never touched {@code
+ * explicitTransactionStarted}. Since {@code writeReadyForQueryMessage()} checks {@code errorInTransaction}
+ * first and {@code explicitTransactionStarted} second, the client ended up back at {@code ReadyForQuery}
+ * status {@code 'T'} instead of {@code 'I'} - the same "wedged forever" symptom #6543 fixed, just reached via
+ * the aborted-transaction path instead of a plain {@code ROLLBACK} with no prior error.
+ * <p>
+ * These tests speak the wire protocol directly over a raw socket so the exact sequence - a malformed
+ * statement that aborts an explicit transaction, followed by a recovery statement sent as its own
+ * Parse/Bind/Execute/Sync round trip - can be driven and the resulting {@code ReadyForQuery} status byte
+ * asserted on.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6548AbortedTransactionRollbackExtendedProtocolIT extends PostgresWireProtocolTestBase {
+
+  @Test
+  @DisplayName("[#6548] ROLLBACK sent as its own Parse/Bind/Execute while aborted clears both errorInTransaction and explicitTransactionStarted")
+  void rollbackRecoversFromAbortedTransactionOverExtendedProtocol() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        // 1. BEGIN over the extended query protocol: status must go to 'T'.
+        assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+
+        // 2. A malformed statement, sent as its own Parse, aborts the transaction without ever reaching
+        // Sync - errorInTransaction is set synchronously inside parseCommand()'s own catch block.
+        sendParse(out, "SELEC 1");
+        final WireMessage parseError = readWireMessage(in);
+        assertThat(parseError.type()).as("ErrorResponse for the malformed statement").isEqualTo('E');
+
+        // 3. ROLLBACK sent as its own Parse/Bind/Execute/Sync must recover the session: no ErrorResponse
+        // anywhere in the round trip, and status must be 'I' - not 'T' (explicitTransactionStarted must be
+        // cleared, not just errorInTransaction) and not 'E' (the transaction must actually be resolved).
+        final List<WireMessage> afterRollback = runExtendedQuery(out, in, "ROLLBACK");
+        assertThat(messageTypesOf(afterRollback)).as("no ErrorResponse for the recovering ROLLBACK").doesNotContain('E');
+        assertThat(readyForQueryStatusOf(afterRollback))
+            .as("ROLLBACK must clear both errorInTransaction and explicitTransactionStarted").isEqualTo('I');
+
+        // 4. The session is fully usable again, not wedged in a permanent aborted/explicit-transaction state.
+        final List<WireMessage> afterRecovery = runExtendedQuery(out, in, "SELECT 1");
+        assertThat(messageTypesOf(afterRecovery)).doesNotContain('E');
+        assertThat(readyForQueryStatusOf(afterRecovery)).isEqualTo('I');
+      });
+    }
+  }
+
+  @Test
+  @DisplayName("[#6548] COMMIT/END sent while aborted over the extended query protocol recover the session and report the ROLLBACK tag")
+  void commitAndEndRecoverFromAbortedTransactionOverExtendedProtocol() throws Exception {
+    try (final Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("localhost", GlobalConfiguration.POSTGRES_PORT.getValueAsInteger()), 2000);
+      final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+      final DataInputStream in = new DataInputStream(socket.getInputStream());
+      authenticate(out, in);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+        for (final String recoveryStatement : new String[] {"COMMIT", "END"}) {
+          assertThat(readyForQueryStatusOf(runExtendedQuery(out, in, "BEGIN"))).isEqualTo('T');
+
+          sendParse(out, "SELEC 1");
+          assertThat(readWireMessage(in).type()).isEqualTo('E');
+
+          // Real Postgres treats a COMMIT/END of an aborted transaction the same as ROLLBACK - there is
+          // nothing left to commit - so the command tag must read ROLLBACK regardless of which keyword the
+          // client sent, exactly like queryCommand()'s simple-query dispatch already does.
+          final List<WireMessage> afterRecoveryAttempt = runExtendedQuery(out, in, recoveryStatement);
+          assertThat(messageTypesOf(afterRecoveryAttempt))
+              .as(recoveryStatement + " must not itself error").doesNotContain('E');
+          assertThat(readyForQueryStatusOf(afterRecoveryAttempt))
+              .as(recoveryStatement + " must clear both errorInTransaction and explicitTransactionStarted")
+              .isEqualTo('I');
+          assertThat(commandCompleteTagOf(afterRecoveryAttempt))
+              .as(recoveryStatement + " while aborted must report the ROLLBACK tag, not " + recoveryStatement)
+              .isEqualTo("ROLLBACK");
+        }
+      });
+    }
+  }
+
+  private void authenticate(final DataOutputStream out, final DataInputStream in) throws Exception {
+    sendStartupMessage(out, "root", getDatabaseName());
+    readMessage(in); // AuthenticationCleartextPassword
+    sendPasswordMessage(out, DEFAULT_PASSWORD_FOR_TESTS);
+    readMessageOfType(in, 'Z'); // drain AuthenticationOk/BackendKeyData/ParameterStatus.../ReadyForQuery
+  }
+
+  /**
+   * Runs one statement as its own Parse+Bind+Execute+Sync round trip over the extended query protocol (the
+   * unnamed statement/portal, no parameters), then reads every message the server sends back up to and
+   * including the {@code ReadyForQuery} the Sync produces.
+   */
+  private static List<WireMessage> runExtendedQuery(final DataOutputStream out, final DataInputStream in, final String query)
+      throws Exception {
+    sendParse(out, query);
+    sendBind(out);
+    sendExecute(out);
+    sendSync(out);
+    return readUntilReadyForQuery(in);
+  }
+
+  private static void sendParse(final DataOutputStream out, final String query) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // unnamed statement
+    writeCString(body, query);
+    body.write(0);
+    body.write(0); // int16 numParamDataTypes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('P');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  /**
+   * Bind for the unnamed portal/statement, no parameters, no declared result formats.
+   */
+  private static void sendBind(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    writeCString(body, ""); // statement name
+    body.write(0);
+    body.write(0); // int16 numParamFormatCodes = 0
+    body.write(0);
+    body.write(0); // int16 numParamValues = 0
+    body.write(0);
+    body.write(0); // int16 numResultFormatCodes = 0
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('B');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendExecute(final DataOutputStream out) throws Exception {
+    final ByteArrayOutputStream body = new ByteArrayOutputStream();
+    writeCString(body, ""); // portal name
+    body.write(0);
+    body.write(0);
+    body.write(0);
+    body.write(0); // int32 limit = 0 (no limit)
+
+    final byte[] bodyBytes = body.toByteArray();
+    out.writeByte('E');
+    out.writeInt(4 + bodyBytes.length);
+    out.write(bodyBytes);
+    out.flush();
+  }
+
+  private static void sendSync(final DataOutputStream out) throws Exception {
+    out.writeByte('S');
+    out.writeInt(4);
+    out.flush();
+  }
+
+  private record WireMessage(char type, byte[] body) {
+  }
+
+  private static WireMessage readWireMessage(final DataInputStream in) throws Exception {
+    final int type = in.readUnsignedByte();
+    final int length = in.readInt();
+    final byte[] body = new byte[length - 4];
+    in.readFully(body);
+    return new WireMessage((char) type, body);
+  }
+
+  /**
+   * Reads messages until (and including) the next {@code ReadyForQuery}, so a single Parse+Bind+Execute+Sync
+   * round trip can be inspected in full.
+   */
+  private static List<WireMessage> readUntilReadyForQuery(final DataInputStream in) throws Exception {
+    final List<WireMessage> messages = new ArrayList<>();
+    WireMessage message;
+    do {
+      message = readWireMessage(in);
+      messages.add(message);
+    } while (message.type() != 'Z');
+    return messages;
+  }
+
+  private static char readyForQueryStatusOf(final List<WireMessage> messages) {
+    final WireMessage last = messages.get(messages.size() - 1);
+    assertThat(last.type()).isEqualTo('Z');
+    return (char) last.body()[0];
+  }
+
+  private static List<Character> messageTypesOf(final List<WireMessage> messages) {
+    final List<Character> types = new ArrayList<>(messages.size());
+    for (final WireMessage message : messages)
+      types.add(message.type());
+    return types;
+  }
+
+  /**
+   * Extracts the tag from the round trip's {@code CommandComplete} ('C') message, e.g. {@code "ROLLBACK"}.
+   */
+  private static String commandCompleteTagOf(final List<WireMessage> messages) {
+    for (final WireMessage message : messages) {
+      if (message.type() == 'C') {
+        final byte[] body = message.body();
+        final int end = body.length > 0 && body[body.length - 1] == 0 ? body.length - 1 : body.length;
+        return new String(body, 0, end, StandardCharsets.UTF_8);
+      }
+    }
+    throw new AssertionError("No CommandComplete message found in " + messageTypesOf(messages));
+  }
+}


### PR DESCRIPTION
## What does this PR do?

`PostgresNetworkExecutor.parseCommand()` started with an unconditional `if (errorInTransaction) return;` before ever inspecting the query text. Once a statement erred inside an explicit `BEGIN` block, a client sending an explicit `ROLLBACK` (or `COMMIT`/`END`, which real Postgres treats identically while aborted) over the **extended query protocol** to recover from the aborted transaction never reached the BEGIN/COMMIT/ROLLBACK dispatch #6546 added to the simple-query path - `Parse` just silently dropped the message.

`Sync`'s own `errorInTransaction` branch calls `database.rollback()` and clears `errorInTransaction`, but never touches `explicitTransactionStarted`. Since `writeReadyForQueryMessage()` checks `errorInTransaction` first and `explicitTransactionStarted` second, the client ended up back at `ReadyForQuery` status `'T'` instead of `'I'` after "recovering" - the same "wedged forever" symptom #6543 fixed, just reached via the aborted-transaction path.

`parseCommand()` now recognizes a transaction-end statement (via the existing `isTransactionEndStatement`/`isCommitStatement`/`isRollbackStatement` helpers) before falling through to the early return while aborted, mirroring `queryCommand()`'s aborted-transaction dispatch:
- Rolls back the active transaction if one is active.
- Clears both `explicitTransactionStarted` and `errorInTransaction`.
- Overrides the portal's query text to `"ROLLBACK"` so `executeCommand()` later reports the `ROLLBACK` command tag regardless of whether the client sent `COMMIT`/`END`/`ROLLBACK` - real Postgres treats a `COMMIT`/`END` of an aborted transaction the same as `ROLLBACK`.
- Stores the resulting portal and writes `ParseComplete`, so the following Bind/Execute/Sync round trip runs through the ordinary (non-aborted) code paths without any changes needed in `bindCommand()`/`executeCommand()` themselves.

Every other statement while aborted still falls through to the silent `return` - `bindCommand()`'s own `errorInTransaction` check (#6545) is what turns an attempt to Bind one of those into an `ErrorResponse`.

## Motivation

Follow-up from the Claude Code review on PR #6546 (fix for #6543), filed as #6548. Without this fix, a client that reaches an aborted transaction while inside an explicit `BEGIN` over the extended protocol has no way back to idle status via extended-protocol `ROLLBACK`/`COMMIT`/`END` - and for many real clients (which re-`Parse` the unnamed statement/portal per statement) the attempt actually desyncs and closes the connection, since `Execute` always removes its portal and the dropped `Parse` leaves nothing for the following `Bind` to find.

## Related issues

Closes #6548

## Additional Notes

New regression test `Issue6548AbortedTransactionRollbackExtendedProtocolIT`:
- Reproduces the wedge: `BEGIN` (extended) -> a malformed `Parse` aborts the transaction -> `ROLLBACK` sent as its own Parse/Bind/Execute/Sync must clear both flags, reporting status `'I'`, not `'T'`.
- Verified red against the unfixed code first (git-stashed the source fix, ran the test, restored it) - it failed with a protocol desync rather than a clean assertion failure, confirming the bug is sharper than "wrong status": some clients get their connection closed outright.
- Covers `COMMIT`/`END` while aborted producing the `ROLLBACK` command tag.
- Confirms the session is fully usable again after recovery.

Full aborted-transaction/rollback regression group (`Issue6543RollbackExtendedProtocolIT`, `Issue6545AbortedTransactionExtendedQueryIT`, `Issue6457AbortedTransactionSimpleQueryIT`, plus this new class) passes: 9/9. Broader `postgresw` integration-test suite: 19/19 of the tests that ran passed; `PostgresProtocolIT` crashed its forked JVM under severe host memory pressure (unrelated general JDBC connectivity test, reproduced the same crash in isolation) - treated as a pre-existing environmental flake, not a regression from this change.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios