### PR TITLE
feat(#4894): M2 - smoke-test the TypeScript client against the server built from this commit

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -897,6 +897,90 @@ jobs:
           path: e2e-js/reports/jest-junit.xml
           retention-days: 7
 
+  # Runs the @arcadedb/client end-to-end suite from ArcadeData/arcadedb-clients against the server
+  # image built from THIS commit, rather than against a published tag.
+  #
+  # Why it exists: the anti-drift test from #4896 compares the REGISTERED ROUTES against the
+  # documented paths, so it is structurally blind to a request-body schema or a response header that
+  # stops matching its handler. That blindness is not theoretical - building the TypeScript client
+  # found four such defects that #4895's and #4896's own reviews missed: #6562 (CommandRequest
+  # omitted the required 'language', so a generated client could not call /command at all), #6563
+  # (X-Request-Id undocumented on every response), #6558 (ai/chat returned SSE where the spec said
+  # JSON) and #6584 (CommandRequest omits 'limit'). This job is the only check that catches that
+  # class on the pull request that introduces it, instead of whenever someone next regenerates a
+  # client.
+  #
+  # It is deliberately NON-BLOCKING (continue-on-error) while the cross-repo arrangement is new: a
+  # breakage in arcadedb-clients, or a transient failure fetching it, must not wedge server
+  # development. Read its result, do not ignore it - a red here means a server change altered the
+  # wire in a way the OpenAPI contract does not describe. Revisit the non-blocking setting once the
+  # job has proven stable.
+  #
+  # It tracks the clients repository's main branch on purpose: the question this answers is "does
+  # the current client still work against this server", and pinning a commit would let that drift.
+  client-smoke-test:
+    runs-on: ubuntu-latest
+    needs: build-and-package
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the clients repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ArcadeData/arcadedb-clients
+          ref: main
+          path: clients
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # testcontainers requires Node >= 22.22; the clients repository's own e2e job uses 24.
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: "clients/typescript/package-lock.json"
+
+      - name: Download docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: arcadedb-docker-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+
+      # ARCADEDB_DOCKER_IMAGE overrides the published image the suite otherwise pins. Without it the
+      # suite would test a released server and tell us nothing about this commit.
+      - name: Run the client e2e suite against this build
+        id: client-e2e
+        working-directory: clients/typescript
+        run: |
+          npm ci
+          npm run e2e
+        env:
+          ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      # continue-on-error keeps a red here from blocking the pull request, which also means the run's
+      # overall status stays green and the failure is easy to scroll past. Write it into the run
+      # summary so it cannot be missed, and say what it means, because the natural reading ("some
+      # flaky client test") is the wrong one.
+      - name: Report a smoke-test failure in the run summary
+        if: failure() && steps.client-e2e.outcome == 'failure'
+        run: |
+          {
+            echo "## TypeScript client smoke test FAILED"
+            echo
+            echo "The \`@arcadedb/client\` end-to-end suite failed against the server image built"
+            echo "from this commit. It passes against released servers, so this most likely means"
+            echo "**this change altered the HTTP wire in a way the OpenAPI contract does not"
+            echo "describe**."
+            echo
+            echo "This is exactly the class of defect the #4896 anti-drift test cannot see: that"
+            echo "test compares registered routes, not request-body schemas or response headers."
+            echo
+            echo "Do not merge on the assumption that this is flaky. Check the job log first."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   studio-e2e-tests:
     runs-on: ubuntu-latest
     needs: build-and-package


### PR DESCRIPTION
Second half of M2 of #4894. Adds a `client-smoke-test` job that runs the `@arcadedb/client` end-to-end suite from `ArcadeData/arcadedb-clients` against the server image built from **this commit**, rather than against a published tag.

Depends on ArcadeData/arcadedb-clients#4, already merged, which added the `ARCADEDB_DOCKER_IMAGE` override the job uses.

## Why

The anti-drift test from #4896 compares the **registered routes** against the documented paths. It is structurally blind to a request-body schema or a response header that stops matching its handler.

That blindness is not theoretical. Building the TypeScript client against this contract found four such defects in three days, every one of them invisible to #4896 and to the reviews of #4895 and #4896 themselves:

- #6562 - `CommandRequest` omitted the required `language`, so a strictly generated client could not call `/command` at all
- #6563 - `X-Request-Id` was an undocumented response header on every endpoint
- #6558 - `POST /api/v1/ai/chat` returned SSE while the spec documented JSON
- #6584 - `CommandRequest` also omits `limit`, which `PostCommandHandler` honors (open)

Each was found by a human building a client, weeks or months after the contract shipped. This job catches that class **on the pull request that introduces it**.

## Design notes

**Non-blocking, deliberately.** `continue-on-error: true`, so a breakage in the clients repository - or a transient failure fetching it - cannot wedge server development while this cross-repo arrangement is new. There is precedent for job-level `continue-on-error` in `native-image.yml`'s non-required matrix legs.

**A failure is written to the run summary.** Because `continue-on-error` keeps the overall run green, a red job is easy to scroll past. The job writes an explicit block to `$GITHUB_STEP_SUMMARY` stating what a failure means, since the natural reading ("a flaky client test") is the wrong one: the suite passes against released servers, so a failure here most likely means the change under review altered the wire in a way the contract does not describe.

**It tracks the clients repository's `main`, not a pinned commit.** The question being answered is "does the current client still work against this server". Pinning would let that drift and quietly stop testing anything.

**Node 24** because `testcontainers` requires `>= 22.22`, matching the clients repository's own e2e job.

## Verification

The workflow parses, and the job is wired as intended (17 jobs total, `needs: build-and-package`, the image override passed from `needs.build-and-package.outputs.image-tag`).

The suite-and-override half was verified directly while preparing ArcadeData/arcadedb-clients#4:

- with `ARCADEDB_DOCKER_IMAGE` set to a bogus tag, Docker fails with `failed to resolve reference ... not found` and the run exits 1, proving the variable is genuinely read rather than ignored
- with it set to a locally built `26.9.1-SNAPSHOT` image, the suite passes 6/6 - the exact scenario this job automates
- with it unset, the suite passes 6/6 on its published pin, so the clients repository's own CI is unaffected

What cannot be verified outside CI is the job-level plumbing: the cross-repository checkout, the image artifact download, and the `image-tag` output. Those are exercised for the first time by this pull request's own run, so the job's result here is the verification.

## Follow-up

Promoting this from non-blocking to blocking is a one-line change, worth doing once the job has proven stable across a few releases.
