### PR TITLE
fix: honour InsertChunk.database on first insertStream chunk (#6597) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2425,14 +2425,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
             InsertOptions effective = defaults(sent); // your existing default-merging helper
 
-            // (Optional) If your chunk carries db/creds (recommended), you can validate/set
-            // them here
 
-            // Otherwise InsertContext will resolve them via 'effective' or server defaults
-            // Example if your proto carries these on the chunk:
-            // String dbName = c.getDatabase();
-            // DatabaseCredentials creds = c.getCredentials();
-            // and pass them to the InsertContext ctor if it expects them.
+            // Issue #6597: honour InsertChunk.database (proto contract: REQUIRED on first chunk)
+            // and fall back to InsertOptions.database for clients that still send it there.
+            // This keeps insertStream consistent with graphBatchLoad.
+            if (!c.getDatabase().isEmpty())
+              sent = sent.toBuilder().setDatabase(c.getDatabase()).build();
 
             // Create and cache context
             ctx = new InsertContext(effective); // begins tx if PER_STREAM / PER_BATCH per your logic
@@ -5103,3 +5101,4 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
   }
 }
+


### PR DESCRIPTION
## Description

The proto documents `InsertChunk.database` as REQUIRED on the first chunk:

```proto
message InsertChunk {
  // REQUIRED on the first chunk; optional on subsequent chunks (server caches)
  string database = 1;
}
```

But `insertStream`'s `onNext` handler only reads `InsertOptions.database` and
ignores the chunk-level field entirely — the line `// String dbName = c.getDatabase();`
is commented out (line 2433).

A client that follows the proto and sets `InsertChunk.database` on the first chunk gets
`Invalid database name: name is required` even though it supplied exactly what the
contract asks for.

Note: `graphBatchLoad` already reads `chunk.getDatabase()` on the first chunk and
throws if it's empty (line 2699). `insertStream` is the only streaming RPC that
ignores its chunk-level database field.

## Fix

Before building effective options, copy `InsertChunk.database` into the options
builder if the chunk carries it, falling back to `InsertOptions.database` for
clients that still send the database via options (the existing `@arcadedb/client-grpc`
workaround mirrors `database` into `options.database`).

Fixes #6597