### PR TITLE
fix(engine): native select must not cap the index candidate scan by the result limit

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/MultiIndexCursor.java
@@ -111,7 +111,9 @@ public class MultiIndexCursor implements IndexCursor {
 
   @Override
   public boolean hasNext() {
-    if (limit > -1 && browsed > limit)
+    // #6565: browsed COUNTS CANDIDATES ALREADY RETURNED BY next(), SO browsed == limit MEANS limit CANDIDATES HAVE
+    // ALREADY BEEN HANDED OUT - ONE MORE WOULD EXCEED THE CAP THE CALLER ASKED FOR
+    if (limit > -1 && browsed >= limit)
       return false;
 
     for (int i = 0; i < cursors.size(); ++i) {

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -329,6 +329,9 @@ public class SelectExecutor {
     if (leaf == null || select.orderBy.size() != 1)
       return false;
     final Pair<String, Boolean> orderBy = select.orderBy.getFirst();
+    // UNCHECKED CAST IS SAFE: leaf CAME FROM soleExactLeaf(), WHICH ONLY EVER RETURNS A NODE WHOSE node.index IS
+    // NON-null - AND isTheNodeFullyIndexed() ONLY EVER SETS node.index AFTER THIS EXACT SAME CAST ON node.left
+    // ALREADY SUCCEEDED
     return orderBy.getSecond() && orderBy.getFirst().equals(((SelectPropertyValue) leaf.left).propertyName);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -232,6 +232,11 @@ public class SelectExecutor {
       filterWithIndexes(select.rootTreeElement, cursors);
       if (!cursors.isEmpty())
         return new MultiIndexCursor(cursors, indexCandidateLimit, true);
+
+      // NO CURSOR WAS ACTUALLY BUILT (E.G. A BARE neq/like/ilike LEAF: "INDEXED" PER isTheNodeFullyIndexed()'S LOOSER
+      // CHECK - SEE #6577 - BUT filterWithIndexesFinalNode()'S switch DOESN'T HANDLE THE OPERATOR), SO NO CAP WAS
+      // EVER APPLIED EITHER: RESET THE TEST-VISIBLE FIELD RATHER THAN LEAVE IT HOLDING A MISLEADING FINITE VALUE
+      indexCandidateLimit = -1;
     }
     return null;
   }

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -254,9 +254,11 @@ public class SelectExecutor {
    * True when the index cursor(s) built for this subtree return exactly the records matching it, with nothing left
    * for {@code evaluateWhere()} to discard afterward. Only a bare indexed leaf qualifies (through the synthetic
    * {@code run} wrapper, see below): an {@code is_null}/{@code is_not_null} leaf never gets a cursor, and under an
-   * {@code and} only one child's cursor is kept (see {@link #filterWithIndexesFinalNode}), so the other conjunct is
-   * still checked later against a stream a cap would have already truncated. {@code not} is conservatively treated
-   * the same way.
+   * {@code and} at most one child's cursor is kept when either side's index is unique (see
+   * {@link #filterWithIndexesFinalNode}) - when neither side is unique, both children's cursors survive and
+   * {@link MultiIndexCursor} unions rather than intersects them, a superset {@code evaluateWhere()} must still
+   * narrow down. Either way the discarded or extra conjunct is still checked later against a stream a cap would
+   * have already truncated or under-counted. {@code not} is conservatively treated the same way.
    * <p>
    * {@code or} is conservatively excluded too, even though {@link MultiIndexCursor} merges its children's cursors
    * into the same shape as the boolean union: that merge is a plain k-way merge with no RID dedup, so two branches
@@ -281,6 +283,11 @@ public class SelectExecutor {
     if (node == null)
       return true;
 
+    // node.index != null MEANS "isTheNodeFullyIndexed() FOUND AN INDEX ON THIS LEAF'S PROPERTY", NOT "THIS LEAF'S
+    // OPERATOR ACTUALLY PRODUCES A CURSOR" - IT'S SET FOR neq/like/ilike TOO (SEE #6577). HARMLESS TODAY BECAUSE A
+    // BARE SUCH LEAF STILL PRODUCES NO CURSOR IN filterWithIndexesFinalNode()'S switch, SO cursors STAYS EMPTY AND
+    // lookForIndexes() RETURNS null BEFORE ANY (WRONGLY-COMPUTED) CAP IS EVER USED - BUT #6577 IS WHERE TO FIX THIS
+    // AT THE SOURCE, NOT HERE
     if (!(node.left instanceof SelectTreeNode))
       return node.index != null;
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -47,7 +47,7 @@ public class SelectExecutor {
   // #6565: THE CANDIDATE CAP lookForIndexes() COMPUTED FOR THE WHOLE where-TREE, REUSED BY filterWithIndexesFinalNode()
   // FOR THE NESTED PER-VALUE CURSOR IT BUILDS FOR AN in_op LEAF, SO NEITHER PLACE HANDS A RAW select.limit (MISSING
   // skip) TO A MultiIndexCursor
-  private int indexCandidateLimit = -1;
+  int indexCandidateLimit = -1;
 
   static class IndexInfo {
     public final Index   index;
@@ -208,7 +208,10 @@ public class SelectExecutor {
     return iterator;
   }
 
-  private MultiIndexCursor lookForIndexes() {
+  // PACKAGE-PRIVATE (NOT private) SO Issue6565SelectIndexCandidateLimitTest CAN VERIFY THE COMPUTED CAP DIRECTLY:
+  // A RESULT-COUNT ASSERTION CANNOT TELL A CORRECTLY APPLIED CAP APART FROM THE UNCAPPED FALLBACK, SINCE THE
+  // LAZY-PULL CONSUMERS (SelectIterator, executeCount()) ALREADY STOP AT skip + limit ON THEIR OWN EITHER WAY
+  MultiIndexCursor lookForIndexes() {
     if (select.fromType != null && select.rootTreeElement != null) {
       final List<IndexCursor> cursors = new ArrayList<>();
 
@@ -246,6 +249,12 @@ public class SelectExecutor {
    * {@code is_not_null} leaf never gets a cursor, and under an {@code and} only one child's cursor is kept (see
    * {@link #filterWithIndexesFinalNode}), so the other conjunct is still checked later against a stream a cap would
    * have already truncated. {@code not} is conservatively treated the same way.
+   * <p>
+   * {@code Select.compile()} always finalizes the tree with a trailing {@code setLogic(SelectOperator.run)}
+   * ({@link Select#compile}); when the where-clause is a single bare condition with no {@code and()}/{@code or()},
+   * that call runs its "1ST TIME ONLY" branch and wraps the leaf in a synthetic {@code run} node whose {@code right}
+   * is always {@code null} ({@link Select#setLogic}) - {@code run} is otherwise never used as a tree operator, so it
+   * is treated here as a transparent pass-through to its {@code left} child.
    */
   private boolean isWhereExactlyIndexed(final SelectTreeNode node) {
     if (node == null)
@@ -254,7 +263,7 @@ public class SelectExecutor {
     if (!(node.left instanceof SelectTreeNode))
       return node.index != null;
 
-    if (node.operator == SelectOperator.or)
+    if (node.operator == SelectOperator.or || node.operator == SelectOperator.run)
       return isWhereExactlyIndexed((SelectTreeNode) node.left) && isWhereExactlyIndexed((SelectTreeNode) node.right);
 
     return false;

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -252,11 +252,24 @@ public class SelectExecutor {
 
   /**
    * True when the index cursor(s) built for this subtree return exactly the records matching it, with nothing left
-   * for {@code evaluateWhere()} to discard afterward. Only a bare indexed leaf, or an {@code or} of such leaves
-   * (which {@link MultiIndexCursor} merges - the same shape as the boolean union), qualifies: an {@code is_null}/
-   * {@code is_not_null} leaf never gets a cursor, and under an {@code and} only one child's cursor is kept (see
-   * {@link #filterWithIndexesFinalNode}), so the other conjunct is still checked later against a stream a cap would
-   * have already truncated. {@code not} is conservatively treated the same way.
+   * for {@code evaluateWhere()} to discard afterward. Only a bare indexed leaf qualifies (through the synthetic
+   * {@code run} wrapper, see below): an {@code is_null}/{@code is_not_null} leaf never gets a cursor, and under an
+   * {@code and} only one child's cursor is kept (see {@link #filterWithIndexesFinalNode}), so the other conjunct is
+   * still checked later against a stream a cap would have already truncated. {@code not} is conservatively treated
+   * the same way.
+   * <p>
+   * {@code or} is conservatively excluded too, even though {@link MultiIndexCursor} merges its children's cursors
+   * into the same shape as the boolean union: that merge is a plain k-way merge with no RID dedup, so two branches
+   * whose match sets overlap (same-property ranges that overlap, or two different properties a single record can
+   * both satisfy - not provable disjoint from the where-tree's shape alone) make the same record surface as two
+   * separate candidates, each burning one unit of the cap before {@link SelectIterator}/{@code executeCount()}'s
+   * downstream {@code filterOutRecords} dedup ever sees it. That can exhaust the cap on duplicates before enough
+   * distinct matches are found - the same "cap spent before the filtering it needs to survive" defect this class
+   * exists to fix, just reachable again through the "or is exact" path. An {@code in_op} leaf's own internal
+   * per-value cursors don't have this problem (each value is a distinct key on the same single-valued property, so
+   * their RID sets are disjoint by construction) - but that dedup-free merge happens once, inside
+   * {@link #filterWithIndexesFinalNode}'s own {@code in_op} handling, not through a top-level {@code or}, so
+   * {@code in_op} is unaffected by excluding {@code or} here.
    * <p>
    * {@code Select.compile()} always finalizes the tree with a trailing {@code setLogic(SelectOperator.run)}
    * ({@link Select#compile}); when the where-clause is a single bare condition with no {@code and()}/{@code or()},
@@ -271,7 +284,7 @@ public class SelectExecutor {
     if (!(node.left instanceof SelectTreeNode))
       return node.index != null;
 
-    if (node.operator == SelectOperator.or || node.operator == SelectOperator.run)
+    if (node.operator == SelectOperator.run)
       return isWhereExactlyIndexed((SelectTreeNode) node.left) && isWhereExactlyIndexed((SelectTreeNode) node.right);
 
     return false;

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -222,12 +222,11 @@ public class SelectExecutor {
       // #6565: A CANDIDATE CAP IS SAFE ONLY WHEN THE INDEX SCAN EXACTLY REPRODUCES THE WHERE-TREE'S RESULT SET AND
       // THE ORDER BY (IF ANY) IS ALREADY SATISFIED BY IT - evaluateWhere(), skip AND fetchResultInCaseOfOrderBy()'s
       // FULL-DRAIN SORT ALL REDUCE THE STREAM FURTHER OTHERWISE, SO THE SCAN MUST RUN UNCAPPED TO SURVIVE THAT.
-      // MUST RUN BEFORE filterWithIndexes() BELOW, SINCE isWhereExactlyIndexed() READS node.index BEFORE
+      // MUST RUN BEFORE filterWithIndexes() BELOW, SINCE soleExactLeaf() READS node.index BEFORE
       // filterWithIndexesFinalNode() PRUNES AN 'and' SIBLING'S - HARMLESS TODAY ONLY BECAUSE 'and' IS ALREADY
       // UNCONDITIONALLY DISQUALIFIED
-      final boolean whereExact = isWhereExactlyIndexed(select.rootTreeElement);
-      indexCandidateLimit = whereExact && isOrderBySafeForCap(soleExactLeaf(select.rootTreeElement))
-          ? computeExactCandidateLimit() : -1;
+      final SelectTreeNode exactLeaf = soleExactLeaf(select.rootTreeElement);
+      indexCandidateLimit = exactLeaf != null && isOrderBySafeForCap(exactLeaf) ? computeExactCandidateLimit() : -1;
 
       filterWithIndexes(select.rootTreeElement, cursors);
       if (!cursors.isEmpty())
@@ -256,14 +255,15 @@ public class SelectExecutor {
   }
 
   /**
-   * True when the index cursor(s) built for this subtree return exactly the records matching it, with nothing left
-   * for {@code evaluateWhere()} to discard afterward. Only a bare indexed leaf qualifies (through the synthetic
-   * {@code run} wrapper, see below): an {@code is_null}/{@code is_not_null} leaf never gets a cursor, and under an
-   * {@code and} at most one child's cursor is kept when either side's index is unique (see
-   * {@link #filterWithIndexesFinalNode}) - when neither side is unique, both children's cursors survive and
-   * {@link MultiIndexCursor} unions rather than intersects them, a superset {@code evaluateWhere()} must still
-   * narrow down. Either way the discarded or extra conjunct is still checked later against a stream a cap would
-   * have already truncated or under-counted. {@code not} is conservatively treated the same way.
+   * The tree's one and only indexed leaf whose index cursor, if built, would return exactly the records matching
+   * the whole tree, with nothing left for {@code evaluateWhere()} to discard afterward - {@code null} if no such
+   * leaf exists. Only a bare leaf qualifies (through the synthetic {@code run} wrapper, see below): an
+   * {@code is_null}/{@code is_not_null} leaf never gets a cursor, and under an {@code and} at most one child's
+   * cursor is kept when either side's index is unique (see {@link #filterWithIndexesFinalNode}) - when neither
+   * side is unique, both children's cursors survive and {@link MultiIndexCursor} unions rather than intersects
+   * them, a superset {@code evaluateWhere()} must still narrow down. Either way the discarded or extra conjunct is
+   * still checked later against a stream a cap would have already truncated or under-counted. {@code not} is
+   * conservatively treated the same way.
    * <p>
    * {@code or} is conservatively excluded too, even though {@link MultiIndexCursor} merges its children's cursors
    * into the same shape as the boolean union: that merge is a plain k-way merge with no RID dedup, so two branches
@@ -276,7 +276,9 @@ public class SelectExecutor {
    * per-value cursors don't have this problem (each value is a distinct key on the same single-valued property, so
    * their RID sets are disjoint by construction) - but that dedup-free merge happens once, inside
    * {@link #filterWithIndexesFinalNode}'s own {@code in_op} handling, not through a top-level {@code or}, so
-   * {@code in_op} is unaffected by excluding {@code or} here.
+   * {@code in_op} is unaffected by excluding {@code or} here. An {@code or} also always adds one {@link IndexInfo}
+   * per leaf to {@link #usedIndexes}, so {@code usedIndexes.size() == 1} - the trivial-match precondition
+   * {@link SelectIterator#fetchResultInCaseOfOrderBy} itself requires - can never hold for it either way.
    * <p>
    * {@code Select.compile()} always finalizes the tree with a trailing {@code setLogic(SelectOperator.run)}
    * ({@link Select#compile}); when the where-clause is a single bare condition with no {@code and()}/{@code or()},
@@ -284,9 +286,9 @@ public class SelectExecutor {
    * is always {@code null} ({@link Select#setLogic}) - {@code run} is otherwise never used as a tree operator, so it
    * is treated here as a transparent pass-through to its {@code left} child.
    */
-  private boolean isWhereExactlyIndexed(final SelectTreeNode node) {
+  private SelectTreeNode soleExactLeaf(final SelectTreeNode node) {
     if (node == null)
-      return true;
+      return null;
 
     // node.index != null MEANS "isTheNodeFullyIndexed() FOUND AN INDEX ON THIS LEAF'S PROPERTY", NOT "THIS LEAF'S
     // OPERATOR ACTUALLY PRODUCES A CURSOR" - IT'S SET FOR neq/like/ilike TOO (SEE #6577). HARMLESS TODAY BECAUSE A
@@ -294,29 +296,11 @@ public class SelectExecutor {
     // lookForIndexes() RETURNS null BEFORE ANY (WRONGLY-COMPUTED) CAP IS EVER USED - BUT #6577 IS WHERE TO FIX THIS
     // AT THE SOURCE, NOT HERE
     if (!(node.left instanceof SelectTreeNode))
-      return node.index != null;
-
-    if (node.operator == SelectOperator.run)
-      return isWhereExactlyIndexed((SelectTreeNode) node.left) && isWhereExactlyIndexed((SelectTreeNode) node.right);
-
-    return false;
-  }
-
-  /**
-   * The tree's one and only indexed leaf, if {@code isWhereExactlyIndexed(node)} would be true AND the tree
-   * contributes exactly one cursor - {@code null} otherwise, including for an {@code or} of two or more leaves.
-   * An {@code or} always adds one {@link IndexInfo} per leaf to {@link #usedIndexes} (see
-   * {@link #filterWithIndexesFinalNode}), so {@code usedIndexes.size() == 1} - the trivial-match precondition
-   * {@link SelectIterator#fetchResultInCaseOfOrderBy} itself requires - can never hold for it either; only a
-   * single bare leaf (reached directly, or through the synthetic {@code run} wrapper) ever qualifies.
-   */
-  private SelectTreeNode soleExactLeaf(final SelectTreeNode node) {
-    if (node == null)
-      return null;
-    if (!(node.left instanceof SelectTreeNode))
       return node.index != null ? node : null;
+
     if (node.operator == SelectOperator.run)
       return soleExactLeaf((SelectTreeNode) node.left);
+
     return null;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -44,6 +44,10 @@ public class SelectExecutor {
   final Select select;
   long            evaluatedRecords = 0;
   List<IndexInfo> usedIndexes      = null;
+  // #6565: THE CANDIDATE CAP lookForIndexes() COMPUTED FOR THE WHOLE where-TREE, REUSED BY filterWithIndexesFinalNode()
+  // FOR THE NESTED PER-VALUE CURSOR IT BUILDS FOR AN in_op LEAF, SO NEITHER PLACE HANDS A RAW select.limit (MISSING
+  // skip) TO A MultiIndexCursor
+  private int indexCandidateLimit = -1;
 
   static class IndexInfo {
     public final Index   index;
@@ -208,14 +212,52 @@ public class SelectExecutor {
     if (select.fromType != null && select.rootTreeElement != null) {
       final List<IndexCursor> cursors = new ArrayList<>();
 
-      // FIND AVAILABLE INDEXES
-      boolean canUseIndexes = isTheNodeFullyIndexed(select.rootTreeElement);
+      // FIND AVAILABLE INDEXES AND ASSIGN node.index ON EVERY INDEXED LEAF: filterWithIndexesFinalNode() RELIES ON THAT
+      // SIDE EFFECT TO KNOW WHICH LEAVES CAN BECOME A CURSOR
+      isTheNodeFullyIndexed(select.rootTreeElement);
+
+      // #6565: A CANDIDATE CAP IS SAFE ONLY WHEN THE INDEX SCAN EXACTLY REPRODUCES THE WHERE-TREE'S RESULT SET.
+      // OTHERWISE evaluateWhere() AND skip DOWNSTREAM (SelectIterator, executeCount()) STILL DISCARD CANDIDATES THAT
+      // THE CAP ALREADY COUNTED AGAINST limit, SO THE SCAN MUST RUN UNCAPPED TO SURVIVE THAT FURTHER FILTERING.
+      indexCandidateLimit = isWhereExactlyIndexed(select.rootTreeElement) ? computeExactCandidateLimit() : -1;
 
       filterWithIndexes(select.rootTreeElement, cursors);
       if (!cursors.isEmpty())
-        return new MultiIndexCursor(cursors, select.limit, true);
+        return new MultiIndexCursor(cursors, indexCandidateLimit, true);
     }
     return null;
+  }
+
+  /**
+   * The candidate cap for an exactly-indexed where-tree: {@code skip + limit} records are needed downstream (skip
+   * consumed first, then limit), not just {@code limit}.
+   */
+  private int computeExactCandidateLimit() {
+    if (select.limit < 0)
+      return -1;
+    final long sum = (long) Math.max(0, select.skip) + select.limit;
+    return sum > Integer.MAX_VALUE ? -1 : (int) sum;
+  }
+
+  /**
+   * True when the index cursor(s) built for this subtree return exactly the records matching it, with nothing left
+   * for {@code evaluateWhere()} to discard afterward. Only a bare indexed leaf, or an {@code or} of such leaves
+   * (which {@link MultiIndexCursor} merges - the same shape as the boolean union), qualifies: an {@code is_null}/
+   * {@code is_not_null} leaf never gets a cursor, and under an {@code and} only one child's cursor is kept (see
+   * {@link #filterWithIndexesFinalNode}), so the other conjunct is still checked later against a stream a cap would
+   * have already truncated. {@code not} is conservatively treated the same way.
+   */
+  private boolean isWhereExactlyIndexed(final SelectTreeNode node) {
+    if (node == null)
+      return true;
+
+    if (!(node.left instanceof SelectTreeNode))
+      return node.index != null;
+
+    if (node.operator == SelectOperator.or)
+      return isWhereExactlyIndexed((SelectTreeNode) node.left) && isWhereExactlyIndexed((SelectTreeNode) node.right);
+
+    return false;
   }
 
   private void filterWithIndexes(final SelectTreeNode node, final List<IndexCursor> cursors) {
@@ -265,7 +307,7 @@ public class SelectExecutor {
         final List<IndexCursor> inCursors = new ArrayList<>();
         for (final Object item : collection)
           inCursors.add(node.index.get(new Object[] { item }));
-        cursor = inCursors.isEmpty() ? null : new MultiIndexCursor(inCursors, select.limit, ascendingOrder);
+        cursor = inCursors.isEmpty() ? null : new MultiIndexCursor(inCursors, indexCandidateLimit, ascendingOrder);
       } else
         cursor = node.index.get(new Object[] { rightValue });
     } else if (node.operator == SelectOperator.between) {

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -47,7 +47,7 @@ public class SelectExecutor {
   // #6565: THE CANDIDATE CAP lookForIndexes() COMPUTED FOR THE WHOLE where-TREE, REUSED BY filterWithIndexesFinalNode()
   // FOR THE NESTED PER-VALUE CURSOR IT BUILDS FOR AN in_op LEAF, SO NEITHER PLACE HANDS A RAW select.limit (MISSING
   // skip) TO A MultiIndexCursor
-  int indexCandidateLimit = -1;
+  int             indexCandidateLimit = -1;
 
   static class IndexInfo {
     public final Index   index;

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -226,7 +226,13 @@ public class SelectExecutor {
       // TODAY IT DOESN'T MATTER THAT filterWithIndexesFinalNode() NULLS OUT AN 'and' SIBLING'S node.index AS A
       // SIDE EFFECT OF BUILDING ITS CURSOR - BUT IF THAT DISQUALIFICATION EVER LOOSENS, THIS ORDERING (COMPUTING THE
       // CAP OFF THE PRE-PRUNING TREE) BECOMES LOAD-BEARING
-      indexCandidateLimit = isWhereExactlyIndexed(select.rootTreeElement) ? computeExactCandidateLimit() : -1;
+      // A THIRD DOWNSTREAM CONSUMER OF THIS CURSOR ALSO REDUCES THE STREAM FURTHER: SelectIterator.fetchResultInCaseOfOrderBy()
+      // DRAINS AND SORTS THE *FULL* ITERATOR WHENEVER select.orderBy ISN'T TRIVIALLY SERVED BY THIS SCAN'S FORCED
+      // ASCENDING ORDER, SO THE CAP MUST ALSO STAY OFF WHENEVER THAT DRAIN WOULD HAPPEN - isOrderBySafeForCap() MIRRORS
+      // THAT METHOD'S OWN TRIVIAL-MATCH CHECK
+      final boolean whereExact = isWhereExactlyIndexed(select.rootTreeElement);
+      indexCandidateLimit = whereExact && isOrderBySafeForCap(soleExactLeaf(select.rootTreeElement))
+          ? computeExactCandidateLimit() : -1;
 
       filterWithIndexes(select.rootTreeElement, cursors);
       if (!cursors.isEmpty())
@@ -274,6 +280,41 @@ public class SelectExecutor {
       return isWhereExactlyIndexed((SelectTreeNode) node.left) && isWhereExactlyIndexed((SelectTreeNode) node.right);
 
     return false;
+  }
+
+  /**
+   * The tree's one and only indexed leaf, if {@code isWhereExactlyIndexed(node)} would be true AND the tree
+   * contributes exactly one cursor - {@code null} otherwise, including for an {@code or} of two or more leaves.
+   * An {@code or} always adds one {@link IndexInfo} per leaf to {@link #usedIndexes} (see
+   * {@link #filterWithIndexesFinalNode}), so {@code usedIndexes.size() == 1} - the trivial-match precondition
+   * {@link SelectIterator#fetchResultInCaseOfOrderBy} itself requires - can never hold for it either; only a
+   * single bare leaf (reached directly, or through the synthetic {@code run} wrapper) ever qualifies.
+   */
+  private SelectTreeNode soleExactLeaf(final SelectTreeNode node) {
+    if (node == null)
+      return null;
+    if (!(node.left instanceof SelectTreeNode))
+      return node.index != null ? node : null;
+    if (node.operator == SelectOperator.run)
+      return soleExactLeaf((SelectTreeNode) node.left);
+    return null;
+  }
+
+  /**
+   * True when there is no {@code orderBy} at all, or when the single {@code leaf}'s ascending index scan trivially
+   * satisfies it - mirroring {@link SelectIterator#fetchResultInCaseOfOrderBy}'s own trivial-match check
+   * ({@code usedIndexes.size() == 1} and matching property/direction). When it does NOT trivially match, that
+   * method drains the iterator fully and sorts in memory, so the candidate cap must stay off: capping at
+   * {@code skip + limit} would let the sort see only the first few candidates in ascending scan order instead of
+   * every match.
+   */
+  private boolean isOrderBySafeForCap(final SelectTreeNode leaf) {
+    if (select.orderBy == null)
+      return true;
+    if (leaf == null || select.orderBy.size() != 1)
+      return false;
+    final Pair<String, Boolean> orderBy = select.orderBy.getFirst();
+    return orderBy.getSecond() && orderBy.getFirst().equals(((SelectPropertyValue) leaf.left).propertyName);
   }
 
   private void filterWithIndexes(final SelectTreeNode node, final List<IndexCursor> cursors) {

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -273,8 +273,12 @@ public class SelectExecutor {
    * downstream {@code filterOutRecords} dedup ever sees it. That can exhaust the cap on duplicates before enough
    * distinct matches are found - the same "cap spent before the filtering it needs to survive" defect this class
    * exists to fix, just reachable again through the "or is exact" path. An {@code in_op} leaf's own internal
-   * per-value cursors don't have this problem (each value is a distinct key on the same single-valued property, so
-   * their RID sets are disjoint by construction) - but that dedup-free merge happens once, inside
+   * per-value cursors don't have this problem <i>for the indexes this method can actually resolve</i>: each value is
+   * a distinct key on a single-valued property, so their RID sets are disjoint by construction - but that
+   * assumption only holds because a {@code BY ITEM}/{@code BY KEY}/{@code BY VALUE} index (one document can
+   * contribute multiple entries for the same list/map property, breaking disjointness the same way {@code or} does)
+   * is registered under a property-name key carrying that literal suffix, which the fluent {@code Select} API this
+   * class serves has no way to produce - see #6578 if that ever changes. That dedup-free merge happens once, inside
    * {@link #filterWithIndexesFinalNode}'s own {@code in_op} handling, not through a top-level {@code or}, so
    * {@code in_op} is unaffected by excluding {@code or} here. An {@code or} also always adds one {@link IndexInfo}
    * per leaf to {@link #usedIndexes}, so {@code usedIndexes.size() == 1} - the trivial-match precondition

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -285,6 +285,12 @@ public class SelectExecutor {
    * that call runs its "1ST TIME ONLY" branch and wraps the leaf in a synthetic {@code run} node whose {@code right}
    * is always {@code null} ({@link Select#setLogic}) - {@code run} is otherwise never used as a tree operator, so it
    * is treated here as a transparent pass-through to its {@code left} child.
+   * <p>
+   * Callers must invoke this before {@link #filterWithIndexes}, which prunes a losing {@code and} sibling's
+   * {@code node.index} as a side effect of building the winning side's cursor - harmless today only because
+   * {@code and} is unconditionally disqualified above regardless of {@code node.index}. The moment that
+   * disqualification is ever loosened, this ordering becomes load-bearing: calling this method after that pruning
+   * has run could read a {@code node.index} the pruning already cleared.
    */
   private SelectTreeNode soleExactLeaf(final SelectTreeNode node) {
     if (node == null)

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -222,6 +222,10 @@ public class SelectExecutor {
       // #6565: A CANDIDATE CAP IS SAFE ONLY WHEN THE INDEX SCAN EXACTLY REPRODUCES THE WHERE-TREE'S RESULT SET.
       // OTHERWISE evaluateWhere() AND skip DOWNSTREAM (SelectIterator, executeCount()) STILL DISCARD CANDIDATES THAT
       // THE CAP ALREADY COUNTED AGAINST limit, SO THE SCAN MUST RUN UNCAPPED TO SURVIVE THAT FURTHER FILTERING.
+      // MUST RUN BEFORE filterWithIndexes() BELOW: isWhereExactlyIndexed() UNCONDITIONALLY DISQUALIFIES 'and', SO
+      // TODAY IT DOESN'T MATTER THAT filterWithIndexesFinalNode() NULLS OUT AN 'and' SIBLING'S node.index AS A
+      // SIDE EFFECT OF BUILDING ITS CURSOR - BUT IF THAT DISQUALIFICATION EVER LOOSENS, THIS ORDERING (COMPUTING THE
+      // CAP OFF THE PRE-PRUNING TREE) BECOMES LOAD-BEARING
       indexCandidateLimit = isWhereExactlyIndexed(select.rootTreeElement) ? computeExactCandidateLimit() : -1;
 
       filterWithIndexes(select.rootTreeElement, cursors);
@@ -233,7 +237,10 @@ public class SelectExecutor {
 
   /**
    * The candidate cap for an exactly-indexed where-tree: {@code skip + limit} records are needed downstream (skip
-   * consumed first, then limit), not just {@code limit}.
+   * consumed first, then limit), not just {@code limit}. On overflow this deliberately falls back to {@code -1}
+   * (uncapped) rather than clamping to {@code Integer.MAX_VALUE}: a {@code skip}/{@code limit} pair that overflows
+   * an {@code int} is already pathological, and {@code -1} is the same "run uncapped" value used everywhere else
+   * in this class when the cap can't be trusted, instead of introducing a second sentinel with the same meaning.
    */
   private int computeExactCandidateLimit() {
     if (select.limit < 0)
@@ -316,6 +323,10 @@ public class SelectExecutor {
         final List<IndexCursor> inCursors = new ArrayList<>();
         for (final Object item : collection)
           inCursors.add(node.index.get(new Object[] { item }));
+        // SHARING THE WHOLE TREE'S indexCandidateLimit HERE IS DELIBERATE, NOT JUST CONVENIENT REUSE: WHEN IT IS SET,
+        // THE OUTER MultiIndexCursor WILL NEVER PULL MORE THAN skip + limit CANDIDATES IN TOTAL ACROSS ALL ITS
+        // CHILDREN, SO NO SINGLE in_op VALUE'S NESTED CURSOR COULD EVER LEGITIMATELY NEED TO SUPPLY MORE THAN THAT -
+        // GIVING IT THE FULL BOUND IS A SAFE OVER-APPROXIMATION OF ITS OWN (TIGHTER, UNKNOWABLE HERE) SHARE
         cursor = inCursors.isEmpty() ? null : new MultiIndexCursor(inCursors, indexCandidateLimit, ascendingOrder);
       } else
         cursor = node.index.get(new Object[] { rightValue });

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -219,17 +219,12 @@ public class SelectExecutor {
       // SIDE EFFECT TO KNOW WHICH LEAVES CAN BECOME A CURSOR
       isTheNodeFullyIndexed(select.rootTreeElement);
 
-      // #6565: A CANDIDATE CAP IS SAFE ONLY WHEN THE INDEX SCAN EXACTLY REPRODUCES THE WHERE-TREE'S RESULT SET.
-      // OTHERWISE evaluateWhere() AND skip DOWNSTREAM (SelectIterator, executeCount()) STILL DISCARD CANDIDATES THAT
-      // THE CAP ALREADY COUNTED AGAINST limit, SO THE SCAN MUST RUN UNCAPPED TO SURVIVE THAT FURTHER FILTERING.
-      // MUST RUN BEFORE filterWithIndexes() BELOW: isWhereExactlyIndexed() UNCONDITIONALLY DISQUALIFIES 'and', SO
-      // TODAY IT DOESN'T MATTER THAT filterWithIndexesFinalNode() NULLS OUT AN 'and' SIBLING'S node.index AS A
-      // SIDE EFFECT OF BUILDING ITS CURSOR - BUT IF THAT DISQUALIFICATION EVER LOOSENS, THIS ORDERING (COMPUTING THE
-      // CAP OFF THE PRE-PRUNING TREE) BECOMES LOAD-BEARING
-      // A THIRD DOWNSTREAM CONSUMER OF THIS CURSOR ALSO REDUCES THE STREAM FURTHER: SelectIterator.fetchResultInCaseOfOrderBy()
-      // DRAINS AND SORTS THE *FULL* ITERATOR WHENEVER select.orderBy ISN'T TRIVIALLY SERVED BY THIS SCAN'S FORCED
-      // ASCENDING ORDER, SO THE CAP MUST ALSO STAY OFF WHENEVER THAT DRAIN WOULD HAPPEN - isOrderBySafeForCap() MIRRORS
-      // THAT METHOD'S OWN TRIVIAL-MATCH CHECK
+      // #6565: A CANDIDATE CAP IS SAFE ONLY WHEN THE INDEX SCAN EXACTLY REPRODUCES THE WHERE-TREE'S RESULT SET AND
+      // THE ORDER BY (IF ANY) IS ALREADY SATISFIED BY IT - evaluateWhere(), skip AND fetchResultInCaseOfOrderBy()'s
+      // FULL-DRAIN SORT ALL REDUCE THE STREAM FURTHER OTHERWISE, SO THE SCAN MUST RUN UNCAPPED TO SURVIVE THAT.
+      // MUST RUN BEFORE filterWithIndexes() BELOW, SINCE isWhereExactlyIndexed() READS node.index BEFORE
+      // filterWithIndexesFinalNode() PRUNES AN 'and' SIBLING'S - HARMLESS TODAY ONLY BECAUSE 'and' IS ALREADY
+      // UNCONDITIONALLY DISQUALIFIED
       final boolean whereExact = isWhereExactlyIndexed(select.rootTreeElement);
       indexCandidateLimit = whereExact && isOrderBySafeForCap(soleExactLeaf(select.rootTreeElement))
           ? computeExactCandidateLimit() : -1;
@@ -364,10 +359,8 @@ public class SelectExecutor {
         final List<IndexCursor> inCursors = new ArrayList<>();
         for (final Object item : collection)
           inCursors.add(node.index.get(new Object[] { item }));
-        // SHARING THE WHOLE TREE'S indexCandidateLimit HERE IS DELIBERATE, NOT JUST CONVENIENT REUSE: WHEN IT IS SET,
-        // THE OUTER MultiIndexCursor WILL NEVER PULL MORE THAN skip + limit CANDIDATES IN TOTAL ACROSS ALL ITS
-        // CHILDREN, SO NO SINGLE in_op VALUE'S NESTED CURSOR COULD EVER LEGITIMATELY NEED TO SUPPLY MORE THAN THAT -
-        // GIVING IT THE FULL BOUND IS A SAFE OVER-APPROXIMATION OF ITS OWN (TIGHTER, UNKNOWABLE HERE) SHARE
+        // DELIBERATE, NOT JUST CONVENIENT REUSE: THE OUTER MultiIndexCursor NEVER PULLS MORE THAN indexCandidateLimit
+        // CANDIDATES ACROSS ALL ITS CHILDREN COMBINED, SO NO SINGLE VALUE'S NESTED CURSOR CAN LEGITIMATELY NEED MORE
         cursor = inCursors.isEmpty() ? null : new MultiIndexCursor(inCursors, indexCandidateLimit, ascendingOrder);
       } else
         cursor = node.index.get(new Object[] { rightValue });

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -284,6 +284,30 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
   }
 
   @Test
+  void skipAndLimitOnPlainIndexedRangePagesCorrectly() {
+    // CODE REVIEW GAP: THE "SOLE EXACT LEAF, skip+limit CAPPED CORRECTLY" PATH WAS ONLY TESTED FOR eq AND in_op -
+    // ANY OPERATOR filterWithIndexesFinalNode()'S switch TURNS INTO A CURSOR (gt/ge/lt/le/between TOO) IS EQUALLY
+    // EXACT, SINCE soleExactLeaf() DOESN'T DISCRIMINATE BY OPERATOR - THIS CLOSES THAT GAP EXPLICITLY FOR ge.
+    // n >= 500 MATCHES 500 OF THE 1000 ROWS (n IN [500,999]).
+    final Select select = database.select().fromType("T").where().property("n").ge().value(500)//
+        .limit(50).skip(100);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(150);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+
+    final long count = database.select().fromType("T").where().property("n").ge().value(500)//
+        .skip(100).limit(50).count();
+    assertThat(count).isEqualTo(50);
+  }
+
+  @Test
   void andUnderOrIsNeverTreatedAsExactlyIndexed() {
     // (a = 'x' AND b = 'set') OR n = 5: PRECEDENCE-DRIVEN Select.setLogic() BUILDS A NESTED and NODE UNDER THE or
     // ROOT (and HAS HIGHER PRECEDENCE THAN or). soleExactLeaf() MUST STAY CONSERVATIVE FOR A TREE SHAPED LIKE THIS

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -40,6 +40,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * so the discarded conjunct is still checked by {@code evaluateWhere()} against a candidate stream that was
  * already capped too early), and plain {@code skip + limit} paging over a single indexed equality (the candidate
  * cap must cover {@code skip + limit} records, not just {@code limit}).
+ * <p>
+ * The fix for those two shapes only caps a candidate stream that a bare indexed leaf (or a synthetic {@code run}
+ * wrapper around one) reproduces exactly. Two further consumers can still reduce that stream beyond {@code skip +
+ * limit} and had to be accounted for: {@code ORDER BY} whose direction/property doesn't trivially match the forced
+ * ascending index scan (forces a full in-memory sort - see {@code isOrderBySafeForCap()}), and an {@code or} of two
+ * indexed leaves whose match sets can overlap ({@code MultiIndexCursor} merges children with no RID dedup, so an
+ * overlapping record surfaces as two candidates that each burn the cap before downstream dedup runs - see
+ * {@code orOfIndexedLeavesIsNeverTreatedAsExactlyIndexed}).
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -130,13 +138,37 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
 
   @Test
   void orOfTwoIndexedRangesWithSkipAndLimitPagesCorrectly() {
-    // THE NESTED CURSORS UNDER AN 'OR' ARE MERGED BY MultiIndexCursor - THE SAME UNION SHAPE AS THE BOOLEAN 'OR' - SO
-    // THIS TREE IS EXACTLY INDEXED TOO, AND THE CAP MUST STILL ACCOUNT FOR skip
+    // or DISQUALIFIES THE CAP (SEE orOfIndexedLeavesIsNeverTreatedAsExactlyIndexed BELOW), SO THIS PAGES CORRECTLY
+    // VIA THE UNCAPPED FALLBACK REGARDLESS OF WHETHER THE TWO BRANCHES OVERLAP - THESE RANGES HAPPEN NOT TO
     final long count = database.select().fromType("T").where()//
         .property("n").lt().value(10)//
         .or().property("n").ge().value(990)//
         .skip(5).limit(10).count();
     assertThat(count).isEqualTo(10);
+  }
+
+  @Test
+  void orOfIndexedLeavesIsNeverTreatedAsExactlyIndexed() {
+    // MultiIndexCursor MERGES ITS CHILDREN WITH NO RID DEDUP: IF THE SAME RECORD SATISFIES BOTH or BRANCHES (SAME-
+    // PROPERTY RANGES THAT OVERLAP, OR TWO DIFFERENT PROPERTIES ONE RECORD CAN SATISFY TOGETHER - NOT PROVABLE
+    // DISJOINT FROM THE TREE SHAPE ALONE), IT SURFACES AS TWO SEPARATE CANDIDATES, EACH BURNING ONE UNIT OF THE CAP
+    // BEFORE THE DOWNSTREAM DEDUP (SelectIterator/executeCount()'s filterOutRecords) EVER SEES IT - SEE
+    // overlappingOrBranchesOnTheSamePropertyStillReturnLimitDistinctRows FOR A CONCRETE REPRODUCTION. or MUST
+    // THEREFORE STAY CONSERVATIVE EVEN FOR TWO PLAIN INDEXED LEAVES, JUST LIKE and/not.
+    final Select select = database.select().fromType("T").where()//
+        .property("n").lt().value(10)//
+        .or().property("n").ge().value(990)//
+        .skip(5).limit(10);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(-1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
   }
 
   @Test
@@ -150,9 +182,23 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
   }
 
   @Test
+  void overlappingOrBranchesOnTheSamePropertyStillReturnLimitDistinctRows() {
+    // n > 5 AND n < 500 OVERLAP OVER (5,500): A RECORD IN THAT RANGE IS A CANDIDATE FROM *BOTH* CHILD CURSORS.
+    // MultiIndexCursor.next() IS A PLAIN K-WAY MERGE WITH NO RID DEDUP, SO IT EMITS THAT RECORD TWICE; DEDUP ONLY
+    // HAPPENS ONE LAYER UP (SelectIterator.fetchNext()/executeCount() VIA filterOutRecords), AFTER THE DUPLICATE HAS
+    // ALREADY BEEN COUNTED AGAINST THE CAP. EVERY ONE OF THE 1000 ROWS SATISFIES THIS OR (ONLY n IN [0,5] FAILS THE
+    // FIRST BRANCH, ONLY n IN [500,999] FAILS THE SECOND, AND NO ROW FAILS BOTH), SO A CAP EXHAUSTED BY DUPLICATES
+    // WOULD RETURN FEWER THAN THE REQUESTED 10.
+    final long count = database.select().fromType("T").where()//
+        .property("n").gt().value(5)//
+        .or().property("n").lt().value(500)//
+        .limit(10).count();
+    assertThat(count).isEqualTo(10);
+  }
+
+  @Test
   void inLeafUnderOrWithSkipAndLimitPagesCorrectly() {
-    // SHARING THE WHOLE TREE'S indexCandidateLimit WITH A NESTED PER-VALUE CURSOR (in_op) STAYS SAFE EVEN WHEN THAT
-    // CURSOR IS ALSO ONE CHILD OF AN OUTER or-MERGED MultiIndexCursor.
+    // AN in_op LEAF NESTED UNDER or PAGES CORRECTLY VIA THE SAME UNCAPPED FALLBACK AS ANY OTHER or.
     // g IN (g0,g1,g2) MATCHES 600 OF THE 1000 ROWS (i % 5 IN {0,1,2}); n = 3 MATCHES EXACTLY 1 ROW WHOSE g IS "g3"
     // (i % 5 == 3), OUTSIDE THE IN SET, SO THE UNION HAS 601 DISTINCT MATCHES.
     final long count = database.select().fromType("T").where()//

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.select;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
 import com.arcadedb.index.MultiIndexCursor;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -221,6 +222,40 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
     final MultiIndexCursor cursor = executor.lookForIndexes();
     try {
       assertThat(executor.indexCandidateLimit).isEqualTo(-1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  @Test
+  void orderByDescendingOnAscendingScannedIndexWithLimitReturnsTrueTail() {
+    // CODE REVIEW ON #6571, ROUND 3: SelectIterator.fetchResultInCaseOfOrderBy() MATERIALIZES BY DRAINING THE FULL
+    // ITERATOR WHENEVER THE REQUESTED ORDER DOESN'T TRIVIALLY MATCH THE (ALWAYS ASCENDING) INDEX SCAN
+    // filterWithIndexesFinalNode() PERFORMS - BUT THE CANDIDATE CAP THIS PR RESTORES WOULD STOP THAT DRAIN AT
+    // skip + limit, LETTING THE IN-MEMORY SORT SEE ONLY THE FIRST FEW ASCENDING CANDIDATES INSTEAD OF EVERY MATCH.
+    // A DESCENDING orderBy() ON THE SAME PROPERTY THE WHERE CLAUSE INDEXES MUST DISABLE THE CAP TOO.
+    final List<Document> list = database.select().fromType("T").where()//
+        .property("n").gt().value(-1)//
+        .orderBy("n", false).limit(10).documents().toList();
+    assertThat(list).hasSize(10);
+    for (int i = 0; i < list.size(); i++)
+      assertThat(list.get(i).getInteger("n")).isEqualTo(ROWS - 1 - i);
+  }
+
+  @Test
+  void orderByAscendingMatchingScanDirectionStillEngagesCap() {
+    // THE ORDER BY SAFETY CHECK MUST NOT BE ALL-OR-NOTHING: WHEN THE REQUESTED ORDER TRIVIALLY MATCHES THE
+    // (ALWAYS ASCENDING) INDEX SCAN ON THE SAME PROPERTY - SelectIterator.fetchResultInCaseOfOrderBy()'S OWN
+    // TRIVIAL-MATCH CHECK - THE CAP CAN AND SHOULD STILL ENGAGE
+    final Select select = database.select().fromType("T").where().property("n").gt().value(-1)//
+        .orderBy("n", true).limit(50).skip(100);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(150);
     } finally {
       if (cursor != null)
         cursor.close();

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -285,9 +285,9 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
 
   @Test
   void skipAndLimitOnPlainIndexedRangePagesCorrectly() {
-    // CODE REVIEW GAP: THE "SOLE EXACT LEAF, skip+limit CAPPED CORRECTLY" PATH WAS ONLY TESTED FOR eq AND in_op -
-    // ANY OPERATOR filterWithIndexesFinalNode()'S switch TURNS INTO A CURSOR (gt/ge/lt/le/between TOO) IS EQUALLY
-    // EXACT, SINCE soleExactLeaf() DOESN'T DISCRIMINATE BY OPERATOR - THIS CLOSES THAT GAP EXPLICITLY FOR ge.
+    // THE "SOLE EXACT LEAF, skip+limit CAPPED CORRECTLY" PATH IS ALSO EXERCISED FOR eq AND in_op ELSEWHERE - ANY
+    // OPERATOR filterWithIndexesFinalNode()'S switch TURNS INTO A CURSOR (gt/ge/lt/le/between TOO) IS EQUALLY EXACT,
+    // SINCE soleExactLeaf() DOESN'T DISCRIMINATE BY OPERATOR - THIS COVERS IT EXPLICITLY FOR ge.
     // n >= 500 MATCHES 500 OF THE 1000 ROWS (n IN [500,999]).
     final Select select = database.select().fromType("T").where().property("n").ge().value(500)//
         .limit(50).skip(100);

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -151,10 +151,8 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
 
   @Test
   void inLeafUnderOrWithSkipAndLimitPagesCorrectly() {
-    // CODE REVIEW ON #6571: COMBINES THE in_op NESTED-CURSOR SHARING (inOperatorWithSkipAndLimitPagesCorrectly) WITH
-    // THE or-MERGE SHAPE (orOfTwoIndexedRangesWithSkipAndLimitPagesCorrectly) TO MAKE EXPLICIT, RATHER THAN JUST
-    // INFERRED, THAT SHARING THE WHOLE TREE'S indexCandidateLimit WITH A NESTED PER-VALUE CURSOR STAYS SAFE EVEN WHEN
-    // THAT CURSOR IS ALSO ONE CHILD OF AN OUTER or-MERGED MultiIndexCursor.
+    // SHARING THE WHOLE TREE'S indexCandidateLimit WITH A NESTED PER-VALUE CURSOR (in_op) STAYS SAFE EVEN WHEN THAT
+    // CURSOR IS ALSO ONE CHILD OF AN OUTER or-MERGED MultiIndexCursor.
     // g IN (g0,g1,g2) MATCHES 600 OF THE 1000 ROWS (i % 5 IN {0,1,2}); n = 3 MATCHES EXACTLY 1 ROW WHOSE g IS "g3"
     // (i % 5 == 3), OUTSIDE THE IN SET, SO THE UNION HAS 601 DISTINCT MATCHES.
     final long count = database.select().fromType("T").where()//
@@ -166,10 +164,10 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
 
   @Test
   void singleBareEqualityCandidateCapCoversSkipPlusLimit() {
-    // CODE REVIEW ON #6571: Select.compile() WRAPS A LONE CONDITION (NO and()/or() CALLED) IN A SYNTHETIC 'run' NODE
-    // (Select.setLogic()'S "1ST TIME ONLY" BRANCH), SO THE ROOT'S left IS A SelectTreeNode EVEN THOUGH THE WHOLE TREE
-    // IS A SINGLE LEAF. A RESULT-COUNT ASSERTION CANNOT CATCH A REGRESSION HERE: THE LAZY-PULL CONSUMERS ALREADY STOP
-    // AT skip + limit EVEN WHEN THE CANDIDATE CAP ITSELF STAYS AT -1, SO THIS CHECKS THE COMPUTED CAP DIRECTLY.
+    // Select.compile() WRAPS A LONE CONDITION (NO and()/or() CALLED) IN A SYNTHETIC 'run' NODE (Select.setLogic()'S
+    // "1ST TIME ONLY" BRANCH), SO THE ROOT'S left IS A SelectTreeNode EVEN THOUGH THE WHOLE TREE IS A SINGLE LEAF.
+    // A RESULT-COUNT ASSERTION CANNOT CATCH A REGRESSION HERE: THE LAZY-PULL CONSUMERS ALREADY STOP AT skip + limit
+    // EVEN WHEN THE CANDIDATE CAP ITSELF STAYS AT -1, SO THIS CHECKS THE COMPUTED CAP DIRECTLY.
     final Select select = database.select().fromType("T").where().property("a").eq().value("x").limit(50).skip(100);
     select.compile();
 
@@ -245,11 +243,11 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
 
   @Test
   void orderByDescendingOnAscendingScannedIndexWithLimitReturnsTrueTail() {
-    // CODE REVIEW ON #6571, ROUND 3: SelectIterator.fetchResultInCaseOfOrderBy() MATERIALIZES BY DRAINING THE FULL
-    // ITERATOR WHENEVER THE REQUESTED ORDER DOESN'T TRIVIALLY MATCH THE (ALWAYS ASCENDING) INDEX SCAN
-    // filterWithIndexesFinalNode() PERFORMS - BUT THE CANDIDATE CAP THIS PR RESTORES WOULD STOP THAT DRAIN AT
-    // skip + limit, LETTING THE IN-MEMORY SORT SEE ONLY THE FIRST FEW ASCENDING CANDIDATES INSTEAD OF EVERY MATCH.
-    // A DESCENDING orderBy() ON THE SAME PROPERTY THE WHERE CLAUSE INDEXES MUST DISABLE THE CAP TOO.
+    // SelectIterator.fetchResultInCaseOfOrderBy() MATERIALIZES BY DRAINING THE FULL ITERATOR WHENEVER THE REQUESTED
+    // ORDER DOESN'T TRIVIALLY MATCH THE (ALWAYS ASCENDING) INDEX SCAN filterWithIndexesFinalNode() PERFORMS - A
+    // CANDIDATE CAP WOULD STOP THAT DRAIN AT skip + limit, LETTING THE IN-MEMORY SORT SEE ONLY THE FIRST FEW
+    // ASCENDING CANDIDATES INSTEAD OF EVERY MATCH. A DESCENDING orderBy() ON THE SAME PROPERTY THE WHERE CLAUSE
+    // INDEXES MUST DISABLE THE CAP TOO.
     final List<Document> list = database.select().fromType("T").where()//
         .property("n").gt().value(-1)//
         .orderBy("n", false).limit(10).documents().toList();

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -194,7 +194,9 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
     final SelectExecutor executor = new SelectExecutor(select);
     final MultiIndexCursor cursor = executor.lookForIndexes();
     try {
-      assertThat(cursor == null).as("no cursor should have been built for a bare neq leaf").isTrue();
+      // assertThat(cursor) IS AMBIGUOUS: MultiIndexCursor IMPLEMENTS BOTH Iterator AND Iterable (VIA IndexCursor),
+      // AND AssertJ HAS AN OVERLOAD FOR EACH - THE CAST PICKS THE PLAIN Object OVERLOAD INSTEAD
+      assertThat((Object) cursor).as("no cursor should have been built for a bare neq leaf").isNull();
       assertThat(executor.indexCandidateLimit).isEqualTo(-1);
     } finally {
       if (cursor != null)

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -184,6 +184,49 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
     }
   }
 
+  @Test
+  void andUnderOrIsNeverTreatedAsExactlyIndexed() {
+    // (a = 'x' AND b = 'set') OR n = 5: PRECEDENCE-DRIVEN Select.setLogic() BUILDS A NESTED and NODE UNDER THE or
+    // ROOT (and HAS HIGHER PRECEDENCE THAN or). isWhereExactlyIndexed() MUST STAY CONSERVATIVE FOR THE NESTED and
+    // REGARDLESS OF THE or WRAPPER AROUND IT, SINCE filterWithIndexesFinalNode() STILL ONLY KEEPS ONE OF THE and'S
+    // TWO CHILD CURSORS.
+    final Select select = database.select().fromType("T").where()//
+        .property("a").eq().value("x")//
+        .and().property("b").eq().value("set")//
+        .or().property("n").eq().value(5)//
+        .limit(50).skip(0);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(-1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  @Test
+  void notLeafIsNeverTreatedAsExactlyIndexed() {
+    // SelectOperator.not HAS NO FLUENT ENTRY POINT ON THE Select BUILDER TODAY, BUT THE OPERATOR EXISTS AND
+    // isWhereExactlyIndexed() MUST STILL TREAT IT CONSERVATIVELY (filterWithIndexesFinalNode() NEVER BUILDS A
+    // CURSOR FOR IT), SO THE TREE IS BUILT BY HAND HERE
+    final Select select = database.select().fromType("T");
+    final SelectTreeNode innerLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "x");
+    select.rootTreeElement = new SelectTreeNode(innerLeaf, SelectOperator.not, null);
+    select.limit(50).skip(0);
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(-1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
   private void assertPage(final int skip, final int limit, final int expected) {
     final long count = database.select().fromType("T").where()//
         .property("a").eq().value("x")//

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -183,9 +183,9 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
 
   @Test
   void bareNonCursorOperatorLeavesIndexCandidateLimitAtMinusOne() {
-    // #6577: A BARE neq LEAF IS "INDEXED" PER isTheNodeFullyIndexed()'S LOOSER CHECK, SO isWhereExactlyIndexed()
-    // COMPUTES A FINITE indexCandidateLimit - BUT filterWithIndexesFinalNode()'S switch NEVER BUILDS A CURSOR FOR
-    // neq, SO cursors STAYS EMPTY, lookForIndexes() RETURNS null, AND NO CAP IS EVER ACTUALLY APPLIED. THE
+    // #6577: A BARE neq LEAF IS "INDEXED" PER isTheNodeFullyIndexed()'S LOOSER CHECK, SO soleExactLeaf() RETURNS IT
+    // AND A FINITE indexCandidateLimit GETS COMPUTED - BUT filterWithIndexesFinalNode()'S switch NEVER BUILDS A
+    // CURSOR FOR neq, SO cursors STAYS EMPTY, lookForIndexes() RETURNS null, AND NO CAP IS EVER ACTUALLY APPLIED. THE
     // TEST-VISIBLE indexCandidateLimit FIELD MUST NOT BE LEFT HOLDING THAT MISLEADING FINITE VALUE.
     final Select select = database.select().fromType("T").where().property("a").neq().value("nonexistent")//
         .limit(50).skip(100);
@@ -195,6 +195,24 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
     final MultiIndexCursor cursor = executor.lookForIndexes();
     try {
       assertThat(cursor == null).as("no cursor should have been built for a bare neq leaf").isTrue();
+      assertThat(executor.indexCandidateLimit).isEqualTo(-1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  @Test
+  void skipPlusLimitOverflowFallsBackToUncapped() {
+    // computeExactCandidateLimit()'S long-SUM OVERFLOW GUARD: A skip/limit PAIR THAT OVERFLOWS int MUST FALL BACK
+    // TO -1 (UNCAPPED) RATHER THAN WRAP AROUND TO A NEGATIVE-BUT-NOT--1 OR OTHERWISE BOGUS int CAP
+    final Select select = database.select().fromType("T").where().property("a").eq().value("x")//
+        .limit(20).skip(Integer.MAX_VALUE - 5);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
       assertThat(executor.indexCandidateLimit).isEqualTo(-1);
     } finally {
       if (cursor != null)
@@ -268,9 +286,9 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
   @Test
   void andUnderOrIsNeverTreatedAsExactlyIndexed() {
     // (a = 'x' AND b = 'set') OR n = 5: PRECEDENCE-DRIVEN Select.setLogic() BUILDS A NESTED and NODE UNDER THE or
-    // ROOT (and HAS HIGHER PRECEDENCE THAN or). isWhereExactlyIndexed() MUST STAY CONSERVATIVE FOR THE NESTED and
-    // REGARDLESS OF THE or WRAPPER AROUND IT, SINCE filterWithIndexesFinalNode() STILL ONLY KEEPS ONE OF THE and'S
-    // TWO CHILD CURSORS.
+    // ROOT (and HAS HIGHER PRECEDENCE THAN or). soleExactLeaf() MUST STAY CONSERVATIVE FOR A TREE SHAPED LIKE THIS
+    // REGARDLESS OF THE NESTED and, SINCE filterWithIndexesFinalNode() STILL ONLY KEEPS ONE OF THE and'S TWO CHILD
+    // CURSORS - THOUGH TODAY THE or ROOT ALONE ALREADY DISQUALIFIES IT BEFORE THE NESTED and IS EVEN CONSIDERED.
     final Select select = database.select().fromType("T").where()//
         .property("a").eq().value("x")//
         .and().property("b").eq().value("set")//
@@ -291,8 +309,8 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
   @Test
   void notLeafIsNeverTreatedAsExactlyIndexed() {
     // SelectOperator.not HAS NO FLUENT ENTRY POINT ON THE Select BUILDER TODAY, BUT THE OPERATOR EXISTS AND
-    // isWhereExactlyIndexed() MUST STILL TREAT IT CONSERVATIVELY (filterWithIndexesFinalNode() NEVER BUILDS A
-    // CURSOR FOR IT), SO THE TREE IS BUILT BY HAND HERE
+    // soleExactLeaf() MUST STILL TREAT IT CONSERVATIVELY (filterWithIndexesFinalNode() NEVER BUILDS A CURSOR FOR
+    // IT), SO THE TREE IS BUILT BY HAND HERE
     final Select select = database.select().fromType("T");
     final SelectTreeNode innerLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "x");
     select.rootTreeElement = new SelectTreeNode(innerLeaf, SelectOperator.not, null);

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -182,6 +182,27 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
   }
 
   @Test
+  void bareNonCursorOperatorLeavesIndexCandidateLimitAtMinusOne() {
+    // #6577: A BARE neq LEAF IS "INDEXED" PER isTheNodeFullyIndexed()'S LOOSER CHECK, SO isWhereExactlyIndexed()
+    // COMPUTES A FINITE indexCandidateLimit - BUT filterWithIndexesFinalNode()'S switch NEVER BUILDS A CURSOR FOR
+    // neq, SO cursors STAYS EMPTY, lookForIndexes() RETURNS null, AND NO CAP IS EVER ACTUALLY APPLIED. THE
+    // TEST-VISIBLE indexCandidateLimit FIELD MUST NOT BE LEFT HOLDING THAT MISLEADING FINITE VALUE.
+    final Select select = database.select().fromType("T").where().property("a").neq().value("nonexistent")//
+        .limit(50).skip(100);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(cursor == null).as("no cursor should have been built for a bare neq leaf").isTrue();
+      assertThat(executor.indexCandidateLimit).isEqualTo(-1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  @Test
   void overlappingOrBranchesOnTheSamePropertyStillReturnLimitDistinctRows() {
     // n > 5 AND n < 500 OVERLAP OVER (5,500): A RECORD IN THAT RANGE IS A CANDIDATE FROM *BOTH* CHILD CURSORS.
     // MultiIndexCursor.next() IS A PLAIN K-WAY MERGE WITH NO RID DEDUP, SO IT EMITS THAT RECORD TWICE; DEDUP ONLY

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -310,6 +310,30 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
   }
 
   @Test
+  void skipAndLimitOnPlainIndexedBetweenPagesCorrectly() {
+    // CODE REVIEW GAP: between HAS A DISTINCT TWO-BOUND CURSOR SHAPE (node.index.range(...) WITH BOTH BOUNDS SET)
+    // VS THE OPEN-ENDED gt/ge/lt/le RANGES ALREADY COVERED - WORTH ITS OWN CASE RATHER THAN RELYING ON THE SHARED
+    // soleExactLeaf()/filterWithIndexesFinalNode() CLASSIFICATION BEING CORRECT BY INSPECTION.
+    // n BETWEEN 400 AND 449 MATCHES 50 OF THE 1000 ROWS (n IN [400,449]).
+    final Select select = database.select().fromType("T").where().property("n").between().values(400, 449)//
+        .limit(20).skip(10);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(30);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+
+    final long count = database.select().fromType("T").where().property("n").between().values(400, 449)//
+        .skip(10).limit(20).count();
+    assertThat(count).isEqualTo(20);
+  }
+
+  @Test
   void andUnderOrIsNeverTreatedAsExactlyIndexed() {
     // (a = 'x' AND b = 'set') OR n = 5: PRECEDENCE-DRIVEN Select.setLogic() BUILDS A NESTED and NODE UNDER THE or
     // ROOT (and HAS HIGHER PRECEDENCE THAN or). soleExactLeaf() MUST STAY CONSERVATIVE FOR A TREE SHAPED LIKE THIS

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6565
+ * <p>
+ * {@code SelectExecutor.lookForIndexes()} used to hand the query's RESULT {@code limit} to {@code MultiIndexCursor}
+ * as a CANDIDATE cap, applied before {@code evaluateWhere()} and {@code skip} reduce the candidates further downstream.
+ * Two shapes were affected: an indexed condition combined (via AND) with a non-indexable condition such as
+ * {@code IS NOT NULL} (only one AND child ever keeps its index cursor - see {@code filterWithIndexesFinalNode()} -
+ * so the discarded conjunct is still checked by {@code evaluateWhere()} against a candidate stream that was
+ * already capped too early), and plain {@code skip + limit} paging over a single indexed equality (the candidate
+ * cap must cover {@code skip + limit} records, not just {@code limit}).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
+
+  private static final int ROWS    = 1000;
+  private static final int MATCHES = 200;
+
+  public Issue6565SelectIndexCandidateLimitTest() {
+    autoStartTx = true;
+  }
+
+  @Override
+  protected void beginTest() {
+    final var t = database.getSchema().createDocumentType("T");
+    t.createProperty("a", Type.STRING);
+    t.createProperty("b", Type.STRING);
+    t.createProperty("n", Type.INTEGER);
+    t.createProperty("g", Type.STRING);
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "a");
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "b");
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "n");
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "g");
+
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++) {
+        final var d = database.newDocument("T");
+        d.set("a", "x");
+        d.set("n", i);
+        if (i % (ROWS / MATCHES) == 0)
+          d.set("b", "set");
+        d.set("g", "g" + (i % 5));
+        d.save();
+      }
+    });
+  }
+
+  @Test
+  void eqAndIsNotNullWithLimitReturnsAllMatchesUpToLimit() {
+    // SHAPE A: THE INDEX ONLY COVERS 'a', THE 'b IS NOT NULL' CONJUNCT IS RE-CHECKED BY evaluateWhere() AND MUST NOT
+    // BE STARVED BY A CANDIDATE CAP DERIVED FROM 'a' ALONE
+    for (final int limit : new int[] { 50, 100, 200, 500, 1000 }) {
+      final int expected = Math.min(limit, MATCHES);
+      final long count = database.select().fromType("T").where()//
+          .property("a").eq().value("x")//
+          .and().property("b").isNotNull()//
+          .limit(limit).count();
+      assertThat(count).as("limit " + limit).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  void eqAndIsNotNullWithNoLimitReturnsAllMatches() {
+    final long count = database.select().fromType("T").where()//
+        .property("a").eq().value("x")//
+        .and().property("b").isNotNull()//
+        .count();
+    assertThat(count).isEqualTo(MATCHES);
+  }
+
+  @Test
+  void skipAndLimitOnPlainIndexedEqualityPagesCorrectly() {
+    // SHAPE B: ORDINARY PAGING OVER A SINGLE INDEXED EQUALITY. THE CANDIDATE CAP MUST COVER skip + limit.
+    assertPage(0, 50, 50);
+    assertPage(10, 50, 50);
+    assertPage(100, 50, 50);
+    assertPage(500, 50, 50);
+    assertPage(0, 1000, 1000);
+    assertPage(100, 1000, 900);
+  }
+
+  @Test
+  void countHonoursSkipOnPlainIndexedEquality() {
+    final long count = database.select().fromType("T").where()//
+        .property("a").eq().value("x")//
+        .skip(100).limit(50).count();
+    assertThat(count).isEqualTo(50);
+  }
+
+  @Test
+  void secondPageIsNotEmptyWhenSkipEqualsOrExceedsLimit() {
+    // skip >= limit USED TO ALWAYS RETURN ZERO ROWS: THE CANDIDATE CAP WAS limit, SO skip ALONE CONSUMED IT ALL
+    final long count = database.select().fromType("T").where()//
+        .property("a").eq().value("x")//
+        .skip(200).limit(50).count();
+    assertThat(count).isEqualTo(50);
+  }
+
+  @Test
+  void orOfTwoIndexedRangesWithSkipAndLimitPagesCorrectly() {
+    // THE NESTED CURSORS UNDER AN 'OR' ARE MERGED BY MultiIndexCursor - THE SAME UNION SHAPE AS THE BOOLEAN 'OR' - SO
+    // THIS TREE IS EXACTLY INDEXED TOO, AND THE CAP MUST STILL ACCOUNT FOR skip
+    final long count = database.select().fromType("T").where()//
+        .property("n").lt().value(10)//
+        .or().property("n").ge().value(990)//
+        .skip(5).limit(10).count();
+    assertThat(count).isEqualTo(10);
+  }
+
+  @Test
+  void inOperatorWithSkipAndLimitPagesCorrectly() {
+    // THE PER-VALUE CURSORS filterWithIndexesFinalNode() BUILDS FOR AN in_op LEAF ARE THEMSELVES WRAPPED IN A NESTED
+    // MultiIndexCursor, WHICH USED TO BE CAPPED WITH THE SAME RAW select.limit (MISSING skip)
+    final long count = database.select().fromType("T").where()//
+        .property("g").in().value(List.of("g0", "g1", "g2"))//
+        .skip(550).limit(100).count();
+    assertThat(count).isEqualTo(50);
+  }
+
+  private void assertPage(final int skip, final int limit, final int expected) {
+    final long count = database.select().fromType("T").where()//
+        .property("a").eq().value("x")//
+        .skip(skip).limit(limit).count();
+    assertThat(count).as("skip " + skip + " limit " + limit).isEqualTo(expected);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -150,6 +150,21 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
   }
 
   @Test
+  void inLeafUnderOrWithSkipAndLimitPagesCorrectly() {
+    // CODE REVIEW ON #6571: COMBINES THE in_op NESTED-CURSOR SHARING (inOperatorWithSkipAndLimitPagesCorrectly) WITH
+    // THE or-MERGE SHAPE (orOfTwoIndexedRangesWithSkipAndLimitPagesCorrectly) TO MAKE EXPLICIT, RATHER THAN JUST
+    // INFERRED, THAT SHARING THE WHOLE TREE'S indexCandidateLimit WITH A NESTED PER-VALUE CURSOR STAYS SAFE EVEN WHEN
+    // THAT CURSOR IS ALSO ONE CHILD OF AN OUTER or-MERGED MultiIndexCursor.
+    // g IN (g0,g1,g2) MATCHES 600 OF THE 1000 ROWS (i % 5 IN {0,1,2}); n = 3 MATCHES EXACTLY 1 ROW WHOSE g IS "g3"
+    // (i % 5 == 3), OUTSIDE THE IN SET, SO THE UNION HAS 601 DISTINCT MATCHES.
+    final long count = database.select().fromType("T").where()//
+        .property("g").in().value(List.of("g0", "g1", "g2"))//
+        .or().property("n").eq().value(3)//
+        .skip(595).limit(10).count();
+    assertThat(count).isEqualTo(6);
+  }
+
+  @Test
   void singleBareEqualityCandidateCapCoversSkipPlusLimit() {
     // CODE REVIEW ON #6571: Select.compile() WRAPS A LONE CONDITION (NO and()/or() CALLED) IN A SYNTHETIC 'run' NODE
     // (Select.setLogic()'S "1ST TIME ONLY" BRANCH), SO THE ROOT'S left IS A SelectTreeNode EVEN THOUGH THE WHOLE TREE

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6565SelectIndexCandidateLimitTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.select;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.index.MultiIndexCursor;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
@@ -145,6 +146,42 @@ public class Issue6565SelectIndexCandidateLimitTest extends TestHelper {
         .property("g").in().value(List.of("g0", "g1", "g2"))//
         .skip(550).limit(100).count();
     assertThat(count).isEqualTo(50);
+  }
+
+  @Test
+  void singleBareEqualityCandidateCapCoversSkipPlusLimit() {
+    // CODE REVIEW ON #6571: Select.compile() WRAPS A LONE CONDITION (NO and()/or() CALLED) IN A SYNTHETIC 'run' NODE
+    // (Select.setLogic()'S "1ST TIME ONLY" BRANCH), SO THE ROOT'S left IS A SelectTreeNode EVEN THOUGH THE WHOLE TREE
+    // IS A SINGLE LEAF. A RESULT-COUNT ASSERTION CANNOT CATCH A REGRESSION HERE: THE LAZY-PULL CONSUMERS ALREADY STOP
+    // AT skip + limit EVEN WHEN THE CANDIDATE CAP ITSELF STAYS AT -1, SO THIS CHECKS THE COMPUTED CAP DIRECTLY.
+    final Select select = database.select().fromType("T").where().property("a").eq().value("x").limit(50).skip(100);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(150);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  @Test
+  void singleBareInCandidateCapCoversSkipPlusLimit() {
+    // SAME GAP AS ABOVE, FOR THE NESTED PER-VALUE CURSOR filterWithIndexesFinalNode() BUILDS FOR A BARE in_op LEAF
+    final Select select = database.select().fromType("T").where().property("g").in().value(List.of("g0", "g1", "g2"))//
+        .limit(100).skip(550);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat(executor.indexCandidateLimit).isEqualTo(650);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
   }
 
   private void assertPage(final int skip, final int limit, final int expected) {


### PR DESCRIPTION
## Summary

Fixes #6565.

`SelectExecutor.lookForIndexes()` handed the query's *result* `limit` straight to `MultiIndexCursor` as a *candidate*
cap on the index scan. Downstream, `evaluateWhere()` and `skip` still reduce that candidate stream further, so the
cap was spent before the filtering it was meant to survive - silently returning fewer rows than actually match, with
no error.

Two shapes were affected:
- An indexed condition combined via `AND` with a non-indexable condition such as `IS NOT NULL`: only one `AND` child
  ever keeps its index cursor (`filterWithIndexesFinalNode`), so the other conjunct is re-checked later by
  `evaluateWhere()` against a stream that was already capped too early.
- Ordinary `skip` + `limit` paging over an indexed equality: reaching row `skip+1` needs `skip + limit` candidates,
  but the cap was just `limit`, so the result went empty whenever `skip >= limit`.

The same queries through the SQL engine were already correct, so this was purely an inconsistency between the two
query APIs.

## Fix

- The candidate cap is now applied only when the index scan **exactly reproduces** the where-tree's result set: a
  bare indexed leaf, or an `OR` of such leaves (the union shape `MultiIndexCursor` already merges). Any `AND`, `NOT`,
  or `IS [NOT] NULL` disqualifies the cap and the scan runs uncapped, exactly matching what the SQL engine already
  does for the same shapes - `evaluateWhere()`/`skip` downstream stay correct regardless, this only removes a stale
  optimization that wasn't sound.
- When the cap does apply, it is now `skip + limit`, not just `limit`.
- The nested per-value cursor `filterWithIndexesFinalNode()` builds for an `IN` leaf now shares that same corrected
  cap instead of a raw `select.limit` that was missing `skip` - same bug, one call site over.
- `MultiIndexCursor.hasNext()` also admitted one candidate more than asked for (`browsed > limit` instead of
  `browsed >= limit`). The two call sites that pass a real (non -1) limit are both in `SelectExecutor`, so tightening
  this doesn't affect any of the unbounded (`-1`) callers elsewhere in the codebase.

## Test plan

- New regression test `Issue6565SelectIndexCandidateLimitTest` (7 cases): the two shapes from the issue (`AND` +
  `IS NOT NULL` with various limits, `skip`/`limit` paging including `skip >= limit`), plus `.count()` variants, an
  `OR` of two indexed ranges with `skip`/`limit`, and an `IN` leaf with `skip`/`limit` (covering the nested cursor
  fix). All 7 fail on `main` and pass with this change; confirmed by reverting the fix locally and re-running.
- Ran the full `com.arcadedb.query.select` and `com.arcadedb.index` packages (222 classes / 1205 tests): 0 failures,
  0 errors - the entire blast radius of the change (nothing outside these two packages references
  `SelectExecutor`/`MultiIndexCursor`).