### PR TITLE
feat(ci): reject needs.<job>.outputs.<name> references the producer never declares

### DIFF
--- a/.github/scripts/check-workflow-needs-outputs.py
+++ b/.github/scripts/check-workflow-needs-outputs.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts that every `needs.<job>.outputs.<name>` expression names an output the referenced job
+# actually declares.
+#
+# GitHub Actions does not validate this. A reference to an output that no job declares is accepted
+# as valid YAML and silently evaluates to the empty string at runtime, so the mistake produces a
+# workflow that looks correct, parses correctly, and quietly passes nothing where a value was meant
+# to go.
+#
+# That is not hypothetical here. `build-and-package` had no `outputs:` block at all while SEVEN jobs
+# passed `needs.build-and-package.outputs.image-tag` as ARCADEDB_DOCKER_IMAGE. Every one of them
+# received "". It survived for as long as it did because the consumers were each defensive in a way
+# that hid it: e2e-go guards `!= ""`, js-bolt-conformance falls back with `||`, and two e2e-js
+# suites hardcode `arcadedata/arcadedb:latest` and never read the variable. Since the saved image
+# artifact carries only the `:latest` tag, those fallbacks all landed on the right image - so the
+# suites tested the correct thing by luck, and the documented intent (e2e-go's README: "the
+# branch-built image is docker loaded under the tag passed via ARCADEDB_DOCKER_IMAGE") had never
+# actually held. It took a newly added consumer, strict enough to pass "" straight through to
+# Docker, to surface it as `invalid reference format`.
+#
+# This is the same family as check-workflow-artifact-deps.py: valid-looking YAML that is silently
+# wrong at runtime, where the failure mode is indistinguishable from working.
+#
+# Known boundaries, both deliberate:
+#   - A job that delegates to a reusable workflow (`jobs.<id>.uses:`) declares its outputs inside
+#     the called workflow, which this script does not follow. References INTO such a job are
+#     skipped rather than reported, because this check gates every other job and a false violation
+#     here is expensive. Nothing in this repository needs it yet.
+#   - A `needs` reference to a job that does not exist at all is reported: that is never valid, and
+#     it is the other half of the same typo.
+#
+# Usage:
+#   check-workflow-needs-outputs.py                 # check .github/workflows
+#   check-workflow-needs-outputs.py FILE|DIR ...    # check the given workflows
+#
+# @author Luca Garulli (l.garulli@arcadedata.com)
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# `needs.<job>.outputs.<name>`, as it appears inside a ${{ }} expression. Job ids and output names
+# are both restricted to the characters GitHub allows, so this does not need to parse expressions.
+NEEDS_OUTPUT = re.compile(r"needs\.([A-Za-z_][A-Za-z0-9_-]*)\.outputs\.([A-Za-z_][A-Za-z0-9_-]*)")
+
+
+def workflow_files(argv):
+    """Every workflow to check: the arguments if given, otherwise .github/workflows."""
+    targets = [Path(a) for a in argv] or [Path(".github/workflows")]
+    files = []
+    for target in targets:
+        if target.is_dir():
+            files.extend(sorted(p for p in target.iterdir() if p.suffix in (".yml", ".yaml")))
+        else:
+            files.append(target)
+    return files
+
+
+def declared_outputs(job):
+    """The output names a job declares, or None when the job cannot be resolved from here.
+
+    None and an empty set mean different things: None is a reusable-workflow job whose outputs live
+    somewhere this script does not read, and a reference into it is not evidence of a mistake. An
+    empty set is a job that genuinely declares nothing, and any reference into it is a defect.
+    """
+    if not isinstance(job, dict):
+        return None
+    if "uses" in job:
+        return None
+    outputs = job.get("outputs")
+    if outputs is None:
+        return set()
+    if not isinstance(outputs, dict):
+        return set()
+    return set(outputs.keys())
+
+
+def references(node, path="", found=None):
+    """Every (job, output, where) triple reachable from a parsed workflow node."""
+    if found is None:
+        found = []
+    if isinstance(node, str):
+        for job, output in NEEDS_OUTPUT.findall(node):
+            found.append((job, output, path))
+    elif isinstance(node, dict):
+        for key, value in node.items():
+            references(value, f"{path}.{key}" if path else str(key), found)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            references(value, f"{path}[{index}]", found)
+    return found
+
+
+def check(path):
+    """Violations in one workflow file, as printable strings."""
+    try:
+        document = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as error:
+        return [f"{path}: not parseable as YAML: {error}"]
+
+    if not isinstance(document, dict):
+        return []
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    violations = []
+    for job_id, job in jobs.items():
+        for target, output, where in references(job):
+            if target not in jobs:
+                violations.append(
+                    f"{path}: job '{job_id}' references needs.{target}.outputs.{output} at "
+                    f"'{where}', but no job '{target}' exists in this workflow"
+                )
+                continue
+
+            available = declared_outputs(jobs[target])
+            if available is None:
+                # A reusable-workflow job: its outputs are declared in the called workflow.
+                continue
+            if output not in available:
+                declared = ", ".join(sorted(available)) if available else "none"
+                violations.append(
+                    f"{path}: job '{job_id}' references needs.{target}.outputs.{output} at "
+                    f"'{where}', but job '{target}' declares no such output (declares: {declared}). "
+                    f"GitHub Actions resolves this to an empty string at runtime instead of failing."
+                )
+    return violations
+
+
+def main():
+    violations = []
+    for path in workflow_files(sys.argv[1:]):
+        violations.extend(check(path))
+
+    if violations:
+        print("Undeclared workflow outputs referenced through `needs`:\n")
+        for violation in violations:
+            print(f"  {violation}")
+        print(
+            "\nEach of these evaluates to an empty string at runtime. Declare the output on the "
+            "producing job, or stop referencing it."
+        )
+        return 1
+
+    print("check-workflow-needs-outputs: every needs.<job>.outputs.<name> reference resolves")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-workflow-needs-outputs.py
+++ b/.github/scripts/check-workflow-needs-outputs.py
@@ -57,7 +57,10 @@ import re
 import sys
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ImportError:  # pragma: no cover - the workflow installs it explicitly
+    sys.exit("check-workflow-needs-outputs: PyYAML is required (pip install pyyaml)")
 
 # `needs.<job>.outputs.<name>`, as it appears inside a ${{ }} expression. Job ids and output names
 # are both restricted to the characters GitHub allows, so this does not need to parse expressions.

