### PR TITLE
fix(engine): a dangling vertex reference is a not-found, not a conflict to retry (#6572)

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3781,3 +3781,40 @@ strictly better than the pre-fix full pool teardown, but a workload that provoke
 that slot would benefit from more parallelism (raising `parallelLevel`) rather than sharing one.
 
 [#6509](https://github.com/ArcadeData/arcadedb/issues/6509)
+
+## A dangling vertex reference is reported as a not-found, not as a conflict to retry (#6572)
+
+An adjacency entry whose target vertex record was removed without the entry being disconnected - the documented
+legacy of a pre-#5670 best-effort edge delete - hands a caller a handle to a record that is not there. Deleting
+through it (`for (Vertex v : src.getVertices(OUT, "E1")) v.delete()`) reached
+`GraphEngine.getEdgeHeadChunkForWrite`, whose lazy load of the vertex raised `RecordNotFoundException`, and that was
+converted wholesale into the retryable `ConcurrentModificationException` the method exists to produce for a head
+CHUNK that a concurrent commit has not published yet.
+
+Two things were wrong at once, and both of them hurt a batch job. The type said "retry me" for a record that is
+gone, so every attempt failed identically, the retry budget was spent on a foregone conclusion and the whole
+transaction rolled back - one stale reference killing an entire nightly sweep, permanently, with no work
+committed. And the advice said `CHECK DATABASE RECORD <rid> FIX`, which rebuilds the edge list *of* that record
+from the surviving edges - while that record is precisely the one that no longer exists.
+
+The evidence separating the two cases was already on the exception: the RID it names. A missing chunk (or stripe
+head) really can be the publication window; the vertex the caller asked to modify cannot. When the cause names the
+vertex's own RID, `getEdgeHeadChunkForWrite` now raises `VertexNotFoundException` - a `RecordNotFoundException`,
+deliberately not a `NeedRetryException` - saying that the vertex does not exist and that it was reached through a
+stale reference, and pointing at `CHECK DATABASE FIX`, which sweeps and drops the entries that point at missing
+records. The RECORD scope is ruled out in words rather than rendered as a runnable command, since the entry to drop
+lives on the vertex at the *other* end and no index maps a vertex back to the lists that name it. Everything else
+keeps the #5670 conflict and the #5764 scoped advice unchanged.
+
+Deleting a vertex whose record is already gone therefore stays an ERROR rather than becoming a silent no-op: that
+is what `bucket.deleteRecord` answers for every other record shape, and for this vertex a few steps further down
+the same delete. What changes is only that the error says what is wrong. Callers that walk possibly-stale
+references can now tell "this will never work" from "try again" by catching `RecordNotFoundException`, and skip the
+entry instead of losing the batch.
+
+One related tolerance moves with it: `deleteEdge` already treats an endpoint vertex that is gone as "nothing to
+disconnect on that side", decided by an `existsRecord` probe. The probe and the head-pointer read are two separate
+reads, so the same fact can now surface between them as `VertexNotFoundException`; `disconnectEndpoint` tolerates it
+identically rather than promoting a window the probe would have absorbed into a hard failure.
+
+[#6572](https://github.com/ArcadeData/arcadedb/issues/6572)

--- a/engine/src/main/java/com/arcadedb/exception/VertexNotFoundException.java
+++ b/engine/src/main/java/com/arcadedb/exception/VertexNotFoundException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.exception;
+
+import com.arcadedb.database.RID;
+
+/**
+ * A caller about to WRITE a vertex's edge list found the vertex RECORD ITSELF absent (#6572). The reference it
+ * arrived through - an adjacency entry, a RID held across transactions, a traversal step - names a record that is
+ * not there.
+ * <p>
+ * A {@link RecordNotFoundException}, and deliberately NOT a {@link NeedRetryException}, which is the whole reason
+ * this type exists. The read side of an edge list cannot always tell "gone" from "not visible yet": a concurrent
+ * commit publishes its pages one at a time and the reader takes no commit lock, so a HEAD CHUNK can legitimately
+ * be unreadable a moment before it appears, and {@code GraphEngine.getEdgeHeadChunkForWrite} answers that window
+ * with a retryable {@link ConcurrentModificationException} (#5670). One case inside that window is not a window at
+ * all: when the missing record is the VERTEX the caller asked to modify, no amount of retrying makes it exist
+ * again. Reported as a conflict it cost the caller a full retry budget of identical failures and then rolled back
+ * a transaction - a single stale reference could kill a whole batch job, every run.
+ * <p>
+ * The repair is also different, which is the second reason the two must not share a type. An unreadable CHUNK is
+ * repaired by {@code CHECK DATABASE RECORD <vertex> FIX}, which rebuilds that vertex's edge list from the
+ * surviving edge records. Here the vertex is precisely what is gone, so there is nothing to rebuild the list of;
+ * what has to be dropped is the reference on the OTHER endpoint, which only a database-wide (or type-wide) sweep
+ * can find - no index maps a vertex back to the lists that name it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class VertexNotFoundException extends RecordNotFoundException {
+  public VertexNotFoundException(final String s, final RID rid, final Exception e) {
+    super(s, rid, e);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -41,6 +41,7 @@ import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.SerializationException;
 import com.arcadedb.exception.ValidationException;
+import com.arcadedb.exception.VertexNotFoundException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
@@ -750,7 +751,25 @@ public class GraphEngine {
     if (endpoint == null)
       return;
 
-    final EdgeLinkedList list = getEdgeHeadChunkForWrite(endpoint, direction);
+    final EdgeLinkedList list;
+    try {
+      list = getEdgeHeadChunkForWrite(endpoint, direction);
+    } catch (final VertexNotFoundException e) {
+      // The SAME answer resolveEndpointToDisconnect gives for an endpoint that is gone - nothing to disconnect -
+      // for the same fact discovered one frame later (#6572). Its existsRecord probe and this lazy load are two
+      // reads with a gap between them, so a concurrent commit deleting the endpoint in that gap lands here
+      // instead of there; and a MATERIALISED handle answers its head pointer from the buffer it already holds, so
+      // the probe is what catches the common case and this is what catches the rest. Tolerating both keeps the
+      // window a no-op rather than promoting it to a hard failure the probe would have absorbed.
+      //
+      // Narrow on purpose: ONLY the endpoint vertex being absent. A RecordNotFoundException from anywhere else in
+      // the read - a chunk of a list that does exist - is the #5670 case and must keep reaching the caller as the
+      // retryable conflict getEdgeHeadChunkForWrite turned it into, or the back-reference outlives its edge again.
+      LogManager.instance()
+          .log(this, Level.FINE, "Cannot disconnect edge %s from its %s endpoint %s: the vertex no longer exists", e,
+              edge.getIdentity(), direction, endpoint.getIdentity());
+      return;
+    }
     if (list != null)
       list.removeEdge(edge);
   }
@@ -771,10 +790,15 @@ public class GraphEngine {
       return null;
     try {
       // NOT redundant with the resolution below, however much it looks it: Edge.getOutVertex/getInVertex load with
-      // loadContent=false, which hands back a LAZY handle without touching the bucket. A deleted endpoint therefore
-      // does not surface here at all - it surfaces later, inside getEdgeHeadChunkForWrite, which maps it to a
-      // retryable conflict. This check is what keeps the two apart: vertex gone = nothing to disconnect (tolerated),
-      // vertex present but its list unreadable = a conflict to retry. Removing it turns the first into the second.
+      // loadContent=false, which hands back a LAZY handle without touching the bucket, so a deleted endpoint does
+      // not surface here at all. This check is what keeps the two cases apart: vertex gone = nothing to disconnect
+      // (tolerated), vertex present but its list unreadable = a conflict to retry.
+      //
+      // Since #6572 it is no longer the ONLY thing keeping them apart - getEdgeHeadChunkForWrite names the missing
+      // vertex as a VertexNotFoundException and the caller tolerates that too - but it is still load-bearing, for
+      // the case that raises nothing at all: a handle already MATERIALISED earlier in this transaction answers its
+      // head pointer from the buffer it holds, without going back to the bucket, so a delete committed since would
+      // have this method hand back a vertex that is gone and the caller write chunks of a dead list.
       if (!edge.getDatabase().existsRecord(endpointRID))
         return null;
       final Vertex endpoint = direction == Vertex.DIRECTION.OUT ? edge.getOutVertex() : edge.getInVertex();
@@ -987,6 +1011,15 @@ public class GraphEngine {
    * exactly this case - see {@link #scopedRepairAdvice} and {@link #danglingRepairAdvice} for which of the two
    * each outcome deserves.
    * <p>
+   * #6572: one outcome deserves neither, and it is the only one that is not about the edge LIST. Deleting a vertex
+   * whose RECORD is already gone - reached through a stale adjacency entry, or through a RID held past the delete -
+   * fails with {@link VertexNotFoundException} instead of a retryable conflict, before the walk starts. Not
+   * tolerated, in either mode: deleting a record that does not exist is an error on every other path in the engine
+   * too ({@code bucket.deleteRecord} raises it for a document, and for this vertex a few steps further down), and
+   * silently succeeding would hide the one thing the caller needs to know - that something still points at a record
+   * that is not there. What changes is only that the failure says so, and names {@link #missingVertexRepairAdvice}
+   * instead of a repair aimed at the missing record.
+   * <p>
    * #5760 removes the two costs this method used to pay for the walk, both of which fall out of ONE observation:
    * the vertex's own lists are dropped wholesale at the end, so nothing this method does to them is worth doing.
    * <ul>
@@ -1039,10 +1072,11 @@ public class GraphEngine {
    *   <li>a corrupt or truncated buffer ({@link SerializationException} and the rest of the decode family) is
    *   tolerated by {@code deleteEdgesOf}, because such a vertex reaches here with {@code force == false} and
    *   failing would make it undeletable - the complaint #4420 and #4432 fixed;</li>
-   *   <li>a vanished record, or a multi-page body a concurrent commit is rewriting, is a retryable conflict
+   *   <li>a multi-page body a concurrent commit is rewriting is a retryable conflict
    *   {@link #getEdgeHeadChunkForWrite} raises as a {@link ConcurrentModificationException} - and one that
    *   {@code force} then absorbs, which is how {@code LocalDatabase.deleteRecordNoLock} deletes a record whose own
-   *   chunk chain is broken.</li>
+   *   chunk chain is broken; a vertex record that has VANISHED is the one case {@code force} cannot absorb, and it
+   *   is answered by {@link VertexNotFoundException} rather than by a conflict (#6572).</li>
    * </ul>
    * Re-raising any of them from here would replace a handled outcome with a raw failure the force policy never
    * gets to see. Nothing is hidden by swallowing them either: the very next thing the delete does is read the same
@@ -1068,6 +1102,7 @@ public class GraphEngine {
    * so the edge sweep still runs once per distinct vertex type named.
    *
    * @see #danglingRepairAdvice() for the other outcome - the delete went THROUGH and left references behind.
+   * @see #missingVertexRepairAdvice() for the third - the vertex itself is gone, so there is no list to rebuild.
    */
   private static String scopedRepairAdvice(final RID vertexRID) {
     return "run `CHECK DATABASE RECORD " + vertexRID + " FIX` to rebuild its edge list from the surviving edge "
@@ -1083,6 +1118,29 @@ public class GraphEngine {
   private static String danglingRepairAdvice() {
     return "run `CHECK DATABASE FIX` to drop the references that now dangle - rebuilding the list first with "
         + "`CHECK DATABASE RECORD <vertex> FIX` and deleting without force is what keeps the edges";
+  }
+
+  /**
+   * #6572: the repair for the THIRD outcome - the vertex the caller asked to modify does not exist at all, so it
+   * was reached through a reference that outlived it.
+   * <p>
+   * Whole-database (or whole-type) for a reason the operator would otherwise waste a run discovering: the RECORD
+   * scope needs a record, and this RID has none. What must be dropped is the adjacency entry on the OTHER endpoint,
+   * and nothing here can name it - a vertex handle carries no back-pointer to the list it was read from, and no
+   * index maps a vertex to the lists that reference it, which is the same reason
+   * {@link #scopedRepairAdvice(RID)} warns that its own scope does not save the edge sweep. Finding the referrer
+   * is a scan, and {@code CHECK DATABASE FIX} is the one that does it.
+   * <p>
+   * The scope that does NOT apply is ruled out in words rather than rendered as a command, and the distinction is
+   * not cosmetic: the RECORD form is exactly what the conflict this used to be reported as advertised, so an
+   * operator who met the old message has to be told it was the wrong tool - but a message that spells the command
+   * out with the RID substituted in is one a hurried reader (or a log grep) pastes into a console anyway. Same
+   * line {@link #danglingRepairAdvice} draws when it names the scoped form for a vertex it cannot identify.
+   */
+  private static String missingVertexRepairAdvice() {
+    return "run `CHECK DATABASE FIX` to drop the adjacency entries that still point at it - the RECORD scope cannot "
+        + "help here, since the edge list it would rebuild belongs to the record that is gone, and the entry to drop "
+        + "lives on the vertex at the other end, which only a sweep can find";
   }
 
   /**
@@ -1317,6 +1375,14 @@ public class GraphEngine {
    * well, which no retry can bring back, so that case now fails the delete once the retries are spent instead of
    * quietly completing it. A chunk that cannot be DECODED takes the other path for the reason spelled out there,
    * not because it is less permanent.
+   * <p>
+   * The VERTEX RECORD being the missing one no longer reaches here at all (#6572): it is a
+   * {@link VertexNotFoundException}, not a {@link NeedRetryException}, so it passes this handler and the
+   * {@code force} gate below untouched. Deliberately, and it costs {@code force} nothing: tolerating the edge list
+   * of a record that does not exist cannot complete the delete either. All the old force path bought was a WARNING
+   * about edges surviving a vertex that was already gone, followed by the same not-found from the
+   * {@code bucket.deleteRecord} at the end of {@link #deleteVertex}. Failing at the read is that outcome, reported
+   * once and reported accurately.
    */
   private void tolerateUnreadableEdgeList(final NeedRetryException e, final VertexInternal vertex,
       final Vertex.DIRECTION direction, final boolean force) {
@@ -2005,6 +2071,13 @@ public class GraphEngine {
    * back-reference. Repair belongs to {@code CHECK DATABASE}, which rebuilds an unloadable chain from the surviving
    * edge records and drops the references into it, after which the removal goes through normally.
    * <p>
+   * ONE record inside that window is not indistinguishable, and since #6572 it is not treated as though it were:
+   * the VERTEX. The head-RID read below lazy-loads the vertex record, so a caller that arrived through a stale
+   * reference - an adjacency entry whose target was removed without the entry being disconnected, the documented
+   * legacy of a pre-#5670 best-effort edge delete - fails here naming the vertex's own RID rather than a chunk's.
+   * That is a fact about the graph, not about timing: it gets {@link VertexNotFoundException}, which is not
+   * retryable and whose advice points at a repair that exists. See the catch for the discriminator.
+   * <p>
    * That price reaches {@link #deleteVertex} too, from both sides. Disconnecting an edge touches the vertex at the
    * OTHER end, so deleting a healthy vertex whose NEIGHBOUR's list cannot be read reports a conflict; and #5680
    * routes the collection of the vertex's OWN edges through here as well, so a delete can no longer remove the
@@ -2017,23 +2090,37 @@ public class GraphEngine {
     if (direction != Vertex.DIRECTION.OUT && direction != Vertex.DIRECTION.IN)
       return null;
 
+    final RID vertexRID = vertex.getIdentity();
+
     // The head-RID read stays INSIDE the try: on a not-yet-materialised ImmutableVertex it lazy-loads the record,
-    // so a vertex deleted since the caller resolved it raises RecordNotFoundException here rather than at the chunk
-    // lookup. That is the same transient this method exists to convert - letting it escape raw would fail the
-    // transaction with an exception that is NOT retryable.
+    // so a vertex whose record cannot be read raises RecordNotFoundException here rather than at the chunk lookup.
+    // Which of the two answers below it gets depends on WHICH record was missing - see the catch.
     try {
       final RID rid = direction == Vertex.DIRECTION.OUT ? vertex.getOutEdgesHeadChunk() : vertex.getInEdgesHeadChunk();
       if (rid == null)
         return null;
       return buildEdgeList(vertex, direction, rid);
     } catch (final RecordNotFoundException e) {
+      // #6572: the two cases are told apart by the ONE piece of evidence that separates them, and it is already
+      // on the exception - the RID it names. Anything else (a head chunk, a chunk one hop in, a stripe head) is a
+      // record whose absence really can be the publication window this method exists to convert; the VERTEX ITSELF
+      // cannot. It is not invisible, it is gone, so a retry re-runs the whole transaction to fail identically, and
+      // the repair the conflict advertises is aimed at rebuilding the edge list of the record that no longer
+      // exists. Reported honestly it is a plain not-found: no retry budget spent, and the advice names a command
+      // that can actually be run. RID.equals(null) is false, so a cause carrying no RID takes the conflict arm.
+      if (vertexRID != null && vertexRID.equals(e.getRID()))
+        throw new VertexNotFoundException(
+            "Vertex " + vertexRID + " does not exist, so its " + direction + " edge list cannot be modified: it was "
+                + "reached through a reference to a record that is gone (a stale edge entry, or a RID held past the "
+                + "delete). Retrying cannot make it exist: " + missingVertexRepairAdvice(), vertexRID, e);
+
       // The cause and the interpolated e.getMessage() are NOT redundant, though they read that way (#5764). This
       // message is the only place the missing CHUNK's RID appears - the text above names the vertex, not the chunk,
       // which is inside the record-not-found message - and the top-level message is what a log line and an HTTP
       // error body carry, while the cause chain surfaces only in a full trace or a development-mode detail field.
       // Pinned by Issue5670EdgeDeleteDanglingBackRefTest, which asserts the head chunk's RID is in this message.
       throw new ConcurrentModificationException(
-          "Edge list " + direction + " of vertex " + vertex.getIdentity()
+          "Edge list " + direction + " of vertex " + vertexRID
               + " is not fully visible yet (concurrent commit in flight): " + e.getMessage(), e);
     }
   }

--- a/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5670EdgeDeleteDanglingBackRefTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.VertexNotFoundException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -124,12 +125,19 @@ class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
 
   /**
    * The head RID is read off the vertex INSIDE the strict lookup's try, because on a handle that has not loaded its
-   * record yet that read lazy-loads it - so an endpoint deleted since the caller resolved it surfaces here rather
-   * than at the chunk lookup. Escaping raw, that is a plain {@code RecordNotFoundException}: not a
-   * {@code NeedRetryException}, so it would fail the transaction outright instead of retrying it.
+   * record yet that read lazy-loads it - so a vertex deleted since the caller resolved it surfaces here rather than
+   * at the chunk lookup, and does not escape as a raw failure from a walk whose every other miss is answered.
+   * <p>
+   * It is answered SEPARATELY from the chunk misses around it, which is the correction #6572 made to this test:
+   * the conflict below used to be a {@code ConcurrentModificationException} like the ones above, on the argument
+   * that a raw {@code RecordNotFoundException} is not retryable. That is true and was the wrong conclusion - a
+   * vertex record that is GONE cannot become visible on a retry, so the retryable type spent a caller's whole
+   * budget on a foregone failure and advertised a repair aimed at the missing record. The evidence is the RID the
+   * cause names: the vertex's own here, a chunk's in every other test in this class. See
+   * {@code Issue6572DanglingVertexReferenceTest} for the delete-level contract this underpins.
    */
   @Test
-  void headChunkForWriteRaisesRetryableConflictWhenTheVertexItselfVanishes() {
+  void headChunkForWriteRaisesANonRetryableNotFoundWhenTheVertexItselfVanishes() {
     createSchema();
     final RID hubRID = createHub();
     createEdges(hubRID, 20);
@@ -142,8 +150,9 @@ class Issue5670EdgeDeleteDanglingBackRefTest extends TestHelper {
 
       assertThatThrownBy(
           () -> ((DatabaseInternal) database).getGraphEngine().getEdgeHeadChunkForWrite(lazyHub, Vertex.DIRECTION.IN))
-          .isInstanceOf(ConcurrentModificationException.class)
-          .isInstanceOf(NeedRetryException.class);
+          .isInstanceOf(VertexNotFoundException.class)
+          .isNotInstanceOf(NeedRetryException.class)
+          .hasMessageContaining(hubRID.toString());
     } finally {
       database.rollback();
     }

--- a/engine/src/test/java/com/arcadedb/graph/Issue6572DanglingVertexReferenceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6572DanglingVertexReferenceTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.exception.VertexNotFoundException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * #6572: meeting a DANGLING VERTEX REFERENCE must be reported as what it is.
+ * <p>
+ * An adjacency entry whose target record was removed without the entry being disconnected - the documented legacy
+ * of a pre-#5670 best-effort edge delete - hands a caller a vertex handle to a record that is not there. Deleting
+ * through it reached {@code GraphEngine.getEdgeHeadChunkForWrite}, whose lazy load of the vertex raised
+ * {@code RecordNotFoundException}, and that was converted wholesale into the retryable conflict the method exists
+ * to produce for an unreadable CHUNK. Two things were then wrong at once, and both hurt a batch job:
+ * <ul>
+ *   <li>the type said "retry me" for a record that is gone, so every attempt failed identically, the retry budget
+ *   was spent on a foregone conclusion and the whole transaction rolled back - one stale reference killing a
+ *   nightly sweep, permanently;</li>
+ *   <li>the advice said {@code CHECK DATABASE RECORD <rid> FIX}, which rebuilds the edge list OF that record from
+ *   the surviving edges - and that record is precisely the one that no longer exists.</li>
+ * </ul>
+ * The evidence separating the two cases was already on the exception: the RID it names. When it is the vertex's
+ * own, this is not a publication window, and these tests pin that it is answered with a non-retryable
+ * {@link VertexNotFoundException} naming a repair that actually applies - while the CHUNK case keeps the conflict
+ * and the scoped advice #5764 gave it.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6572DanglingVertexReferenceTest extends TestHelper {
+  private RID srcRID;
+  private RID targetRID;
+  private RID edgeRID;
+
+  /** These tests deliberately leave a reference into a deleted record, so the end-of-test check would always fire. */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  /**
+   * The reported shape, single-threaded and with nothing else touching the database: the vertex named by the
+   * failure and the record reported missing are the SAME RID, which is the one thing a concurrent commit in flight
+   * can never produce.
+   */
+  @Test
+  void aDeleteReachedThroughAStaleReferenceFailsAsNotFoundRatherThanAsAConflict() {
+    createDanglingReference();
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(this::deleteEverythingSrcPointsAt, false, 3));
+
+    assertThat(thrown).isInstanceOf(VertexNotFoundException.class).isInstanceOf(RecordNotFoundException.class);
+    assertThat(thrown).as("a record that is gone must not be advertised as retryable: %s", thrown)
+        .isNotInstanceOf(NeedRetryException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(targetRID);
+
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage())
+        .contains(targetRID.toString())
+        .contains("does not exist")
+        .doesNotContain("concurrent commit in flight");
+
+    // The advice must name a repair that can be run, and must not hand the operator a copy-pasteable command
+    // aimed at the record that is gone - which is precisely what the conflict this replaces used to do.
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage()).contains("CHECK DATABASE FIX");
+    assertThat(scopedRepairCommandIn(thrown.getMessage()))
+        .as("no runnable RECORD-scoped command may appear: %s", thrown.getMessage()).isNull();
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage()).doesNotContain("CHECK DATABASE RECORD " + targetRID);
+
+    // The original not-found is kept, so the trace still says which record and which read found it missing.
+    assertThat(thrown.getCause()).as("the diagnosis must WRAP the not-found, not replace it")
+        .isInstanceOf(RecordNotFoundException.class);
+  }
+
+  /**
+   * The half of the report that hurt most: the exception type is what the retry machinery reads, so reporting a
+   * gone record as a conflict re-ran the whole transaction to fail identically each time. Counted rather than
+   * inferred - the block must run exactly ONCE out of the three attempts offered.
+   */
+  @Test
+  void theFailureDoesNotSpendTheRetryBudget() {
+    createDanglingReference();
+
+    final AtomicInteger attempts = new AtomicInteger();
+    assertThatThrownBy(() -> database.transaction(() -> {
+      attempts.incrementAndGet();
+      deleteEverythingSrcPointsAt();
+    }, false, 3)).isInstanceOf(VertexNotFoundException.class);
+
+    assertThat(attempts.get()).as("a failure that can never succeed must not be retried").isEqualTo(1);
+  }
+
+  /**
+   * The advice is only worth printing if it repairs the database, so this runs it. {@code CHECK DATABASE FIX} at
+   * DATABASE scope drops the entry pointing at the missing record; the delete that failed then goes through.
+   */
+  @Test
+  void theRepairItAdvertisesIsTheOneThatWorks() {
+    createDanglingReference();
+
+    assertThatThrownBy(() -> database.transaction(this::deleteEverythingSrcPointsAt, false, 1))
+        .isInstanceOf(VertexNotFoundException.class);
+
+    try (final ResultSet rs = database.command("sql", "check database fix")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(longProperty(row, "autoFix")).as("the fix must repair something: %s", row.toJSON()).isGreaterThan(0L);
+    }
+
+    // The stale entry is gone, so the sweep that could not run at all now completes.
+    database.transaction(this::deleteEverythingSrcPointsAt);
+    database.transaction(() -> assertThat(srcRID.asVertex().countEdges(Vertex.DIRECTION.OUT, "E1")).isEqualTo(0L));
+
+    assertIntegrityClean();
+  }
+
+  /**
+   * The other half of the split, guarded so the fix cannot creep over it: a vertex that EXISTS whose head chunk
+   * cannot be read is still the publication window #5670 answers with a retryable conflict, and still carries the
+   * scoped repair #5764 gave it - the list of a record that is there really can be rebuilt.
+   */
+  @Test
+  void anUnreadableChunkKeepsItsRetryableConflictAndItsScopedAdvice() {
+    createDanglingReference();
+
+    final RID headChunk = outHeadChunk(srcRID);
+    deleteRecord(headChunk);
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(() -> srcRID.asVertex().delete(), false, 1));
+
+    assertThat(thrown).isInstanceOf(ConcurrentModificationException.class).isInstanceOf(NeedRetryException.class);
+    assertThat(thrown).isNotInstanceOf(VertexNotFoundException.class);
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage()).contains(headChunk.toString());
+    assertThat(scopedRepairCommandIn(thrown.getMessage())).as("%s", thrown.getMessage())
+        .isEqualTo("CHECK DATABASE RECORD " + srcRID + " FIX");
+  }
+
+  /**
+   * Unchanged, and the policy the new tolerance in {@code disconnectEndpoint} extends: an EDGE whose endpoint
+   * vertex is gone has nothing to disconnect on that side, so its delete succeeds instead of failing. Deleting the
+   * edge is in fact the hand repair for this corruption, and it leaves the graph clean.
+   */
+  @Test
+  void deletingAnEdgeWhoseEndpointVertexIsGoneStaysTolerated() {
+    createDanglingReference();
+
+    database.transaction(() -> edgeRID.asEdge().delete());
+
+    database.transaction(() -> {
+      assertThat(database.existsRecord(edgeRID)).isFalse();
+      assertThat(srcRID.asVertex().countEdges(Vertex.DIRECTION.OUT, "E1")).isEqualTo(0L);
+    });
+    assertIntegrityClean();
+  }
+
+  /**
+   * {@code src --E1--> target}, with target's RECORD dropped straight out of its bucket and the adjacency entry on
+   * src left in place: the state a pre-#5670 delete left behind, reproduced without any concurrency.
+   */
+  private void createDanglingReference() {
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Src", 1);
+      database.getSchema().createVertexType("Target", 1);
+      database.getSchema().createEdgeType("E1", 1);
+    });
+
+    database.transaction(() -> {
+      final MutableVertex src = database.newVertex("Src");
+      src.save();
+      final MutableVertex target = database.newVertex("Target");
+      target.save();
+      srcRID = src.getIdentity();
+      targetRID = target.getIdentity();
+      edgeRID = src.newEdge("E1", target).getIdentity();
+    });
+
+    deleteRecord(targetRID);
+
+    // The reference really is still there: src still reports one outgoing edge into the record that is gone.
+    database.transaction(() -> assertThat(srcRID.asVertex().countEdges(Vertex.DIRECTION.OUT, "E1")).isEqualTo(1L));
+  }
+
+  /** The batch job's inner loop: walk what src points at and delete it - reaching the target through the entry. */
+  private void deleteEverythingSrcPointsAt() {
+    for (final Vertex v : srcRID.asVertex().getVertices(Vertex.DIRECTION.OUT, "E1"))
+      v.delete();
+  }
+
+  private RID outHeadChunk(final RID vertexRID) {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> holder[0] = ((VertexInternal) vertexRID.asVertex()).getOutEdgesHeadChunk());
+    assertThat(holder[0]).as("the vertex must have an outgoing edge list").isNotNull();
+    return holder[0];
+  }
+
+  private void deleteRecord(final RID rid) {
+    database.transaction(() -> database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid));
+    database.transaction(() -> assertThat(database.existsRecord(rid)).isFalse());
+  }
+
+  /** The {@code CHECK DATABASE RECORD <rid> FIX} command a message tells the operator to run, or null. */
+  private static String scopedRepairCommandIn(final String message) {
+    final int start = message.indexOf("`CHECK DATABASE RECORD ");
+    if (start < 0)
+      return null;
+    final int end = message.indexOf('`', start + 1);
+    return end < 0 ? null : message.substring(start + 1, end);
+  }
+
+  /** Asserts on the fields {@code check database} actually reports, so a typo cannot make this vacuously pass. */
+  private void assertIntegrityClean() {
+    try (final ResultSet rs = database.command("sql", "check database")) {
+      assertThat(rs.hasNext()).isTrue();
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(longProperty(row, "autoFix")).as("autoFix: %s", row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "invalidLinks")).as("invalidLinks: %s", row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "totalWarnings")).as("totalWarnings: %s", row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "totalCorruptedRecords")).as("totalCorruptedRecords: %s", row.toJSON()).isEqualTo(0L);
+      }
+    }
+  }
+
+  /** Reads a numeric check-database property, failing loudly when the field does not exist (a vacuous assertion). */
+  private static long longProperty(final Result row, final String name) {
+    final Object value = row.getProperty(name);
+    assertThat(value).as("check database must report '%s': %s", name, row.toJSON()).isNotNull();
+    return ((Number) value).longValue();
+  }
+}


