### PR TITLE
feat(#4894): M0 - make the OpenAPI spec a publishable, self-identifying contract

### DIFF
--- a/.github/workflows/publish-contract.yml
+++ b/.github/workflows/publish-contract.yml
@@ -1,0 +1,80 @@
+name: publish-contract
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish contract artifacts for (e.g. 26.9.1)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      ROOT_PASSWORD: contractfetch
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Start the released server
+        run: |
+          docker run -d --name arcadedb-contract -p 2480:2480 \
+            -e JAVA_OPTS="-Darcadedb.server.rootPassword=$ROOT_PASSWORD" \
+            "arcadedata/arcadedb:$TAG"
+
+      - name: Wait for readiness
+        run: |
+          for _ in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:2480/api/v1/ready || true)
+            if [ "$code" = "204" ]; then
+              echo "server ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "server did not become ready within 120s"
+          docker logs arcadedb-contract
+          exit 1
+
+      - name: Fetch the OpenAPI contract
+        run: |
+          curl -sS --fail -u "root:$ROOT_PASSWORD" \
+            http://localhost:2480/api/v1/openapi.json | jq -S . > "arcadedb-openapi-$TAG.json"
+
+      - name: Verify the contract identifies this release
+        run: |
+          declared=$(jq -r '.info.version' "arcadedb-openapi-$TAG.json")
+          if [ "$declared" != "$TAG" ]; then
+            echo "spec declares info.version=$declared but this release is $TAG"
+            exit 1
+          fi
+
+      - name: Copy the proto
+        run: cp grpc/src/main/proto/arcadedb-server.proto "arcadedb-server-$TAG.proto"
+
+      - name: Checksum both artifacts
+        run: |
+          sha256sum "arcadedb-openapi-$TAG.json" > "arcadedb-openapi-$TAG.json.sha256"
+          sha256sum "arcadedb-server-$TAG.proto" > "arcadedb-server-$TAG.proto.sha256"
+
+      - name: Attach to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$TAG" \
+            "arcadedb-openapi-$TAG.json" "arcadedb-openapi-$TAG.json.sha256" \
+            "arcadedb-server-$TAG.proto" "arcadedb-server-$TAG.proto.sha256" \
+            --clobber
+
+      - name: Stop the server
+        if: always()
+        run: docker rm -f arcadedb-contract || true

--- a/.github/workflows/publish-contract.yml
+++ b/.github/workflows/publish-contract.yml
@@ -15,8 +15,12 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
+    defaults:
+      run:
+        shell: bash
     env:
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
       ROOT_PASSWORD: contractfetch
@@ -27,7 +31,7 @@ jobs:
 
       - name: Start the released server
         run: |
-          docker run -d --name arcadedb-contract -p 2480:2480 \
+          docker run -d --name arcadedb-contract -p 127.0.0.1:2480:2480 \
             -e JAVA_OPTS="-Darcadedb.server.rootPassword=$ROOT_PASSWORD" \
             "arcadedata/arcadedb:$TAG"
 
@@ -46,7 +50,9 @@ jobs:
           exit 1
 
       - name: Fetch the OpenAPI contract
+        shell: bash
         run: |
+          set -o pipefail
           curl -sS --fail -u "root:$ROOT_PASSWORD" \
             http://localhost:2480/api/v1/openapi.json | jq -S . > "arcadedb-openapi-$TAG.json"
 

