### PR TITLE
fix: reject CountEdgesStep optimization when UNWIND precedes OPTIONAL MATCH [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -3111,6 +3111,94 @@ public class CypherExecutionPlan {
   }
 
   /**
+   * Variable names referenced by a WITH clause's non-aggregated (grouping-key) items, keyed by
+   * plain variable name where the item is a bare variable, or by its full expression text
+   * otherwise - matching how {@code boundVariables} containment is checked elsewhere for the
+   * same items.
+   */
+  private static Set<String> groupingKeyVariableNames(final List<ReturnClause.ReturnItem> groupingKeys) {
+    final Set<String> names = new HashSet<>();
+    for (final ReturnClause.ReturnItem key : groupingKeys)
+      names.add(key.getExpression() instanceof VariableExpression
+          ? ((VariableExpression) key.getExpression()).getVariableName()
+          : key.getExpression().getText());
+    return names;
+  }
+
+  /**
+   * Variables a single clause binds into scope, for the sole purpose of judging whether it can
+   * fan a single input row out into several. Returns {@code null} when the clause's effect on
+   * row cardinality cannot be proven safe, which the caller treats as "assume it can fan out".
+   */
+  private static Set<String> variablesIntroducedByClause(final ClauseEntry entry) {
+    switch (entry.getType()) {
+    case UNWIND:
+      final UnwindClause unwind = entry.getTypedClause();
+      return Collections.singleton(unwind.getVariable());
+
+    case LOAD_CSV:
+      final LoadCSVClause loadCsv = entry.getTypedClause();
+      return Collections.singleton(loadCsv.getVariable());
+
+    case MATCH:
+      final MatchClause match = entry.getTypedClause();
+      final Set<String> vars = new HashSet<>();
+      if (match.hasPathPatterns()) {
+        for (final PathPattern pattern : match.getPathPatterns()) {
+          for (final NodePattern node : pattern.getNodes())
+            if (node.getVariable() != null)
+              vars.add(node.getVariable());
+          for (final RelationshipPattern rel : pattern.getRelationships())
+            if (rel.getVariable() != null)
+              vars.add(rel.getVariable());
+          if (pattern.hasPathVariable())
+            vars.add(pattern.getPathVariable());
+        }
+      }
+      return vars;
+
+    case WITH:
+    case MERGE:
+    case CREATE:
+    case SET:
+    case REMOVE:
+    case DELETE:
+    case FOREACH:
+      // These clauses project, mutate or (for WITH) possibly aggregate the existing row
+      // stream - none of them can turn one input row into several, so they carry no fan-out
+      // risk regardless of which variables they touch.
+      return Collections.emptySet();
+
+    default:
+      // CALL / SUBQUERY / FINISH and any future clause type: row-cardinality effects are not
+      // analyzed here, so assume the worst rather than silently mis-optimize.
+      return null;
+    }
+  }
+
+  /**
+   * True when every clause before {@code currentIndex} is guaranteed not to fan a single input
+   * row out into several for the same combination of {@code groupingKeyVariables} - the
+   * precondition the CountEdgesStep optimization relies on, since it emits one output row PER
+   * input row rather than aggregating (issue #6629: an UNWIND before an OPTIONAL MATCH + WITH
+   * count() produced one row per UNWIND element instead of one grouped row; the same break
+   * happens through a cartesian-product MATCH, a variable-length hop, or any other clause that
+   * introduces a variable the WITH does not group by).
+   */
+  private static boolean isRowPerGroupUpToClause(final List<ClauseEntry> clausesInOrder, final int currentIndex,
+      final Set<String> groupingKeyVariables) {
+    for (int i = 0; i < currentIndex; i++) {
+      final Set<String> introduced = variablesIntroducedByClause(clausesInOrder.get(i));
+      if (introduced == null)
+        return false;
+      for (final String var : introduced)
+        if (!groupingKeyVariables.contains(var))
+          return false;
+    }
+    return true;
+  }
+
+  /**
    * Attempts to optimize chained OPTIONAL MATCH + count() pattern.
    * <p>
    * Detects pattern:
@@ -3129,18 +3217,6 @@ public class CypherExecutionPlan {
       final AbstractExecutionStep currentStep,
       final CommandContext context,
       final Set<String> boundVariables) {
-    // 0. A preceding UNWIND fans a single input row out to many rows. CountEdgesStep emits one
-    // output row PER input row, so replacing the OPTIONAL MATCH + WITH aggregation with it would
-    // yield per-row counts instead of the single grouped count the WITH boundary requires
-    // (issue #6629: `... UNWIND [...] OPTIONAL MATCH ... WITH a, count(m)` returned N rows of
-    // c=1 instead of 1 row of c=2). The optimization is only valid when the input rows are
-    // already the aggregation groups, which UNWIND / LOAD CSV break.
-    for (int i = 0; i < currentIndex; i++) {
-      final ClauseEntry.ClauseType type = clausesInOrder.get(i).getType();
-      if (type == ClauseEntry.ClauseType.UNWIND || type == ClauseEntry.ClauseType.LOAD_CSV)
-        return null;
-    }
-
     // 1. First OPTIONAL MATCH must have exactly one path pattern (single hop)
     if (!firstMatch.hasPathPatterns() || firstMatch.getPathPatterns().size() != 1)
       return null;
@@ -3301,6 +3377,15 @@ public class CypherExecutionPlan {
     if (aggregationCount != 1 || countExpr == null)
       return null;
 
+    // A preceding clause that fans a single input row out into several rows for the same
+    // grouping-key values invalidates this optimization: CountEdgesStep emits one output row
+    // PER input row, so the WITH aggregation would see per-row counts instead of one grouped
+    // count (issue #6629). Any variable introduced upstream that is not itself part of the
+    // grouping key is a potential fan-out source (UNWIND, LOAD CSV, a cartesian-product MATCH,
+    // a variable-length hop, ...) and rules the fast path out.
+    if (!isRowPerGroupUpToClause(clausesInOrder, currentIndex, groupingKeyVariableNames(groupingKeys)))
+      return null;
+
     // Count argument must be the target variable
     final String countArgVariable = ((VariableExpression) countExpr.getArguments().get(0)).getVariableName();
     if (!countArgVariable.equals(targetVar))
@@ -3422,18 +3507,6 @@ public class CypherExecutionPlan {
       final CommandContext context,
       final Set<String> boundVariables) {
 
-    // 0. A preceding UNWIND fans a single input row out to many rows. CountEdgesStep emits one
-    // output row PER input row, so replacing the OPTIONAL MATCH + WITH aggregation with it would
-    // yield per-row counts instead of the single grouped count the WITH boundary requires
-    // (issue #6629: `... UNWIND [...] OPTIONAL MATCH ... WITH a, count(m)` returned N rows of
-    // c=1 instead of 1 row of c=2). The optimization is only valid when the input rows are
-    // already the aggregation groups, which UNWIND / LOAD CSV break.
-    for (int i = 0; i < currentIndex; i++) {
-      final ClauseEntry.ClauseType type = clausesInOrder.get(i).getType();
-      if (type == ClauseEntry.ClauseType.UNWIND || type == ClauseEntry.ClauseType.LOAD_CSV)
-        return null;
-    }
-
     // 1. Must be OPTIONAL MATCH with exactly one path pattern
     if (!matchClause.hasPathPatterns() || matchClause.getPathPatterns().size() != 1)
       return null;
@@ -3504,6 +3577,15 @@ public class CypherExecutionPlan {
 
     // Must have exactly one aggregation
     if (aggregationCount != 1 || countExpr == null)
+      return null;
+
+    // A preceding clause that fans a single input row out into several rows for the same
+    // grouping-key values invalidates this optimization: CountEdgesStep emits one output row
+    // PER input row, so the WITH aggregation would see per-row counts instead of one grouped
+    // count (issue #6629). Any variable introduced upstream that is not itself part of the
+    // grouping key is a potential fan-out source (UNWIND, LOAD CSV, a cartesian-product MATCH,
+    // a variable-length hop, ...) and rules the fast path out.
+    if (!isRowPerGroupUpToClause(clausesInOrder, currentIndex, groupingKeyVariableNames(groupingKeys)))
       return null;
 
     // Get the count argument variable name

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -3145,12 +3145,21 @@ public class CypherExecutionPlan {
       final Set<String> vars = new HashSet<>();
       if (match.hasPathPatterns()) {
         for (final PathPattern pattern : match.getPathPatterns()) {
-          for (final NodePattern node : pattern.getNodes())
-            if (node.getVariable() != null)
-              vars.add(node.getVariable());
-          for (final RelationshipPattern rel : pattern.getRelationships())
-            if (rel.getVariable() != null)
-              vars.add(rel.getVariable());
+          for (final NodePattern node : pattern.getNodes()) {
+            // An anonymous node has no name to check against the grouping keys, so its
+            // multiplicity can never be ruled out - bail rather than silently ignore it.
+            if (node.getVariable() == null)
+              return null;
+            vars.add(node.getVariable());
+          }
+          for (final RelationshipPattern rel : pattern.getRelationships()) {
+            // Same reasoning for an anonymous relationship, plus: a variable-length relationship
+            // (named or not) can match several distinct paths between the same two endpoints,
+            // fanning a row out on its own even when every variable is otherwise accounted for.
+            if (rel.getVariable() == null || rel.isVariableLength())
+              return null;
+            vars.add(rel.getVariable());
+          }
           if (pattern.hasPathVariable())
             vars.add(pattern.getPathVariable());
         }
@@ -3158,7 +3167,6 @@ public class CypherExecutionPlan {
       return vars;
 
     case WITH:
-    case MERGE:
     case CREATE:
     case SET:
     case REMOVE:
@@ -3170,8 +3178,11 @@ public class CypherExecutionPlan {
       return Collections.emptySet();
 
     default:
-      // CALL / SUBQUERY / FINISH and any future clause type: row-cardinality effects are not
-      // analyzed here, so assume the worst rather than silently mis-optimize.
+      // MERGE can return one row PER EXISTING MATCH when its pattern matches more than one
+      // element (see MergeStep, "MERGE returns ALL matching elements"), so it is a fan-out
+      // source like any MATCH and is deliberately not in the safe list above. CALL / SUBQUERY /
+      // FINISH and any future clause type are equally unanalyzed here: assume the worst rather
+      // than silently mis-optimize.
       return null;
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -3129,6 +3129,18 @@ public class CypherExecutionPlan {
       final AbstractExecutionStep currentStep,
       final CommandContext context,
       final Set<String> boundVariables) {
+    // 0. A preceding UNWIND fans a single input row out to many rows. CountEdgesStep emits one
+    // output row PER input row, so replacing the OPTIONAL MATCH + WITH aggregation with it would
+    // yield per-row counts instead of the single grouped count the WITH boundary requires
+    // (issue #6629: `... UNWIND [...] OPTIONAL MATCH ... WITH a, count(m)` returned N rows of
+    // c=1 instead of 1 row of c=2). The optimization is only valid when the input rows are
+    // already the aggregation groups, which UNWIND / LOAD CSV break.
+    for (int i = 0; i < currentIndex; i++) {
+      final ClauseEntry.ClauseType type = clausesInOrder.get(i).getType();
+      if (type == ClauseEntry.ClauseType.UNWIND || type == ClauseEntry.ClauseType.LOAD_CSV)
+        return null;
+    }
+
     // 1. First OPTIONAL MATCH must have exactly one path pattern (single hop)
     if (!firstMatch.hasPathPatterns() || firstMatch.getPathPatterns().size() != 1)
       return null;
@@ -3409,6 +3421,18 @@ public class CypherExecutionPlan {
       final AbstractExecutionStep currentStep,
       final CommandContext context,
       final Set<String> boundVariables) {
+
+    // 0. A preceding UNWIND fans a single input row out to many rows. CountEdgesStep emits one
+    // output row PER input row, so replacing the OPTIONAL MATCH + WITH aggregation with it would
+    // yield per-row counts instead of the single grouped count the WITH boundary requires
+    // (issue #6629: `... UNWIND [...] OPTIONAL MATCH ... WITH a, count(m)` returned N rows of
+    // c=1 instead of 1 row of c=2). The optimization is only valid when the input rows are
+    // already the aggregation groups, which UNWIND / LOAD CSV break.
+    for (int i = 0; i < currentIndex; i++) {
+      final ClauseEntry.ClauseType type = clausesInOrder.get(i).getType();
+      if (type == ClauseEntry.ClauseType.UNWIND || type == ClauseEntry.ClauseType.LOAD_CSV)
+        return null;
+    }
 
     // 1. Must be OPTIONAL MATCH with exactly one path pattern
     if (!matchClause.hasPathPatterns() || matchClause.getPathPatterns().size() != 1)

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6629FanoutBeforeOptionalMatchCountTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6629FanoutBeforeOptionalMatchCountTest.java
@@ -115,4 +115,49 @@ class Issue6629FanoutBeforeOptionalMatchCountTest {
     assertThat(result.hasNext()).isFalse();
     result.close();
   }
+
+  @Test
+  void anonymousPredecessorFanoutBeforeOptionalMatchCollapsesToOneGroup() {
+    // Two anonymous, unnamed R-edges into (a) fan the input stream out to 2 rows for the same
+    // a=x1 before the OPTIONAL MATCH runs, exactly like UNWIND does - but through pattern
+    // elements that have no name to check against the WITH's grouping keys.
+    database.transaction(() -> {
+      database.getSchema().createEdgeType("R");
+      database.newVertex("X").set("_id", "x3").save();
+      database.command("sql",
+          "CREATE EDGE R FROM (SELECT FROM X WHERE _id = 'x2') TO (SELECT FROM X WHERE _id = 'x1')");
+      database.command("sql",
+          "CREATE EDGE R FROM (SELECT FROM X WHERE _id = 'x3') TO (SELECT FROM X WHERE _id = 'x1')");
+    });
+
+    final ResultSet result = database.query("opencypher",
+        "MATCH ()-[:R]->(a:X {_id:'x1'}) OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN c");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(2L);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
+  void mergeMatchingMultipleExistingNodesBeforeOptionalMatchCollapsesToOneGroup() {
+    // MERGE returns one row PER EXISTING MATCH when its pattern matches more than one element
+    // (MergeStep), fanning the input stream out to 2 rows for the same a=x1 before the OPTIONAL
+    // MATCH runs, the same shape as UNWIND but through a clause the guard must not assume safe.
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Y");
+      database.newVertex("Y").set("foo", 1).save();
+      database.newVertex("Y").set("foo", 1).save();
+    });
+
+    final ResultSet result = database.command("opencypher",
+        "MATCH (a:X {_id:'x1'}) MERGE (b:Y {foo: 1}) OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN c");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(2L);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6629FanoutBeforeOptionalMatchCountTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6629FanoutBeforeOptionalMatchCountTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #6629: the OPTIONAL MATCH + WITH count() fast-path optimization
+ * (CountEdgesStep) assumes the bound vertex appears exactly once per input row. Any preceding
+ * clause that fans a single input row out into several rows for the same bound vertex breaks
+ * that assumption, since CountEdgesStep emits one output row per input row instead of collapsing
+ * into the WITH aggregation's group.
+ * <p>
+ * PR #6630 guards against UNWIND / LOAD CSV preceding the OPTIONAL MATCH. This test also covers
+ * other row-fanout sources (cartesian-product MATCH, variable-length paths) that are not excluded
+ * by that guard, to check whether the same bug survives through them.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6629FanoutBeforeOptionalMatchCountTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testissue6629fanout").create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("X");
+      database.getSchema().createEdgeType("L");
+      database.command("sql", "CREATE VERTEX X SET _id = 'x1'");
+      database.command("sql", "CREATE VERTEX X SET _id = 'x2'");
+      database.command("sql",
+          "CREATE EDGE L FROM (SELECT FROM X WHERE _id = 'x1') TO (SELECT FROM X WHERE _id = 'x2')");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void unwindBeforeOptionalMatchCollapsesToOneGroup() {
+    final ResultSet result = database.query("opencypher",
+        "MATCH (a:X {_id:'x1'}) UNWIND [1, 2] AS u OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN c");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(2L);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
+  void cartesianProductBeforeOptionalMatchCollapsesToOneGroup() {
+    // (b) is an unrelated pattern that cartesian-products with (a), fanning out the input
+    // stream to 2 rows per (a) before the OPTIONAL MATCH runs - the same fan-out shape as
+    // UNWIND, just produced by a MATCH clause instead.
+    final ResultSet result = database.query("opencypher",
+        "MATCH (a:X {_id:'x1'}), (b:X) OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN c");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(2L);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
+  void zeroMatchesStillCollapseToOneGroupWithUnwind() {
+    final ResultSet result = database.query("opencypher",
+        "MATCH (a:X {_id:'x2'}) UNWIND [1, 2] AS u OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN c");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(0L);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
+  void controlWithoutUnwindStillOptimized() {
+    final ResultSet result = database.query("opencypher",
+        "MATCH (a:X {_id:'x1'}) OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN c");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(1L);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+}


### PR DESCRIPTION
## Description

Fixes #6629: The aggregation boundary loses grouping after UNWIND + OPTIONAL MATCH.

### Root Cause

The `tryOptimizeOptionalMatchCount` optimization (and its chained variant) replaces an `OPTIONAL MATCH ... WITH a, count(m) AS c` pattern with a `CountEdgesStep` that directly counts edges from the bound vertex. This is correct when the bound vertex appears exactly once in the input stream.

However, when an `UNWIND` clause precedes the `OPTIONAL MATCH`, the input stream has multiple rows for the same bound vertex. Since `CountEdgesStep` emits **one output row per input row**, the downstream WITH aggregation sees per-row counts instead of a grouped result — N UNWIND rows produce N output rows with per-row counts, not one grouped row.

### Example

```cypher
MATCH (a:X {_id:'x1'}) UNWIND [1, 2] AS u OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN a, c;
```

Before (broken): 2 rows with `c=1` each
After (fixed): 1 row with `c=2`

### Fix

Added a guard in both `tryOptimizeOptionalMatchCount` and `tryOptimizeChainedOptionalMatchCount` that scans the preceding clauses (from index 0 to `currentIndex`) for `UNWIND` or `LOAD_CSV` — both of which fan out rows. When found, the optimization returns `null` and falls back to the general `GroupByAggregationStep`, which correctly aggregates across all rows sharing the same grouping key.

### Controls that still work

- Control 1: `MATCH (a) OPTIONAL MATCH (a)-[:L]->(m) WITH a, count(m) AS c` — no UNWIND, still optimized
- Control 2: `MATCH (a) UNWIND [1,2] AS u WITH a, count(*) AS c` — no OPTIONAL MATCH, not affected
- Control 3: `MATCH (a) UNWIND [...] OPTIONAL MATCH (a)-[:L]->(m) WITH a, count(m)` — now correctly falls back