### PR TITLE
feat(#6632): optionally defer the Graph Analytical View CSR restore to first use

### DIFF
--- a/docs/6632-gav-lazy-restore.md
+++ b/docs/6632-gav-lazy-restore.md
@@ -1,0 +1,93 @@
+# Issue #6632 (item 1): an open() still loads a Graph Analytical View's CSR even when the session never uses it
+
+Issue: https://github.com/ArcadeData/arcadedb/issues/6632
+
+Addresses item 1 only. Item 2 of that issue is a documentation gap in `arcadedb-docs` for the
+pre-existing `arcadedb.gavRestoreAwaitTimeout` setting, which is a different repository.
+
+## Root cause / analysis
+
+`LocalDatabase.open()` calls `GraphAnalyticalViewPersistence.restoreAll(database)`, which for each
+persisted definition calls `builder.skipPersistence().restoreFromDiskOrBuildAsync()`. Since #6588 (merged) that
+reads the persisted CSR from disk instead of rebuilding it by a full graph scan, which is a large win:
+at 10M vertices / 40M edges the scan was 52,923 ms and the restore is 984 ms, 53x cheaper.
+
+The read still happens on the open path, unconditionally, for every session. A database that HAS a view
+therefore pays to load it at every open whether or not that session goes on to use it. On the same 10M
+graph an open with no view configured at all is ~3 ms, so a session that opens the database, reads a
+document type and closes spends ~984 ms of its ~987 ms lifetime loading a structure it never touches.
+
+That is a different question from the one #6583 filed, not a smaller version of it. Creating a Graph
+Analytical View declares that it should be *available*; it is not a statement that every process which
+subsequently opens the database intends to traverse it. The sessions that pay and get nothing are the
+short-lived ones, which are exactly the ones where a fixed cost dominates: a CLI query against a
+document type, a backup, a schema inspection, a health check, an embedded session in a test suite that
+opens and closes a database per test.
+
+## Fix
+
+Add a new `SCOPE.DATABASE` setting, `GAV_LAZY_RESTORE` (`arcadedb.gavLazyRestore`, `Boolean`, default
+`false`). When `false` (the default), behaviour is unchanged: `open()` reads the persisted CSR exactly as
+it does today. When `true`, `restoreFromDiskOrBuildAsync()` registers the view and reads nothing, and the
+first lookup that would actually use the view pays the restore instead.
+
+The hook is a new `GraphTraversalProvider.tryLazyActivate()` default method, called from the single
+chokepoint in `GraphTraversalProviderRegistry.findProvider()` when a provider is not ready. It returns
+`false` on the interface, so a provider that does not implement it is skipped exactly as it always was,
+and `GraphAnalyticalView`'s override is itself gated on the flag, so with the flag off every state
+returns `false` and the default path is untouched.
+
+Three callers deliberately do *not* trigger a load:
+
+- **The query planner.** `StatisticsProvider.exactMeanFromTraversalProvider()` asks whether acceleration
+  exists while *costing a plan*. It now uses a new non-triggering `findProviderIfReady()`. Loading a
+  structure there would move a multi-hundred-millisecond stall out of `open()`, where it is predictable
+  and happens once, and into an arbitrary query's planning phase.
+- **A `STALE` view.** Staleness is not-ready for a completely different reason than
+  deferred-and-not-yet-loaded. Whether a stale view may serve a query belongs to `GAV_USE_WHEN_STALE` and
+  whether it gets refreshed belongs to the update mode; a first-use load must not override either by
+  starting a rebuild that would not otherwise run.
+- **`restoreAll()`'s `GAV_RESTORE_AWAIT_TIMEOUT` wait.** A deferred view is `NOT_BUILT` with no build in
+  flight, and `readyLatch` is created at construction rather than left null, so `awaitReady()` would sit
+  on a latch nobody counts down and burn the whole budget before returning `false`. The two settings on
+  together would otherwise give an `open()` that blocks for the full timeout *and* still has not loaded
+  the view.
+
+## Behaviour changes when the flag is on
+
+- The first query that could use the view pays the restore. The work is conserved, not removed: it
+  reappears in full on that query and the second query is unaffected.
+- A restore failure (missing file, changed definition, invalidated certificate) is discovered at first
+  use rather than at open, and falls back to `buildAsync()` exactly as the eager path does.
+- Where there is **no usable persisted CSR**, the eager path has the rebuild running from `open()`, so a
+  session that opens and queries some seconds later can find the view ready; under lazy the rebuild does
+  not start until the first query asks, so that session now misses. Laziness cannot both do no work at
+  open and have the work already done. This is the price, and the main reason the default is `false`.
+
+## Files changed
+
+- `engine/src/main/java/com/arcadedb/GlobalConfiguration.java` - new `GAV_LAZY_RESTORE` setting.
+- `engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java` - new `tryLazyActivate()` default method.
+- `engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java` - `findProvider()` gives a not-ready provider one chance to activate; new non-triggering `findProviderIfReady()`.
+- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java` - `tryLazyActivate()` override, gated on the flag, leaving `STALE` alone.
+- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java` - `restoreFromDiskOrBuildAsync()` returns without reading anything under the flag.
+- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java` - `restoreAll()` skips the await when there is nothing to await.
+- `engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/StatisticsProvider.java` - planner uses the non-triggering lookup.
+- `engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java` - five regression tests.
+
+## Test plan
+
+- `lazyRestoreLeavesTheViewUnloadedAtOpenAndLoadsItOnFirstUse` - after reopen the view is `NOT_BUILT` and
+  not restored; the first `findProvider()` returns it, and it is then `READY`, restored from the
+  persisted CSR (not a fresh scan), with the right node and edge counts.
+- `lazyRestoreIsOffByDefaultSoOpenStillRestoresEagerly` - the default path is unchanged.
+- `lazyRestoreIsNotTriggeredByThePlannersReadinessCheck` - `findProviderIfReady()` returns `null` and
+  leaves the status exactly as it was, while `findProvider()` still loads.
+- `lazyActivationLeavesAStaleViewAlone` - a stale view stays `STALE`. Fails on unpatched code with
+  `BUILDING`.
+- `lazyRestoreDoesNotWaitOutTheRestoreAwaitTimeout` - `open()` does not sit out a 60s await budget.
+  Fails on unpatched code at 60.33 s against a 20 s tripwire (1.79 s with the fix). Measured with
+  `StallAwareStopwatch`, as a tripwire between "did not wait" and "waited out the budget", not a
+  latency budget.
+- Full `GraphAnalyticalViewTest`, `GraphTraversalProvider*`, `CSR*`, `StatisticsProviderTest` and the
+  openCypher cardinality/optimizer suites run for regressions: 242 tests, all green.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -2123,6 +2123,15 @@ public enum GlobalConfiguration {
       When true, the query planner uses stale Graph Analytical Views (GAV/CSR) for traversals instead of falling back to OLTP. \
       Stale data is faster but may not reflect the latest committed changes""", Boolean.class, false),
 
+  GAV_LAZY_RESTORE("arcadedb.gavLazyRestore", SCOPE.DATABASE,
+      """
+      When true, a Graph Analytical View's persisted CSR is NOT read at database open(). It is read on the \
+      first query that would actually use the view, so a session that opens a database and never touches the \
+      view pays nothing for it. Creating a view declares that it should be AVAILABLE, which is not the same \
+      statement as "load it into memory the instant anyone opens this database". Default false, which keeps \
+      the eager behaviour: open() pays the restore whether or not the session goes on to use the view""",
+      Boolean.class, false),
+
   GAV_RESTORE_AWAIT_TIMEOUT("arcadedb.gavRestoreAwaitTimeout", SCOPE.DATABASE,
       """
       Milliseconds database open() blocks waiting for Graph Analytical Views (GAV/CSR) restored from persisted \

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProvider.java
@@ -51,6 +51,23 @@ public interface GraphTraversalProvider {
   boolean isReady();
 
   /**
+   * Asked by {@link GraphTraversalProviderRegistry#findProvider} when this provider is NOT ready, to give it one
+   * chance to become ready before the query gives up on it and falls back to the ordinary path (issue #6583).
+   *
+   * <p>Exists so that loading a persisted structure can be deferred from database open() to the first query that
+   * would actually use it. Opening a database that HAS a view is not a statement that this session intends to use
+   * the view, and the eager path charges every session for it either way.
+   *
+   * <p>The default returns false, which is exactly the behaviour every provider had before this hook existed: not
+   * ready means skip me. A provider that can cheaply make itself ready overrides it.
+   *
+   * @return true if the provider is now ready and safe to use for this query
+   */
+  default boolean tryLazyActivate() {
+    return false;
+  }
+
+  /**
    * Returns the name of this provider.
    */
   String getName();

--- a/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphTraversalProviderRegistry.java
@@ -100,6 +100,26 @@ public class GraphTraversalProviderRegistry {
   }
 
   /**
+   * Like {@link #findProvider}, but never triggers lazy activation: a provider that is not ready is simply not
+   * returned. For callers that are ASKING WHETHER acceleration exists rather than about to use it, above all the
+   * query planner, where blocking to load a structure while costing a plan would be a surprise.
+   */
+  public static GraphTraversalProvider findProviderIfReady(final Database database, final String... edgeTypes) {
+    if (!hasAnyProviders)
+      return null;
+    final CopyOnWriteArrayList<GraphTraversalProvider> list;
+    synchronized (REGISTRY) {
+      list = REGISTRY.get(unwrap(database));
+    }
+    if (list == null)
+      return null;
+    for (final GraphTraversalProvider provider : list)
+      if (provider.isReady() && covers(provider, edgeTypes))
+        return provider;
+    return null;
+  }
+
+  /**
    * Finds the first ready provider that covers all the given edge types.
    *
    * @param database  the database
@@ -120,31 +140,41 @@ public class GraphTraversalProviderRegistry {
       return null;
     // CopyOnWriteArrayList iteration is safe outside the lock
     for (final GraphTraversalProvider provider : list) {
-      if (!provider.isReady())
+      // LAZY ACTIVATION (issue #6583). A provider that is not ready gets one chance to become ready before the
+      // query gives up on it. Under GAV_LAZY_RESTORE this is where a persisted CSR is read, instead of at
+      // database open(): a session that opens a database with a view and never runs a query the view could
+      // serve then pays nothing for it at all.
+      //
+      // Default-off, and the default path is unchanged: tryLazyActivate() returns false on the interface, so a
+      // provider that does not implement it is skipped exactly as it always was, and GraphAnalyticalView's
+      // override returns false for every state unless the flag is on.
+      //
+      // NOT called from findProviderIfReady(), which is what the query PLANNER uses. Triggering a
+      // multi-hundred-millisecond load while costing a plan would move the stall somewhere far less
+      // predictable than open(), and the planner only wants to know whether acceleration is available now.
+      if (!provider.isReady() && !provider.tryLazyActivate())
         continue;
-      if (edgeTypes == null || edgeTypes.length == 0) {
-        if (provider.coversEdgeType(null)) {
-          if (provider.isStale())
-            LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
-                "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", provider.getName());
-          return provider;
-        }
-      } else {
-        boolean allCovered = true;
-        for (final String et : edgeTypes)
-          if (!provider.coversEdgeType(et)) {
-            allCovered = false;
-            break;
-          }
-        if (allCovered) {
-          if (provider.isStale())
-            LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
-                "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", provider.getName());
-          return provider;
-        }
+      if (covers(provider, edgeTypes)) {
+        if (provider.isStale())
+          LogManager.instance().log(GraphTraversalProviderRegistry.class, Level.FINE,
+              "Using stale GraphTraversalProvider '%s' for query acceleration (data may not reflect latest commits)", provider.getName());
+        return provider;
       }
     }
     return null;
+  }
+
+  /**
+   * Whether a provider covers every requested edge type. A null or empty request means "all types", which is
+   * asked of the provider as {@code coversEdgeType(null)} rather than assumed here.
+   */
+  private static boolean covers(final GraphTraversalProvider provider, final String... edgeTypes) {
+    if (edgeTypes == null || edgeTypes.length == 0)
+      return provider.coversEdgeType(null);
+    for (final String edgeType : edgeTypes)
+      if (!provider.coversEdgeType(edgeType))
+        return false;
+    return true;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1551,6 +1551,45 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   }
 
   /**
+   * Lazy activation entry point (issue #6583): under {@link GlobalConfiguration#GAV_LAZY_RESTORE} the persisted CSR
+   * is not read at database open(), so the first query that could use this view reads it here instead.
+   *
+   * <p>Falls back exactly as the eager path does. If the certificate no longer holds, or there is no usable file,
+   * this kicks off the ordinary async rebuild and returns false, so THIS query runs unaccelerated and a later one
+   * picks the view up once the rebuild completes. That is the same outcome the eager path produces for an
+   * invalidated certificate; only the moment of discovery moves.
+   */
+  @Override
+  public synchronized boolean tryLazyActivate() {
+    // Gated on the flag, so with GAV_LAZY_RESTORE off this returns false for every state and the caller
+    // behaves exactly as it did before the hook existed.
+    if (!database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_LAZY_RESTORE))
+      return false;
+
+    switch (status) {
+    case READY:
+      return true;
+    case BUILDING:
+      return false;                      // a build is already in flight; do not start a second one
+    case STALE:
+      // Deliberately untouched. Whether a stale view may serve a query is GAV_USE_WHEN_STALE's decision and
+      // whether it gets refreshed is UpdateMode's; a lazy FIRST load has no business overriding either.
+      return false;
+    default:
+      break;                             // NOT_BUILT: the state a lazily registered view is in at open()
+    }
+
+    if (tryRestoreFromPersistedCsr())
+      return true;
+
+    // No usable persisted CSR (missing file, changed definition, invalidated certificate). Fall back to the
+    // ordinary async rebuild and let THIS query run unaccelerated, which is what the eager path does too for
+    // an invalid certificate. Only the moment of discovery moves.
+    buildAsync();
+    return false;
+  }
+
+  /**
    * Attempts to load a persisted CSR from disk instead of scanning the graph (see #6583). Returns true and leaves
    * the view READY with the loaded snapshot when a file exists, its definition matches this view's configuration,
    * and its freshness certificate (the database's last committed transaction id at persist time) still matches the

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewBuilder.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.graph.olap;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 
 /**
@@ -207,6 +208,16 @@ public class GraphAnalyticalViewBuilder {
   GraphAnalyticalView restoreFromDiskOrBuildAsync() {
     final GraphAnalyticalView view = createView();
     try {
+      // LAZY (issue #6583, GAV_LAZY_RESTORE, default false): register the view and read NOTHING. The persisted
+      // CSR is read by GraphTraversalProvider.tryLazyActivate() on the first query that could use it, so a
+      // session which opens this database and never touches the view pays nothing for it.
+      //
+      // Deliberately does not call buildAsync() either. Under lazy the whole point is that open() does no work
+      // for a view the caller has not asked about, and starting a full graph scan in the background would be
+      // exactly that work, merely off the critical path.
+      if (database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_LAZY_RESTORE))
+        return view;
+
       if (!view.tryRestoreFromPersistedCsr())
         view.buildAsync();
     } catch (final Exception e) {

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalViewPersistence.java
@@ -189,7 +189,14 @@ public class GraphAnalyticalViewPersistence {
     // GAV_RESTORE_AWAIT_TIMEOUT, block here (bounded by the configured budget, shared across every
     // restored view) until each triggered build reaches READY, so the session that pays for the
     // rebuild is the session that benefits from it.
-    final long awaitTimeoutMs = database.getConfiguration().getValueAsLong(GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT);
+    //
+    // Nothing to await under GAV_LAZY_RESTORE (#6583 follow-up): a deferred view is NOT_BUILT with no build in
+    // flight, so awaitReady() would sit on a latch nobody is going to count down and burn the WHOLE budget
+    // before returning false. That turns the two options on together into the worst of both -- an open() that
+    // blocks for the full timeout AND still has not loaded the view. The load is the first caller's to pay.
+    final long awaitTimeoutMs = database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GAV_LAZY_RESTORE)
+        ? 0L
+        : database.getConfiguration().getValueAsLong(GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT);
     if (awaitTimeoutMs > 0 && !restoredViews.isEmpty()) {
       final long deadline = System.currentTimeMillis() + awaitTimeoutMs;
       for (final GraphAnalyticalView view : restoredViews) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/StatisticsProvider.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/statistics/StatisticsProvider.java
@@ -450,7 +450,10 @@ public class StatisticsProvider {
    * entirely (#5834) instead of paying for it and then discovering a provider existed all along.
    */
   private OptionalDouble exactMeanFromTraversalProvider(final String edgeType) {
-    final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(database, edgeType);
+    // findProviderIfReady, NOT findProvider: this runs while COSTING A PLAN, and under
+    // GAV_LAZY_RESTORE findProvider() would read a persisted CSR from disk here. Planning is the
+    // wrong place to discover a multi-hundred-millisecond load (issue #6583).
+    final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProviderIfReady(database, edgeType);
     if (provider == null)
       return OptionalDouble.empty();
     final double exact = provider.getMeanEdgesPerConnectedPair(edgeType);

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAnalyticalViewTest.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.DefaultDataEncryption;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.NeighborView;
@@ -33,6 +34,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.StallAwareStopwatch;
 import org.junit.jupiter.api.Test;
 
 import javax.crypto.SecretKey;
@@ -5429,5 +5431,216 @@ class GraphAnalyticalViewTest extends TestHelper {
     assertThat(gav.getMeanEdgesPerConnectedPair("FOLLOWS")).isNegative();
 
     gav.drop();
+  }
+
+  // --- lazy CSR restore (issue #6583 follow-up) tests ---
+
+  /**
+   * Issue #6583 follow-up. Persisting the CSR made a reopen 53x cheaper than a rebuild, but a session that
+   * opens a database and never touches the view still pays to load it: at 10M vertices / 40M edges the
+   * restore is ~984 ms of an otherwise ~3 ms open. Creating a view declares that it should be AVAILABLE,
+   * which is not the same statement as "load it the instant anyone opens this database".
+   * <p>
+   * Under {@link GlobalConfiguration#GAV_LAZY_RESTORE} the view is registered at open but nothing is read,
+   * and the first lookup that would actually use it pays the restore instead.
+   */
+  @Test
+  void lazyRestoreLeavesTheViewUnloadedAtOpenAndLoadsItOnFirstUse() {
+    final Object previous = GlobalConfiguration.GAV_LAZY_RESTORE.getValue();
+    try {
+      final String dbPath = buildPersistedCsrFixture("csr-lazy-first-use");
+
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(true);
+      final Database db2 = new DatabaseFactory(dbPath).open();
+      try {
+        final GraphAnalyticalView view = GraphAnalyticalViewRegistry.get(db2, "csr-lazy-first-use");
+        assertThat(view).as("the view is still registered; only its DATA is deferred").isNotNull();
+        assertThat(view.getStatus())
+            .as("open() must not read the persisted CSR when lazy restore is on")
+            .isEqualTo(GraphAnalyticalView.Status.NOT_BUILT);
+        assertThat(view.isRestoredFromPersistedCsr()).isFalse();
+
+        // The first lookup that would use the view is what pays for it.
+        final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db2, "FOLLOWS");
+        assertThat(provider).as("the first use must load the view, not skip it").isSameAs(view);
+        assertThat(view.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+        assertThat(view.isRestoredFromPersistedCsr())
+            .as("the deferred load must still come from the persisted CSR, not a fresh scan")
+            .isTrue();
+        assertThat(view.getNodeCount()).isEqualTo(3);
+        assertThat(view.getEdgeCount()).isEqualTo(2);
+      } finally {
+        db2.close();
+      }
+    } finally {
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(previous);
+    }
+  }
+
+  /**
+   * The flag is off by default, and with it off open() must behave exactly as it did before lazy restore
+   * existed: the CSR is read eagerly and the view is READY before anyone asks for it.
+   */
+  @Test
+  void lazyRestoreIsOffByDefaultSoOpenStillRestoresEagerly() {
+    final String dbPath = buildPersistedCsrFixture("csr-lazy-default-off");
+
+    final Database db2 = new DatabaseFactory(dbPath).open();
+    try {
+      final GraphAnalyticalView view = GraphAnalyticalViewRegistry.get(db2, "csr-lazy-default-off");
+      assertThat(view).isNotNull();
+      assertThat(view.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+      assertThat(view.isRestoredFromPersistedCsr())
+          .as("default behaviour is unchanged: open() restores without being asked")
+          .isTrue();
+    } finally {
+      db2.close();
+    }
+  }
+
+  /**
+   * The query PLANNER asks whether acceleration exists while costing a plan. Under lazy restore that question
+   * must stay a question: if planning could trigger the load, the stall would move from open() -- where it is
+   * predictable and happens once -- into an arbitrary query's planning phase.
+   */
+  @Test
+  void lazyRestoreIsNotTriggeredByThePlannersReadinessCheck() {
+    final Object previous = GlobalConfiguration.GAV_LAZY_RESTORE.getValue();
+    try {
+      final String dbPath = buildPersistedCsrFixture("csr-lazy-planner");
+
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(true);
+      final Database db2 = new DatabaseFactory(dbPath).open();
+      try {
+        final GraphAnalyticalView view = GraphAnalyticalViewRegistry.get(db2, "csr-lazy-planner");
+        assertThat(view.getStatus()).isEqualTo(GraphAnalyticalView.Status.NOT_BUILT);
+
+        assertThat(GraphTraversalProviderRegistry.findProviderIfReady(db2, "FOLLOWS"))
+            .as("a readiness CHECK must not load anything")
+            .isNull();
+        assertThat(view.getStatus())
+            .as("asking whether the view is ready must leave it exactly as it was")
+            .isEqualTo(GraphAnalyticalView.Status.NOT_BUILT);
+
+        // ...and the load still happens for a caller that is actually going to use it.
+        assertThat(GraphTraversalProviderRegistry.findProvider(db2, "FOLLOWS")).isSameAs(view);
+        assertThat(view.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+      } finally {
+        db2.close();
+      }
+    } finally {
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(previous);
+    }
+  }
+
+  /**
+   * A STALE view is not-ready for the same reason a lazily-deferred one is, but for a completely different
+   * cause, and lazy activation must not confuse the two. Whether a stale view may serve a query belongs to
+   * {@link GlobalConfiguration#GAV_USE_WHEN_STALE} and whether it gets refreshed belongs to the update mode;
+   * a first-use load has no business overriding either by kicking off a rebuild that would not otherwise run.
+   */
+  @Test
+  void lazyActivationLeavesAStaleViewAlone() {
+    final Object previous = GlobalConfiguration.GAV_LAZY_RESTORE.getValue();
+    try {
+      database.getSchema().createVertexType("Person");
+      database.getSchema().createEdgeType("FOLLOWS");
+      database.begin();
+      final MutableVertex a = database.newVertex("Person").save();
+      final MutableVertex b = database.newVertex("Person").save();
+      a.newEdge("FOLLOWS", b);
+      database.commit();
+
+      final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+          .withName("csr-lazy-stale")
+          .withVertexTypes("Person")
+          .withEdgeTypes("FOLLOWS")
+          .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+          .build();
+      assertThat(gav.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+
+      database.begin();
+      database.newVertex("Person").save();
+      database.commit();
+      assertThat(gav.getStatus()).isEqualTo(GraphAnalyticalView.Status.STALE);
+
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(true);
+      assertThat(GraphTraversalProviderRegistry.findProvider(database, "FOLLOWS"))
+          .as("a stale view is still not usable when GAV_USE_WHEN_STALE is off")
+          .isNull();
+      assertThat(gav.getStatus())
+          .as("lazy activation must not rebuild a stale view behind the update mode's back")
+          .isEqualTo(GraphAnalyticalView.Status.STALE);
+
+      gav.drop();
+    } finally {
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(previous);
+    }
+  }
+
+  /**
+   * {@link GlobalConfiguration#GAV_RESTORE_AWAIT_TIMEOUT} makes open() block until the restored views are
+   * READY. A lazily deferred view never becomes READY on its own, and its ready-latch is created up front
+   * rather than left null, so awaiting one burns the entire budget and then returns false: the two options
+   * on together would give an open() that blocks for the full timeout AND still has not loaded anything.
+   * <p>
+   * The bound below is a tripwire between "did not wait" and "waited out the whole budget", not a latency
+   * budget. Widening it is safe; narrowing it is what would break.
+   */
+  @Test
+  void lazyRestoreDoesNotWaitOutTheRestoreAwaitTimeout() {
+    final Object previousLazy = GlobalConfiguration.GAV_LAZY_RESTORE.getValue();
+    final Object previousAwait = GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT.getValue();
+    try {
+      final String dbPath = buildPersistedCsrFixture("csr-lazy-await");
+
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(true);
+      GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT.setValue(60_000L);
+
+      final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+      final Database db2 = new DatabaseFactory(dbPath).open();
+      try {
+        stopwatch.assertGaveUpWithin(20_000L,
+            "an open() that skipped the await from one that sat on the latch for the whole 60s budget");
+        assertThat(GraphAnalyticalViewRegistry.get(db2, "csr-lazy-await").getStatus())
+            .as("and it skipped the wait because there was nothing to wait FOR, not by loading the view")
+            .isEqualTo(GraphAnalyticalView.Status.NOT_BUILT);
+      } finally {
+        db2.close();
+      }
+    } finally {
+      GlobalConfiguration.GAV_LAZY_RESTORE.setValue(previousLazy);
+      GlobalConfiguration.GAV_RESTORE_AWAIT_TIMEOUT.setValue(previousAwait);
+    }
+  }
+
+  /**
+   * Builds a small graph, persists its CSR with a clean close, and returns the database path so a test can
+   * reopen it. The caller's {@code database} is closed; TestHelper reopens its own handle at teardown.
+   */
+  private String buildPersistedCsrFixture(final String viewName) {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("FOLLOWS");
+    database.begin();
+    final MutableVertex a = database.newVertex("Person").save();
+    final MutableVertex b = database.newVertex("Person").save();
+    final MutableVertex c = database.newVertex("Person").save();
+    a.newEdge("FOLLOWS", b);
+    b.newEdge("FOLLOWS", c);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withName(viewName)
+        .withVertexTypes("Person")
+        .withEdgeTypes("FOLLOWS")
+        .withUpdateMode(GraphAnalyticalView.UpdateMode.OFF)
+        .build();
+    assertThat(gav.getStatus()).isEqualTo(GraphAnalyticalView.Status.READY);
+
+    final String dbPath = database.getDatabasePath();
+    final File csrFile = GraphAnalyticalViewCSRPersistence.fileFor(database, viewName);
+    database.close();
+    assertThat(csrFile).as("the fixture is only meaningful if the close actually persisted a CSR").exists();
+    return dbPath;
   }
 }


### PR DESCRIPTION
Addresses **item 1 of #6632**. Item 2 (documenting `arcadedb.gavRestoreAwaitTimeout`) is an `arcadedb-docs` change and is not touched here, so this does not close the issue.

I had this built against `fix/6583-gav-csr-persistence` before #6588 merged; it is now rebased onto `main` (`bc5d31a63`). Entirely happy for it to be closed if you would rather write it yourself now that the issue is filed - it is offered as a starting point, not a claim on the work.

**If you do write your own, these are the three things worth taking from here**, because each is a place where the obvious implementation is wrong and two of them only showed up once the test was written:

1. **The query planner must not trigger the load.** `StatisticsProvider.exactMeanFromTraversalProvider()` calls `findProvider()` while *costing a plan*. If that can load a CSR, the stall does not go away, it moves from `open()` into an arbitrary query's planning phase.
2. **A `STALE` view must be left alone.** It is not-ready for a different reason than deferred-and-not-yet-loaded, and treating the two alike makes an ordinary query start a rebuild that does not happen today. Observed without the guard: a query moved the view `STALE` -> `BUILDING`.
3. **`GAV_RESTORE_AWAIT_TIMEOUT` must be skipped.** A deferred view is `NOT_BUILT` with no build in flight, and `readyLatch` is created at construction rather than left null, so `awaitReady()` sits on a latch nobody counts down and burns the entire budget. Without the guard, the two settings on together gave an `open()` that blocked for the full 60 s **and** still had not loaded the view.

## What this is

#6588 turned a reopen from a full graph scan into a file read: 52,923 ms to 984 ms at 10M vertices / 40M edges. The remaining 984 ms is still paid by a session that never touches the view, because creating a view says it should be **available**, not that it should be loaded the instant anyone opens the database. On the same graph an open with no view configured at all is ~3 ms, so such a session spends ~99.7% of its open time on a structure it never reads.

Behind `arcadedb.gavLazyRestore` (`GAV_LAZY_RESTORE`, default `false`) the view is registered at open and nothing is read. The first lookup that would actually use it pays the restore instead.

## Measurements

A session here is: open, then close, with **no query in between**. Medians of 5 reps after 2 warmups, ms.

| vertices | edges | no view open | no view close | EAGER open | EAGER close | LAZY open | LAZY close | LAZY open vs no view |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 10,000 | 40,000 | 5.89 | 5.81 | 7.70 | 5.58 | 5.68 | 5.43 | -0.21 |
| 50,000 | 200,000 | 4.41 | 5.27 | 20.72 | 5.99 | 4.59 | 5.24 | +0.18 |
| 100,000 | 400,000 | 3.32 | 5.17 | 15.33 | 6.23 | 3.67 | 5.13 | +0.35 |
| 300,000 | 1,200,000 | 3.52 | 6.47 | 21.30 | 6.86 | 3.50 | 6.01 | -0.02 |
| 1,000,000 | 4,000,000 | 3.80 | 6.21 | 98.45 | 6.33 | 3.20 | 6.14 | -0.60 |
| 1,000,000 | 8,000,000 | 2.82 | 5.77 | 146.58 | 14.77 | 3.23 | 5.67 | +0.41 |
| 1,000,000 | 16,000,000 | 3.84 | 5.45 | 345.68 | 14.48 | 3.18 | 5.55 | -0.56 |

The eager cost tracks the graph (98 -> 147 -> 346 ms as edges double), while the lazy open sits flat at ~3.2 ms and lands within +-0.6 ms of having no view at all at every size. That is the point: a deferred open reads nothing, so its cost does not depend on how big the thing it did not read is.

A 3M/12M and a 10M/40M row are still measuring as I open this; I will post them here when they land rather than extrapolate. What is already measured at 10M on #6588 as merged, from the benchmark comments you quoted in #6632, is the eager side: **983.88 ms** open with a view that is never queried, against **3.04 ms** with no view.

### The restore is not removed, it moves

Same fixture, 200k vertices / 800k edges, opening and then running the same query twice:

| arm | open | query 1 | query 2 |
|:--|---:|---:|---:|
| view, EAGER | 17.46 | 3.97 | 0.52 |
| view, LAZY | 5.92 | 14.39 | 0.50 |

Eager pays 11.5 ms at open that lazy does not; lazy pays 10.4 ms on the first query that eager does not. The second query is identical either way. The work is conserved - what changes is that a session which never asks is no longer charged for it.

### Is the view actually live afterwards, and does it still give the same answer?

| vertices | edges | status after open | status after first query | verdict |
|---:|---:|:--|:--|:--|
| 10,000 | 40,000 | `NOT_BUILT` | `READY` | view is live |
| 200,000 | 800,000 | `NOT_BUILT` | `READY` | view is live |

| vertices | edges | no view | view EAGER | view LAZY | |
|---:|---:|---:|---:|---:|:--|
| 10,000 | 40,000 | 160,000 | 160,000 | 160,000 | agree |
| 200,000 | 800,000 | 16 | 16 | 16 | agree |

The status column is the check that discriminates, and it is why the tests assert on state rather than on counts: row counts agree whether the view served the query or the ordinary path did, so counts alone cannot separate "loaded and used" from "silently skipped".

## Design

The hook is `GraphTraversalProvider.tryLazyActivate()`, called from the single chokepoint in `GraphTraversalProviderRegistry.findProvider()`. It defaults to `false` on the interface, so a provider that does not implement it is skipped exactly as it always was, and `GraphAnalyticalView`'s override is itself gated on the flag, so with the flag off every state returns `false` and the default path is unchanged. `findProviderIfReady()` is the non-triggering variant added for the planner.

## Behaviour changes, disclosed

With the flag **off**, nothing changes. `lazyRestoreIsOffByDefaultSoOpenStillRestoresEagerly` pins that.

With the flag **on**:

- The first query that could use the view pays the restore, per the table above.
- A restore failure (missing file, changed definition, invalidated certificate) is discovered at first use rather than at open, and falls back to `buildAsync()` exactly as the eager path does, with that query running unaccelerated.
- **This cuts against the change in one case and I would rather state it than have you find it.** Where there is no usable persisted CSR, the eager path has the rebuild running from `open()`, so a session that opens and then queries some seconds later can find the view ready. Under lazy the rebuild does not start until the first query asks, so that session now misses. Laziness cannot both do no work at open and have the work already done. That is the price, and it is the main reason the default is `false`.
- Views are likewise not built at open when `GAV_PERSIST_CSR` is disabled entirely, for the same reason.

## Testing

Five new tests in `GraphAnalyticalViewTest`: first-use loading, flag off by default, the planner's readiness check not triggering a load, the stale view left alone, and the await timeout not being waited out.

Two of them I checked fail on unpatched code, since an assertion that passes either way is decoration:

| test | with the guard | without it |
|:--|:--|:--|
| `lazyActivationLeavesAStaleViewAlone` | `STALE` | `BUILDING` |
| `lazyRestoreDoesNotWaitOutTheRestoreAwaitTimeout` | 1.79 s | 60.33 s against a 20 s tripwire |

The timing one uses `StallAwareStopwatch.assertGaveUpWithin()` as a tripwire between "did not wait" and "waited out the budget", not as a latency budget, per `CLAUDE.md`.

Regression run: `GraphAnalyticalView*`, `GraphTraversalProvider*`, `CSR*`, `Issue6049*`, `StatisticsProviderTest`, `GraphStatisticsCacheTest`, `CypherGAV*`, `Cypher*Cardinality*`, `CypherOptimizer*`, `AnchorSelectorTest` - **242 tests, 0 failures**, on the rebased tree.

## Open questions for you

- Should this ever be the default? I have left it off. The argument for on is that the cost is invisible to whoever pays it; the argument against is the no-persisted-CSR case above.
- Would you rather have it per-view (`CREATE GRAPH ANALYTICAL VIEW ... LAZY`) than database-wide? That is arguably the more honest shape, since laziness is a statement about one view's usage pattern, but it is a bigger surface and I did not want to presume the DDL.

## Environment

Intel Core Ultra X9 388H, 12 threads pinned via `--cpuset-cpus 0-11`, 30 GiB RAM, Samsung NVMe SSD, Ubuntu. `eclipse-temurin:25-jdk`, `-Xms8g -Xmx16g`. Engine at `ba84722bd` (#6588's head) plus this change. Fixtures are synthetic: N vertices of type `P` with a unique index on `id`, `fanout` edges of type `E` from each vertex to `(i + f * 7919) mod N`, `UPDATE MODE OFF`, CSR persisted by a clean close before measuring.