--- a/docs/superpowers/plans/2026-08-21-spec-driven-client-generation-m0-4894.md
+++ b/docs/superpowers/plans/2026-08-21-spec-driven-client-generation-m0-4894.md
@@ -1,0 +1,728 @@
+# Spec-Driven Client Generation, Milestone 0 - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the ArcadeDB OpenAPI spec and gRPC proto into a versioned, self-identifying, downloadable contract that a generated client can be built from.
+
+**Architecture:** Milestone 0 of the rescoped Epic #4894. All work is in `ArcadeData/arcadedb`. Three small spec-fidelity fixes make the generated types correct and self-identifying, then one workflow publishes the contract as GitHub Release assets so the future `ArcadeData/arcadedb-clients` repository has something versioned to generate against. No client code is written here.
+
+**Tech Stack:** Java 21, swagger-models (`io.swagger.v3.oas.models`), JUnit 5 + AssertJ, Maven, GitHub Actions, Docker.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-spec-driven-client-generation-4894-design.md`
+
+## Global Constraints
+
+- **Do not commit without the maintainer's go-ahead.** `CLAUDE.md` states "do not commit on git, I will do it after a review." Every task below ends with a commit step; confirm with the maintainer before the first one, then follow whatever cadence they set.
+- **Never add Claude as an author** of any source code or commit.
+- **No em dash characters (`—`)** in any file. Use a normal dash, a comma, or rephrase.
+- **Java style:** use `final` on variables and parameters; single-statement `if` bodies need no braces; import classes rather than using fully-qualified names.
+- **Test style:** `assertThat(x.isFoo()).isTrue();` (AssertJ). Every assertion carries an `.as(...)` explaining what breaks if it fails, matching the existing openapi contributor tests.
+- **License headers:** every new `.java` file needs the Apache 2.0 header used by its siblings. **GitHub workflow files must NOT have one.**
+- **Maven, subset builds need `-am`:** `./mvnw -o -pl server -am test`. Without `-am`, Maven resolves `arcadedb-engine` from `~/.m2` instead of the working tree, and a behaviour-only change then silently tests a stale artifact.
+- **Never pass `-Dtest` to skip a class.** It replaces Surefire's include patterns and drags `*IT` classes into the `test` phase, where they fail by the hundred. Use `-DexcludedGroups=benchmark,vector` instead.
+- **Integration tests are skipped unless `-DskipITs=false`.**
+- **Server tests bind port 2480.** Run `lsof -nP -iTCP:2480 -sTCP:LISTEN` before believing a wall of red in the `server` module; a stray server makes failures read as `403 Too many failed authentication attempts`.
+- **Count results from Maven's `Results:` summary**, not by aggregating `surefire-reports/*.txt`.
+
+---
+
+## File Map
+
+| File | Responsibility | Task |
+|---|---|---|
+| GitHub issues #4894, #4897-#4903 | Epic restructuring; new M0 tracking issues | 1 |
+| `server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java` | Stamp the real build version into `info.version` | 2 |
+| `server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java` | Assert the served spec identifies its server release | 2 |
+| `server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java` | New `headerParam` and `stringHeader` builders | 3 |
+| `server/src/test/java/com/arcadedb/server/http/handler/openapi/SpecBuildersTest.java` | Cover the new builders | 3 |
+| `server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java` | Model `arcadedb-session-id` on the transaction-bearing operations | 3 |
+| `server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java` | Assert the session header is declared where it belongs | 3 |
+| `server/src/main/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpec.java` | Model PromQL `data.result` as a `oneOf` over its three shapes | 4 |
+| `server/src/test/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpecTest.java` | Assert the three shapes are declared | 4 |
+| `.github/workflows/publish-contract.yml` | Publish the OpenAPI spec and proto as release assets | 5 |
+
+---
+
+## Task 1: Restructure Epic #4894 and file the M0 tracking issues
+
+**Context:** This task comes first because tasks 2 through 5 use `feat(#N)` and `fix(#N)` commit messages that reference the issues created here. It is project-management work with no code and no test cycle; its verification is that the issues read correctly.
+
+**Files:** none. All changes are GitHub issues via `gh`.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: four issue numbers, referred to below as `$ISSUE_VERSION` (M0-1), `$ISSUE_SESSION` (M0-6), `$ISSUE_PROMQL` (M0-3), and `$ISSUE_CONTRACT` (M0-2). Record them at the top of your working notes; later tasks need them.
+
+- [ ] **Step 1: Read the current Epic body so nothing worth keeping is lost**
+
+```bash
+gh issue view 4894 --repo ArcadeData/arcadedb --json body -q .body > /tmp/4894-old-body.md
+wc -l /tmp/4894-old-body.md
+```
+
+Expected: the existing Epic body, roughly 90 lines. Keep the "Two specs, two personas" and "Non-goals" sections; they survive the rescope unchanged.
+
+- [ ] **Step 2: Write the new Epic body**
+
+Write `/tmp/4894-new-body.md` containing the M0/M1/M2/M3+ structure from the spec. It must state, at minimum: the two-repository topology and why (#4896 already gates spec-versus-routes, so a client repo risks staleness rather than incorrectness); that the contract is published as versioned release assets; the M0 checklist referencing the four issues created in step 4; that M1 is the TypeScript client for HTTP and gRPC in `ArcadeData/arcadedb-clients`; that M2 is the non-blocking smoke job; and that M3+ languages are deliberately undesigned until M1 and M2 are proven. Link the spec document.
+
+- [ ] **Step 3: Apply the new body**
+
+```bash
+gh issue edit 4894 --repo ArcadeData/arcadedb --body-file /tmp/4894-new-body.md
+```
+
+Expected: `https://github.com/ArcadeData/arcadedb/issues/4894`.
+
+- [ ] **Step 4: File the four M0 issues**
+
+```bash
+gh issue create --repo ArcadeData/arcadedb \
+  --title "OpenAPI: info.version is hardcoded to 1.0.0, so the spec cannot identify its server release" \
+  --label enhancement \
+  --body "Part of #4894 (M0-1). \`OpenApiSpecGenerator.createApiInfo()\` calls \`info.setVersion(\"1.0.0\")\`, so a client generated from the spec has no way to record which server release produced it. Set it from \`Constants.getVersion()\`."
+
+gh issue create --repo ArcadeData/arcadedb \
+  --title "OpenAPI: the arcadedb-session-id header is undocumented, so generated clients cannot use transactions" \
+  --label bug \
+  --body "Part of #4894 (M0-6). \`PostBeginHandler\` returns \`arcadedb-session-id\` as a response header and \`AbstractServerHttpHandler\` reads it as a request header, but the spec models it nowhere: not on \`beginTransaction\`, \`commitTransaction\`, \`rollbackTransaction\`, \`executeQueryPost\`, or \`executeCommand\`. A client generated from the spec therefore cannot open, use, or close a transaction in a typed way. Note this is invisible to the #4896 anti-drift test, which compares routes rather than payload and header shapes."
+
+gh issue create --repo ArcadeData/arcadedb \
+  --title "OpenAPI: PromQL data.result is an opaque object array, so generated clients get untyped results" \
+  --label enhancement \
+  --body "Part of #4894 (M0-3). \`PrometheusApiSpec.createDataResponseSchema()\` declares \`data.result\` as an array of bare \`type: object\`, with the three real shapes (vector, matrix, scalar) described only in prose. Model them as a \`oneOf\` so a generated client can narrow on \`resultType\`."
+
+gh issue create --repo ArcadeData/arcadedb \
+  --title "Publish the OpenAPI spec and gRPC proto as versioned release assets" \
+  --label enhancement \
+  --body "Part of #4894 (M0-2). The OpenAPI spec exists only behind a running server and the proto only in the source tree, so the \`arcadedb-clients\` repository has no versioned contract to generate against. Publish both, with sha256 files, as GitHub Release assets on \`release: [published]\`, reusing the \`gh release upload\` pattern already in \`native-image.yml\`."
+```
+
+Expected: four issue URLs. Record the numbers.
+
+- [ ] **Step 5: Close the superseded child issues**
+
+For each of 4897, 4898, 4899, 4900, 4901, 4902, 4903, post a comment saying what replaced it, then close as not planned. #4897 and #4900 merge into the single M1 TypeScript deliverable; #4899 splits into the proto half of M0-2 plus `buf generate` in the clients repo; #4898, #4901, #4902 and #4903 defer to M3+.
+
+```bash
+for n in 4897 4898 4899 4900 4901 4902 4903; do
+  gh issue comment "$n" --repo ArcadeData/arcadedb \
+    --body "Superseded by the rescope of #4894. See the design at \`docs/superpowers/specs/2026-08-21-spec-driven-client-generation-4894-design.md\`. Closing in favour of the milestone structure tracked on the Epic."
+  gh issue close "$n" --repo ArcadeData/arcadedb --reason "not planned"
+done
+```
+
+Expected: seven comments and seven closures.
+
+- [ ] **Step 6: Verify the Epic renders correctly**
+
+```bash
+gh issue view 4894 --repo ArcadeData/arcadedb
+```
+
+Expected: the M0 checklist links the four new issues, and the closed children show as struck through where referenced.
+
+---
+
+## Task 2: Stamp the real server version into the OpenAPI spec
+
+**Context:** `info.version` is hardcoded to `"1.0.0"`. A generated client must be able to record which server release produced its types, and Task 5's workflow gates on this value matching the release tag.
+
+**Files:**
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java` (the `createApiInfo()` method, around line 110-128)
+- Test: `server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java`
+
+**Interfaces:**
+- Consumes: `$ISSUE_VERSION` from Task 1.
+- Produces: the served spec's `info.version` equals `com.arcadedb.Constants.getVersion()`. Task 5's workflow depends on this.
+
+**Why an IT rather than a unit test:** `OpenApiSpecGenerator`'s constructor takes an `HttpServer`, and `createApiInfo()` is private, so there is no seam for a unit test. `OpenApiSpecGenerationIT` already boots a server and fetches the spec over HTTP, which is also the exact path Task 5's workflow uses.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `OpenApiSpecGenerationIT`, and add `import com.arcadedb.Constants;` to the imports:
+
+```java
+  @Test
+  void specDeclaresTheRunningServerVersion() throws Exception {
+    final String specContent = getOpenApiSpec();
+    final SwaggerParseResult result = new OpenAPIV3Parser().readContents(specContent, null, new ParseOptions());
+    final Info info = result.getOpenAPI().getInfo();
+
+    assertThat(info.getVersion())
+        .as("a generated client must record which server release produced its types")
+        .isEqualTo(Constants.getVersion());
+
+    assertThat(info.getVersion())
+        .as("the placeholder must be gone, not merely coincidentally equal")
+        .isNotEqualTo("1.0.0");
+  }
+```
+
+`Info`, `OpenAPIV3Parser`, `ParseOptions`, `SwaggerParseResult` and `getOpenApiSpec()` are already present in this file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+lsof -nP -iTCP:2480 -sTCP:LISTEN
+./mvnw -o -pl server -am verify -DskipITs=false -Dit.test=OpenApiSpecGenerationIT -DfailIfNoTests=false
+```
+
+Expected: FAIL on `specDeclaresTheRunningServerVersion`, reporting `expected: "26.9.1-SNAPSHOT" but was: "1.0.0"` (the exact version follows the current `pom.xml`). Confirm from Maven's `Results:` summary that the IT actually ran; a run reporting zero tests is a harness problem, not a pass.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `OpenApiSpecGenerator.java`, add `import com.arcadedb.Constants;` and change the one line in `createApiInfo()`:
+
+```java
+    info.setVersion(Constants.getVersion());
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+./mvnw -o -pl server -am verify -DskipITs=false -Dit.test=OpenApiSpecGenerationIT -DfailIfNoTests=false
+```
+
+Expected: PASS, with the full `OpenApiSpecGenerationIT` suite green (15 tests before this change, 16 after).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java \
+        server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
+git commit -m "feat(#$ISSUE_VERSION): stamp the running server version into the OpenAPI spec"
+```
+
+---
+
+## Task 3: Model the `arcadedb-session-id` header
+
+**Context:** `PostBeginHandler` returns the session id as a response header and `AbstractServerHttpHandler` reads it as a request header, but the spec models it nowhere. Without it a generated client cannot open, use, or close a transaction in a typed way. This is the single change that unblocks the `transaction(fn)` facade in M1.
+
+**Files:**
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java`
+- Test: `server/src/test/java/com/arcadedb/server/http/handler/openapi/SpecBuildersTest.java`
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java`
+- Test: `server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java`
+
+**Interfaces:**
+- Consumes: `$ISSUE_SESSION` from Task 1.
+- Produces: `SpecBuilders.headerParam(String name, String description, boolean required)` returning `io.swagger.v3.oas.models.parameters.Parameter`, and `SpecBuilders.stringHeader(String description)` returning `io.swagger.v3.oas.models.headers.Header`. Both are used only by `CoreApiSpec` today but are domain-free and available to any contributor.
+
+- [ ] **Step 1: Determine whether the header is mandatory on commit and rollback**
+
+Do not guess this. Handler shapes in this codebase routinely contradict what the route name implies; the #4895 effort produced 38 such corrections, every one found by reading the handler.
+
+```bash
+sed -n '1,120p' server/src/main/java/com/arcadedb/server/http/handler/PostCommitHandler.java
+sed -n '1,120p' server/src/main/java/com/arcadedb/server/http/handler/PostRollbackHandler.java
+sed -n '235,255p;435,450p' server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+```
+
+Decide: if a commit or rollback without the header is rejected, declare the parameter `required = true`; if it is tolerated, declare `required = false`. Record which you found and why in the commit message. On `executeQueryPost` and `executeCommand` the parameter is **always** `required = false`, because calls outside a transaction must remain legal.
+
+- [ ] **Step 2: Write the failing builder test**
+
+Add to `SpecBuildersTest`:
+
+```java
+  @Test
+  void headerParamDeclaresAStringHeaderParameter() {
+    final Parameter param = SpecBuilders.headerParam("x-example", "An example header", true);
+
+    assertThat(param.getIn())
+        .as("a header parameter that is not in:header binds as a query string by default")
+        .isEqualTo("header");
+    assertThat(param.getRequired()).isTrue();
+    assertThat(param.getSchema().getType()).isEqualTo("string");
+  }
+
+  @Test
+  void stringHeaderDescribesAResponseHeader() {
+    final Header header = SpecBuilders.stringHeader("An example response header");
+
+    assertThat(header.getDescription()).isEqualTo("An example response header");
+    assertThat(header.getSchema().getType()).isEqualTo("string");
+  }
+```
+
+Add `import io.swagger.v3.oas.models.headers.Header;` and `import io.swagger.v3.oas.models.parameters.Parameter;` to the test if not already present.
+
+- [ ] **Step 3: Run to verify it fails**
+
+```bash
+./mvnw -o -pl server -am test -Dsurefire.includes='**/openapi/SpecBuildersTest.java'
+```
+
+Expected: compilation failure, `cannot find symbol: method headerParam`.
+
+- [ ] **Step 4: Implement the builders**
+
+In `SpecBuilders.java`, add `import io.swagger.v3.oas.models.headers.Header;` and these two methods next to `queryParam`:
+
+```java
+  public static Parameter headerParam(final String name, final String description, final boolean required) {
+    final Parameter param = new Parameter();
+    param.setName(name);
+    param.setIn("header");
+    param.setRequired(required);
+    param.setDescription(description);
+    param.setSchema(new Schema<>().type("string"));
+    return param;
+  }
+
+  public static Header stringHeader(final String description) {
+    final Header header = new Header();
+    header.setDescription(description);
+    header.setSchema(new Schema<>().type("string"));
+    return header;
+  }
+```
+
+- [ ] **Step 5: Run to verify the builder tests pass**
+
+```bash
+./mvnw -o -pl server -am test -Dsurefire.includes='**/openapi/SpecBuildersTest.java'
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write the failing CoreApiSpec tests**
+
+Add to `CoreApiSpecTest`. Note these assert the **literal** header string rather than importing `HttpSessionManager.ARCADEDB_SESSION_ID`: the wire name is the contract, and a test that reads the same constant as the production code would stay green through a rename that breaks every client.
+
+```java
+  @Test
+  void beginDeclaresTheSessionIdResponseHeader() {
+    final Operation post = openAPI.getPaths().get("/api/v1/begin/{database}").getPost();
+
+    assertThat(post.getResponses().get("200").getHeaders())
+        .as("a client that cannot read the session id cannot use the transaction it just opened")
+        .containsKey("arcadedb-session-id");
+  }
+
+  @Test
+  void commitAndRollbackDeclareTheSessionIdRequestHeader() {
+    for (final String path : List.of("/api/v1/commit/{database}", "/api/v1/rollback/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+      final Parameter header = post.getParameters().stream()
+          .filter(p -> "arcadedb-session-id".equals(p.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("no session header declared on " + path));
+
+      assertThat(header.getIn())
+          .as("the session id travels as a header on " + path)
+          .isEqualTo("header");
+    }
+  }
+
+  @Test
+  void queryAndCommandAcceptAnOptionalSessionIdHeader() {
+    for (final String path : List.of("/api/v1/query/{database}", "/api/v1/command/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+      final Parameter header = post.getParameters().stream()
+          .filter(p -> "arcadedb-session-id".equals(p.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("no session header declared on " + path));
+
+      assertThat(header.getRequired())
+          .as("running outside a transaction must remain legal on " + path)
+          .isFalse();
+    }
+  }
+```
+
+`List`, `Operation` and `Parameter` are already imported in this file.
+
+- [ ] **Step 7: Run to verify they fail**
+
+```bash
+./mvnw -o -pl server -am test -Dsurefire.includes='**/openapi/CoreApiSpecTest.java'
+```
+
+Expected: three failures. `beginDeclaresTheSessionIdResponseHeader` fails with the headers map null or empty; the other two fail with `AssertionError: no session header declared on ...`.
+
+- [ ] **Step 8: Implement the spec changes**
+
+In `CoreApiSpec.java`, add these imports:
+
+```java
+import com.arcadedb.server.http.HttpSessionManager;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+```
+
+(`ApiResponses` may already be imported. `Parameter` is already imported.)
+
+Add these constants to the class:
+
+```java
+  private static final String SESSION_HEADER = HttpSessionManager.ARCADEDB_SESSION_ID;
+
+  private static final String SESSION_REQUEST_DESCRIPTION = """
+      Session id returned by 'beginTransaction'. Present it on every call that must run inside that \
+      transaction, and on the commit or rollback that ends it. Omit it to run outside a transaction.""";
+```
+
+Add the begin-specific response builder next to `createTransactionResponses()`:
+
+```java
+  /**
+   * The transaction responses plus the session-id header that 'begin' alone returns. Built from a
+   * fresh {@link #createTransactionResponses()} every call, so the header is never attached to the
+   * shared instance that commit and rollback also use.
+   */
+  private ApiResponses createBeginResponses() {
+    final ApiResponses responses = createTransactionResponses();
+    responses.get("200").addHeaderObject(SESSION_HEADER, SpecBuilders.stringHeader("""
+        Session id identifying the transaction just opened. Present it on the '%s' request header \
+        of every subsequent call that belongs to this transaction.""".formatted(SESSION_HEADER)));
+    return responses;
+  }
+```
+
+In `createBeginPath()`, change the responses line to:
+
+```java
+    postOp.setResponses(createBeginResponses());
+```
+
+In `createCommitPath()` and `createRollbackPath()`, add after the `pathParam` line (using the `required` value you determined in Step 1):
+
+```java
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, true));
+```
+
+In `createPostQueryPath()`, `createCommandPath()` and `createGetQueryPath()`, add after the `pathParam` line:
+
+```java
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
+```
+
+In `createGetQueryPath()` the operation variable is a GET, so use whatever local name that method already uses rather than `postOp`. The GET query path is included because it extends the same base handler and therefore honours the same session header; the spec document lists five operations, and this is a sixth added for consistency.
+
+- [ ] **Step 9: Run to verify the tests pass**
+
+```bash
+./mvnw -o -pl server -am test -Dsurefire.includes='**/openapi/*Test.java'
+```
+
+Expected: the whole openapi contributor package green. Run the wider package, not just `CoreApiSpecTest`: `ApiSpecPathConstantsTest` and the IT assert operation inventories, and adding parameters must not disturb them.
+
+- [ ] **Step 10: Run the integration test**
+
+```bash
+lsof -nP -iTCP:2480 -sTCP:LISTEN
+./mvnw -o -pl server -am verify -DskipITs=false -Dit.test=OpenApiSpecGenerationIT -DfailIfNoTests=false
+```
+
+Expected: PASS. This confirms the assembled spec still parses cleanly and has no unresolved refs.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java \
+        server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java \
+        server/src/test/java/com/arcadedb/server/http/handler/openapi/SpecBuildersTest.java \
+        server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+git commit -m "fix(#$ISSUE_SESSION): document the arcadedb-session-id header on the transaction operations"
+```
+
+---
+
+## Task 4: Model PromQL result shapes as a `oneOf`
+
+**Context:** `data.result` is declared as an array of bare `type: object`, with the vector, matrix and scalar shapes described only in prose. A generated client gets untyped entries, which defeats the PromQL half of the M1 facade.
+
+**Files:**
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpec.java` (the `createDataResponseSchema()` method)
+- Test: `server/src/test/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpecTest.java`
+
+**Interfaces:**
+- Consumes: `$ISSUE_PROMQL` from Task 1.
+- Produces: the `PromQLDataResponse` component's `data.result` property carries a three-branch `oneOf`.
+
+- [ ] **Step 1: Verify the three shapes against the handler**
+
+The existing prose describes vector entries as carrying `metric` and a single `value` pair, matrix entries as carrying `metric` and a list of `values` pairs, and a scalar as replacing the array with a single pair. Confirm this against the code before encoding it as structure:
+
+```bash
+grep -rn "resultType\|vector\|matrix\|scalar" server/src/main/java/com/arcadedb/server/http/handler/GetPromQLQueryHandler.java | head -30
+```
+
+If the handler disagrees with the prose, follow the handler and note the discrepancy in the commit message.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `PrometheusApiSpecTest`:
+
+```java
+  @Test
+  void promQlResultDeclaresItsThreeShapes() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+
+    assertThat(result.getOneOf())
+        .as("vector, matrix and scalar are structurally different; a client must narrow on resultType")
+        .hasSize(3);
+  }
+
+  @Test
+  void promQlVectorEntriesCarryMetricAndValue() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+    final Schema<?> vectorEntry = result.getOneOf().get(0).getItems();
+
+    assertThat(vectorEntry.getProperties().keySet())
+        .as("an instant sample is a labelled metric plus one [timestamp, value] pair")
+        .containsExactlyInAnyOrder("metric", "value");
+  }
+```
+
+Confirm the setup block in this test class matches `CoreApiSpecTest`'s (`openAPI.setPaths(new Paths()); openAPI.setComponents(new Components()); new PrometheusApiSpec().contribute(openAPI);`) and that the component really is registered as `PromQLDataResponse`; adjust the key if the contributor uses a different name.
+
+- [ ] **Step 3: Run to verify it fails**
+
+```bash
+./mvnw -o -pl server -am test -Dsurefire.includes='**/openapi/PrometheusApiSpecTest.java'
+```
+
+Expected: FAIL, `getOneOf()` is null because `result` is currently a plain array.
+
+- [ ] **Step 4: Implement the schema**
+
+Replace `createDataResponseSchema()` in `PrometheusApiSpec.java` with:
+
+```java
+  private Schema<?> createDataResponseSchema() {
+    final Schema<String> resultType = SpecBuilders.string(
+        "Shape of 'result': a vector of instant samples, a matrix of range samples, or a scalar");
+    resultType.setEnum(List.of("vector", "matrix", "scalar"));
+
+    final Schema<Object> vectorEntry = SpecBuilders.object("One instant sample");
+    vectorEntry.addProperty("metric", SpecBuilders.object("Label map, including the '__name__' label"));
+    vectorEntry.addProperty("value", samplePair());
+
+    final Schema<Object> matrixEntry = SpecBuilders.object("One range series");
+    matrixEntry.addProperty("metric", SpecBuilders.object("Label map, including the '__name__' label"));
+    matrixEntry.addProperty("values", SpecBuilders.arrayOf(samplePair(), "Samples ordered by timestamp"));
+
+    final Schema<Object> result = new Schema<>();
+    result.setDescription("""
+        Evaluation result, shaped by 'resultType': an array of instant samples when 'vector', an \
+        array of range series when 'matrix', and a single [timestamp, value] pair when 'scalar'.""");
+    result.setOneOf(List.of(
+        SpecBuilders.arrayOf(vectorEntry, "Entries when resultType is 'vector'"),
+        SpecBuilders.arrayOf(matrixEntry, "Entries when resultType is 'matrix'"),
+        samplePair()));
+
+    final Schema<Object> data = SpecBuilders.object("Evaluation result");
+    data.addProperty("resultType", resultType);
+    data.addProperty("result", result);
+
+    final Schema<Object> schema = SpecBuilders.object("Prometheus query response");
+    schema.addProperty("status", SpecBuilders.string("Always 'success' on a 200"));
+    schema.addProperty("data", data);
+    return schema;
+  }
+
+  /**
+   * A fresh [timestamp, value] pair schema on every call. Returning a shared instance would place
+   * one mutable schema object at several points in the document, the same defect class that put one
+   * ApiResponse under two status keys during #4895.
+   */
+  private Schema<?> samplePair() {
+    return SpecBuilders.arrayOf(
+        SpecBuilders.object("Unix timestamp in seconds, then the sample value as a string"),
+        "One [timestamp, value] pair");
+  }
+```
+
+- [ ] **Step 5: Run to verify the tests pass**
+
+```bash
+./mvnw -o -pl server -am test -Dsurefire.includes='**/openapi/*Test.java'
+```
+
+Expected: the whole openapi contributor package green.
+
+- [ ] **Step 6: Run the integration test to confirm refs still resolve**
+
+```bash
+lsof -nP -iTCP:2480 -sTCP:LISTEN
+./mvnw -o -pl server -am verify -DskipITs=false -Dit.test=OpenApiSpecGenerationIT -DfailIfNoTests=false
+```
+
+Expected: PASS, including the existing zero-unresolved-refs assertion. A malformed `oneOf` surfaces here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpec.java \
+        server/src/test/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpecTest.java
+git commit -m "feat(#$ISSUE_PROMQL): model the PromQL vector, matrix and scalar result shapes"
+```
+
+---
+
+## Task 5: Publish the contract as release assets
+
+**Context:** The OpenAPI spec exists only behind a running server and the proto only in the source tree. The `arcadedb-clients` repository needs a versioned, downloadable contract. This reuses the `release: [published]` plus `gh release upload` pattern already proven by `native-image.yml`.
+
+**Files:**
+- Create: `.github/workflows/publish-contract.yml`
+
+**Interfaces:**
+- Consumes: `$ISSUE_CONTRACT` from Task 1, and Task 2's guarantee that `info.version` equals the server version.
+- Produces: four assets on every published release: `arcadedb-openapi-<tag>.json`, `arcadedb-server-<tag>.proto`, and a `.sha256` for each.
+
+- [ ] **Step 1: Create the workflow**
+
+No license header on workflow files.
+
+```yaml
+name: publish-contract
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish contract artifacts for (e.g. 26.9.1)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      ROOT_PASSWORD: contractfetch
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Start the released server
+        run: |
+          docker run -d --name arcadedb-contract -p 2480:2480 \
+            -e JAVA_OPTS="-Darcadedb.server.rootPassword=$ROOT_PASSWORD" \
+            "arcadedata/arcadedb:$TAG"
+
+      - name: Wait for readiness
+        run: |
+          for _ in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:2480/api/v1/ready || true)
+            if [ "$code" = "204" ]; then
+              echo "server ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "server did not become ready within 120s"
+          docker logs arcadedb-contract
+          exit 1
+
+      - name: Fetch the OpenAPI contract
+        run: |
+          curl -sS --fail -u "root:$ROOT_PASSWORD" \
+            http://localhost:2480/api/v1/openapi.json | jq -S . > "arcadedb-openapi-$TAG.json"
+
+      - name: Verify the contract identifies this release
+        run: |
+          declared=$(jq -r '.info.version' "arcadedb-openapi-$TAG.json")
+          if [ "$declared" != "$TAG" ]; then
+            echo "spec declares info.version=$declared but this release is $TAG"
+            exit 1
+          fi
+
+      - name: Copy the proto
+        run: cp grpc/src/main/proto/arcadedb-server.proto "arcadedb-server-$TAG.proto"
+
+      - name: Checksum both artifacts
+        run: |
+          sha256sum "arcadedb-openapi-$TAG.json" > "arcadedb-openapi-$TAG.json.sha256"
+          sha256sum "arcadedb-server-$TAG.proto" > "arcadedb-server-$TAG.proto.sha256"
+
+      - name: Attach to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$TAG" \
+            "arcadedb-openapi-$TAG.json" "arcadedb-openapi-$TAG.json.sha256" \
+            "arcadedb-server-$TAG.proto" "arcadedb-server-$TAG.proto.sha256" \
+            --clobber
+
+      - name: Stop the server
+        if: always()
+        run: docker rm -f arcadedb-contract || true
+```
+
+`jq -S` sorts keys so the published contract is byte-stable across runs, which is what makes the clients repo's drift diff meaningful rather than noisy.
+
+- [ ] **Step 2: Validate the workflow parses**
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/publish-contract.yml')); print('valid')"
+```
+
+Expected: `valid`.
+
+- [ ] **Step 3: Rehearse the fetch locally against a dev image**
+
+The workflow cannot be exercised end to end before a release exists that contains Task 2's fix. Rehearse everything except `gh release upload`:
+
+```bash
+cd package && ../mvnw install -Pdocker -DskipTests && cd ..
+docker run -d --name arcadedb-contract-local -p 2480:2480 \
+  -e JAVA_OPTS="-Darcadedb.server.rootPassword=contractfetch" \
+  arcadedata/arcadedb:latest
+sleep 30
+curl -sS --fail -u root:contractfetch http://localhost:2480/api/v1/openapi.json | jq -S . > /tmp/contract.json
+jq -r '.info.version' /tmp/contract.json
+jq '.paths | keys | length' /tmp/contract.json
+docker rm -f arcadedb-contract-local
+```
+
+Expected: `info.version` prints the working tree's version rather than `1.0.0`, and the path count is 61. Note the image tag used here is `latest` built from your tree, not a released tag.
+
+- [ ] **Step 4: Confirm the version gate actually gates**
+
+Run the workflow via `workflow_dispatch` against the released tag `26.8.1`. It **must fail** at "Verify the contract identifies this release", because 26.8.1 predates Task 2 and still declares `1.0.0`. That failure is the proof the gate works; do not weaken it. The first successful run happens on the first release cut after this branch merges.
+
+```bash
+gh workflow run publish-contract.yml --repo ArcadeData/arcadedb -f tag=26.8.1
+gh run list --repo ArcadeData/arcadedb --workflow=publish-contract.yml --limit 1
+```
+
+Expected: a failed run whose failing step is the version verification, with `spec declares info.version=1.0.0 but this release is 26.8.1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/publish-contract.yml
+git commit -m "feat(#$ISSUE_CONTRACT): publish the OpenAPI spec and proto as release assets"
+```
+
+---
+
+## Done criteria for M0
+
+- [ ] Epic #4894 describes the M0/M1/M2/M3+ structure; #4897 through #4903 are closed as superseded.
+- [ ] `/api/v1/openapi.json` reports the running server's version.
+- [ ] `beginTransaction` declares the `arcadedb-session-id` response header; `commitTransaction`, `rollbackTransaction`, `executeQuery`, `executeQueryPost` and `executeCommand` declare it as a request header.
+- [ ] `PromQLDataResponse`'s `data.result` carries a three-branch `oneOf`.
+- [ ] `publish-contract.yml` exists, parses, and its version gate has been shown to fail on a pre-fix tag.
+- [ ] `./mvnw -o -pl server -am verify -DskipITs=false -Dit.test=OpenApiSpecGenerationIT` is green.
+
+## Deliberately not in this plan
+
+- **M0-4, the `ai/chat` SSE mismatch.** `mode=auto` returns `text/event-stream` while the spec documents JSON, and OpenAPI 3.0 cannot express a response content type selected by a request-body value. Fixing it needs a server behaviour change (split the operation, or move to Accept-header negotiation), which is a design decision of its own. It gates nothing in M1 and belongs in its own issue.
+- **M1 and M2.** M1 is planned separately once M0 has landed and a real contract artifact exists, so that plan can be concrete about the generated types instead of guessing at them.

