### PR TITLE
fix(#6583): persist Graph Analytical View CSR so an unchanged reopen skips the rebuild scan

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2130,6 +2130,17 @@ public enum GlobalConfiguration {
       but open() returns immediately and queries issued right after it run unaccelerated until the rebuild completes. \
       A positive value trades a slower open() for the restored view being usable by the query that triggered the reopen""",
       Long.class, 0L),
+
+  GAV_PERSIST_CSR("arcadedb.gavPersistCsr", SCOPE.DATABASE,
+      """
+      When true (default), a Graph Analytical View (GAV/CSR) that is READY (with no pending overlay changes) when \
+      the database closes cleanly writes its CSR to disk alongside a freshness certificate (the database's last \
+      committed transaction id at build time). If nothing was committed to the database between that close and the \
+      next open, the certificate still matches and the persisted CSR is reused as-is instead of being rebuilt by a \
+      full graph scan (issue #6583). Any commit in between invalidates the certificate and falls back to the \
+      previous behavior: an async rebuild triggered on open. Set to false to disable persisting the CSR file \
+      (e.g. to avoid its disk footprint or the extra write at close)""",
+      Boolean.class, true),
   ;
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -276,6 +276,16 @@ public interface DatabaseInternal extends Database {
   }
 
   /**
+   * Returns the {@link DataEncryption} configured via {@link #setDataEncryption}, or null if none is configured.
+   * Used by components that persist data outside the normal record/page path (e.g. {@code
+   * GraphAnalyticalViewCSRPersistence}, issue #6583) so that opting into encryption for a database's records also
+   * covers side files derived from that data, rather than only the pages the serializer itself writes.
+   */
+  default DataEncryption getDataEncryption() {
+    return getSerializer().getDataEncryption();
+  }
+
+  /**
    * Returns true if writes against this database are forwarded to a replication layer
    * (e.g. Raft). Components that capture WAL bytes for replication (like {@link com.arcadedb.graph.GraphBatch})
    * must keep the WAL on for committed transactions when this is true, otherwise the

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -68,6 +68,21 @@ public class TransactionManager {
   private final AtomicLong                   statsPagesWritten   = new AtomicLong();
   private final AtomicLong                   statsBytesWritten   = new AtomicLong();
   /**
+   * True once this open has reconstructed {@link #getLastTransactionId()} from real evidence - either the marker
+   * persisted at a previous clean close, or WAL replay - rather than falling through to the "no transaction has
+   * ever been committed" default of -1 for a reason that says nothing about whether one actually has. That default
+   * is legitimate for a genuinely empty database, but it is the SAME value a database with real history reports
+   * when its recency marker is lost or corrupted with no WAL left to recover it from (a clean close removes the
+   * WAL, so the marker is the only durable record at that point) - and unlike the marker itself, this counter is
+   * not required to be monotonic across that failure: it restarts from 0 and climbs back through every value it
+   * held before, including ones a persisted derived structure (see {@code GraphAnalyticalViewCSRPersistence},
+   * issue #6583) may have recorded as its freshness certificate. A consumer that only compares the numeric value
+   * would eventually see a stale certificate become numeric equal again and silently accept it. Callers relying on
+   * this counter for "has anything changed since X" must additionally check this flag and refuse to trust an
+   * equality match while it is false.
+   */
+  private volatile boolean                   recencySignalReliable;
+  /**
    * Held SHARED for the whole of {@link #applyChanges}, and EXCLUSIVELY by the snapshot t0 barrier
    * ({@code PageManager.openSnapshot}, issue #6075). Replicated and crash-recovery replay is the one writer that
    * reaches the data files outside the asynchronous flush pipeline, so parking the flush thread does not park it;
@@ -89,6 +104,7 @@ public class TransactionManager {
     final long persistedLastTxId = readPersistedLastTransactionId();
     if (persistedLastTxId >= 0)
       transactionIds.set(persistedLastTxId + 1);
+    this.recencySignalReliable = persistedLastTxId >= 0;
 
     if (database.getMode() == ComponentFile.MODE.READ_WRITE) {
       createWALFilePool();
@@ -382,8 +398,12 @@ public class TransactionManager {
         // Only update the next-tx counter if recovery actually applied a transaction. When
         // lastTxId is still -1 the counter must keep the persistedLastTxId value loaded by the
         // constructor; overwriting it with 0 would lose recency and risk transaction-id reuse.
-        if (lastTxId != -1)
+        if (lastTxId != -1) {
           transactionIds.set(lastTxId + 1);
+          // Reconstructed from real evidence (replayed WAL transactions), regardless of what the
+          // constructor found (or didn't) in the persisted marker.
+          recencySignalReliable = true;
+        }
 
         if (!walGapDetected) {
           // REMOVE ALL WAL FILES
@@ -794,6 +814,19 @@ public class TransactionManager {
    */
   public long getLastTransactionId() {
     return transactionIds.get() - 1;
+  }
+
+  /**
+   * True when {@link #getLastTransactionId()} was reconstructed from real evidence this open (a marker persisted
+   * at a previous clean close, or WAL replay), rather than falling through to the "nothing ever committed" default
+   * because both were missing or unreadable. False means the counter may be lower than a value it held before a
+   * marker was lost, and will climb back through that value as the database keeps operating - so an equality
+   * comparison against a number recorded before this open cannot be trusted while this is false, even once the
+   * numbers happen to match again. See the field-level Javadoc on {@code recencySignalReliable} for the failure
+   * this guards (issue #6583).
+   */
+  public boolean isRecencySignalReliable() {
+    return recencySignalReliable;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/olap/Column.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/Column.java
@@ -207,6 +207,37 @@ public class Column {
   }
 
   /**
+   * Reconstructs a column from arrays previously produced by the getters above (see
+   * {@link GraphAnalyticalViewCSRPersistence}). {@code dictionaryValues} is only used for
+   * {@link Type#STRING} and must be indexed by dictionary code (the order {@link DictionaryEncoding#getValues()}
+   * returns them in), so re-encoding them in that order reproduces the exact same codes.
+   */
+  static Column restore(final String name, final Type type, final int nodeCount, final long[] nullBitset,
+      final int[] intData, final long[] longData, final double[] doubleData,
+      final int[] stringCodes, final String[] dictionaryValues) {
+    final Column column = new Column(name, type, nodeCount);
+    System.arraycopy(nullBitset, 0, column.nullBitset, 0, nullBitset.length);
+    switch (type) {
+    case INT:
+      column.intData = intData;
+      break;
+    case LONG:
+      column.longData = longData;
+      break;
+    case DOUBLE:
+      column.doubleData = doubleData;
+      break;
+    case STRING:
+      column.stringCodes = stringCodes;
+      column.dictionary = new DictionaryEncoding();
+      for (final String value : dictionaryValues)
+        column.dictionary.encode(value);
+      break;
+    }
+    return column;
+  }
+
+  /**
    * Returns approximate memory usage in bytes.
    */
   public long getMemoryUsageBytes() {

--- a/engine/src/main/java/com/arcadedb/graph/olap/ColumnStore.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/ColumnStore.java
@@ -74,6 +74,14 @@ public class ColumnStore {
   }
 
   /**
+   * Registers a column reconstructed by {@link GraphAnalyticalViewCSRPersistence} from a persisted CSR.
+   * Package-private: outside the OLAP package, columns are only ever created via {@link #createColumn}.
+   */
+  void putColumn(final Column column) {
+    columns.put(column.getName(), column);
+  }
+
+  /**
    * Returns the column for the given property name, or null if not present.
    */
   public Column getColumn(final String name) {

--- a/engine/src/main/java/com/arcadedb/graph/olap/DictionaryEncoding.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/DictionaryEncoding.java
@@ -47,6 +47,11 @@ public class DictionaryEncoding {
   /**
    * Encodes a string value, returning its integer code.
    * Assigns a new code if the value hasn't been seen before.
+   * <p>
+   * Codes are assigned sequentially as {@code codeToString.size()} at first sight, so replaying {@link
+   * #getValues()} through {@code encode()} in order (as {@code Column.restore()} does when reconstructing a
+   * persisted column, see issue #6583) reproduces the exact same codes. Changing this assignment scheme would
+   * need a matching change there.
    */
   public int encode(final String value) {
     final Integer existing = stringToCode.get(value);
@@ -83,6 +88,9 @@ public class DictionaryEncoding {
 
   /**
    * Returns the dictionary values as an array (indexed by code).
+   * <p>
+   * Order matters: see the note on {@link #encode(String)} about reconstructing an equivalent dictionary by
+   * replaying this array back through {@code encode()}.
    */
   public String[] getValues() {
     return codeToString.toArray(new String[0]);

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -187,12 +187,23 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // True when this snapshot was loaded from a persisted CSR file rather than produced by a scan of the graph.
     // Exposed via isRestoredFromPersistedCsr() — mainly for tests and operational visibility.
     final boolean                        restoredFromDisk;
+    // The vertex/edge/property scope actually scanned into this snapshot. Usually identical to the enclosing
+    // view's own vertexTypes/edgeTypes/propertyFilter/edgePropertyFilter fields, EXCEPT when produced by the
+    // public two-arg build(vertexTypes, edgeTypes), which lets a caller rescan a NAMED view with a scope
+    // narrower than it was constructed with — those fields are final and never updated to match. Recorded here
+    // (rather than read from the view's fields) so persistCsrIfPossible() can write a certificate that describes
+    // what this snapshot actually covers, not what the view was originally configured for (#6583 review).
+    final String[]                       vertexTypes;
+    final String[]                       edgeTypes;
+    final String[]                       propertyFilter;
+    final String[]                       edgePropertyFilter;
 
     Snapshot(final Map<String, CSRAdjacencyIndex> csrPerType, final NodeIdMapping nodeMapping,
         final ColumnStore[] bucketColumns, final Map<String, ColumnStore> edgeColumnStores,
         final Map<String, int[]> bwdToFwd,
         final DeltaOverlay overlay, final long buildTimestamp, final long buildDurationMs,
-        final long asOfTransactionId, final boolean restoredFromDisk) {
+        final long asOfTransactionId, final boolean restoredFromDisk,
+        final String[] vertexTypes, final String[] edgeTypes, final String[] propertyFilter, final String[] edgePropertyFilter) {
       this.csrPerType = csrPerType;
       this.nodeMapping = nodeMapping;
       this.bucketColumns = bucketColumns;
@@ -203,11 +214,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       this.buildDurationMs = buildDurationMs;
       this.asOfTransactionId = asOfTransactionId;
       this.restoredFromDisk = restoredFromDisk;
+      this.vertexTypes = vertexTypes;
+      this.edgeTypes = edgeTypes;
+      this.propertyFilter = propertyFilter;
+      this.edgePropertyFilter = edgePropertyFilter;
     }
 
     Snapshot withOverlay(final DeltaOverlay newOverlay) {
       return new Snapshot(csrPerType, nodeMapping, bucketColumns, edgeColumnStores, bwdToFwd,
-          newOverlay, buildTimestamp, buildDurationMs, asOfTransactionId, restoredFromDisk);
+          newOverlay, buildTimestamp, buildDurationMs, asOfTransactionId, restoredFromDisk,
+          vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
     }
 
   }
@@ -314,7 +330,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       final long durationMs = System.currentTimeMillis() - buildStart;
 
       // Atomic swap — readers see all-or-nothing
-      this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId);
+      this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
       this.status = Status.READY;
       this.notifyAll();
       invalidateGraphStatisticsCache();
@@ -360,7 +376,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
             final long durationMs = System.currentTimeMillis() - buildStart;
 
             synchronized (GraphAnalyticalView.this) {
-              this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId);
+              this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
               this.status = Status.READY;
               GraphAnalyticalView.this.notifyAll();
               if (deltaCollector == null)
@@ -1437,10 +1453,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
 
   // --- Private helpers ---
 
-  private static Snapshot snapshotFromResult(final CSRBuilder.CSRResult result, final long durationMs, final long asOfTransactionId) {
+  private static Snapshot snapshotFromResult(final CSRBuilder.CSRResult result, final long durationMs, final long asOfTransactionId,
+      final String[] builtVertexTypes, final String[] builtEdgeTypes, final String[] builtPropertyFilter,
+      final String[] builtEdgePropertyFilter) {
     return new Snapshot(result.getCsrPerType(), result.getMapping(), result.getBucketColumns(),
         result.getEdgeColumnStores(), result.getBwdToFwd(),
-        null, System.currentTimeMillis(), durationMs, asOfTransactionId, false);
+        null, System.currentTimeMillis(), durationMs, asOfTransactionId, false,
+        builtVertexTypes, builtEdgeTypes, builtPropertyFilter, builtEdgePropertyFilter);
   }
 
   /**
@@ -1486,7 +1505,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_PERSIST_CSR))
       return;
     try {
-      GraphAnalyticalViewCSRPersistence.save(database, name, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter, snap);
+      // Written from snap's OWN recorded scope, not this.vertexTypes/edgeTypes/propertyFilter/edgePropertyFilter:
+      // the public two-arg build(vertexTypes, edgeTypes) can rescan a named view with a scope narrower than it
+      // was constructed with, and those fields (final, never updated) would then describe more than snap actually
+      // covers - the header must match what was actually scanned, or a later reopen could restore a snapshot that
+      // silently under-covers what the view claims to (#6583 review).
+      GraphAnalyticalViewCSRPersistence.save(database, name, snap.vertexTypes, snap.edgeTypes, snap.propertyFilter,
+          snap.edgePropertyFilter, snap);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "GraphAnalyticalView '%s': failed to persist CSR to disk", e, name);
     }
@@ -1584,7 +1609,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
               // that would be lost by an unconditional swap.
               synchronized (GraphAnalyticalView.this) {
                 if (updateMode == UpdateMode.ASYNCHRONOUS) {
-                  this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId);
+                  this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
                   this.status = Status.READY;
                 } else
                   LogManager.instance().log(this, Level.INFO,
@@ -1701,7 +1726,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                   LogManager.instance().log(this, Level.INFO,
                       "GraphAnalyticalView '%s': compaction result discarded (delta buffer overflowed during rebuild)", name);
                 } else {
-                  Snapshot fresh = snapshotFromResult(result, durationMs, asOfTransactionId);
+                  Snapshot fresh = snapshotFromResult(result, durationMs, asOfTransactionId, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
 
                   // Re-apply any deltas that arrived during the rebuild.
                   // These may not be in the fresh CSR (committed after the CSR scan of their bucket).

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1538,7 +1538,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       // silently under-covers what the view claims to (#6583 review).
       GraphAnalyticalViewCSRPersistence.save(database, name, snap.vertexTypes, snap.edgeTypes, snap.propertyFilter,
           snap.edgePropertyFilter, snap);
-    } catch (final Exception e) {
+    } catch (final OutOfMemoryError | Exception e) {
+      // OutOfMemoryError is caught deliberately, matching load()'s equivalent guard: save() assembles the whole
+      // CSR payload into one contiguous byte[] (and a second one if encryption is configured) before writing
+      // anything, right at shutdown()/database.close() after a build/rescan has already put memory pressure on
+      // the JVM. Left uncaught, an OOM here would propagate out of GraphAnalyticalViewRegistry.shutdownAll()'s
+      // per-view loop with no try/catch of its own, aborting it and leaking every view after this one in
+      // iteration order (unregisterChangeListeners()/GraphTraversalProviderRegistry.unregister() never run for
+      // them) - directly contradicting this method's own "failures are logged and otherwise ignored" contract.
       LogManager.instance().log(this, Level.WARNING, "GraphAnalyticalView '%s': failed to persist CSR to disk", e, name);
     }
   }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -323,7 +323,22 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     status = Status.BUILDING;
     buildError = null;
     try {
-      final long asOfTransactionId = currentLastTransactionId();
+      // Unlike buildAsync()/onRelevantCommit()/applyDelta()'s rebuild - each of which calls database.begin() on a
+      // fresh worker thread AFTER sampling asOfTransactionId, so the scan's transaction cannot have cached
+      // anything before that point - this method runs the scan on whatever transaction is already active on the
+      // CALLING thread (e.g. REBUILD GRAPH ANALYTICAL VIEW / a caller invoking build() directly inside its own
+      // transaction), or with none active at all. Under the default READ_COMMITTED that's harmless (no per-page
+      // caching, every read is current). Under REPEATABLE_READ, a transaction that was already open - and may
+      // already have cached some of the pages this scan is about to read - can miss a commit that landed between
+      // its own begin() and this sample, while asOfTransactionId (sampled here) claims coverage through it. The
+      // certificate would then be wrong in the direction that matters: a "complete" persisted CSR that is
+      // actually missing something. Since there is no way from here to know which pages (if any) that ambient
+      // transaction already cached, treat the certificate as unusable whenever that risk exists at all, rather
+      // than trying to bound it: asOfTransactionId=-1 makes persistCsrIfPossible() skip persisting this snapshot
+      // (see its existing "< 0" guard), the same way a snapshot that must never be persisted already reads.
+      final boolean certificateMayBeUnsound = database.isTransactionActive()
+          && database.getTransactionIsolationLevel() == Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ;
+      final long asOfTransactionId = certificateMayBeUnsound ? -1L : currentLastTransactionId();
       final long buildStart = System.currentTimeMillis();
       final CSRBuilder builder = new CSRBuilder(database, propertyFilter, edgePropertyFilter, propertySampleSize);
       final CSRBuilder.CSRResult result = builder.build(vertexTypes, edgeTypes);

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1580,6 +1580,24 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     invalidateGraphStatisticsCache();
     if (deltaCollector == null)
       registerChangeListeners();
+
+    // A commit to a covered type landing between sampling currentTxId (above) and the listener registration
+    // just above this line would be invisible to the restored snapshot (no scan ran to absorb it, unlike
+    // buildAsync(), whose real scan runs AFTER its own sample so a racing commit is already captured in what
+    // it reads) and invisible to onRelevantCommit()/applyDelta() too (the listeners were not live yet when it
+    // happened). Not reachable via the current call site - restoreAll() runs synchronously inside
+    // LocalDatabase.open(), before the Database is handed to any caller, so nothing holding a reference to it
+    // can commit concurrently - but checked defensively so this stays correct if that context ever changes
+    // (e.g. an HA replica replaying commits concurrently with a local open). Marking STALE mirrors exactly
+    // what onRelevantCommit() does for a real relevant commit under OFF/SYNCHRONOUS mode: conservative, but
+    // never wrong.
+    if (currentLastTransactionId() != currentTxId) {
+      LogManager.instance().log(this, Level.WARNING,
+          "GraphAnalyticalView '%s': a commit landed while restoring its CSR from disk; marking it STALE rather than risk missing it",
+          name);
+      status = Status.STALE;
+    }
+
     LogManager.instance().log(this, Level.INFO,
         "GraphAnalyticalView '%s': restored CSR from disk (asOfTransactionId=%d), skipping full rebuild", name, currentTxId);
     return true;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -481,6 +481,9 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   private void shutdown(final boolean persistCsr) {
     awaitInFlightTasks(SHUTDOWN_AWAIT_MS);
     synchronized (this) {
+      // Runs the persist-to-disk write (when eligible) while holding this instance's monitor: any concurrent
+      // awaitReady()/getStatus() caller blocks for the duration of the write, not just of a scan - accepted
+      // because it only happens once per close and is gated by GAV_PERSIST_CSR.
       if (persistCsr)
         persistCsrIfPossible();
       unregisterChangeListeners();
@@ -1514,8 +1517,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (restored == null)
       return false;
 
-    final CountDownLatch latch = new CountDownLatch(1);
-    readyLatch = latch;
+    // Reuse the latch already installed (by the constructor, since this is always the first status
+    // transition attempted on a freshly built view) rather than publishing a new one: the view is
+    // registered before this method runs, so a concurrent awaitReady() caller may already be waiting
+    // on that original latch. Counting down a *new* instance instead would leave that caller hanging
+    // until its timeout even though the view is READY.
+    final CountDownLatch latch = readyLatch;
     this.snapshot = restored;
     this.status = Status.READY;
     this.notifyAll();

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1507,6 +1507,17 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   private void persistCsrIfPossible() {
     if (name == null || status != Status.READY)
       return;
+    // The certificate is only sound where TransactionManager.getLastTransactionId() reflects every commit that
+    // could have touched the covered types. That holds for a standalone database or an HA leader (the only paths
+    // that call getNextTransactionId()), but not for a follower: TransactionManager.applyChanges(), the path
+    // replicated commits are applied through, never advances that counter, so a follower's certificate would
+    // freeze at whatever value it had when this snapshot was built, then "match" on every later reopen no matter
+    // how much further replicated data has landed since - the same failure shape as the lost-recency-marker case,
+    // but permanent rather than self-healing. Leader-only mirrors the existing precedent for HA-unsafe derived
+    // state (see TimeSeriesMaintenanceScheduler.runMaintenance()) with no compile dependency on the HA module.
+    final DatabaseInternal dbInternal = (DatabaseInternal) database;
+    if (dbInternal.isReplicated() && !dbInternal.isLeader())
+      return;
     final Snapshot snap = this.snapshot;
     if (snap == null || snap.asOfTransactionId < 0)
       return;
@@ -1545,6 +1556,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       return false;
     if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_PERSIST_CSR))
       return false;
+    // Mirrors the same leader-only gate in persistCsrIfPossible(): a follower's certificate can never be trusted
+    // (its TransactionManager counter is frozen against replicated commits), so this file - if one even exists,
+    // e.g. left over from a promotion/demotion - must never be restored on this node either. Checked before
+    // isRecencySignalReliable() purely because it is the cheaper of the two disqualifying checks.
+    final DatabaseInternal dbInternal = (DatabaseInternal) database;
+    if (dbInternal.isReplicated() && !dbInternal.isLeader())
+      return false;
     // The certificate is a plain equality check against the database's last committed transaction id, which is
     // only sound while that counter's own history is verifiably continuous. If this open couldn't reconstruct it
     // from real evidence (a lost/corrupt recency marker with no WAL left to recover it from - a clean close
@@ -1553,7 +1571,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // carry as its certificate. Refusing the fast path here until a fresh, trustworthy certificate is written at
     // this session's own close is the same "no manifest reads as unverifiable, not as valid" rule #6106 already
     // established for the vector index's correspondence artifact.
-    if (!((DatabaseInternal) database).getTransactionManager().isRecencySignalReliable())
+    if (!dbInternal.getTransactionManager().isRecencySignalReliable())
       return false;
     final long currentTxId = currentLastTransactionId();
     final Snapshot restored;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1530,6 +1530,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       return false;
     if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_PERSIST_CSR))
       return false;
+    // The certificate is a plain equality check against the database's last committed transaction id, which is
+    // only sound while that counter's own history is verifiably continuous. If this open couldn't reconstruct it
+    // from real evidence (a lost/corrupt recency marker with no WAL left to recover it from - a clean close
+    // removes the WAL, so the marker is the sole durable record at that point), the counter silently restarts
+    // and will climb back through every value it held before, including one a stale file on disk might still
+    // carry as its certificate. Refusing the fast path here until a fresh, trustworthy certificate is written at
+    // this session's own close is the same "no manifest reads as unverifiable, not as valid" rule #6106 already
+    // established for the vector index's correspondence artifact.
+    if (!((DatabaseInternal) database).getTransactionManager().isRecencySignalReliable())
+      return false;
     final long currentTxId = currentLastTransactionId();
     final Snapshot restored;
     try {

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -178,11 +178,21 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     final DeltaOverlay                   overlay;
     final long                           buildTimestamp;
     final long                           buildDurationMs;
+    // The database's last committed transaction id as of the start of the scan that produced this CSR (see
+    // #6583). Persisted alongside the CSR as its freshness certificate: on a later open, if the database's last
+    // committed transaction id still equals this value, nothing was committed in between, so the persisted CSR is
+    // still exactly correct and can be reused without a rescan. -1 for a snapshot that must never be persisted
+    // (not applicable — no build has produced one yet).
+    final long                           asOfTransactionId;
+    // True when this snapshot was loaded from a persisted CSR file rather than produced by a scan of the graph.
+    // Exposed via isRestoredFromPersistedCsr() — mainly for tests and operational visibility.
+    final boolean                        restoredFromDisk;
 
     Snapshot(final Map<String, CSRAdjacencyIndex> csrPerType, final NodeIdMapping nodeMapping,
         final ColumnStore[] bucketColumns, final Map<String, ColumnStore> edgeColumnStores,
         final Map<String, int[]> bwdToFwd,
-        final DeltaOverlay overlay, final long buildTimestamp, final long buildDurationMs) {
+        final DeltaOverlay overlay, final long buildTimestamp, final long buildDurationMs,
+        final long asOfTransactionId, final boolean restoredFromDisk) {
       this.csrPerType = csrPerType;
       this.nodeMapping = nodeMapping;
       this.bucketColumns = bucketColumns;
@@ -191,11 +201,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       this.overlay = overlay;
       this.buildTimestamp = buildTimestamp;
       this.buildDurationMs = buildDurationMs;
+      this.asOfTransactionId = asOfTransactionId;
+      this.restoredFromDisk = restoredFromDisk;
     }
 
     Snapshot withOverlay(final DeltaOverlay newOverlay) {
       return new Snapshot(csrPerType, nodeMapping, bucketColumns, edgeColumnStores, bwdToFwd,
-          newOverlay, buildTimestamp, buildDurationMs);
+          newOverlay, buildTimestamp, buildDurationMs, asOfTransactionId, restoredFromDisk);
     }
 
   }
@@ -295,13 +307,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     status = Status.BUILDING;
     buildError = null;
     try {
+      final long asOfTransactionId = currentLastTransactionId();
       final long buildStart = System.currentTimeMillis();
       final CSRBuilder builder = new CSRBuilder(database, propertyFilter, edgePropertyFilter, propertySampleSize);
       final CSRBuilder.CSRResult result = builder.build(vertexTypes, edgeTypes);
       final long durationMs = System.currentTimeMillis() - buildStart;
 
       // Atomic swap — readers see all-or-nothing
-      this.snapshot = snapshotFromResult(result, durationMs);
+      this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId);
       this.status = Status.READY;
       this.notifyAll();
       invalidateGraphStatisticsCache();
@@ -337,6 +350,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
       getExecutor().execute(() -> {
         BUILD_PERMITS.acquireUninterruptibly();
         try {
+          final long asOfTransactionId = currentLastTransactionId();
           // The build thread needs its own read transaction for database iteration
           database.begin();
           try {
@@ -346,7 +360,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
             final long durationMs = System.currentTimeMillis() - buildStart;
 
             synchronized (GraphAnalyticalView.this) {
-              this.snapshot = snapshotFromResult(result, durationMs);
+              this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId);
               this.status = Status.READY;
               GraphAnalyticalView.this.notifyAll();
               if (deltaCollector == null)
@@ -442,9 +456,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * Call this when the view is no longer needed (user-initiated removal).
    */
   public void drop() {
-    shutdown();
-    if (name != null)
+    // Dropped views have no schema definition left to restore against, so persisting the CSR here
+    // would just be written and immediately deleted below.
+    shutdown(false);
+    if (name != null) {
       GraphAnalyticalViewPersistence.remove(database, name);
+      GraphAnalyticalViewCSRPersistence.delete(database, name);
+    }
   }
 
   /**
@@ -457,8 +475,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * (or even closed the database) and crash with a misleading SEVERE log line.
    */
   public void shutdown() {
+    shutdown(true);
+  }
+
+  private void shutdown(final boolean persistCsr) {
     awaitInFlightTasks(SHUTDOWN_AWAIT_MS);
     synchronized (this) {
+      if (persistCsr)
+        persistCsrIfPossible();
       unregisterChangeListeners();
       GraphTraversalProviderRegistry.unregister(database, this);
       if (name != null)
@@ -1116,6 +1140,16 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     return snapshot != null;
   }
 
+  /**
+   * Returns true when the current CSR was loaded from a persisted file (see #6583) rather than produced by a scan
+   * of the graph on this open. Mainly useful for tests and operational visibility (e.g. confirming that a reopen
+   * skipped the O(V+E) rebuild).
+   */
+  public boolean isRestoredFromPersistedCsr() {
+    final Snapshot snap = this.snapshot;
+    return snap != null && snap.restoredFromDisk;
+  }
+
   public boolean isReady() {
     final Status s = status;
     if (s == Status.READY)
@@ -1400,10 +1434,98 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
 
   // --- Private helpers ---
 
-  private static Snapshot snapshotFromResult(final CSRBuilder.CSRResult result, final long durationMs) {
+  private static Snapshot snapshotFromResult(final CSRBuilder.CSRResult result, final long durationMs, final long asOfTransactionId) {
     return new Snapshot(result.getCsrPerType(), result.getMapping(), result.getBucketColumns(),
         result.getEdgeColumnStores(), result.getBwdToFwd(),
-        null, System.currentTimeMillis(), durationMs);
+        null, System.currentTimeMillis(), durationMs, asOfTransactionId, false);
+  }
+
+  /**
+   * The database's last committed transaction id, sampled before a CSR scan starts (see {@link
+   * Snapshot#asOfTransactionId}). Reading it before {@code database.begin()} for the scan — rather than after — is
+   * what makes the certificate sound: whatever the scan reads, it reads no earlier than this point, so "nothing
+   * committed since this value" on a later open implies "nothing committed since the scan ran", regardless of the
+   * read transaction's own isolation semantics.
+   */
+  private long currentLastTransactionId() {
+    return ((DatabaseInternal) database).getTransactionManager().getLastTransactionId();
+  }
+
+  /**
+   * Persists the current CSR to disk (see #6583) so the next open can reuse it instead of rescanning the graph,
+   * when doing so is both possible and safe:
+   * <ul>
+   *   <li>the view is named — an anonymous view has no schema definition to restore against on a later open, so
+   *       there would be nothing to reload the file for</li>
+   *   <li>status is READY with a valid certificate — a STALE view's on-disk certificate would already be
+   *       superseded by the very commit that made it STALE, so persisting it would only cost a write that the
+   *       next open's certificate check is guaranteed to reject; BUILDING has no completed snapshot yet</li>
+   *   <li>the overlay (if any) has no pending changes — the certificate vouches only for the base CSR, so a
+   *       SYNCHRONOUS view with buffered overlay deltas would silently drop them if reloaded from this file</li>
+   * </ul>
+   * Called from {@link #shutdown()} while holding this instance's monitor, after any in-flight build/compaction
+   * has settled. Failures are logged and otherwise ignored: the next open simply falls back to a full rebuild,
+   * exactly as it always has.
+   */
+  private void persistCsrIfPossible() {
+    if (name == null || status != Status.READY)
+      return;
+    final Snapshot snap = this.snapshot;
+    if (snap == null || snap.asOfTransactionId < 0)
+      return;
+    if (snap.overlay != null && snap.overlay.hasChanges())
+      return;
+    // Nothing has changed since this exact snapshot was loaded from disk on this open (no overlay changes,
+    // per the check above, and a fresh scan always produces a new Snapshot instance) — the file on disk
+    // already matches it byte-for-byte, so writing it again would be pure waste.
+    if (snap.restoredFromDisk)
+      return;
+    if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_PERSIST_CSR))
+      return;
+    try {
+      GraphAnalyticalViewCSRPersistence.save(database, name, vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter, snap);
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "GraphAnalyticalView '%s': failed to persist CSR to disk", e, name);
+    }
+  }
+
+  /**
+   * Attempts to load a persisted CSR from disk instead of scanning the graph (see #6583). Returns true and leaves
+   * the view READY with the loaded snapshot when a file exists, its definition matches this view's configuration,
+   * and its freshness certificate (the database's last committed transaction id at persist time) still matches the
+   * database's current last committed transaction id — i.e. nothing was committed in between. Returns false
+   * (leaving the view's state untouched) for a missing file, a mismatched definition or certificate, or any read
+   * failure, so the caller can fall back to {@link #buildAsync()} exactly as it would have without this path.
+   */
+  synchronized boolean tryRestoreFromPersistedCsr() {
+    if (name == null)
+      return false;
+    if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_PERSIST_CSR))
+      return false;
+    final long currentTxId = currentLastTransactionId();
+    final Snapshot restored;
+    try {
+      restored = GraphAnalyticalViewCSRPersistence.load(database, name, vertexTypes, edgeTypes, propertyFilter,
+          edgePropertyFilter, currentTxId);
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "GraphAnalyticalView '%s': failed to load persisted CSR from disk", e, name);
+      return false;
+    }
+    if (restored == null)
+      return false;
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    readyLatch = latch;
+    this.snapshot = restored;
+    this.status = Status.READY;
+    this.notifyAll();
+    latch.countDown();
+    invalidateGraphStatisticsCache();
+    if (deltaCollector == null)
+      registerChangeListeners();
+    LogManager.instance().log(this, Level.INFO,
+        "GraphAnalyticalView '%s': restored CSR from disk (asOfTransactionId=%d), skipping full rebuild", name, currentTxId);
+    return true;
   }
 
   private void registerChangeListeners() {
@@ -1443,6 +1565,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         getExecutor().execute(() -> {
           BUILD_PERMITS.acquireUninterruptibly();
           try {
+            final long asOfTransactionId = currentLastTransactionId();
             database.begin();
             try {
               final long buildStart = System.currentTimeMillis();
@@ -1454,7 +1577,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
               // that would be lost by an unconditional swap.
               synchronized (GraphAnalyticalView.this) {
                 if (updateMode == UpdateMode.ASYNCHRONOUS) {
-                  this.snapshot = snapshotFromResult(result, durationMs);
+                  this.snapshot = snapshotFromResult(result, durationMs, asOfTransactionId);
                   this.status = Status.READY;
                 } else
                   LogManager.instance().log(this, Level.INFO,
@@ -1552,6 +1675,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         getExecutor().execute(() -> {
           BUILD_PERMITS.acquireUninterruptibly();
           try {
+            final long asOfTransactionId = currentLastTransactionId();
             database.begin();
             try {
               final long buildStart = System.currentTimeMillis();
@@ -1570,7 +1694,7 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
                   LogManager.instance().log(this, Level.INFO,
                       "GraphAnalyticalView '%s': compaction result discarded (delta buffer overflowed during rebuild)", name);
                 } else {
-                  Snapshot fresh = snapshotFromResult(result, durationMs);
+                  Snapshot fresh = snapshotFromResult(result, durationMs, asOfTransactionId);
 
                   // Re-apply any deltas that arrived during the rebuild.
                   // These may not be in the fresh CSR (committed after the CSR scan of their bucket).

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
@@ -196,6 +196,26 @@ public class GraphAnalyticalViewBuilder {
     return this;
   }
 
+  /**
+   * Used by {@link GraphAnalyticalViewPersistence#restoreAll} on database open (see #6583): first tries to load a
+   * persisted CSR from disk whose freshness certificate still matches (nothing was committed to the database since
+   * it was written), and only falls back to the usual {@link #buildAsync()} full graph scan when there is no
+   * usable file. Either way the view is registered and returned immediately; check {@link
+   * GraphAnalyticalView#getStatus()} / {@link GraphAnalyticalView#awaitReady} for completion exactly as with
+   * {@link #buildAsync()}.
+   */
+  GraphAnalyticalView restoreFromDiskOrBuildAsync() {
+    final GraphAnalyticalView view = createView();
+    try {
+      if (!view.tryRestoreFromPersistedCsr())
+        view.buildAsync();
+    } catch (final Exception e) {
+      view.shutdown();
+      throw e;
+    }
+    return view;
+  }
+
   private GraphAnalyticalView createView() {
     final GraphAnalyticalView view = new GraphAnalyticalView(database, name, vertexTypes, edgeTypes, properties, edgeProperties, updateMode);
     if (compactionThreshold >= 0)

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -161,9 +161,18 @@ class GraphAnalyticalViewCSRPersistence {
 
     final Path targetPath = target.toPath();
     try {
-      Files.move(tmp.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-    } catch (final AtomicMoveNotSupportedException e) {
-      Files.move(tmp.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+      try {
+        Files.move(tmp.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } catch (final AtomicMoveNotSupportedException e) {
+        Files.move(tmp.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } catch (final IOException e) {
+      // A failing move (disk full, permissions) would otherwise leave the tmp file - nanoTime()-suffixed, so a
+      // persistently failing move orphans a new one on every close - behind forever alongside a still-usable
+      // (if stale) previous target file. Clean it up either way; the caller already treats a save() failure as
+      // "no persistence this cycle", exactly as if this file had never been written.
+      Files.deleteIfExists(tmp.toPath());
+      throw e;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph.olap;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.log.LogManager;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
+import java.util.zip.CheckedOutputStream;
+
+/**
+ * Reads and writes a {@link GraphAnalyticalView}'s built CSR (adjacency indexes, node ID mapping and columnar
+ * property storage) to a single file beside the database, so that a later open can reuse it instead of rebuilding
+ * it with a full graph scan (see issue #6583).
+ * <p>
+ * The header carries a freshness certificate — {@code asOfTransactionId}, the database's last committed
+ * transaction id sampled just before the scan that produced this CSR started (see {@link
+ * GraphAnalyticalView.Snapshot#asOfTransactionId}) — plus the exact vertex/edge/property filter the view was built
+ * with. {@link #load} checks both against the caller-supplied current state before it even attempts to parse the
+ * (potentially large) payload that follows: a database-wide transaction count is a coarser signal than "did a
+ * covered type change", but it is sound with no extra bookkeeping — if nothing at all was committed since the
+ * certificate was written, the covered types certainly didn't change either — and it costs nothing to check, unlike
+ * a per-type watermark this engine does not otherwise maintain.
+ * <p>
+ * Any failure to parse the file (corruption, truncation, a version this build does not understand, a checksum
+ * mismatch) is treated exactly like a missing file: {@link #load} returns null and the caller falls back to a full
+ * rebuild, exactly as it always has when nothing was persisted.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class GraphAnalyticalViewCSRPersistence {
+  private static final int    MAGIC           = 0x47415643; // "GAVC"
+  private static final int    FORMAT_VERSION  = 1;
+  private static final String FILE_PREFIX     = "gav-";
+  private static final String FILE_EXTENSION  = ".csr";
+
+  private GraphAnalyticalViewCSRPersistence() {
+  }
+
+  static File fileFor(final Database database, final String viewName) {
+    return new File(database.getDatabasePath(), FILE_PREFIX + viewName + FILE_EXTENSION);
+  }
+
+  static void delete(final Database database, final String viewName) {
+    try {
+      Files.deleteIfExists(fileFor(database, viewName).toPath());
+    } catch (final IOException e) {
+      LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.FINE,
+          "Could not delete persisted CSR file for GraphAnalyticalView '%s': %s", null, viewName, e.getMessage());
+    }
+  }
+
+  // --- Save ---
+
+  static void save(final Database database, final String viewName, final String[] vertexTypes, final String[] edgeTypes,
+      final String[] propertyFilter, final String[] edgePropertyFilter, final GraphAnalyticalView.Snapshot snapshot)
+      throws IOException {
+    final File target = fileFor(database, viewName);
+    final File parent = target.getParentFile();
+    if (parent != null && !parent.exists())
+      Files.createDirectories(parent.toPath());
+    final File tmp = new File(parent, target.getName() + "." + Long.toHexString(System.nanoTime()) + ".tmp");
+
+    try (final FileOutputStream fos = new FileOutputStream(tmp);
+        final CheckedOutputStream checked = new CheckedOutputStream(new BufferedOutputStream(fos), new CRC32());
+        final DataOutputStream out = new DataOutputStream(checked)) {
+
+      out.writeInt(MAGIC);
+      out.writeInt(FORMAT_VERSION);
+      writeStringArray(out, vertexTypes);
+      writeStringArray(out, edgeTypes);
+      writeStringArray(out, propertyFilter);
+      writeStringArray(out, edgePropertyFilter);
+      out.writeLong(snapshot.asOfTransactionId);
+
+      writeNodeMapping(out, snapshot.nodeMapping);
+      writeBucketColumns(out, snapshot.bucketColumns);
+      writeCsrPerType(out, snapshot.csrPerType);
+      writeOptionalColumnStoreMap(out, snapshot.edgeColumnStores);
+      writeOptionalIntArrayMap(out, snapshot.bwdToFwd);
+
+      out.flush();
+      out.writeLong(checked.getChecksum().getValue());
+    } catch (final IOException | RuntimeException e) {
+      Files.deleteIfExists(tmp.toPath());
+      throw e;
+    }
+
+    final Path targetPath = target.toPath();
+    try {
+      Files.move(tmp.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+    } catch (final AtomicMoveNotSupportedException e) {
+      Files.move(tmp.toPath(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  private static void writeStringArray(final DataOutputStream out, final String[] values) throws IOException {
+    if (values == null) {
+      out.writeInt(-1);
+      return;
+    }
+    out.writeInt(values.length);
+    for (final String v : values)
+      out.writeUTF(v);
+  }
+
+  private static void writeNodeMapping(final DataOutputStream out, final NodeIdMapping mapping) throws IOException {
+    final int numBuckets = mapping.getNumBuckets();
+    out.writeInt(numBuckets);
+    for (int i = 0; i < numBuckets; i++) {
+      out.writeInt(mapping.getBucketId(i));
+      out.writeUTF(mapping.getBucketTypeName(i));
+      final int size = mapping.getBucketSize(i);
+      out.writeInt(size);
+      for (int p = 0; p < size; p++)
+        out.writeLong(mapping.getPosition(i, p));
+    }
+    final int[] oldToNew = mapping.getOldToNewMapping();
+    out.writeBoolean(oldToNew != null);
+    if (oldToNew != null)
+      writeIntArray(out, oldToNew);
+  }
+
+  private static void writeBucketColumns(final DataOutputStream out, final ColumnStore[] bucketColumns) throws IOException {
+    out.writeInt(bucketColumns.length);
+    for (final ColumnStore store : bucketColumns)
+      writeColumnStore(out, store);
+  }
+
+  private static void writeColumnStore(final DataOutputStream out, final ColumnStore store) throws IOException {
+    out.writeInt(store.getNodeCount());
+    out.writeInt(store.getColumnCount());
+    for (final String name : store.getPropertyNames())
+      writeColumn(out, store.getColumn(name));
+  }
+
+  private static void writeColumn(final DataOutputStream out, final Column column) throws IOException {
+    out.writeUTF(column.getName());
+    out.writeByte(column.getType().ordinal());
+    writeLongArray(out, column.getNullBitset());
+    switch (column.getType()) {
+    case INT:
+      writeIntArray(out, column.getIntData());
+      break;
+    case LONG:
+      writeLongArray(out, column.getLongData());
+      break;
+    case DOUBLE:
+      writeDoubleArray(out, column.getDoubleData());
+      break;
+    case STRING:
+      writeStringArray(out, column.getDictionary().getValues());
+      writeIntArray(out, column.getStringCodes());
+      break;
+    }
+  }
+
+  private static void writeCsrPerType(final DataOutputStream out, final Map<String, CSRAdjacencyIndex> csrPerType) throws IOException {
+    out.writeInt(csrPerType.size());
+    for (final Map.Entry<String, CSRAdjacencyIndex> entry : csrPerType.entrySet()) {
+      out.writeUTF(entry.getKey());
+      final CSRAdjacencyIndex csr = entry.getValue();
+      out.writeInt(csr.getNodeCount());
+      out.writeInt(csr.getEdgeCount());
+      writeIntArray(out, csr.getForwardOffsets());
+      writeIntArray(out, csr.getForwardNeighbors());
+      writeIntArray(out, csr.getBackwardOffsets());
+      writeIntArray(out, csr.getBackwardNeighbors());
+    }
+  }
+
+  private static void writeOptionalColumnStoreMap(final DataOutputStream out, final Map<String, ColumnStore> edgeColumnStores)
+      throws IOException {
+    out.writeBoolean(edgeColumnStores != null);
+    if (edgeColumnStores == null)
+      return;
+    out.writeInt(edgeColumnStores.size());
+    for (final Map.Entry<String, ColumnStore> entry : edgeColumnStores.entrySet()) {
+      out.writeUTF(entry.getKey());
+      writeColumnStore(out, entry.getValue());
+    }
+  }
+
+  private static void writeOptionalIntArrayMap(final DataOutputStream out, final Map<String, int[]> map) throws IOException {
+    out.writeBoolean(map != null);
+    if (map == null)
+      return;
+    out.writeInt(map.size());
+    for (final Map.Entry<String, int[]> entry : map.entrySet()) {
+      out.writeUTF(entry.getKey());
+      writeIntArray(out, entry.getValue());
+    }
+  }
+
+  private static void writeIntArray(final DataOutputStream out, final int[] array) throws IOException {
+    out.writeInt(array.length);
+    for (final int v : array)
+      out.writeInt(v);
+  }
+
+  private static void writeLongArray(final DataOutputStream out, final long[] array) throws IOException {
+    out.writeInt(array.length);
+    for (final long v : array)
+      out.writeLong(v);
+  }
+
+  private static void writeDoubleArray(final DataOutputStream out, final double[] array) throws IOException {
+    out.writeInt(array.length);
+    for (final double v : array)
+      out.writeDouble(v);
+  }
+
+  // --- Load ---
+
+  /**
+   * Loads a persisted CSR, returning null (never throwing for anything short of an I/O error unrelated to the
+   * file's own content) when the file is absent, its definition doesn't match the caller's, or its certificate
+   * doesn't match {@code currentLastTransactionId}. In the last two cases the header is all that gets read.
+   */
+  static GraphAnalyticalView.Snapshot load(final Database database, final String viewName, final String[] vertexTypes,
+      final String[] edgeTypes, final String[] propertyFilter, final String[] edgePropertyFilter,
+      final long currentLastTransactionId) throws IOException {
+    final File file = fileFor(database, viewName);
+    if (!file.isFile())
+      return null;
+
+    try (final FileInputStream fis = new FileInputStream(file);
+        final CheckedInputStream checked = new CheckedInputStream(new BufferedInputStream(fis), new CRC32());
+        final DataInputStream in = new DataInputStream(checked)) {
+
+      if (in.readInt() != MAGIC || in.readInt() != FORMAT_VERSION)
+        return null;
+      if (!Arrays.equals(readStringArray(in), vertexTypes)
+          || !Arrays.equals(readStringArray(in), edgeTypes)
+          || !Arrays.equals(readStringArray(in), propertyFilter)
+          || !Arrays.equals(readStringArray(in), edgePropertyFilter))
+        return null;
+      final long asOfTransactionId = in.readLong();
+      if (asOfTransactionId != currentLastTransactionId)
+        return null;
+
+      final NodeIdMapping mapping = readNodeMapping(in);
+      final ColumnStore[] bucketColumns = readBucketColumns(in);
+      final Map<String, CSRAdjacencyIndex> csrPerType = readCsrPerType(in);
+      final Map<String, ColumnStore> edgeColumnStores = readOptionalColumnStoreMap(in);
+      final Map<String, int[]> bwdToFwd = readOptionalIntArrayMap(in);
+
+      final long computedCrc = checked.getChecksum().getValue();
+      final long storedCrc = in.readLong();
+      if (computedCrc != storedCrc) {
+        LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.WARNING,
+            "Persisted CSR for GraphAnalyticalView '%s' failed checksum verification, discarding and falling back to rebuild",
+            null, viewName);
+        delete(database, viewName);
+        return null;
+      }
+
+      return new GraphAnalyticalView.Snapshot(csrPerType, mapping, bucketColumns, edgeColumnStores, bwdToFwd,
+          null, System.currentTimeMillis(), 0L, asOfTransactionId, true);
+    } catch (final EOFException | NegativeArraySizeException | IllegalArgumentException | ArrayIndexOutOfBoundsException e) {
+      LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.WARNING,
+          "Persisted CSR for GraphAnalyticalView '%s' is truncated or corrupt (%s), discarding and falling back to rebuild",
+          null, viewName, e.toString());
+      delete(database, viewName);
+      return null;
+    }
+  }
+
+  private static String[] readStringArray(final DataInputStream in) throws IOException {
+    final int len = in.readInt();
+    if (len < 0)
+      return null;
+    final String[] values = new String[len];
+    for (int i = 0; i < len; i++)
+      values[i] = in.readUTF();
+    return values;
+  }
+
+  private static NodeIdMapping readNodeMapping(final DataInputStream in) throws IOException {
+    final int numBuckets = in.readInt();
+    final int[] bucketIds = new int[numBuckets];
+    final String[] bucketTypeNames = new String[numBuckets];
+    final long[][] positions = new long[numBuckets][];
+    for (int i = 0; i < numBuckets; i++) {
+      bucketIds[i] = in.readInt();
+      bucketTypeNames[i] = in.readUTF();
+      final int size = in.readInt();
+      positions[i] = readLongArray(in, size);
+    }
+    final boolean reordered = in.readBoolean();
+    final int[] oldToNew = reordered ? readIntArray(in) : null;
+    return NodeIdMapping.restore(bucketIds, bucketTypeNames, positions, oldToNew);
+  }
+
+  private static ColumnStore[] readBucketColumns(final DataInputStream in) throws IOException {
+    final int numBuckets = in.readInt();
+    final ColumnStore[] result = new ColumnStore[numBuckets];
+    for (int i = 0; i < numBuckets; i++)
+      result[i] = readColumnStore(in);
+    return result;
+  }
+
+  private static ColumnStore readColumnStore(final DataInputStream in) throws IOException {
+    final int nodeCount = in.readInt();
+    final int columnCount = in.readInt();
+    final ColumnStore store = new ColumnStore(nodeCount);
+    for (int c = 0; c < columnCount; c++)
+      store.putColumn(readColumn(in, nodeCount));
+    return store;
+  }
+
+  private static Column readColumn(final DataInputStream in, final int nodeCount) throws IOException {
+    final String name = in.readUTF();
+    final Column.Type type = Column.Type.values()[in.readUnsignedByte()];
+    final long[] nullBitset = readLongArray(in);
+    int[] intData = null;
+    long[] longData = null;
+    double[] doubleData = null;
+    int[] stringCodes = null;
+    String[] dictionaryValues = null;
+    switch (type) {
+    case INT:
+      intData = readIntArray(in);
+      break;
+    case LONG:
+      longData = readLongArray(in);
+      break;
+    case DOUBLE:
+      doubleData = readDoubleArray(in);
+      break;
+    case STRING:
+      dictionaryValues = readStringArray(in);
+      stringCodes = readIntArray(in);
+      break;
+    }
+    return Column.restore(name, type, nodeCount, nullBitset, intData, longData, doubleData, stringCodes, dictionaryValues);
+  }
+
+  private static Map<String, CSRAdjacencyIndex> readCsrPerType(final DataInputStream in) throws IOException {
+    final int count = in.readInt();
+    final Map<String, CSRAdjacencyIndex> result = new HashMap<>(Math.max(16, count * 2));
+    for (int i = 0; i < count; i++) {
+      final String edgeTypeName = in.readUTF();
+      final int nodeCount = in.readInt();
+      final int edgeCount = in.readInt();
+      final int[] fwdOffsets = readIntArray(in);
+      final int[] fwdNeighbors = readIntArray(in);
+      final int[] bwdOffsets = readIntArray(in);
+      final int[] bwdNeighbors = readIntArray(in);
+      result.put(edgeTypeName, new CSRAdjacencyIndex(fwdOffsets, fwdNeighbors, bwdOffsets, bwdNeighbors, nodeCount, edgeCount));
+    }
+    return result;
+  }
+
+  private static Map<String, ColumnStore> readOptionalColumnStoreMap(final DataInputStream in) throws IOException {
+    if (!in.readBoolean())
+      return null;
+    final int count = in.readInt();
+    final Map<String, ColumnStore> result = new LinkedHashMap<>(Math.max(16, count * 2));
+    for (int i = 0; i < count; i++)
+      result.put(in.readUTF(), readColumnStore(in));
+    return result;
+  }
+
+  private static Map<String, int[]> readOptionalIntArrayMap(final DataInputStream in) throws IOException {
+    if (!in.readBoolean())
+      return null;
+    final int count = in.readInt();
+    final Map<String, int[]> result = new LinkedHashMap<>(Math.max(16, count * 2));
+    for (int i = 0; i < count; i++)
+      result.put(in.readUTF(), readIntArray(in));
+    return result;
+  }
+
+  private static int[] readIntArray(final DataInputStream in) throws IOException {
+    final int len = in.readInt();
+    final int[] array = new int[len];
+    for (int i = 0; i < len; i++)
+      array[i] = in.readInt();
+    return array;
+  }
+
+  private static long[] readLongArray(final DataInputStream in) throws IOException {
+    return readLongArray(in, in.readInt());
+  }
+
+  private static long[] readLongArray(final DataInputStream in, final int len) throws IOException {
+    final long[] array = new long[len];
+    for (int i = 0; i < len; i++)
+      array[i] = in.readLong();
+    return array;
+  }
+
+  private static double[] readDoubleArray(final DataInputStream in) throws IOException {
+    final int len = in.readInt();
+    final double[] array = new double[len];
+    for (int i = 0; i < len; i++)
+      array[i] = in.readDouble();
+    return array;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -394,9 +394,13 @@ class GraphAnalyticalViewCSRPersistence {
             null, System.currentTimeMillis(), 0L, asOfTransactionId, true,
             vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
       }
-    } catch (final EOFException | OutOfMemoryError | RuntimeException e) {
+    } catch (final IOException | OutOfMemoryError | RuntimeException e) {
+      // IOException here also catches the "encrypted but no DataEncryption configured" case thrown above:
+      // routed through the same log+delete+return-null path as truncation/corruption for consistency, rather
+      // than propagating past this method to be caught (still safely, just less informatively) by the broad
+      // Exception handling in tryRestoreFromPersistedCsr()/persistCsrIfPossible().
       LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.WARNING,
-          "Persisted CSR for GraphAnalyticalView '%s' is truncated or corrupt (%s), discarding and falling back to rebuild",
+          "Persisted CSR for GraphAnalyticalView '%s' is unusable (%s), discarding and falling back to rebuild",
           null, viewName, e.toString());
       delete(database, viewName);
       return null;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DataEncryption;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.FileUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -86,8 +87,18 @@ class GraphAnalyticalViewCSRPersistence {
   private GraphAnalyticalViewCSRPersistence() {
   }
 
+  /**
+   * A GAV name is a SQL identifier a schema-privileged user controls, and (unlike a type or bucket name) nothing
+   * upstream of this class validates it against path separators - a name such as {@code ../../../tmp/evil} would
+   * otherwise let {@link #save}/{@link #delete} write, overwrite or delete an arbitrary file the server process can
+   * reach. Encode it exactly like {@link com.arcadedb.schema.LocalSchema} encodes a type name before it becomes a
+   * component file name: {@link FileUtils#encode} percent-encodes {@code /} and {@code \} (and leaves the rest of
+   * the identifier's characters intact), so the result is always a single path segment under the database directory
+   * regardless of what the name contains.
+   */
   static File fileFor(final Database database, final String viewName) {
-    return new File(database.getDatabasePath(), FILE_PREFIX + viewName + FILE_EXTENSION);
+    final String encodedName = FileUtils.encode(viewName, database.getSchema().getEncoding());
+    return new File(database.getDatabasePath(), FILE_PREFIX + encodedName + FILE_EXTENSION);
   }
 
   static void delete(final Database database, final String viewName) {

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -286,7 +286,7 @@ class GraphAnalyticalViewCSRPersistence {
     out.writeInt(array.length);
     if (array.length == 0)
       return;
-    final byte[] bytes = new byte[array.length * Integer.BYTES];
+    final byte[] bytes = new byte[Math.multiplyExact(array.length, Integer.BYTES)];
     ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer().put(array);
     out.write(bytes);
   }
@@ -295,7 +295,7 @@ class GraphAnalyticalViewCSRPersistence {
     out.writeInt(array.length);
     if (array.length == 0)
       return;
-    final byte[] bytes = new byte[array.length * Long.BYTES];
+    final byte[] bytes = new byte[Math.multiplyExact(array.length, Long.BYTES)];
     ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asLongBuffer().put(array);
     out.write(bytes);
   }
@@ -304,7 +304,7 @@ class GraphAnalyticalViewCSRPersistence {
     out.writeInt(array.length);
     if (array.length == 0)
       return;
-    final byte[] bytes = new byte[array.length * Double.BYTES];
+    final byte[] bytes = new byte[Math.multiplyExact(array.length, Double.BYTES)];
     ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asDoubleBuffer().put(array);
     out.write(bytes);
   }
@@ -517,7 +517,7 @@ class GraphAnalyticalViewCSRPersistence {
     final int[] array = new int[len];
     if (len == 0)
       return array;
-    final byte[] bytes = new byte[len * Integer.BYTES];
+    final byte[] bytes = new byte[Math.multiplyExact(len, Integer.BYTES)];
     in.readFully(bytes);
     ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer().get(array);
     return array;
@@ -528,7 +528,7 @@ class GraphAnalyticalViewCSRPersistence {
     final long[] array = new long[len];
     if (len == 0)
       return array;
-    final byte[] bytes = new byte[len * Long.BYTES];
+    final byte[] bytes = new byte[Math.multiplyExact(len, Long.BYTES)];
     in.readFully(bytes);
     ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asLongBuffer().get(array);
     return array;
@@ -539,7 +539,7 @@ class GraphAnalyticalViewCSRPersistence {
     final double[] array = new double[len];
     if (len == 0)
       return array;
-    final byte[] bytes = new byte[len * Double.BYTES];
+    final byte[] bytes = new byte[Math.multiplyExact(len, Double.BYTES)];
     in.readFully(bytes);
     ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asDoubleBuffer().get(array);
     return array;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -341,6 +341,11 @@ class GraphAnalyticalViewCSRPersistence {
         return null;
       encrypted = in.readBoolean();
       final int payloadLength = in.readInt();
+      // A corrupt header could carry a huge but individually plausible length; check it against what's actually
+      // left in the file before allocating, rather than relying on readFully() to eventually fail with
+      // EOFException after the allocation already happened.
+      if (payloadLength < 0 || payloadLength > file.length())
+        throw new EOFException("declared payload length " + payloadLength + " exceeds the file's remaining size");
       storedPayload = new byte[payloadLength];
       in.readFully(storedPayload);
 
@@ -377,7 +382,8 @@ class GraphAnalyticalViewCSRPersistence {
         final Map<String, int[]> bwdToFwd = readOptionalIntArrayMap(payloadIn);
 
         return new GraphAnalyticalView.Snapshot(csrPerType, mapping, bucketColumns, edgeColumnStores, bwdToFwd,
-            null, System.currentTimeMillis(), 0L, asOfTransactionId, true);
+            null, System.currentTimeMillis(), 0L, asOfTransactionId, true,
+            vertexTypes, edgeTypes, propertyFilter, edgePropertyFilter);
       }
     } catch (final EOFException | OutOfMemoryError | RuntimeException e) {
       LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.WARNING,

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -350,11 +350,14 @@ class GraphAnalyticalViewCSRPersistence {
         return null;
       encrypted = in.readBoolean();
       final int payloadLength = in.readInt();
-      // A corrupt header could carry a huge but individually plausible length; check it against what's actually
-      // left in the file before allocating, rather than relying on readFully() to eventually fail with
-      // EOFException after the allocation already happened.
+      // A corrupt header could carry a huge but individually plausible length; check it against the file's total
+      // size before allocating, rather than relying on readFully() to eventually fail with EOFException after the
+      // allocation already happened. Looser than checking against what's actually left after the header (a length
+      // just under the file's full size would still pass here and then legitimately fail readFully() a few bytes
+      // later), but that remaining failure is already handled as corruption, so this bound only needs to reject the
+      // implausible case cheaply, not pinpoint the exact one.
       if (payloadLength < 0 || payloadLength > file.length())
-        throw new EOFException("declared payload length " + payloadLength + " exceeds the file's remaining size");
+        throw new EOFException("declared payload length " + payloadLength + " exceeds the file's total size");
       storedPayload = new byte[payloadLength];
       in.readFully(storedPayload);
 

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -18,11 +18,13 @@
  */
 package com.arcadedb.graph.olap;
 
+import com.arcadedb.database.DataEncryption;
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.log.LogManager;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
@@ -30,6 +32,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,22 +45,31 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.zip.CRC32;
-import java.util.zip.CheckedInputStream;
-import java.util.zip.CheckedOutputStream;
 
 /**
  * Reads and writes a {@link GraphAnalyticalView}'s built CSR (adjacency indexes, node ID mapping and columnar
  * property storage) to a single file beside the database, so that a later open can reuse it instead of rebuilding
  * it with a full graph scan (see issue #6583).
  * <p>
- * The header carries a freshness certificate — {@code asOfTransactionId}, the database's last committed
- * transaction id sampled just before the scan that produced this CSR started (see {@link
- * GraphAnalyticalView.Snapshot#asOfTransactionId}) — plus the exact vertex/edge/property filter the view was built
- * with. {@link #load} checks both against the caller-supplied current state before it even attempts to parse the
- * (potentially large) payload that follows: a database-wide transaction count is a coarser signal than "did a
- * covered type change", but it is sound with no extra bookkeeping — if nothing at all was committed since the
- * certificate was written, the covered types certainly didn't change either — and it costs nothing to check, unlike
- * a per-type watermark this engine does not otherwise maintain.
+ * The file is a small plaintext header followed by one opaque payload blob:
+ * <ul>
+ *   <li>the header carries the freshness certificate - {@code asOfTransactionId}, the database's last committed
+ *       transaction id sampled just before the scan that produced this CSR started (see {@link
+ *       GraphAnalyticalView.Snapshot#asOfTransactionId}) - plus the exact vertex/edge/property filter the view was
+ *       built with. {@link #load} checks both against the caller-supplied current state before it even attempts to
+ *       touch the (potentially large) payload: a database-wide transaction count is a coarser signal than "did a
+ *       covered type change", but it is sound with no extra bookkeeping - if nothing at all was committed since the
+ *       certificate was written, the covered types certainly didn't change either - and it costs nothing to check,
+ *       unlike a per-type watermark this engine does not otherwise maintain;</li>
+ *   <li>the payload holds every array making up the CSR, built once into an in-memory buffer and written (or read)
+ *       in one bulk I/O call per array via {@link ByteBuffer} bulk views rather than one JDK stream call per array
+ *       element - this is a graph's serialized size, so it is exactly the part a per-element loop would make slow at
+ *       the scale this issue is about. When the database has a {@link DataEncryption} configured (see {@link
+ *       DatabaseInternal#getDataEncryption()}), the assembled payload is encrypted as a single block before it
+ *       reaches disk and decrypted as a single block after being read back, so opting into encryption for a
+ *       database's records also covers this side file: the header itself carries no vertex/edge/property values,
+ *       only type and property *names* already visible in the schema, so it is left in the clear.</li>
+ * </ul>
  * <p>
  * Any failure to parse the file (corruption, truncation, a version this build does not understand, a checksum
  * mismatch) is treated exactly like a missing file: {@link #load} returns null and the caller falls back to a full
@@ -64,10 +78,10 @@ import java.util.zip.CheckedOutputStream;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 class GraphAnalyticalViewCSRPersistence {
-  private static final int    MAGIC           = 0x47415643; // "GAVC"
-  private static final int    FORMAT_VERSION  = 1;
-  private static final String FILE_PREFIX     = "gav-";
-  private static final String FILE_EXTENSION  = ".csr";
+  private static final int    MAGIC          = 0x47415643; // "GAVC"
+  private static final int    FORMAT_VERSION = 1;
+  private static final String FILE_PREFIX    = "gav-";
+  private static final String FILE_EXTENSION = ".csr";
 
   private GraphAnalyticalViewCSRPersistence() {
   }
@@ -85,37 +99,50 @@ class GraphAnalyticalViewCSRPersistence {
     }
   }
 
+  private static DataEncryption dataEncryptionOf(final Database database) {
+    return ((DatabaseInternal) database).getDataEncryption();
+  }
+
   // --- Save ---
 
   static void save(final Database database, final String viewName, final String[] vertexTypes, final String[] edgeTypes,
       final String[] propertyFilter, final String[] edgePropertyFilter, final GraphAnalyticalView.Snapshot snapshot)
       throws IOException {
+    final ByteArrayOutputStream payloadBuffer = new ByteArrayOutputStream(1024);
+    try (final DataOutputStream payloadOut = new DataOutputStream(payloadBuffer)) {
+      writeNodeMapping(payloadOut, snapshot.nodeMapping);
+      writeBucketColumns(payloadOut, snapshot.bucketColumns);
+      writeCsrPerType(payloadOut, snapshot.csrPerType);
+      writeOptionalColumnStoreMap(payloadOut, snapshot.edgeColumnStores);
+      writeOptionalIntArrayMap(payloadOut, snapshot.bwdToFwd);
+    }
+    final byte[] rawPayload = payloadBuffer.toByteArray();
+
+    final DataEncryption encryption = dataEncryptionOf(database);
+    final byte[] storedPayload = encryption != null ? encryption.encrypt(rawPayload) : rawPayload;
+
+    final CRC32 crc = new CRC32();
+    crc.update(storedPayload);
+
     final File target = fileFor(database, viewName);
     final File parent = target.getParentFile();
     if (parent != null && !parent.exists())
       Files.createDirectories(parent.toPath());
     final File tmp = new File(parent, target.getName() + "." + Long.toHexString(System.nanoTime()) + ".tmp");
 
-    try (final FileOutputStream fos = new FileOutputStream(tmp);
-        final CheckedOutputStream checked = new CheckedOutputStream(new BufferedOutputStream(fos), new CRC32());
-        final DataOutputStream out = new DataOutputStream(checked)) {
-
+    try (final DataOutputStream out = new DataOutputStream(new FileOutputStream(tmp))) {
       out.writeInt(MAGIC);
       out.writeInt(FORMAT_VERSION);
+      writeString(out, viewName);
       writeStringArray(out, vertexTypes);
       writeStringArray(out, edgeTypes);
       writeStringArray(out, propertyFilter);
       writeStringArray(out, edgePropertyFilter);
       out.writeLong(snapshot.asOfTransactionId);
-
-      writeNodeMapping(out, snapshot.nodeMapping);
-      writeBucketColumns(out, snapshot.bucketColumns);
-      writeCsrPerType(out, snapshot.csrPerType);
-      writeOptionalColumnStoreMap(out, snapshot.edgeColumnStores);
-      writeOptionalIntArrayMap(out, snapshot.bwdToFwd);
-
-      out.flush();
-      out.writeLong(checked.getChecksum().getValue());
+      out.writeBoolean(encryption != null);
+      out.writeInt(storedPayload.length);
+      out.write(storedPayload);
+      out.writeLong(crc.getValue());
     } catch (final IOException | RuntimeException e) {
       Files.deleteIfExists(tmp.toPath());
       throw e;
@@ -129,6 +156,16 @@ class GraphAnalyticalViewCSRPersistence {
     }
   }
 
+  private static void writeString(final DataOutputStream out, final String value) throws IOException {
+    if (value == null) {
+      out.writeInt(-1);
+      return;
+    }
+    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    out.writeInt(bytes.length);
+    out.write(bytes);
+  }
+
   private static void writeStringArray(final DataOutputStream out, final String[] values) throws IOException {
     if (values == null) {
       out.writeInt(-1);
@@ -136,7 +173,7 @@ class GraphAnalyticalViewCSRPersistence {
     }
     out.writeInt(values.length);
     for (final String v : values)
-      out.writeUTF(v);
+      writeString(out, v);
   }
 
   private static void writeNodeMapping(final DataOutputStream out, final NodeIdMapping mapping) throws IOException {
@@ -144,11 +181,12 @@ class GraphAnalyticalViewCSRPersistence {
     out.writeInt(numBuckets);
     for (int i = 0; i < numBuckets; i++) {
       out.writeInt(mapping.getBucketId(i));
-      out.writeUTF(mapping.getBucketTypeName(i));
+      writeString(out, mapping.getBucketTypeName(i));
       final int size = mapping.getBucketSize(i);
-      out.writeInt(size);
+      final long[] positions = new long[size];
       for (int p = 0; p < size; p++)
-        out.writeLong(mapping.getPosition(i, p));
+        positions[p] = mapping.getPosition(i, p);
+      writeLongArray(out, positions);
     }
     final int[] oldToNew = mapping.getOldToNewMapping();
     out.writeBoolean(oldToNew != null);
@@ -170,7 +208,7 @@ class GraphAnalyticalViewCSRPersistence {
   }
 
   private static void writeColumn(final DataOutputStream out, final Column column) throws IOException {
-    out.writeUTF(column.getName());
+    writeString(out, column.getName());
     out.writeByte(column.getType().ordinal());
     writeLongArray(out, column.getNullBitset());
     switch (column.getType()) {
@@ -193,7 +231,7 @@ class GraphAnalyticalViewCSRPersistence {
   private static void writeCsrPerType(final DataOutputStream out, final Map<String, CSRAdjacencyIndex> csrPerType) throws IOException {
     out.writeInt(csrPerType.size());
     for (final Map.Entry<String, CSRAdjacencyIndex> entry : csrPerType.entrySet()) {
-      out.writeUTF(entry.getKey());
+      writeString(out, entry.getKey());
       final CSRAdjacencyIndex csr = entry.getValue();
       out.writeInt(csr.getNodeCount());
       out.writeInt(csr.getEdgeCount());
@@ -211,7 +249,7 @@ class GraphAnalyticalViewCSRPersistence {
       return;
     out.writeInt(edgeColumnStores.size());
     for (final Map.Entry<String, ColumnStore> entry : edgeColumnStores.entrySet()) {
-      out.writeUTF(entry.getKey());
+      writeString(out, entry.getKey());
       writeColumnStore(out, entry.getValue());
     }
   }
@@ -222,27 +260,42 @@ class GraphAnalyticalViewCSRPersistence {
       return;
     out.writeInt(map.size());
     for (final Map.Entry<String, int[]> entry : map.entrySet()) {
-      out.writeUTF(entry.getKey());
+      writeString(out, entry.getKey());
       writeIntArray(out, entry.getValue());
     }
   }
 
+  /**
+   * Writes the array length followed by its raw bytes in one bulk {@link ByteBuffer} conversion and one {@code
+   * write(byte[])} call, instead of one {@code DataOutputStream} call per element - the difference between a handful
+   * of bulk copies and tens of millions of small virtual calls for the multi-million-element offset/neighbor arrays
+   * a 1M-vertex CSR produces.
+   */
   private static void writeIntArray(final DataOutputStream out, final int[] array) throws IOException {
     out.writeInt(array.length);
-    for (final int v : array)
-      out.writeInt(v);
+    if (array.length == 0)
+      return;
+    final byte[] bytes = new byte[array.length * Integer.BYTES];
+    ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer().put(array);
+    out.write(bytes);
   }
 
   private static void writeLongArray(final DataOutputStream out, final long[] array) throws IOException {
     out.writeInt(array.length);
-    for (final long v : array)
-      out.writeLong(v);
+    if (array.length == 0)
+      return;
+    final byte[] bytes = new byte[array.length * Long.BYTES];
+    ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asLongBuffer().put(array);
+    out.write(bytes);
   }
 
   private static void writeDoubleArray(final DataOutputStream out, final double[] array) throws IOException {
     out.writeInt(array.length);
-    for (final double v : array)
-      out.writeDouble(v);
+    if (array.length == 0)
+      return;
+    final byte[] bytes = new byte[array.length * Double.BYTES];
+    ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asDoubleBuffer().put(array);
+    out.write(bytes);
   }
 
   // --- Load ---
@@ -250,7 +303,7 @@ class GraphAnalyticalViewCSRPersistence {
   /**
    * Loads a persisted CSR, returning null (never throwing for anything short of an I/O error unrelated to the
    * file's own content) when the file is absent, its definition doesn't match the caller's, or its certificate
-   * doesn't match {@code currentLastTransactionId}. In the last two cases the header is all that gets read.
+   * doesn't match {@code currentLastTransactionId}. In the last two cases the payload is never even read.
    */
   static GraphAnalyticalView.Snapshot load(final Database database, final String viewName, final String[] vertexTypes,
       final String[] edgeTypes, final String[] propertyFilter, final String[] edgePropertyFilter,
@@ -259,28 +312,30 @@ class GraphAnalyticalViewCSRPersistence {
     if (!file.isFile())
       return null;
 
-    try (final FileInputStream fis = new FileInputStream(file);
-        final CheckedInputStream checked = new CheckedInputStream(new BufferedInputStream(fis), new CRC32());
-        final DataInputStream in = new DataInputStream(checked)) {
+    final byte[] storedPayload;
+    final boolean encrypted;
+    final long asOfTransactionId;
 
+    try (final DataInputStream in = new DataInputStream(new FileInputStream(file))) {
       if (in.readInt() != MAGIC || in.readInt() != FORMAT_VERSION)
         return null;
-      if (!Arrays.equals(readStringArray(in), vertexTypes)
+      if (!viewName.equals(readString(in))
+          || !Arrays.equals(readStringArray(in), vertexTypes)
           || !Arrays.equals(readStringArray(in), edgeTypes)
           || !Arrays.equals(readStringArray(in), propertyFilter)
           || !Arrays.equals(readStringArray(in), edgePropertyFilter))
         return null;
-      final long asOfTransactionId = in.readLong();
+      asOfTransactionId = in.readLong();
       if (asOfTransactionId != currentLastTransactionId)
         return null;
+      encrypted = in.readBoolean();
+      final int payloadLength = in.readInt();
+      storedPayload = new byte[payloadLength];
+      in.readFully(storedPayload);
 
-      final NodeIdMapping mapping = readNodeMapping(in);
-      final ColumnStore[] bucketColumns = readBucketColumns(in);
-      final Map<String, CSRAdjacencyIndex> csrPerType = readCsrPerType(in);
-      final Map<String, ColumnStore> edgeColumnStores = readOptionalColumnStoreMap(in);
-      final Map<String, int[]> bwdToFwd = readOptionalIntArrayMap(in);
-
-      final long computedCrc = checked.getChecksum().getValue();
+      final CRC32 crc = new CRC32();
+      crc.update(storedPayload);
+      final long computedCrc = crc.getValue();
       final long storedCrc = in.readLong();
       if (computedCrc != storedCrc) {
         LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.WARNING,
@@ -289,10 +344,31 @@ class GraphAnalyticalViewCSRPersistence {
         delete(database, viewName);
         return null;
       }
+    } catch (final EOFException | NegativeArraySizeException | OutOfMemoryError e) {
+      LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.WARNING,
+          "Persisted CSR for GraphAnalyticalView '%s' is truncated or corrupt (%s), discarding and falling back to rebuild",
+          null, viewName, e.toString());
+      delete(database, viewName);
+      return null;
+    }
 
-      return new GraphAnalyticalView.Snapshot(csrPerType, mapping, bucketColumns, edgeColumnStores, bwdToFwd,
-          null, System.currentTimeMillis(), 0L, asOfTransactionId, true);
-    } catch (final EOFException | NegativeArraySizeException | IllegalArgumentException | ArrayIndexOutOfBoundsException e) {
+    try {
+      final DataEncryption encryption = dataEncryptionOf(database);
+      if (encrypted && encryption == null)
+        throw new IOException("persisted CSR is encrypted but no DataEncryption is configured on this database");
+      final byte[] rawPayload = encrypted ? encryption.decrypt(storedPayload) : storedPayload;
+
+      try (final DataInputStream payloadIn = new DataInputStream(new ByteArrayInputStream(rawPayload))) {
+        final NodeIdMapping mapping = readNodeMapping(payloadIn);
+        final ColumnStore[] bucketColumns = readBucketColumns(payloadIn);
+        final Map<String, CSRAdjacencyIndex> csrPerType = readCsrPerType(payloadIn);
+        final Map<String, ColumnStore> edgeColumnStores = readOptionalColumnStoreMap(payloadIn);
+        final Map<String, int[]> bwdToFwd = readOptionalIntArrayMap(payloadIn);
+
+        return new GraphAnalyticalView.Snapshot(csrPerType, mapping, bucketColumns, edgeColumnStores, bwdToFwd,
+            null, System.currentTimeMillis(), 0L, asOfTransactionId, true);
+      }
+    } catch (final EOFException | OutOfMemoryError | RuntimeException e) {
       LogManager.instance().log(GraphAnalyticalViewCSRPersistence.class, Level.WARNING,
           "Persisted CSR for GraphAnalyticalView '%s' is truncated or corrupt (%s), discarding and falling back to rebuild",
           null, viewName, e.toString());
@@ -301,13 +377,22 @@ class GraphAnalyticalViewCSRPersistence {
     }
   }
 
+  private static String readString(final DataInputStream in) throws IOException {
+    final int len = in.readInt();
+    if (len < 0)
+      return null;
+    final byte[] bytes = new byte[len];
+    in.readFully(bytes);
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
   private static String[] readStringArray(final DataInputStream in) throws IOException {
     final int len = in.readInt();
     if (len < 0)
       return null;
     final String[] values = new String[len];
     for (int i = 0; i < len; i++)
-      values[i] = in.readUTF();
+      values[i] = readString(in);
     return values;
   }
 
@@ -318,9 +403,8 @@ class GraphAnalyticalViewCSRPersistence {
     final long[][] positions = new long[numBuckets][];
     for (int i = 0; i < numBuckets; i++) {
       bucketIds[i] = in.readInt();
-      bucketTypeNames[i] = in.readUTF();
-      final int size = in.readInt();
-      positions[i] = readLongArray(in, size);
+      bucketTypeNames[i] = readString(in);
+      positions[i] = readLongArray(in);
     }
     final boolean reordered = in.readBoolean();
     final int[] oldToNew = reordered ? readIntArray(in) : null;
@@ -345,7 +429,7 @@ class GraphAnalyticalViewCSRPersistence {
   }
 
   private static Column readColumn(final DataInputStream in, final int nodeCount) throws IOException {
-    final String name = in.readUTF();
+    final String name = readString(in);
     final Column.Type type = Column.Type.values()[in.readUnsignedByte()];
     final long[] nullBitset = readLongArray(in);
     int[] intData = null;
@@ -375,7 +459,7 @@ class GraphAnalyticalViewCSRPersistence {
     final int count = in.readInt();
     final Map<String, CSRAdjacencyIndex> result = new HashMap<>(Math.max(16, count * 2));
     for (int i = 0; i < count; i++) {
-      final String edgeTypeName = in.readUTF();
+      final String edgeTypeName = readString(in);
       final int nodeCount = in.readInt();
       final int edgeCount = in.readInt();
       final int[] fwdOffsets = readIntArray(in);
@@ -393,7 +477,7 @@ class GraphAnalyticalViewCSRPersistence {
     final int count = in.readInt();
     final Map<String, ColumnStore> result = new LinkedHashMap<>(Math.max(16, count * 2));
     for (int i = 0; i < count; i++)
-      result.put(in.readUTF(), readColumnStore(in));
+      result.put(readString(in), readColumnStore(in));
     return result;
   }
 
@@ -403,34 +487,44 @@ class GraphAnalyticalViewCSRPersistence {
     final int count = in.readInt();
     final Map<String, int[]> result = new LinkedHashMap<>(Math.max(16, count * 2));
     for (int i = 0; i < count; i++)
-      result.put(in.readUTF(), readIntArray(in));
+      result.put(readString(in), readIntArray(in));
     return result;
   }
 
+  /**
+   * Reads the length written by {@link #writeIntArray} followed by one bulk read and one bulk {@link ByteBuffer}
+   * conversion, mirroring the write side.
+   */
   private static int[] readIntArray(final DataInputStream in) throws IOException {
     final int len = in.readInt();
     final int[] array = new int[len];
-    for (int i = 0; i < len; i++)
-      array[i] = in.readInt();
+    if (len == 0)
+      return array;
+    final byte[] bytes = new byte[len * Integer.BYTES];
+    in.readFully(bytes);
+    ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer().get(array);
     return array;
   }
 
   private static long[] readLongArray(final DataInputStream in) throws IOException {
-    return readLongArray(in, in.readInt());
-  }
-
-  private static long[] readLongArray(final DataInputStream in, final int len) throws IOException {
+    final int len = in.readInt();
     final long[] array = new long[len];
-    for (int i = 0; i < len; i++)
-      array[i] = in.readLong();
+    if (len == 0)
+      return array;
+    final byte[] bytes = new byte[len * Long.BYTES];
+    in.readFully(bytes);
+    ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asLongBuffer().get(array);
     return array;
   }
 
   private static double[] readDoubleArray(final DataInputStream in) throws IOException {
     final int len = in.readInt();
     final double[] array = new double[len];
-    for (int i = 0; i < len; i++)
-      array[i] = in.readDouble();
+    if (len == 0)
+      return array;
+    final byte[] bytes = new byte[len * Double.BYTES];
+    in.readFully(bytes);
+    ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).asDoubleBuffer().get(array);
     return array;
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java
@@ -202,11 +202,7 @@ class GraphAnalyticalViewCSRPersistence {
     for (int i = 0; i < numBuckets; i++) {
       out.writeInt(mapping.getBucketId(i));
       writeString(out, mapping.getBucketTypeName(i));
-      final int size = mapping.getBucketSize(i);
-      final long[] positions = new long[size];
-      for (int p = 0; p < size; p++)
-        positions[p] = mapping.getPosition(i, p);
-      writeLongArray(out, positions);
+      writeLongArray(out, mapping.getPositions(i));
     }
     final int[] oldToNew = mapping.getOldToNewMapping();
     out.writeBoolean(oldToNew != null);

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
@@ -147,7 +147,10 @@ public class GraphAnalyticalViewPersistence {
         final int ct = gavDef.getInt("compactionThreshold", -1);
         if (ct >= 0)
           builder.withCompactionThreshold(ct);
-        restoredViews.add(builder.skipPersistence().buildAsync());
+        // Tries a persisted CSR from disk first (issue #6583) and only falls back to the async full
+        // rebuild below when there is none usable — see restoreFromDiskOrBuildAsync() for the certificate
+        // check that decides between the two.
+        restoredViews.add(builder.skipPersistence().restoreFromDiskOrBuildAsync());
         count++;
 
         LogManager.instance().log(GraphAnalyticalViewPersistence.class, Level.INFO,

--- a/engine/src/main/java/com/arcadedb/graph/olap/NodeIdMapping.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/NodeIdMapping.java
@@ -435,6 +435,16 @@ public class NodeIdMapping {
   }
 
   /**
+   * Returns the backing sorted position array for a bucket directly, with no copy - the array is never mutated
+   * after {@link #compact()}/{@link #restore}, so sharing the reference is safe. Package-private: used by {@link
+   * GraphAnalyticalViewCSRPersistence} to serialize a bucket's positions in one bulk write instead of rebuilding
+   * the array element-by-element via {@link #getPosition} first.
+   */
+  long[] getPositions(final int bucketIdx) {
+    return positions[bucketIdx];
+  }
+
+  /**
    * Applies a BFS-based vertex reordering for improved cache locality.
    * After this call, all global IDs returned by this mapping are BFS-ordered.
    *

--- a/engine/src/main/java/com/arcadedb/graph/olap/NodeIdMapping.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/NodeIdMapping.java
@@ -83,6 +83,70 @@ public class NodeIdMapping {
     this.totalSize = 0;
   }
 
+  private NodeIdMapping() {
+  }
+
+  /**
+   * Reconstructs a compacted mapping from arrays previously produced by {@link #getBucketId}, {@link
+   * #getBucketTypeName}, {@link #getPosition}, and {@link #getOldToNewMapping} (see {@link
+   * GraphAnalyticalViewCSRPersistence}). The result is immutable and ready for lookups, exactly like one that went
+   * through {@link #compact()} — {@code addNode()}/{@code compact()} are not usable on it.
+   *
+   * @param positions      per-bucket sorted RID positions, already in the order {@code bucketIds} expects
+   * @param oldToNewMapping the BFS/RCM permutation to reapply, or null if the original mapping was never reordered
+   */
+  static NodeIdMapping restore(final int[] bucketIds, final String[] bucketTypeNames, final long[][] positions,
+      final int[] oldToNewMapping) {
+    final NodeIdMapping mapping = new NodeIdMapping();
+    mapping.numBuckets = bucketIds.length;
+    mapping.bucketIds = bucketIds;
+    mapping.bucketTypeNames = bucketTypeNames;
+    mapping.positions = positions;
+    mapping.bucketBase = new int[bucketIds.length];
+    mapping.bucketSizes = new int[bucketIds.length];
+
+    int total = 0;
+    for (int i = 0; i < bucketIds.length; i++) {
+      mapping.bucketBase[i] = total;
+      mapping.bucketSizes[i] = positions[i].length;
+      total += positions[i].length;
+    }
+    mapping.totalSize = total;
+
+    mapping.bucketIdToIdx = new int[16];
+    Arrays.fill(mapping.bucketIdToIdx, -1);
+    for (int idx = 0; idx < bucketIds.length; idx++) {
+      final int bucketId = bucketIds[idx];
+      if (bucketId < MAX_DIRECT_BUCKET_ID) {
+        if (bucketId >= mapping.bucketIdToIdx.length) {
+          final int newLen = Math.min(Math.max(bucketId + 1, mapping.bucketIdToIdx.length * 2), MAX_DIRECT_BUCKET_ID);
+          final int[] grown = new int[newLen];
+          Arrays.fill(grown, -1);
+          System.arraycopy(mapping.bucketIdToIdx, 0, grown, 0, mapping.bucketIdToIdx.length);
+          mapping.bucketIdToIdx = grown;
+        }
+        mapping.bucketIdToIdx[bucketId] = idx;
+      } else {
+        if (mapping.bucketIdToIdxSparse == null)
+          mapping.bucketIdToIdxSparse = new HashMap<>();
+        mapping.bucketIdToIdxSparse.put(bucketId, idx);
+      }
+    }
+
+    if (oldToNewMapping != null)
+      mapping.applyReordering(oldToNewMapping);
+
+    return mapping;
+  }
+
+  /**
+   * Returns the BFS/RCM reordering permutation applied by {@link #applyReordering}, or null if the mapping was
+   * never reordered. Package-private: used only to persist the mapping (see {@link GraphAnalyticalViewCSRPersistence}).
+   */
+  int[] getOldToNewMapping() {
+    return oldToNew;
+  }
+
   /**
    * Registers a bucket and prepares it for node collection.
    * Must be called before addNode().

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -1420,6 +1420,10 @@ public class BinarySerializer {
     this.dataEncryption = dataEncryption;
   }
 
+  public DataEncryption getDataEncryption() {
+    return dataEncryption;
+  }
+
   /**
    * Converts a spatial4j Shape object to WKT (Well-Known Text) format.
    * Optimized with cached WKT writer to avoid creating a new writer for each Point.

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2541,6 +2541,65 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6583 code review: {@code build(vertexTypes, edgeTypes)} lets a caller rescan a
+   * NAMED, registered view with a scope narrower than it was constructed with - the constructor's
+   * vertexTypes/edgeTypes fields are final and never updated to match. Persisting the resulting snapshot
+   * must record the scope actually scanned, not the view's original (wider) construction-time fields:
+   * otherwise the file's header would claim the view's full original coverage while the payload only
+   * covers the narrower rescan, and a reopen could restore that mismatch silently - READY, but serving
+   * less than what {@code coversVertexType()}/{@code coversEdgeType()} claim.
+   */
+  @Test
+  void rescanningWithANarrowerScopePersistsThatNarrowerScopeNotTheConstructionTimeOne() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createVertexType("Company");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.getSchema().createEdgeType("WORKS_AT");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    final MutableVertex c = database.newVertex("Company").save();
+    a.newEdge("FOLLOWS", b);
+    a.newEdge("WORKS_AT", c);
+    database.commit();
+
+    // Constructed covering BOTH vertex types and BOTH edge types.
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("csr-scope-mismatch-test")
+        .withVertexTypes("Person", "Company")
+        .withEdgeTypes("FOLLOWS", "WORKS_AT")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    assertThat(gav.getNodeCount()).isEqualTo(3);
+    assertThat(gav.getEdgeCount()).isEqualTo(2);
+
+    // Directly rescan with a NARROWER scope than construction - bypasses the builder and the SQL REBUILD
+    // path, which is exactly why this needs its own coverage.
+    gav.build(new String[] { "Person" }, new String[] { "FOLLOWS" });
+    assertThat(gav.getNodeCount()).isEqualTo(2);
+    assertThat(gav.getEdgeCount()).isEqualTo(1);
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-scope-mismatch-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+
+    // The view's own construction-time scope (Person+Company, FOLLOWS+WORKS_AT) no longer matches what
+    // was actually persisted (Person only, FOLLOWS only), so the certificate/definition check in load()
+    // must reject the file and fall back to a full rebuild under the view's REAL, full scope - not restore
+    // the narrower snapshot while claiming full coverage.
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("a persisted narrower-scope snapshot must never be silently served as the view's full construction-time scope")
+        .isFalse();
+    assertThat(restored.getNodeCount()).isEqualTo(3);
+    assertThat(restored.getEdgeCount()).isEqualTo(2);
+
+    restored.drop();
+  }
+
+  /**
    * Regression for issue #6583 code review: a GAV name is a schema-privileged user's choice of SQL
    * identifier, not validated against path separators anywhere upstream, so {@code fileFor()} must not
    * let a name like {@code ../../../tmp/evil} escape the database directory - which would otherwise give

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2337,6 +2337,160 @@ class GraphAnalyticalViewTest extends TestHelper {
     }
   }
 
+  // --- CSR persistence across reopen (issue #6583) tests ---
+
+  /**
+   * Regression for issue #6583: a Graph Analytical View's CSR was rebuilt by a full graph scan on
+   * every open, so a session that never queried it still paid the whole scan cost at close (the
+   * async rebuild triggered by {@code restoreAll()} is awaited by {@code shutdown()}).
+   * <p>
+   * When nothing has been committed to the database between a clean close and the next open, the
+   * CSR persisted at close time must be reused as-is: no rebuild, verified here via
+   * {@link GraphAnalyticalView#isRestoredFromPersistedCsr()}. The test also exercises vertex
+   * properties (STRING + INT columns), edge properties (DOUBLE column via the bwdToFwd index) and
+   * the BFS/RCM reordering permutation, to confirm the persisted format round-trips every part of
+   * the CSR, not just the adjacency arrays.
+   */
+  @Test
+  void csrPersistedAtCleanCloseIsReusedOnReopenWithoutRebuilding() {
+    database.getSchema().createVertexType("Person").createProperty("name", Type.STRING);
+    database.getSchema().getType("Person").createProperty("age", Type.INTEGER);
+    database.getSchema().createEdgeType("FOLLOWS").createProperty("weight", Type.DOUBLE);
+
+    database.begin();
+    final List<RID> ids = new ArrayList<>();
+    for (int i = 0; i < 20; i++)
+      ids.add(database.newVertex("Person").set("name", "P" + i).set("age", 20 + i).save().getIdentity());
+    for (int i = 0; i < ids.size() - 1; i++)
+      ids.get(i).asVertex().modify().newEdge("FOLLOWS", ids.get(i + 1).asVertex(), "weight", (double) i);
+    // A couple of extra edges so the graph isn't a plain chain (exercises BFS/RCM reordering).
+    ids.get(0).asVertex().modify().newEdge("FOLLOWS", ids.get(10).asVertex(), "weight", 99.0);
+    ids.get(5).asVertex().modify().newEdge("FOLLOWS", ids.get(2).asVertex(), "weight", 42.0);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("csr-persist-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withProperties("name", "age")
+        .withEdgeProperties("weight")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    assertThat(gav.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(gav.isRestoredFromPersistedCsr()).isFalse();
+
+    final int expectedNodeCount = gav.getNodeCount();
+    final int expectedEdgeCount = gav.getEdgeCount();
+    final int p0 = gav.getNodeId(ids.get(0));
+    final int p1 = gav.getNodeId(ids.get(1));
+    final int[] expectedP0Out = gav.getVertices(p0, Vertex.DIRECTION.OUT, "FOLLOWS");
+    Arrays.sort(expectedP0Out);
+    final Object expectedName = gav.getProperty(p1, "name");
+    final Object expectedAge = gav.getProperty(p1, "age");
+    final Object expectedWeight = gav.getEdgeProperty(p0, 0, Vertex.DIRECTION.OUT, "FOLLOWS", "weight");
+
+    final String dbPath = database.getDatabasePath();
+    database.close();
+
+    final Database db2 = new DatabaseFactory(dbPath).open();
+    try {
+      final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(db2, "csr-persist-test");
+      assertThat(restored).isNotNull();
+      assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+
+      assertThat(restored.isRestoredFromPersistedCsr())
+          .as("nothing was committed between close and reopen: the persisted CSR must be reused, not rebuilt")
+          .isTrue();
+
+      assertThat(restored.getNodeCount()).isEqualTo(expectedNodeCount);
+      assertThat(restored.getEdgeCount()).isEqualTo(expectedEdgeCount);
+
+      final int restoredP0 = restored.getNodeId(ids.get(0));
+      final int restoredP1 = restored.getNodeId(ids.get(1));
+      final int[] restoredP0Out = restored.getVertices(restoredP0, Vertex.DIRECTION.OUT, "FOLLOWS");
+      Arrays.sort(restoredP0Out);
+
+      assertThat(restoredP0Out).isEqualTo(expectedP0Out);
+      assertThat(restored.getProperty(restoredP1, "name")).isEqualTo(expectedName);
+      assertThat(restored.getProperty(restoredP1, "age")).isEqualTo(expectedAge);
+      assertThat(restored.getEdgeProperty(restoredP0, 0, Vertex.DIRECTION.OUT, "FOLLOWS", "weight")).isEqualTo(expectedWeight);
+
+      restored.drop();
+    } finally {
+      db2.close();
+    }
+
+    database = new DatabaseFactory(dbPath).open();
+  }
+
+  /**
+   * Regression for issue #6583: the persisted CSR must only be trusted when the certificate
+   * (the database's last committed transaction id as of the build) still matches. A commit that
+   * happens after a reopen restores from disk - even one that lands after the fast-path restore -
+   * must force the NEXT reopen back onto a full rebuild rather than silently serving stale data.
+   */
+  @Test
+  void csrPersistedCsrIsInvalidatedByMutationAcrossReopens() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "Alice").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "Bob").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+    final RID bId = b.getIdentity();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-stale-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    final String dbPath = database.getDatabasePath();
+    database.close();
+
+    // First reopen: nothing changed since close, so the fast path restores from disk.
+    Database db2 = new DatabaseFactory(dbPath).open();
+    GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(db2, "csr-stale-test");
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr()).isTrue();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+
+    // Mutate a covered type — OFF mode flips the view STALE immediately, so it will not be
+    // (re)persisted on this close, and the on-disk certificate now describes a superseded state.
+    // Vertex handles from the closed first session can't be reused, so re-resolve b by RID.
+    db2.begin();
+    final MutableVertex c = db2.newVertex("Person").set("name", "Charlie").save();
+    ((Vertex) db2.lookupByRID(bId, true)).modify().newEdge("FOLLOWS", c);
+    db2.commit();
+    assertThat(restored.getStatus()).isEqualTo(GraphAnalyticalView.Status.STALE);
+    db2.close();
+
+    // Second reopen: the persisted certificate no longer matches the database's last transaction
+    // id, so restoreAll() must fall back to a full rebuild rather than trusting the stale file.
+    db2 = new DatabaseFactory(dbPath).open();
+    try {
+      restored = GraphAnalyticalViewRegistry.get(db2, "csr-stale-test");
+      assertThat(restored).isNotNull();
+      assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+
+      assertThat(restored.isRestoredFromPersistedCsr())
+          .as("a commit happened after the CSR was persisted: it must be rebuilt, not reused")
+          .isFalse();
+      assertThat(restored.getNodeCount()).isEqualTo(3);
+      assertThat(restored.getEdgeCount()).isEqualTo(2);
+
+      restored.drop();
+    } finally {
+      db2.close();
+    }
+
+    database = new DatabaseFactory(dbPath).open();
+  }
+
   // --- Incremental update (delta overlay) tests ---
 
   @Test

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -20,7 +20,6 @@ package com.arcadedb.graph.olap;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
-import com.arcadedb.database.DataEncryption;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
@@ -2781,8 +2780,8 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
-   * Regression for issue #6583 code review: when the database has a {@link DataEncryption} configured,
-   * the persisted CSR must not leak record data in cleartext to a plain file beside it. Verifies both that
+   * Regression for issue #6583 code review: when the database has a {@link com.arcadedb.database.DataEncryption}
+   * configured, the persisted CSR must not leak record data in cleartext to a plain file beside it. Verifies both that
    * a distinctive property value never appears verbatim in the persisted file's bytes, and that the round
    * trip through encrypt-at-persist/decrypt-at-restore still produces the exact same data.
    * <p>

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2435,6 +2435,42 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6583 code review: an earlier round replaced {@code DataOutputStream.writeUTF()}
+   * (a 64KB modified-UTF-8 cap) with length-prefixed raw UTF-8 encoding specifically so a STRING property
+   * value longer than that limit wouldn't make persistence throw. Pins that fix with an actual value past
+   * the boundary, round-tripped through persist and restore.
+   */
+  @Test
+  void csrPersistenceRoundTripsAStringPropertyLongerThan64KB() {
+    database.getSchema().createVertexType("Person").createProperty("bio", Type.STRING);
+    final String longBio = "x".repeat(100_000); // comfortably past writeUTF's 65535-byte modified-UTF-8 cap
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("bio", longBio).save();
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-long-string-test")
+        .withVertexTypes("Person")
+        .withProperties("bio")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-long-string-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("persisting a >64KB STRING value must not silently fail and force every reopen back to a rebuild")
+        .isTrue();
+
+    final int id = restored.getNodeId(a.getIdentity());
+    assertThat(restored.getProperty(id, "bio")).isEqualTo(longBio);
+
+    restored.drop();
+  }
+
+  /**
    * Regression for issue #6583: the persisted CSR must only be trusted when the certificate
    * (the database's last committed transaction id as of the build) still matches. A commit that
    * happens after a reopen restores from disk - even one that lands after the fast-path restore -

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2541,6 +2541,60 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6583 code review: {@code build(vertexTypes, edgeTypes)} - unlike {@code
+   * buildAsync()}/{@code onRelevantCommit()}/{@code applyDelta()}'s rebuild, which each open a fresh
+   * transaction on a dedicated worker thread AFTER sampling the certificate - runs its scan on whatever
+   * transaction is already active on the calling thread (this is what {@code REBUILD GRAPH ANALYTICAL VIEW}
+   * and a direct {@code build()} call both do). Under {@code REPEATABLE_READ}, a transaction that was already
+   * open before this call may have cached pages the scan is about to read, so it could miss a commit that
+   * landed between that transaction's own begin() and this call - while the certificate sampled here would
+   * still claim full coverage. The resulting snapshot must never be persisted in that situation, regardless
+   * of whether an actual missed commit occurred: there is no way to tell from here whether it did.
+   */
+  @Test
+  void syncBuildUnderAnAlreadyActiveRepeatableReadTransactionIsNeverPersisted() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("csr-repeatable-read-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    assertThat(gav.getNodeCount()).isEqualTo(2);
+
+    final Database.TRANSACTION_ISOLATION_LEVEL original = database.getTransactionIsolationLevel();
+    database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    try {
+      database.begin();
+      try {
+        // Rescans on THIS already-active transaction, exactly the REBUILD GRAPH ANALYTICAL VIEW / direct
+        // build() path the review flagged - the certificate sampled inside build() cannot vouch for what
+        // this transaction may have already cached before this call.
+        gav.build(new String[] { "Person" }, new String[] { "FOLLOWS" });
+      } finally {
+        database.commit();
+      }
+    } finally {
+      database.setTransactionIsolationLevel(original);
+    }
+
+    gav.shutdown();
+    assertThat(GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-repeatable-read-test"))
+        .as("a synchronous build() scanned under an already-active REPEATABLE_READ transaction must never be "
+            + "persisted: its certificate cannot be trusted to describe what the scan actually saw")
+        .doesNotExist();
+
+    gav.drop();
+  }
+
+  /**
    * Regression for issue #6583, raised in review by the issue's original reporter: the certificate is an
    * equality test against {@code TransactionManager.getLastTransactionId()}, which is NOT guaranteed
    * monotonic across a lost or corrupted recency marker - a clean close removes the WAL, so the marker is

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2541,6 +2541,44 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6583 code review: a GAV name is a schema-privileged user's choice of SQL
+   * identifier, not validated against path separators anywhere upstream, so {@code fileFor()} must not
+   * let a name like {@code ../../../tmp/evil} escape the database directory - which would otherwise give
+   * {@code save()}/{@code delete()} an arbitrary-file write/delete primitive.
+   */
+  @Test
+  void csrFilePathStaysUnderDatabaseDirectoryEvenForATraversalName() throws Exception {
+    final String maliciousName = "../../../../tmp/arcadedb-issue-6583-traversal-marker";
+
+    final File csrFile = GraphAnalyticalViewCSRPersistence.fileFor(database, maliciousName);
+
+    final String databaseCanonicalPath = new File(database.getDatabasePath()).getCanonicalPath();
+    assertThat(csrFile.getCanonicalPath())
+        .as("the resolved CSR file must stay a direct child of the database directory regardless of the view name")
+        .isEqualTo(databaseCanonicalPath + File.separator + csrFile.getName());
+    assertThat(csrFile.getParentFile().getCanonicalPath()).isEqualTo(databaseCanonicalPath);
+
+    database.getSchema().createVertexType("Person");
+    database.begin();
+    database.newVertex("Person").save();
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName(maliciousName)
+        .withVertexTypes("Person")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    gav.shutdown(); // persists the CSR to disk
+
+    assertThat(csrFile).exists();
+    assertThat(new File("/tmp/arcadedb-issue-6583-traversal-marker.csr"))
+        .as("the traversal segments must never resolve outside the database directory")
+        .doesNotExist();
+
+    gav.drop();
+  }
+
+  /**
    * Regression for issue #6583 code review: {@code drop()} must remove the persisted CSR file, not just
    * the schema definition, so a later view created under the same name never risks loading a stale file
    * left over from a previous, unrelated view.
@@ -2595,9 +2633,11 @@ class GraphAnalyticalViewTest extends TestHelper {
         .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
         .build();
 
+    // fileFor() resolves through the schema (for its filename encoding), so it must run before close().
+    final File csrFile = GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-corrupt-test");
+    final String dbPath = database.getDatabasePath();
     database.close();
 
-    final File csrFile = GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-corrupt-test");
     assertThat(csrFile).exists();
     // Truncate the file to a few bytes past its header — the certificate check passes (it's still there),
     // but the payload it points into is gone.
@@ -2605,7 +2645,7 @@ class GraphAnalyticalViewTest extends TestHelper {
       raf.setLength(Math.min(raf.length(), 64));
     }
 
-    database = new DatabaseFactory(database.getDatabasePath()).open();
+    database = new DatabaseFactory(dbPath).open();
 
     final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-corrupt-test");
     assertThat(restored).isNotNull();

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.Test;
 import javax.crypto.SecretKey;
 import java.io.File;
 import java.io.RandomAccessFile;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
@@ -2652,6 +2654,100 @@ class GraphAnalyticalViewTest extends TestHelper {
     }
 
     database = new DatabaseFactory(dbPath).open();
+  }
+
+  /**
+   * Regression for issue #6583 code review (raised in the tenth-round pass): the certificate is sound only
+   * where {@code TransactionManager.getLastTransactionId()} reflects every commit that could have touched a
+   * covered type. That holds for a standalone database or an HA leader - the only paths that call {@code
+   * getNextTransactionId()} - but {@code TransactionManager.applyChanges()}, the path replicated commits are
+   * applied through on a follower, never advances that counter. A follower's certificate would therefore
+   * freeze at whatever value it had when a snapshot was built and "match" on every later reopen no matter how
+   * much further replicated data has landed since - unlike the lost-recency-marker case, this one never
+   * self-heals. Both {@code persistCsrIfPossible()} and {@code tryRestoreFromPersistedCsr()} must refuse
+   * outright on a non-leader replica, mirroring the existing leader-only gate on {@code
+   * TimeSeriesMaintenanceScheduler}'s destructive maintenance.
+   */
+  @Test
+  void csrPersistenceIsLeaderOnlyUnderHA() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    final DatabaseInternal realDb = (DatabaseInternal) database;
+    final DatabaseInternal followerView = nodeView(realDb, false);
+
+    // A follower must never persist, even though the view itself builds and reads normally - a follower
+    // still serves reads, it just can't certify a CSR against a counter replicated commits don't advance.
+    final GraphAnalyticalView followerGav = GraphAnalyticalView.builder(followerView)
+        .withName("csr-ha-persist-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    assertThat(followerGav.getNodeCount()).isEqualTo(2);
+    followerGav.shutdown();
+    assertThat(GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-ha-persist-test"))
+        .as("a follower's certificate is unsound and must never be persisted")
+        .doesNotExist();
+    GraphAnalyticalViewPersistence.remove(database, "csr-ha-persist-test");
+
+    // A leader (standalone == always leader) persists a real, valid file...
+    final GraphAnalyticalView leaderGav = GraphAnalyticalView.builder(database)
+        .withName("csr-ha-restore-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    leaderGav.shutdown();
+    assertThat(GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-ha-restore-test")).exists();
+
+    // ...but a node that is a follower must still refuse to restore it, even though the certificate would
+    // otherwise match exactly (nothing committed in between).
+    final GraphAnalyticalViewBuilder followerBuilder = GraphAnalyticalView.builder(followerView)
+        .withName("csr-ha-restore-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .skipPersistence();
+    final GraphAnalyticalView followerRestored = followerBuilder.restoreFromDiskOrBuildAsync();
+    assertThat(followerRestored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(followerRestored.isRestoredFromPersistedCsr())
+        .as("a follower must never trust a persisted CSR's certificate, even when it would otherwise match exactly")
+        .isFalse();
+    assertThat(followerRestored.getNodeCount()).isEqualTo(2);
+
+    followerRestored.drop();
+    leaderGav.drop();
+  }
+
+  /**
+   * A view of the database that only differs in being replicated, and in whether this node leads. Avoids pulling a
+   * mocking framework into the engine module just to flip two flags (same approach used by
+   * LSMVectorIndexAutoCompactionTest/Issue5470ReplicatedCommitEveryTest).
+   */
+  private static DatabaseInternal nodeView(final DatabaseInternal delegate, final boolean leader) {
+    return (DatabaseInternal) Proxy.newProxyInstance(DatabaseInternal.class.getClassLoader(),
+        new Class<?>[] { DatabaseInternal.class }, (proxy, method, args) -> {
+          if (args == null || args.length == 0)
+            switch (method.getName()) {
+            case "isReplicated" -> {
+              return Boolean.TRUE;
+            }
+            case "isLeader" -> {
+              return leader;
+            }
+            }
+          try {
+            return method.invoke(delegate, args);
+          } catch (final InvocationTargetException e) {
+            throw e.getCause();
+          }
+        });
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.graph.olap;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DataEncryption;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.DefaultDataEncryption;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.MutableVertex;
@@ -32,6 +35,11 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.SecretKey;
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -2489,6 +2497,177 @@ class GraphAnalyticalViewTest extends TestHelper {
     }
 
     database = new DatabaseFactory(dbPath).open();
+  }
+
+  /**
+   * Regression for issue #6583 code review: {@code GAV_PERSIST_CSR=false} must suppress persistence
+   * entirely - no file written at close, and a reopen must fall back to the full rebuild rather than
+   * finding (and trusting) a leftover file from before the setting was flipped off.
+   */
+  @Test
+  void csrPersistDisabledByConfigWritesNoFileAndForcesRebuild() {
+    final Object defaultValue = GlobalConfiguration.GAV_PERSIST_CSR.getValue();
+    GlobalConfiguration.GAV_PERSIST_CSR.setValue(false);
+    try {
+      database.getSchema().createVertexType("Person");
+      database.getSchema().createEdgeType("FOLLOWS");
+      database.begin();
+      final MutableVertex a = database.newVertex("Person").save();
+      final MutableVertex b = database.newVertex("Person").save();
+      a.newEdge("FOLLOWS", b);
+      database.commit();
+
+      GraphAnalyticalView.builder(database)
+          .withName("csr-persist-disabled-test")
+          .withVertexTypes("Person")
+          .withEdgeTypes("FOLLOWS")
+          .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+          .build();
+
+      reopenDatabase();
+
+      assertThat(GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-persist-disabled-test")).doesNotExist();
+
+      final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-persist-disabled-test");
+      assertThat(restored).isNotNull();
+      assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+      assertThat(restored.isRestoredFromPersistedCsr()).isFalse();
+      assertThat(restored.getNodeCount()).isEqualTo(2);
+
+      restored.drop();
+    } finally {
+      GlobalConfiguration.GAV_PERSIST_CSR.setValue(defaultValue);
+    }
+  }
+
+  /**
+   * Regression for issue #6583 code review: {@code drop()} must remove the persisted CSR file, not just
+   * the schema definition, so a later view created under the same name never risks loading a stale file
+   * left over from a previous, unrelated view.
+   */
+  @Test
+  void dropDeletesPersistedCsrFile() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("csr-drop-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-drop-test");
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-drop-test")).exists();
+
+    restored.drop();
+
+    assertThat(GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-drop-test")).doesNotExist();
+  }
+
+  /**
+   * Regression for issue #6583 code review: a corrupted persisted CSR (truncated, or with a flipped byte
+   * that survives the header checks but fails the CRC) must be treated exactly like a missing file - fall
+   * back to a full rebuild - rather than propagating a parse failure or, worse, silently serving garbage.
+   */
+  @Test
+  void truncatedPersistedCsrFallsBackToRebuild() throws Exception {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-corrupt-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    database.close();
+
+    final File csrFile = GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-corrupt-test");
+    assertThat(csrFile).exists();
+    // Truncate the file to a few bytes past its header — the certificate check passes (it's still there),
+    // but the payload it points into is gone.
+    try (final RandomAccessFile raf = new RandomAccessFile(csrFile, "rw")) {
+      raf.setLength(Math.min(raf.length(), 64));
+    }
+
+    database = new DatabaseFactory(database.getDatabasePath()).open();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-corrupt-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("a truncated file must not be trusted, even though its header/certificate is intact")
+        .isFalse();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+    assertThat(restored.getEdgeCount()).isEqualTo(1);
+
+    restored.drop();
+  }
+
+  /**
+   * Regression for issue #6583 code review: when the database has a {@link DataEncryption} configured,
+   * the persisted CSR must not leak record data in cleartext to a plain file beside it. Verifies both that
+   * a distinctive property value never appears verbatim in the persisted file's bytes, and that the round
+   * trip through encrypt-at-persist/decrypt-at-restore still produces the exact same data.
+   * <p>
+   * Exercises {@link GraphAnalyticalView#shutdown()} (persists, without closing the whole database) and
+   * {@link GraphAnalyticalViewCSRPersistence#load} directly rather than a full close/reopen cycle, because
+   * {@code setDataEncryption()} on a freshly reopened database instance would otherwise race the
+   * {@code restoreAll()} disk-restore attempt that already ran during {@code open()} - the point here is
+   * the codec's own encrypt/decrypt round trip, which this reaches deterministically.
+   */
+  @Test
+  void csrPersistenceEncryptsPayloadWhenDatabaseHasDataEncryptionConfigured() throws Exception {
+    final SecretKey key = DefaultDataEncryption.getSecretKeyFromPasswordUsingDefaults("password", "salt");
+    database.setDataEncryption(DefaultDataEncryption.useDefaults(key));
+
+    database.getSchema().createVertexType("Person").createProperty("name", Type.STRING);
+    database.begin();
+    final String secretName = "Zzq7vXk9SensitiveMarker42";
+    database.newVertex("Person").set("name", secretName).save();
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName("csr-encrypted-test")
+        .withVertexTypes("Person")
+        .withProperties("name")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    final long asOfTransactionId = ((DatabaseInternal) database).getTransactionManager().getLastTransactionId();
+    gav.shutdown(); // persists the CSR to disk (view is READY, no pending overlay changes)
+
+    final File csrFile = GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-encrypted-test");
+    assertThat(csrFile).exists();
+    final byte[] fileBytes = Files.readAllBytes(csrFile.toPath());
+    assertThat(new String(fileBytes, StandardCharsets.ISO_8859_1))
+        .as("the persisted CSR must not contain the plaintext property value when encryption is configured")
+        .doesNotContain(secretName);
+
+    final GraphAnalyticalView.Snapshot restored = GraphAnalyticalViewCSRPersistence.load(database, "csr-encrypted-test",
+        new String[] { "Person" }, null, new String[] { "name" }, null, asOfTransactionId);
+    assertThat(restored).as("the persisted CSR must decrypt and parse back correctly").isNotNull();
+    assertThat(restored.nodeMapping.size()).isEqualTo(1);
+    assertThat(restored.bucketColumns[0].getValue(0, "name")).isEqualTo(secretName);
+
+    gav.drop();
+    database.setDataEncryption(null);
   }
 
   // --- Incremental update (delta overlay) tests ---

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.DefaultDataEncryption;
 import com.arcadedb.database.RID;
+import com.arcadedb.engine.TransactionManager;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.NeighborView;
@@ -2538,6 +2539,66 @@ class GraphAnalyticalViewTest extends TestHelper {
     } finally {
       GlobalConfiguration.GAV_PERSIST_CSR.setValue(defaultValue);
     }
+  }
+
+  /**
+   * Regression for issue #6583, raised in review by the issue's original reporter: the certificate is an
+   * equality test against {@code TransactionManager.getLastTransactionId()}, which is NOT guaranteed
+   * monotonic across a lost or corrupted recency marker - a clean close removes the WAL, so the marker is
+   * the sole durable record at that point, and its loss resets the counter to climb back from ~0, through
+   * every value it held before, including one a stale persisted CSR might still carry as its certificate.
+   * {@code isRecencySignalReliable()} must be false whenever that marker is missing with nothing to recover
+   * it from, and the disk-restore fast path must refuse to trust ANY certificate match while it is false -
+   * not just this test's case, where the numbers don't even happen to collide, but structurally, so a
+   * later coincidental collision can never be silently accepted either.
+   */
+  @Test
+  void lostRecencyMarkerForcesRebuildRatherThanTrustingAPossiblyStaleCertificate() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lost-marker-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    final String dbPath = database.getDatabasePath();
+    database.close();
+
+    // Simulate a lost/corrupted recency marker. A clean close already removed the WAL, so this file was
+    // the sole durable record of "last committed transaction id" - without it, the next open cannot tell
+    // a genuinely empty database apart from one that lost its history.
+    final File markerFile = new File(dbPath, TransactionManager.LAST_TX_ID_FILE_NAME);
+    assertThat(markerFile).exists();
+    assertThat(markerFile.delete()).isTrue();
+
+    final Database db2 = new DatabaseFactory(dbPath).open();
+    try {
+      assertThat(((DatabaseInternal) db2).getTransactionManager().isRecencySignalReliable())
+          .as("a missing recency marker with no WAL to recover from must not be treated as a reliable signal")
+          .isFalse();
+
+      final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(db2, "csr-lost-marker-test");
+      assertThat(restored).isNotNull();
+      assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+      assertThat(restored.isRestoredFromPersistedCsr())
+          .as("an unreliable recency signal must never certify a persisted CSR, however the numbers compare")
+          .isFalse();
+      assertThat(restored.getNodeCount()).isEqualTo(2);
+
+      restored.drop();
+    } finally {
+      db2.close();
+    }
+
+    database = new DatabaseFactory(dbPath).open();
   }
 
   /**


### PR DESCRIPTION
## Summary
- A Graph Analytical View's CSR was rebuilt by a full graph scan on every database open, and `shutdown()` awaits any in-flight async rebuild, so that cost landed on close (4.03s at 1M vertices for a session that ran no query at all).
- The CSR is now persisted to disk when a named view is READY (with no pending overlay changes) at a clean close, alongside a freshness certificate: the database's last committed transaction id as of the scan that produced it.
- On the next open, if the database's current last committed transaction id still matches the certificate, nothing was committed in between, so the persisted CSR is loaded as-is instead of rescanned. Any commit in between invalidates the certificate and falls back to the existing async rebuild - unchanged behavior.
- New toggle `arcadedb.gavPersistCsr` (default `true`) to disable persistence if the disk footprint or the extra write at close isn't wanted.

## Why this certificate, not a vertex-set checksum
A checksum over `NodeIdMapping` (bucket ids + per-bucket RID positions) only certifies which vertices exist - it would miss an edge added between two already-mapped vertices, or a property changed on an existing vertex, either of which leaves the RID set untouched but makes a "certified" CSR wrong. The database's last committed transaction id is already tracked durably (`TransactionManager`, persisted at clean close, used for HA bootstrap recency) and "unchanged since the CSR was built" is sound for the *whole* CSR - vertices, edges and properties - not just the vertex mapping. It's coarser (an unrelated type committing invalidates it too) but the check is two `long`s, not a per-bucket scan.

## Scope
Delta-serving a stale CSR (the existing `DeltaOverlay` machinery already does something close to this for live `SYNCHRONOUS` views) is left for a follow-up. A CSR's contiguous layout makes partial coverage real surgery rather than an append, and the certificate alone already collapses the issue's reported case - an unchanged database - from O(graph size) to O(1), which is where the measured pain was.

Closes #6583

## Test plan
- [x] New regression tests in `GraphAnalyticalViewTest`:
  - `csrPersistedAtCleanCloseIsReusedOnReopenWithoutRebuilding`: builds a view with vertex properties (STRING+INT), edge properties (DOUBLE) and BFS/RCM reordering, closes, reopens, and asserts `isRestoredFromPersistedCsr()` is true with byte-for-byte-equivalent query results.
  - `csrPersistedCsrIsInvalidatedByMutationAcrossReopens`: confirms a commit between closes forces the next reopen back onto a full rebuild rather than serving stale data.
- [x] Full `com.arcadedb.graph.olap` package (182 tests) and adjacent GAV-consuming suites (OpenCypher GAV eligibility/cardinality, SQL MATCH GAV expand-into, statistics provider) pass.
- [x] Manual sanity check at 100k vertices / 400k edges: open+close with no query repeated 3x - first close persists, every reopen after restores from disk, open and close both land near the "no view" baseline instead of the ~570ms this issue measured.

## Files changed
- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewCSRPersistence.java` (new): binary codec for the CSR + certificate, atomic write, CRC32 verification on read
- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java`: certificate capture at build time, persist-on-shutdown, disk-restore path
- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java`: `restoreFromDiskOrBuildAsync()`
- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java`: wires the disk-restore path into `restoreAll()`
- `engine/src/main/java/com/arcadedb/graph/olap/NodeIdMapping.java`: restore factory + permutation getter
- `engine/src/main/java/com/arcadedb/graph/olap/Column.java`, `ColumnStore.java`: restore factory / column insertion for deserialization
- `engine/src/main/java/com/arcadedb/GlobalConfiguration.java`: new `GAV_PERSIST_CSR` setting
- `engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java`: regression tests