### PR TITLE
fix(#6586): one answer for a missing vertex on both sides of an edge list, decided before the walk

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3838,7 +3838,10 @@ other failure that delete can produce.
 
 `deleteVertex` now settles it before the walk, by reading the bucket's slot rather than trusting a handle: the
 vertex record either has a slot or it does not, and a `VertexNotFoundException` naming `CHECK DATABASE FIX` is
-raised immediately instead of after a full traversal that is about to be rolled back. That probe checks
+raised immediately instead of after a full traversal that is about to be rolled back. The probe is paid on every
+vertex delete, not only the failing ones: it is one slot-marker read on the page the delete is about to write,
+which is already in the page cache by then, bought against a doomed full walk of an adjacency list on the rare
+path - and against a diagnosis that was wrong. That probe checks
 `READ_RECORD` on the bucket, where the physical delete under it checks only `DELETE_RECORD` - which changes when a
 caller lacking the read permission is told, not whether it needs it: every route into a vertex delete already read
 the record from that same bucket, a lazy handle when the head-pointer read loads it and a materialised one when it

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3818,3 +3818,44 @@ reads, so the same fact can now surface between them as `VertexNotFoundException
 identically rather than promoting a window the probe would have absorbed into a hard failure.
 
 [#6572](https://github.com/ArcadeData/arcadedb/issues/6572)
+
+## Both sides of an edge list answer a missing vertex the same way, and a delete decides it up front (#6586)
+
+#6572 split "the vertex record is gone" out of `GraphEngine.getEdgeHeadChunkForWrite`'s retryable conflict using
+the RID the `RecordNotFoundException` names. That split fires only when the head-pointer read has to go back to the
+bucket, so two adjacent paths reached the same fact - a caller writing the edge list of a vertex whose record does
+not exist - without going through the discriminator, and each still answered it in its own, worse way.
+
+The first is the delete. A **materialised** handle - a RID whose content was loaded earlier in the same transaction
+and used after the record went away - answers `getOutEdgesHeadChunk()` straight out of the buffer it already holds,
+touches no bucket and raises nothing. The whole removal walk then ran on those stale heads, disconnecting every edge
+from its far endpoint, and only the re-read at the end of the delete noticed. What it reported was
+`ConcurrentModificationException: Vertex #4:0 was deleted by a concurrent transaction while its edges were being
+removed` - retryable, so the caller spent its budget re-running a transaction that could only fail identically; and
+untrue, since a single-threaded run reaches it too, with the same wording whether the record was removed by a
+concurrent writer, by this very transaction, or never existed at all. It also carried no repair advice, unlike every
+other failure that delete can produce.
+
+`deleteVertex` now settles it before the walk, by reading the bucket's slot rather than trusting a handle: the
+vertex record either has a slot or it does not, and a `VertexNotFoundException` naming `CHECK DATABASE FIX` is
+raised immediately instead of after a full traversal that is about to be rolled back. The check reads only the slot
+marker, so a vertex with a corrupt or truncated body is unaffected - it stays deletable, as #4420 and #4432 require -
+and it is not tolerated under `force` either, for the reason #6572 spells out. The re-read at the end of the delete
+keeps a conflict only for a record other than the vertex (a continuation chunk a concurrent commit is republishing);
+a vertex that has vanished gets the same non-retryable answer as everywhere else, and the `ClassCastException` arm
+next to it no longer asserts a slot reuse this frame cannot establish.
+
+The second is the append. `GraphEngine.getOrCreateEdgeList` read the head RID *outside* its `try`, so on a vertex
+whose record is gone the lazy load escaped raw as `RecordNotFoundException: Record #4:0 not found`. The verdict was
+right - it was never retryable - but nothing else was there: it did not say the missing record is a vertex, that it
+was an *endpoint* of an edge being created (the common shape is `connectIncomingEdge`, where the target is gone
+rather than the vertex the caller named), which side of the list was being written, or what to run. It now raises
+the same `VertexNotFoundException`, with the same message shape and the same advice as the removal side.
+
+One catchable type therefore covers the whole surface: removing an entry from an edge list, adding one to it, and
+deleting the vertex outright. An application sweeping possibly-stale references catches `VertexNotFoundException`
+(or `RecordNotFoundException`) once and skips the entry, instead of matching on messages or on the accident of which
+read noticed first. An unreadable *chunk* of a vertex that does exist keeps the retryable
+`ConcurrentModificationException` and #5764's scoped advice, on both paths.
+
+[#6586](https://github.com/ArcadeData/arcadedb/issues/6586)

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3849,6 +3849,12 @@ keeps a conflict only for a record other than the vertex (a continuation chunk a
 a vertex that has vanished gets the same non-retryable answer as everywhere else, and the `ClassCastException` arm
 next to it no longer asserts a slot reuse this frame cannot establish.
 
+That last part is worth spelling out for anyone whose retry logic pattern-matches on the exception type: a
+*genuinely* concurrent delete - another transaction removing the vertex between the probe and that re-read, which is
+the one case the old message actually described - is now reported as `VertexNotFoundException` too, not as a
+retryable conflict. The outcome is unchanged, since a retry would only rediscover the absence at the probe on the
+next attempt and fail there; what changes is that it is reported once instead of after the budget is spent.
+
 The second is the append. `GraphEngine.getOrCreateEdgeList` read the head RID *outside* its `try`, so on a vertex
 whose record is gone the lazy load escaped raw as `RecordNotFoundException: Record #4:0 not found`. The verdict was
 right - it was never retryable - but nothing else was there: it did not say the missing record is a vertex, that it

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3861,6 +3861,11 @@ the next attempt and fail there, so what changes is that it is reported once rat
 A loop that wants the old shape should catch `RecordNotFoundException` (or `VertexNotFoundException`) alongside the
 conflict and treat it as "already gone" - which is what it would have concluded after exhausting its retries.
 
+One note for anyone reading causes closely in a log: when the absence is established by the delete's slot probe
+rather than by a failed read, the wrapped `RecordNotFoundException` is raised at the probe, so its top stack frame
+is that check and not a bucket read. The record really is missing either way; only the frame that established it
+differs.
+
 The second is the append. `GraphEngine.getOrCreateEdgeList` read the head RID *outside* its `try`, so on a vertex
 whose record is gone the lazy load escaped raw as `RecordNotFoundException: Record #4:0 not found`. The verdict was
 right - it was never retryable - but nothing else was there: it did not say the missing record is a vertex, that it

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3852,11 +3852,14 @@ keeps a conflict only for a record other than the vertex (a continuation chunk a
 a vertex that has vanished gets the same non-retryable answer as everywhere else, and the `ClassCastException` arm
 next to it no longer asserts a slot reuse this frame cannot establish.
 
-That last part is worth spelling out for anyone whose retry logic pattern-matches on the exception type: a
-*genuinely* concurrent delete - another transaction removing the vertex between the probe and that re-read, which is
-the one case the old message actually described - is now reported as `VertexNotFoundException` too, not as a
-retryable conflict. The outcome is unchanged, since a retry would only rediscover the absence at the probe on the
-next attempt and fail there; what changes is that it is reported once instead of after the budget is spent.
+**Upgrading:** a caller that wraps vertex deletes in its own `catch (ConcurrentModificationException)` retry loop
+should read this paragraph. A *genuinely* concurrent delete - another transaction removing the vertex between the
+probe and that re-read, which is the one case the old message actually described - is now reported as
+`VertexNotFoundException` too, not as a retryable conflict, so such a loop no longer catches it and the failure
+propagates instead of being retried. That is the intended outcome: the retry could only rediscover the absence on
+the next attempt and fail there, so what changes is that it is reported once rather than after the budget is spent.
+A loop that wants the old shape should catch `RecordNotFoundException` (or `VertexNotFoundException`) alongside the
+conflict and treat it as "already gone" - which is what it would have concluded after exhausting its retries.
 
 The second is the append. `GraphEngine.getOrCreateEdgeList` read the head RID *outside* its `try`, so on a vertex
 whose record is gone the lazy load escaped raw as `RecordNotFoundException: Record #4:0 not found`. The verdict was

--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3838,7 +3838,11 @@ other failure that delete can produce.
 
 `deleteVertex` now settles it before the walk, by reading the bucket's slot rather than trusting a handle: the
 vertex record either has a slot or it does not, and a `VertexNotFoundException` naming `CHECK DATABASE FIX` is
-raised immediately instead of after a full traversal that is about to be rolled back. The check reads only the slot
+raised immediately instead of after a full traversal that is about to be rolled back. That probe checks
+`READ_RECORD` on the bucket, where the physical delete under it checks only `DELETE_RECORD` - which changes when a
+caller lacking the read permission is told, not whether it needs it: every route into a vertex delete already read
+the record from that same bucket, a lazy handle when the head-pointer read loads it and a materialised one when it
+was materialised. The check reads only the slot
 marker, so a vertex with a corrupt or truncated body is unaffected - it stays deletable, as #4420 and #4432 require -
 and it is not tolerated under `force` either, for the reason #6572 spells out. The re-read at the end of the delete
 keeps a conflict only for a record other than the vertex (a continuation chunk a concurrent commit is republishing);

--- a/engine/src/main/java/com/arcadedb/exception/VertexNotFoundException.java
+++ b/engine/src/main/java/com/arcadedb/exception/VertexNotFoundException.java
@@ -21,9 +21,15 @@ package com.arcadedb.exception;
 import com.arcadedb.database.RID;
 
 /**
- * A caller about to WRITE a vertex's edge list found the vertex RECORD ITSELF absent (#6572). The reference it
- * arrived through - an adjacency entry, a RID held across transactions, a traversal step - names a record that is
- * not there.
+ * A caller about to WRITE a vertex found the vertex RECORD ITSELF absent (#6572). The reference it arrived through -
+ * an adjacency entry, a RID held across transactions, a traversal step - names a record that is not there.
+ * <p>
+ * ONE type for that fact, whichever operation met it (#6586): REMOVING an entry from an edge list
+ * ({@code GraphEngine.getEdgeHeadChunkForWrite}), APPENDING one to it ({@code GraphEngine.getOrCreateEdgeList} -
+ * typically the far endpoint of an edge being created, which is not the vertex the caller named), or DELETING the
+ * vertex outright ({@code GraphEngine.deleteVertex}, which probes the slot before it walks anything). A sweep over a
+ * graph that has to skip such a reference catches this and only this, instead of matching on messages or on the
+ * accident of which read noticed first.
  * <p>
  * A {@link RecordNotFoundException}, and deliberately NOT a {@link NeedRetryException}, which is the whole reason
  * this type exists. The read side of an edge list cannot always tell "gone" from "not visible yet": a concurrent

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -475,6 +475,14 @@ public class GraphEngine {
    * type: a classic {@link EdgeSegment} chain yields an {@link EdgeLinkedList}, a {@link StripeDirectory}
    * (super-node promoted vertex, #5156) yields a {@link StripedEdgeList}. The head page is anchored in the
    * transaction at read time (#5147/#5153).
+   * <p>
+   * #6586: every read of the VERTEX RECORD here is guarded, and a missing one is told apart from a missing CHUNK by
+   * the same evidence #6572 used on the removal side - the RID the {@link RecordNotFoundException} names. The head
+   * pointer used to be read OUTSIDE the {@code try}, so on a not-yet-materialised handle to a record that is gone
+   * (the usual shape: {@code connectIncomingEdge} resolving the TARGET of a new edge, which arrives as a lazy
+   * handle) the lazy load escaped as a bare {@code Record #x:y not found} - correct as a verdict, and mute as a
+   * diagnosis. It now answers {@link #missingVertexOnEdgeListWrite}, exactly as {@link #getEdgeHeadChunkForWrite}
+   * does for the same fact on the other side of the same list.
    */
   public EdgeLinkedList getOrCreateEdgeList(VertexInternal vertex, final Vertex.DIRECTION direction) {
     // Resolve the transaction's own WRITTEN copy of the vertex first (a cache lookup, NO page anchoring):
@@ -489,7 +497,22 @@ public class GraphEngine {
         vertex = inTxVertex;
     }
 
-    RID headRID = direction == Vertex.DIRECTION.OUT ? vertex.getOutEdgesHeadChunk() : vertex.getInEdgesHeadChunk();
+    final RID vertexRID = vertex.getIdentity();
+
+    final RID headRID;
+    try {
+      // INSIDE a try since #6586: on a lazy handle this is the read that loads the vertex record, so it is where a
+      // vertex that no longer exists surfaces - one frame before the head-chunk lookup the catch below was written
+      // for. A multi-page vertex body whose continuation chunk is not visible yet reaches here too, and that one IS
+      // the publication window, so the two are separated by the RID the not-found names rather than by the site.
+      headRID = direction == Vertex.DIRECTION.OUT ? vertex.getOutEdgesHeadChunk() : vertex.getInEdgesHeadChunk();
+    } catch (final RecordNotFoundException e) {
+      if (vertexRID != null && vertexRID.equals(e.getRID()))
+        throw missingVertexOnEdgeListWrite(vertexRID, direction, e);
+      throw new ConcurrentModificationException(
+          "Vertex " + vertexRID + " is not fully visible yet (concurrent commit in flight), so its " + direction
+              + " edge list cannot be extended: " + e.getMessage(), e);
+    }
 
     if (headRID != null)
       try {
@@ -528,7 +551,17 @@ public class GraphEngine {
     // mutable copy only now - anchoring the vertex page is correct here because the vertex is in the write set.
     // modify() reloads the record when it is not already part of the transaction: re-check the head, a
     // concurrent transaction may have created it in the meantime.
-    final MutableVertex mutable = vertex.modify();
+    final MutableVertex mutable;
+    try {
+      mutable = vertex.modify();
+    } catch (final RecordNotFoundException e) {
+      // #6586: modify() RELOADS a handle the transaction does not already hold, so a vertex whose head pointer was
+      // answered from a buffer materialised earlier - which touches no bucket and therefore raises nothing above -
+      // is discovered here instead. Same fact, same answer.
+      if (vertexRID != null && vertexRID.equals(e.getRID()))
+        throw missingVertexOnEdgeListWrite(vertexRID, direction, e);
+      throw e;
+    }
     final RID reloadedHead = direction == Vertex.DIRECTION.OUT ? mutable.getOutEdgesHeadChunk() : mutable.getInEdgesHeadChunk();
     if (reloadedHead != null)
       return getOrCreateEdgeList(mutable, direction);
@@ -1020,6 +1053,13 @@ public class GraphEngine {
    * that is not there. What changes is only that the failure says so, and names {@link #missingVertexRepairAdvice}
    * instead of a repair aimed at the missing record.
    * <p>
+   * #6586 makes "before the walk starts" true of every handle rather than only of the ones that go back to the
+   * bucket to answer their head pointers. A materialised handle answers them from the buffer it already holds, so
+   * the absence was discovered only by the re-read at the END - after a full traversal that disconnected every edge
+   * from its far endpoint, and in a frame that could not tell a stale reference from a concurrent delete. The slot
+   * probe at the top decides it once, for both shapes, and costs one page-cached slot read on a path that is about
+   * to write that same page.
+   * <p>
    * #5760 removes the two costs this method used to pay for the walk, both of which fall out of ONE observation:
    * the vertex's own lists are dropped wholesale at the end, so nothing this method does to them is worth doing.
    * <ul>
@@ -1041,6 +1081,33 @@ public class GraphEngine {
     // and would hide the newest edges, which is the same "see nothing, delete anyway" defect by another route.
     final VertexInternal mostUpdatedVertex = getMostUpdatedVertex(vertex);
 
+    // #6586: DECIDED HERE, before the walk, and by reading the BUCKET rather than by trusting a handle. #6572
+    // already answers "the vertex record is gone" honestly - but only where it can see it, and the one read that
+    // sees it is a read that goes back to the bucket. A MATERIALISED handle (a RID whose content was loaded
+    // earlier in this transaction and used after the record went away) answers its head pointers straight out of
+    // the buffer it already holds, so the whole removal walk ran on stale heads, disconnected every edge from its
+    // FAR endpoint, and only the re-read in checkEdgeListHeadsUnchanged found out - which then reported a vertex
+    // that this transaction had itself removed, or that never existed, as a retryable concurrent delete. A
+    // one-slot probe converts a full traversal spent reaching a foregone failure into an immediate, correctly
+    // typed one, and leaves that re-read with a claim it can actually prove (see checkEdgeListHeadsUnchanged).
+    //
+    // The BUCKET and not database.existsRecord(), deliberately: the latter answers from the transaction's record
+    // caches first, which is precisely where a handle to a deleted record survives, so it would confirm the very
+    // thing being questioned. The slot marker is the ground truth, read through this transaction's view of the
+    // page - a record created earlier in this transaction has its slot allocated eagerly (that is why a rollback
+    // has to reset identities to provisional), so it is seen as present here just as it is by the delete below.
+    //
+    // Not tolerated under force either, for the reason #6572 spells out: deleting a record that is not there is an
+    // error on every other path in the engine too, and succeeding quietly would hide the one thing the caller
+    // needs to know - that something still points at a record that is gone.
+    final RID vertexRID = mostUpdatedVertex.getIdentity();
+    final Bucket vertexBucket = database.getSchema().getBucketByIdIfExists(vertexRID.getBucketId());
+    if (vertexBucket == null || !vertexBucket.existsRecord(vertexRID))
+      // A bucket that no longer exists means the same thing to the caller as a slot that no longer holds a record
+      // (#4501): the RID names nothing. Answering it here also keeps getBucketById's SchemaException - a message
+      // about internal file ids - off a path whose whole subject is a reference that outlived its target.
+      throw missingVertexOnDelete(vertexRID, notFoundOnProbe(vertexRID));
+
     // The heads this delete is about to walk, kept for checkEdgeListHeadsUnchanged below.
     final RID[] headsAtWalkStart = readEdgeListHeads(mostUpdatedVertex);
 
@@ -1055,9 +1122,17 @@ public class GraphEngine {
     if (!force && headsAtWalkStart != null)
       checkEdgeListHeadsUnchanged(mostUpdatedVertex, headsAtWalkStart[0], headsAtWalkStart[1]);
 
-    // DELETE VERTEX RECORD
-    mostUpdatedVertex.getDatabase().getSchema().getBucketById(mostUpdatedVertex.getIdentity().getBucketId())
-        .deleteRecord(mostUpdatedVertex.getIdentity(), force);
+    // DELETE VERTEX RECORD. #6586: the probe at the top is what normally decides this, so a not-found HERE is the
+    // residual - the record went away between the two, or the probe's page view was superseded. Answering it with
+    // the same type keeps the contract whole (this method reports a missing vertex ONE way) instead of letting the
+    // last statement leak the bare "Record #x:y not found" the append path used to.
+    try {
+      vertexBucket.deleteRecord(vertexRID, force);
+    } catch (final RecordNotFoundException e) {
+      if (e instanceof VertexNotFoundException || !vertexRID.equals(e.getRID()))
+        throw e;
+      throw missingVertexOnDelete(vertexRID, e);
+    }
   }
 
   /**
@@ -1144,6 +1219,68 @@ public class GraphEngine {
   }
 
   /**
+   * #6586: the ONE answer to "the vertex whose edge list this write needs does not exist", shared by every path that
+   * can discover it, so that both sides of the same list report the same fact the same way.
+   * <p>
+   * #6572 gave the REMOVAL side of an edge list ({@link #getEdgeHeadChunkForWrite}) a typed, non-retryable failure
+   * carrying a repair that applies. The APPEND side ({@link #getOrCreateEdgeList}) reached the identical fact - a
+   * lazy load of the vertex record finding nothing - and answered it with a bare {@code RecordNotFoundException}:
+   * the right VERDICT, since it is not retryable either, but none of the diagnosis. An operator reading
+   * {@code Record #4:0 not found} in a log cannot tell that the missing record is a VERTEX, that it was an ENDPOINT
+   * of an edge being created rather than the vertex the caller named, which SIDE of the list was being written, or
+   * what to run to repair it. Nothing about the append path makes any of that less true than on the removal path,
+   * so there is no reason for the two to differ - and an application that wants to skip such an endpoint has to be
+   * able to catch ONE type whichever side of the list it met it on.
+   * <p>
+   * Deliberately NOT parameterised on the operation: the wording is the contract these paths share, and a caller
+   * that wants to say more says it around this, not inside it.
+   *
+   * @param vertexRID the vertex whose record is absent - always the RID the cause names, never a neighbour's
+   * @param direction the side of the edge list the caller was about to write
+   * @param cause     the not-found this diagnosis wraps; kept so the trace still names the read that found it
+   */
+  private static VertexNotFoundException missingVertexOnEdgeListWrite(final RID vertexRID,
+      final Vertex.DIRECTION direction, final Exception cause) {
+    return new VertexNotFoundException(
+        "Vertex " + vertexRID + " does not exist, so its " + direction + " edge list cannot be modified: it was "
+            + "reached through a reference to a record that is gone (a stale edge entry, or a RID held past the "
+            + "delete). Retrying cannot make it exist: " + missingVertexRepairAdvice(), vertexRID, cause);
+  }
+
+  /**
+   * #6586: the same answer for the operation that is not a list write at all - deleting a vertex whose record is
+   * already gone.
+   * <p>
+   * Separate from {@link #missingVertexOnEdgeListWrite} only because there is no direction to name and because
+   * "cannot be deleted" is what the caller asked for; the type, the verdict and the repair are identical, which is
+   * the point - a caller sweeping a graph catches ONE type whether it met the missing vertex while reading a list,
+   * while extending one, or while dropping the vertex outright.
+   *
+   * @param cause the not-found this diagnosis wraps - either the one the bucket raised, or the one
+   *              {@link #notFoundOnProbe} gives the slot probe's answer so the chain reads the same either way
+   */
+  private static VertexNotFoundException missingVertexOnDelete(final RID vertexRID, final Exception cause) {
+    return new VertexNotFoundException(
+        "Vertex " + vertexRID + " does not exist, so it cannot be deleted: it was reached through a reference to a "
+            + "record that is gone (a stale edge entry, or a RID held past the delete). Retrying cannot make it "
+            + "exist: " + missingVertexRepairAdvice(), vertexRID, cause);
+  }
+
+  /**
+   * #6586: the not-found a PROBE establishes, so the diagnosis built on it still WRAPS one.
+   * <p>
+   * Every other path here discovers the absence by attempting a read and catching what the bucket raises, and the
+   * cause chain is load-bearing rather than decorative: it is what a full trace uses to say which record was
+   * missing and which read found it missing, and #6572 pins it. A slot probe answers with a boolean instead, so the
+   * fact has to be given the same shape - the same class, the same RID and the same wording the bucket itself uses
+   * for an empty slot, raised at the frame that found it. Not a fabrication of anything that did not happen: the
+   * record really is not there, and the probe really is the read that established it.
+   */
+  private static RecordNotFoundException notFoundOnProbe(final RID vertexRID) {
+    return new RecordNotFoundException("Record " + vertexRID + " not found", vertexRID);
+  }
+
+  /**
    * #5764: the same retryable conflict, carrying the repair command for the vertex whose list could not be read.
    * <p>
    * A conflict is normally absorbed by the transaction retry and never seen, so the one run that DOES surface this
@@ -1217,6 +1354,10 @@ public class GraphEngine {
    * <p>
    * A vertex this transaction has WRITTEN itself needs no check: its own copy is authoritative, and a concurrent
    * commit over it cannot pass the version check on that write.
+   * <p>
+   * #6586: the failures of that re-read are answered by what they are rather than by where they happen. A vertex
+   * that has VANISHED is not a conflict at any point - see the catch - and one that reads back as something other
+   * than a vertex no longer asserts a cause this frame cannot establish.
    */
   private void checkEdgeListHeadsUnchanged(final VertexInternal vertex, final RID walkedOutHead,
       final RID walkedInHead) {
@@ -1236,14 +1377,36 @@ public class GraphEngine {
       // cache if this transaction wrote the record earlier, which is exactly the case the guard above returns on.
       committed = (VertexInternal) database.lookupByRID(vertexRID, true);
     } catch (final RecordNotFoundException e) {
-      // The vertex is already gone: a concurrent transaction deleted it while this one was disconnecting its
-      // edges. Retry, and let the re-read decide there is nothing left to delete.
-      throw new ConcurrentModificationException(
-          "Vertex " + vertexRID + " was deleted by a concurrent transaction while its edges were being removed", e);
+      // #6586: told apart by the RID the not-found names, the discriminator #6572 established. A record OTHER than
+      // the vertex - a continuation chunk of a multi-page vertex body a concurrent commit is republishing - really
+      // is the publication window this check runs inside, and stays the retryable conflict it always was.
+      if (!vertexRID.equals(e.getRID()))
+        throw new ConcurrentModificationException(
+            "Vertex " + vertexRID + " is not fully visible while its edges are being removed (concurrent commit in "
+                + "flight): " + e.getMessage(), e);
+
+      // The VERTEX ITSELF is gone. This used to be asserted as a concurrent delete and reported as retryable, and
+      // it was neither: single-threaded runs reached it too - a materialised handle used past its record's removal
+      // walked the whole list off a stale buffer and arrived here - so the message named a cause that had not
+      // happened, and the retry re-ran a transaction that could only fail identically.
+      //
+      // deleteVertex now probes the slot before the walk, so a delete that gets this far DID see the record in its
+      // bucket when it started. The claim is therefore provable rather than assumed - nothing else removes it
+      // between the probe and here, since this method runs before the physical delete - but it changes nothing
+      // about the verdict: the record is gone for good, and a retry would only spend an attempt rediscovering that
+      // at the probe. Same type as every other "the vertex is not there" this engine can raise (#6586).
+      throw missingVertexOnDelete(vertexRID, e);
     } catch (final ClassCastException e) {
-      // The RID no longer names a vertex: the slot was reused after a concurrent delete. Same answer as above.
+      // #6586: what is OBSERVED, without a cause invented to explain it. The old wording asserted a slot reused
+      // after a concurrent delete, which this frame cannot establish: a bucket maps to exactly one type, so the
+      // record read back through the same RID normally cannot change kind at all, and the ways it can - a type
+      // re-mapped by a DDL committing underneath, a handle from a bucket that has since been reassigned - are not
+      // distinguishable here. Retryable is kept for the same reason it was chosen: unlike a record that is gone,
+      // this really can resolve on a re-read against a settled schema, and there is no better-typed answer to
+      // promote it to.
       throw new ConcurrentModificationException(
-          "Vertex " + vertexRID + " no longer names a vertex record (concurrent commit in flight)", e);
+          "Vertex " + vertexRID + " no longer reads back as a vertex record while its edges are being removed "
+              + "(concurrent commit in flight)", e);
     }
 
     final RID[] committedHeads = readEdgeListHeads(committed);
@@ -2109,10 +2272,7 @@ public class GraphEngine {
       // exists. Reported honestly it is a plain not-found: no retry budget spent, and the advice names a command
       // that can actually be run. RID.equals(null) is false, so a cause carrying no RID takes the conflict arm.
       if (vertexRID != null && vertexRID.equals(e.getRID()))
-        throw new VertexNotFoundException(
-            "Vertex " + vertexRID + " does not exist, so its " + direction + " edge list cannot be modified: it was "
-                + "reached through a reference to a record that is gone (a stale edge entry, or a RID held past the "
-                + "delete). Retrying cannot make it exist: " + missingVertexRepairAdvice(), vertexRID, e);
+        throw missingVertexOnEdgeListWrite(vertexRID, direction, e);
 
       // The cause and the interpolated e.getMessage() are NOT redundant, though they read that way (#5764). This
       // message is the only place the missing CHUNK's RID appears - the text above names the vertex, not the chunk,

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1271,8 +1271,7 @@ public class GraphEngine {
    * the point - a caller sweeping a graph catches ONE type whether it met the missing vertex while reading a list,
    * while extending one, or while dropping the vertex outright.
    *
-   * @param cause the not-found this diagnosis wraps - either the one the bucket raised, or the one
-   *              {@link #notFoundOnProbe} gives the slot probe's answer so the chain reads the same either way
+   * @param cause the not-found this diagnosis wraps: the bucket's own, or {@link #notFoundOnProbe}'s
    */
   private static VertexNotFoundException missingVertexOnDelete(final RID vertexRID, final Exception cause) {
     return new VertexNotFoundException(

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1121,11 +1121,7 @@ public class GraphEngine {
     // materialised one because materialising it was itself a read. The one thing that changes is WHEN a caller
     // lacking it is told, which is now before the walk rather than during it.
     final RID vertexRID = mostUpdatedVertex.getIdentity();
-    final Bucket vertexBucket = database.getSchema().getBucketByIdIfExists(vertexRID.getBucketId());
-    if (vertexBucket == null || !vertexBucket.existsRecord(vertexRID))
-      // A bucket that no longer exists means the same thing to the caller as a slot that no longer holds a record
-      // (#4501): the RID names nothing. Answering it here also keeps getBucketById's SchemaException - a message
-      // about internal file ids - off a path whose whole subject is a reference that outlived its target.
+    if (!vertexBucketOf(vertexRID).existsRecord(vertexRID))
       throw missingVertexOnDelete(vertexRID, notFoundOnProbe(vertexRID));
 
     // The heads this delete is about to walk, kept for checkEdgeListHeadsUnchanged below.
@@ -1161,12 +1157,8 @@ public class GraphEngine {
     // and the probe a few lines up has already ruled that out for a single-threaded caller. The RID is still
     // compared rather than assumed, since the day that stops holding is exactly the day a silent mis-attribution
     // would be hardest to spot.
-    final Bucket bucketAtDelete = database.getSchema().getBucketByIdIfExists(vertexRID.getBucketId());
-    if (bucketAtDelete == null)
-      throw missingVertexOnDelete(vertexRID, notFoundOnProbe(vertexRID));
-
     try {
-      bucketAtDelete.deleteRecord(vertexRID, force);
+      vertexBucketOf(vertexRID).deleteRecord(vertexRID, force);
     } catch (final RecordNotFoundException e) {
       if (!vertexRID.equals(e.getRID()))
         throw e;
@@ -1284,6 +1276,26 @@ public class GraphEngine {
         "Vertex " + vertexRID + " does not exist, so its " + direction + " edge list cannot be modified: it was "
             + "reached through a reference to a record that is gone (a stale edge entry, or a RID held past the "
             + "delete). Retrying cannot make it exist: " + missingVertexRepairAdvice(), vertexRID, cause);
+  }
+
+  /**
+   * The bucket holding {@code vertexRID}, or the same failure a missing SLOT produces when the whole BUCKET is
+   * gone (#6586).
+   * <p>
+   * {@code getBucketByIdIfExists} and not {@code getBucketById}: a RID whose bucket has been dropped names nothing,
+   * exactly as a RID whose slot is empty does (#4501), and that is what the caller has to be told. The
+   * {@code SchemaException} the strict form raises talks about an internal file id instead, on a path whose whole
+   * subject is a reference that outlived its target.
+   * <p>
+   * Called TWICE inside {@link #deleteVertex} rather than resolved once and carried, which is the point of it being
+   * a method: the edge walk between the two can be long on a super-node, so the delete resolves the bucket again
+   * instead of writing through a reference taken before that walk began.
+   */
+  private Bucket vertexBucketOf(final RID vertexRID) {
+    final Bucket bucket = database.getSchema().getBucketByIdIfExists(vertexRID.getBucketId());
+    if (bucket == null)
+      throw missingVertexOnDelete(vertexRID, notFoundOnProbe(vertexRID));
+    return bucket;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1142,17 +1142,18 @@ public class GraphEngine {
     if (!force && headsAtWalkStart != null)
       checkEdgeListHeadsUnchanged(mostUpdatedVertex, headsAtWalkStart[0], headsAtWalkStart[1]);
 
-    // DELETE VERTEX RECORD, through the bucket the probe already resolved rather than through a second schema
-    // lookup. The assumption that makes that safe is worth stating: nothing between the two points can re-map this
-    // vertex's bucket, because everything between them is this method's own edge walk - no user code, no DDL, and
-    // the before-delete events fired one frame up in LocalDatabase.deleteRecordNoLock have already run. Reusing it
-    // is also the better failure mode of the two: a bucket that HAS gone is answered as "the RID names nothing"
-    // by the probe, rather than as getBucketById's SchemaException about an internal file id.
+    // DELETE VERTEX RECORD, through a bucket resolved AGAIN rather than through the one the probe captured. The
+    // walk between the two can be long on a super-node, so the reference taken before it is a reference that has
+    // had time to go stale - and a delete written through a bucket whose file has since been closed or re-mapped
+    // is the one mistake here that would not announce itself. Re-resolving costs a map lookup on a path that has
+    // just walked an adjacency list; the freshness is worth more. Null-tolerantly, so a bucket dropped underneath
+    // this delete answers "the RID names nothing" like the probe does, rather than getBucketById's SchemaException
+    // about an internal file id.
     //
-    // #6586: the probe at the top is what normally decides this, so a not-found HERE would be
-    // the residual - the record going away between the two. Answering it with the same type keeps the contract
-    // whole (this method reports a missing vertex ONE way) instead of letting the last statement leak the bare
-    // "Record #x:y not found" the append path used to.
+    // #6586: the probe at the top is what normally decides the not-found, so one HERE is the residual - the record
+    // going away between the two. Answering it with the same type keeps the contract whole (this method reports a
+    // missing vertex ONE way) instead of letting the last statement leak the bare "Record #x:y not found" the
+    // append path used to.
     //
     // FUTURE-PROOFING, not a live path, and worth saying so before someone goes hunting for the case that reaches
     // it: LocalBucket.deleteRecordInternal already swallows every not-found naming a record OTHER than the one it
@@ -1160,8 +1161,12 @@ public class GraphEngine {
     // and the probe a few lines up has already ruled that out for a single-threaded caller. The RID is still
     // compared rather than assumed, since the day that stops holding is exactly the day a silent mis-attribution
     // would be hardest to spot.
+    final Bucket bucketAtDelete = database.getSchema().getBucketByIdIfExists(vertexRID.getBucketId());
+    if (bucketAtDelete == null)
+      throw missingVertexOnDelete(vertexRID, notFoundOnProbe(vertexRID));
+
     try {
-      vertexBucket.deleteRecord(vertexRID, force);
+      bucketAtDelete.deleteRecord(vertexRID, force);
     } catch (final RecordNotFoundException e) {
       if (!vertexRID.equals(e.getRID()))
         throw e;

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -509,6 +509,12 @@ public class GraphEngine {
     } catch (final RecordNotFoundException e) {
       if (vertexRID != null && vertexRID.equals(e.getRID()))
         throw missingVertexOnEdgeListWrite(vertexRID, direction, e);
+      // DEFENSIVE, and stated so nobody hunts for the case that reaches it: a not-found from THIS read naming a
+      // record other than the vertex would have to be a continuation chunk of a multi-page vertex body, which the
+      // loader reports as BrokenChunkChainException or as a conflict of its own (#6258) rather than as a bare
+      // not-found. It is converted rather than rethrown because the policy for an unidentified missing record on a
+      // path about to WRITE a list is #5670's - retry, do not skip the write - and that is the one thing this arm
+      // must not get wrong if it ever does become reachable.
       throw new ConcurrentModificationException(
           "Vertex " + vertexRID + " is not fully visible yet (concurrent commit in flight), so its " + direction
               + " edge list cannot be extended: " + e.getMessage(), e);

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1142,7 +1142,14 @@ public class GraphEngine {
     if (!force && headsAtWalkStart != null)
       checkEdgeListHeadsUnchanged(mostUpdatedVertex, headsAtWalkStart[0], headsAtWalkStart[1]);
 
-    // DELETE VERTEX RECORD. #6586: the probe at the top is what normally decides this, so a not-found HERE would be
+    // DELETE VERTEX RECORD, through the bucket the probe already resolved rather than through a second schema
+    // lookup. The assumption that makes that safe is worth stating: nothing between the two points can re-map this
+    // vertex's bucket, because everything between them is this method's own edge walk - no user code, no DDL, and
+    // the before-delete events fired one frame up in LocalDatabase.deleteRecordNoLock have already run. Reusing it
+    // is also the better failure mode of the two: a bucket that HAS gone is answered as "the RID names nothing"
+    // by the probe, rather than as getBucketById's SchemaException about an internal file id.
+    //
+    // #6586: the probe at the top is what normally decides this, so a not-found HERE would be
     // the residual - the record going away between the two. Answering it with the same type keeps the contract
     // whole (this method reports a missing vertex ONE way) instead of letting the last statement leak the bare
     // "Record #x:y not found" the append path used to.
@@ -1421,6 +1428,11 @@ public class GraphEngine {
       // between the probe and here, since this method runs before the physical delete - but it changes nothing
       // about the verdict: the record is gone for good, and a retry would only spend an attempt rediscovering that
       // at the probe. Same type as every other "the vertex is not there" this engine can raise (#6586).
+      //
+      // Reached only by a GENUINELY concurrent delete now, which is why no test pins this line: the single-threaded
+      // shapes that used to arrive here are all decided by the probe, and racing two real transactions into a
+      // window a few instructions wide is not something a test can do deterministically. Covered by reasoning, and
+      // said so rather than left to look like an oversight.
       throw missingVertexOnDelete(vertexRID, e);
     } catch (final ClassCastException e) {
       // #6586: what is OBSERVED, without a cause invented to explain it. The old wording asserted a slot reused

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1100,6 +1100,14 @@ public class GraphEngine {
     // Not tolerated under force either, for the reason #6572 spells out: deleting a record that is not there is an
     // error on every other path in the engine too, and succeeding quietly would hide the one thing the caller
     // needs to know - that something still points at a record that is gone.
+    //
+    // Bucket.existsRecord checks READ_RECORD on the file, where deleteRecord below checks only DELETE_RECORD, so
+    // this states a requirement the delete did not state HERE before. It does not widen what a caller must hold:
+    // a probe that answers whether a record exists IS a read, resolveEndpointToDisconnect already runs one on this
+    // same path for the endpoint at the far end, and every route into this method already needed READ_RECORD on
+    // this very bucket - a lazy handle because the head-pointer read loads the record a few lines down, and a
+    // materialised one because materialising it was itself a read. The one thing that changes is WHEN a caller
+    // lacking it is told, which is now before the walk rather than during it.
     final RID vertexRID = mostUpdatedVertex.getIdentity();
     final Bucket vertexBucket = database.getSchema().getBucketByIdIfExists(vertexRID.getBucketId());
     if (vertexBucket == null || !vertexBucket.existsRecord(vertexRID))
@@ -1122,14 +1130,21 @@ public class GraphEngine {
     if (!force && headsAtWalkStart != null)
       checkEdgeListHeadsUnchanged(mostUpdatedVertex, headsAtWalkStart[0], headsAtWalkStart[1]);
 
-    // DELETE VERTEX RECORD. #6586: the probe at the top is what normally decides this, so a not-found HERE is the
-    // residual - the record went away between the two, or the probe's page view was superseded. Answering it with
-    // the same type keeps the contract whole (this method reports a missing vertex ONE way) instead of letting the
-    // last statement leak the bare "Record #x:y not found" the append path used to.
+    // DELETE VERTEX RECORD. #6586: the probe at the top is what normally decides this, so a not-found HERE would be
+    // the residual - the record going away between the two. Answering it with the same type keeps the contract
+    // whole (this method reports a missing vertex ONE way) instead of letting the last statement leak the bare
+    // "Record #x:y not found" the append path used to.
+    //
+    // FUTURE-PROOFING, not a live path, and worth saying so before someone goes hunting for the case that reaches
+    // it: LocalBucket.deleteRecordInternal already swallows every not-found naming a record OTHER than the one it
+    // was given (placeholder content, continuation chunks), so anything escaping here can only name vertexRID -
+    // and the probe a few lines up has already ruled that out for a single-threaded caller. The RID is still
+    // compared rather than assumed, since the day that stops holding is exactly the day a silent mis-attribution
+    // would be hardest to spot.
     try {
       vertexBucket.deleteRecord(vertexRID, force);
     } catch (final RecordNotFoundException e) {
-      if (e instanceof VertexNotFoundException || !vertexRID.equals(e.getRID()))
+      if (!vertexRID.equals(e.getRID()))
         throw e;
       throw missingVertexOnDelete(vertexRID, e);
     }

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -566,6 +566,12 @@ public class GraphEngine {
       // is discovered here instead. Same fact, same answer.
       if (vertexRID != null && vertexRID.equals(e.getRID()))
         throw missingVertexOnEdgeListWrite(vertexRID, direction, e);
+      // The "some OTHER record" case is rethrown here where the head read above converts it to a conflict, and the
+      // asymmetry is deliberate rather than an omission. Up there the read is the FIRST thing this method does, so
+      // an unidentified missing record has to be answered by the policy for a list write that has not begun -
+      // #5670's, retry rather than skip. Down here the vertex has already been read successfully once, three lines
+      // up, so a not-found naming anything else is not a fact about this list at all; re-typing it as a conflict on
+      // this list would be inventing a diagnosis, which is the whole thing #6586 is about not doing.
       throw e;
     }
     final RID reloadedHead = direction == Vertex.DIRECTION.OUT ? mutable.getOutEdgesHeadChunk() : mutable.getInEdgesHeadChunk();

--- a/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
@@ -20,18 +20,24 @@ package com.arcadedb.graph;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
+import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.exception.VertexNotFoundException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -395,6 +401,89 @@ class Issue6586MissingVertexDiagnosisTest extends TestHelper {
     assertThat(thrown).isInstanceOf(VertexNotFoundException.class);
     assertThat(thrown).isNotInstanceOf(NeedRetryException.class);
     assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(targetRID);
+  }
+
+  /**
+   * The probe reads the slot through {@code Bucket.existsRecord}, which checks {@code READ_RECORD}, where the
+   * physical delete under it checks only {@code DELETE_RECORD}. That is a real asymmetry, and this pins why it
+   * cannot cost anybody a delete they used to be able to perform: a principal without {@code READ_RECORD} on the
+   * bucket cannot obtain a vertex handle in the first place, so it never reaches {@code deleteVertex} to be
+   * refused there. The refusal it gets is the same one, from the same check, that it always got.
+   * <p>
+   * Both halves matter. The first asserts the read is refused; the second grants {@code READ_RECORD} back, leaving
+   * the same {@code DELETE_RECORD} grant in place, and asserts the delete then goes through - without which the
+   * first half would prove only that the stub user denies everything.
+   */
+  @Test
+  void aPrincipalWithoutReadPermissionCannotReachTheDeleteAtAll() {
+    final String path = "target/databases/Issue6586PermissionProbe";
+
+    final DatabaseFactory factory = new DatabaseFactory(path).setSecurity(database -> {
+    });
+    if (factory.exists())
+      factory.open().drop();
+
+    final Database restricted = factory.create();
+    try {
+      restricted.transaction(() -> restricted.getSchema().createVertexType("Guarded", 1));
+
+      final RID[] guarded = new RID[1];
+      restricted.transaction(() -> {
+        final MutableVertex v = restricted.newVertex("Guarded");
+        v.save();
+        guarded[0] = v.getIdentity();
+      });
+
+      final Set<SecurityDatabaseUser.ACCESS> granted = EnumSet.of(SecurityDatabaseUser.ACCESS.DELETE_RECORD);
+      DatabaseContext.INSTANCE.getContext(restricted.getDatabasePath()).setCurrentUser(userGranting(granted));
+
+      // lookupByRID rather than RID.asVertex(): the latter rewraps everything that is not already a not-found into
+      // one (DatabaseRID.asVertex), so a permission denial reaches the caller disguised as "Record #x:y not found".
+      // Pre-existing and not this issue's subject, but it would make the assertion below read the wrong failure.
+      assertThat(catchThrowable(
+          () -> restricted.transaction(() -> restricted.lookupByRID(guarded[0], true), false, 1)))
+          .as("a handle cannot be obtained without READ_RECORD, which is what keeps the probe out of the picture")
+          .isInstanceOf(SecurityException.class);
+
+      granted.add(SecurityDatabaseUser.ACCESS.READ_RECORD);
+      restricted.transaction(() -> guarded[0].asVertex().delete());
+      restricted.transaction(() -> assertThat(restricted.existsRecord(guarded[0])).isFalse());
+
+    } finally {
+      DatabaseContext.INSTANCE.getContext(restricted.getDatabasePath()).setCurrentUser(null);
+      restricted.drop();
+      factory.close();
+    }
+  }
+
+  /** A principal that allows the database wholesale and exactly {@code granted} on every file. */
+  private static SecurityDatabaseUser userGranting(final Set<SecurityDatabaseUser.ACCESS> granted) {
+    return new SecurityDatabaseUser() {
+      @Override
+      public String getName() {
+        return "restricted";
+      }
+
+      @Override
+      public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public boolean requestAccessOnFile(final int fileId, final ACCESS access) {
+        return granted.contains(access);
+      }
+
+      @Override
+      public long getResultSetLimit() {
+        return -1L;
+      }
+
+      @Override
+      public long getReadTimeout() {
+        return -1L;
+      }
+    };
   }
 
   // ---------------------------------------------------------------------------------------------------------

--- a/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.exception.VertexNotFoundException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * #6586: the two paths #6572 did not reach, where a caller meets a vertex whose RECORD is gone.
+ * <p>
+ * #6572 split "the vertex is not there" out of {@code GraphEngine.getEdgeHeadChunkForWrite}'s retryable conflict
+ * using the RID the {@code RecordNotFoundException} names, and gave it a non-retryable
+ * {@link VertexNotFoundException} carrying a repair that applies. That split fires only when the head-pointer read
+ * has to go back to the bucket, so two adjacent paths still answered the same fact in their own, worse way:
+ * <ul>
+ *   <li>a MATERIALISED handle - a RID whose content was loaded earlier in the transaction and used after the
+ *   record went away - answers its head pointers out of the buffer it already holds, so the whole removal walk ran
+ *   on stale heads and only the re-read at the end of the delete noticed. It then reported a
+ *   {@link ConcurrentModificationException} asserting the vertex "was deleted by a concurrent transaction", which
+ *   was retryable (a full budget spent on a foregone failure) and, single-threaded, simply untrue;</li>
+ *   <li>the APPEND path ({@code getOrCreateEdgeList}) read the head RID OUTSIDE its {@code try}, so the lazy load
+ *   escaped as a bare {@code Record #x:y not found}: the right verdict, and no diagnosis at all - not that the
+ *   record is a VERTEX, not that it is an ENDPOINT of an edge being created, not which side of the list, and no
+ *   repair to run.</li>
+ * </ul>
+ * Both sides of the same list must now answer alike, and the delete must decide it before it walks anything.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6586MissingVertexDiagnosisTest extends TestHelper {
+  private RID srcRID;
+  private RID targetRID;
+
+  /** Most of these tests deliberately leave a reference into a deleted record, so the end-of-test check would fire. */
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // ITEM 1 - the removal side reached through a materialised handle
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * The reported shape: single-threaded, nothing else touching the database, and the failure nonetheless named a
+   * concurrent transaction as the cause. It must name what actually happened, and must not advertise a retry that
+   * cannot work.
+   */
+  @Test
+  void aDeleteThroughAMaterialisedHandleIsNotReportedAsAConcurrentDelete() {
+    createGraph();
+
+    final Throwable thrown = catchThrowable(
+        () -> database.transaction(this::deleteTargetThroughAMaterialisedHandle, false, 1));
+
+    assertThat(thrown).isInstanceOf(VertexNotFoundException.class).isInstanceOf(RecordNotFoundException.class);
+    assertThat(thrown).as("a record that is gone must not be advertised as retryable: %s", thrown)
+        .isNotInstanceOf(NeedRetryException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(targetRID);
+
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage())
+        .contains(targetRID.toString())
+        .contains("does not exist")
+        .contains("cannot be deleted")
+        .doesNotContain("concurrent");
+
+    // Every other failure this delete can produce says how to recover; this one used to say nothing.
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage()).contains("CHECK DATABASE FIX");
+    assertThat(scopedRepairCommandIn(thrown.getMessage()))
+        .as("no runnable RECORD-scoped command may appear, its target is the record that is gone: %s",
+            thrown.getMessage())
+        .isNull();
+  }
+
+  /**
+   * The cost the old diagnosis hid: the whole edge walk ran, disconnecting every edge from its FAR endpoint, only
+   * to reach a failure that was decidable up front.
+   * <p>
+   * Proven with a TRIPWIRE rather than by inspection, and the tripwire is armed first so the assertion cannot pass
+   * vacuously: src's edge-list head chunk is destroyed, which makes the walk itself fail with a conflict naming
+   * that chunk. The first half of this test shows the walk really does run and really does hit it; the second half
+   * shows that with the vertex record gone the delete never gets there.
+   */
+  @Test
+  void theDeleteIsRefusedBeforeTheWalkDisconnectsAnything() {
+    createGraph();
+
+    final RID headChunk = outHeadChunk(srcRID);
+    deleteRecordOf(headChunk);
+
+    final Throwable walked = catchThrowable(() -> database.transaction(() -> targetRID.asVertex().delete(), false, 1));
+    assertThat(walked).as("tripwire: with the vertex present the walk must run and fail on src's unreadable list")
+        .isInstanceOf(ConcurrentModificationException.class);
+    assertThat(walked.getMessage()).as("%s", walked.getMessage()).contains(headChunk.toString());
+
+    final Throwable refused = catchThrowable(
+        () -> database.transaction(this::deleteTargetThroughAMaterialisedHandle, false, 1));
+
+    assertThat(refused).as("the missing vertex must be decided before the walk: %s", refused)
+        .isInstanceOf(VertexNotFoundException.class);
+    assertThat(refused.getMessage()).as("the walk never ran, so no chunk of it may appear: %s", refused.getMessage())
+        .doesNotContain(headChunk.toString());
+  }
+
+  /** The half that hurt a batch job: the type is what the retry machinery reads. Counted, not inferred. */
+  @Test
+  void theDeleteDoesNotSpendTheRetryBudget() {
+    createGraph();
+
+    final AtomicInteger attempts = new AtomicInteger();
+    assertThatThrownBy(() -> database.transaction(() -> {
+      attempts.incrementAndGet();
+      deleteTargetThroughAMaterialisedHandle();
+    }, false, 3)).isInstanceOf(VertexNotFoundException.class);
+
+    assertThat(attempts.get()).as("a failure that can never succeed must not be retried").isEqualTo(1);
+  }
+
+  /** The same answer whichever handle the caller holds: a LAZY one (#6572's path) and a materialised one agree. */
+  @Test
+  void bothHandleShapesAnswerTheMissingVertexWithOneCatchableType() {
+    createDanglingReference();
+
+    final Throwable throughAStaleEntry = catchThrowable(() -> database.transaction(() -> {
+      for (final Vertex v : srcRID.asVertex().getVertices(Vertex.DIRECTION.OUT, "E1"))
+        v.delete();
+    }, false, 1));
+
+    createGraph();
+    final Throwable throughAMaterialisedHandle = catchThrowable(
+        () -> database.transaction(this::deleteTargetThroughAMaterialisedHandle, false, 1));
+
+    assertThat(throughAStaleEntry).isInstanceOf(VertexNotFoundException.class);
+    assertThat(throughAMaterialisedHandle).isInstanceOf(VertexNotFoundException.class);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // ITEM 2 - the append side
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * Creating an edge whose TARGET record is gone used to raise {@code RecordNotFoundException: Record #x:y not
+   * found} - a verdict with no diagnosis. It must say the same things the removal side says: that the missing
+   * record is a vertex, which side of the list was being written, and what to run.
+   */
+  @Test
+  void theAppendPathNamesTheMissingEndpointVertexTheWayTheRemovalSideDoes() {
+    createDanglingReference();
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(this::linkEverythingSrcPointsAtToItself, false, 1));
+
+    assertThat(thrown).isInstanceOf(VertexNotFoundException.class).isInstanceOf(RecordNotFoundException.class);
+    assertThat(thrown).as("unchanged verdict: a record that is gone was never retryable here either: %s", thrown)
+        .isNotInstanceOf(NeedRetryException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(targetRID);
+
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage())
+        .contains(targetRID.toString())
+        .contains("does not exist")
+        // The endpoint that is gone is the TARGET, so the side named must be the one being written on it.
+        .contains(Vertex.DIRECTION.IN + " edge list")
+        .contains("CHECK DATABASE FIX");
+    assertThat(scopedRepairCommandIn(thrown.getMessage())).as("%s", thrown.getMessage()).isNull();
+
+    assertThat(thrown.getCause()).as("the diagnosis must WRAP the not-found, not replace it")
+        .isInstanceOf(RecordNotFoundException.class);
+  }
+
+  /** The other side of the append: the SOURCE vertex is the one that is gone, so OUT is the side named. */
+  @Test
+  void theAppendPathNamesTheMissingSourceVertexToo() {
+    createGraph();
+    deleteRecordOf(srcRID);
+
+    // A LAZY handle, the shape a stale RID from a previous traversal step has: resolving it eagerly would fail in
+    // the caller's own lookup and never reach the append at all.
+    final Throwable thrown = catchThrowable(() -> database.transaction(
+        () -> database.lookupByRID(srcRID, false).asVertex().newEdge("E1", targetRID.asVertex()), false, 1));
+
+    assertThat(thrown).isInstanceOf(VertexNotFoundException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(srcRID);
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage()).contains(Vertex.DIRECTION.OUT + " edge list");
+  }
+
+  /**
+   * The guard against the fix creeping over the case it must not touch: a vertex that EXISTS whose head chunk
+   * cannot be read is still the publication window #5670 answers with a retryable conflict on the append path,
+   * exactly as {@code getEdgeHeadChunkForWrite} keeps it on the removal path.
+   */
+  @Test
+  void theAppendPathKeepsItsRetryableConflictForAnUnreadableHeadChunk() {
+    createGraph();
+
+    final RID headChunk = outHeadChunk(srcRID);
+    deleteRecordOf(headChunk);
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(
+        () -> srcRID.asVertex().newEdge("E1", targetRID.asVertex()), false, 1));
+
+    assertThat(thrown).isInstanceOf(ConcurrentModificationException.class).isInstanceOf(NeedRetryException.class);
+    assertThat(thrown).isNotInstanceOf(VertexNotFoundException.class);
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage()).contains(headChunk.toString());
+  }
+
+  /** The advice is only worth printing if it repairs the database, so this runs it. */
+  @Test
+  void theRepairTheAppendPathAdvertisesIsTheOneThatWorks() {
+    createDanglingReference();
+
+    assertThatThrownBy(() -> database.transaction(this::linkEverythingSrcPointsAtToItself, false, 1))
+        .isInstanceOf(VertexNotFoundException.class);
+
+    try (final ResultSet rs = database.command("sql", "check database fix")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(longProperty(row, "autoFix")).as("the fix must repair something: %s", row.toJSON()).isGreaterThan(0L);
+    }
+
+    // The stale entry is gone, so the sweep that could not run at all now completes - over nothing.
+    database.transaction(this::linkEverythingSrcPointsAtToItself);
+    database.transaction(() -> assertThat(srcRID.asVertex().countEdges(Vertex.DIRECTION.OUT, "E1")).isEqualTo(0L));
+
+    assertIntegrityClean();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // The probe must not change what a healthy delete does
+  // ---------------------------------------------------------------------------------------------------------
+
+  /**
+   * The slot probe reads the BUCKET, not the transaction's record caches, so it has to see a record this very
+   * transaction created a statement earlier - whose slot is allocated eagerly at save() but whose only in-memory
+   * form is the transaction's own copy. If that assumption were wrong, create-then-delete would stop working.
+   */
+  @Test
+  void aVertexCreatedAndDeletedInTheSameTransactionStillDeletes() {
+    createGraph();
+
+    final RID[] created = new RID[1];
+    database.transaction(() -> {
+      final MutableVertex extra = database.newVertex("Target");
+      extra.save();
+      created[0] = extra.getIdentity();
+      srcRID.asVertex().newEdge("E1", extra);
+      extra.delete();
+    });
+
+    database.transaction(() -> {
+      assertThat(database.existsRecord(created[0])).isFalse();
+      assertThat(srcRID.asVertex().countEdges(Vertex.DIRECTION.OUT, "E1")).isEqualTo(1L);
+    });
+    assertIntegrityClean();
+  }
+
+  /** An ordinary delete of a healthy connected vertex is untouched, edges and all. */
+  @Test
+  void anOrdinaryVertexDeleteIsUnaffected() {
+    createGraph();
+
+    database.transaction(() -> targetRID.asVertex().delete());
+
+    database.transaction(() -> {
+      assertThat(database.existsRecord(targetRID)).isFalse();
+      assertThat(srcRID.asVertex().countEdges(Vertex.DIRECTION.OUT, "E1")).isEqualTo(0L);
+    });
+    assertIntegrityClean();
+  }
+
+  /** Deleting the same vertex twice in one transaction is the plainest form of "a RID held past the delete". */
+  @Test
+  void deletingTheSameVertexTwiceInOneTransactionSaysItIsGone() {
+    createGraph();
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(() -> {
+      final Vertex target = targetRID.asVertex();
+      target.delete();
+      target.delete();
+    }, false, 1));
+
+    assertThat(thrown).isInstanceOf(VertexNotFoundException.class);
+    assertThat(thrown).isNotInstanceOf(NeedRetryException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(targetRID);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Fixtures
+  // ---------------------------------------------------------------------------------------------------------
+
+  /** {@code src --E1--> target}, plain vertex types, single-threaded, nothing else writing the database. */
+  private void createGraph() {
+    if (!database.getSchema().existsType("Src"))
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Src", 1);
+        database.getSchema().createVertexType("Target", 1);
+        database.getSchema().createEdgeType("E1", 1);
+      });
+
+    database.transaction(() -> {
+      final MutableVertex src = database.newVertex("Src");
+      src.save();
+      final MutableVertex target = database.newVertex("Target");
+      target.save();
+      srcRID = src.getIdentity();
+      targetRID = target.getIdentity();
+      src.newEdge("E1", target);
+    });
+  }
+
+  /**
+   * The same graph with target's RECORD dropped straight out of its bucket and the adjacency entry on src left in
+   * place: the state a pre-#5670 best-effort edge delete left behind, reproduced without any concurrency.
+   */
+  private void createDanglingReference() {
+    createGraph();
+    deleteRecordOf(targetRID);
+
+    database.transaction(() -> assertThat(srcRID.asVertex().countEdges(Vertex.DIRECTION.OUT, "E1")).isEqualTo(1L));
+  }
+
+  /**
+   * A RID held past its record: the buffer is loaded first, so every later read of the vertex answers from it and
+   * touches no bucket at all - which is why #6572's discriminator, which lives in a read that DOES go back to the
+   * bucket, never runs on this shape.
+   */
+  private void deleteTargetThroughAMaterialisedHandle() {
+    final Vertex target = database.lookupByRID(targetRID, true).asVertex();
+    assertThat(target.getPropertyNames()).as("the buffer must be materialised for this fixture to mean anything")
+        .isNotNull();
+
+    database.getSchema().getBucketById(targetRID.getBucketId()).deleteRecord(targetRID);
+
+    target.delete();
+  }
+
+  /** Walk what src points at and create an edge back: reaching the missing target through the stale entry. */
+  private void linkEverythingSrcPointsAtToItself() {
+    for (final Vertex v : srcRID.asVertex().getVertices(Vertex.DIRECTION.OUT, "E1"))
+      srcRID.asVertex().newEdge("E1", v);
+  }
+
+  private RID outHeadChunk(final RID vertexRID) {
+    final RID[] holder = new RID[1];
+    database.transaction(() -> holder[0] = ((VertexInternal) vertexRID.asVertex()).getOutEdgesHeadChunk());
+    assertThat(holder[0]).as("the vertex must have an outgoing edge list").isNotNull();
+    return holder[0];
+  }
+
+  private void deleteRecordOf(final RID rid) {
+    database.transaction(() -> database.getSchema().getBucketById(rid.getBucketId()).deleteRecord(rid));
+    database.transaction(() -> assertThat(database.existsRecord(rid)).isFalse());
+  }
+
+  /** The {@code CHECK DATABASE RECORD <rid> FIX} command a message tells the operator to run, or null. */
+  private static String scopedRepairCommandIn(final String message) {
+    final int start = message.indexOf("`CHECK DATABASE RECORD ");
+    if (start < 0)
+      return null;
+    final int end = message.indexOf('`', start + 1);
+    return end < 0 ? null : message.substring(start + 1, end);
+  }
+
+  /** Asserts on the fields {@code check database} actually reports, so a typo cannot make this vacuously pass. */
+  private void assertIntegrityClean() {
+    try (final ResultSet rs = database.command("sql", "check database")) {
+      assertThat(rs.hasNext()).isTrue();
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(longProperty(row, "autoFix")).as("autoFix: %s", row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "invalidLinks")).as("invalidLinks: %s", row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "totalWarnings")).as("totalWarnings: %s", row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "totalCorruptedRecords")).as("totalCorruptedRecords: %s", row.toJSON())
+            .isEqualTo(0L);
+      }
+    }
+  }
+
+  /** Reads a numeric check-database property, failing loudly when the field does not exist (a vacuous assertion). */
+  private static long longProperty(final Result row, final String name) {
+    final Object value = row.getProperty(name);
+    assertThat(value).as("check database must report '%s': %s", name, row.toJSON()).isNotNull();
+    return ((Number) value).longValue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.graph;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.NeedRetryException;
@@ -144,6 +145,33 @@ class Issue6586MissingVertexDiagnosisTest extends TestHelper {
     }, false, 3)).isInstanceOf(VertexNotFoundException.class);
 
     assertThat(attempts.get()).as("a failure that can never succeed must not be retried").isEqualTo(1);
+  }
+
+  /**
+   * {@code force} is the documented escape hatch from every other refusal this delete can raise - a list whose
+   * chunks cannot be read, a body that will not decode - and it is precisely the flag a later reader would assume
+   * should suppress this one too. It must not: a record that is not there cannot be deleted by insisting, and
+   * succeeding quietly would hide the reference that outlived it. Pinned so the intent survives that assumption.
+   */
+  @Test
+  void forceDoesNotSuppressAMissingVertexRecord() {
+    createDanglingReference();
+
+    final GraphEngine graphEngine = ((DatabaseInternal) database).getGraphEngine();
+
+    final Throwable thrown = catchThrowable(() -> database.transaction(() -> graphEngine.deleteVertex(
+        (VertexInternal) database.lookupByRID(targetRID, false).asVertex(), true), false, 1));
+
+    assertThat(thrown).as("force must not turn a record that is gone into a deleted one: %s", thrown)
+        .isInstanceOf(VertexNotFoundException.class);
+    assertThat(thrown).isNotInstanceOf(NeedRetryException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(targetRID);
+
+    // And the tripwire for that assertion: the SAME call on a vertex that does exist goes through, so the failure
+    // above is about the missing record rather than about force being unusable from here.
+    database.transaction(
+        () -> graphEngine.deleteVertex((VertexInternal) database.lookupByRID(srcRID, true).asVertex(), true));
+    database.transaction(() -> assertThat(database.existsRecord(srcRID)).isFalse());
   }
 
   /** The same answer whichever handle the caller holds: a LAZY one (#6572's path) and a materialised one agree. */

--- a/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.VertexNotFoundException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -199,6 +200,35 @@ class Issue6586MissingVertexDiagnosisTest extends TestHelper {
     } finally {
       database.getConfiguration().setValue(GlobalConfiguration.DELETE_TOLERATE_BROKEN_CHAIN, previous);
     }
+  }
+
+  /**
+   * The other way a RID can name nothing: its BUCKET is gone, not just its slot (#4501). A handle held across a
+   * {@code DROP TYPE} is the plainest form of it, and the answer has to be the same - what the caller needs to know
+   * is that the reference outlived its target, not that some internal file id failed to resolve, which is all
+   * {@code getBucketById}'s {@code SchemaException} would have told them.
+   */
+  @Test
+  void aRidWhoseBucketIsGoneAnswersLikeARidWhoseSlotIsEmpty() {
+    createGraph();
+
+    // Materialised BEFORE the drop, so the delete below reads nothing through the schema on its way in.
+    final VertexInternal held = (VertexInternal) database.lookupByRID(targetRID, true).asVertex();
+    assertThat(held.getPropertyNames()).isNotNull();
+
+    database.transaction(() -> database.getSchema().dropType("Target"));
+    assertThat(database.getSchema().getBucketByIdIfExists(targetRID.getBucketId()))
+        .as("the fixture must actually remove the bucket, or this test proves nothing").isNull();
+
+    final GraphEngine graphEngine = ((DatabaseInternal) database).getGraphEngine();
+    final Throwable thrown = catchThrowable(
+        () -> database.transaction(() -> graphEngine.deleteVertex(held, false), false, 1));
+
+    assertThat(thrown).isInstanceOf(VertexNotFoundException.class);
+    assertThat(thrown).isNotInstanceOf(SchemaException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(targetRID);
+    assertThat(thrown.getMessage()).as("%s", thrown.getMessage()).contains(targetRID.toString())
+        .contains("does not exist");
   }
 
   /** The same answer whichever handle the caller holds: a LAZY one (#6572's path) and a materialised one agree. */

--- a/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue6586MissingVertexDiagnosisTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.graph;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
@@ -172,6 +173,32 @@ class Issue6586MissingVertexDiagnosisTest extends TestHelper {
     database.transaction(
         () -> graphEngine.deleteVertex((VertexInternal) database.lookupByRID(srcRID, true).asVertex(), true));
     database.transaction(() -> assertThat(database.existsRecord(srcRID)).isFalse());
+  }
+
+  /**
+   * The other lever that turns a refusal into a forced delete, and the reason it cannot reach this one:
+   * {@code LocalDatabase.deleteRecordNoLock} re-runs {@code deleteVertex} with {@code force} when a
+   * {@link ConcurrentModificationException} escapes AND the chain is confirmed broken - and since #6572 a missing
+   * vertex is no longer a {@code ConcurrentModificationException} at all, so that arm cannot see it. Pinned with
+   * the opt-in actually ON, because "it does not apply" is exactly the kind of claim that quietly stops holding.
+   */
+  @Test
+  void theBrokenChainOptInDoesNotForceThroughAMissingVertexRecord() {
+    createDanglingReference();
+
+    final Object previous = database.getConfiguration().getValue(GlobalConfiguration.DELETE_TOLERATE_BROKEN_CHAIN);
+    database.getConfiguration().setValue(GlobalConfiguration.DELETE_TOLERATE_BROKEN_CHAIN, true);
+    try {
+      final Throwable thrown = catchThrowable(() -> database.transaction(() -> {
+        for (final Vertex v : srcRID.asVertex().getVertices(Vertex.DIRECTION.OUT, "E1"))
+          v.delete();
+      }, false, 1));
+
+      assertThat(thrown).as("the broken-chain opt-in must not absorb a vertex that is not there: %s", thrown)
+          .isInstanceOf(VertexNotFoundException.class);
+    } finally {
+      database.getConfiguration().setValue(GlobalConfiguration.DELETE_TOLERATE_BROKEN_CHAIN, previous);
+    }
   }
 
   /** The same answer whichever handle the caller holds: a LAZY one (#6572's path) and a materialised one agree. */


### PR DESCRIPTION
Fixes #6586.

Both items were reproduced against the merged #6576 code before anything was changed, with the exact output the issue quotes:

```
ITEM1 >>> com.arcadedb.exception.ConcurrentModificationException: Vertex #4:0 was deleted by a concurrent transaction while its edges were being removed
ITEM2 >>> com.arcadedb.exception.RecordNotFoundException: Record #4:0 not found
```

and after the fix both answer:

```
ITEM1 >>> com.arcadedb.exception.VertexNotFoundException: Vertex #4:0 does not exist, so it cannot be deleted: it was reached through a reference to a record that is gone (a stale edge entry, or a RID held past the delete). Retrying cannot make it exist: run `CHECK DATABASE FIX` ...
ITEM2 >>> com.arcadedb.exception.VertexNotFoundException: Vertex #4:0 does not exist, so its IN edge list cannot be modified: it was reached through a reference to a record that is gone (a stale edge entry, or a RID held past the delete). Retrying cannot make it exist: run `CHECK DATABASE FIX` ...
```

## Item 1 - the delete

`deleteVertex` now probes the vertex's slot in its bucket before it reads any head pointer, and raises `VertexNotFoundException` there.

**Why not the discriminator the issue proposes.** The issue suggests using the fact that `readEdgeListHeads` already ran at the top of `deleteVertex` as proof "the record was there when the walk started". It is not proof, and it fails on exactly the case at hand: for a materialised handle that read answers from the buffer the handle already holds without touching the bucket, so it succeeds for a record that is gone. A discriminator built on it would still misclassify the reported shape, and would still pay for the full traversal first.

The slot probe reads the ground truth instead, and it also removes the wasted work the issue calls out - the walk had already disconnected the far-end reference of every edge before the failure fired.

Three deliberate choices in the probe:

- **the bucket, not `database.existsRecord()`**: the latter answers from the transaction's record caches first, which is precisely where a handle to a deleted record survives, so it would confirm the very thing being questioned;
- **the slot marker only**: `getRecord` would follow placeholder and chunk indirection and could raise on a corrupt body, which would make a corrupt vertex undeletable again (#4420/#4432). `Issue4432CorruptVertexDeleteTest` still passes;
- **not tolerated under `force`**, for the reason #6572 spells out: deleting a record that is not there is an error on every other path in the engine too, and succeeding quietly would hide the one thing the caller needs to know.

With the probe in front of it, `checkEdgeListHeadsUnchanged`'s re-read is left with a claim it can prove. Its `RecordNotFoundException` catch now splits on the same RID discriminator: a record other than the vertex (a continuation chunk a concurrent commit is republishing) keeps the retryable conflict, the vertex itself gets the same non-retryable `VertexNotFoundException` - retrying would only spend an attempt rediscovering the absence at the probe. The `ClassCastException` arm next to it no longer asserts a slot reuse this frame cannot establish; it stays retryable, since unlike a record that is gone a type read can genuinely resolve against a settled schema, and the comment says why.

## Item 2 - the append

`getOrCreateEdgeList` read the head RID outside its `try`. It moves inside and splits on the same discriminator, so a lazy handle to a record that is gone now gets the message and advice the removal side has. `vertex.modify()` in the create-the-first-chunk branch is guarded too - it reloads a handle the transaction does not already hold, which is where a materialised handle with no head pointer surfaces.

Rather than copying `getEdgeHeadChunkForWrite`'s message as the issue suggests, the wording moved into shared factories (`missingVertexOnEdgeListWrite`, `missingVertexOnDelete`) that all four sites call, so the two sides cannot drift apart again.

One catchable type therefore covers the whole surface: removing an entry from an edge list, adding one to it, and deleting the vertex outright. An unreadable *chunk* of a vertex that does exist keeps the retryable `ConcurrentModificationException` and #5764's scoped advice on both paths, guarded by tests.

## Tests

`Issue6586MissingVertexDiagnosisTest` (13), including:

- `theDeleteIsRefusedBeforeTheWalkDisconnectsAnything` - arms a tripwire first (src's head chunk destroyed, so the walk itself fails with a conflict naming that chunk) and asserts it fires when the vertex IS there, so the "refused before the walk" assertion cannot pass vacuously;
- `theDeleteDoesNotSpendTheRetryBudget` - attempts counted, must be exactly 1 of 3 offered;
- `theAppendPathKeepsItsRetryableConflictForAnUnreadableHeadChunk` - the guard against the fix creeping over the case it must not touch;
- `theRepairTheAppendPathAdvertisesIsTheOneThatWorks` - runs `CHECK DATABASE FIX` and then completes the operation that could not run at all;
- `aVertexCreatedAndDeletedInTheSameTransactionStillDeletes` - pins the probe's eager-slot-allocation assumption, which is what would break if the ground-truth read were wrong.
- `forceDoesNotSuppressAMissingVertexRecord` and `theBrokenChainOptInDoesNotForceThroughAMissingVertexRecord` - the two levers that turn a refused delete into a forced one, pinned against the one refusal neither may absorb.

Green: `engine` 13200 tests, `network`/`server` modules 458 + 157 + 822, all 0 failures.

## Also updated

- `docs/release-26.9.1.md` - a section for #6586.
- `arcadedb-docs` (`sql-database-admin.adoc`) has a matching edit committed locally as `lvca`, not pushed, broadening the #6572 paragraph to the append and delete paths.

## Related, not in this PR

#6491 (`DETACH DELETE` after `TRAIL`/self-loop fan-out) is the same family. It is not fixed here, but it is affected: Cypher's `DeleteStep` already tolerates `RecordNotFoundException`, so the materialised-handle case that used to escape as an untolerated `ConcurrentModificationException` is now caught and skipped by that existing arm. Worth re-reading #6491 against this before diagnosing it separately.