--- a/docs/superpowers/specs/2026-08-21-spec-driven-client-generation-4894-design.md
+++ b/docs/superpowers/specs/2026-08-21-spec-driven-client-generation-4894-design.md
@@ -1,0 +1,306 @@
+# Spec-Driven Client Generation: Rescoped Design (Epic #4894)
+
+**Status:** design approved, plan pending
+**Date:** 2026-08-21
+**Supersedes:** the original Epic #4894 body and child issues #4897 through #4903
+
+## 1. Why this rescope
+
+The original Epic proposed generating clients for six-plus languages, all hosted inside the
+`ArcadeData/arcadedb` monorepo, with a `fetch`-native TypeScript client (#4897) as the priority
+deliverable. Two things changed that plan.
+
+First, repository topology. The `ArcadeData` org already runs a strongly polyrepo layout: nearly
+everything that is not the Java server lives in its own repository, including things that are
+effectively clients (`arcadedb-grafana-datasource`, `langchain-arcadedb`, `llama-index-arcadedb`,
+`arcadedb-haystack`, and the TypeScript monorepo `arcadedb-claude`). There is also a direct, recent
+precedent for extraction: `arcadedb-helm` was pulled out of `k8s/helm/` with a full written plan,
+GitHub Pages serving, and a manual-dispatch release workflow. Hosting six language toolchains,
+lockfiles, and Dependabot lanes inside the Java repository would run against that grain.
+
+Second, the risk of splitting turned out to be smaller than it first appears. The obvious objection
+is that a separate repository cannot block a server PR that changes the API. But #4896 already
+shipped, and it asserts on every server PR that the OpenAPI spec matches the routes Undertow
+actually registers. That gate is language-independent and stays in the server repository. What a
+separate client repository can suffer is therefore *staleness* (generated from an older contract),
+not *incorrectness* (generated from a lying contract). Staleness is bounded by versioned contract
+artifacts, scheduled regeneration, and one smoke job.
+
+The scope also narrows. Rather than fanning out to six languages at once, this rescope builds one
+repository and one language (TypeScript, covering both HTTP and gRPC), proves the infrastructure,
+and only then designs the remaining languages.
+
+## 2. Decisions
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Client shape | Generated core plus a thin hand-written ergonomic facade; raw client exported as an escape hatch |
+| 2 | Type generation | Generated types committed to git, freshness enforced by a CI drift check |
+| 3 | Publish boundary | Build and CI-wire now; publishing behind a manual `workflow_dispatch` |
+| 4 | Facade width | Data plane, discovery and lifecycle, time series, and the Grafana/PromQL read paths |
+| 5 | Spec fidelity gaps | Fixed in Java in the server repository, so every future language inherits the fix |
+| 6 | gRPC transport target | Node, Bun, and Deno. Browser gRPC deferred |
+| 7 | Packaging | Two packages: `@arcadedb/client` and `@arcadedb/client-grpc` |
+| 8 | Identity | Repo `ArcadeData/arcadedb-clients`; npm scope `@arcadedb` |
+| 9 | Epic restructuring | Epic stays in `arcadedb` as a cross-repo umbrella |
+
+## 3. Architecture and the contract boundary
+
+Two repositories with one explicit contract between them.
+
+**`ArcadeData/arcadedb` owns the contract.** It is the only place the API surface is defined, and
+#4896's anti-drift test already proves that definition matches the registered routes on every PR.
+
+**`ArcadeData/arcadedb-clients` owns the consumers.** It never guesses at the API. It consumes two
+artifacts attached to the GitHub Release for a given server version:
+
+- `arcadedb-openapi-<version>.json`, fetched from a running server of exactly that version
+- `arcadedb-server-<version>.proto`, copied verbatim from `grpc/src/main/proto/`
+
+This reuses infrastructure that already exists. Releases are created manually, and
+`native-image.yml` already triggers on `release: [published]` and attaches assets with
+`gh release upload`. Publishing the contract is one more workflow on the same trigger.
+
+### Known limitation
+
+A server PR that changes a *payload shape* without changing a *route* is invisible to #4896. The
+mitigation is the M2 smoke job, which must exercise the facade surface rather than a token single
+query. Section 9 records a concrete instance of this class of defect that was found while drafting
+this design.
+
+## 4. M0: work that stays in `arcadedb`
+
+| Item | Description | Blocks M1? |
+|---|---|---|
+| M0-1 | Stamp the real build version into `info.version`, currently hardcoded to `"1.0.0"` | No |
+| M0-2 | Publish `openapi.json` and the proto as release assets, with `.sha256` files | Yes |
+| M0-3 | Model PromQL `data.result` as an `anyOf` over vector/matrix/scalar (`oneOf` cannot work: an empty result array validates against every branch) | Yes, for the facade |
+| M0-4 | Settle `ai/chat`: `mode=auto` returns `text/event-stream` while the spec documents JSON | No |
+| M0-5 | Rewrite Epic #4894; close #4897 through #4903 as superseded | No |
+| M0-6 | Model the `arcadedb-session-id` header on `begin`, `commit`, `rollback`, `query`, `command` | Yes |
+
+M0-1, M0-3, and M0-6 are small, independent, and coverable by the existing per-domain contributor
+unit tests. M0-2 should land last so the first published contract already carries the fixes. M0-4
+carries design risk and is deliberately off the critical path.
+
+Plugin routes are declared statically in `PluginApiSpec`, so a default server yields the complete
+63-operation spec without loading the Raft or metrics plugins.
+
+## 5. The `arcadedb-clients` repository
+
+```
+arcadedb-clients/
+├── package.json                 # npm workspaces root, private
+├── contracts/
+│   ├── arcadedb-openapi-<ver>.json       # committed, from the release asset
+│   └── arcadedb-server-<ver>.proto       # committed, from the release asset
+├── packages/
+│   ├── client/                  # @arcadedb/client
+│   │   └── src/generated/schema.d.ts     # committed, from openapi-typescript
+│   └── client-grpc/             # @arcadedb/client-grpc
+│       └── src/gen/                      # committed, from buf generate
+├── e2e/                         # testcontainers suites for both packages
+├── scripts/                     # fetch-contract, generate
+└── .github/workflows/
+```
+
+**npm workspaces, not pnpm.** The org already runs npm everywhere, CI already caches it, and
+Dependabot supports npm workspaces natively. Not worth a new tool for two packages.
+
+**`tsc` only, ESM-only, no bundler.** A thin library ships unbundled ES modules and lets the
+consumer's bundler tree-shake. Bundling would make tree-shaking harder, not easier. ESM-only avoids
+the dual-package hazard, and every named target speaks ESM natively. Accepted cost: consumers on
+CommonJS Node cannot `require()` these packages.
+
+**Both the contract and the generated code are committed.** The contract makes generation
+reproducible offline and turns a version bump into a reviewable diff. The generated code makes the
+repository buildable and editable without Docker, which matters because the facade is hand-written
+TypeScript that must typecheck against those types.
+
+**Two independent checks.** A fast `npm run generate && git diff --exit-code` on every PR proves the
+committed generated code matches the committed contract, with no network and no Docker. A separate
+scheduled job fetches the newest release's contract and opens a PR when it differs. Splitting them
+keeps the PR gate fast and delivers "the server moved" as a reviewable PR rather than a red build.
+
+## 6. `@arcadedb/client` (HTTP)
+
+One runtime dependency: `openapi-fetch`. Everything else is types, generated by `openapi-typescript`.
+
+```ts
+const db = createClient({
+  baseUrl: "https://host:2480",
+  auth: basicAuth("root", pw),        // or bearerAuth("at-...")
+});
+```
+
+`createClient` returns the facade with the raw `openapi-fetch` client exposed as `.raw`, keeping the
+other 50-odd operations reachable with full generated types.
+
+Facade surface:
+
+- **Data plane:** `query`, `command`, `transaction(fn)`
+- **Discovery and lifecycle:** `listDatabases`, `exists`, `serverInfo`, `health`, `ready`
+- **Time series:** `ts.write`, `ts.query`, the latter narrowing the existing `oneOf` between
+  aggregated and raw responses into a discriminated union
+- **Dashboards:** `grafana.query`, `promql.query`, `promql.queryRange`, `promql.labels`,
+  `promql.series`, each returning its own envelope rather than one union of four
+
+`transaction(fn)` is the piece that earns the facade. It calls `begin`, reads the session id from the
+response header, threads it through every call made on the handle passed to `fn`, and commits on
+return or rolls back on throw in a `finally`. It depends entirely on M0-6.
+
+**Errors.** Any non-2xx becomes a thrown `ArcadeDBError` carrying `status` plus the server's `error`,
+`exception`, `detail`, and `requestId`. One deliberate exception: `exists` returns
+`200 {result:false}` both when a database is absent and when the caller is unauthorized. The facade
+returns the boolean and documents that it cannot distinguish the two cases, rather than inventing a
+certainty the server does not provide.
+
+**Tree-shaking.** `sideEffects: false` plus per-module ESM output. Importing only `query` must not
+pull the PromQL or Grafana modules into a bundle; this is an explicit size-check test.
+
+## 7. `@arcadedb/client-grpc`
+
+**Codegen.** `buf generate` over the committed proto using `protoc-gen-es`. Connect-ES v2 and
+protobuf-es v2 generate message types and service descriptors from that single plugin, so there is
+no second generator to keep in step. Output is committed under `src/gen/` and covered by the same
+drift gate.
+
+**Transport.** `createGrpcTransport` from `@connectrpc/connect-node`, speaking real gRPC over
+HTTP/2, matching the `NettyServerBuilder` server. Node is the supported target and the one CI gates
+on. Bun and Deno are exercised in e2e and documented as supported only if those legs actually pass.
+
+**Why not the browser.** `GrpcServerPlugin` builds on `NettyServerBuilder` (and `XdsServerBuilder`
+for xDS), with no gRPC-Web handler, no Connect protocol, and no servlet adapter anywhere in
+`grpcw/`. A browser cannot speak plain gRPC over HTTP/2, so the original #4900 promise of browser
+use "without a proxy" is not achievable against today's server. Making it true would require a
+gRPC-Web translation layer on a security-sensitive path, to put the wrong transport in front of the
+persona the HTTP client already serves. Deferred to M3+.
+
+**Auth.** The server accepts `authorization: Bearer <token>` metadata, or a username/password pair
+on `x-arcade-user` and `x-arcade-password` with an optional `x-arcade-database`. This differs from
+HTTP's standard `Authorization: Basic`, which is why the two packages need separate auth helpers and
+why a shared core package is not yet justified. `passwordAuth` refuses to attach credentials to an
+insecure channel unless the caller explicitly opts in, because gRPC metadata is plaintext and
+plaintext credential exposure was one of the findings in the closed hardening issue #5048.
+
+**Surface.** Deliberately thinner than the HTTP facade. The generated Connect clients are already
+ergonomic for unary calls, so the hand-written layer covers only streaming query results and
+bidirectional bulk ingest, both exposed as async iterables. Both proto services are exposed, with
+the admin service on its own import path so data-plane users never surface admin RPCs in
+autocomplete.
+
+## 8. CI, testing, release, and versioning
+
+### CI
+
+**`arcadedb-clients`, every PR:** install, typecheck, lint, unit tests, drift gate, tree-shaking
+size check, then e2e via Testcontainers against a pinned published image. The e2e harness must
+enable the gRPC plugin and map both ports.
+
+**`arcadedb-clients`, scheduled:** fetch the newest release's contract assets; if they differ from
+`contracts/`, open a PR with the new contract, regenerated code, and version bump.
+
+**`arcadedb`, M2 smoke job:** after `build-and-package` produces the Docker image, check out
+`arcadedb-clients` and run its e2e suite against that freshly built tag. This is the only check that
+catches a payload-shape change on the PR that introduces it. **Non-blocking initially**, so a
+clients-repo problem cannot wedge server development.
+
+Test layering: unit tests for the facade against a mocked fetch and a mocked transport, e2e for
+anything touching the wire, and the drift gate treated as a test rather than a build step.
+
+### Versioning
+
+Packages use **independent semver** and record the contract they were generated from in an
+`arcadedb.serverVersion` field, exported as a `CONTRACT_VERSION` constant and stated in the README
+with a compatibility table.
+
+Strict lockstep with the server version was rejected: it deadlocks the first time a client needs a
+fix while the server has not moved, since npm forbids republishing a version, prereleases sort
+*before* the release, and npm will not accept two versions differing only in build metadata. A
+machine-readable `CONTRACT_VERSION` serves the actual goal (knowing exactly which server release a
+client was generated against) better than a version string that merely resembles the server's.
+
+### Release
+
+`workflow_dispatch` with a version input, gated on the contract in `contracts/` matching what the
+packages claim. Publishing uses **npm Trusted Publishing over OIDC** rather than a long-lived
+`NPM_TOKEN`: no stored credential to rotate or leak, and provenance attestation comes free. This
+repository already uses `id-token: write` in `mvn-release.yml`.
+
+## 9. Findings that shaped this design
+
+Each was verified in source while drafting, and each changed the design.
+
+**The session header is undocumented.** `createBeginPath()` documents only the `database` path
+parameter and its responses. `PostBeginHandler` returns `arcadedb-session-id` as a response header
+and `AbstractServerHttpHandler` reads it as a request header, but the spec models it nowhere. A
+client generated from today's spec cannot do transactions in a typed way at all. This became M0-6,
+and it is a precise instance of the payload-shape gap #4896 cannot see: the route exists and is
+documented, only the header modelling is missing.
+
+**`info.version` is hardcoded to `"1.0.0"`.** The spec does not identify which server produced it,
+which undermines the entire "versioned to the server release" goal. This became M0-1.
+
+**Browser gRPC is not achievable today.** See section 7.
+
+**PromQL `data.result` is opaque.** The three real shapes live only in a prose description, so
+generated entries are effectively untyped. This became M0-3, modelled with `anyOf` rather than
+`oneOf` since an empty result array cannot be excluded from matching more than one branch.
+
+**Grafana is already modelled correctly, and needs no work.** An earlier draft of this design listed
+the Grafana DataFrame envelope alongside PromQL as a fidelity gap. That was wrong.
+`GrafanaApiSpec.createQueryResponseSchema()` already models the per-`refId` map via
+`results.setAdditionalProperties(perTarget)`, along with frames, `schema.fields`, column-major
+`data.values`, and the per-target `error`. The only opaque leaf is the individual cell value, which
+is genuinely heterogeneous and correctly left as-is. M0-3 is therefore PromQL only.
+
+**The gRPC surface is hardened.** All twelve issues from the 2026-07 gRPC audit (#5039 through
+#5050) are closed, including both critical security findings and the silent-data-loss items.
+Publishing a public gRPC client no longer sits on top of an unaudited surface.
+
+## 10. Sequencing
+
+**M0, in `arcadedb`.** Rewrite the Epic first, since it frames everything. Then in parallel: M0-1,
+M0-3, M0-6. Then M0-2 last, so the first published contract carries the fixes. M0-4 proceeds
+independently and gates nothing.
+
+*Scheduling constraint:* contract assets appear only when a release is published, so M1 would
+otherwise idle until the next server release. `scripts/fetch-contract.sh` must therefore accept
+either a release asset or a locally booted server image, letting M1 start against a dev-built
+contract and switch to the published asset when one exists.
+
+**M1, in `arcadedb-clients`.** Bootstrap the repository, claim the npm org, wire contracts and
+codegen and the drift gate, then build `@arcadedb/client` and its e2e suite, then
+`@arcadedb/client-grpc` and its e2e suite, then the release workflow, then READMEs and the
+compatibility table. The two packages parallelize once the codegen scaffolding exists.
+
+**M2, in `arcadedb`.** The non-blocking smoke job, once the clients repo has a working e2e suite.
+
+**M3+.** Python, Go, C#, and Rust, plus browser gRPC if demand appears. Designed only after M1 and
+M2 have proven the infrastructure.
+
+The critical path to a usable TS client is M0-6 and M0-2, then M1's codegen scaffolding.
+
+## 11. Prerequisites and open items
+
+- **Claim the `arcadedb` npm org** and configure trusted publishing for both package names. Requires
+  the maintainer's npm account; nothing blocks until the first `workflow_dispatch` publish. Neither
+  `@arcadedb/client` nor `@arcadedata/client` is published today, and neither org resolves on the
+  registry, so the scope appears unclaimed. That probe cannot distinguish unclaimed from private.
+- **Confirm the gRPC plugin's port setting name** for the e2e harness.
+- ~~Confirm whether `/api/v1/openapi.json` requires authentication.~~ **Resolved:**
+  `GetOpenApiHandler.isRequireAuthentication()` returns `true`, so the contract-publishing workflow
+  must authenticate. This is not a real obstacle: the workflow starts the container itself, so it
+  sets the root password and uses it on the fetch.
+- **M0-4 (`ai/chat`) needs its own design decision:** split the operation, or move to Accept-header
+  content negotiation.
+
+## 12. Non-goals
+
+- Hand-writing per-language clients. The existing `grpc-client` Java module is grandfathered as a
+  reference, not a template, and is not retrofitted here.
+- Unifying the HTTP and gRPC specs. They stay two contracts serving two personas.
+- Exposing the admin and observability surface over gRPC.
+- Browser gRPC, and every non-TypeScript language, until M1 and M2 have proven the infrastructure.
+- A shared `@arcadedb/client-core` package. The genuinely shared surface today is small, and the
+  auth mechanisms differ between transports. Revisit once Python and Go reveal what is common.

--- a/docs/superpowers/specs/2026-08-21-spec-driven-client-generation-4894-design.md
+++ b/docs/superpowers/specs/2026-08-21-spec-driven-client-generation-4894-design.md
@@ -72,16 +72,18 @@ this design.
 
 | Item | Description | Blocks M1? |
 |---|---|---|
-| M0-1 | Stamp the real build version into `info.version`, currently hardcoded to `"1.0.0"` | No |
+| M0-1 | Stamp the bare release version into `info.version` (not the build-stamped `Constants.getVersion()`, which `publish-contract.yml` cannot match against the release tag), currently hardcoded to `"1.0.0"` | No |
 | M0-2 | Publish `openapi.json` and the proto as release assets, with `.sha256` files | Yes |
 | M0-3 | Model PromQL `data.result` as an `anyOf` over vector/matrix/scalar (`oneOf` cannot work: an empty result array validates against every branch) | Yes, for the facade |
 | M0-4 | Settle `ai/chat`: `mode=auto` returns `text/event-stream` while the spec documents JSON | No |
 | M0-5 | Rewrite Epic #4894; close #4897 through #4903 as superseded | No |
 | M0-6 | Model the `arcadedb-session-id` header on `begin`, `commit`, `rollback`, `query`, `command` | Yes |
 
-M0-1, M0-3, and M0-6 are small, independent, and coverable by the existing per-domain contributor
-unit tests. M0-2 should land last so the first published contract already carries the fixes. M0-4
-carries design risk and is deliberately off the critical path.
+M0-3 and M0-6 are small, independent, and coverable by the existing per-domain contributor unit
+tests. M0-1 is not: `createApiInfo()` lives in `OpenApiSpecGenerator` itself, which has no
+per-domain contributor class, so it is covered by `OpenApiSpecGeneratorTest` instead. M0-2 should
+land last so the first published contract already carries the fixes. M0-4 carries design risk and
+is deliberately off the critical path.
 
 Plugin routes are declared statically in `PluginApiSpec`, so a default server yields the complete
 63-operation spec without loading the Raft or metrics plugins.

--- a/server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java
@@ -113,7 +113,7 @@ public class OpenApiSpecGenerator {
     info.setTitle("ArcadeDB HTTP API");
     info.setDescription(
         "Multi-Model DBMS HTTP API for Graph, Document, Key/Value, Search Engine, Time Series, and Vector Embedding operations");
-    info.setVersion(Constants.getVersion());
+    info.setVersion(Constants.getRawVersion());
 
     final Contact contact = new Contact();
     contact.setName("Arcade Data Ltd");

--- a/server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/OpenApiSpecGenerator.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.Constants;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.openapi.AiApiSpec;
 import com.arcadedb.server.http.handler.openapi.AuthApiSpec;
@@ -112,7 +113,7 @@ public class OpenApiSpecGenerator {
     info.setTitle("ArcadeDB HTTP API");
     info.setDescription(
         "Multi-Model DBMS HTTP API for Graph, Document, Key/Value, Search Engine, Time Series, and Vector Embedding operations");
-    info.setVersion("1.0.0");
+    info.setVersion(Constants.getVersion());
 
     final Contact contact = new Contact();
     contact.setName("Arcade Data Ltd");

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler.openapi;
 
+import com.arcadedb.server.http.HttpSessionManager;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
@@ -37,6 +38,12 @@ import java.util.List;
  * lifecycle.
  */
 public class CoreApiSpec implements OpenApiContributor {
+
+  private static final String SESSION_HEADER = HttpSessionManager.ARCADEDB_SESSION_ID;
+
+  private static final String SESSION_REQUEST_DESCRIPTION = """
+      Session id returned by 'beginTransaction'. Present it on every call that must run inside that \
+      transaction, and on the commit or rollback that ends it. Omit it to run outside a transaction.""";
 
   @Override
   public void contribute(final OpenAPI openAPI) {
@@ -179,6 +186,7 @@ public class CoreApiSpec implements OpenApiContributor {
     getOp.addParametersItem(SpecBuilders.pathParam("language", "Query language (sql, cypher, gremlin, graphql, mongo)",
         List.of("sql", "cypher", "gremlin", "graphql", "mongo")));
     getOp.addParametersItem(SpecBuilders.pathParam("command", "Query or command to execute"));
+    getOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
     getOp.setResponses(createQueryResponses());
     pathItem.setGet(getOp);
 
@@ -194,6 +202,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("executeQueryPost");
     postOp.addTagsItem("Query");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
     postOp.setRequestBody(SpecBuilders.jsonBody("Query request with command and optional parameters", "QueryRequest", true));
     postOp.setResponses(createQueryResponses());
     pathItem.setPost(postOp);
@@ -210,6 +219,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("executeCommand");
     postOp.addTagsItem("Command");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
     postOp.setRequestBody(SpecBuilders.jsonBody("Command request with command and optional parameters", "CommandRequest", true));
     postOp.setResponses(createCommandResponses());
     pathItem.setPost(postOp);
@@ -226,7 +236,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("beginTransaction");
     postOp.addTagsItem("Transaction");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
-    postOp.setResponses(createTransactionResponses());
+    postOp.setResponses(createBeginResponses());
     pathItem.setPost(postOp);
 
     return pathItem;
@@ -241,6 +251,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("commitTransaction");
     postOp.addTagsItem("Transaction");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
     postOp.setResponses(createTransactionResponses());
     pathItem.setPost(postOp);
 
@@ -256,6 +267,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("rollbackTransaction");
     postOp.addTagsItem("Transaction");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
     postOp.setResponses(createTransactionResponses());
     pathItem.setPost(postOp);
 
@@ -483,13 +495,29 @@ public class CoreApiSpec implements OpenApiContributor {
 
     final ApiResponse successResponse = new ApiResponse();
     successResponse.setDescription("Transaction operation completed successfully");
-    responses.addApiResponse("200", successResponse);
+    responses.addApiResponse("204", successResponse);
 
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
     responses.addApiResponse("404", SpecBuilders.errorResponse("Database not found"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));
 
+    return responses;
+  }
+
+  /**
+   * The transaction responses plus the session-id header that 'begin' alone returns, and the 409
+   * PostBeginHandler returns when the request carries a session id that still resolves. Built from a
+   * fresh {@link #createTransactionResponses()} every call, so neither addition lands on the shared
+   * instance that commit and rollback also use.
+   */
+  private ApiResponses createBeginResponses() {
+    final ApiResponses responses = createTransactionResponses();
+    responses.get("204").addHeaderObject(SESSION_HEADER, SpecBuilders.stringHeader("""
+        Session id identifying the transaction just opened. Present it on the '%s' request header \
+        of every subsequent call that belongs to this transaction.""".formatted(SESSION_HEADER)));
+    responses.addApiResponse("409", SpecBuilders.errorResponse(
+        "A transaction is already open on this session"));
     return responses;
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -50,6 +50,16 @@ public class CoreApiSpec implements OpenApiContributor {
       Supplying a session id here that still resolves to an open transaction does not start a nested \
       transaction; it makes the call fail with 409 instead.""";
 
+  // Used only by commit and rollback: on those two, unlike query/command, omitting the header is
+  // NOT a safe "run outside a transaction". requiresTransaction() is false and isTransactionActive()
+  // is false on the fresh context, so the handler still answers 204 while committing or rolling back
+  // nothing. A generated client that loses the session id would otherwise report success while the
+  // caller's writes are gone.
+  private static final String TRANSACTION_END_SESSION_REQUEST_DESCRIPTION = """
+      Session id returned by 'beginTransaction', identifying the transaction to end. Omitting it, or \
+      presenting an id that no longer resolves to an open transaction, is an idempotent no-op: the \
+      call still answers 204, but commits or rolls back nothing.""";
+
   @Override
   public void contribute(final OpenAPI openAPI) {
     openAPI.getPaths().addPathItem("/api/v1/server", createServerPath());
@@ -257,7 +267,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("commitTransaction");
     postOp.addTagsItem("Transaction");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
-    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, TRANSACTION_END_SESSION_REQUEST_DESCRIPTION, false));
     postOp.setResponses(createTransactionResponses());
     pathItem.setPost(postOp);
 
@@ -273,7 +283,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("rollbackTransaction");
     postOp.addTagsItem("Transaction");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
-    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, TRANSACTION_END_SESSION_REQUEST_DESCRIPTION, false));
     postOp.setResponses(createTransactionResponses());
     pathItem.setPost(postOp);
 
@@ -477,7 +487,9 @@ public class CoreApiSpec implements OpenApiContributor {
     responses.addApiResponse("200", SpecBuilders.jsonResponse("Query executed successfully", "QueryResponse"));
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
-    responses.addApiResponse("404", SpecBuilders.errorResponse("Database not found"));
+    responses.addApiResponse("404", SpecBuilders.errorResponse(
+        "Database not found, or the session id header names a transaction that no longer resolves "
+            + "(\"Remote transaction session not found or expired\")"));
     responses.addApiResponse("413", SpecBuilders.errorResponse(
         "The result exceeds 'arcadedb.server.httpQueryMaxResultRows': narrow or page the query"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));
@@ -489,7 +501,9 @@ public class CoreApiSpec implements OpenApiContributor {
     responses.addApiResponse("200", SpecBuilders.jsonResponse("Command executed successfully", "QueryResponse"));
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
-    responses.addApiResponse("404", SpecBuilders.errorResponse("Database not found"));
+    responses.addApiResponse("404", SpecBuilders.errorResponse(
+        "Database not found, or the session id header names a transaction that no longer resolves "
+            + "(\"Remote transaction session not found or expired\")"));
     responses.addApiResponse("413", SpecBuilders.errorResponse(
         "The result exceeds 'arcadedb.server.httpQueryMaxResultRows': narrow or page the command"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -202,7 +202,7 @@ public class CoreApiSpec implements OpenApiContributor {
         List.of("sql", "cypher", "gremlin", "graphql", "mongo")));
     getOp.addParametersItem(SpecBuilders.pathParam("command", "Query or command to execute"));
     getOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, SESSION_REQUEST_DESCRIPTION, false));
-    getOp.setResponses(createQueryResponses());
+    getOp.setResponses(createGetQueryResponses());
     pathItem.setGet(getOp);
 
     return pathItem;
@@ -482,14 +482,26 @@ public class CoreApiSpec implements OpenApiContributor {
     return responses;
   }
 
+  // GetQueryHandler.requiresTransaction() returns false, so a stale session id on GET query degrades
+  // session-less (DatabaseAbstractHandler.setTransactionInThreadLocal) and answers 200, never 404. The
+  // POST endpoint has no such override, so its 404 does cover the stale-session case.
   private ApiResponses createQueryResponses() {
+    return createQueryResponses(true);
+  }
+
+  private ApiResponses createGetQueryResponses() {
+    return createQueryResponses(false);
+  }
+
+  private ApiResponses createQueryResponses(final boolean sessionAware) {
     final ApiResponses responses = new ApiResponses();
     responses.addApiResponse("200", SpecBuilders.jsonResponse("Query executed successfully", "QueryResponse"));
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
-    responses.addApiResponse("404", SpecBuilders.errorResponse(
-        "Database not found, or the session id header names a transaction that no longer resolves "
-            + "(\"Remote transaction session not found or expired\")"));
+    responses.addApiResponse("404", SpecBuilders.errorResponse(sessionAware
+        ? "Database not found, or the session id header names a transaction that no longer resolves "
+            + "(\"Remote transaction session not found or expired\")"
+        : "Database not found"));
     responses.addApiResponse("413", SpecBuilders.errorResponse(
         "The result exceeds 'arcadedb.server.httpQueryMaxResultRows': narrow or page the query"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -45,6 +45,11 @@ public class CoreApiSpec implements OpenApiContributor {
       Session id returned by 'beginTransaction'. Present it on every call that must run inside that \
       transaction, and on the commit or rollback that ends it. Omit it to run outside a transaction.""";
 
+  private static final String BEGIN_SESSION_REQUEST_DESCRIPTION = """
+      Normally omitted: 'beginTransaction' opens a new transaction and returns its own session id. \
+      Supplying a session id here that still resolves to an open transaction does not start a nested \
+      transaction; it makes the call fail with 409 instead.""";
+
   @Override
   public void contribute(final OpenAPI openAPI) {
     openAPI.getPaths().addPathItem("/api/v1/server", createServerPath());
@@ -236,6 +241,7 @@ public class CoreApiSpec implements OpenApiContributor {
     postOp.setOperationId("beginTransaction");
     postOp.addTagsItem("Transaction");
     postOp.addParametersItem(SpecBuilders.pathParam("database", "Database name"));
+    postOp.addParametersItem(SpecBuilders.headerParam(SESSION_HEADER, BEGIN_SESSION_REQUEST_DESCRIPTION, false));
     postOp.setResponses(createBeginResponses());
     pathItem.setPost(postOp);
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpec.java
@@ -244,18 +244,23 @@ public class PrometheusApiSpec implements OpenApiContributor {
     resultType.setEnum(List.of("vector", "matrix", "scalar"));
 
     final Schema<Object> vectorEntry = SpecBuilders.object("One instant sample");
-    vectorEntry.addProperty("metric", SpecBuilders.object("Label map, including the '__name__' label"));
+    vectorEntry.addProperty("metric", metricLabelsSchema());
     vectorEntry.addProperty("value", samplePair());
+    vectorEntry.setRequired(List.of("metric", "value"));
 
     final Schema<Object> matrixEntry = SpecBuilders.object("One range series");
-    matrixEntry.addProperty("metric", SpecBuilders.object("Label map, including the '__name__' label"));
+    matrixEntry.addProperty("metric", metricLabelsSchema());
     matrixEntry.addProperty("values", SpecBuilders.arrayOf(samplePair(), "Samples ordered by timestamp"));
+    matrixEntry.setRequired(List.of("metric", "values"));
 
     final Schema<Object> result = new Schema<>();
     result.setDescription("""
         Evaluation result, shaped by 'resultType': an array of instant samples when 'vector', an \
         array of range series when 'matrix', and a single [timestamp, value] pair when 'scalar'.""");
-    result.setOneOf(List.of(
+    // anyOf, not oneOf: an empty 'result' array (a normal empty vector or matrix result) validates
+    // against every branch here, so oneOf's "exactly one match" can never be satisfied. 'resultType'
+    // remains the real narrowing key for a human, or a hand-written narrowing function.
+    result.setAnyOf(List.of(
         SpecBuilders.arrayOf(vectorEntry, "Entries when resultType is 'vector'"),
         SpecBuilders.arrayOf(matrixEntry, "Entries when resultType is 'matrix'"),
         samplePair()));
@@ -274,11 +279,30 @@ public class PrometheusApiSpec implements OpenApiContributor {
    * A fresh [timestamp, value] pair schema on every call. Returning a shared instance would place
    * one mutable schema object at several points in the document, the same defect class that put one
    * ApiResponse under two status keys during #4895.
+   * <p>
+   * The server actually sends a 2-element JSON array of a number then a string (see
+   * {@code PromQLResponseFormatter}), neither of which is an object, so the items schema is left
+   * unconstrained rather than typed as 'object'. The tuple shape is instead pinned with
+   * minItems/maxItems.
    */
   private Schema<?> samplePair() {
-    return SpecBuilders.arrayOf(
-        SpecBuilders.object("Unix timestamp in seconds, then the sample value as a string"),
-        "One [timestamp, value] pair");
+    final Schema<?> pair = SpecBuilders.arrayOf(new Schema<>(),
+        "One [timestamp, value] pair: a Unix timestamp in seconds (number), then the sample value (string)");
+    pair.setMinItems(2);
+    pair.setMaxItems(2);
+    return pair;
+  }
+
+  /**
+   * The PromQL label map is free-form (label names are not known ahead of time), but every value
+   * {@code labelsToJson} writes is a JSON string, so 'additionalProperties' is pinned to a string
+   * schema rather than left as bare 'object'. That is what makes a generator emit Map&lt;String,
+   * String&gt; instead of Map&lt;String, Object&gt;.
+   */
+  private Schema<Object> metricLabelsSchema() {
+    final Schema<Object> schema = SpecBuilders.object("Label map, including the '__name__' label");
+    schema.setAdditionalProperties(SpecBuilders.string("Label value"));
+    return schema;
   }
 
   private Schema<?> createLabelsResponseSchema() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpec.java
@@ -243,19 +243,42 @@ public class PrometheusApiSpec implements OpenApiContributor {
         "Shape of 'result': a vector of instant samples, a matrix of range samples, or a scalar");
     resultType.setEnum(List.of("vector", "matrix", "scalar"));
 
+    final Schema<Object> vectorEntry = SpecBuilders.object("One instant sample");
+    vectorEntry.addProperty("metric", SpecBuilders.object("Label map, including the '__name__' label"));
+    vectorEntry.addProperty("value", samplePair());
+
+    final Schema<Object> matrixEntry = SpecBuilders.object("One range series");
+    matrixEntry.addProperty("metric", SpecBuilders.object("Label map, including the '__name__' label"));
+    matrixEntry.addProperty("values", SpecBuilders.arrayOf(samplePair(), "Samples ordered by timestamp"));
+
+    final Schema<Object> result = new Schema<>();
+    result.setDescription("""
+        Evaluation result, shaped by 'resultType': an array of instant samples when 'vector', an \
+        array of range series when 'matrix', and a single [timestamp, value] pair when 'scalar'.""");
+    result.setOneOf(List.of(
+        SpecBuilders.arrayOf(vectorEntry, "Entries when resultType is 'vector'"),
+        SpecBuilders.arrayOf(matrixEntry, "Entries when resultType is 'matrix'"),
+        samplePair()));
+
     final Schema<Object> data = SpecBuilders.object("Evaluation result");
     data.addProperty("resultType", resultType);
-    data.addProperty("result", SpecBuilders.arrayOf(
-        SpecBuilders.object(
-            "A vector entry carries 'metric' and a single 'value'; a matrix entry carries 'metric' and 'values'"),
-        "Result entries. A vector result's entries carry [timestamp, value] in 'value'; a matrix "
-            + "result's entries carry a list of [timestamp, value] pairs in 'values'. A scalar result "
-            + "replaces this array with a single [timestamp, value] pair."));
+    data.addProperty("result", result);
 
     final Schema<Object> schema = SpecBuilders.object("Prometheus query response");
     schema.addProperty("status", SpecBuilders.string("Always 'success' on a 200"));
     schema.addProperty("data", data);
     return schema;
+  }
+
+  /**
+   * A fresh [timestamp, value] pair schema on every call. Returning a shared instance would place
+   * one mutable schema object at several points in the document, the same defect class that put one
+   * ApiResponse under two status keys during #4895.
+   */
+  private Schema<?> samplePair() {
+    return SpecBuilders.arrayOf(
+        SpecBuilders.object("Unix timestamp in seconds, then the sample value as a string"),
+        "One [timestamp, value] pair");
   }
 
   private Schema<?> createLabelsResponseSchema() {

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/SpecBuilders.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.http.handler.openapi;
 
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
@@ -73,6 +74,23 @@ public final class SpecBuilders {
     param.setDescription(description);
     param.setSchema(new Schema<>().type(type));
     return param;
+  }
+
+  public static Parameter headerParam(final String name, final String description, final boolean required) {
+    final Parameter param = new Parameter();
+    param.setName(name);
+    param.setIn("header");
+    param.setRequired(required);
+    param.setDescription(description);
+    param.setSchema(new Schema<>().type("string"));
+    return param;
+  }
+
+  public static Header stringHeader(final String description) {
+    final Header header = new Header();
+    header.setDescription(description);
+    header.setSchema(new Schema<>().type("string"));
+    return header;
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
@@ -331,8 +331,12 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
     final Info info = result.getOpenAPI().getInfo();
 
     assertThat(info.getVersion())
-        .as("a generated client must record which server release produced its types")
-        .isEqualTo(Constants.getVersion());
+        .as("a generated client must record which server release produced its types, as the bare version")
+        .isEqualTo(Constants.getRawVersion());
+
+    assertThat(info.getVersion())
+        .as("a build stamp is not a release identity; publish-contract.yml compares this to the bare tag")
+        .doesNotContain(" (build ");
 
     assertThat(info.getVersion())
         .as("the placeholder must be gone, not merely coincidentally equal")

--- a/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/OpenApiSpecGenerationIT.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http;
 
+import com.arcadedb.Constants;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.http.handler.OpenApiSpecGenerator;
@@ -321,6 +322,21 @@ class OpenApiSpecGenerationIT extends BaseGraphServerTest {
         .hasSize(2);
     assertThat(openAPI.getSecurity().stream().flatMap(r -> r.keySet().stream()).toList())
         .containsExactlyInAnyOrder("basicAuth", "bearerAuth");
+  }
+
+  @Test
+  void specDeclaresTheRunningServerVersion() throws Exception {
+    final String specContent = getOpenApiSpec();
+    final SwaggerParseResult result = new OpenAPIV3Parser().readContents(specContent, null, new ParseOptions());
+    final Info info = result.getOpenAPI().getInfo();
+
+    assertThat(info.getVersion())
+        .as("a generated client must record which server release produced its types")
+        .isEqualTo(Constants.getVersion());
+
+    assertThat(info.getVersion())
+        .as("the placeholder must be gone, not merely coincidentally equal")
+        .isNotEqualTo("1.0.0");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/http/handler/OpenApiSpecGeneratorTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/OpenApiSpecGeneratorTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.Constants;
 import com.arcadedb.server.http.handler.openapi.OpenApiContributor;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -62,5 +63,27 @@ class OpenApiSpecGeneratorTest {
         schemaOwner.put(schemaName, contributorName);
       }
     }
+  }
+
+  /**
+   * publish-contract.yml compares the served document's {@code info.version} to the bare release
+   * tag. {@link Constants#getVersion()} appends a build suffix ("... (build ...)"); using it here
+   * would break that comparison on every publish. This guards {@code createApiInfo()} in the only
+   * unit lane that runs on this machine: the IT that also asserts this cannot bind port 2480 here.
+   */
+  @Test
+  void infoVersionIsTheBareReleaseVersionNotTheBuildStampedOne() {
+    final OpenAPI openAPI = new OpenApiSpecGenerator(null).generateSpec();
+
+    final String version = openAPI.getInfo().getVersion();
+
+    assertThat(version)
+        .as("publish-contract.yml compares info.version to the bare release tag, so it must equal "
+            + "Constants.getRawVersion(), not the build-stamped Constants.getVersion()")
+        .isEqualTo(Constants.getRawVersion());
+    assertThat(version)
+        .as("a build-stamped version (\"... (build ...)\") would never equal the release tag and "
+            + "would break the publish gate forever")
+        .doesNotContain(" (build ");
   }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -234,4 +234,55 @@ class CoreApiSpecTest {
         .as("PostBeginHandler returns 409 when the request carries a session id that still resolves")
         .containsKey("409");
   }
+
+  @Test
+  void commitAndRollbackDoNotAdvertiseTheSessionIdResponseHeader() {
+    for (final String path : List.of("/api/v1/commit/{database}", "/api/v1/rollback/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+
+      assertThat(post.getResponses().get("204").getHeaders())
+          .as("PostCommitHandler/PostRollbackHandler strip the session header before responding on "
+              + path + "; advertising it here would be a lie only 'begin' is entitled to make")
+          .isNullOrEmpty();
+    }
+  }
+
+  @Test
+  void commitAndRollbackDoNotDeclareA409() {
+    for (final String path : List.of("/api/v1/commit/{database}", "/api/v1/rollback/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+
+      assertThat(post.getResponses())
+          .as("only 'begin' can answer 409 for an already-open session; " + path
+              + " must not share that response with it via a memoized createTransactionResponses()")
+          .doesNotContainKey("409");
+    }
+  }
+
+  @Test
+  void commitAndRollbackWarnThatALostOrStaleSessionIdIsASilentNoOp() {
+    for (final String path : List.of("/api/v1/commit/{database}", "/api/v1/rollback/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+      final Parameter header = post.getParameters().stream()
+          .filter(p -> "arcadedb-session-id".equals(p.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("no session header declared on " + path));
+
+      assertThat(header.getDescription())
+          .as(path + " must warn that an omitted or stale session id still answers 204 while "
+              + "committing or rolling back nothing, or a generated client will report success on data loss")
+          .contains("no-op");
+    }
+  }
+
+  @Test
+  void queryAndCommand404CoversAStaleSessionIdNotOnlyAMissingDatabase() {
+    for (final String path : List.of("/api/v1/query/{database}", "/api/v1/command/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+
+      assertThat(post.getResponses().get("404").getDescription())
+          .as(path + " also answers 404 for a stale session id, not only a missing database")
+          .contains("Remote transaction session not found or expired");
+    }
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -285,4 +285,23 @@ class CoreApiSpecTest {
           .contains("Remote transaction session not found or expired");
     }
   }
+
+  @Test
+  void getQuery404DoesNotClaimTheStaleSessionCasePostAndCommandDo() {
+    final Operation get = openAPI.getPaths().get("/api/v1/query/{database}/{language}/{command}").getGet();
+
+    assertThat(get.getResponses().get("404").getDescription())
+        .as("GetQueryHandler.requiresTransaction() returns false, so a stale session id degrades "
+            + "session-less and answers 200, never 404: the GET query 404 must not claim otherwise")
+        .doesNotContain("Remote transaction session not found or expired");
+
+    for (final String path : List.of("/api/v1/query/{database}", "/api/v1/command/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+
+      assertThat(post.getResponses().get("404").getDescription())
+          .as(path + " has no requiresTransaction() override, so its 404 must still cover the "
+              + "stale-session case")
+          .contains("Remote transaction session not found or expired");
+    }
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -152,4 +152,69 @@ class CoreApiSpecTest {
         .as("GetReadyHandler.execute only ever returns 204 or 503")
         .containsExactlyInAnyOrder("204", "503");
   }
+
+  @Test
+  void beginDeclaresTheSessionIdResponseHeader() {
+    final Operation post = openAPI.getPaths().get("/api/v1/begin/{database}").getPost();
+
+    assertThat(post.getResponses().get("204").getHeaders())
+        .as("a client that cannot read the session id cannot use the transaction it just opened")
+        .containsKey("arcadedb-session-id");
+  }
+
+  @Test
+  void commitAndRollbackDeclareTheSessionIdRequestHeader() {
+    for (final String path : List.of("/api/v1/commit/{database}", "/api/v1/rollback/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+      final Parameter header = post.getParameters().stream()
+          .filter(p -> "arcadedb-session-id".equals(p.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("no session header declared on " + path));
+
+      assertThat(header.getIn())
+          .as("the session id travels as a header on " + path)
+          .isEqualTo("header");
+    }
+  }
+
+  @Test
+  void queryAndCommandAcceptAnOptionalSessionIdHeader() {
+    for (final String path : List.of("/api/v1/query/{database}", "/api/v1/command/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+      final Parameter header = post.getParameters().stream()
+          .filter(p -> "arcadedb-session-id".equals(p.getName()))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("no session header declared on " + path));
+
+      assertThat(header.getRequired())
+          .as("running outside a transaction must remain legal on " + path)
+          .isFalse();
+    }
+  }
+
+  @Test
+  void transactionOperationsDeclare204AndNot200() {
+    for (final String path : List.of("/api/v1/begin/{database}", "/api/v1/commit/{database}",
+        "/api/v1/rollback/{database}")) {
+      final Operation post = openAPI.getPaths().get(path).getPost();
+
+      assertThat(post.getResponses())
+          .as("PostBeginHandler, PostCommitHandler and PostRollbackHandler all return "
+              + "'new ExecutionResponse(204, \"\")', so " + path + " must declare 204")
+          .containsKey("204");
+      assertThat(post.getResponses())
+          .as(path + " must not declare 200: the handler never returns it, and a generated client "
+              + "would deserialize a body that is never sent")
+          .doesNotContainKey("200");
+    }
+  }
+
+  @Test
+  void beginDeclaresA409ForAnAlreadyOpenSession() {
+    final Operation post = openAPI.getPaths().get("/api/v1/begin/{database}").getPost();
+
+    assertThat(post.getResponses())
+        .as("PostBeginHandler returns 409 when the request carries a session id that still resolves")
+        .containsKey("409");
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -163,6 +163,23 @@ class CoreApiSpecTest {
   }
 
   @Test
+  void beginDeclaresTheSessionIdRequestHeaderAsOptional() {
+    final Operation post = openAPI.getPaths().get("/api/v1/begin/{database}").getPost();
+    final Parameter header = post.getParameters().stream()
+        .filter(p -> "arcadedb-session-id".equals(p.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no session header declared on /api/v1/begin/{database}"));
+
+    assertThat(header.getIn())
+        .as("PostBeginHandler reads the session id from a request header, not a query parameter")
+        .isEqualTo("header");
+    assertThat(header.getRequired())
+        .as("a client cannot otherwise know what triggers the 409: supplying an id that still "
+            + "resolves is what triggers it, not omitting the header")
+        .isFalse();
+  }
+
+  @Test
   void commitAndRollbackDeclareTheSessionIdRequestHeader() {
     for (final String path : List.of("/api/v1/commit/{database}", "/api/v1/rollback/{database}")) {
       final Operation post = openAPI.getPaths().get(path).getPost();

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpecTest.java
@@ -150,6 +150,29 @@ class PrometheusApiSpecTest {
   }
 
   @Test
+  void promQlResultDeclaresItsThreeShapes() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+
+    assertThat(result.getOneOf())
+        .as("vector, matrix and scalar are structurally different; a client must narrow on resultType")
+        .hasSize(3);
+  }
+
+  @Test
+  void promQlVectorEntriesCarryMetricAndValue() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+    final Schema<?> vectorEntry = result.getOneOf().get(0).getItems();
+
+    assertThat(vectorEntry.getProperties().keySet())
+        .as("an instant sample is a labelled metric plus one [timestamp, value] pair")
+        .containsExactlyInAnyOrder("metric", "value");
+  }
+
+  @Test
   void everyPromQlOperationUsesTheErrorEnvelopeNotTheGenericOne() {
     final Schema<?> error = openAPI.getComponents().getSchemas().get("PromQLErrorResponse");
     assertThat(error.getProperties().keySet())

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/PrometheusApiSpecTest.java
@@ -156,7 +156,10 @@ class PrometheusApiSpecTest {
     final Schema<?> result = (Schema<?>) data.getProperties().get("result");
 
     assertThat(result.getOneOf())
-        .as("vector, matrix and scalar are structurally different; a client must narrow on resultType")
+        .as("oneOf must be gone: an empty result array matches every branch, so 'exactly one match' can never hold")
+        .isNull();
+    assertThat(result.getAnyOf())
+        .as("vector, matrix and scalar are structurally different; a client narrows on resultType")
         .hasSize(3);
   }
 
@@ -165,11 +168,85 @@ class PrometheusApiSpecTest {
     final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
     final Schema<?> data = (Schema<?>) response.getProperties().get("data");
     final Schema<?> result = (Schema<?>) data.getProperties().get("result");
-    final Schema<?> vectorEntry = result.getOneOf().get(0).getItems();
+    final Schema<?> vectorEntry = result.getAnyOf().get(0).getItems();
 
     assertThat(vectorEntry.getProperties().keySet())
         .as("an instant sample is a labelled metric plus one [timestamp, value] pair")
         .containsExactlyInAnyOrder("metric", "value");
+    assertThat(vectorEntry.getRequired())
+        .as("branch index 0 is assumed to be the vector branch throughout this test class; guard that coupling")
+        .containsExactlyInAnyOrder("metric", "value");
+  }
+
+  @Test
+  void promQlMatrixEntriesRequireMetricAndValues() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+    final Schema<?> matrixEntry = result.getAnyOf().get(1).getItems();
+
+    assertThat(matrixEntry.getRequired())
+        .as("a range series is discriminated from a vector entry by its 'values' plural")
+        .containsExactlyInAnyOrder("metric", "values");
+  }
+
+  @Test
+  void samplePairItemsAreUnconstrainedNotObjectTyped() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+    final Schema<?> scalarPair = result.getAnyOf().get(2);
+
+    assertThat(scalarPair.getType())
+        .as("a [timestamp, value] pair is an array")
+        .isEqualTo("array");
+    assertThat(scalarPair.getItems().getType())
+        .as("the server sends a number then a string, never an object; a typed 'object' item breaks a "
+            + "generated Go client's unmarshalling of every PromQL response")
+        .isNull();
+    assertThat(scalarPair.getMinItems())
+        .as("the tuple is always exactly 2 elements")
+        .isEqualTo(2);
+    assertThat(scalarPair.getMaxItems())
+        .as("the tuple is always exactly 2 elements")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void samplePairIsAFreshInstanceEveryCall() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+    final Schema<?> vectorEntry = result.getAnyOf().get(0).getItems();
+    final Schema<?> matrixEntry = result.getAnyOf().get(1).getItems();
+
+    final Schema<?> vectorValuePair = vectorEntry.getProperties().get("value");
+    final Schema<?> matrixValuesPair = matrixEntry.getProperties().get("values").getItems();
+    final Schema<?> scalarPair = result.getAnyOf().get(2);
+
+    assertThat(vectorValuePair)
+        .as("each samplePair() call must build its own schema instance, not share one mutable object")
+        .isNotSameAs(matrixValuesPair)
+        .isNotSameAs(scalarPair);
+    assertThat(matrixValuesPair)
+        .as("each samplePair() call must build its own schema instance, not share one mutable object")
+        .isNotSameAs(scalarPair);
+  }
+
+  @Test
+  void metricLabelMapConstrainsValuesToStrings() {
+    final Schema<?> response = openAPI.getComponents().getSchemas().get("PromQLDataResponse");
+    final Schema<?> data = (Schema<?>) response.getProperties().get("data");
+    final Schema<?> result = (Schema<?>) data.getProperties().get("result");
+    final Schema<?> vectorEntry = result.getAnyOf().get(0).getItems();
+    final Schema<?> metric = (Schema<?>) vectorEntry.getProperties().get("metric");
+
+    assertThat(metric.getAdditionalProperties())
+        .as("labelsToJson only ever writes string values, so a generator should emit Map<String,String>")
+        .isInstanceOf(Schema.class);
+    assertThat(((Schema<?>) metric.getAdditionalProperties()).getType())
+        .as("label values are strings")
+        .isEqualTo("string");
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/SpecBuildersTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/SpecBuildersTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.http.handler.openapi;
 
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -100,5 +101,32 @@ class SpecBuildersTest {
     SpecBuilders.basicAuthOnly(op);
     assertThat(op.getSecurity()).hasSize(1);
     assertThat(op.getSecurity().getFirst()).containsOnlyKeys("basicAuth");
+  }
+
+  @Test
+  void headerParamDeclaresAStringHeaderParameter() {
+    final Parameter param = SpecBuilders.headerParam("x-example", "An example header", true);
+
+    assertThat(param.getIn())
+        .as("a header parameter that is not in:header binds as a query string by default")
+        .isEqualTo("header");
+    assertThat(param.getRequired())
+        .as("the required flag passed to headerParam must reach the parameter")
+        .isTrue();
+    assertThat(param.getSchema().getType())
+        .as("a header value is always transmitted as a string")
+        .isEqualTo("string");
+  }
+
+  @Test
+  void stringHeaderDescribesAResponseHeader() {
+    final Header header = SpecBuilders.stringHeader("An example response header");
+
+    assertThat(header.getDescription())
+        .as("the description passed to stringHeader must reach the response header")
+        .isEqualTo("An example response header");
+    assertThat(header.getSchema().getType())
+        .as("a header value is always transmitted as a string")
+        .isEqualTo("string");
   }
 }


### PR DESCRIPTION
Milestone 0 of the rescoped Epic #4894. Makes the OpenAPI spec correct, self-identifying and downloadable, so client libraries can be generated from it. No client code here.

Closes #6551
Closes #6552
Closes #6553
Closes #6554

## Why

A generated client is only as correct as the spec it comes from, and anything wrong in this spec propagates silently into every language binding. Four defects blocked that, all found by reading handlers rather than trusting the existing documentation.

## What changed

**`info.version` was hardcoded to `"1.0.0"`** (#6551). The spec could not identify which server release produced it, which defeats "versioned to the server release" and leaves the publishing workflow with nothing to gate on. It now reports `Constants.getRawVersion()`.

Deliberately **not** `Constants.getVersion()`: that appends `" (build <sha>/<millis>/<branch>)"` whenever the buildnumber plugin has run, which is always. That value would fail the release gate below on every release forever, make the spec non-deterministic between builds of the same commit, and leak the build branch name into a public artifact.

**The `arcadedb-session-id` header was undocumented across the whole spec** (#6552). `PostBeginHandler` returns it as a response header and `AbstractServerHttpHandler` reads it as a request header, but nothing modelled it. A client generated from the old spec could not open, use, or close a transaction in a typed way at all.

Note this is invisible to #4896's anti-drift test, which compares registered routes against documented paths. Every route involved exists and is documented; only the header modelling was missing. It is a worked example of the payload-shape gap that test cannot see.

Fixing it surfaced two more defects in the same operations:

- **All three transaction handlers return 204, and the spec declared 200.** `PostBeginHandler`, `PostCommitHandler` and `PostRollbackHandler` each `return new ExecutionResponse(204, "")`. Corrected, with a test asserting `doesNotContainKey("200")` so it cannot regress.
- **`beginTransaction` returns an undeclared 409** when the request carries a session id that still resolves. Now documented, on begin only.

The header is `required = false` on commit and rollback: both guard with `if (database.isTransactionActive())` and are documented idempotent no-ops when the session is already gone, so omitting it is legal. Their description says so explicitly, because on `/commit` omitting it yields a 204 having committed nothing, and a client that loses the session id would otherwise report success while the writes are gone.

**PromQL `data.result` was an opaque object array** (#6553), with the vector, matrix and scalar shapes described only in prose. Now modelled structurally.

`anyOf` rather than `oneOf`, for two reasons that both make `oneOf` unusable: an empty result array (a normal query matching nothing) validates against every array branch, and a matrix result carrying exactly two series is an outer array of length 2, so it also matches the scalar branch. `oneOf` demands exactly one match, so Go and C# generated unmarshallers would error on both.

**The contract is now published** (#6554). `publish-contract.yml` triggers on `release: [published]`, starts the released image, fetches `/api/v1/openapi.json` (authenticated, since `GetOpenApiHandler.isRequireAuthentication()` returns true), normalises it with `jq -S` for byte-stability, and attaches it plus `arcadedb-server.proto` and a `.sha256` for each. It gates on the served `info.version` matching the release tag, which is what #6551 makes possible.

## Verification

131 unit tests green in the openapi package.

The version guard deliberately lives in `OpenApiSpecGeneratorTest`, a plain unit test, not only in the integration lane. An earlier revision of this work asserted `isEqualTo(Constants.getVersion())` -- the same expression the production code used -- which is a tautology that cannot fail. It was replaced with an assertion that the value does not contain `" (build "`, and that assertion was proved to fail against the old code before being trusted.

The publish workflow's version gate was exercised both ways: against the published `26.8.1` image it correctly rejected (`declared=1.0.0` vs `tag=26.8.1`), and against a matching spec it accepted. `gh release upload` itself is unexercised until the first real release.

## Scope notes

`GET /api/v1/query/{database}/{language}/{command}` keeps a plain "Database not found" 404 while the POST query and command operations mention the stale-session case. `GetQueryHandler` overrides `requiresTransaction()` to `false`, so a stale session id there degrades session-less and answers 200, never 404.

A planned Grafana schema fix was dropped: `GrafanaApiSpec` already models the per-`refId` DataFrame envelope correctly via `setAdditionalProperties`, including frames, `schema.fields`, column-major `data.values` and the per-target `error`.

Not included, and tracked separately: the `ai/chat` content-type mismatch, where `mode=auto` returns `text/event-stream` while the spec documents JSON. OpenAPI 3.0 cannot express a response content type selected by a request-body value, so it needs a server behaviour change rather than a spec change. It gates nothing in M1.
