### PR TITLE
fix(#6632): defer a Graph Analytical View's persisted CSR read to first use

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2126,9 +2126,13 @@ public enum GlobalConfiguration {
   GAV_RESTORE_AWAIT_TIMEOUT("arcadedb.gavRestoreAwaitTimeout", SCOPE.DATABASE,
       """
       Milliseconds database open() blocks waiting for Graph Analytical Views (GAV/CSR) restored from persisted \
-      definitions to reach READY before returning. 0 (default) does not wait: the async rebuild is still triggered, \
-      but open() returns immediately and queries issued right after it run unaccelerated until the rebuild completes. \
-      A positive value trades a slower open() for the restored view being usable by the query that triggered the reopen""",
+      definitions to reach READY before returning. 0 (default) does not wait: when no persisted CSR plausibly \
+      applies, the full rebuild is still triggered immediately in the background, but open() returns before it \
+      completes and queries issued right after run unaccelerated until it does; when a persisted CSR does plausibly \
+      apply (see arcadedb.gavPersistCsr), nothing is even started at open() time as of v26.9.1 - it is deferred to \
+      whichever query touches the view first, so the fast path costs nothing for a session that never queries it. \
+      A positive value here forces the wait either way, trading a slower open() for the restored/rebuilt view being \
+      usable by the query that triggered the reopen""",
       Long.class, 0L),
 
   GAV_PERSIST_CSR("arcadedb.gavPersistCsr", SCOPE.DATABASE,

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
@@ -172,15 +172,22 @@ public class GraphTraversalProviderRegistry {
 
     final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
     for (final GraphTraversalProvider provider : list) {
-      if (provider.isReady())
-        continue;
+      // A GraphAnalyticalView always goes through awaitReady(), regardless of isReady(): since a deferred
+      // restore-from-disk (see #6632) reports READY the moment a persisted CSR plausibly applies, before
+      // the disk read that actually resolves it has even run, isReady() alone is no longer a trustworthy
+      // "nothing left to do" signal for this provider type - awaitReady() is the one call that triggers
+      // that read. It is cheap/idempotent once nothing is pending (its own trigger call no-ops and the
+      // wait loop returns immediately), so this costs nothing extra for an already-settled view.
       if (provider instanceof GraphAnalyticalView) {
         final long remainingNanos = deadlineNanos - System.nanoTime();
         if (remainingNanos <= 0)
           return false;
         if (!((GraphAnalyticalView) provider).awaitReady(remainingNanos, TimeUnit.NANOSECONDS))
           return false;
+        continue;
       }
+      if (provider.isReady())
+        continue;
     }
     return true;
   }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1614,6 +1614,11 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * from scratch, whenever the deferred restore actually runs, and correctly falls back to a rebuild if
    * anything no longer holds by then (including a commit that landed while the restore was pending, since
    * nothing is watching for one — see {@link #restoreFromDiskOrBuildAsync()}).
+   * <p>
+   * KEEP IN SYNC with {@link #tryRestoreFromPersistedCsr()}'s own guard clauses (review on PR #6633): a
+   * drift between the two can't corrupt data — {@code tryRestoreFromPersistedCsr()} always has the final,
+   * authoritative say — but it would either waste a lazy round-trip that immediately falls back to a
+   * rebuild, or skip the lazy fast path entirely for a case that would have actually succeeded.
    */
   private boolean mayHavePersistedCsr() {
     if (name == null)
@@ -1757,6 +1762,9 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * database's current last committed transaction id — i.e. nothing was committed in between. Returns false
    * (leaving the view's state untouched) for a missing file, a mismatched definition or certificate, or any read
    * failure, so the caller can fall back to {@link #buildAsync()} exactly as it would have without this path.
+   * <p>
+   * The guard clauses below are mirrored (cheaply, without the file read) by {@link #mayHavePersistedCsr()} —
+   * KEEP THEM IN SYNC (review on PR #6633).
    */
   synchronized boolean tryRestoreFromPersistedCsr() {
     if (name == null)
@@ -1810,12 +1818,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     // just above this line would be invisible to the restored snapshot (no scan ran to absorb it, unlike
     // buildAsync(), whose real scan runs AFTER its own sample so a racing commit is already captured in what
     // it reads) and invisible to onRelevantCommit()/applyDelta() too (the listeners were not live yet when it
-    // happened). Not reachable via the current call site - restoreAll() runs synchronously inside
-    // LocalDatabase.open(), before the Database is handed to any caller, so nothing holding a reference to it
-    // can commit concurrently - but checked defensively so this stays correct if that context ever changes
-    // (e.g. an HA replica replaying commits concurrently with a local open). Marking STALE mirrors exactly
-    // what onRelevantCommit() does for a real relevant commit under OFF/SYNCHRONOUS mode: conservative, but
-    // never wrong.
+    // happened). This specific few-instruction window is still only defensive - no existing test hits it -
+    // but the surrounding claim that this whole method is unreachable outside LocalDatabase.open() no longer
+    // holds since #6632 (review on PR #6633): dispatchDeferredRestore()'s background task also calls this
+    // method, well after open() has returned and the caller can freely commit against it. The COARSER case -
+    // a commit landing before this method is even dispatched, caught by the certificate mismatch in
+    // GraphAnalyticalViewCSRPersistence.load() above rather than by this specific check - is genuinely
+    // reachable and exercised by csrLazyPendingRestoreCatchesAnInterveningCommitBeforeFirstQuery. Marking
+    // STALE here mirrors exactly what onRelevantCommit() does for a real relevant commit under
+    // OFF/SYNCHRONOUS mode: conservative, but never wrong.
     if (currentLastTransactionId() != currentTxId) {
       LogManager.instance().log(this, Level.WARNING,
           "GraphAnalyticalView '%s': a commit landed while restoring its CSR from disk; marking it STALE rather than risk missing it",

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -332,6 +332,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * @param edgeTypes   edge type names to include (null = all)
    */
   public synchronized void build(final String[] vertexTypes, final String[] edgeTypes) {
+    // A direct build() (e.g. REBUILD GRAPH ANALYTICAL VIEW) supersedes any not-yet-resolved deferred
+    // restore-from-disk (see #6632): without clearing this, a later awaitReady() call would still see
+    // pendingDiskRestore == true and dispatch dispatchDeferredRestore(), re-reading a possibly-superseded
+    // persisted file (or a wholly redundant rebuild) right after this scan already produced a fresh,
+    // authoritative snapshot.
+    pendingDiskRestore = false;
     final CountDownLatch latch = new CountDownLatch(1);
     readyLatch = latch;
     status = Status.BUILDING;
@@ -384,6 +390,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   public synchronized void buildAsync() {
     if (!buildQueued.compareAndSet(false, true))
       return; // a build is already queued or running
+    // See build(vertexTypes, edgeTypes)'s identical guard: supersedes any not-yet-resolved deferred
+    // restore-from-disk (see #6632). Also reached, harmlessly, from dispatchDeferredRestore()'s own
+    // fallback call - pendingDiskRestore is already false there by the time it calls this.
+    pendingDiskRestore = false;
     final CountDownLatch latch = new CountDownLatch(1);
     readyLatch = latch;
     status = Status.BUILDING;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -243,6 +243,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   private volatile Status            status    = Status.NOT_BUILT;
   private volatile CountDownLatch    readyLatch = new CountDownLatch(1);
   private volatile Throwable         buildError;
+  // True from the moment restoreFromDiskOrBuildAsync() finds a plausible persisted CSR (see #6632) until
+  // whatever touches the view first — checkBuilt() or awaitReady() — resolves it. Written before `status`
+  // is flipped to READY (see restoreFromDiskOrBuildAsync()) and read without synchronization elsewhere, so
+  // its value is guaranteed visible to any thread that observes that READY write — the same plain-volatile
+  // publish pattern `snapshot`+`status` already rely on throughout this class (e.g. build()).
+  private volatile boolean           pendingDiskRestore;
 
   // Incremental auto-update
   private DeltaCollector         deltaCollector;
@@ -445,10 +451,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
 
   /**
    * Waits until the view reaches READY status or the timeout expires.
+   * <p>
+   * If the view is still a deferred restore-from-disk (see #6632), this is one of the two ways — the
+   * other being a real query, via {@link #checkBuilt()} — that dispatches it: an explicit status wait is
+   * a legitimate signal that the caller wants the view actually resolved, not just optimistically READY.
    *
    * @return true if the view is READY, false if the timeout elapsed or the build failed
    */
   public boolean awaitReady(final long timeout, final TimeUnit unit) {
+    triggerDeferredDiskRestoreIfPending();
     final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
     try {
       while (true) {
@@ -1551,6 +1562,127 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
+   * Used by {@link GraphAnalyticalViewBuilder#restoreFromDiskOrBuildAsync} on database open (see #6583,
+   * #6632). Before #6632 this eagerly called {@link #tryRestoreFromPersistedCsr()} right here, which reads
+   * and deserializes the whole persisted CSR — a real, if bounded, cost (hundreds of ms to ~1s at 10M
+   * vertices, per #6632's own measurements) that a session which never queries the view paid for nothing.
+   * When a persisted file plausibly applies, this instead marks the view READY without touching the file
+   * and defers the actual read to whatever happens first: a real query ({@link #checkBuilt()}) or an
+   * explicit {@link #awaitReady} call — so a session that opens and closes without ever touching the view
+   * now costs what the no-view baseline costs, not what a restore costs.
+   * <p>
+   * When no persisted file could plausibly apply — disabled, an HA follower, an unreliable recency signal,
+   * or simply nothing on disk — falls back to the unchanged, already-async {@link #buildAsync()}
+   * immediately instead of deferring: a full scan is expensive regardless of whether it's queried, so
+   * there's nothing to gain by delaying its (already background) start, and every ms of head start
+   * shortens how long a soon-arriving query has to wait for it.
+   */
+  void restoreFromDiskOrBuildAsync() {
+    if (mayHavePersistedCsr()) {
+      // Order matters: a concurrent reader that observes status==READY (a volatile read) is guaranteed,
+      // by plain volatile publish semantics, to also observe every plain write that preceded it on this
+      // thread — including pendingDiskRestore — so checkBuilt()/awaitReady() can never see READY paired
+      // with a stale pendingDiskRestore=false. Same pattern build() already relies on for snapshot+status.
+      pendingDiskRestore = true;
+      status = Status.READY;
+    } else
+      buildAsync();
+  }
+
+  /**
+   * Cheap, synchronous check: does a persisted CSR file plausibly apply right now? Mirrors every guard in
+   * {@link #tryRestoreFromPersistedCsr()} except the (expensive) definition/certificate read — a "yes"
+   * here is a hint, not a promise: {@link #tryRestoreFromPersistedCsr()} re-verifies everything itself,
+   * from scratch, whenever the deferred restore actually runs, and correctly falls back to a rebuild if
+   * anything no longer holds by then (including a commit that landed while the restore was pending, since
+   * nothing is watching for one — see {@link #restoreFromDiskOrBuildAsync()}).
+   */
+  private boolean mayHavePersistedCsr() {
+    if (name == null)
+      return false;
+    if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_PERSIST_CSR))
+      return false;
+    final DatabaseInternal dbInternal = (DatabaseInternal) database;
+    if (dbInternal.isReplicated() && !dbInternal.isLeader())
+      return false;
+    if (!dbInternal.getTransactionManager().isRecencySignalReliable())
+      return false;
+    return GraphAnalyticalViewCSRPersistence.fileFor(database, name).isFile();
+  }
+
+  /**
+   * Dispatches the deferred restore-or-build (see #restoreFromDiskOrBuildAsync()) exactly once, the first
+   * time either {@link #checkBuilt()} or {@link #awaitReady} needs it resolved. A no-op once already
+   * dispatched (including by a concurrent caller — the double-checked {@code pendingDiskRestore} flag is
+   * the single point of truth for "has this already been kicked off").
+   */
+  private void triggerDeferredDiskRestoreIfPending() {
+    if (!pendingDiskRestore)
+      return;
+    final CountDownLatch latch;
+    synchronized (this) {
+      if (!pendingDiskRestore)
+        return;
+      pendingDiskRestore = false;
+      latch = new CountDownLatch(1);
+      readyLatch = latch;
+      status = Status.BUILDING;
+    }
+    inFlightTasks.incrementAndGet();
+    try {
+      getExecutor().execute(() -> {
+        try {
+          BUILD_PERMITS.acquireUninterruptibly();
+          final boolean restored;
+          try {
+            restored = tryRestoreFromPersistedCsr();
+          } finally {
+            BUILD_PERMITS.release();
+          }
+          if (!restored)
+            // No usable file after all (vanished, corrupted, or invalidated by a commit that landed while
+            // this was pending and unwatched) — fall back exactly as the eager #6583 path always did.
+            buildAsync();
+        } finally {
+          latch.countDown();
+          taskCompleted();
+        }
+      });
+    } catch (final RejectedExecutionException e) {
+      status = Status.NOT_BUILT;
+      latch.countDown();
+      taskCompleted();
+      LogManager.instance().log(this, Level.WARNING,
+          "GraphAnalyticalView '%s': deferred restore-from-disk rejected (executor shut down)", name);
+    }
+  }
+
+  /**
+   * Blocks the calling thread until a BUILDING view settles to READY/STALE/NOT_BUILT, with no timeout —
+   * only {@link #checkBuilt()} uses this, and its caller has no fallback once it is already there. Tolerant
+   * of {@code readyLatch} being swapped mid-wait (e.g. {@link #triggerDeferredDiskRestoreIfPending}'s own
+   * latch being superseded by a nested {@link #buildAsync()} fallback's own): re-reads both fields together
+   * on every iteration, same as {@link #awaitReady}'s loop.
+   */
+  private void awaitDeferredDiskRestoreSettled() {
+    try {
+      while (true) {
+        final Status currentStatus;
+        final CountDownLatch latch;
+        synchronized (this) {
+          currentStatus = status;
+          latch = readyLatch;
+        }
+        if (currentStatus != Status.BUILDING)
+          return;
+        latch.await();
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
    * Attempts to load a persisted CSR from disk instead of scanning the graph (see #6583). Returns true and leaves
    * the view READY with the loaded snapshot when a file exists, its definition matches this view's configuration,
    * and its freshness certificate (the database's last committed transaction id at persist time) still matches the
@@ -2159,9 +2291,20 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   /**
    * Checks the view is built and returns a consistent snapshot for the caller to use.
    * All public methods should capture this once and use it throughout their execution.
+   * <p>
+   * If the view is still a deferred restore-from-disk (see #6632), a real query is the other legitimate
+   * trigger for it (alongside an explicit {@link #awaitReady} call): unlike a caller that merely polls
+   * {@link #getStatus()}, this method's caller has no OLTP fallback once it is already here, so this
+   * blocks (no timeout — same contract {@link #build()} already has for a cold view) until the deferred
+   * work resolves one way or another.
    */
   private Snapshot checkBuilt() {
-    final Snapshot snap = this.snapshot;
+    Snapshot snap = this.snapshot;
+    if (snap == null && pendingDiskRestore) {
+      triggerDeferredDiskRestoreIfPending();
+      awaitDeferredDiskRestoreSettled();
+      snap = this.snapshot;
+    }
     if (snap == null)
       throw new IllegalStateException("GraphAnalyticalView has not been built yet. Call build() first.");
     return snap;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1643,6 +1643,22 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
             // No usable file after all (vanished, corrupted, or invalidated by a commit that landed while
             // this was pending and unwatched) — fall back exactly as the eager #6583 path always did.
             buildAsync();
+        } catch (final Exception e) {
+          // tryRestoreFromPersistedCsr() only catches around its own load() call, so anything else
+          // unexpected (e.g. the database closing mid-check) would otherwise leave status stuck at
+          // BUILDING forever - awaitDeferredDiskRestoreSettled()'s loop would then busy-spin on every
+          // future checkBuilt() call (its latch is already counted down, so await() returns instantly,
+          // and status never leaves BUILDING to end the loop). Mirrors buildAsync()'s own catch exactly.
+          synchronized (this) {
+            buildError = e;
+            status = snapshot != null ? Status.STALE : Status.NOT_BUILT;
+            notifyAll();
+          }
+          if (isBenignShutdownError(e))
+            LogManager.instance().log(this, Level.FINE,
+                "Deferred restore of GraphAnalyticalView '%s' aborted because the database is closing", name);
+          else
+            LogManager.instance().log(this, Level.WARNING, "Failed to resolve deferred restore for GraphAnalyticalView '%s'", e, name);
         } finally {
           latch.countDown();
           taskCompleted();
@@ -2297,12 +2313,20 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * {@link #getStatus()}, this method's caller has no OLTP fallback once it is already here, so this
    * blocks (no timeout — same contract {@link #build()} already has for a cold view) until the deferred
    * work resolves one way or another.
+   * <p>
+   * Gates the wait on {@code status == BUILDING} rather than on {@code pendingDiskRestore}: the latter is
+   * a "has this been dispatched yet" flag that {@link #triggerDeferredDiskRestoreIfPending} clears for
+   * every caller the instant the FIRST one dispatches it, not a "is work still in flight" flag. Gating on
+   * it directly would let a second, concurrent caller land here after dispatch but before completion, see
+   * {@code pendingDiskRestore == false}, and fall straight through to the exception below despite the
+   * view being legitimately mid-restore rather than actually broken.
    */
   private Snapshot checkBuilt() {
     Snapshot snap = this.snapshot;
-    if (snap == null && pendingDiskRestore) {
-      triggerDeferredDiskRestoreIfPending();
-      awaitDeferredDiskRestoreSettled();
+    if (snap == null) {
+      triggerDeferredDiskRestoreIfPending(); // no-op if another thread already dispatched it
+      if (status == Status.BUILDING)
+        awaitDeferredDiskRestoreSettled();
       snap = this.snapshot;
     }
     if (snap == null)

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1708,8 +1708,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
         }
       });
     } catch (final RejectedExecutionException e) {
+      // Mirrors buildAsync()'s equivalent handler exactly (review on PR #6633): buildError/notifyAll()
+      // were missing here, and status was unconditionally NOT_BUILT even when a prior snapshot exists
+      // (e.g. a rebuild superseded by this same dispatch, or a stale-but-still-served one) - both quietly
+      // made getBuildError()/isReady()'s STALE+useWhenStale path less reliable for this rejection path
+      // than for every other one in this class.
       deferredRestoreInFlight = false;
-      status = Status.NOT_BUILT;
+      buildError = e;
+      status = snapshot != null ? Status.STALE : Status.NOT_BUILT;
+      notifyAll();
       latch.countDown();
       taskCompleted();
       LogManager.instance().log(this, Level.WARNING,

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -249,6 +249,14 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   // its value is guaranteed visible to any thread that observes that READY write — the same plain-volatile
   // publish pattern `snapshot`+`status` already rely on throughout this class (e.g. build()).
   private volatile boolean           pendingDiskRestore;
+  // True for the FULL duration of a dispatched deferred restore, including a buildAsync() fallback if the
+  // restore turns out unusable — see dispatchDeferredRestore(). Unlike pendingDiskRestore (cleared the
+  // instant the FIRST caller dispatches the work, not when the work finishes), this is what checkBuilt()
+  // gates its wait on: it stays true until the view actually settles, so a second concurrent caller landing
+  // after dispatch but before completion still waits instead of throwing (review on PR #6633), while a
+  // caller that hits a genuinely unrelated BUILDING view — a brand-new one built directly via buildAsync(),
+  // which never sets this flag at all — keeps that method's own documented fail-fast contract unchanged.
+  private volatile boolean           deferredRestoreInFlight;
 
   // Incremental auto-update
   private DeltaCollector         deltaCollector;
@@ -1611,23 +1619,42 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
+   * Cheap fast-path check before {@link #dispatchDeferredRestore()}: avoids paying for that method's
+   * {@code synchronized} entry (and the monitor contention that would imply under concurrent callers) on
+   * every {@link #checkBuilt()}/{@link #awaitReady} call once nothing is pending anymore, which is the
+   * overwhelmingly common case after the first caller resolves it.
+   */
+  private void triggerDeferredDiskRestoreIfPending() {
+    if (pendingDiskRestore)
+      dispatchDeferredRestore();
+  }
+
+  /**
    * Dispatches the deferred restore-or-build (see #restoreFromDiskOrBuildAsync()) exactly once, the first
    * time either {@link #checkBuilt()} or {@link #awaitReady} needs it resolved. A no-op once already
    * dispatched (including by a concurrent caller — the double-checked {@code pendingDiskRestore} flag is
    * the single point of truth for "has this already been kicked off").
+   * <p>
+   * The whole method is {@code synchronized}, mirroring {@link #buildAsync()} and {@link
+   * #onRelevantCommit()} exactly: {@code inFlightTasks.incrementAndGet()} and the executor dispatch happen
+   * while still holding {@code this}'s monitor, so {@link #shutdown()}'s {@code awaitInFlightTasks()} can
+   * never observe {@code inFlightTasks == 0} in the gap between deciding to dispatch and the counter
+   * actually reflecting it — the same race {@code awaitInFlightTasks()}'s own javadoc calls out ("counter is
+   * incremented synchronously when a task is scheduled"). An earlier version of this method incremented the
+   * counter just outside the synchronized block and reopened exactly that gap (review on PR #6633).
    */
-  private void triggerDeferredDiskRestoreIfPending() {
+  private synchronized void dispatchDeferredRestore() {
     if (!pendingDiskRestore)
       return;
-    final CountDownLatch latch;
-    synchronized (this) {
-      if (!pendingDiskRestore)
-        return;
-      pendingDiskRestore = false;
-      latch = new CountDownLatch(1);
-      readyLatch = latch;
-      status = Status.BUILDING;
-    }
+    pendingDiskRestore = false;
+    // Stays true for the FULL chain, including a buildAsync() fallback the dispatched task below waits out
+    // itself — not just until the outer task hands off to it — so checkBuilt() only ever waits for work
+    // this method actually started, never for an unrelated buildAsync()/onRelevantCommit() rebuild on a
+    // brand-new view built directly (which keeps its own documented fail-fast contract unchanged).
+    deferredRestoreInFlight = true;
+    final CountDownLatch latch = new CountDownLatch(1);
+    readyLatch = latch;
+    status = Status.BUILDING;
     inFlightTasks.incrementAndGet();
     try {
       getExecutor().execute(() -> {
@@ -1639,10 +1666,15 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
           } finally {
             BUILD_PERMITS.release();
           }
-          if (!restored)
+          if (!restored) {
             // No usable file after all (vanished, corrupted, or invalidated by a commit that landed while
             // this was pending and unwatched) — fall back exactly as the eager #6583 path always did.
+            // Waited out here (this virtual thread parking costs nothing) rather than left to complete on
+            // its own dispatched task, so deferredRestoreInFlight stays true for the fallback's own
+            // duration too, not just for the near-instant hand-off to it.
             buildAsync();
+            awaitDeferredDiskRestoreSettled();
+          }
         } catch (final Exception e) {
           // tryRestoreFromPersistedCsr() only catches around its own load() call, so anything else
           // unexpected (e.g. the database closing mid-check) would otherwise leave status stuck at
@@ -1660,11 +1692,13 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
           else
             LogManager.instance().log(this, Level.WARNING, "Failed to resolve deferred restore for GraphAnalyticalView '%s'", e, name);
         } finally {
+          deferredRestoreInFlight = false;
           latch.countDown();
           taskCompleted();
         }
       });
     } catch (final RejectedExecutionException e) {
+      deferredRestoreInFlight = false;
       status = Status.NOT_BUILT;
       latch.countDown();
       taskCompleted();
@@ -1674,11 +1708,12 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
-   * Blocks the calling thread until a BUILDING view settles to READY/STALE/NOT_BUILT, with no timeout —
-   * only {@link #checkBuilt()} uses this, and its caller has no fallback once it is already there. Tolerant
-   * of {@code readyLatch} being swapped mid-wait (e.g. {@link #triggerDeferredDiskRestoreIfPending}'s own
-   * latch being superseded by a nested {@link #buildAsync()} fallback's own): re-reads both fields together
-   * on every iteration, same as {@link #awaitReady}'s loop.
+   * Blocks the calling thread until a BUILDING view settles to READY/STALE/NOT_BUILT, with no timeout.
+   * Used by {@link #checkBuilt()} (whose caller has no fallback once it is already there) and, internally,
+   * by {@link #dispatchDeferredRestore()} itself to wait out its own {@link #buildAsync()} fallback. Tolerant
+   * of {@code readyLatch} being swapped mid-wait (e.g. {@link #dispatchDeferredRestore}'s own latch being
+   * superseded by a nested {@link #buildAsync()} fallback's own): re-reads both fields together on every
+   * iteration, same as {@link #awaitReady}'s loop.
    */
   private void awaitDeferredDiskRestoreSettled() {
     try {
@@ -1740,11 +1775,11 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
     if (restored == null)
       return false;
 
-    // Reuse the latch already installed (by the constructor, since this is always the first status
-    // transition attempted on a freshly built view) rather than publishing a new one: the view is
-    // registered before this method runs, so a concurrent awaitReady() caller may already be waiting
-    // on that original latch. Counting down a *new* instance instead would leave that caller hanging
-    // until its timeout even though the view is READY.
+    // Reuse whichever latch is already installed rather than publishing a new one: the view is registered
+    // before this method runs (directly, as the first status transition on a freshly built view; or via
+    // dispatchDeferredRestore(), which installs its own before calling this - see #6632), so a concurrent
+    // awaitReady() caller may already be waiting on that installed latch. Counting down a *new* instance
+    // instead would leave that caller hanging until its timeout even though the view is READY.
     final CountDownLatch latch = readyLatch;
     this.snapshot = restored;
     this.status = Status.READY;
@@ -2314,18 +2349,24 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
    * blocks (no timeout — same contract {@link #build()} already has for a cold view) until the deferred
    * work resolves one way or another.
    * <p>
-   * Gates the wait on {@code status == BUILDING} rather than on {@code pendingDiskRestore}: the latter is
-   * a "has this been dispatched yet" flag that {@link #triggerDeferredDiskRestoreIfPending} clears for
+   * Gates the wait on {@code deferredRestoreInFlight} rather than on {@code pendingDiskRestore}: the latter
+   * is a "has this been dispatched yet" flag that {@link #triggerDeferredDiskRestoreIfPending} clears for
    * every caller the instant the FIRST one dispatches it, not a "is work still in flight" flag. Gating on
    * it directly would let a second, concurrent caller land here after dispatch but before completion, see
-   * {@code pendingDiskRestore == false}, and fall straight through to the exception below despite the
-   * view being legitimately mid-restore rather than actually broken.
+   * {@code pendingDiskRestore == false}, and fall straight through to the exception below despite the view
+   * being legitimately mid-restore rather than actually broken. Gating on plain {@code status == BUILDING}
+   * instead would fix that but over-reach: it would also make this method block, with no timeout, for a
+   * brand-new view whose {@link #buildAsync()} was called directly and hasn't completed yet — a real,
+   * unrelated (and, per that method's own javadoc, documented as non-blocking) scenario this fix has no
+   * business changing. {@code deferredRestoreInFlight} stays true for the exact duration of the work THIS
+   * mechanism started (including a {@link #buildAsync()} fallback if the restore itself turns out unusable —
+   * see {@link #dispatchDeferredRestore()}), so it correctly waits for that and only that.
    */
   private Snapshot checkBuilt() {
     Snapshot snap = this.snapshot;
     if (snap == null) {
-      triggerDeferredDiskRestoreIfPending(); // no-op if another thread already dispatched it
-      if (status == Status.BUILDING)
+      triggerDeferredDiskRestoreIfPending(); // no-op if not applicable, or another thread already dispatched it
+      if (deferredRestoreInFlight)
         awaitDeferredDiskRestoreSettled();
       snap = this.snapshot;
     }

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
@@ -197,18 +197,19 @@ public class GraphAnalyticalViewBuilder {
   }
 
   /**
-   * Used by {@link GraphAnalyticalViewPersistence#restoreAll} on database open (see #6583): first tries to load a
-   * persisted CSR from disk whose freshness certificate still matches (nothing was committed to the database since
-   * it was written), and only falls back to the usual {@link #buildAsync()} full graph scan when there is no
-   * usable file. Either way the view is registered and returned immediately; check {@link
-   * GraphAnalyticalView#getStatus()} / {@link GraphAnalyticalView#awaitReady} for completion exactly as with
-   * {@link #buildAsync()}.
+   * Used by {@link GraphAnalyticalViewPersistence#restoreAll} on database open (see #6583, #6632): when a
+   * persisted CSR plausibly applies, marks the view READY immediately and defers the actual disk read to
+   * whatever touches it first (a real query, or an explicit {@link GraphAnalyticalView#awaitReady} call) —
+   * see {@link GraphAnalyticalView#restoreFromDiskOrBuildAsync()} — rather than reading it eagerly right
+   * here. Falls back to the usual {@link #buildAsync()} full graph scan immediately when there is no
+   * plausibly-usable file. Either way the view is registered and returned immediately; check {@link
+   * GraphAnalyticalView#getStatus()} / {@link GraphAnalyticalView#awaitReady} for completion exactly as
+   * with {@link #buildAsync()}.
    */
   GraphAnalyticalView restoreFromDiskOrBuildAsync() {
     final GraphAnalyticalView view = createView();
     try {
-      if (!view.tryRestoreFromPersistedCsr())
-        view.buildAsync();
+      view.restoreFromDiskOrBuildAsync();
     } catch (final Exception e) {
       view.shutdown();
       throw e;

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
@@ -147,9 +147,10 @@ public class GraphAnalyticalViewPersistence {
         final int ct = gavDef.getInt("compactionThreshold", -1);
         if (ct >= 0)
           builder.withCompactionThreshold(ct);
-        // Tries a persisted CSR from disk first (issue #6583) and only falls back to the async full
-        // rebuild below when there is none usable — see restoreFromDiskOrBuildAsync() for the certificate
-        // check that decides between the two.
+        // Defers to a persisted CSR from disk if one plausibly applies (issue #6583, made lazy by #6632 —
+        // the actual read waits for a real query or an explicit awaitReady()) and only falls back to the
+        // async full rebuild below when there is none — see restoreFromDiskOrBuildAsync() for the check
+        // that decides between the two.
         restoredViews.add(builder.skipPersistence().restoreFromDiskOrBuildAsync());
         count++;
 

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2657,6 +2657,105 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6632 code review round 3: {@link GraphTraversalProviderRegistry#awaitAll} is
+   * documented as ensuring "all CSR structures are built before running performance-critical queries" -
+   * it checks {@code isReady()} first and only falls back to {@code awaitReady()} when that is false. A
+   * deferred restore-from-disk reports READY the moment a persisted CSR plausibly applies, before the
+   * disk read that actually resolves it has run, so {@code isReady()} alone can no longer tell {@code
+   * awaitAll()} there is nothing left to do. Verifies {@code awaitAll()} still resolves the view rather
+   * than short-circuiting past it.
+   */
+  @Test
+  void csrLazyRestoreAwaitAllTriggersDeferredRestore() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lazy-awaitall-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-lazy-awaitall-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.isBuilt())
+        .as("nothing has triggered the deferred restore yet")
+        .isFalse();
+
+    assertThat(GraphTraversalProviderRegistry.awaitAll(database, 10, TimeUnit.SECONDS))
+        .as("awaitAll() must resolve a lazy-pending GAV, not short-circuit past it via isReady()")
+        .isTrue();
+
+    assertThat(restored.isBuilt())
+        .as("awaitAll() must have actually triggered and completed the deferred restore")
+        .isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr()).isTrue();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+
+    restored.drop();
+  }
+
+  /**
+   * Regression for issue #6632 code review round 3: {@code build()}/{@code buildAsync()} must clear
+   * {@code pendingDiskRestore}, or a later {@code awaitReady()} call (e.g. via {@code awaitAll()}) would
+   * still see it set and re-dispatch a redundant restore-from-disk attempt right after a direct rebuild
+   * (what {@code REBUILD GRAPH ANALYTICAL VIEW} does - fetch the live instance and call {@code build()}
+   * directly) already produced a fresh, authoritative snapshot - silently replacing it with a disk-restored
+   * one if the certificate happens to still match (nothing committed since reopen, which a rescan alone
+   * does not change).
+   */
+  @Test
+  void csrLazyPendingRestoreSupersededByDirectRebuildIsNotReTriggered() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lazy-rebuild-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-lazy-rebuild-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.isBuilt())
+        .as("nothing has triggered the deferred restore yet")
+        .isFalse();
+
+    // Simulates REBUILD GRAPH ANALYTICAL VIEW: a direct build() call, bypassing checkBuilt()/awaitReady().
+    restored.build();
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("a direct rebuild must produce a fresh scan, not a disk restore")
+        .isFalse();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+
+    // A later awaitReady() call (e.g. from awaitAll()) must not re-dispatch the now-superseded deferred
+    // restore and silently overwrite the freshly rebuilt snapshot.
+    assertThat(restored.awaitReady(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("the direct rebuild's snapshot must not have been replaced by a stale disk restore")
+        .isFalse();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+
+    restored.drop();
+  }
+
+  /**
    * Regression for issue #6632: a session that opens a database with a persisted-CSR view and never
    * queries it must not pay for the deferred restore at shutdown() either — shutdown() has no reason to
    * wait for work that was never triggered, and {@code persistCsrIfPossible()} must not attempt to

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2592,6 +2592,71 @@ class GraphAnalyticalViewTest extends TestHelper {
   }
 
   /**
+   * Regression for issue #6632 code review: a second, concurrent query landing after the first has already
+   * dispatched the deferred restore, but before it completes, must wait for it too — not throw. The bug
+   * this pins: {@code pendingDiskRestore} is a "has this been dispatched yet" flag, cleared for every
+   * caller the instant the FIRST one dispatches it; a {@code checkBuilt()} that gated its wait on that flag
+   * directly would let a second caller see it already {@code false} and fall straight through to {@code
+   * IllegalStateException}, despite the view being legitimately mid-restore rather than actually broken.
+   * Two threads call {@code getNodeCount()} at (as close to) the same instant as a {@link CyclicBarrier}
+   * can arrange, immediately after reopen; both must return successfully with the correct data.
+   */
+  @Test
+  void csrLazyRestoreConcurrentFirstQueriesBothSucceed() throws Exception {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lazy-concurrent-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-lazy-concurrent-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.isBuilt())
+        .as("nothing has triggered the deferred restore yet")
+        .isFalse();
+
+    final int threadCount = 2;
+    final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+    final int[] results = new int[threadCount];
+    final Throwable[] failures = new Throwable[threadCount];
+    final Thread[] threads = new Thread[threadCount];
+    for (int t = 0; t < threadCount; t++) {
+      final int idx = t;
+      threads[t] = new Thread(() -> {
+        try {
+          barrier.await(5, TimeUnit.SECONDS);
+          results[idx] = restored.getNodeCount();
+        } catch (final Throwable e) {
+          failures[idx] = e;
+        }
+      });
+      threads[t].start();
+    }
+    for (final Thread thread : threads)
+      thread.join(10_000);
+
+    for (int t = 0; t < threadCount; t++)
+      assertThat(failures[t])
+          .as("thread %d must not throw while another thread's deferred restore is in flight", t)
+          .isNull();
+    for (int t = 0; t < threadCount; t++)
+      assertThat(results[t]).isEqualTo(2);
+
+    restored.drop();
+  }
+
+  /**
    * Regression for issue #6632: a session that opens a database with a persisted-CSR view and never
    * queries it must not pay for the deferred restore at shutdown() either — shutdown() has no reason to
    * wait for work that was never triggered, and {@code persistCsrIfPossible()} must not attempt to

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -2537,6 +2537,157 @@ class GraphAnalyticalViewTest extends TestHelper {
     database = new DatabaseFactory(dbPath).open();
   }
 
+  // --- Lazy CSR restore across reopen (issue #6632, follow-up to #6583) tests ---
+
+  /**
+   * Regression for issue #6632: before this fix, {@code restoreAll()} eagerly read and deserialized the
+   * whole persisted CSR during {@code database.open()} (the #6583 fast path), so a session that opened a
+   * database with a view and never queried it still paid that cost — bounded, but real (up to ~1s at 10M
+   * vertices per the issue's own measurements) — for nothing. The read is now deferred to whatever touches
+   * the view first: a real data query ({@code checkBuilt()}) or an explicit {@link
+   * GraphAnalyticalView#awaitReady}. Verifies the deferral directly: immediately after reopen, before
+   * anything queries or awaits the view, it must already report READY (so the query planner routes to it)
+   * but NOT yet built (nothing was read from disk yet); the first real query then resolves it
+   * transparently, with the same correct data the eager path always returned.
+   */
+  @Test
+  void csrLazyRestoreIsDeferredUntilFirstQuery() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").set("name", "Alice").save();
+    final MutableVertex b = database.newVertex("Person").set("name", "Bob").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lazy-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-lazy-test");
+    assertThat(restored).isNotNull();
+
+    assertThat(restored.getStatus())
+        .as("a plausible persisted CSR must mark the view READY immediately so the query planner uses it")
+        .isEqualTo(GraphAnalyticalView.Status.READY);
+    assertThat(restored.isBuilt())
+        .as("but the payload must not be read from disk until something actually needs it")
+        .isFalse();
+
+    // First real query: resolves the deferred restore transparently.
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+    assertThat(restored.getEdgeCount()).isEqualTo(1);
+    assertThat(restored.isBuilt()).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("nothing was committed between close and reopen: the deferred read must still find the persisted CSR usable")
+        .isTrue();
+
+    restored.drop();
+  }
+
+  /**
+   * Regression for issue #6632: a session that opens a database with a persisted-CSR view and never
+   * queries it must not pay for the deferred restore at shutdown() either — shutdown() has no reason to
+   * wait for work that was never triggered, and {@code persistCsrIfPossible()} must not attempt to
+   * re-persist a snapshot that was never loaded. Confirms the round trip stays intact across such a
+   * skipped session: closing without querying must not corrupt or discard the persisted file, and the
+   * NEXT reopen must still restore from it correctly.
+   */
+  @Test
+  void csrLazyRestoreNeverTriggeredIsHarmlessAtClose() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lazy-skip-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+    assertThat(GraphAnalyticalViewCSRPersistence.fileFor(database, "csr-lazy-skip-test")).exists();
+
+    // Reopen again WITHOUT ever touching the view (no query, no awaitReady()) — reopenDatabase() itself
+    // closes then reopens, so this session's shutdown() must not choke on the never-triggered restore.
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-lazy-skip-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("the skipped session must not have discarded or corrupted the persisted file")
+        .isTrue();
+    assertThat(restored.getNodeCount()).isEqualTo(2);
+
+    restored.drop();
+  }
+
+  /**
+   * Regression for issue #6632: if a commit lands on a covered type AFTER reopen but BEFORE anything ever
+   * triggers the deferred restore (no query, no {@code awaitReady()} yet — so no change listeners are even
+   * registered to see it coming, unlike the already-loaded case), the deferred restore's own fresh
+   * certificate re-sample (inside {@code tryRestoreFromPersistedCsr()}, unchanged from #6583) must still
+   * catch the mismatch and fall back to a full rebuild rather than serving the now-stale persisted
+   * snapshot.
+   */
+  @Test
+  void csrLazyPendingRestoreCatchesAnInterveningCommitBeforeFirstQuery() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    database.commit();
+    final RID bId = b.getIdentity();
+
+    GraphAnalyticalView.builder(database)
+        .withName("csr-lazy-invalidate-test")
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+
+    reopenDatabase();
+
+    final GraphAnalyticalView restored = GraphAnalyticalViewRegistry.get(database, "csr-lazy-invalidate-test");
+    assertThat(restored).isNotNull();
+    assertThat(restored.isBuilt())
+        .as("nothing has triggered the deferred restore yet")
+        .isFalse();
+
+    // A commit on the covered type, landing while the restore is still pending — no listener is watching
+    // for it, since the deferred tryRestoreFromPersistedCsr() hasn't run yet (and so hasn't registered
+    // any — mirrors #6583's own onRelevantCommit()/DeltaCollector wiring, which only starts after a
+    // successful build).
+    database.begin();
+    final MutableVertex c = database.newVertex("Person").save();
+    ((Vertex) database.lookupByRID(bId, true)).modify().newEdge("FOLLOWS", c);
+    database.commit();
+
+    // First query now triggers the deferred restore, which must discover the certificate no longer
+    // matches (its own fresh currentLastTransactionId() re-sample, unchanged from #6583) and rebuild.
+    assertThat(restored.getNodeCount()).isEqualTo(3);
+    assertThat(restored.getEdgeCount()).isEqualTo(2);
+    assertThat(restored.isRestoredFromPersistedCsr())
+        .as("a commit landed before the first query; the deferred restore must have rebuilt, not served stale data")
+        .isFalse();
+
+    restored.drop();
+  }
+
   /**
    * Regression for issue #6583 code review: {@code GAV_PERSIST_CSR=false} must suppress persistence
    * entirely - no file written at close, and a reopen must fall back to the full rebuild rather than


### PR DESCRIPTION
## Summary
- `restoreAll()` (issue #6583, PR #6588) marked a view READY only after eagerly reading and deserializing its whole persisted CSR right in `restoreFromDiskOrBuildAsync()`, called synchronously from `database.open()`. That read is bounded but real - up to ~1s at 10M vertices per #6632's own measurements - and a session that opens a database with a view and never queries it paid for it anyway.
- When a persisted CSR plausibly applies (`mayHavePersistedCsr()`: the same guards `tryRestoreFromPersistedCsr()` already checks, plus a cheap `File.isFile()` instead of reading the file), the view is now marked READY immediately without touching the file, and the actual read is deferred to whichever happens first: a real query (`checkBuilt()`) or an explicit `awaitReady()` call.
- `tryRestoreFromPersistedCsr()` itself is untouched: it already re-samples the freshness certificate from scratch whenever it runs, so a commit landing during the pending window (before any change listener is registered to see it coming) is still caught correctly and falls back to a rebuild - no new invalidation logic needed.
- When no persisted file could plausibly apply, the existing eager `buildAsync()` path is unchanged: a full scan is expensive regardless of whether it's queried, so there's nothing to gain by delaying its already-background start.
- Also updates `GAV_RESTORE_AWAIT_TIMEOUT`'s description to reflect the new deferred-restore interaction.

Closes #6632

## Why this is safe
- `shutdown()`'s existing `awaitInFlightTasks()`/`persistCsrIfPossible()` guards already handle a never-triggered pending restore correctly with no changes needed: `inFlightTasks` stays 0 (nothing was dispatched), and `persistCsrIfPossible()` already early-returns when `snapshot == null`.
- `checkBuilt()`/`awaitReady()` are the two existing places every real caller and both existing #6583 regression tests already go through, so the deferred trigger is invisible to well-behaved callers.
- `status` is published READY only after `pendingDiskRestore` is set, following the same plain-volatile publish order `snapshot`+`status` already use elsewhere in this class (e.g. `build()`).

## Test plan
- [x] New regression tests in `GraphAnalyticalViewTest`:
  - `csrLazyRestoreIsDeferredUntilFirstQuery`: reopen shows READY-but-not-built immediately, first query resolves it transparently with correct data.
  - `csrLazyRestoreNeverTriggeredIsHarmlessAtClose`: a session that never touches the view survives close and a later reopen still restores correctly.
  - `csrLazyPendingRestoreCatchesAnInterveningCommitBeforeFirstQuery`: a commit landing before the first query is still caught by the deferred certificate re-check, forcing a rebuild rather than serving stale data.
- [x] Full `GraphAnalyticalViewTest` suite (149 tests) passes.
- [x] Every other GAV-consuming suite passes (244 tests): `GraphAnalyticalViewRegistryTest`, `GAVEligibilityTest`, `StatisticsProviderTest`, `MatchGAVExpandIntoTest`, Cypher GAV cardinality/expand-into tests, `GraphAlgorithmsTest`, algo procedure tests, HA-follower-gating supernode test, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)