### PR TITLE
Fix: edge variable read only inside a list predicate (any/all/none/single) silently anonymized

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherVariableUsage.java
@@ -18,25 +18,29 @@
  */
 package com.arcadedb.query.opencypher.executor;
 
+import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.ClauseEntry;
 import com.arcadedb.query.opencypher.ast.CypherStatement;
 import com.arcadedb.query.opencypher.ast.DeleteClause;
 import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.ForeachClause;
+import com.arcadedb.query.opencypher.ast.MapProjectionExpression;
 import com.arcadedb.query.opencypher.ast.MatchClause;
 import com.arcadedb.query.opencypher.ast.NodePattern;
 import com.arcadedb.query.opencypher.ast.OrderByClause;
 import com.arcadedb.query.opencypher.ast.PathPattern;
+import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
 import com.arcadedb.query.opencypher.ast.RelationshipPattern;
 import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
 import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.ast.SubqueryClause;
 import com.arcadedb.query.opencypher.ast.UnwindClause;
+import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.opencypher.ast.WithClause;
+import com.arcadedb.query.opencypher.parser.CypherExpressionWalker;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Answers one question for both Cypher executors: is a relationship variable used anywhere outside
@@ -60,8 +64,8 @@ public final class CypherVariableUsage {
    * Rather than enumerating every clause type, this method counts how many times
    * the variable appears across all relationship patterns in all MATCH clauses.
    * If it appears more than once, it's a bound reference in another pattern.
-   * Then it checks all expression texts from all other clauses (RETURN, WHERE,
-   * ORDER BY, WITH, UNWIND, SET, DELETE, CREATE, MERGE) for the variable name.
+   * Then it walks the parsed AST of every other clause (RETURN, WHERE,
+   * ORDER BY, WITH, UNWIND, SET, DELETE, CREATE, MERGE) looking for the variable name.
    *
    * @param statement the whole statement the pattern belongs to
    * @param variable  the edge variable name to check
@@ -89,7 +93,7 @@ public final class CypherVariableUsage {
         for (final PathPattern path : match.getPathPatterns()) {
           for (final NodePattern node : path.getNodes())
             if (node.hasWhereExpression()
-                && expressionReferencesVariable(node.getWhereExpression().getText(), variable))
+                && expressionReferencesVariable(node.getWhereExpression(), variable))
               return true;
           for (int i = 0; i < path.getRelationshipCount(); i++) {
             final RelationshipPattern rel = path.getRelationship(i);
@@ -100,7 +104,7 @@ public final class CypherVariableUsage {
             // binding was dropped whenever nothing else in the query mentioned r. The predicate then
             // evaluated against an unbound variable and silently filtered out every row (issue #5464).
             if (rel.hasWhereExpression()
-                && expressionReferencesVariable(rel.getWhereExpression().getText(), variable))
+                && expressionReferencesVariable(rel.getWhereExpression(), variable))
               return true;
           }
         }
@@ -110,7 +114,11 @@ public final class CypherVariableUsage {
     if (relVarCount > 1)
       return true;
 
-    // 2. Check all expression texts from non-MATCH clauses.
+    // 2. Check all expressions from non-MATCH clauses, walking their parsed AST rather than scanning
+    //    Expression#getText(): ANTLR's default getText() concatenates token text with no separating
+    //    whitespace (e.g. "any(item IN r0.k8 WHERE ...)" becomes "any(itemINr0.k8WHERE...)"), which
+    //    silently defeats a word-boundary text scan whenever a keyword ends right where the variable
+    //    begins - "r0" no longer starts a word once it is glued to the "N" of "IN" (issue #6567).
     //    Use clausesInOrder to cover everything: RETURN, WHERE, WITH, UNWIND, SET, DELETE, etc.
     if (statement.getClausesInOrder() != null) {
       for (final ClauseEntry entry : statement.getClausesInOrder()) {
@@ -118,23 +126,23 @@ public final class CypherVariableUsage {
         case RETURN: {
           final ReturnClause rc = entry.getTypedClause();
           for (final ReturnClause.ReturnItem item : rc.getReturnItems())
-            if (expressionReferencesVariable(item.getExpression().getText(), variable))
+            if (expressionReferencesVariable(item.getExpression(), variable))
               return true;
           break;
         }
         case WITH: {
           final WithClause wc = entry.getTypedClause();
           for (final ReturnClause.ReturnItem item : wc.getItems())
-            if (expressionReferencesVariable(item.getExpression().getText(), variable))
+            if (expressionReferencesVariable(item.getExpression(), variable))
               return true;
           if (wc.getWhereClause() != null && wc.getWhereClause().getConditionExpression() != null)
-            if (expressionReferencesVariable(wc.getWhereClause().getConditionExpression().getText(), variable))
+            if (expressionReferencesVariable(wc.getWhereClause().getConditionExpression(), variable))
               return true;
           break;
         }
         case UNWIND: {
           final UnwindClause uc = entry.getTypedClause();
-          if (expressionReferencesVariable(uc.getListExpression().getText(), variable))
+          if (expressionReferencesVariable(uc.getListExpression(), variable))
             return true;
           break;
         }
@@ -147,10 +155,10 @@ public final class CypherVariableUsage {
             if (variable.equals(item.getVariable()))
               return true;
             if (item.getValueExpression() != null
-                && expressionReferencesVariable(item.getValueExpression().getText(), variable))
+                && expressionReferencesVariable(item.getValueExpression(), variable))
               return true;
             if (item.getTargetExpression() != null
-                && expressionReferencesVariable(item.getTargetExpression().getText(), variable))
+                && expressionReferencesVariable(item.getTargetExpression(), variable))
               return true;
           }
           break;
@@ -197,28 +205,32 @@ public final class CypherVariableUsage {
 
     // 3. Check statement-level WHERE, ORDER BY (may not be in clausesInOrder)
     if (statement.getWhereClause() != null && statement.getWhereClause().getConditionExpression() != null)
-      if (expressionReferencesVariable(statement.getWhereClause().getConditionExpression().getText(), variable))
+      if (expressionReferencesVariable(statement.getWhereClause().getConditionExpression(), variable))
         return true;
 
     for (final MatchClause match : statement.getMatchClauses())
       if (match.hasWhereClause() && match.getWhereClause().getConditionExpression() != null)
-        if (expressionReferencesVariable(match.getWhereClause().getConditionExpression().getText(), variable))
+        if (expressionReferencesVariable(match.getWhereClause().getConditionExpression(), variable))
           return true;
 
     if (statement.getOrderByClause() != null)
       for (final OrderByClause.OrderByItem item : statement.getOrderByClause().getItems())
-        if (expressionReferencesVariable(item.getExpression(), variable))
+        // The AST is preferred over getExpression()'s text for the same reason as everywhere else in
+        // this method; fall back to the legacy text scan only for the rare item that kept no AST.
+        if (item.getExpressionAST() != null
+            ? expressionReferencesVariable(item.getExpressionAST(), variable)
+            : expressionReferencesVariable(item.getExpression(), variable))
           return true;
 
     // 4. Check RETURN clause (may not be in clausesInOrder for simple queries)
     if (statement.getReturnClause() != null)
       for (final ReturnClause.ReturnItem item : statement.getReturnClause().getReturnItems())
-        if (expressionReferencesVariable(item.getExpression().getText(), variable))
+        if (expressionReferencesVariable(item.getExpression(), variable))
           return true;
 
     // 5. Check UNWIND clauses (may not be in clausesInOrder for legacy path)
     for (final UnwindClause uc : statement.getUnwindClauses())
-      if (expressionReferencesVariable(uc.getListExpression().getText(), variable))
+      if (expressionReferencesVariable(uc.getListExpression(), variable))
         return true;
 
     return false;
@@ -233,7 +245,7 @@ public final class CypherVariableUsage {
     if (foreachClause == null)
       return false;
     if (foreachClause.getListExpression() != null
-        && expressionReferencesVariable(foreachClause.getListExpression().getText(), variable))
+        && expressionReferencesVariable(foreachClause.getListExpression(), variable))
       return true;
     if (foreachClause.getInnerClauses() != null) {
       for (final ClauseEntry inner : foreachClause.getInnerClauses()) {
@@ -248,10 +260,10 @@ public final class CypherVariableUsage {
             if (variable.equals(item.getVariable()))
               return true;
             if (item.getValueExpression() != null
-                && expressionReferencesVariable(item.getValueExpression().getText(), variable))
+                && expressionReferencesVariable(item.getValueExpression(), variable))
               return true;
             if (item.getTargetExpression() != null
-                && expressionReferencesVariable(item.getTargetExpression().getText(), variable))
+                && expressionReferencesVariable(item.getTargetExpression(), variable))
               return true;
           }
           break;
@@ -304,15 +316,15 @@ public final class CypherVariableUsage {
       case WITH: {
         final WithClause wc = entry.getTypedClause();
         for (final ReturnClause.ReturnItem item : wc.getItems())
-          if (expressionReferencesVariable(item.getExpression().getText(), variable))
+          if (expressionReferencesVariable(item.getExpression(), variable))
             return true;
         if (wc.getWhereClause() != null && wc.getWhereClause().getConditionExpression() != null
-            && expressionReferencesVariable(wc.getWhereClause().getConditionExpression().getText(), variable))
+            && expressionReferencesVariable(wc.getWhereClause().getConditionExpression(), variable))
           return true;
         break;
       }
       case UNWIND:
-        if (expressionReferencesVariable(((UnwindClause) entry.getTypedClause()).getListExpression().getText(), variable))
+        if (expressionReferencesVariable(((UnwindClause) entry.getTypedClause()).getListExpression(), variable))
           return true;
         break;
       case SET: {
@@ -321,10 +333,10 @@ public final class CypherVariableUsage {
           if (variable.equals(item.getVariable()))
             return true;
           if (item.getValueExpression() != null
-              && expressionReferencesVariable(item.getValueExpression().getText(), variable))
+              && expressionReferencesVariable(item.getValueExpression(), variable))
             return true;
           if (item.getTargetExpression() != null
-              && expressionReferencesVariable(item.getTargetExpression().getText(), variable))
+              && expressionReferencesVariable(item.getTargetExpression(), variable))
             return true;
         }
         break;
@@ -343,7 +355,7 @@ public final class CypherVariableUsage {
       case RETURN: {
         final ReturnClause rc = entry.getTypedClause();
         for (final ReturnClause.ReturnItem item : rc.getReturnItems())
-          if (expressionReferencesVariable(item.getExpression().getText(), variable))
+          if (expressionReferencesVariable(item.getExpression(), variable))
             return true;
         break;
       }
@@ -370,7 +382,7 @@ public final class CypherVariableUsage {
     final List<Expression> expressions = deleteClause.getExpressions();
     if (expressions != null)
       for (final Expression expression : expressions)
-        if (expression != null && expressionReferencesVariable(expression.getText(), variable))
+        if (expression != null && expressionReferencesVariable(expression, variable))
           return true;
     return false;
   }
@@ -378,6 +390,14 @@ public final class CypherVariableUsage {
   /**
    * Checks if an expression text references a variable as a standalone identifier.
    * Uses word-boundary matching to avoid false positives (e.g., "relation" matching "r").
+   * <p>
+   * Kept only for text that never had a parsed AST to walk instead. Prefer
+   * {@link #expressionReferencesVariable(Expression, String)} or
+   * {@link #expressionReferencesVariable(BooleanExpression, String)} wherever an AST is available: this
+   * scan runs against {@link Expression#getText()}, which is ANTLR's default {@code getText()} - it
+   * concatenates token text with no separating whitespace, so a keyword sitting right before the
+   * variable in the source (e.g. {@code any(item IN r0.k8 ...)} becoming {@code any(itemINr0.k8...)})
+   * glues onto it and silently defeats the word-boundary check below (issue #6567).
    */
   public static boolean expressionReferencesVariable(final String expressionText, final String variable) {
     if (expressionText == null || variable == null)
@@ -395,5 +415,85 @@ public final class CypherVariableUsage {
       idx++;
     }
     return false;
+  }
+
+  /**
+   * Checks if {@code expression} reads {@code variable} anywhere within it - a plain variable read, a
+   * property access, or a map-projection base - by walking the parsed AST with
+   * {@link CypherExpressionWalker} instead of scanning {@link Expression#getText()}. See
+   * {@link #expressionReferencesVariable(String, String)} for why the text scan is unreliable.
+   */
+  public static boolean expressionReferencesVariable(final Expression expression, final String variable) {
+    if (expression == null || variable == null)
+      return false;
+    final VariableReferenceFinder finder = new VariableReferenceFinder(variable);
+    CypherExpressionWalker.walk(expression, finder);
+    return finder.found;
+  }
+
+  /** {@link #expressionReferencesVariable(Expression, String)}, for a WHERE-clause predicate. */
+  public static boolean expressionReferencesVariable(final BooleanExpression expression, final String variable) {
+    if (expression == null || variable == null)
+      return false;
+    final VariableReferenceFinder finder = new VariableReferenceFinder(variable);
+    CypherExpressionWalker.walk(expression, finder);
+    return finder.found;
+  }
+
+  /**
+   * A {@link CypherExpressionWalker.Visitor} that stops at the first read of one target variable name,
+   * as a plain variable, a property access, a map-projection base, or a re-mention inside a nested
+   * MATCH/CREATE/MERGE pattern. A nested subquery body (a {@code CALL}, or the parsed body of an
+   * {@code EXISTS}/{@code COUNT}/{@code COLLECT}) auto-correlates to the names in scope where it was
+   * written, so the walk keeps using this same finder inside it (the default
+   * {@link CypherExpressionWalker.Visitor#forNestedStatement}) - reading the outer name again in there,
+   * whether as an expression or as a pattern variable it re-binds to, is still reading it. Missing the
+   * pattern case dropped the edge binding for {@code WHERE EXISTS { MATCH (p)-[r:KNOWS]->(x) ... } } -
+   * the body's own MATCH re-mentions the outer "r" only as a relationship-pattern variable, which
+   * {@link #visit(Expression)} never sees (issue #6567 review).
+   */
+  private static final class VariableReferenceFinder implements CypherExpressionWalker.Visitor {
+    private final String  variable;
+    private       boolean found = false;
+
+    VariableReferenceFinder(final String variable) {
+      this.variable = variable;
+    }
+
+    @Override
+    public void visit(final Expression expression) {
+      if (found)
+        return;
+      switch (expression) {
+      case VariableExpression variableExpression -> found = variable.equals(variableExpression.getVariableName());
+      case PropertyAccessExpression property -> found = variable.equals(property.getVariableName());
+      case MapProjectionExpression projection -> found = variable.equals(projection.getVariableName());
+      default -> {
+        // Not a name-carrying node; the walk still descends into its children.
+      }
+      }
+    }
+
+    @Override
+    public void visitPattern(final PathPattern pattern) {
+      if (found)
+        return;
+      if (variable.equals(pattern.getPathVariable())) {
+        found = true;
+        return;
+      }
+      if (pattern.getNodes() != null)
+        for (final NodePattern node : pattern.getNodes())
+          if (node != null && variable.equals(node.getVariable())) {
+            found = true;
+            return;
+          }
+      if (pattern.getRelationships() != null)
+        for (final RelationshipPattern relationship : pattern.getRelationships())
+          if (relationship != null && variable.equals(relationship.getVariable())) {
+            found = true;
+            return;
+          }
+    }
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -1026,18 +1026,21 @@ public class CypherOptimizer {
    */
   private boolean readsOnlyTheAnchor(final BooleanExpression expression, final String anchorVariable,
       final LogicalPlan logicalPlan) {
-    final String text = expression.getText();
-    if (text == null || !CypherVariableUsage.expressionReferencesVariable(text, anchorVariable))
+    // Walks the parsed expression rather than Expression#getText(): ANTLR's default getText()
+    // concatenates token text with no separating whitespace, which can glue a keyword onto the very
+    // next variable name (e.g. "any(item IN r0.k8 ...)" becomes "any(itemINr0.k8...)") and silently
+    // defeat a word-boundary text scan (issue #6567).
+    if (!CypherVariableUsage.expressionReferencesVariable(expression, anchorVariable))
       return false;
 
     for (final String variable : logicalPlan.getPatternNodes().keySet())
-      if (!variable.equals(anchorVariable) && CypherVariableUsage.expressionReferencesVariable(text, variable))
+      if (!variable.equals(anchorVariable) && CypherVariableUsage.expressionReferencesVariable(expression, variable))
         return false;
 
     for (final LogicalRelationship relationship : logicalPlan.getRelationships()) {
       final String relationshipVariable = relationship.getVariable();
       if (relationshipVariable != null && !relationshipVariable.isEmpty()
-          && CypherVariableUsage.expressionReferencesVariable(text, relationshipVariable))
+          && CypherVariableUsage.expressionReferencesVariable(expression, relationshipVariable))
         return false;
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -1670,13 +1670,20 @@ class CypherExpressionBuilder {
    * Expression for chained property access where the base is not a simple variable.
    * Example: list[0].property, func().property
    */
-  private static class ChainedPropertyAccessExpression implements Expression {
+  // Package-private (not private) so CypherExpressionWalker, in this same package, can descend into
+  // baseExpression - the fix for issue #6567 depends on the walk reaching it: without this arm the
+  // walker had already treated startNode(r).name as a leaf and never seen the "r" inside.
+  static class ChainedPropertyAccessExpression implements Expression {
     private final Expression baseExpression;
     private final String propertyName;
 
     ChainedPropertyAccessExpression(final Expression baseExpression, final String propertyName) {
       this.baseExpression = baseExpression;
       this.propertyName = propertyName;
+    }
+
+    public Expression getBaseExpression() {
+      return baseExpression;
     }
 
     @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionWalker.java
@@ -359,6 +359,7 @@ public final class CypherExpressionWalker {
       walk(predicate.getListExpression(), visitor);
       walk(predicate.getWhereExpression(), visitor);
     }
+    case CypherExpressionBuilder.ChainedPropertyAccessExpression chained -> walk(chained.getBaseExpression(), visitor);
     case ReduceExpression reduce -> {
       walk(reduce.getInitialValue(), visitor);
       walk(reduce.getListExpression(), visitor);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
@@ -192,6 +192,24 @@ class CypherVariableUsageTest {
     assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) RETURN endNode(r).name AS n", "r")).isTrue();
   }
 
+  /**
+   * Issue #6567 review: a nested {@code EXISTS { MATCH ... } } body that re-mentions an outer edge only
+   * as a relationship-pattern variable - not inside any expression - is a correlation too. {@code visit
+   * (Expression)} never fires for a pattern variable, so only the walker's {@code visitPattern} callback
+   * sees it; missing that case would drop the outer edge binding the same way the list-predicate gap did.
+   */
+  @Test
+  void aNestedExistsPatternCorrelationReadsIt() {
+    assertThat(isReferenced(
+        "MATCH (a)-[r:KNOWS]->(b) WHERE EXISTS { MATCH (p)-[r]->(x) RETURN x } RETURN count(*)", "r"))
+        .isTrue();
+    // Control: the nested MATCH binds its own, differently-named relationship - the outer "r" is not
+    // mentioned anywhere in the EXISTS body, so it must not be falsely reported as referenced.
+    assertThat(isReferenced(
+        "MATCH (a)-[r:KNOWS]->(b) WHERE EXISTS { MATCH (p)-[q:LIKES]->(x) RETURN x } RETURN count(*)", "r"))
+        .isFalse();
+  }
+
   @Test
   void expressionMatchingIsNullSafeAndBoundaryAware() {
     assertThat(CypherVariableUsage.expressionReferencesVariable((String) null, "r")).isFalse();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherVariableUsageTest.java
@@ -145,9 +145,56 @@ class CypherVariableUsageTest {
     assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) RETURN b.prefixr", "r")).isFalse();
   }
 
+  /**
+   * Issue #6567: a relationship read only inside a list predicate (any/all/none/single) or list
+   * comprehension must keep its real binding. The word-boundary text scan this class used before
+   * missed it: {@code any(item IN r0.k8 WHERE item IS NOT NULL)}'s {@code getText()} - ANTLR's default,
+   * which drops all whitespace between tokens - reads {@code "any(itemINr0.k8WHEREitemISNOTNULL)"},
+   * where "r0" no longer starts a word once it is glued to the "N" of "IN". Anonymizing the edge under
+   * that text then made the WHERE clause's own AST-based evaluation of {@code r0.k8} read a missing
+   * binding instead of the real list, turning a true predicate false and dropping every row.
+   */
+  @Test
+  void aRelationshipReadOnlyInsideAListPredicateIsReferenced() {
+    assertThat(isReferenced(
+        "MATCH (a)-[r0:KNOWS]->(b) WHERE any(item IN r0.tags WHERE item IS NOT NULL) RETURN count(*)", "r0"))
+        .isTrue();
+    assertThat(isReferenced(
+        "MATCH (a)-[r0:KNOWS]->(b) WHERE all(item IN r0.tags WHERE item IS NOT NULL) RETURN count(*)", "r0"))
+        .isTrue();
+    assertThat(isReferenced(
+        "MATCH (a)-[r0:KNOWS]->(b) WHERE none(item IN r0.tags WHERE item IS NULL) RETURN count(*)", "r0"))
+        .isTrue();
+    assertThat(isReferenced(
+        "MATCH (a)-[r0:KNOWS]->(b) WHERE single(item IN r0.tags WHERE item IS NOT NULL) RETURN count(*)", "r0"))
+        .isTrue();
+    assertThat(isReferenced(
+        "MATCH (a)-[r0:KNOWS]->(b) WHERE size([item IN r0.tags WHERE item IS NOT NULL]) > 0 RETURN count(*)", "r0"))
+        .isTrue();
+    // Control: an edge truly absent from the predicate - not even as a loop-scoped iterator name -
+    // must not be reported as referenced just because the statement contains a list predicate at all.
+    assertThat(isReferenced(
+        "MATCH (a)-[unused:KNOWS]->(b) WHERE any(item IN [1,2] WHERE item > 0) RETURN count(*)", "unused"))
+        .isFalse();
+  }
+
+  /**
+   * Issue #6567 review: a relationship read through a chained property access on a function result -
+   * {@code startNode(r).name}, not the simple {@code r.name} - must also keep its real binding.
+   * {@link com.arcadedb.query.opencypher.parser.CypherExpressionWalker} had no case for that node type
+   * (built by {@code CypherExpressionBuilder.ChainedPropertyAccessExpression} whenever a property access
+   * follows something other than a bare variable) and treated it as a leaf, so the walk never reached
+   * the {@code r} inside {@code startNode(r)}.
+   */
+  @Test
+  void aRelationshipReadThroughAChainedPropertyAccessIsReferenced() {
+    assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) RETURN startNode(r).name AS n", "r")).isTrue();
+    assertThat(isReferenced("MATCH (a)-[r:KNOWS]->(b) RETURN endNode(r).name AS n", "r")).isTrue();
+  }
+
   @Test
   void expressionMatchingIsNullSafeAndBoundaryAware() {
-    assertThat(CypherVariableUsage.expressionReferencesVariable(null, "r")).isFalse();
+    assertThat(CypherVariableUsage.expressionReferencesVariable((String) null, "r")).isFalse();
     assertThat(CypherVariableUsage.expressionReferencesVariable("r.since", null)).isFalse();
     assertThat(CypherVariableUsage.expressionReferencesVariable("r", "r")).isTrue();
     assertThat(CypherVariableUsage.expressionReferencesVariable("r.since + rate", "r")).isTrue();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6567ListPredicateEdgeVariableTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6567ListPredicateEdgeVariableTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6567.
+ * <p>
+ * A relationship variable read only inside a WHERE list predicate ({@code any}/{@code all}/
+ * {@code none}/{@code single}) was silently anonymized: {@link com.arcadedb.query.opencypher.executor.CypherVariableUsage}
+ * decided whether {@code r0} kept its real binding by scanning {@code Expression#getText()} for the
+ * name as a standalone word, but that text is ANTLR's default {@code getText()} - it drops every
+ * whitespace between tokens, so {@code any(item IN r0.k8 WHERE item IS NOT NULL)} became
+ * {@code "any(itemINr0.k8WHEREitemISNOTNULL)"} and "r0" was no longer a standalone word once glued to
+ * the "N" of "IN". The relationship pattern step then bound the edge under an internal anonymous name
+ * instead of "r0", so the WHERE clause's own (correct, AST-based) evaluation of {@code r0.k8} read a
+ * missing binding, silently turned a true predicate false, and dropped every row downstream - including
+ * an entire {@code CALL () { ... } IN TRANSACTIONS} subquery whose results a later {@code collect()}
+ * should have seen.
+ * <p>
+ * A value-preserving {@code WITH r0 AS r0} (or any other clause re-mentioning {@code r0} in a way the
+ * text scan could parse) "fixed" the symptom by making the variable look referenced again - which is
+ * why the issue surfaced as two textually-equivalent queries returning different results, rather than
+ * as an outright wrong answer.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6567ListPredicateEdgeVariableTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher",
+        "CREATE (n1:Person {id: 'n1'})-[r1:rt2]->(x:Person {id: 'x', klist: ['a']})-[:rt10]->(n0:Person {id: 'n0'})"
+            + "-[r0:rt8 {k9: 267022112, k8: [1]}]->(t:Person {id: 't', k0: true, k8: [1, 2]})");
+    database.command("opencypher",
+        "CREATE (s:Person {id: 22})-[:rt5]->(n3:Person {id: 'n3', klist: []})-[:rt8]->(n2:Person {id: 'n2', k3: 'e'})");
+  }
+
+  /**
+   * The issue's own reproducer, minimized: a value-preserving {@code WITH} inserted between the
+   * {@code CALL () {...} IN TRANSACTIONS} clause and the final {@code RETURN} must not change the
+   * {@code collect()} result, and both forms must see the subquery's row.
+   */
+  @Test
+  void identityWithBetweenCallInTransactionsAndReturnDoesNotChangeTheResult() {
+    final String withoutIdentityWith = """
+        MATCH
+          (n1)-[r1:rt2]->(x {klist: ['a']})-[:rt10]->(n0)-[r0:rt8|rt1|rt7 {k9: 267022112}]->(t {k0: true, k8: [1, 2]})
+        WHERE any(item IN r0.k8 WHERE item IS NOT NULL)
+        CALL () {
+          MATCH (n2), (n3 {klist: []})-[:rt8]->(n2),
+                ({id: 22})-[r2:rt5|rt2|rt7]->(n3)
+          RETURN n2 AS n15
+        } IN TRANSACTIONS OF 10 ROWS
+        RETURN collect(toStringOrNull(n15.k3)) AS result
+        """;
+    final String withIdentityWith = """
+        MATCH
+          (n1)-[r1:rt2]->(x {klist: ['a']})-[:rt10]->(n0)-[r0:rt8|rt1|rt7 {k9: 267022112}]->(t {k0: true, k8: [1, 2]})
+        WHERE any(item IN r0.k8 WHERE item IS NOT NULL)
+        CALL () {
+          MATCH (n2), (n3 {klist: []})-[:rt8]->(n2),
+                ({id: 22})-[r2:rt5|rt2|rt7]->(n3)
+          RETURN n2 AS n15
+        } IN TRANSACTIONS OF 10 ROWS
+        WITH CASE WHEN r0 IS NULL THEN null ELSE r0 END AS r0, n15
+        RETURN collect(toStringOrNull(n15.k3)) AS result
+        """;
+
+    assertThat(singleResult(withoutIdentityWith)).containsExactly("e");
+    assertThat(singleResult(withIdentityWith)).containsExactly("e");
+  }
+
+  /** Same defect, without CALL/IN TRANSACTIONS: the any() predicate alone must not lose the edge binding. */
+  @Test
+  void anyPredicateOnRelationshipPropertyDoesNotDropTheMatch() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n1)-[r1:rt2]->(x)-[:rt10]->(n0)-[r0:rt8 {k9: 267022112}]->(t) "
+            + "WHERE any(item IN r0.k8 WHERE item IS NOT NULL) "
+            + "RETURN count(*) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isEqualTo(1L);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object> singleResult(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      return (List<Object>) row.getProperty("result");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizerAnchorOnlyFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizerAnchorOnlyFilterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.optimizer;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the {@code CypherOptimizer.readsOnlyTheAnchor} half of issue #6567.
+ * <p>
+ * {@code readsOnlyTheAnchor} decides whether a WHERE conjunct can be pushed straight onto the
+ * anchor node's {@code NodeByLabelScan} - safe only when the conjunct reads the anchor variable and
+ * nothing else. It used to answer that with the same {@code Expression#getText()} word-boundary scan
+ * that caused the executor-side bug: ANTLR's {@code getText()} drops whitespace between tokens, so
+ * {@code any(item IN r0.tags WHERE ...)} renders as {@code "any(itemINr0.tagsWHERE...")}, and a
+ * {@code \br0\b} search no longer finds "r0" because it is glued onto the immediately preceding "IN".
+ * <p>
+ * When the anchor is a different variable than the one glued away, this isn't just a missed
+ * optimization: {@code readsOnlyTheAnchor} wrongly concludes the conjunct depends on the anchor alone
+ * and pushes it onto the anchor scan, where the relationship variable it actually reads is not bound
+ * yet. This test's predicate reads both the anchor node's property and the relationship's list
+ * property in the same {@code any(...)} conjunct, both node labels are present so the query is
+ * eligible for the cost-based optimizer, and it asserts the plan actually took that path (rather than
+ * silently falling back to the legacy evaluator, which was never affected by this bug).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherOptimizerAnchorOnlyFilterTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Person");
+      database.getSchema().createEdgeType("KNOWS");
+    });
+    // Matches: 5 is in the relationship's tags list.
+    database.command("opencypher", "CREATE (:Person {id: 1, threshold: 5})-[:KNOWS {tags: [5, 6]}]->(:Person {id: 11})");
+    // Does not match: 99 is not in the relationship's tags list.
+    database.command("opencypher", "CREATE (:Person {id: 2, threshold: 99})-[:KNOWS {tags: [5, 6]}]->(:Person {id: 12})");
+  }
+
+  @Test
+  void anyPredicateReadingBothAnchorAndRelationshipIsNotWronglyPushedToAnchorScan() {
+    final String query = """
+        MATCH (a:Person)-[r0:KNOWS]->(b:Person)
+        WHERE any(item IN r0.tags WHERE item = a.threshold)
+        RETURN a.id AS aid
+        """;
+
+    // Confirm this query is actually eligible for the cost-based optimizer (both endpoints labeled),
+    // so the assertion below pins CypherOptimizer.readsOnlyTheAnchor rather than the legacy evaluator.
+    try (final ResultSet explain = database.query("opencypher", "EXPLAIN " + query)) {
+      final String plan = explain.getExecutionPlan().get().prettyPrint(0, 2);
+      assertThat(plan).contains("Using Cost-Based Query Optimizer");
+    }
+
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("aid").intValue()).isEqualTo(1);
+      assertThat(rs.hasNext()).isFalse();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6567.

`CypherVariableUsage.isEdgeVariableReferenced` decided whether a relationship variable keeps its real binding (vs. being anonymized for the CSR/GAV fast-path) by scanning `Expression#getText()` for the name as a standalone word. That text is ANTLR's default `getText()`, which drops all whitespace between tokens, so `any(item IN r0.k8 WHERE item IS NOT NULL)` became `any(itemINr0.k8WHEREitemISNOTNULL)` — `r0` no longer starts a word once it's glued to the "N" of "IN". The relationship-pattern step then bound the edge under an internal anonymous name, so the WHERE clause's own (correct, AST-based) evaluation of `r0.k8` read a missing binding, silently turned a true predicate false, and dropped every row downstream — including an entire `CALL () { ... } IN TRANSACTIONS` subquery whose rows a later `collect()` should have seen.

That's why the issue as reported looked like "a value-preserving `WITH`/`CASE` projection changes the result": inserting it made the text scan see the variable name again (by coincidence of what surrounded it), which "fixed" the symptom without addressing the actual defect.

Verified against the reported repro: both the query as originally written and the "control" form the issue used for comparison now return the same (correct) non-empty result.

### The fix

Replaced the text scan with a walk of the already-parsed AST via `CypherExpressionWalker`, which the codebase already uses elsewhere for the same "does this expression reference variable X" question — reusing an existing, better-tested mechanism instead of patching the regex. This surfaced two more gaps that had to be closed for the walker-based approach to be correct, not just for #6567's own repro:

1. **`CypherExpressionWalker` had no case for `ChainedPropertyAccessExpression`** (built for `startNode(r).name`-style access — a property access on something other than a bare variable). It fell to the walker's `default` arm, which treats an unmodeled node as a leaf, so the walk never reached the `r` inside `startNode(r)`. Found by full-suite regression (`startNode`/`endNode` tests went from passing to returning `null`), not by the original issue — the walker's own class doc already warns this is exactly the failure mode of an unhandled composite type.
2. **The new AST-based check needed pattern-variable mentions, not just expression reads.** A nested subquery body (`EXISTS { MATCH (p)-[r:KNOWS]->(x) ... }`) re-mentioning an outer edge only as a relationship-pattern variable is a correlation, which only the walker's `visitPattern` callback sees — `visit(Expression)` never fires for it. Also found by full-suite regression, mirroring the existing `CypherReferencedVariables` collector's handling of the same shape.

`CypherOptimizer.readsOnlyTheAnchor` (filter-pushdown eligibility for the cost-based optimizer) had the identical text-scan pattern and is fixed the same way, so the defect doesn't linger in the newer optimizer path once it starts handling this query shape.

The old text-based `expressionReferencesVariable(String, String)` overload is kept only as a fallback for the one call site (a legacy `ORDER BY` item) that can lack a parsed AST.

## Test plan

- [x] New regression test `Issue6567ListPredicateEdgeVariableTest` reproduces the exact reported query shape (`CALL () {...} IN TRANSACTIONS` + `any()` in WHERE + identity `WITH`) and asserts both forms return the same correct result.
- [x] New unit tests in `CypherVariableUsageTest` cover `any`/`all`/`none`/`single`/list-comprehension referencing an edge property, the `ChainedPropertyAccessExpression` gap (`startNode(r).name`), and a negative control (unrelated edge not falsely flagged as referenced).
- [x] Full `com.arcadedb.query.opencypher.**` suite (447 test classes, 8829 tests) passes with no regressions.
- [x] `mvn -o -pl engine compile` clean.

🔗 https://github.com/ArcadeData/arcadedb/issues/6567