### PR TITLE
fix(#6562): declare 'language' as required on the CommandRequest OpenAPI schema

### DIFF
--- a/docs/6562-openapi-commandrequest-language-field.md
+++ b/docs/6562-openapi-commandrequest-language-field.md
@@ -1,0 +1,36 @@
+# #6562 - OpenAPI CommandRequest omits the required 'language' field
+
+## Root cause
+
+`CoreApiSpec.createCommandRequestSchema()` declared only `command` and `params` on the
+`CommandRequest` OpenAPI schema. But `PostCommandHandler.execute` reads `language` with
+`requireStringField(requestMap, "language")` (no default) and rejects the request with a
+400 ("Language is null") when it is missing or empty. A client generated strictly from the
+OpenAPI contract therefore never sends `language` and every `POST /api/v1/command/{database}`
+call fails at runtime.
+
+`createQueryRequestSchema()` already models `language` correctly, as an optional property
+(the query handler defaults it), which is why only `CommandRequest` needed the fix.
+
+## Affected components
+
+- `server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java` - schema
+  generation for the `/api/v1/command/{database}` request body.
+
+## Fix
+
+Added `language` as a documented, **required** property of the `CommandRequest` schema,
+matching what `PostCommandHandler` actually enforces at runtime.
+
+## Tests
+
+- `server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java`:
+  added `commandRequestDeclaresLanguageAsRequired()`, which fails against the pre-fix schema
+  (confirmed: property absent) and passes after the fix.
+- Full `com.arcadedb.server.http.handler.openapi.*Test` + `OpenApiSpecGeneratorTest` suite
+  (132 tests) run green, no regressions.
+
+## Out of scope
+
+The TypeScript client's widened-cast workaround referenced in the issue lives in the
+`arcadedb-clients` repo (tracked under #4894), not in this repository.

--- a/docs/6562-openapi-commandrequest-language-field.md
+++ b/docs/6562-openapi-commandrequest-language-field.md
@@ -34,3 +34,30 @@ matching what `PostCommandHandler` actually enforces at runtime.
 
 The TypeScript client's widened-cast workaround referenced in the issue lives in the
 `arcadedb-clients` repo (tracked under #4894), not in this repository.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6580
+
+## Review cycles
+
+- **cycle 1** - head `d3dd7f6` - initial commit (schema + regression test + tracking doc).
+  `claude[bot]` posted a review as a PR issue comment (not a formal GitHub review) 30s after
+  push: LGTM, no actionable items. It confirmed the root-cause premise against
+  `PostCommandHandler.execute` directly, endorsed the minimal diff and test, and flagged one
+  explicitly out-of-scope observation (see below). Working tree stayed clean - no code changes
+  needed in response.
+
+## Deferred items
+
+None deferred (nothing actionable/unclear). One **out-of-scope nitpick** from the review, not
+acted on here per the reviewer's own framing ("beyond what #6562 asked for"):
+
+- `CommandRequest`'s schema still doesn't document `limit`, `serializer`, `profileExecution`,
+  `typeHints`, or `awaitResponse`, all of which `PostCommandHandler` also reads from the request
+  body (`QueryRequest` already documents `serializer`/`limit`). Worth a follow-up issue for full
+  parity between the two schemas.
+
+## Final state
+
+`clean-approval` - 1 review cycle, zero actionable feedback, working tree unchanged after review.

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -580,13 +580,14 @@ public class CoreApiSpec implements OpenApiContributor {
   private Schema<?> createCommandRequestSchema() {
     final Schema<Object> schema = SpecBuilders.object("Command request object");
     schema.addProperty("command", SpecBuilders.string("Command to execute"));
+    schema.addProperty("language", SpecBuilders.string("Command language").example("sql"));
     schema.addProperty("params", SpecBuilders.object(
         """
         Command parameters. Values may be JSON primitives, arrays, or typed-marker objects: \
         {"$bytes": "<base64>"} for byte[] (standard or URL-safe base64), \
         {"$int8": [v0, v1, ...]} for byte[] from integers in [-128, 127] (used to send \
         INT8-encoded vectors to LSM_VECTOR indexes without a float32 round-trip)."""));
-    schema.setRequired(List.of("command"));
+    schema.setRequired(List.of("command", "language"));
     return schema;
   }
 

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -287,6 +287,20 @@ class CoreApiSpecTest {
   }
 
   @Test
+  void commandRequestDeclaresLanguageAsRequired() {
+    final Schema<?> schema = openAPI.getComponents().getSchemas().get("CommandRequest");
+
+    assertThat(schema.getProperties())
+        .as("PostCommandHandler.execute rejects a request with no language (400 \"Language is null\"), "
+            + "so a client generated strictly from the contract must be told to send it")
+        .containsKey("language");
+    assertThat(schema.getRequired())
+        .as("PostCommandHandler.execute treats a missing or empty language exactly like a missing "
+            + "command: both fail requireStringField / the explicit null-or-empty check with a 400")
+        .contains("language");
+  }
+
+  @Test
   void getQuery404DoesNotClaimTheStaleSessionCasePostAndCommandDo() {
     final Operation get = openAPI.getPaths().get("/api/v1/query/{database}/{language}/{command}").getGet();
 


### PR DESCRIPTION
Closes #6562

`CoreApiSpec.createCommandRequestSchema()` declared only `command` and `params` on the `CommandRequest` OpenAPI schema, but `PostCommandHandler.execute` reads `language` via `requireStringField(requestMap, "language")` with no default and rejects the request with a 400 ("Language is null") when it is missing or empty. A client generated strictly from the contract therefore never sends `language`, and every `POST /api/v1/command/{database}` call fails at runtime. `QueryRequest` already models `language` correctly as optional (its handler defaults it), so only `CommandRequest` needed the fix.

## Test plan

- [x] Added `CoreApiSpecTest.commandRequestDeclaresLanguageAsRequired()`, confirmed it fails against the pre-fix schema (property absent) and passes after adding `language` to the schema's properties and required list.
- [x] Ran the full `com.arcadedb.server.http.handler.openapi.*Test` + `OpenApiSpecGeneratorTest` suite (132 tests) - all green, no regressions.