### PR TITLE
fix(#6592): match composite index prefixes in the native Select query builder

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -215,20 +215,30 @@ public class SelectExecutor {
     if (select.fromType != null && select.rootTreeElement != null) {
       final List<IndexCursor> cursors = new ArrayList<>();
 
-      // FIND AVAILABLE INDEXES AND ASSIGN node.index ON EVERY INDEXED LEAF: filterWithIndexesFinalNode() RELIES ON THAT
-      // SIDE EFFECT TO KNOW WHICH LEAVES CAN BECOME A CURSOR
-      isTheNodeFullyIndexed(select.rootTreeElement);
+      // #6592: A COMPOSITE (MULTI-PROPERTY) INDEX IS REGISTERED UNDER ITS FULL PROPERTY LIST (SEE
+      // LocalDocumentType.indexesByProperties), NOT UNDER ANY SUBSET OF IT - SO A PLAIN AND-CONJUNCTION OF EQUALITY
+      // LEAVES THAT ONLY COVERS THE LEADING PROPERTIES OF SUCH AN INDEX CAN NEVER BE FOUND BY THE PER-LEAF,
+      // SINGLE-PROPERTY LOOKUP BELOW (isTheNodeFullyIndexed()). TRY A PREFIX MATCH AGAINST EVERY COMPOSITE INDEX ON
+      // THE TYPE FIRST; ONLY FALL BACK TO THE SINGLE-PROPERTY PATH WHEN NO SUCH INDEX COVERS ANY LEADING PROPERTY.
+      final boolean compositeIndexUsed = matchCompositeIndex(cursors);
 
-      // #6565: A CANDIDATE CAP IS SAFE ONLY WHEN THE INDEX SCAN EXACTLY REPRODUCES THE WHERE-TREE'S RESULT SET AND
-      // THE ORDER BY (IF ANY) IS ALREADY SATISFIED BY IT - evaluateWhere(), skip AND fetchResultInCaseOfOrderBy()'s
-      // FULL-DRAIN SORT ALL REDUCE THE STREAM FURTHER OTHERWISE, SO THE SCAN MUST RUN UNCAPPED TO SURVIVE THAT.
-      // MUST RUN BEFORE filterWithIndexes() BELOW, SINCE soleExactLeaf() READS node.index BEFORE
-      // filterWithIndexesFinalNode() PRUNES AN 'and' SIBLING'S - HARMLESS TODAY ONLY BECAUSE 'and' IS ALREADY
-      // UNCONDITIONALLY DISQUALIFIED
-      final SelectTreeNode exactLeaf = soleExactLeaf(select.rootTreeElement);
-      indexCandidateLimit = exactLeaf != null && isOrderBySafeForCap(exactLeaf) ? computeExactCandidateLimit() : -1;
+      if (!compositeIndexUsed) {
+        // FIND AVAILABLE INDEXES AND ASSIGN node.index ON EVERY INDEXED LEAF: filterWithIndexesFinalNode() RELIES ON THAT
+        // SIDE EFFECT TO KNOW WHICH LEAVES CAN BECOME A CURSOR
+        isTheNodeFullyIndexed(select.rootTreeElement);
 
-      filterWithIndexes(select.rootTreeElement, cursors);
+        // #6565: A CANDIDATE CAP IS SAFE ONLY WHEN THE INDEX SCAN EXACTLY REPRODUCES THE WHERE-TREE'S RESULT SET AND
+        // THE ORDER BY (IF ANY) IS ALREADY SATISFIED BY IT - evaluateWhere(), skip AND fetchResultInCaseOfOrderBy()'s
+        // FULL-DRAIN SORT ALL REDUCE THE STREAM FURTHER OTHERWISE, SO THE SCAN MUST RUN UNCAPPED TO SURVIVE THAT.
+        // MUST RUN BEFORE filterWithIndexes() BELOW, SINCE soleExactLeaf() READS node.index BEFORE
+        // filterWithIndexesFinalNode() PRUNES AN 'and' SIBLING'S - HARMLESS TODAY ONLY BECAUSE 'and' IS ALREADY
+        // UNCONDITIONALLY DISQUALIFIED
+        final SelectTreeNode exactLeaf = soleExactLeaf(select.rootTreeElement);
+        indexCandidateLimit = exactLeaf != null && isOrderBySafeForCap(exactLeaf) ? computeExactCandidateLimit() : -1;
+
+        filterWithIndexes(select.rootTreeElement, cursors);
+      }
+
       if (!cursors.isEmpty())
         return new MultiIndexCursor(cursors, indexCandidateLimit, true);
 
@@ -238,6 +248,145 @@ public class SelectExecutor {
       indexCandidateLimit = -1;
     }
     return null;
+  }
+
+  /**
+   * Prefix-matches the where-tree against every composite index on {@link Select#fromType}: a plain AND-conjunction
+   * of equality leaves (no {@code or}/{@code not} anywhere - see {@link #isPureAndConjunction}) covering the leading
+   * N properties of an index registered on M &gt;= N properties can be answered with a single partial-key cursor,
+   * exactly like the SQL executor's {@code IndexSearchDescriptor} already does for plain {@code SELECT} statements
+   * (see {@code SelectExecutionPlanner.buildIndexSearchDescriptor}). Single-property indexes are left to the existing
+   * {@link #isTheNodeFullyIndexed}/{@link #filterWithIndexes} path, which already handles them (including the
+   * {@code or} and mixed-operator cases this method deliberately does not attempt).
+   * <p>
+   * When the trailing (N+1-th) index property is also the query's sole {@code ORDER BY} column, the cursor is built
+   * as a range scan in the requested direction instead of a plain equality lookup, so the index itself already
+   * returns the rows in the requested order - mirroring the SQL executor's {@code fullySorted} elision and letting
+   * {@link SelectIterator#fetchResultInCaseOfOrderBy} skip its full materialize-and-sort fallback.
+   *
+   * @return {@code true} when a composite-index cursor was built and appended to {@code cursors}
+   */
+  private boolean matchCompositeIndex(final List<IndexCursor> cursors) {
+    if (!isPureAndConjunction(select.rootTreeElement))
+      return false;
+
+    final Map<String, SelectTreeNode> andEqLeaves = new LinkedHashMap<>();
+    collectAndEqLeaves(select.rootTreeElement, andEqLeaves);
+    if (andEqLeaves.isEmpty())
+      return false;
+
+    TypeIndex bestIndex = null;
+    int bestPrefixLength = 0;
+
+    for (final TypeIndex candidate : select.fromType.getAllIndexes(true)) {
+      final List<String> properties = candidate.getPropertyNames();
+      if (properties.size() < 2)
+        // SINGLE-PROPERTY INDEXES ARE HANDLED BY THE EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH
+        continue;
+
+      int prefixLength = 0;
+      while (prefixLength < properties.size() && andEqLeaves.containsKey(properties.get(prefixLength)))
+        prefixLength++;
+
+      if (prefixLength == 0)
+        continue;
+
+      if (prefixLength > bestPrefixLength || (prefixLength == bestPrefixLength && !bestIndex.isUnique() && candidate.isUnique())) {
+        bestIndex = candidate;
+        bestPrefixLength = prefixLength;
+      }
+    }
+
+    if (bestIndex == null)
+      return false;
+
+    final List<String> indexProperties = bestIndex.getPropertyNames();
+    final Object[] keys = new Object[bestPrefixLength];
+    for (int i = 0; i < bestPrefixLength; i++) {
+      final SelectTreeNode leaf = andEqLeaves.get(indexProperties.get(i));
+      keys[i] = leaf.right instanceof SelectParameterValue value ? value.eval(null) : leaf.right;
+    }
+
+    final String trailingProperty = bestPrefixLength < indexProperties.size() ? indexProperties.get(bestPrefixLength) : null;
+    final boolean orderByElided = select.orderBy != null && select.orderBy.size() == 1 && trailingProperty != null
+        && select.orderBy.getFirst().getFirst().equals(trailingProperty);
+
+    // A KEY SHORTER THAN THE INDEX'S FULL ARITY IS A PREFIX, NOT AN EXACT KEY: get() PERFORMS A SINGLE POSITIONAL
+    // LOOKUP AND ONLY RETURNS EVERY MATCH WHEN THE KEY'S ARITY MATCHES THE INDEX'S OWN EXACTLY, SO A PREFIX MUST GO
+    // THROUGH range() WITH EQUAL (INCLUSIVE) BEGIN/END BOUNDS INSTEAD - SEE LSMTreeIndexCompacted's "PARTIAL KEY
+    // COMPARISON...MATCHES BY PREFIX" (PURPOSE=2). trailingProperty == null IFF bestPrefixLength == indexProperties.size(),
+    // WHICH IS EXACTLY WHEN orderByElided CAN NEVER BE true EITHER (NO TRAILING PROPERTY LEFT TO ORDER BY).
+    final boolean fullKeyMatch = trailingProperty == null;
+    final boolean ascendingOrder = orderByElided ? select.orderBy.getFirst().getSecond() : true;
+    final IndexCursor cursor = fullKeyMatch ? bestIndex.get(keys) : bestIndex.range(ascendingOrder, keys, true, keys, true);
+
+    if (cursor == null)
+      return false;
+
+    if (usedIndexes == null)
+      usedIndexes = new ArrayList<>();
+    // fetchResultInCaseOfOrderBy()'S TRIVIAL-MATCH CHECK KEYS OFF usedIndexes.getFirst().property/order: RECORD THE
+    // TRAILING PROPERTY (NOT THE LAST *MATCHED* ONE) WHEN THE ORDER BY WAS ELIDED, SO IT RECOGNIZES THE RANGE SCAN AS
+    // ALREADY SATISFYING THE ORDER BY AND SKIPS THE FULL MATERIALIZE-AND-SORT FALLBACK.
+    usedIndexes.add(new IndexInfo(bestIndex, orderByElided ? trailingProperty : indexProperties.get(bestPrefixLength - 1), ascendingOrder));
+    cursors.add(cursor);
+
+    // THE CANDIDATE CAP (SEE #6565's computeExactCandidateLimit()) IS SAFE ONLY WHEN THIS CURSOR EXACTLY REPRODUCES
+    // THE WHOLE WHERE-TREE'S RESULT SET (EVERY LEAF WAS CONSUMED BY THE MATCHED PREFIX, NOTHING LEFT FOR
+    // evaluateWhere() TO DISCARD) AND THE ORDER BY, IF ANY, IS ALREADY SATISFIED BY THE CURSOR ITSELF - OTHERWISE
+    // fetchResultInCaseOfOrderBy()'S FULL-DRAIN SORT NEEDS EVERY MATCH, NOT JUST skip + limit OF THEM.
+    final boolean exactMatch = bestPrefixLength == countAndLeaves(select.rootTreeElement);
+    indexCandidateLimit = exactMatch && (select.orderBy == null || orderByElided) ? computeExactCandidateLimit() : -1;
+
+    return true;
+  }
+
+  /**
+   * True when {@code node} and everything under it is connected purely by {@code and} (through the synthetic
+   * {@code run} wrapper {@link Select#compile()} adds around a single bare leaf - see {@link #soleExactLeaf}) with
+   * no {@code or}/{@code not} anywhere. Only such a tree can be safely resolved through one composite-index prefix
+   * match: an {@code or}/{@code not} would need the same per-branch reasoning {@link #isTheNodeFullyIndexed} already
+   * does for the single-property case, which this method deliberately leaves untouched.
+   */
+  private boolean isPureAndConjunction(final SelectTreeNode node) {
+    if (!(node.left instanceof SelectTreeNode))
+      return true;
+    if (node.operator == SelectOperator.run)
+      return isPureAndConjunction((SelectTreeNode) node.left);
+    if (node.operator != SelectOperator.and)
+      return false;
+    return isPureAndConjunction((SelectTreeNode) node.left) && (node.right == null || isPureAndConjunction((SelectTreeNode) node.right));
+  }
+
+  /**
+   * Collects every {@code eq} leaf of a {@link #isPureAndConjunction} tree, keyed by property name. A leaf using any
+   * other operator (a range, an {@code in_op}, ...) is simply left out of the map: a composite-index prefix match
+   * only needs the leading properties bound by equality, and every leaf stays in the tree regardless for the final
+   * {@link #evaluateWhere} pass.
+   */
+  private void collectAndEqLeaves(final SelectTreeNode node, final Map<String, SelectTreeNode> target) {
+    if (!(node.left instanceof SelectTreeNode)) {
+      if (node.operator == SelectOperator.eq && node.left instanceof SelectPropertyValue leftProperty
+          && !(node.right instanceof SelectPropertyValue))
+        target.putIfAbsent(leftProperty.propertyName, node);
+      return;
+    }
+    collectAndEqLeaves((SelectTreeNode) node.left, target);
+    if (node.right != null)
+      collectAndEqLeaves((SelectTreeNode) node.right, target);
+  }
+
+  /**
+   * Counts every leaf (regardless of operator) of a {@link #isPureAndConjunction} tree - used by
+   * {@link #matchCompositeIndex} to tell whether the matched prefix consumed the whole where-tree.
+   */
+  private int countAndLeaves(final SelectTreeNode node) {
+    if (!(node.left instanceof SelectTreeNode))
+      return 1;
+    int count = countAndLeaves((SelectTreeNode) node.left);
+    if (node.right != null)
+      count += countAndLeaves((SelectTreeNode) node.right);
+    return count;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -269,8 +269,8 @@ public class SelectExecutor {
   private boolean matchCompositeIndex(final List<IndexCursor> cursors) {
     // CHEAP UPFRONT GUARD: A TYPE WITH ONLY SINGLE-PROPERTY INDEXES (THE COMMON CASE) CAN NEVER PRODUCE A COMPOSITE
     // MATCH, SO SKIP THE WHERE-TREE WALK (isPureAndConjunction()/collectAndEqLeaves()) AND THE PER-QUERY ALLOCATION
-    // AND SORT BELOW ENTIRELY - THOSE TYPES ALREADY GO THROUGH isTheNodeFullyIndexed()/filterWithIndexes() JUST AS
-    // FAST AS BEFORE THIS METHOD EXISTED
+    // AND SORT BELOW ENTIRELY, LEAVING ONLY THIS ONE getAllIndexes(true) ITERATION (ALREADY NEEDED TO TELL WHETHER
+    // ANY COMPOSITE INDEX EXISTS AT ALL) BEFORE FALLING THROUGH TO isTheNodeFullyIndexed()/filterWithIndexes()
     // ONLY AN INDEX THAT supportsOrderedIterations() CAN SERVE A PARTIAL-PREFIX MATCH: THAT BRANCH BUILDS A cursor
     // VIA range(), WHICH THROWS UnsupportedOperationException OTHERWISE (SEE TypeIndex.range()) - TRUE ONLY FOR
     // LSM_TREE, NOT FOR HASH/UNIQUE_HASH (A COMMON SHAPE FOR EDGE-UNIQUENESS INDEXES ON (@out, @in), E.G.
@@ -334,15 +334,33 @@ public class SelectExecutor {
     }
 
     final String trailingProperty = bestPrefixLength < indexProperties.size() ? indexProperties.get(bestPrefixLength) : null;
+    // trailingProperty == null IFF bestPrefixLength == indexProperties.size() - I.E. EVERY PROPERTY OF THE INDEX IS
+    // BOUND BY EQUALITY, NOT JUST A LEADING SUBSET OF THEM
+    final boolean fullKeyMatch = trailingProperty == null;
+
+    if (!fullKeyMatch) {
+      // A PARTIAL-PREFIX MATCH SCANS EVERY ROW SHARING THE MATCHED PREFIX AND LEAVES ANY EQ-BOUND PROPERTY OUTSIDE
+      // THAT PREFIX TO evaluateWhere() - IF ONE OF THOSE PROPERTIES ALREADY HAS ITS OWN STANDALONE INDEX (A REAL
+      // SHAPE: A NON-UNIQUE COMPOSITE INDEX SERVING ONE QUERY PATTERN COEXISTING WITH A UNIQUE SINGLE-PROPERTY INDEX
+      // ENFORCING A CONSTRAINT ON ANOTHER COLUMN - LocalDocumentType.indexesByProperties HAPPILY LETS BOTH COEXIST),
+      // THAT STANDALONE INDEX CAN ANSWER THE QUERY FAR MORE PRECISELY THAN SCANNING THE WHOLE PREFIX RANGE. DEFER TO
+      // THE PRE-EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH IN THAT CASE - IT ALREADY CORRECTLY PICKS
+      // BETWEEN COMPETING SINGLE-PROPERTY INDEXES (PREFERRING A UNIQUE ONE). A PROPERTY ALREADY COVERED BY THE
+      // MATCHED PREFIX ITSELF IS EXEMPT: THE PREFIX SCAN IS AT LEAST AS SELECTIVE FOR THAT PROPERTY AS A STANDALONE
+      // INDEX ON IT ALONE WOULD BE.
+      final Set<String> matchedPrefixProperties = new HashSet<>(indexProperties.subList(0, bestPrefixLength));
+      for (final String property : andEqLeaves.keySet())
+        if (!matchedPrefixProperties.contains(property) && select.fromType.getPolymorphicIndexByProperties(property) != null)
+          return false;
+    }
+
     final boolean orderByElided = select.orderBy != null && select.orderBy.size() == 1 && trailingProperty != null
         && select.orderBy.getFirst().getFirst().equals(trailingProperty);
 
     // A KEY SHORTER THAN THE INDEX'S FULL ARITY IS A PREFIX, NOT AN EXACT KEY: get() PERFORMS A SINGLE POSITIONAL
     // LOOKUP AND ONLY RETURNS EVERY MATCH WHEN THE KEY'S ARITY MATCHES THE INDEX'S OWN EXACTLY, SO A PREFIX MUST GO
     // THROUGH range() WITH EQUAL (INCLUSIVE) BEGIN/END BOUNDS INSTEAD - SEE LSMTreeIndexCompacted's "PARTIAL KEY
-    // COMPARISON...MATCHES BY PREFIX" (PURPOSE=2). trailingProperty == null IFF bestPrefixLength == indexProperties.size(),
-    // WHICH IS EXACTLY WHEN orderByElided CAN NEVER BE true EITHER (NO TRAILING PROPERTY LEFT TO ORDER BY).
-    final boolean fullKeyMatch = trailingProperty == null;
+    // COMPARISON...MATCHES BY PREFIX" (PURPOSE=2).
     final boolean ascendingOrder = orderByElided ? select.orderBy.getFirst().getSecond() : true;
     final IndexCursor cursor = fullKeyMatch ? bestIndex.get(keys) : bestIndex.range(ascendingOrder, keys, true, keys, true);
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -278,7 +278,14 @@ public class SelectExecutor {
     TypeIndex bestIndex = null;
     int bestPrefixLength = 0;
 
-    for (final TypeIndex candidate : select.fromType.getAllIndexes(true)) {
+    // getAllIndexes(true) IS BACKED BY A HashSet FOR A POLYMORPHIC TYPE (LocalDocumentType.getAllIndexes()), SO ITS
+    // ITERATION ORDER IS UNSPECIFIED - SORT BY NAME FIRST SO TWO INDEXES TIED ON PREFIX LENGTH AND UNIQUENESS (E.G.
+    // TWO COMPOSITE INDEXES SHARING THE SAME LEADING PROPERTIES BUT DIFFERENT TRAILING ONES) ARE PICKED BETWEEN
+    // DETERMINISTICALLY ACROSS RUNS, RATHER THAN LEAVING WHICH ONE'S ORDER BY GETS ELIDED TO HASH-BUCKET LUCK
+    final List<TypeIndex> candidates = new ArrayList<>(select.fromType.getAllIndexes(true));
+    candidates.sort(Comparator.comparing(TypeIndex::getName));
+
+    for (final TypeIndex candidate : candidates) {
       final List<String> properties = candidate.getPropertyNames();
       if (properties.size() < 2)
         // SINGLE-PROPERTY INDEXES ARE HANDLED BY THE EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -267,6 +267,18 @@ public class SelectExecutor {
    * @return {@code true} when a composite-index cursor was built and appended to {@code cursors}
    */
   private boolean matchCompositeIndex(final List<IndexCursor> cursors) {
+    // CHEAP UPFRONT GUARD: A TYPE WITH ONLY SINGLE-PROPERTY INDEXES (THE COMMON CASE) CAN NEVER PRODUCE A COMPOSITE
+    // MATCH, SO SKIP THE WHERE-TREE WALK (isPureAndConjunction()/collectAndEqLeaves()) AND THE PER-QUERY ALLOCATION
+    // AND SORT BELOW ENTIRELY - THOSE TYPES ALREADY GO THROUGH isTheNodeFullyIndexed()/filterWithIndexes() JUST AS
+    // FAST AS BEFORE THIS METHOD EXISTED
+    final List<TypeIndex> candidates = new ArrayList<>();
+    for (final TypeIndex candidate : select.fromType.getAllIndexes(true))
+      if (candidate.getPropertyNames().size() >= 2)
+        candidates.add(candidate);
+
+    if (candidates.isEmpty())
+      return false;
+
     if (!isPureAndConjunction(select.rootTreeElement))
       return false;
 
@@ -275,21 +287,18 @@ public class SelectExecutor {
     if (andEqLeaves.isEmpty())
       return false;
 
-    TypeIndex bestIndex = null;
-    int bestPrefixLength = 0;
-
     // getAllIndexes(true) IS BACKED BY A HashSet FOR A POLYMORPHIC TYPE (LocalDocumentType.getAllIndexes()), SO ITS
     // ITERATION ORDER IS UNSPECIFIED - SORT BY NAME FIRST SO TWO INDEXES TIED ON PREFIX LENGTH AND UNIQUENESS (E.G.
     // TWO COMPOSITE INDEXES SHARING THE SAME LEADING PROPERTIES BUT DIFFERENT TRAILING ONES) ARE PICKED BETWEEN
     // DETERMINISTICALLY ACROSS RUNS, RATHER THAN LEAVING WHICH ONE'S ORDER BY GETS ELIDED TO HASH-BUCKET LUCK
-    final List<TypeIndex> candidates = new ArrayList<>(select.fromType.getAllIndexes(true));
-    candidates.sort(Comparator.comparing(TypeIndex::getName));
+    if (candidates.size() > 1)
+      candidates.sort(Comparator.comparing(TypeIndex::getName));
+
+    TypeIndex bestIndex = null;
+    int bestPrefixLength = 0;
 
     for (final TypeIndex candidate : candidates) {
       final List<String> properties = candidate.getPropertyNames();
-      if (properties.size() < 2)
-        // SINGLE-PROPERTY INDEXES ARE HANDLED BY THE EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH
-        continue;
 
       int prefixLength = 0;
       while (prefixLength < properties.size() && andEqLeaves.containsKey(properties.get(prefixLength)))

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -271,9 +271,16 @@ public class SelectExecutor {
     // MATCH, SO SKIP THE WHERE-TREE WALK (isPureAndConjunction()/collectAndEqLeaves()) AND THE PER-QUERY ALLOCATION
     // AND SORT BELOW ENTIRELY - THOSE TYPES ALREADY GO THROUGH isTheNodeFullyIndexed()/filterWithIndexes() JUST AS
     // FAST AS BEFORE THIS METHOD EXISTED
+    // ONLY AN INDEX THAT supportsOrderedIterations() CAN SERVE A PARTIAL-PREFIX MATCH: THAT BRANCH BUILDS A cursor
+    // VIA range(), WHICH THROWS UnsupportedOperationException OTHERWISE (SEE TypeIndex.range()) - TRUE ONLY FOR
+    // LSM_TREE, NOT FOR HASH/UNIQUE_HASH (A COMMON SHAPE FOR EDGE-UNIQUENESS INDEXES ON (@out, @in), E.G.
+    // Issue5677HashIndexLinkKeyTest), FULL_TEXT, GEOSPATIAL, LSM_VECTOR OR LSM_SPARSE_VECTOR. EXCLUDING THOSE HERE,
+    // RATHER THAN ONLY GUARDING THE range() CALL BELOW, ALSO AVOIDS get() DOING A RAW EQUALITY LOOKUP ON A
+    // FULL-KEY-MATCHED FULL_TEXT INDEX INSTEAD OF A TOKENIZED SEARCH - A TYPE WITH ONLY SUCH INDEXES SIMPLY FALLS
+    // BACK TO THE PRE-EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH, EXACTLY AS BEFORE THIS METHOD EXISTED
     final List<TypeIndex> candidates = new ArrayList<>();
     for (final TypeIndex candidate : select.fromType.getAllIndexes(true))
-      if (candidate.getPropertyNames().size() >= 2)
+      if (candidate.getPropertyNames().size() >= 2 && candidate.supportsOrderedIterations())
         candidates.add(candidate);
 
     if (candidates.isEmpty())
@@ -307,6 +314,9 @@ public class SelectExecutor {
       if (prefixLength == 0)
         continue;
 
+      // bestIndex IS GUARANTEED NON-null HERE WHEN prefixLength == bestPrefixLength: THE FIRST CANDIDATE TO EVER
+      // QUALIFY (prefixLength > 0) ALWAYS TAKES THE prefixLength > bestPrefixLength BRANCH INSTEAD, SINCE
+      // bestPrefixLength STARTS AT 0 AND ONLY A QUALIFYING CANDIDATE (prefixLength > 0) REACHES THIS LINE
       if (prefixLength > bestPrefixLength || (prefixLength == bestPrefixLength && !bestIndex.isUnique() && candidate.isUnique())) {
         bestIndex = candidate;
         bestPrefixLength = prefixLength;

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -340,18 +340,24 @@ public class SelectExecutor {
 
     if (!fullKeyMatch) {
       // A PARTIAL-PREFIX MATCH SCANS EVERY ROW SHARING THE MATCHED PREFIX AND LEAVES ANY EQ-BOUND PROPERTY OUTSIDE
-      // THAT PREFIX TO evaluateWhere() - IF ONE OF THOSE PROPERTIES ALREADY HAS ITS OWN STANDALONE INDEX (A REAL
-      // SHAPE: A NON-UNIQUE COMPOSITE INDEX SERVING ONE QUERY PATTERN COEXISTING WITH A UNIQUE SINGLE-PROPERTY INDEX
-      // ENFORCING A CONSTRAINT ON ANOTHER COLUMN - LocalDocumentType.indexesByProperties HAPPILY LETS BOTH COEXIST),
-      // THAT STANDALONE INDEX CAN ANSWER THE QUERY FAR MORE PRECISELY THAN SCANNING THE WHOLE PREFIX RANGE. DEFER TO
-      // THE PRE-EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH IN THAT CASE - IT ALREADY CORRECTLY PICKS
-      // BETWEEN COMPETING SINGLE-PROPERTY INDEXES (PREFERRING A UNIQUE ONE). A PROPERTY ALREADY COVERED BY THE
-      // MATCHED PREFIX ITSELF IS EXEMPT: THE PREFIX SCAN IS AT LEAST AS SELECTIVE FOR THAT PROPERTY AS A STANDALONE
-      // INDEX ON IT ALONE WOULD BE.
+      // THAT PREFIX TO evaluateWhere() - IF ONE OF THOSE PROPERTIES ALREADY HAS ITS OWN STANDALONE *UNIQUE* INDEX (A
+      // REAL SHAPE: A NON-UNIQUE COMPOSITE INDEX SERVING ONE QUERY PATTERN COEXISTING WITH A UNIQUE SINGLE-PROPERTY
+      // INDEX ENFORCING A CONSTRAINT ON ANOTHER COLUMN - LocalDocumentType.indexesByProperties HAPPILY LETS BOTH
+      // COEXIST), THAT STANDALONE INDEX IS GUARANTEED TO ANSWER THE QUERY MORE PRECISELY (AT MOST ONE ROW) THAN
+      // SCANNING THE WHOLE PREFIX RANGE, SO DEFER TO THE PRE-EXISTING isTheNodeFullyIndexed()/filterWithIndexes()
+      // PATH IN THAT CASE. A NON-UNIQUE STANDALONE INDEX GIVES NO SUCH GUARANTEE - IT COULD BE LESS SELECTIVE THAN
+      // THE COMPOSITE PREFIX'S OWN COMBINED LEADING PROPERTIES (E.G. A LOW-CARDINALITY FLAG), AND THIS METHOD HAS NO
+      // COST-BASED WAY TO COMPARE THE TWO - SO IT IS DELIBERATELY NOT ENOUGH TO TRIGGER DEFERRAL ON ITS OWN. A
+      // PROPERTY ALREADY COVERED BY THE MATCHED PREFIX ITSELF IS EXEMPT EITHER WAY: THE PREFIX SCAN IS AT LEAST AS
+      // SELECTIVE FOR THAT PROPERTY AS A STANDALONE INDEX ON IT ALONE WOULD BE.
       final Set<String> matchedPrefixProperties = new HashSet<>(indexProperties.subList(0, bestPrefixLength));
-      for (final String property : andEqLeaves.keySet())
-        if (!matchedPrefixProperties.contains(property) && select.fromType.getPolymorphicIndexByProperties(property) != null)
+      for (final String property : andEqLeaves.keySet()) {
+        if (matchedPrefixProperties.contains(property))
+          continue;
+        final TypeIndex standaloneIndex = select.fromType.getPolymorphicIndexByProperties(property);
+        if (standaloneIndex != null && standaloneIndex.isUnique())
           return false;
+      }
     }
 
     final boolean orderByElided = select.orderBy != null && select.orderBy.size() == 1 && trailingProperty != null

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -216,6 +216,36 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeHashIndexPartialPrefixFallsBackToScan() {
+    // A COMPOSITE HASH INDEX DOES NOT SUPPORT ORDERED ITERATIONS (TypeIndex.supportsOrderedIterations() == false),
+    // SO A PARTIAL-PREFIX MATCH AGAINST IT MUST NOT ATTEMPT range() - WHICH WOULD THROW UnsupportedOperationException
+    // - AND MUST INSTEAD FALL BACK TO THE PRE-EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH (A FULL SCAN
+    // HERE, SINCE NEITHER PROPERTY HAS ITS OWN STANDALONE INDEX), EXACTLY AS BEFORE THIS COMPOSITE-INDEX SUPPORT
+    // EXISTED. A UNIQUE_HASH INDEX ON (@out, @in) IS A COMMON EDGE-UNIQUENESS IDIOM IN THIS CODEBASE
+    // (Issue5677HashIndexLinkKeyTest) THAT MUST KEEP WORKING WHEN ONLY ONE ENDPOINT IS BOUND.
+    final VertexType hashType = database.getSchema().createVertexType("HashComposite");
+    hashType.createProperty("hashKey1", Type.STRING);
+    hashType.createProperty("hashKey2", Type.STRING);
+    hashType.createTypeIndex(Schema.INDEX_TYPE.HASH, false, "hashKey1", "hashKey2");
+
+    database.transaction(() -> {
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("HashComposite").set("hashKey1", "a", "hashKey2", "k" + i).save();
+      for (int i = 0; i < OTHER_SIZE; i++)
+        database.newVertex("HashComposite").set("hashKey1", "other", "hashKey2", "k" + i).save();
+    });
+
+    // ONLY hashKey1 IS BOUND: A PARTIAL PREFIX OF THE 2-PROPERTY HASH INDEX
+    final SelectCompiled select = database.select().fromType("HashComposite")//
+        .where().property("hashKey1").eq().value("a").compile();
+
+    final List<Vertex> list = select.vertices().toList();
+
+    assertThat(list).hasSize(GROUP_SIZE);
+    list.forEach(v -> assertThat(v.getString("hashKey1")).isEqualTo("a"));
+  }
+
+  @Test
   void compositeIndexNotUsedUnderOr() {
     // AN 'or' MUST NOT ATTEMPT THE COMPOSITE PREFIX MATCH: NEITHER PROPERTY HAS ITS OWN STANDALONE INDEX HERE, SO NO
     // INDEX CAN BE USED AND THE QUERY FALLS BACK TO A FULL TYPE SCAN, JUST LIKE BEFORE THE COMPOSITE-INDEX SUPPORT

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -286,6 +286,43 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeIndexPartialPrefixDefersToStandaloneIndexOnUnmatchedProperty() {
+    // A NON-UNIQUE COMPOSITE INDEX (key1, key2, key3) COEXISTS WITH A STANDALONE UNIQUE INDEX ON key3 ALONE - A REAL
+    // SCHEMA SHAPE (ONE INDEX FOR A QUERY PATTERN, ANOTHER ENFORCING A UNIQUENESS CONSTRAINT). key2 IS UNBOUND, SO
+    // THE COMPOSITE PREFIX MATCH STOPS AT key1 (prefixLength=1) AND WOULD OTHERWISE SCAN EVERY key1='a' ROW - key3,
+    // BOUND BY EQUALITY BUT OUTSIDE THAT PREFIX, MUST INSTEAD DEFER TO ITS OWN STANDALONE UNIQUE INDEX, WHICH
+    // ANSWERS THE QUERY WITH A SINGLE-ROW LOOKUP INSTEAD OF SCANNING THE WHOLE key1='a' GROUP
+    final VertexType precedence = database.getSchema().createVertexType("PrecedenceCheck");
+    precedence.createProperty("key1", Type.STRING);
+    precedence.createProperty("key2", Type.STRING);
+    precedence.createProperty("key3", Type.STRING);
+    precedence.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "key1", "key2", "key3");
+    precedence.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "key3");
+
+    database.transaction(() -> {
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("PrecedenceCheck").set("key1", "a", "key2", "k" + i, "key3", "u" + i).save();
+      for (int i = 0; i < OTHER_SIZE; i++)
+        database.newVertex("PrecedenceCheck").set("key1", "other", "key2", "k" + i, "key3", "other" + i).save();
+    });
+
+    final SelectCompiled select = database.select().fromType("PrecedenceCheck")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key3").eq().value("u3")//
+        .compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final List<Vertex> list = result.toList();
+
+    assertThat(list).hasSize(1);
+    assertThat(list.getFirst().getString("key3")).isEqualTo("u3");
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    // THE STANDALONE UNIQUE INDEX ON key3 MUST WIN OVER THE COMPOSITE PREFIX MATCH: ONLY THE SINGLE MATCHING RECORD
+    // IS EVALUATED, NOT THE WHOLE key1='a' GROUP
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+  }
+
+  @Test
   void compositeHashIndexPartialPrefixFallsBackToScan() {
     // A COMPOSITE HASH INDEX DOES NOT SUPPORT ORDERED ITERATIONS (TypeIndex.supportsOrderedIterations() == false),
     // SO A PARTIAL-PREFIX MATCH AGAINST IT MUST NOT ATTEMPT range() - WHICH WOULD THROW UnsupportedOperationException

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -216,6 +216,76 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeIndexTieBreakFallsBackToAlphabeticalOrder() {
+    // TWO COMPOSITE INDEXES TIE ON BOTH MATCHED PREFIX LENGTH (1, JUST groupKey) AND UNIQUENESS (BOTH NON-UNIQUE):
+    // THE TIE FALLS THROUGH TO THE candidates SORT-BY-NAME ORDERING. THE AUTO-GENERATED NAME IS
+    // "<Type>[<properties>]" (SEE TypeIndex.updateTypeName()), SO "AlphaTie[groupKey,valA]" SORTS BEFORE
+    // "AlphaTie[groupKey,valB]" - OBSERVED HERE BY WHETHER ORDER BY valA GETS ELIDED (IT MUST, SINCE THE
+    // ALPHABETICALLY-FIRST INDEX'S TRAILING PROPERTY IS valA, NOT valB)
+    final VertexType alphaTie = database.getSchema().createVertexType("AlphaTie");
+    alphaTie.createProperty("groupKey", Type.STRING);
+    alphaTie.createProperty("valA", Type.LONG);
+    alphaTie.createProperty("valB", Type.LONG);
+    alphaTie.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "groupKey", "valA");
+    alphaTie.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "groupKey", "valB");
+
+    database.transaction(() -> {
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("AlphaTie").set("groupKey", "g", "valA", (long) i, "valB", (long) i).save();
+    });
+
+    final SelectCompiled select = database.select().fromType("AlphaTie")//
+        .where().property("groupKey").eq().value("g")//
+        .orderBy("valA", false)//
+        .limit(1)//
+        .compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final Vertex first = result.nextOrNull();
+
+    assertThat(first).isNotNull();
+    assertThat(first.getLong("valA")).isEqualTo(GROUP_SIZE - 1);
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    // ORDER BY valA MUST BE ELIDED (NOT A FULL MATERIALIZE-AND-SORT): ONLY THE SINGLE RETURNED CANDIDATE IS EVALUATED
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+  }
+
+  @Test
+  void compositeIndexMultiColumnOrderByDisablesElision() {
+    // A MULTI-COLUMN ORDER BY (size() > 1) MUST NEVER BE TREATED AS ELIDED, EVEN THOUGH ITS FIRST COLUMN MATCHES THE
+    // COMPOSITE INDEX'S TRAILING PROPERTY - orderByElided EXPLICITLY REQUIRES select.orderBy.size() == 1. ROWS
+    // SHARING THE SAME PRIMARY (orderedAt) VALUE MUST STILL COME OUT ORDERED BY THE SECONDARY COLUMN (tiebreaker),
+    // WHICH ONLY A FULL MATERIALIZE-AND-SORT (NOT A BARE INDEX SCAN OVER orderedAt ALONE) CAN GUARANTEE
+    final VertexType multiSort = database.getSchema().createVertexType("MultiSort");
+    multiSort.createProperty("groupKey", Type.STRING);
+    multiSort.createProperty("orderedAt", Type.LONG);
+    multiSort.createProperty("tiebreaker", Type.LONG);
+    multiSort.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "groupKey", "orderedAt");
+
+    database.transaction(() -> {
+      // THREE ROWS SHARE orderedAt=100, DIFFERING ONLY BY tiebreaker - INSERTED OUT OF tiebreaker ORDER
+      database.newVertex("MultiSort").set("groupKey", "g", "orderedAt", 100L, "tiebreaker", 3L).save();
+      database.newVertex("MultiSort").set("groupKey", "g", "orderedAt", 100L, "tiebreaker", 1L).save();
+      database.newVertex("MultiSort").set("groupKey", "g", "orderedAt", 100L, "tiebreaker", 2L).save();
+      database.newVertex("MultiSort").set("groupKey", "g", "orderedAt", 200L, "tiebreaker", 0L).save();
+    });
+
+    final SelectCompiled select = database.select().fromType("MultiSort")//
+        .where().property("groupKey").eq().value("g")//
+        .orderBy("orderedAt", false)//
+        .orderBy("tiebreaker", true)//
+        .compile();
+
+    final List<Vertex> list = select.vertices().toList();
+
+    assertThat(list).hasSize(4);
+    assertThat(list.get(0).getLong("orderedAt")).isEqualTo(200L);
+    assertThat(list.get(1).getLong("tiebreaker")).isEqualTo(1L);
+    assertThat(list.get(2).getLong("tiebreaker")).isEqualTo(2L);
+    assertThat(list.get(3).getLong("tiebreaker")).isEqualTo(3L);
+  }
+
+  @Test
   void compositeHashIndexPartialPrefixFallsBackToScan() {
     // A COMPOSITE HASH INDEX DOES NOT SUPPORT ORDERED ITERATIONS (TypeIndex.supportsOrderedIterations() == false),
     // SO A PARTIAL-PREFIX MATCH AGAINST IT MUST NOT ATTEMPT range() - WHICH WOULD THROW UnsupportedOperationException

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -85,6 +85,24 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeIndexPrefixMatchWithParameterBinding() {
+    // matchCompositeIndex() HAS A DEDICATED SelectParameterValue BRANCH FOR THE MATCHED PREFIX'S KEYS, MIRRORING THE
+    // PRE-EXISTING SINGLE-PROPERTY PATH - EXERCISE IT WITH .parameter(...) RATHER THAN .value(...), THE WAY
+    // SelectIndexExecutionTest DOES FOR THAT PATH
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().parameter("k1")//
+        .and().property("key2").eq().parameter("k2").compile();
+
+    final List<Vertex> list = select.parameter("k1", "a").parameter("k2", "b").vertices().toList();
+
+    assertThat(list).hasSize(GROUP_SIZE);
+    list.forEach(v -> {
+      assertThat(v.getString("key1")).isEqualTo("a");
+      assertThat(v.getString("key2")).isEqualTo("b");
+    });
+  }
+
+  @Test
   void compositeIndexPrefixMatchWithOrderByDescLimitOne() {
     // EXACT SCENARIO FROM ISSUE #6592: EQUALITY ON THE LEADING TWO PROPERTIES OF THE COMPOSITE INDEX, ORDER BY THE
     // TRAILING PROPERTY DESCENDING, LIMIT 1 - MUST RETURN THE MOST RECENT MATCH WITHOUT A FULL TYPE SCAN NOR SORT

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -341,6 +341,43 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeIndexPartialPrefixKeepsMatchWhenUnmatchedStandaloneIndexIsNotUnique() {
+    // UNLIKE compositeIndexPartialPrefixDefersToStandaloneIndexOnUnmatchedProperty, THE STANDALONE INDEX ON key3
+    // HERE IS NON-UNIQUE: DEFERRING TO IT WOULD GIVE UP NO GUARANTEED PRECISION (evaluateWhere() STILL NARROWS THE
+    // RESULT DOWN CORRECTLY EITHER WAY, AND A NON-UNIQUE INDEX COULD EVEN BE LESS SELECTIVE THAN THE COMPOSITE
+    // PREFIX'S OWN COMBINED LEADING PROPERTIES) - SO THE COMPOSITE PREFIX MATCH ON key1 MUST STILL WIN RATHER THAN
+    // FALLING BACK TO A SINGLE-PROPERTY PATH
+    final VertexType precedence = database.getSchema().createVertexType("PrecedenceCheckNonUnique");
+    precedence.createProperty("key1", Type.STRING);
+    precedence.createProperty("key2", Type.STRING);
+    precedence.createProperty("key3", Type.STRING);
+    precedence.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "key1", "key2", "key3");
+    precedence.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "key3");
+
+    database.transaction(() -> {
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("PrecedenceCheckNonUnique").set("key1", "a", "key2", "k" + i, "key3", "u" + i).save();
+      for (int i = 0; i < OTHER_SIZE; i++)
+        database.newVertex("PrecedenceCheckNonUnique").set("key1", "other", "key2", "k" + i, "key3", "other" + i).save();
+    });
+
+    final SelectCompiled select = database.select().fromType("PrecedenceCheckNonUnique")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key3").eq().value("u3")//
+        .compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final List<Vertex> list = result.toList();
+
+    assertThat(list).hasSize(1);
+    assertThat(list.getFirst().getString("key3")).isEqualTo("u3");
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    // THE COMPOSITE PREFIX MATCH IS KEPT: EVERY key1='a' ROW IS EVALUATED (NOT JUST THE ONE MATCHING key3), SINCE A
+    // NON-UNIQUE STANDALONE INDEX ON key3 DOES NOT TRIGGER DEFERRAL
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo((long) GROUP_SIZE);
+  }
+
+  @Test
   void compositeHashIndexPartialPrefixFallsBackToScan() {
     // A COMPOSITE HASH INDEX DOES NOT SUPPORT ORDERED ITERATIONS (TypeIndex.supportsOrderedIterations() == false),
     // SO A PARTIAL-PREFIX MATCH AGAINST IT MUST NOT ATTEMPT range() - WHICH WOULD THROW UnsupportedOperationException

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.select;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.MultiIndexCursor;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
@@ -420,5 +421,29 @@ public class SelectCompositeIndexTest extends TestHelper {
 
     assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(0);
     assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo((long) (GROUP_SIZE + OTHER_SIZE));
+  }
+
+  @Test
+  void compositeIndexNotUsedWithNotInTheConjunction() {
+    // SelectOperator.not HAS NO FLUENT ENTRY POINT ON THE Select BUILDER TODAY (SEE
+    // Issue6565SelectIndexCandidateLimitTest.notLeafIsNeverTreatedAsExactlyIndexed) - THE TREE IS BUILT BY HAND HERE.
+    // isPureAndConjunction() MUST REJECT A not() ANYWHERE IN AN OTHERWISE COMPOSITE-ELIGIBLE AND CHAIN THE SAME WAY
+    // IT ALREADY REJECTS or(), FALLING BACK TO THE PRE-EXISTING isTheNodeFullyIndexed()/filterWithIndexes() PATH (NO
+    // CURSOR AT ALL HERE, SINCE NEITHER key1 NOR key2 HAS ITS OWN STANDALONE INDEX)
+    final Select select = database.select().fromType("Supplier");
+    final SelectTreeNode key1Leaf = new SelectTreeNode(new SelectPropertyValue("key1"), SelectOperator.eq, "a");
+    final SelectTreeNode notKey1 = new SelectTreeNode(key1Leaf, SelectOperator.not, null);
+    final SelectTreeNode key2Leaf = new SelectTreeNode(new SelectPropertyValue("key2"), SelectOperator.eq, "b");
+    select.rootTreeElement = new SelectTreeNode(notKey1, SelectOperator.and, key2Leaf);
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      assertThat((Object) cursor).isNull();
+      assertThat(executor.metrics().get("usedIndexes")).isEqualTo(0);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -125,6 +125,24 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeIndexFullKeyMatchIsUsed() {
+    // ALL THREE PROPERTIES OF THE COMPOSITE INDEX ARE BOUND BY EQUALITY: THE KEY'S ARITY MATCHES THE INDEX'S OWN
+    // EXACTLY, SO THIS GOES THROUGH THE PLAIN get() LOOKUP RATHER THAN THE PARTIAL-KEY range() SCAN
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key2").eq().value("b")//
+        .and().property("orderedAt").eq().value(3L).compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final List<Vertex> list = result.toList();
+
+    assertThat(list).hasSize(1);
+    assertThat(list.getFirst().getLong("orderedAt")).isEqualTo(3L);
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+  }
+
+  @Test
   void compositeIndexNotUsedUnderOr() {
     // AN 'or' MUST NOT ATTEMPT THE COMPOSITE PREFIX MATCH: NEITHER PROPERTY HAS ITS OWN STANDALONE INDEX HERE, SO NO
     // INDEX CAN BE USED AND THE QUERY FALLS BACK TO A FULL TYPE SCAN, JUST LIKE BEFORE THE COMPOSITE-INDEX SUPPORT

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -143,6 +143,79 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeIndexPrefixMatchWithSkipAndLimit() {
+    // THE #6565 CANDIDATE CAP (skip + limit) ON THE COMPOSITE-INDEX/ORDER-BY-ELIDED PATH MUST BEHAVE LIKE IT DOES ON
+    // THE SINGLE-PROPERTY PATH (SEE Issue6565SelectIndexCandidateLimitTest)
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key2").eq().value("b")//
+        .orderBy("orderedAt", true)//
+        .skip(1)//
+        .limit(2)//
+        .compile();
+
+    final List<Vertex> list = select.vertices().toList();
+
+    assertThat(list).hasSize(2);
+    assertThat(list.get(0).getLong("orderedAt")).isEqualTo(1L);
+    assertThat(list.get(1).getLong("orderedAt")).isEqualTo(2L);
+  }
+
+  @Test
+  void compositeIndexPrefixWithTrailingRangeAndLimitStaysCorrect() {
+    // A THIRD LEAF ON THE COMPOSITE INDEX'S OWN TRAILING PROPERTY, BUT VIA gt (NOT eq), IS NOT PART OF THE MATCHED
+    // PREFIX (ONLY eq LEAVES ARE COLLECTED INTO andEqLeaves) - exactMatch MUST STAY false SO THE #6565 CANDIDATE CAP
+    // STAYS DISABLED. WERE IT WRONGLY CAPPED AT skip + limit, THE UNDERLYING ASCENDING RANGE SCAN WOULD HAND OUT
+    // ONLY THE FIRST 2 (LOWEST orderedAt) CANDIDATES - orderedAt 0 AND 1 - BOTH OF WHICH FAIL THE gt(2) FILTER,
+    // YIELDING ZERO RESULTS INSTEAD OF THE CORRECT TWO (orderedAt 3 AND 4)
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key2").eq().value("b")//
+        .and().property("orderedAt").gt().value(2L)//
+        .limit(2)//
+        .compile();
+
+    final List<Vertex> list = select.vertices().toList();
+
+    assertThat(list).hasSize(2);
+    list.forEach(v -> assertThat(v.getLong("orderedAt")).isGreaterThan(2L));
+  }
+
+  @Test
+  void compositeIndexTieBreakPrefersUniqueIndex() {
+    // TWO COMPOSITE INDEXES TIE ON MATCHED PREFIX LENGTH (2): (tieKey1, tieKey2, payload) NON-UNIQUE AND
+    // (tieKey1, tieKey3) UNIQUE. THE TIE MUST BE BROKEN TOWARD THE UNIQUE ONE - OBSERVED INDIRECTLY HERE SINCE A
+    // UNIQUE get() LOOKUP EVALUATES EXACTLY 1 CANDIDATE, WHILE THE NON-UNIQUE INDEX'S (tieKey1, tieKey2) PREFIX WOULD
+    // HAVE MATCHED EVERY ROW IN THE GROUP BEFORE evaluateWhere() COULD FILTER DOWN BY tieKey3
+    final VertexType tieBreak = database.getSchema().createVertexType("TieBreak");
+    tieBreak.createProperty("tieKey1", Type.STRING);
+    tieBreak.createProperty("tieKey2", Type.STRING);
+    tieBreak.createProperty("tieKey3", Type.STRING);
+    tieBreak.createProperty("payload", Type.LONG);
+    tieBreak.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "tieKey1", "tieKey2", "payload");
+    tieBreak.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "tieKey1", "tieKey3");
+
+    database.transaction(() -> {
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("TieBreak").set("tieKey1", "x", "tieKey2", "y", "tieKey3", "k" + i, "payload", (long) i).save();
+    });
+
+    final SelectCompiled select = database.select().fromType("TieBreak")//
+        .where().property("tieKey1").eq().value("x")//
+        .and().property("tieKey2").eq().value("y")//
+        .and().property("tieKey3").eq().value("k3")//
+        .compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final List<Vertex> list = result.toList();
+
+    assertThat(list).hasSize(1);
+    assertThat(list.getFirst().getLong("payload")).isEqualTo(3L);
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+  }
+
+  @Test
   void compositeIndexNotUsedUnderOr() {
     // AN 'or' MUST NOT ATTEMPT THE COMPOSITE PREFIX MATCH: NEITHER PROPERTY HAS ITS OWN STANDALONE INDEX HERE, SO NO
     // INDEX CAN BE USED AND THE QUERY FALLS BACK TO A FULL TYPE SCAN, JUST LIKE BEFORE THE COMPOSITE-INDEX SUPPORT

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/ArcadeData/arcadedb/issues/6592: a composite (multi-property) index was
+ * never considered by the native {@link Select} query builder unless every one of its properties appeared as a
+ * separate equality leaf in the where-tree - a plain AND of only the index's LEADING properties fell back to a full
+ * type scan even though the index could answer it with a partial-key lookup.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SelectCompositeIndexTest extends TestHelper {
+
+  private static final int GROUP_SIZE = 5;
+  private static final int OTHER_SIZE = 495;
+
+  public SelectCompositeIndexTest() {
+    autoStartTx = true;
+  }
+
+  @Override
+  protected void beginTest() {
+    final VertexType supplier = database.getSchema().createVertexType("Supplier");
+    supplier.createProperty("key1", Type.STRING);
+    supplier.createProperty("key2", Type.STRING);
+    supplier.createProperty("orderedAt", Type.LONG);
+    supplier.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "key1", "key2", "orderedAt");
+
+    database.transaction(() -> {
+      for (int i = 0; i < GROUP_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "a", "key2", "b", "orderedAt", (long) i).save();
+      for (int i = 0; i < OTHER_SIZE; i++)
+        database.newVertex("Supplier").set("key1", "other", "key2", "other", "orderedAt", (long) i).save();
+    });
+  }
+
+  @Test
+  void compositeIndexPrefixMatchIsUsed() {
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key2").eq().value("b").compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final List<Vertex> list = result.toList();
+
+    assertThat(list).hasSize(GROUP_SIZE);
+    list.forEach(v -> {
+      assertThat(v.getString("key1")).isEqualTo("a");
+      assertThat(v.getString("key2")).isEqualTo("b");
+    });
+
+    // THE COMPOSITE INDEX MUST BE USED (NOT A FULL TYPE SCAN) EVEN THOUGH ONLY A LEADING PREFIX (key1, key2) OF THE
+    // 3-PROPERTY INDEX (key1, key2, orderedAt) IS BOUND BY EQUALITY
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo((long) GROUP_SIZE);
+  }
+
+  @Test
+  void compositeIndexPrefixMatchWithOrderByDescLimitOne() {
+    // EXACT SCENARIO FROM ISSUE #6592: EQUALITY ON THE LEADING TWO PROPERTIES OF THE COMPOSITE INDEX, ORDER BY THE
+    // TRAILING PROPERTY DESCENDING, LIMIT 1 - MUST RETURN THE MOST RECENT MATCH WITHOUT A FULL TYPE SCAN NOR SORT
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key2").eq().value("b")//
+        .orderBy("orderedAt", false)//
+        .limit(1)//
+        .compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final Vertex first = result.nextOrNull();
+
+    assertThat(first).isNotNull();
+    assertThat(first.getString("key1")).isEqualTo("a");
+    assertThat(first.getString("key2")).isEqualTo("b");
+    assertThat(first.getLong("orderedAt")).isEqualTo(GROUP_SIZE - 1);
+    assertThat(result.hasNext()).isFalse();
+
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    // THE ORDER BY IS SATISFIED BY THE INDEX'S OWN SCAN DIRECTION: ONLY THE (SINGLE) RETURNED CANDIDATE IS EVALUATED,
+    // NOT THE WHOLE key1='a' AND key2='b' GROUP NOR THE FULL TYPE
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+  }
+
+  @Test
+  void compositeIndexPartialPrefixStillUsed() {
+    // ONLY key1 IS BOUND: STILL A VALID (SHORTER) PREFIX OF THE SAME COMPOSITE INDEX
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a").compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    final List<Vertex> list = result.toList();
+
+    assertThat(list).hasSize(GROUP_SIZE);
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo((long) GROUP_SIZE);
+  }
+
+  @Test
+  void compositeIndexNotUsedUnderOr() {
+    // AN 'or' MUST NOT ATTEMPT THE COMPOSITE PREFIX MATCH: NEITHER PROPERTY HAS ITS OWN STANDALONE INDEX HERE, SO NO
+    // INDEX CAN BE USED AND THE QUERY FALLS BACK TO A FULL TYPE SCAN, JUST LIKE BEFORE THE COMPOSITE-INDEX SUPPORT
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .or().property("key2").eq().value("b").compile();
+
+    final SelectIterator<Vertex> result = select.vertices();
+    result.toList();
+
+    assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(0);
+    assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo((long) (GROUP_SIZE + OTHER_SIZE));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6592.

`SelectExecutor.isTheNodeFullyIndexed()` (the native `com.arcadedb.query.select.Select` fluent query builder, *not* the SQL executor) only ever looked up an index for one property name at a time. A composite (multi-property) index is registered under its **full** property list (`LocalDocumentType.indexesByProperties`), never under any subset of it, so an AND-conjunction of equality conditions covering only the **leading** properties of a composite index (e.g. `key1 = 'a' AND key2 = 'b'` against an index on `(key1, key2, orderedAt)`) was never recognized and silently fell back to a full type scan.

I verified independently that the SQL executor (`SelectExecutionPlanner.buildIndexSearchDescriptor`/`fullySorted`) already handles this correctly for plain `SELECT` statements - prefix matching and ORDER BY elision by the trailing index column both already work there. The bug is confined to the native query-builder path.

### Fix

`SelectExecutor` now tries a composite-index prefix match first, for a pure AND-conjunction of equality leaves (no `or`/`not` - those keep going through the existing per-leaf path unchanged):

- Every composite index (2+ properties) on the type is checked for how many of its **leading** properties are covered by an `eq` leaf in the where-tree; the longest such prefix wins (ties broken toward a unique index).
- The matched prefix becomes a partial-key cursor: `index.get(keys)` when the prefix covers the whole index, `index.range(ascending, keys, true, keys, true)` for a genuine partial-key scan (a partial key is a *prefix*, not an exact key - `get()` only returns every match when the key's arity matches the index's own exactly).
- When the trailing (first unmatched) index property is also the query's sole `ORDER BY` column, the range scan direction is chosen to match it, so the index itself already returns rows in the requested order - `SelectIterator.fetchResultInCaseOfOrderBy()`'s full materialize-and-sort fallback is skipped, exactly like the reported `ORDER BY ordered_at DESC LIMIT 1` case.
- The `#6565` candidate cap (`skip + limit`) is only applied when the matched prefix consumes the *entire* where-tree and the order-by, if any, is satisfied by the cursor itself - otherwise it runs uncapped, same safety invariant as the existing single-property path.

Single-property indexes and any tree containing `or`/`not` are left entirely to the pre-existing `isTheNodeFullyIndexed()`/`filterWithIndexes()` logic - no behavior change there.

## Test plan

- [x] New regression test `SelectCompositeIndexTest` (TDD - written and confirmed failing before the fix):
  - composite index prefix (`key1 AND key2`) is used instead of a full type scan
  - the exact reported scenario: prefix equality + `ORDER BY <trailing column> DESC LIMIT 1` returns the correct row while only evaluating that one candidate (no full scan, no in-memory sort)
  - a shorter prefix (`key1` alone) still uses the composite index
  - an `or` over the same two properties (no standalone single-property index) still correctly falls back to a full scan, unchanged from before
- [x] `mvn -o -pl engine -am test -Dtest='Select*Test'` (302 tests, includes all of `com.arcadedb.query.select.*` plus the related SQL executor select suites) - all pass
- [x] `mvn -o -pl engine -am test -Dtest='Issue6565SelectIndexCandidateLimitTest'` (the candidate-cap safety test this change's cap logic must not regress) - all 20 pass
- [x] `mvn -o -pl engine -am compile` - clean