### PR TITLE
fix(#6592): retry the next candidate when the tx-overlay's closest key is fully tombstoned

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -644,7 +644,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
       final TreeMap<TransactionIndexContext.ComparableKey, Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey>> indexChanges = index.getDatabase()
           .getTransaction().getIndexChanges().getIndexKeys(index.getName());
       if (indexChanges != null) {
-        final Map.Entry<TransactionIndexContext.ComparableKey, Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey>> entry;
+        Map.Entry<TransactionIndexContext.ComparableKey, Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey>> entry;
         // #4947: biased navigation keys, never plain ComparableKeys. A PARTIAL key compares equal to every
         // entry sharing its prefix, so plain ceiling/floor/higher/lower land in the MIDDLE of the prefix run
         // (wherever the tree walk first hits equality) and silently skip the run's other entries. The biased
@@ -666,32 +666,37 @@ public class LSMTreeIndexCursor implements IndexCursor {
             entry = indexChanges.lowerEntry(TransactionIndexContext.lowNavigationKey(keys));
         }
 
-        final Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey> values =
-            entry != null ? entry.getValue() : null;
-        if (values != null) {
-          for (final TransactionIndexContext.IndexKey value : values.values()) {
-            if (value != null) {
-              if (value.operation == TransactionIndexContext.IndexKey.IndexKeyOperation.REMOVE)
-                // REMOVED
-                break;
+        // The first candidate found above can be entirely dead (every pending change on it is a REMOVE - e.g.
+        // a record inserted and deleted again within this same transaction): walk to the NEXT candidate in the
+        // same direction instead of giving up, exactly like the on-page cursor skips a fully-tombstoned key via
+        // advanceCursor()+continue in the constructor above. Stopping at the first dead key used to make the
+        // WHOLE in-tx overlay look exhausted beyond it, even though older/newer pending keys past it were still
+        // live - e.g. a composite-index prefix scan whose ORDER BY DESC starts from the just-deleted top of the
+        // group came back empty instead of falling through to the next surviving row (#6592 follow-up).
+        while (entry != null) {
+          final Object[] tmpKeys = entry.getKey().values;
 
-              final Object[] tmpKeys = entry.getKey().values;
+          if (typedToKeys != null) {
+            // #5055: toKeys bounds the FAR end of the scan, whose direction flips with the order: for an
+            // ascending scan it is the upper bound (skip entries ABOVE it), for a descending scan it is the
+            // lower bound (skip entries BELOW it). #5932: tmpKeys comes straight from the overlay's own
+            // ComparableKey, so the bound compared against it must be typedToKeys (no disk byte[]-for-String
+            // encoding), not serializedToKeys.
+            final int cmp = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, tmpKeys, typedToKeys);
+            final boolean pastBound = (ascendingOrder && cmp > 0) || (!ascendingOrder && cmp < 0) || (!toKeysInclusive && cmp == 0);
+            if (pastBound)
+              // EVERY CANDIDATE FURTHER IN THIS DIRECTION IS EVEN FURTHER PAST THE BOUND: STOP, DON'T WALK THE
+              // REST OF THE OVERLAY FOR NOTHING
+              break;
+          }
 
-              if (typedToKeys != null) {
-                // #5055: toKeys bounds the FAR end of the scan, whose direction flips with the order: for an
-                // ascending scan it is the upper bound (skip entries ABOVE it), for a descending scan it is the
-                // lower bound (skip entries BELOW it). The filter used the ascending sense unconditionally, so
-                // a descending in-tx overlay dropped every entry above the lower bound - e.g. the top key of a
-                // range, including a committed/uncommitted collision there.
-                // #5932: tmpKeys comes straight from the overlay's own ComparableKey, so the bound compared
-                // against it must be typedToKeys (no disk byte[]-for-String encoding), not serializedToKeys.
-                final int cmp = LSMTreeIndexMutable.compareKeys(comparator, binaryKeyTypes, tmpKeys, typedToKeys);
-
-                if (ascendingOrder ? cmp > 0 : cmp < 0)
-                  continue;
-                else if (!toKeysInclusive && cmp == 0)
-                  continue;
-              }
+          final Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey> values = entry.getValue();
+          if (values != null) {
+            for (final TransactionIndexContext.IndexKey value : values.values()) {
+              if (value == null || value.operation == TransactionIndexContext.IndexKey.IndexKeyOperation.REMOVE)
+                // REMOVED: A NON-UNIQUE KEY CAN STILL HOLD OTHER LIVE VALUES, SO SKIP JUST THIS ONE RATHER THAN
+                // THE WHOLE KEY
+                continue;
 
               if (txChanges == null) {
                 txChanges = new HashSet<>();
@@ -703,6 +708,13 @@ public class LSMTreeIndexCursor implements IndexCursor {
               txChanges.add(new IndexCursorEntry(tmpKeys, value.rid, 1));
             }
           }
+
+          if (txChanges != null)
+            // FOUND A LIVE CANDIDATE
+            break;
+
+          // THIS KEY HAD NOTHING LIVE: TRY THE NEXT ONE IN THE SAME DIRECTION
+          entry = ascendingOrder ? indexChanges.higherEntry(entry.getKey()) : indexChanges.lowerEntry(entry.getKey());
         }
       }
 

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue6592ClosestEntryInTxSkipsTombstonedKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue6592ClosestEntryInTxSkipsTombstonedKeyTest.java
@@ -157,4 +157,59 @@ class Issue6592ClosestEntryInTxSkipsTombstonedKeyTest extends TestHelper {
       database.rollback();
     }
   }
+
+  @Test
+  void descendingPrefixScanWalksPastTwoConsecutiveTombstonedKeysToTheSurvivor() {
+    final TypeIndex index = createCompositeIndex();
+
+    database.begin();
+    try {
+      // DELETE THE TOP TWO OF A THREE-ROW GROUP: THE RETRY LOOP MUST HOP TWICE (orderedAt=2, THEN orderedAt=1)
+      // BEFORE LANDING ON THE SOLE SURVIVOR (orderedAt=0), NOT JUST ONE
+      final RID[] rids = new RID[3];
+      for (int i = 0; i < rids.length; ++i)
+        rids[i] = database.newDocument(TYPE_NAME).set("key1", "a", "key2", "b", "orderedAt", (long) i).save().getIdentity();
+      database.deleteRecord(rids[2].getRecord());
+      database.deleteRecord(rids[1].getRecord());
+
+      final IndexCursor cursor = index.range(false, new Object[] { "a", "b" }, true, new Object[] { "a", "b" }, true);
+      try {
+        assertThat(cursor.hasNext()).isTrue();
+        cursor.next();
+        assertThat((Long) cursor.getKeys()[2]).isEqualTo(0L);
+        assertThat(cursor.hasNext()).as("only the survivor remains").isFalse();
+      } finally {
+        cursor.close();
+      }
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  void prefixScanReturnsEmptyRatherThanLeakingIntoAnAdjacentKeyWhenTheWholeGroupIsTombstoned() {
+    final TypeIndex index = createCompositeIndex();
+
+    database.begin();
+    try {
+      // AN ADJACENT GROUP (key1=a, key2=c) SORTS RIGHT AFTER THE (a,b) PREFIX'S OWN RANGE. DELETING EVERY ROW OF
+      // (a,b) MUST MAKE THE RETRY LOOP HIT typedToKeys' BOUND (pastBound) AND STOP, RATHER THAN WALK STRAIGHT
+      // THROUGH INTO THE ADJACENT GROUP'S ENTRIES
+      final RID[] rids = new RID[2];
+      for (int i = 0; i < rids.length; ++i)
+        rids[i] = database.newDocument(TYPE_NAME).set("key1", "a", "key2", "b", "orderedAt", (long) i).save().getIdentity();
+      database.newDocument(TYPE_NAME).set("key1", "a", "key2", "c", "orderedAt", 0L).save();
+      for (final RID rid : rids)
+        database.deleteRecord(rid.getRecord());
+
+      try (final IndexCursor descCursor = index.range(false, new Object[] { "a", "b" }, true, new Object[] { "a", "b" }, true)) {
+        assertThat(descCursor.hasNext()).as("the whole (a,b) group is tombstoned - must not leak into (a,c)").isFalse();
+      }
+      try (final IndexCursor ascCursor = index.range(true, new Object[] { "a", "b" }, true, new Object[] { "a", "b" }, true)) {
+        assertThat(ascCursor.hasNext()).as("same check ascending").isFalse();
+      }
+    } finally {
+      database.rollback();
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue6592ClosestEntryInTxSkipsTombstonedKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue6592ClosestEntryInTxSkipsTombstonedKeyTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Follow-up regression for https://github.com/ArcadeData/arcadedb/issues/6592: once a composite-index prefix
+ * scan is answered with a range() cursor, {@link LSMTreeIndexCursor#getClosestEntryInTx} finds the single
+ * closest pending (uncommitted) key with one floor/ceiling/higher/lower lookup and used to give up entirely
+ * when THAT key turned out to be fully removed (every pending change on it a REMOVE) - e.g. a record inserted
+ * and deleted again within the same transaction. Instead of walking to the next candidate key in the same
+ * direction, exactly like the on-page cursor skips a fully-tombstoned key via advanceCursor()+continue, the
+ * overlay was left empty for the rest of the scan: a prefix range scan whose ORDER BY DESC starts from the
+ * just-deleted top of the group came back with nothing, even though older rows of the same group were still
+ * live and pending in the very same transaction.
+ * <p>
+ * A second, narrower defect lived in the same loop: on a non-unique index, a key can carry BOTH a live insert
+ * (a different RID) and a REMOVE in the same transaction. The old code {@code break}-ed the whole per-key
+ * values loop on the first REMOVE it saw (map iteration order is unspecified), silently dropping the sibling
+ * live RID too.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6592ClosestEntryInTxSkipsTombstonedKeyTest extends TestHelper {
+  private static final String TYPE_NAME   = "Supplier";
+  private static final int    GROUP_SIZE  = 10;
+
+  private TypeIndex createCompositeIndex() {
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("key1", String.class);
+    type.createProperty("key2", String.class);
+    type.createProperty("orderedAt", Long.class);
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "key1", "key2", "orderedAt" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
+    return database.getSchema().getType(TYPE_NAME).getPolymorphicIndexByProperties("key1", "key2", "orderedAt");
+  }
+
+  private static long countAndAssertOrder(final IndexCursor cursor, final boolean descending) {
+    long previous = -1;
+    long count = 0;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        // getKeys() describes the entry next() LAST RETURNED (see LSMTreeIndexCursor's class docs, #5635).
+        final long orderedAt = (Long) cursor.getKeys()[2];
+        if (count > 0)
+          assertThat(descending ? orderedAt < previous : orderedAt > previous)
+              .as("keys must come out strictly %s (got %d after %d)", descending ? "descending" : "ascending", orderedAt, previous)
+              .isTrue();
+        previous = orderedAt;
+        ++count;
+      }
+    } finally {
+      cursor.close();
+    }
+    return count;
+  }
+
+  @Test
+  void descendingPrefixScanSkipsTheJustDeletedTopOfTheGroupWhileUncommitted() {
+    final TypeIndex index = createCompositeIndex();
+
+    database.begin();
+    try {
+      // INSERT THE WHOLE GROUP AND DELETE ITS TOP - THE ENTRY A DESCENDING SCAN STARTS FROM - ALL WITHIN THE SAME
+      // STILL-OPEN TRANSACTION, SO THE ENTRY EXISTS ONLY AS A PENDING INSERT+REMOVE PAIR IN THE TX OVERLAY, NEVER
+      // ON ANY PAGE
+      RID top = null;
+      for (int i = 0; i < GROUP_SIZE; ++i) {
+        final RID rid = database.newDocument(TYPE_NAME).set("key1", "a", "key2", "b", "orderedAt", (long) i).save().getIdentity();
+        if (i == GROUP_SIZE - 1)
+          top = rid;
+      }
+      database.deleteRecord(top.getRecord());
+
+      final IndexCursor cursor = index.range(false, new Object[] { "a", "b" }, true, new Object[] { "a", "b" }, true);
+      final long count = countAndAssertOrder(cursor, true);
+
+      assertThat(count).as("the delete removed exactly one of the %d rows in the group", GROUP_SIZE).isEqualTo(GROUP_SIZE - 1);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  void ascendingPrefixScanSkipsTheJustDeletedBottomOfTheGroupWhileUncommitted() {
+    final TypeIndex index = createCompositeIndex();
+
+    database.begin();
+    try {
+      // MIRROR CASE: DELETE THE BOTTOM OF THE GROUP, THE ENTRY AN ASCENDING SCAN STARTS FROM
+      RID bottom = null;
+      for (int i = 0; i < GROUP_SIZE; ++i) {
+        final RID rid = database.newDocument(TYPE_NAME).set("key1", "a", "key2", "b", "orderedAt", (long) i).save().getIdentity();
+        if (i == 0)
+          bottom = rid;
+      }
+      database.deleteRecord(bottom.getRecord());
+
+      final IndexCursor cursor = index.range(true, new Object[] { "a", "b" }, true, new Object[] { "a", "b" }, true);
+      final long count = countAndAssertOrder(cursor, false);
+
+      assertThat(count).as("the delete removed exactly one of the %d rows in the group", GROUP_SIZE).isEqualTo(GROUP_SIZE - 1);
+    } finally {
+      database.rollback();
+    }
+  }
+
+  @Test
+  void nonUniqueKeySharedByALiveInsertAndARemoveKeepsTheLiveOne() {
+    final TypeIndex index = createCompositeIndex();
+
+    database.begin();
+    try {
+      // TWO DOCUMENTS SHARE THE EXACT SAME COMPOSITE KEY (NON-UNIQUE INDEX): INSERT BOTH, THEN DELETE ONLY ONE OF
+      // THEM, ALL WITHIN THIS SAME UNCOMMITTED TRANSACTION - THE KEY'S PENDING CHANGES NOW MIX A REMOVE (FOR THE
+      // DELETED RID) WITH A LIVE INSERT (FOR THE SURVIVING RID)
+      final RID toDelete = database.newDocument(TYPE_NAME).set("key1", "a", "key2", "b", "orderedAt", 0L).save().getIdentity();
+      database.newDocument(TYPE_NAME).set("key1", "a", "key2", "b", "orderedAt", 0L).save();
+      database.deleteRecord(toDelete.getRecord());
+
+      final IndexCursor cursor = index.range(false, new Object[] { "a", "b" }, true, new Object[] { "a", "b" }, true);
+      try {
+        assertThat(cursor.hasNext()).as("the surviving sibling under the same key must still be found").isTrue();
+        cursor.next();
+        assertThat(cursor.hasNext()).as("only the deleted RID is gone, not the whole key").isFalse();
+      } finally {
+        cursor.close();
+      }
+    } finally {
+      database.rollback();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectCompositeIndexTest.java
@@ -130,6 +130,31 @@ public class SelectCompositeIndexTest extends TestHelper {
   }
 
   @Test
+  void compositeIndexPrefixMatchWithOrderByDescLimitOneAfterDeletingTopWithinSameTransaction() {
+    // FOLLOW-UP TO ISSUE #6592: DELETING THE CURRENT TOP OF THE GROUP AND IMMEDIATELY QUERYING BACK, ALL WITHIN
+    // THE SAME STILL-OPEN TRANSACTION, USED TO MAKE THE COMPOSITE-INDEX RANGE SCAN RETURN NOTHING AT ALL INSTEAD
+    // OF FALLING THROUGH TO THE NEXT SURVIVING ROW - SEE LSMTreeIndexCursor.getClosestEntryInTx()
+    final List<Vertex> top = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key2").eq().value("b")//
+        .and().property("orderedAt").eq().value((long) (GROUP_SIZE - 1))//
+        .compile().vertices().toList();
+    top.forEach(Vertex::delete);
+
+    final SelectCompiled select = database.select().fromType("Supplier")//
+        .where().property("key1").eq().value("a")//
+        .and().property("key2").eq().value("b")//
+        .orderBy("orderedAt", false)//
+        .limit(1)//
+        .compile();
+
+    final Vertex first = select.vertices().nextOrNull();
+
+    assertThat(first).isNotNull();
+    assertThat(first.getLong("orderedAt")).isEqualTo(GROUP_SIZE - 2);
+  }
+
+  @Test
   void compositeIndexPartialPrefixStillUsed() {
     // ONLY key1 IS BOUND: STILL A VALID (SHORTER) PREFIX OF THE SAME COMPOSITE INDEX
     final SelectCompiled select = database.select().fromType("Supplier")//


### PR DESCRIPTION
## Summary

Follow-up to #6592 (see the [comment thread](https://github.com/ArcadeData/arcadedb/issues/6592#issuecomment-5384823581)): after PR #6595 made the native `Select` query builder use a composite-index prefix match for `ORDER BY ... DESC LIMIT 1`, a report surfaced that the query could return nothing at all when the top row of the group had just been deleted in the same transaction.

**Root cause:** `LSMTreeIndexCursor.getClosestEntryInTx()` looks up the single closest pending (uncommitted) key in the transaction overlay with one `floor`/`ceiling`/`higher`/`lower` call. If that one candidate turned out to be entirely tombstoned (every pending change on it a `REMOVE` - e.g. a record inserted and deleted again within the same transaction), the method gave up entirely instead of walking to the next candidate key in the same direction, the way the on-page cursor already skips a fully-tombstoned key. Since a `DESC LIMIT 1` scan starts exactly at the top of the group, deleting that row earlier in the same transaction made the whole overlay look exhausted from that point on, even though older rows of the group were still live and pending in the very same transaction.

A second, narrower defect in the same loop: on a non-unique index, a key can carry both a live insert (a different RID) and a `REMOVE` in the same transaction. The old code broke out of the whole per-key values loop on the first `REMOVE` it saw (map iteration order is unspecified), silently dropping the sibling live RID too.

**Fix:** the lookup now loops - skipping a fully-dead key and continuing in the same direction - and only skips the individual removed value rather than discarding the whole key.

## Test plan

- [x] New `Issue6592ClosestEntryInTxSkipsTombstonedKeyTest` (3 tests) exercises the low-level cursor directly for DESC, ASC, and the mixed live-insert/remove case on a non-unique key. Verified each fails without the fix and passes with it.
- [x] Added an end-to-end regression to `SelectCompositeIndexTest` reproducing the original report's scenario through the native `Select` builder.
- [x] `SelectCompositeIndexTest`, `Issue6592ClosestEntryInTxSkipsTombstonedKeyTest`, and related select/order-by/tx-overlay suites all pass.