--- a/.github/scripts/check-workflow-needs-outputs.py
+++ b/.github/scripts/check-workflow-needs-outputs.py
@@ -66,6 +66,11 @@ except ImportError:  # pragma: no cover - the workflow installs it explicitly
 # are both restricted to the characters GitHub allows, so this does not need to parse expressions.
 NEEDS_OUTPUT = re.compile(r"needs\.([A-Za-z_][A-Za-z0-9_-]*)\.outputs\.([A-Za-z_][A-Za-z0-9_-]*)")
 
+# Only text inside ${{ }} is an expression. Without this gate a `run:` step that merely PRINTS the
+# words needs.build.outputs.tag - an echo, a comment, an error message - would be read as a live
+# reference and reported as a violation. Same gate the sibling artifact-deps script applies.
+EXPRESSION = re.compile(r"\$\{\{.*?\}\}")
+
 
 def workflow_files(argv):
     """Every workflow to check: the arguments if given, otherwise .github/workflows."""
@@ -98,13 +103,33 @@ def declared_outputs(job):
     return set(outputs.keys())
 
 
+def needs_of(job):
+    """The jobs a job lists as DIRECT dependencies.
+
+    Direct, not transitive, and the distinction is the whole point. An artifact survives a
+    transitive wait - it is uploaded to the run - which is why the sibling artifact-deps script
+    resolves a full `needs` closure. The `needs` CONTEXT does not work that way: it carries "the
+    outputs of all jobs that are defined as a dependency of the current job", so a job that reaches
+    the producer only transitively reads an empty string, exactly like a job that never declared the
+    dependency at all. Using a transitive closure here would accept precisely the reference this
+    script exists to reject.
+    """
+    if not isinstance(job, dict):
+        return []
+    needs = job.get("needs")
+    if isinstance(needs, str):
+        return [needs]
+    return [n for n in needs if isinstance(n, str)] if isinstance(needs, list) else []
+
+
 def references(node, path="", found=None):
     """Every (job, output, where) triple reachable from a parsed workflow node."""
     if found is None:
         found = []
     if isinstance(node, str):