### PR DESCRIPTION
Fixes #6572.

## The problem

`GraphEngine.getEdgeHeadChunkForWrite` wrapped **every** `RecordNotFoundException` from its lazy vertex load into the retryable `ConcurrentModificationException` that #5670 invented for a head chunk a concurrent commit has not published yet. The reported failure named the same RID in both halves:

```
ConcurrentModificationException: Edge list OUT of vertex #98:4138 is not fully visible yet
(concurrent commit in flight): Record #98:4138 not found. If it persists once the retries are
spent the list is genuinely broken: run `CHECK DATABASE RECORD #98:4138 FIX` to rebuild its
edge list from the surviving edge records, then retry the delete
```

Single-threaded job, nothing else writing. The vertex was reached through a **dangling adjacency entry** - one whose target record was removed without the entry being disconnected, the documented legacy of a pre-#5670 best-effort edge delete. Two things were wrong at once, and both hurt a batch job:

- the type said "retry me" for a record that is **gone**, so every attempt failed identically, the retry budget was spent on a foregone conclusion, and the whole transaction rolled back with no work committed - one stale reference killing a nightly sweep, permanently;
- the advice said `CHECK DATABASE RECORD <rid> FIX`, which rebuilds the edge list **of** that record from the surviving edges, while that record is precisely the one that no longer exists.

## The fix

The evidence separating the two cases was already on the exception: **the RID it names**. A missing head chunk, mid-chain chunk or stripe head really can be the publication window; the vertex the caller asked to modify cannot.

When the cause names the vertex's own RID, the read now raises the new `VertexNotFoundException` - a `RecordNotFoundException`, deliberately **not** a `NeedRetryException`:

```
Vertex #98:4138 does not exist, so its OUT edge list cannot be modified: it was reached through
a reference to a record that is gone (a stale edge entry, or a RID held past the delete).
Retrying cannot make it exist: run `CHECK DATABASE FIX` to drop the adjacency entries that still
point at it - the RECORD scope cannot help here, since the edge list it would rebuild belongs to
the record that is gone, and the entry to drop lives on the vertex at the other end, which only
a sweep can find
```

Everything else keeps the #5670 conflict and the #5764 scoped advice, unchanged.

Two deliberate details:

- **The RECORD scope is ruled out in words, not rendered as a command.** An operator who met the old message has to be told it was the wrong tool, but a message that spells the command out with the RID substituted in is one a hurried reader (or a log grep) pastes into a console anyway. Same line #5764's `danglingRepairAdvice` already draws.
- **The referrer cannot be named at the throw site.** A vertex handle carries no back-pointer to the list it was read from, and no index maps a vertex back to the lists that name it. That is exactly why the repair has to be a sweep.

## Deleting a missing vertex stays an error

Asked in the issue, answered here rather than silently: it stays an error, not a tolerated no-op. `bucket.deleteRecord` raises not-found for every other record shape - and for this vertex a few steps further down the very same delete - so tolerating it in the graph path alone would relocate the asymmetry while hiding the one thing the caller needs to know. `deleteEdge`'s `ALREADY DELETED: IGNORE IT` arm is narrower than it reads: it covers only the final physical removal, after both disconnections are done, because a self-loop is walked from both of the vertex's lists and reaches it twice.

What changes is that the failure says what is wrong, and that a caller walking possibly-stale references can now tell "this will never work" from "try again" by catching `RecordNotFoundException`, and skip the entry instead of losing the batch.

One tolerance moves with it: `disconnectEndpoint` catches the new exception and treats it as "nothing to disconnect on that side" - the same answer `resolveEndpointToDisconnect`'s `existsRecord` probe already gives. The probe and the head-pointer read are two reads with a gap, so the same fact can surface between them. The probe **stays**: a handle materialised earlier in the transaction answers its head pointer from its own buffer and raises nothing at all, so neither check replaces the other.

## Verification

`Issue6572DanglingVertexReferenceTest` (5 tests):

- the reported repro, with no concurrency: type, RID, cause chain and advice;
- **the retry budget is counted, not inferred** - the block runs exactly 1 of the 3 attempts offered;
- **the advice is executed, not asserted**: the test runs `CHECK DATABASE FIX`, then the delete that could not proceed completes and `check database` reports clean;
- two guards so the fix cannot creep: an unreadable *chunk* on a vertex that exists keeps its retryable conflict and its `CHECK DATABASE RECORD <vertex> FIX`, and an edge whose endpoint vertex is gone still deletes.

Confirmed non-vacuous: 3 of the 5 fail against the unmodified engine.

`Issue5670EdgeDeleteDanglingBackRefTest.headChunkForWriteRaisesRetryableConflictWhenTheVertexItselfVanishes` pinned the old contract and is corrected in place (renamed to `...RaisesANonRetryableNotFound...`), with the reasoning that led to it rewritten rather than deleted.

Green: 326 graph tests (including the `slow`-tagged concurrent #5670 rounds), 2946 database + SQL, 4934 openCypher, 186 root-package, full-project compile.

`Issue6301AlgoSteinerTreeWeightAlignmentTest.anActiveOverlayDoesNotLendItsWeightsToTheWrongEdges` fails on this branch and fails identically on `main` with this change stashed - pre-existing and unrelated.

## Wire-visible consequence

`ErrorCategory` for this case moves from `RETRY` to `NOT_FOUND`, so HTTP answers 404 instead of a conflict, and every other protocol its not-found vocabulary. That is the intended verdict: the record does not exist.
