### PR TITLE
fix(ci): declare the image-tag output that seven e2e jobs already consume

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -51,6 +51,20 @@ jobs:
   build-and-package:
     runs-on: ubuntu-latest
     needs: setup
+    # Seven downstream jobs pass `needs.build-and-package.outputs.image-tag` as
+    # ARCADEDB_DOCKER_IMAGE, but this block did not exist, so all seven were handed an EMPTY string.
+    # It went unnoticed because every consumer is defensive in a way that hides it: e2e-go guards
+    # `!= ""`, js-bolt-conformance uses `|| "arcadedata/arcadedb:latest"`, and js-pg / js-bolt
+    # hardcode `:latest` and ignore the variable entirely. Since `Save docker image` below saves
+    # ONLY the :latest tag, those fallbacks happen to land on the freshly built image, so the suites
+    # tested the right thing by luck rather than by instruction. The documented intent - e2e-go's
+    # README says "the branch-built image is docker loaded under the tag passed via
+    # ARCADEDB_DOCKER_IMAGE" - has never actually held.
+    #
+    # :latest is the correct value rather than the project version, because the artifact carries no
+    # other tag: `docker load` in a consuming job makes :latest the only reference that resolves.
+    outputs:
+      image-tag: arcadedata/arcadedb:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -955,6 +969,17 @@ jobs:
         id: client-e2e
         working-directory: clients/typescript
         run: |
+          # The client's e2e suite falls back to a PUBLISHED image when this variable is unset, which
+          # is right for that repository's own CI and wrong here: this job would then report green
+          # while testing a released server and telling us nothing about the commit under review.
+          # The first run of this job failed exactly that way, because build-and-package did not
+          # declare an image-tag output at all. Fail loudly rather than test the wrong thing.
+          if [ -z "$ARCADEDB_DOCKER_IMAGE" ]; then
+            echo "ARCADEDB_DOCKER_IMAGE is empty: build-and-package provided no image-tag." >&2
+            echo "Refusing to run, because the suite would silently fall back to a published image." >&2
+            exit 1
+          fi
+          echo "Smoke-testing the client against $ARCADEDB_DOCKER_IMAGE"
           npm ci
           npm run e2e
         env:


### PR DESCRIPTION
`build-and-package` never declared an `outputs:` block, yet **seven** jobs pass `needs.build-and-package.outputs.image-tag` as `ARCADEDB_DOCKER_IMAGE`. All seven have been receiving an empty string.

Found by the M2 client smoke job (#6585) on its first run: it failed in 42 seconds with `(HTTP code 400) unexpected - invalid reference format`, because Docker was handed an empty image reference.

## Why nobody noticed

Every existing consumer is defensive in a way that hides it:

- `e2e-go/fixtures_test.go:101` guards `strings.TrimSpace(os.Getenv(...)) != ""`
- `e2e-js/src/js-bolt-conformance.test.js:36` uses `process.env.ARCADEDB_DOCKER_IMAGE || "arcadedata/arcadedb:latest"`
- `e2e-js/src/js-pg-e2e.test.js` and `js-bolt-e2e.test.js` hardcode `arcadedata/arcadedb:latest` and ignore the variable entirely

And because `Save docker image` saves **only** the `:latest` tag, those fallbacks happen to land on the freshly built image. The suites have been testing the right thing by luck rather than by instruction.

The documented intent has never actually held. `e2e-go/README.md:53-54` says "In CI the branch-built image is `docker load`ed under the tag passed via `ARCADEDB_DOCKER_IMAGE`" - it is loaded, but the tag passed is `""`.

## The fix

Declare the output. `arcadedata/arcadedb:latest` is the correct value rather than the project version, because the artifact carries no other tag: after `docker load` in a consuming job, `:latest` is the only reference that resolves.

This is a no-op for the four suites that already fall back to `:latest`. It makes the seven references honest, and it makes the intent enforceable rather than accidental.

Also adds a guard to the `client-smoke-test` job: it now refuses to run on an empty `ARCADEDB_DOCKER_IMAGE` instead of letting the client's e2e suite fall back to its published pin. That fallback is correct in the clients repository's own CI and wrong here - a smoke test that quietly tests a released server would report green while telling us nothing about the commit under review. That is precisely how the first run failed, and a loud refusal is better than a green lie.

## Verification

The workflow parses; `build-and-package` now exposes `image-tag`, and all seven consumers still resolve. The real verification is this pull request's own run: `client-smoke-test` should now print `Smoke-testing the client against arcadedata/arcadedb:latest` and complete the suite rather than dying on an invalid reference.

Worth noting what this says about the smoke job itself: its first run found a latent defect in the CI harness rather than in the OpenAPI contract. Not the class of bug it was built for, but it did exactly what a smoke test is supposed to do, and it surfaced something four existing suites had been papering over.