-        for job, output in NEEDS_OUTPUT.findall(node):
-            found.append((job, output, path))
+        for expression in EXPRESSION.findall(node):
+            for job, output in NEEDS_OUTPUT.findall(expression):
+                found.append((job, output, path))
     elif isinstance(node, dict):
         for key, value in node.items():
             references(value, f"{path}.{key}" if path else str(key), found)
@@ -129,11 +154,31 @@ def check(path):
 
     violations = []
     for job_id, job in jobs.items():
+        direct_needs = set(needs_of(job))
+        # One line per distinct mistake. The same bad reference often appears twice in a job - once
+        # in `env:` and again in a `run:` - and reporting it twice makes one typo look like two.
+        reported = set()
+
         for target, output, where in references(job):
+            if (target, output) in reported:
+                continue
+
             if target not in jobs:
+                reported.add((target, output))
                 violations.append(
                     f"{path}: job '{job_id}' references needs.{target}.outputs.{output} at "
                     f"'{where}', but no job '{target}' exists in this workflow"
+                )
+                continue
+
+            if target not in direct_needs:
+                reported.add((target, output))
+                declared = ", ".join(sorted(direct_needs)) if direct_needs else "nothing"
+                violations.append(
+                    f"{path}: job '{job_id}' references needs.{target}.outputs.{output} at "
+                    f"'{where}', but '{job_id}' does not list '{target}' in its needs (needs: "
+                    f"{declared}). The needs context carries only DIRECT dependencies, so this "
+                    f"resolves to an empty string at runtime instead of failing."
                 )
                 continue
 
@@ -142,6 +187,7 @@ def check(path):
                 # A reusable-workflow job: its outputs are declared in the called workflow.
                 continue
             if output not in available:
+                reported.add((target, output))
                 declared = ", ".join(sorted(available)) if available else "none"
                 violations.append(
                     f"{path}: job '{job_id}' references needs.{target}.outputs.{output} at "

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -1163,6 +1163,75 @@ YAML
 expect "rejects a reference to a job that does not exist" 1 "no job 'buidl' exists" \
     "$NEEDSOUTPUTS" "$work/needs-missing-job"
 
+# A reference to a job the consumer does not depend on resolves to "" just as surely as an
+# undeclared output does, even when the producer declares the output correctly.
+mkdir -p "$work/needs-not-declared-dep"
+cat >"$work/needs-not-declared-dep/ci.yml" <<'YAML'
+name: not-a-dependency
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: repo/image:latest
+    steps:
+      - run: echo building
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+        env:
+          IMAGE: ${{ needs.build.outputs.image-tag }}
+YAML
+expect "rejects a reference to a job the consumer does not depend on" 1 "does not list 'build'" \
+    "$NEEDSOUTPUTS" "$work/needs-not-declared-dep"
+
+# The needs CONTEXT is not transitive, unlike an artifact: `report` waits for `test` which waits for
+# `build`, so the artifact-deps script would accept the equivalent download, but `needs.build` is
+# still empty here. Getting this wrong in the permissive direction would make the check accept the
+# exact reference it exists to reject.
+mkdir -p "$work/needs-transitive"
+cat >"$work/needs-transitive/ci.yml" <<'YAML'
+name: transitive-outputs
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: repo/image:latest
+    steps:
+      - run: echo building
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+  report:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - run: echo report
+        env:
+          IMAGE: ${{ needs.build.outputs.image-tag }}
+YAML
+expect "rejects a transitively-reached producer, because the needs context is direct-only" 1 "DIRECT" \
+    "$NEEDSOUTPUTS" "$work/needs-transitive"
+
+# Text that merely mentions the expression is not a reference. Without a ${{ }} gate an echo or an
+# error message would be reported as a live violation.
+mkdir -p "$work/needs-plain-text"
+cat >"$work/needs-plain-text/ci.yml" <<'YAML'
+name: plain-text
+on: [ push ]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "set needs.build.outputs.image-tag to use a custom image"
+YAML
+expect "ignores the expression text outside a \${{ }} block" 0 "" \
+    "$NEEDSOUTPUTS" "$work/needs-plain-text"
+
 # A reusable-workflow job declares its outputs in the called workflow, which this script does not
 # read. Reporting it would be a false violation in a check that gates the whole build.
 mkdir -p "$work/needs-reusable"

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -27,6 +27,7 @@ GUARDS="$SCRIPTS/check-test-reporter-guards.py"
 ALLOWLIST="$SCRIPTS/check-license-allowlist.py"
 DBDOCSSYNC="$SCRIPTS/check-database-docs-sync.py"
 CONTROLCHARS="$SCRIPTS/check-source-control-chars.py"
+NEEDSOUTPUTS="$SCRIPTS/check-workflow-needs-outputs.py"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -1086,6 +1087,100 @@ printf 'var x = "\000";\n' >"$work/controlchars-skipped/node_modules/bundle.js"
 printf '\000\001\002' >"$work/controlchars-skipped/logo.png"
 expect "ignores build output, vendored bundles and non-source files" 0 "" \
     "$CONTROLCHARS" "$work/controlchars-skipped"
+
+echo
+echo "check-workflow-needs-outputs.py"
+
+# The shape this script exists for: seven jobs read an output the producer never declares. GitHub
+# resolves it to "" instead of failing, so the workflow looks correct and quietly passes nothing.
+mkdir -p "$work/needs-undeclared"
+cat >"$work/needs-undeclared/ci.yml" <<'YAML'
+name: undeclared
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo building
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+        env:
+          IMAGE: ${{ needs.build.outputs.image-tag }}
+YAML
+expect "rejects a reference to an output the producer never declares" 1 "image-tag" \
+    "$NEEDSOUTPUTS" "$work/needs-undeclared"
+
+# The same workflow with the output declared: the only change that should matter.
+mkdir -p "$work/needs-declared"
+sed 's/    runs-on: ubuntu-latest\n/&/' "$work/needs-undeclared/ci.yml" \
+    | awk '/^  build:/{print; print "    outputs:"; print "      image-tag: repo\/image:latest"; next} {print}' \
+    >"$work/needs-declared/ci.yml"
+expect "accepts the same workflow once the output is declared" 0 "" \
+    "$NEEDSOUTPUTS" "$work/needs-declared"
+
+# A job that declares SOME outputs but not the one referenced is the easier mistake to miss: the
+# `outputs:` block exists, so a reader skims past it.
+mkdir -p "$work/needs-wrong-name"
+cat >"$work/needs-wrong-name/ci.yml" <<'YAML'
+name: wrong-name
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        run: echo "version=1" >> $GITHUB_OUTPUT
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+        env:
+          IMAGE: ${{ needs.build.outputs.image-tag }}
+YAML
+expect "rejects a reference to a name the producer does not declare" 1 "declares: version" \
+    "$NEEDSOUTPUTS" "$work/needs-wrong-name"
+
+# A `needs` reference to a job that does not exist is the other half of the same typo.
+mkdir -p "$work/needs-missing-job"
+cat >"$work/needs-missing-job/ci.yml" <<'YAML'
+name: missing-job
+on: [ push ]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+        env:
+          IMAGE: ${{ needs.buidl.outputs.image-tag }}
+YAML
+expect "rejects a reference to a job that does not exist" 1 "no job 'buidl' exists" \
+    "$NEEDSOUTPUTS" "$work/needs-missing-job"
+
+# A reusable-workflow job declares its outputs in the called workflow, which this script does not
+# read. Reporting it would be a false violation in a check that gates the whole build.
+mkdir -p "$work/needs-reusable"
+cat >"$work/needs-reusable/ci.yml" <<'YAML'
+name: reusable
+on: [ push ]
+jobs:
+  build:
+    uses: ./.github/workflows/called.yml
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+        env:
+          IMAGE: ${{ needs.build.outputs.image-tag }}
+YAML
+expect "ignores a reference into a reusable-workflow job" 0 "" \
+    "$NEEDSOUTPUTS" "$work/needs-reusable"
 
 echo
 if [[ $failures -gt 0 ]]; then

--- a/.github/scripts/tests/test-ci-scripts.sh
+++ b/.github/scripts/tests/test-ci-scripts.sh
@@ -1113,11 +1113,12 @@ YAML
 expect "rejects a reference to an output the producer never declares" 1 "image-tag" \
     "$NEEDSOUTPUTS" "$work/needs-undeclared"
 
-# The same workflow with the output declared: the only change that should matter.
+# The same workflow with the output declared: the only change that should matter. Deriving it from
+# the rejected fixture rather than writing a second one is deliberate - it is what makes the pair
+# evidence, since the declaration is then the only difference between a pass and a failure.
 mkdir -p "$work/needs-declared"
-sed 's/    runs-on: ubuntu-latest\n/&/' "$work/needs-undeclared/ci.yml" \
-    | awk '/^  build:/{print; print "    outputs:"; print "      image-tag: repo\/image:latest"; next} {print}' \
-    >"$work/needs-declared/ci.yml"
+awk '/^  build:/{print; print "    outputs:"; print "      image-tag: repo\/image:latest"; next} {print}' \
+    "$work/needs-undeclared/ci.yml" >"$work/needs-declared/ci.yml"
 expect "accepts the same workflow once the output is declared" 0 "" \
     "$NEEDSOUTPUTS" "$work/needs-declared"
 

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -40,6 +40,8 @@ jobs:
         run: python3 -m pip install --quiet pyyaml==6.0.3
       - name: Check workflow artifact dependencies
         run: ./.github/scripts/check-workflow-artifact-deps.py
+      - name: Check workflow needs outputs
+        run: ./.github/scripts/check-workflow-needs-outputs.py
       - name: Check test reporter guards
         run: ./.github/scripts/check-test-reporter-guards.py
       - name: Check source files for raw control bytes


### PR DESCRIPTION
Follow-up to #6593, suggested in its review. Adds `check-workflow-needs-outputs.py`, which asserts that every `needs.<job>.outputs.<name>` expression names an output the referenced job actually declares.

**Stacked on #6593 and must merge after it.** This branch is based on `fix/4894-declare-image-tag-output`, because the check fails against `main` as it stands - which is the point.

## Why

GitHub Actions does not validate these references. An output no job declares is accepted as valid YAML and silently evaluates to the empty string at runtime, so the mistake produces a workflow that looks correct, parses correctly, and quietly passes nothing where a value was meant to go.

That is the bug #6593 fixes: `build-and-package` had no `outputs:` block while seven jobs passed `needs.build-and-package.outputs.image-tag` as `ARCADEDB_DOCKER_IMAGE`. It survived because every consumer was defensive in a way that hid it - `e2e-go` guards `!= ""`, `js-bolt-conformance` falls back with `||`, and two `e2e-js` suites hardcode `:latest` and never read the variable. Since the saved artifact carries only the `:latest` tag, those fallbacks all landed on the right image, so the suites were correct by luck. It took a newly added consumer strict enough to pass `""` through to Docker to surface it, as `invalid reference format`.

This is the same family as `check-workflow-artifact-deps.py`: valid-looking YAML that is silently wrong at runtime, where the failure mode is indistinguishable from working. It gets a sibling script, runs in the same `setup` job, and needs no new wiring.

## That the check is real, not decorative

Run against `main` without #6593's fix, it reproduces the defect independently - all seven consumers, each with its exact location:

```
mvn-test.yml: job 'java-e2e-tests' references needs.build-and-package.outputs.image-tag at
'steps[6].env.ARCADEDB_DOCKER_IMAGE', but job 'build-and-package' declares no such output
(declares: none). GitHub Actions resolves this to an empty string at runtime instead of failing.
```

With #6593's fix present it exits 0.

Five cases added to `test-ci-scripts.sh`, pinning both directions the way the existing suites do:

- rejects a reference to an output the producer never declares
- accepts the same workflow once the output is declared (same base fixture, one transformation, opposite result)
- rejects a reference to a name the producer does not declare, where an `outputs:` block exists but lacks it - the easier mistake to miss, because a reader skims past the block
- rejects a reference to a job that does not exist, which is the other half of the same typo
- ignores a reference into a reusable-workflow job

75 checks pass in the harness, up from 70.

## Deliberate boundaries

A job delegating to a reusable workflow (`jobs.<id>.uses:`) declares its outputs in the called workflow, which this script does not follow. References into such a job are skipped rather than reported: this check gates every other job, so a false violation here is expensive. The distinction is explicit in the code - `None` means "cannot resolve from here", an empty set means "declares nothing", and only the latter is a defect.

A `needs` reference to a job that does not exist at all is reported, since that is never valid.
