### PR TITLE
fix(opencypher): MERGE mid-query no longer inflates a chained MATCH's cardinality

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -90,6 +90,19 @@ public class MatchNodeStep extends AbstractExecutionStep {
   // need to move to a per-execution scope or be guarded.
   private       String              usedIndexName; // Track which index was used (if any)
   private       String              usedPartitionBucket; // Track partition bucket pruning (if any) - same write-once-per-execution contract as usedIndexName
+  // Fully materialized snapshot of a row-independent full-type-scan's candidates, resolved on the first
+  // getVertexIterator() call of a CHAINED match (prev != null) and replayed for every later re-open instead
+  // of re-opening a live database.iterateType() cursor per outer input row (a chained MATCH, e.g.
+  // MATCH (), p0 = (), re-opens that scan once per outer input row). Without this, a vertex a downstream
+  // MERGE/CREATE creates mid-query - whether of a brand-new type or of a type that already existed - is
+  // visible to a later re-open and retroactively grows this MATCH's cardinality after earlier rows already
+  // reached WHERE/MERGE (issue #6602). Only enabled for a pattern this class can prove is 100% independent of
+  // the current input row: no ID filter (static or dynamic), no dynamic labels, and (for a single-label
+  // pattern) no properties or inline WHERE pushdown that could route to a row-dependent index/partition
+  // lookup - see {@link #isRowIndependentFullScan()}. Scoped to prev != null: a standalone MATCH calls
+  // getVertexIterator() exactly once regardless, so caching there would only add eager materialization cost
+  // (and memory) for large scans with no correctness benefit.
+  private       List<Identifiable>  cachedFullScanCandidates;
 
   /**
    * Creates a match node step.
@@ -364,6 +377,52 @@ public class MatchNodeStep extends AbstractExecutionStep {
   }
 
   private Iterator<Identifiable> getVertexIterator(final Result currentInputResult) {
+    if (cachedFullScanCandidates != null)
+      return cachedFullScanCandidates.iterator();
+
+    final Iterator<Identifiable> computed = computeVertexIterator(currentInputResult);
+
+    // prev != null: only a chained match re-opens this scan per outer input row, which is the only
+    // situation where a live re-open can observe a downstream write made mid-query (issue #6602).
+    if (prev != null && isRowIndependentFullScan()) {
+      final List<Identifiable> materialized = new ArrayList<>();
+      computed.forEachRemaining(materialized::add);
+      cachedFullScanCandidates = materialized;
+      return materialized.iterator();
+    }
+
+    return computed;
+  }
+
+  /**
+   * True when this pattern's candidate set cannot vary from one input row to the next, so the iterator
+   * {@link #computeVertexIterator} returns is safe to materialize once and replay for every later re-open
+   * (see {@link #cachedFullScanCandidates}): no ID filter (static or dynamic) and no dynamic labels - either
+   * of those can resolve to a different, row-dependent target regardless of label count.
+   * <p>
+   * Properties and an inline WHERE pushdown ({@link #whereFilter}) only disqualify a <b>single-label</b>
+   * pattern: that is the only branch of {@code computeVertexIterator} ({@code tryFindAndUseIndex},
+   * {@code tryFindAndUseIndexFromWhere}, {@code tryPartitionPrunedIterator}) where a property value or a
+   * WHERE predicate can steer the scan itself to a row-dependent index/partition lookup. A label-less or
+   * multi-label pattern never takes any of those branches regardless of properties/whereFilter - it always
+   * resolves the same full type scan - and both are applied there only as post-fetch per-row filters (see
+   * {@code matchesProperties}/the {@code whereFilter.evaluate} call in this step's chained-mode fetch loop),
+   * which does not affect what the candidate set is.
+   */
+  private boolean isRowIndependentFullScan() {
+    if ((idFilter != null && !idFilter.isEmpty()) || dynamicIdExpression != null || pattern.hasDynamicLabels())
+      return false;
+    final List<String> labels = pattern.getLabels();
+    if (labels != null && labels.size() == 1) {
+      if (pattern.getProperties() != null && !pattern.getProperties().isEmpty())
+        return false;
+      if (whereFilter != null)
+        return false;
+    }
+    return true;
+  }
+
+  private Iterator<Identifiable> computeVertexIterator(final Result currentInputResult) {
     // OPTIMIZATION: Resolve ID filter - either static (from plan time) or dynamic (from runtime).
     // Static idFilter handles literals/parameters; dynamicIdExpression handles expressions like
     // BatchEntry.destRID that can only be resolved with the current input row (issue #3864).

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -91,25 +91,34 @@ public class MatchNodeStep extends AbstractExecutionStep {
   // (including cachedFullScanCandidates below) need to move to a per-execution scope or be guarded.
   private       String              usedIndexName; // Track which index was used (if any)
   private       String              usedPartitionBucket; // Track partition bucket pruning (if any) - same write-once-per-execution contract as usedIndexName
-  // Fully materialized snapshot of a row-independent full-type-scan's candidates, resolved on the first
-  // getVertexIterator() call of a CHAINED match (prev != null) and replayed for every later re-open instead
-  // of re-opening a live database.iterateType() cursor per outer input row (a chained MATCH, e.g.
-  // MATCH (), p0 = (), re-opens that scan once per outer input row). Without this, a vertex a downstream
-  // MERGE/CREATE creates mid-query - whether of a brand-new type or of a type that already existed - is
-  // visible to a later re-open and retroactively grows this MATCH's cardinality after earlier rows already
-  // reached WHERE/MERGE (issue #6602). Only enabled for a pattern this class can prove is 100% independent of
-  // the current input row: no ID filter (static or dynamic), no dynamic labels, and (for a single-label
-  // pattern) no properties or inline WHERE pushdown that could route to a row-dependent index/partition
-  // lookup - see {@link #isRowIndependentFullScan()}. Scoped to prev != null: a standalone MATCH calls
-  // getVertexIterator() exactly once regardless, so caching there would only add eager materialization cost
-  // (and memory) for large scans with no correctness benefit.
+  // Full snapshot of a row-independent full-type-scan's candidates, populated (via recordingIterator) only
+  // once the first getVertexIterator() call of a CHAINED match (prev != null) has been fully drained by the
+  // caller, and replayed from then on for every later re-open instead of re-opening a live
+  // database.iterateType() cursor per outer input row (a chained MATCH, e.g. MATCH (), p0 = (), re-opens
+  // that scan once per outer input row). Without this, a vertex a downstream MERGE/CREATE creates
+  // mid-query - whether of a brand-new type or of a type that already existed - is visible to a later
+  // re-open and retroactively grows this MATCH's cardinality after earlier rows already reached WHERE/MERGE
+  // (issue #6602). Only enabled for a pattern this class can prove is 100% independent of the current input
+  // row: no ID filter (static or dynamic), no dynamic labels, and (for a single-label pattern) no properties
+  // or a WHERE-driven equality predicate on this pattern's own variable that could route to a row-dependent
+  // index/partition lookup - see {@link #isRowIndependentFullScan()}. Scoped to prev != null: a standalone
+  // MATCH calls getVertexIterator() exactly once regardless, so caching there would only add eager
+  // materialization cost (and memory) for large scans with no correctness benefit.
   // <p>
-  // Memory/CPU tradeoff: for a chained label-less or multi-label pattern over a very large vertex type, this
-  // now holds every candidate's Identifiable in memory for the life of the step instead of streaming a live
-  // cursor per re-open. That is a clear win when the pattern is re-opened many times (turns O(N) per outer
-  // row into one O(N) resolve), but it does mean the full candidate set is resident for the step's lifetime
-  // rather than GC-able as it streams past - deliberate, since re-opening a live cursor per row is exactly
-  // the mechanism issue #6602 exploits, and the RID list is far lighter than the vertices it names.
+  // Performance: staying null until the first pass is fully drained (rather than eagerly draining on the
+  // first call) matters beyond just deferring the cost - it preserves LIMIT push-down/early-termination for
+  // the common case where the outer input produces exactly one row (this scan is opened once, satisfies a
+  // LIMIT after a few elements, and is never re-opened): the bug this field guards against can only occur
+  // from a SECOND re-open onward, so a query shape that never re-opens this scan pays none of the eager-scan
+  // cost, exactly like the pre-fix behaviour. See {@link #recordingIterator}.
+  // <p>
+  // Memory/CPU tradeoff once a genuine second re-open DOES happen: for a chained label-less or multi-label
+  // pattern over a very large vertex type, this then holds every candidate's Identifiable in memory for the
+  // rest of the step's lifetime instead of streaming a live cursor per re-open. That is a clear win when the
+  // pattern is re-opened many times (turns O(N) per outer row into one O(N) resolve), but it does mean the
+  // full candidate set is resident rather than GC-able as it streams past - deliberate, since re-opening a
+  // live cursor per row is exactly the mechanism issue #6602 exploits, and the RID list is far lighter than
+  // the vertices it names.
   private       List<Identifiable>  cachedFullScanCandidates;
 
   /**
@@ -401,15 +410,48 @@ public class MatchNodeStep extends AbstractExecutionStep {
     final Iterator<Identifiable> computed = computeVertexIterator(currentInputResult);
 
     // prev != null: only a chained match re-opens this scan per outer input row, which is the only
-    // situation where a live re-open can observe a downstream write made mid-query (issue #6602).
-    if (prev != null && isRowIndependentFullScan()) {
-      final List<Identifiable> materialized = new ArrayList<>();
-      computed.forEachRemaining(materialized::add);
-      cachedFullScanCandidates = materialized;
-      return materialized.iterator();
-    }
+    // situation where a live re-open can observe a downstream write made mid-query (issue #6602). The
+    // bug this guards against can only occur from the SECOND re-open onward - the first open can never
+    // observe a downstream write, since nothing downstream has run yet - so the first pass stays fully
+    // lazy/streaming (recordingIterator only records what the caller actually consumes) rather than
+    // eagerly draining the whole candidate set. That preserves LIMIT push-down/short-circuiting for the
+    // common case where the outer input produces exactly one row (e.g.
+    // MATCH (a:Anchor {id:$x}), (n) RETURN a, n LIMIT 5) - this scan is opened once, caching would buy
+    // it nothing, and eagerly draining it would turn an O(LIMIT) scan into an O(N) one.
+    if (prev != null && isRowIndependentFullScan())
+      return recordingIterator(computed);
 
     return computed;
+  }
+
+  /**
+   * Wraps {@code source} - a freshly computed, row-independent candidate iterator - so it streams lazily
+   * exactly like the pre-fix behaviour, while recording every element as the caller consumes it. Only once
+   * {@code source} reports {@code hasNext() == false} (fully drained) does the recording get promoted to
+   * {@link #cachedFullScanCandidates}, so a genuine second {@link #getVertexIterator} call - the only
+   * situation issue #6602 can occur in - replays the cache instead of re-opening a live cursor. If the
+   * caller never drains {@code source} to exhaustion (e.g. a LIMIT satisfied after one row, with no second
+   * outer row ever produced), no full scan ever happens and no cache is ever populated - exactly the
+   * pre-fix cost profile for that case.
+   */
+  private Iterator<Identifiable> recordingIterator(final Iterator<Identifiable> source) {
+    final List<Identifiable> recorded = new ArrayList<>();
+    return new Iterator<>() {
+      @Override
+      public boolean hasNext() {
+        final boolean hasNext = source.hasNext();
+        if (!hasNext && cachedFullScanCandidates == null)
+          cachedFullScanCandidates = recorded;
+        return hasNext;
+      }
+
+      @Override
+      public Identifiable next() {
+        final Identifiable next = source.next();
+        recorded.add(next);
+        return next;
+      }
+    };
   }
 
   /**
@@ -589,13 +631,20 @@ public class MatchNodeStep extends AbstractExecutionStep {
       // Labels, the one place that knows what a disjunction means, so a node pattern is scanned the same way
       // wherever it is written - here as the anchor of a MATCH, or as the start of a pattern comprehension,
       // which used to take the first label and nothing else (issues #6338, #6352).
+      // <p>
+      // isRowIndependentFullScan() relies on this branch - like the no-label one below - never routing
+      // through the index/partition-pruning branches above (tryFindAndUseIndex,
+      // tryFindAndUseIndexFromWhere, tryPartitionPrunedIterator), which is why it treats properties/WHERE
+      // as safe to ignore for a multi-label or label-less pattern. If a future change ever gives this
+      // branch an index/partition fast path of its own, isRowIndependentFullScan() must be revisited too.
       @SuppressWarnings("unchecked") final Iterator<Identifiable> labelled =
           (Iterator<Identifiable>) (Object) Labels.iterateMatchingVertices(context.getDatabase(), labels,
               pattern.isLabelDisjunction());
       return labelled;
     }
 
-    // No label specified - iterate ALL vertex types, which is the same rule with nothing to satisfy.
+    // No label specified - iterate ALL vertex types, which is the same rule with nothing to satisfy - and,
+    // like the multi-label branch above, relied on by isRowIndependentFullScan() for the same reason.
     @SuppressWarnings("unchecked") final Iterator<Identifiable> everyVertex =
         (Iterator<Identifiable>) (Object) Labels.iterateMatchingVertices(context.getDatabase(), labels, false);
     return everyVertex;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.engine.Bucket;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
@@ -86,8 +87,8 @@ public class MatchNodeStep extends AbstractExecutionStep {
   // Display-only diagnostic fields surfaced through {@link #prettyPrint}. Mirrors the
   // {@code usedIndexName} pattern: written once during the first iterator setup and read by the
   // pretty printer at plan-print time. Not safe to share a step instance across concurrent MATCH
-  // branches - if a future change drives parallel sub-plans through the same step, both fields
-  // need to move to a per-execution scope or be guarded.
+  // branches - if a future change drives parallel sub-plans through the same step, all three fields
+  // (including cachedFullScanCandidates below) need to move to a per-execution scope or be guarded.
   private       String              usedIndexName; // Track which index was used (if any)
   private       String              usedPartitionBucket; // Track partition bucket pruning (if any) - same write-once-per-execution contract as usedIndexName
   // Fully materialized snapshot of a row-independent full-type-scan's candidates, resolved on the first
@@ -102,6 +103,13 @@ public class MatchNodeStep extends AbstractExecutionStep {
   // lookup - see {@link #isRowIndependentFullScan()}. Scoped to prev != null: a standalone MATCH calls
   // getVertexIterator() exactly once regardless, so caching there would only add eager materialization cost
   // (and memory) for large scans with no correctness benefit.
+  // <p>
+  // Memory/CPU tradeoff: for a chained label-less or multi-label pattern over a very large vertex type, this
+  // now holds every candidate's Identifiable in memory for the life of the step instead of streaming a live
+  // cursor per re-open. That is a clear win when the pattern is re-opened many times (turns O(N) per outer
+  // row into one O(N) resolve), but it does mean the full candidate set is resident for the step's lifetime
+  // rather than GC-able as it streams past - deliberate, since re-opening a live cursor per row is exactly
+  // the mechanism issue #6602 exploits, and the RID list is far lighter than the vertices it names.
   private       List<Identifiable>  cachedFullScanCandidates;
 
   /**
@@ -281,8 +289,18 @@ public class MatchNodeStep extends AbstractExecutionStep {
                   rowCount++;
 
                 final Identifiable identifiable = iterator.next();
-                // Load the record if it's not already loaded
-                final Document record = identifiable.asDocument();
+                // Load the record if it's not already loaded. A RID drawn from
+                // cachedFullScanCandidates (see getVertexIterator) can outlive the vertex it names -
+                // a downstream DELETE for an earlier outer row can remove it before a later re-open
+                // replays the cached list - so, like every other step in this codebase that resolves
+                // a previously-captured RID (FetchFromRidsStep, MatchRelationshipStep, ...), a vertex
+                // that no longer exists is skipped rather than surfaced as an uncaught exception.
+                final Document record;
+                try {
+                  record = identifiable.asDocument();
+                } catch (final RecordNotFoundException e) {
+                  continue;
+                }
                 if (record instanceof Vertex) {
                   final Vertex vertex = (Vertex) record;
 
@@ -400,14 +418,21 @@ public class MatchNodeStep extends AbstractExecutionStep {
    * (see {@link #cachedFullScanCandidates}): no ID filter (static or dynamic) and no dynamic labels - either
    * of those can resolve to a different, row-dependent target regardless of label count.
    * <p>
-   * Properties and an inline WHERE pushdown ({@link #whereFilter}) only disqualify a <b>single-label</b>
-   * pattern: that is the only branch of {@code computeVertexIterator} ({@code tryFindAndUseIndex},
-   * {@code tryFindAndUseIndexFromWhere}, {@code tryPartitionPrunedIterator}) where a property value or a
-   * WHERE predicate can steer the scan itself to a row-dependent index/partition lookup. A label-less or
-   * multi-label pattern never takes any of those branches regardless of properties/whereFilter - it always
-   * resolves the same full type scan - and both are applied there only as post-fetch per-row filters (see
-   * {@code matchesProperties}/the {@code whereFilter.evaluate} call in this step's chained-mode fetch loop),
-   * which does not affect what the candidate set is.
+   * Properties and a WHERE-driven equality predicate on <b>this pattern's own variable</b> only disqualify a
+   * <b>single-label</b> pattern: that is the only branch of {@code computeVertexIterator}
+   * ({@code tryFindAndUseIndex}, {@code tryFindAndUseIndexFromWhere}, {@code tryPartitionPrunedIterator})
+   * where a property value or such a predicate can steer the scan itself to a row-dependent index/partition
+   * lookup. A label-less or multi-label pattern never takes any of those branches regardless of
+   * properties/whereFilter - it always resolves the same full type scan - and both are applied there only as
+   * post-fetch per-row filters (see {@code matchesProperties}/the {@code whereFilter.evaluate} call in this
+   * step's chained-mode fetch loop), which does not affect what the candidate set is.
+   * <p>
+   * {@code whereFilter} itself is checked structurally rather than just for {@code != null}:
+   * {@code tryFindAndUseIndexFromWhere} only ever acts on a {@code variable.property = <expr>} (or reversed)
+   * equality it can find inside {@code whereFilter}'s top-level AND-chain (see
+   * {@link #extractEqualityPredicates}, which recurses through AND only, exactly like this check). A pushed
+   * -down predicate that mentions unrelated variables - e.g. an UNWIND alias a WHERE clause filters on, with
+   * nothing to do with this pattern's own variable - can never route there, so it must not disable caching.
    */
   private boolean isRowIndependentFullScan() {
     if ((idFilter != null && !idFilter.isEmpty()) || dynamicIdExpression != null || pattern.hasDynamicLabels())
@@ -416,10 +441,34 @@ public class MatchNodeStep extends AbstractExecutionStep {
     if (labels != null && labels.size() == 1) {
       if (pattern.getProperties() != null && !pattern.getProperties().isEmpty())
         return false;
-      if (whereFilter != null)
+      if (whereFilterHasEqualityPredicateOnOwnVariable(whereFilter))
         return false;
     }
     return true;
+  }
+
+  /**
+   * Structural (not value-resolving) mirror of {@link #extractEqualityPredicates}'s predicate recognition:
+   * true if {@code expr}'s top-level AND-chain contains a {@code variable.property = <expr>} (or reversed)
+   * comparison against this step's own {@link #variable}, regardless of whether that expression could
+   * actually be resolved for any given row. Recursing through AND only (not OR/NOT/XOR) matches
+   * {@code extractEqualityPredicates} exactly: a predicate {@code extractEqualityPredicates} can never reach
+   * is not something {@code tryFindAndUseIndexFromWhere} can act on either, so it must not disqualify caching.
+   */
+  private boolean whereFilterHasEqualityPredicateOnOwnVariable(final BooleanExpression expr) {
+    if (expr instanceof ComparisonExpression comp) {
+      if (comp.getOperator() != ComparisonExpression.Operator.EQUALS)
+        return false;
+      return isPropertyAccessOnOwnVariable(comp.getLeft()) || isPropertyAccessOnOwnVariable(comp.getRight());
+    }
+    if (expr instanceof LogicalExpression logical && logical.getOperator() == LogicalExpression.Operator.AND)
+      return whereFilterHasEqualityPredicateOnOwnVariable(logical.getLeft())
+          || whereFilterHasEqualityPredicateOnOwnVariable(logical.getRight());
+    return false;
+  }
+
+  private boolean isPropertyAccessOnOwnVariable(final Expression expr) {
+    return expr instanceof PropertyAccessExpression propAccess && variable.equals(propAccess.getVariableName());
   }
 
   private Iterator<Identifiable> computeVertexIterator(final Result currentInputResult) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6602MergeAfterEmptyMatchCardinalityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6602MergeAfterEmptyMatchCardinalityTest.java
@@ -189,4 +189,61 @@ class Issue6602MergeAfterEmptyMatchCardinalityTest extends TestHelper {
     assertThat(rows).hasSize(15);
     assertThat(database.countType("Seed", true)).isEqualTo(16L);
   }
+
+  @Test
+  void singleLabelChainedPatternWithNoPropertiesIsAlsoCacheable() {
+    // The other regression tests exercise the no-label and multi-label branches; this one exercises a
+    // genuine single-label pattern with no properties/WHERE - the branch with the most conditional logic
+    // in isRowIndependentFullScan(), since it is the only one that inspects properties/whereFilter at all.
+    final ResultSet rs = database.command("opencypher", """
+        UNWIND ['D', 'eUu'] AS alias0
+        MATCH (n:Seed), (m:Seed)
+        WHERE NOT ((alias0 + alias0) >= 'a')
+        MERGE (:Seed {id: 999})
+        RETURN {alias0: alias0, n: n, m: m} AS row;
+        """);
+
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+
+    // 15 (outer n:Seed) * 15 (inner m:Seed) = 225, regardless of MERGE creating a 16th matching vertex.
+    assertThat(rows).hasSize(225);
+    assertThat(database.countType("Seed", true)).isEqualTo(16L);
+  }
+
+  @Test
+  void chainedMatchToleratesDownstreamDeleteOfACachedCandidate() {
+    // Flagged in code review: the same mid-query interleaving that lets a downstream MERGE retroactively
+    // grow a chained MATCH's cardinality also lets a downstream DELETE remove a vertex that is sitting in
+    // an earlier, already-cached candidate list (cachedFullScanCandidates). DeleteStep applies each
+    // deletion immediately, per row, with no barrier collecting every row first - so by the time a later
+    // outer row's re-open replays the cache, some of the RIDs in it can already be gone. Before the
+    // RecordNotFoundException guard added alongside the cache, loading one of those stale RIDs would abort
+    // the whole query instead of just skipping the now-nonexistent row.
+    //
+    // m scans a type (:Other) disjoint from what n scans (:Seed) so n's own bound vertices are never among
+    // what m deletes - isolating the one thing this test targets (MatchNodeStep's cached candidate list
+    // going stale) from an unrelated, pre-existing hazard: RETURN's lazy property access on n would itself
+    // throw if n's own vertex had been deleted by the time the RETURN clause evaluates n.id, which is a
+    // separate concern outside MatchNodeStep (and outside what this PR's cache introduces) - not something
+    // to paper over in this test, but not what this test is about either.
+    database.command("opencypher", "UNWIND range(1, 15) AS i CREATE (:Other {id: i});");
+
+    final ResultSet rs = database.command("opencypher", """
+        MATCH (n:Seed), (m:Other)
+        DELETE m
+        RETURN n.id AS n
+        """);
+
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+
+    assertThat(count).isGreaterThan(0);
+    assertThat(database.countType("Seed", true)).isEqualTo(15L);
+    assertThat(database.countType("Other", true)).isEqualTo(0L);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6602MergeAfterEmptyMatchCardinalityTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6602MergeAfterEmptyMatchCardinalityTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #6602.
+ * <p>
+ * A chained {@code MATCH} node pattern with no per-row-varying constraint (no label, a multi-label pattern,
+ * or a single label with no property/WHERE-driven index lookup) re-opened its candidate scan by calling
+ * {@code database.iterateType()} live, on every per-row re-open of
+ * {@link com.arcadedb.query.opencypher.executor.steps.MatchNodeStep}'s inner scan (a chained MATCH re-opens
+ * that scan once per outer input row - e.g. {@code MATCH (), p0 = ()} re-opens the {@code p0} scan once for
+ * every row the {@code ()} pattern produces). Because the step pipeline is pull-based and every step does an
+ * internal read-ahead ({@code if (!prevResults.hasNext()) finished = true;} right after its own fill loop) to
+ * decide whether it is exhausted, a later re-open of that scan could happen AFTER a downstream {@code MERGE}
+ * - logically applied only once all of an earlier MATCH's rows have been produced - had already created a
+ * new vertex. That vertex then leaked into the still-in-flight scan as a spurious extra match, retroactively
+ * inflating the MATCH clause's own row count after WHERE/MERGE had already started consuming its earlier rows
+ * - whether the vertex MERGE created was of a brand-new type or of a type that already existed before the
+ * query started.
+ * <p>
+ * Fixed by materializing the full candidate set once per {@code MatchNodeStep} execution (cached on the step
+ * instance, which is rebuilt fresh for every query execution) instead of re-opening a live database cursor on
+ * every re-open, whenever the pattern is provably independent of the current input row - see
+ * {@code MatchNodeStep#isRowIndependentFullScan}/{@code #cachedFullScanCandidates}. Only applied when the
+ * step is chained ({@code prev != null}); a standalone MATCH calls its vertex iterator exactly once
+ * regardless, so caching there would only add eager-materialization cost with no correctness benefit.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6602MergeAfterEmptyMatchCardinalityTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.command("opencypher", "UNWIND range(1, 15) AS i CREATE (:Seed {id: i});");
+  }
+
+  @Test
+  void mergeAfterZeroLengthMatchDoesNotInflateMatchCardinality() {
+    // The WHERE filter keeps only alias0 = 'D' ('D' < 'a' lexicographically, 'eUu' + 'eUu' >= 'a'),
+    // so the two zero-length MATCH patterns alone must contribute exactly 15 * 15 = 225 rows,
+    // regardless of the MERGE clause creating a brand new vertex type partway through evaluation.
+    final ResultSet rs = database.command("opencypher", """
+        UNWIND ['D', 'eUu'] AS alias0
+        MATCH (), p0 = ()
+        WHERE NOT ((alias0 + alias0) >= 'a')
+        MERGE (:l4 {id: 128})
+        RETURN {alias0: alias0, p0: p0} AS row;
+        """);
+
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+
+    assertThat(rows).hasSize(225);
+
+    // Every p0 binding must be one of the 15 pre-existing Seed vertices, seen exactly 15 times each -
+    // never the vertex MERGE creates mid-query.
+    final Map<Object, Long> p0Counts = rows.stream()
+        .map(r -> (Map<?, ?>) r.getProperty("row"))
+        .collect(java.util.stream.Collectors.groupingBy(m -> m.get("p0"), java.util.stream.Collectors.counting()));
+    assertThat(p0Counts).hasSize(15);
+    assertThat(p0Counts.values()).allSatisfy(count -> assertThat(count).isEqualTo(15L));
+
+    // MERGE must still have created exactly one l4 vertex (correct match-or-create semantics).
+    assertThat(database.countType("l4", true)).isEqualTo(1L);
+  }
+
+  @Test
+  void materializedFormAgreesWithDirectReturn() {
+    // The workaround from the issue report: forcing materialization via collect()+UNWIND before RETURN.
+    // Both forms must return the same row count.
+    final ResultSet rs = database.command("opencypher", """
+        UNWIND ['D', 'eUu'] AS alias0
+        MATCH (), p0 = ()
+        WHERE NOT ((alias0 + alias0) >= 'a')
+        MERGE (:l4 {id: 128})
+        WITH {alias0: alias0, p0: p0} AS row
+        WITH collect(row) AS rows
+        UNWIND rows AS row
+        RETURN row;
+        """);
+
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+
+    assertThat(count).isEqualTo(225);
+    assertThat(database.countType("l4", true)).isEqualTo(1L);
+  }
+
+  @Test
+  void mergeCreatingVertexOfAnAlreadyExistingTypeDoesNotInflateMatchCardinalityEither() {
+    // Same shape, but MERGE creates a vertex of the type the earlier MATCH clauses are already scanning
+    // (:Seed) instead of a brand-new type. Caching only the candidate TYPE list would not have caught this:
+    // database.iterateType() still opens a fresh live cursor per re-open even when the type list itself is
+    // stable, so the new :Seed vertex is just as capable of leaking into a still-in-flight scan of its own
+    // type as a brand-new type is of leaking into a "no label" scan.
+    final ResultSet rs = database.command("opencypher", """
+        UNWIND ['D', 'eUu'] AS alias0
+        MATCH (), p0 = ()
+        WHERE NOT ((alias0 + alias0) >= 'a')
+        MERGE (:Seed {id: 999})
+        RETURN {alias0: alias0, p0: p0} AS row;
+        """);
+
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+
+    assertThat(rows).hasSize(225);
+    assertThat(database.countType("Seed", true)).isEqualTo(16L);
+  }
+
+  @Test
+  void multiLabelPatternWithPropertiesIsStillCacheable() {
+    // A multi-label pattern with a property constraint - e.g. (:A:B {flag: true}) - never routes through
+    // the single-label index/partition-pruning branches of MatchNodeStep#computeVertexIterator, so unlike a
+    // single-label pattern, properties there do not make the scan target row-dependent: they are applied
+    // only as a post-fetch filter. This must be just as cacheable/immune to the leak as a label-less pattern.
+    database.command("opencypher", "UNWIND range(1, 15) AS i CREATE (:A:B {flag: true, id: i});");
+
+    // Both sides use the SAME multi-label + property pattern (not an anonymous ()) so the pre-existing
+    // :Seed vertices from beginTest() - unrelated to this scenario - are not swept into the cartesian too.
+    final ResultSet rs = database.command("opencypher", """
+        UNWIND ['D', 'eUu'] AS alias0
+        MATCH (:A:B {flag: true}), p0 = (:A:B {flag: true})
+        WHERE NOT ((alias0 + alias0) >= 'a')
+        MERGE (:A:B {flag: true, id: 999})
+        RETURN {alias0: alias0, p0: p0} AS row;
+        """);
+
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+
+    // 15 (outer :A:B{flag:true}) * 15 (inner :A:B{flag:true}) = 225, regardless of MERGE creating a 16th
+    // matching :A:B {flag:true} vertex partway through evaluation.
+    assertThat(rows).hasSize(225);
+    assertThat(database.countType("A", true)).isEqualTo(16L);
+  }
+
+  @Test
+  void singleNonChainedMatchIsUnaffected() {
+    // A single MATCH (not cartesian-joined with a second pattern) never re-opens its scan mid-query, so it
+    // was never affected by the bug and must keep behaving exactly as before: only alias0 = 'D' survives the
+    // WHERE filter, contributing the 15 pre-existing Seed vertices - MERGE's new vertex must not appear.
+    final ResultSet rs = database.command("opencypher", """
+        UNWIND ['D', 'eUu'] AS alias0
+        MATCH (n:Seed)
+        WHERE NOT ((alias0 + alias0) >= 'a')
+        MERGE (:Seed {id: 999})
+        RETURN {alias0: alias0, n: n} AS row;
+        """);
+
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+
+    assertThat(rows).hasSize(15);
+    assertThat(database.countType("Seed", true)).isEqualTo(16L);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6602.

A chained `MATCH` node pattern with no per-row-varying constraint (e.g. the
anonymous `()` in `MATCH (), p0 = ()`) re-opened its full vertex scan by
calling `database.iterateType()` live on every per-row re-open. Since a
chained MATCH re-opens that scan once per outer input row, a re-open
happening after a downstream `MERGE` had already created a new vertex - of a
brand-new type or of one that already existed - would see that vertex and add
a spurious extra row, retroactively inflating the MATCH clause's own
cardinality after WHERE/MERGE had already started consuming its earlier rows.

This is a genuine ArcadeDB bug, not a user misunderstanding of Cypher: in
Neo4j/openCypher semantics MERGE runs once per input row from the preceding
clauses and must not retroactively change the cardinality those clauses
already produced (Neo4j guards against exactly this class of hazard with an
"Eager" plan operator).

### Root cause

- `MatchNodeStep`'s chained-mode fetch loop re-opens its vertex iterator once
  per outer input row (`getVertexIterator(currentInputResult)`), whenever the
  current pattern variable isn't already bound.
- For a pattern with no per-row-varying constraint, the resulting scan target
  is always the same set of vertices - but it was still being recomputed live
  via `database.iterateType()` on every re-open, so a vertex created
  mid-query by a downstream `MERGE` could be picked up by a later re-open.
- Because the step pipeline is pull-based and every step does an internal
  read-ahead to decide whether it's exhausted, this re-open can legitimately
  happen interleaved with a downstream `MERGE`'s write, not only after the
  whole query completes.

### Fix

`MatchNodeStep` now materializes its full candidate set once per step
execution and replays it on every later re-open, whenever the pattern is
provably independent of the current input row (no ID filter, no dynamic
labels, and - for a single-label pattern - no properties or inline WHERE
pushdown that could route to a row-dependent index/partition lookup). This is
scoped to chained steps only (`prev != null`); a standalone MATCH already
calls its vertex iterator exactly once, so caching there would only add
eager-materialization cost with no correctness benefit - and as a side
effect, it turns what used to be an O(N) full-type-scan per outer row into a
single O(N) resolve reused across all outer rows for chained/cartesian
patterns.

## Test plan

- [x] New regression test `Issue6602MergeAfterEmptyMatchCardinalityTest`
  covering: the exact issue repro (225 vs 226 rows), the `collect()`+`UNWIND`
  materialized form from the issue's workaround, MERGE creating a vertex of
  an *already-existing* type (not just a brand-new type), a multi-label
  pattern with properties (to confirm the broader fix generalizes correctly),
  and a standalone (non-chained) MATCH staying unaffected.
- [x] Full `com.arcadedb.query.opencypher.**` test package: 8841 tests, 0
  failures, 0 errors (98 skipped/tagged).
- [x] `mvn -o -pl engine -am compile` clean.