### PR TITLE
test(#6600, #6599): pin none() list-predicate edge-variable fix for two more query shapes

### DIFF
--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateNamedPathIssue6600Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateNamedPathIssue6600Test.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6600: a {@code none(item IN r.prop WHERE ...)} list predicate
+ * on a relationship variable matched by the traditional (non-optimized) MATCH plan silently
+ * anonymized the relationship binding - the same root cause as #6567, fixed by making
+ * {@link com.arcadedb.query.opencypher.executor.CypherVariableUsage} walk the parsed AST instead
+ * of scanning {@code Expression#getText()} for the variable name as a standalone word.
+ * <p>
+ * The reported symptom: a {@code MATCH} with a named path and a second comma-separated pattern
+ * part, filtered by {@code none()} on a relationship property, returned 0 rows; appending a
+ * value-preserving {@code CASE} projection after an {@code UNWIND} made the same predicate see the
+ * relationship variable again and the query returned the expected 2 rows.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherNonePredicateNamedPathIssue6600Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", """
+        CREATE (s {k7: true})-[:e {k3: 'm0eNd'}]->
+               (n0 {k3: 'J9qD', k1: true})-[:e]->
+               (n1 {k1: true, klist: ['a', 'b']})-
+               [:rt7 {k4: -833229964, k9: 'b', k11: [1]}]->
+               (u)-[:e]->(v {k6: 1444726425})
+        """);
+  }
+
+  /**
+   * The issue's own reproducer: the query as written and the same query with an identity
+   * {@code CASE} projection appended after {@code UNWIND} must return the same rows.
+   */
+  @Test
+  void nonePredicateOnRelationshipDoesNotDropTheMatch() {
+    final String control = """
+        MATCH p0 = (n1) <-[]- (n0 {k3: 'J9qD', k1: true}) <-[r0 {k3: 'm0eNd'}]- ({k7: true}),
+              (n1) -[r1:rt7 {k4: -833229964, k9: 'b'}]-> () -[]-> ({k6: 1444726425})
+        WHERE none(item IN r1.k11 WHERE item IS NULL)
+        UNWIND coalesce(n1.klist, []) AS alias0
+        RETURN n1, n0, p0, alias0 ORDER BY alias0 ASC LIMIT 14
+        """;
+    final String identityProjection = """
+        MATCH p0 = (n1) <-[]- (n0 {k3: 'J9qD', k1: true}) <-[r0 {k3: 'm0eNd'}]- ({k7: true}),
+              (n1) -[r1:rt7 {k4: -833229964, k9: 'b'}]-> () -[]-> ({k6: 1444726425})
+        WHERE none(item IN r1.k11 WHERE item IS NULL)
+        UNWIND coalesce(n1.klist, []) AS alias0
+        WITH CASE WHEN n1 IS NULL THEN null ELSE n1 END AS n1,
+             CASE WHEN n0 IS NULL THEN null ELSE n0 END AS n0,
+             CASE WHEN r0 IS NULL THEN null ELSE r0 END AS r0,
+             CASE WHEN r1 IS NULL THEN null ELSE r1 END AS r1,
+             CASE WHEN p0 IS NULL THEN null ELSE p0 END AS p0,
+             CASE WHEN alias0 IS NULL THEN null ELSE alias0 END AS alias0
+        RETURN n1, n0, p0, alias0 ORDER BY alias0 ASC LIMIT 14
+        """;
+
+    final List<Object> controlAliases = alias0Values(control);
+    final List<Object> projectionAliases = alias0Values(identityProjection);
+
+    assertThat(controlAliases).containsExactly("a", "b");
+    assertThat(projectionAliases).containsExactly("a", "b");
+  }
+
+  /** Same defect, minimized: a bare {@code none()} predicate on a relationship property alone. */
+  @Test
+  void nonePredicateAloneDoesNotDropTheMatch() {
+    try (final ResultSet rs = database.query("opencypher", """
+        MATCH (n1) -[r1:rt7 {k4: -833229964, k9: 'b'}]-> ()
+        WHERE none(item IN r1.k11 WHERE item IS NULL)
+        RETURN count(*) AS c
+        """)) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isEqualTo(1L);
+    }
+  }
+
+  private List<Object> alias0Values(final String query) {
+    final List<Object> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        values.add(row.getProperty("alias0"));
+      }
+    }
+    return values;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateNamedPathIssue6600Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateNamedPathIssue6600Test.java
@@ -87,6 +87,7 @@ class CypherNonePredicateNamedPathIssue6600Test extends TestHelper {
 
     assertThat(controlAliases).containsExactly("a", "b");
     assertThat(projectionAliases).containsExactly("a", "b");
+    assertThat(controlAliases).isEqualTo(projectionAliases);
   }
 
   /** Same defect, minimized: a bare {@code none()} predicate on a relationship property alone. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateRepeatableBindingsIssue6599Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateRepeatableBindingsIssue6599Test.java
@@ -86,8 +86,12 @@ class CypherNonePredicateRepeatableBindingsIssue6599Test extends TestHelper {
         RETURN __expr_count > 0 AS __v
         """;
 
-    assertThat(singleBoolean(control)).isTrue();
-    assertThat(singleBoolean(identityProjection)).isTrue();
+    final boolean controlValue = singleBoolean(control);
+    final boolean projectionValue = singleBoolean(identityProjection);
+
+    assertThat(controlValue).isTrue();
+    assertThat(projectionValue).isTrue();
+    assertThat(controlValue).isEqualTo(projectionValue);
   }
 
   /** Same defect, minimized: a bare {@code none()} predicate on a relationship property alone. */

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateRepeatableBindingsIssue6599Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherNonePredicateRepeatableBindingsIssue6599Test.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6599: a {@code none(item IN r.prop WHERE ...)} list predicate
+ * on a relationship variable inside a {@code MATCH REPEATABLE ELEMENT BINDINGS} clause nested in a
+ * {@code CALL (...) {...}} subquery silently anonymized the relationship binding - the same root
+ * cause as #6567 and #6600, fixed by making
+ * {@link com.arcadedb.query.opencypher.executor.CypherVariableUsage} walk the parsed AST instead of
+ * scanning {@code Expression#getText()} for the variable name as a standalone word.
+ * <p>
+ * The reported symptom: the query as written returned {@code __v = false} because the subquery's
+ * {@code count(*)} came back 0; appending value-preserving {@code CASE} projections for the
+ * subquery's own bound variables made the same predicate see the relationship variable again and
+ * the query returned the expected {@code __v = true}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherNonePredicateRepeatableBindingsIssue6599Test extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "CREATE (a:Outer {k2: true})-[:rt0 {k4: -1230316915, id: 26}]->(b:Outer {k2: false})");
+    database.command("opencypher", """
+        CREATE (c:l11 {k3: 856175783})<-[f:rt0 {k7: 2081692630, k10: [1386720338, 1309075339]}]-
+               (d:Inner {k7: -1751297746})-
+               [g:rt1 {k3: -1101784399, k7: 1596251831, k10: [1]}]->(h:l7)
+        """);
+  }
+
+  /**
+   * The issue's own reproducer: the query as written and the same query with identity {@code CASE}
+   * projections for the subquery's bound variables must return the same value.
+   */
+  @Test
+  void nonePredicateInsideCallSubqueryDoesNotDropTheMatch() {
+    final String control = """
+        MATCH (n0:Outer {k2: true})-[:rt0 {k4: -1230316915, id: 26}]->(:Outer {k2: false})
+        WHERE (n0.k2 = false OR n0.k2 = true)
+        CALL (n0) {
+          MATCH REPEATABLE ELEMENT BINDINGS
+            p1 = (:l11|l10) <-[r0 {k7: 2081692630, k10: [1386720338, 1309075339]}]-
+                 ({k7: -1751297746}) -[r1:rt1 {k3: -1101784399, k7: 1596251831}]-> (:l7)
+          WHERE none(item IN r1.k10 WHERE item IS NULL)
+          RETURN count(*) AS __expr_count
+        }
+        RETURN __expr_count > 0 AS __v
+        """;
+    final String identityProjection = """
+        MATCH (n0:Outer {k2: true})-[:rt0 {k4: -1230316915, id: 26}]->(:Outer {k2: false})
+        WHERE (n0.k2 = false OR n0.k2 = true)
+        CALL (n0) {
+          MATCH REPEATABLE ELEMENT BINDINGS
+            p1 = (:l11|l10) <-[r0 {k7: 2081692630, k10: [1386720338, 1309075339]}]-
+                 ({k7: -1751297746}) -[r1:rt1 {k3: -1101784399, k7: 1596251831}]-> (:l7)
+          WHERE none(item IN r1.k10 WHERE item IS NULL)
+          WITH CASE WHEN n0 IS NULL THEN null ELSE n0 END AS n0,
+               CASE WHEN r0 IS NULL THEN null ELSE r0 END AS r0,
+               CASE WHEN r1 IS NULL THEN null ELSE r1 END AS r1,
+               CASE WHEN p1 IS NULL THEN null ELSE p1 END AS p1
+          RETURN count(*) AS __expr_count
+        }
+        RETURN __expr_count > 0 AS __v
+        """;
+
+    assertThat(singleBoolean(control)).isTrue();
+    assertThat(singleBoolean(identityProjection)).isTrue();
+  }
+
+  /** Same defect, minimized: a bare {@code none()} predicate on a relationship property alone. */
+  @Test
+  void nonePredicateAloneDoesNotDropTheMatch() {
+    try (final ResultSet rs = database.query("opencypher", """
+        MATCH (:Inner) -[r1:rt1 {k3: -1101784399, k7: 1596251831}]-> (:l7)
+        WHERE none(item IN r1.k10 WHERE item IS NULL)
+        RETURN count(*) AS c
+        """)) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Number>getProperty("c").longValue()).isEqualTo(1L);
+    }
+  }
+
+  private boolean singleBoolean(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().<Boolean>getProperty("__v");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- #6600 and #6599 both reproduce the exact same root cause as #6567, already fixed on `main` by #6570 (commit 6a1eda23e): `CypherVariableUsage.isEdgeVariableReferenced` scanned `Expression#getText()` for a relationship variable as a standalone word, which broke once ANTLR's whitespace-free `getText()` glued the variable name to an adjacent keyword inside a `none()`/`any()`/`all()`/`single()` list predicate (e.g. `r1.k11WHERE...`). The relationship then bound under an internal anonymous name, the predicate silently read a missing property, and rows were dropped — exactly the symptom both issues describe as "a value-preserving `CASE` projection changes the result": the projection happened to make the text scan see the variable name again by coincidence.
- Bisected both reported repros against the history since `26.8.1` and confirmed they already return matching, correct results on `main` after 6a1eda23e. No production code change is needed.
- #6567's own regression test (`Issue6567ListPredicateEdgeVariableTest`) didn't cover either of these two shapes, so this PR adds two pinning tests:
  - `CypherNonePredicateNamedPathIssue6600Test`: a `MATCH` with a named path (`p0 = ...`) plus a second comma-separated pattern part, filtered by `none()` on a relationship property.
  - `CypherNonePredicateRepeatableBindingsIssue6599Test`: a `none()` predicate inside a `MATCH REPEATABLE ELEMENT BINDINGS` clause nested in a `CALL (...) {...}` subquery.

## Test plan

- [x] New tests reproduce each issue's exact query shape (control vs. identity-`CASE`-projection form) and assert both return the same, correct result.
- [x] Full `com.arcadedb.query.opencypher.**` suite: 8840 tests, 0 failures, 0 errors.

Fixes #6600
Fixes #6599

🔗 https://github.com/ArcadeData/arcadedb/issues/6600
🔗 https://github.com/ArcadeData/arcadedb/issues/6599