### PR TITLE
refactor(#6554): share the stale-session 404 description and drop a redundant shell directive

### DIFF
--- a/.github/workflows/publish-contract.yml
+++ b/.github/workflows/publish-contract.yml
@@ -50,7 +50,6 @@ jobs:
           exit 1
 
       - name: Fetch the OpenAPI contract
-        shell: bash
         run: |
           set -o pipefail
           curl -sS --fail -u "root:$ROOT_PASSWORD" \

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -60,6 +60,15 @@ public class CoreApiSpec implements OpenApiContributor {
       presenting an id that no longer resolves to an open transaction, is an idempotent no-op: the \
       call still answers 204, but commits or rolls back nothing.""";
 
+  // Shared by the POST query and command operations, which both reach the stale-session branch of
+  // DatabaseAbstractHandler.setTransactionInThreadLocal. Held in one place so the two cannot desync:
+  // the quoted text is the message AbstractServerHttpHandler actually sends, so a client matching on
+  // it needs both operations to describe it identically. GET query does NOT use this - its handler
+  // overrides requiresTransaction() to false, so a stale id there degrades and answers 200.
+  private static final String STALE_SESSION_404_DESCRIPTION =
+      "Database not found, or the session id header names a transaction that no longer resolves "
+          + "(\"Remote transaction session not found or expired\")";
+
   @Override
   public void contribute(final OpenAPI openAPI) {
     openAPI.getPaths().addPathItem("/api/v1/server", createServerPath());
@@ -499,8 +508,7 @@ public class CoreApiSpec implements OpenApiContributor {
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
     responses.addApiResponse("404", SpecBuilders.errorResponse(sessionAware
-        ? "Database not found, or the session id header names a transaction that no longer resolves "
-            + "(\"Remote transaction session not found or expired\")"
+        ? STALE_SESSION_404_DESCRIPTION
         : "Database not found"));
     responses.addApiResponse("413", SpecBuilders.errorResponse(
         "The result exceeds 'arcadedb.server.httpQueryMaxResultRows': narrow or page the query"));
@@ -513,9 +521,7 @@ public class CoreApiSpec implements OpenApiContributor {
     responses.addApiResponse("200", SpecBuilders.jsonResponse("Command executed successfully", "QueryResponse"));
     responses.addApiResponse("400", SpecBuilders.errorResponse("Bad request"));
     responses.addApiResponse("401", SpecBuilders.errorResponse("Unauthorized"));
-    responses.addApiResponse("404", SpecBuilders.errorResponse(
-        "Database not found, or the session id header names a transaction that no longer resolves "
-            + "(\"Remote transaction session not found or expired\")"));
+    responses.addApiResponse("404", SpecBuilders.errorResponse(STALE_SESSION_404_DESCRIPTION));
     responses.addApiResponse("413", SpecBuilders.errorResponse(
         "The result exceeds 'arcadedb.server.httpQueryMaxResultRows': narrow or page the command"));
     responses.addApiResponse("500", SpecBuilders.errorResponse("Internal server error"));


### PR DESCRIPTION
Two non-blocking observations from the review of #6556, applied after it merged so they did not cost that PR a fresh CI cycle.

**Share the stale-session 404 description.** The text was written out verbatim in both `createQueryResponses(true)` and `createCommandResponses()`. It quotes the literal message `AbstractServerHttpHandler` sends (`Remote transaction session not found or expired`), so a client matching on that string needs both operations to describe it identically, and two copies can desync from a single-sided edit. Now one `STALE_SESSION_404_DESCRIPTION` constant, with a comment recording why the GET query operation deliberately does not use it: `GetQueryHandler` overrides `requiresTransaction()` to `false`, so a stale session id there degrades session-less and answers 200, never 404.

**Drop a redundant `shell: bash`.** `publish-contract.yml` already sets `defaults.run.shell: bash` job-wide, so the step-level directive was noise. `set -o pipefail` stays explicit on the piped step.

No behaviour change. 131 tests green in the openapi package; workflow still parses.
