### PR TITLE
fix(#6629): honor the WITH aggregation boundary after UNWIND + OPTIONAL MATCH

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -3328,19 +3328,9 @@ public class CypherExecutionPlan {
         return null;
     }
 
-    // The bound vertex must be in the grouping keys
-    boolean boundVertexInGroupingKeys = false;
-    for (final ReturnClause.ReturnItem key : groupingKeys) {
-      final String keyExprText = key.getExpression() instanceof VariableExpression
-          ? ((VariableExpression) key.getExpression()).getVariableName()
-          : key.getExpression().getText();
-      if (keyExprText.equals(boundVar)) {
-        boundVertexInGroupingKeys = true;
-        break;
-      }
-    }
-    if (!boundVertexInGroupingKeys)
-      return null;
+    // Note: the bound vertex does not need to be among the grouping keys itself - see the identical
+    // reasoning in tryOptimizeOptionalMatchCount (issue #6629): CountChainedEdgesStep groups its
+    // input rows by the grouping-key VALUES and sums the per-row count within each group.
 
     // 7. Compute directions and types
     // First hop: bound -> intermediate
@@ -3562,23 +3552,11 @@ public class CypherExecutionPlan {
         return null;
     }
 
-    // The bound vertex must be in the grouping keys to ensure correct aggregation.
-    // Without this, CountEdgesStep would emit one row per input row instead of aggregating.
-    // Example: MATCH (q)-[:HAS_ANSWER]->(a) ... WITH q, count(c) AS cnt
-    // If 'a' is the bound vertex but only 'q' is in grouping keys, and there are multiple
-    // answers per question, CountEdgesStep would produce multiple rows per question.
-    boolean boundVertexInGroupingKeys = false;
-    for (final ReturnClause.ReturnItem key : groupingKeys) {
-      final String keyExprText = key.getExpression() instanceof VariableExpression
-          ? ((VariableExpression) key.getExpression()).getVariableName()
-          : key.getExpression().getText();
-      if (keyExprText.equals(boundVar)) {
-        boundVertexInGroupingKeys = true;
-        break;
-      }
-    }
-    if (!boundVertexInGroupingKeys)
-      return null;
+    // Note: the bound vertex does not need to be among the grouping keys itself - CountEdgesStep
+    // groups its input rows by the grouping-key VALUES and sums the per-row edge count within each
+    // group (issue #6629), so it is correct even when several input rows (a fan-out MATCH hop, an
+    // UNWIND) share the same grouping key but carry different bound-vertex identities, e.g.
+    // MATCH (q)-[:HAS_ANSWER]->(a) OPTIONAL MATCH (a)-[:HAS_COMMENT]->(c) WITH q, count(c) AS cnt.
 
     // Compute direction relative to bound vertex
     // Pattern direction is from firstNode to lastNode

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountChainedEdgesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountChainedEdgesStep.java
@@ -32,6 +32,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +44,12 @@ import java.util.Map;
  * OPTIONAL MATCH (bound)-[r1:TYPE1]->(intermediate)
  * OPTIONAL MATCH (target)-[r2:TYPE2]->(intermediate)
  * WITH bound, count(target) AS cnt
+ * <p>
+ * A row-multiplying clause upstream (UNWIND, an earlier fan-out MATCH hop) can feed this step
+ * more than one input row per distinct grouping-key combination - each still needs its own count,
+ * but the WITH aggregation boundary collapses them into one output row per group rather than
+ * passing every input row through (issue #6629). This step therefore groups by the pass-through
+ * key values and sums the per-row counts within each group.
  */
 public final class CountChainedEdgesStep extends AbstractExecutionStep {
   private final String boundVertexVariable;
@@ -81,7 +88,13 @@ public final class CountChainedEdgesStep extends AbstractExecutionStep {
     final String[] allTypes = mergeEdgeTypes(firstHopTypes, secondHopTypes);
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db, allTypes);
 
-    final List<Result> results = new ArrayList<>();
+    final String[] aliasOutputNames = passThroughAliases.keySet().toArray(new String[0]);
+    final String[] aliasVarNames = passThroughAliases.values().toArray(new String[0]);
+
+    // One accumulated count per distinct grouping-key combination (LinkedHashMap to keep the
+    // first-seen group order, matching GroupByAggregationStep).
+    final Map<GroupKeyValues, long[]> groups = new LinkedHashMap<>();
+
     while (prevResult.hasNext()) {
       final Result inputRow = prevResult.next();
       final long begin = context.isProfiling() ? System.nanoTime() : 0;
@@ -89,13 +102,12 @@ public final class CountChainedEdgesStep extends AbstractExecutionStep {
         if (context.isProfiling())
           rowCount++;
 
-        final ResultInternal result = new ResultInternal();
+        final Object[] keyValues = new Object[aliasVarNames.length];
+        for (int i = 0; i < aliasVarNames.length; i++)
+          keyValues[i] = inputRow.getProperty(aliasVarNames[i]);
+        final GroupKeyValues groupKey = new GroupKeyValues(keyValues);
 
-        // Copy pass-through properties with their WITH aliases
-        for (final Map.Entry<String, String> entry : passThroughAliases.entrySet())
-          result.setProperty(entry.getKey(), inputRow.getProperty(entry.getValue()));
-
-        // Get the bound vertex and count through the chain
+        // Get the bound vertex and count through the chain for this row
         final Object vertexObj = inputRow.getProperty(boundVertexVariable);
         final long totalCount;
 
@@ -121,12 +133,22 @@ public final class CountChainedEdgesStep extends AbstractExecutionStep {
           totalCount = 0L; // NULL vertex = LEFT OUTER JOIN semantics
         }
 
-        result.setProperty(countOutputAlias, totalCount);
-        results.add(result);
+        final long[] accumulator = groups.computeIfAbsent(groupKey, k -> new long[1]);
+        accumulator[0] += totalCount;
       } finally {
         if (context.isProfiling())
           cost += System.nanoTime() - begin;
       }
+    }
+
+    final List<Result> results = new ArrayList<>(groups.size());
+    for (final Map.Entry<GroupKeyValues, long[]> entry : groups.entrySet()) {
+      final ResultInternal result = new ResultInternal();
+      final Object[] keyValues = entry.getKey().values;
+      for (int i = 0; i < aliasOutputNames.length; i++)
+        result.setProperty(aliasOutputNames[i], keyValues[i]);
+      result.setProperty(countOutputAlias, entry.getValue()[0]);
+      results.add(result);
     }
 
     return new IteratorResultSet(results.iterator());

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountEdgesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CountEdgesStep.java
@@ -31,6 +31,7 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +42,12 @@ import java.util.Map;
  * Pattern detected:
  * OPTIONAL MATCH (x)-[r:TYPE]->(y) ... WITH y, count(x) AS cnt
  * where x is only used for counting.
+ * <p>
+ * A row-multiplying clause upstream (UNWIND, an earlier fan-out MATCH hop) can feed this step
+ * more than one input row per distinct grouping-key combination - each still needs its own edge
+ * count, but the WITH aggregation boundary collapses them into one output row per group rather
+ * than passing every input row through (issue #6629). This step therefore groups by the
+ * pass-through key values and sums the per-row edge counts within each group.
  */
 public final class CountEdgesStep extends AbstractExecutionStep {
   private final String boundVertexVariable;
@@ -68,7 +75,13 @@ public final class CountEdgesStep extends AbstractExecutionStep {
     final Database db = context.getDatabase();
     final GraphTraversalProvider provider = GraphTraversalProviderRegistry.findProvider(db, edgeTypes);
 
-    final List<Result> results = new ArrayList<>();
+    final String[] aliasOutputNames = passThroughAliases.keySet().toArray(new String[0]);
+    final String[] aliasVarNames = passThroughAliases.values().toArray(new String[0]);
+
+    // One accumulated count per distinct grouping-key combination (LinkedHashMap to keep the
+    // first-seen group order, matching GroupByAggregationStep).
+    final Map<GroupKeyValues, long[]> groups = new LinkedHashMap<>();
+
     while (prevResult.hasNext()) {
       final Result inputRow = prevResult.next();
       final long begin = context.isProfiling() ? System.nanoTime() : 0;
@@ -76,13 +89,12 @@ public final class CountEdgesStep extends AbstractExecutionStep {
         if (context.isProfiling())
           rowCount++;
 
-        final ResultInternal result = new ResultInternal();
+        final Object[] keyValues = new Object[aliasVarNames.length];
+        for (int i = 0; i < aliasVarNames.length; i++)
+          keyValues[i] = inputRow.getProperty(aliasVarNames[i]);
+        final GroupKeyValues groupKey = new GroupKeyValues(keyValues);
 
-        // Copy pass-through properties with their WITH aliases
-        for (final Map.Entry<String, String> entry : passThroughAliases.entrySet())
-          result.setProperty(entry.getKey(), inputRow.getProperty(entry.getValue()));
-
-        // Get the vertex and count edges
+        // Get the vertex and count edges for this row
         final Object vertexObj = inputRow.getProperty(boundVertexVariable);
         final long count;
         if (vertexObj instanceof Vertex) {
@@ -96,12 +108,22 @@ public final class CountEdgesStep extends AbstractExecutionStep {
         } else
           count = 0L; // NULL vertex = LEFT OUTER JOIN semantics
 
-        result.setProperty(countOutputAlias, count);
-        results.add(result);
+        final long[] accumulator = groups.computeIfAbsent(groupKey, k -> new long[1]);
+        accumulator[0] += count;
       } finally {
         if (context.isProfiling())
           cost += System.nanoTime() - begin;
       }
+    }
+
+    final List<Result> results = new ArrayList<>(groups.size());
+    for (final Map.Entry<GroupKeyValues, long[]> entry : groups.entrySet()) {
+      final ResultInternal result = new ResultInternal();
+      final Object[] keyValues = entry.getKey().values;
+      for (int i = 0; i < aliasOutputNames.length; i++)
+        result.setProperty(aliasOutputNames[i], keyValues[i]);
+      result.setProperty(countOutputAlias, entry.getValue()[0]);
+      results.add(result);
     }
 
     return new IteratorResultSet(results.iterator());

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupByAggregationStep.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Execution step for GROUP BY aggregation.
@@ -415,39 +414,6 @@ public class GroupByAggregationStep extends AbstractExecutionStep {
     AggregationItem(final String outputName, final FunctionCallExpression funcExpr) {
       this.outputName = outputName;
       this.funcExpr = funcExpr;
-    }
-  }
-
-  /**
-   * Represents the values of grouping keys for a specific group.
-   * Uses an Object array with cached hashCode for fast HashMap operations.
-   */
-  private static class GroupKeyValues {
-    final Object[] values;
-    private final int hash;
-
-    GroupKeyValues(final Object[] values) {
-      this.values = values;
-      // Pre-compute and cache hash to avoid recomputation on every HashMap lookup
-      int h = 1;
-      for (final Object v : values)
-        h = 31 * h + (v == null ? 0 : v.hashCode());
-      this.hash = h;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) return true;
-      if (!(o instanceof GroupKeyValues that)) return false;
-      if (hash != that.hash || values.length != that.values.length) return false;
-      for (int i = 0; i < values.length; i++)
-        if (!Objects.equals(values[i], that.values[i])) return false;
-      return true;
-    }
-
-    @Override
-    public int hashCode() {
-      return hash;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupKeyValues.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/GroupKeyValues.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import java.util.Objects;
+
+/**
+ * Represents the values of one or more grouping keys, used as a {@code HashMap} key by the
+ * aggregation steps (issue #6629: a row-multiplying clause upstream of a GROUP BY, such as
+ * UNWIND, must still collapse into one output row per distinct key combination). Caches its
+ * hash code since the same instance is hashed on every row of its group.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class GroupKeyValues {
+  final Object[] values;
+  private final int hash;
+
+  GroupKeyValues(final Object[] values) {
+    this.values = values;
+    int h = 1;
+    for (final Object v : values)
+      h = 31 * h + (v == null ? 0 : v.hashCode());
+    this.hash = h;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (!(o instanceof GroupKeyValues that))
+      return false;
+    if (hash != that.hash || values.length != that.values.length)
+      return false;
+    for (int i = 0; i < values.length; i++)
+      if (!Objects.equals(values[i], that.values[i]))
+        return false;
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CountEdgesOptimizationTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CountEdgesOptimizationTest.java
@@ -272,14 +272,15 @@ class CountEdgesOptimizationTest {
   }
 
   @Test
-  void boundVertexNotInGroupingKeysShouldNotOptimize() {
-    // Regression test for issue #3399
-    // When the bound vertex is NOT in the grouping keys and there are multiple
-    // bound vertices per grouping key, the optimization must not apply because
-    // CountEdgesStep doesn't aggregate - it emits one row per input row.
+  void boundVertexNotInGroupingKeysStillAggregatesCorrectly() {
+    // Regression test for issue #3399, updated for issue #6629.
+    // The bound vertex 'a' (answer) is NOT in the grouping keys (q is), and there are multiple
+    // bound vertices per grouping key. CountEdgesStep now groups its input rows by the grouping
+    // key values and sums the per-row edge count within each group, so the optimization applies
+    // here too and still produces the correct aggregated total (it no longer needs to fall back
+    // to the general GroupByAggregationStep to get a correct answer).
     //
     // Simplified test: Multiple answers per question, count comments per question
-    // The bound vertex 'a' (answer) is NOT in the grouping keys
 
     // Use a fresh database for this test; close the default one to avoid ambiguous database context
     database.drop();

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6629UnwindOptionalMatchAggregationScopeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6629UnwindOptionalMatchAggregationScopeTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6629: {@code OPTIONAL MATCH (x)-[:TYPE]->(y) ... WITH y, count(x) AS cnt} is fused by the planner into
+ * {@code CountEdgesStep} (and, for two consecutive OPTIONAL MATCHes, {@code CountChainedEdgesStep}), which counts
+ * edges directly instead of materializing the OPTIONAL MATCH rows. Both steps used to emit one output row per
+ * INPUT row instead of aggregating, on the (previously unstated) assumption that exactly one input row reaches
+ * them per distinct value of the bound vertex. UNWIND breaks that assumption - it fans a single bound vertex out
+ * into several input rows - so the WITH aggregation boundary was silently lost: N UNWIND rows produced N output
+ * rows, each carrying a per-row count, instead of one grouped row carrying the total.
+ * <p>
+ * Both steps now group their input rows by the WITH clause's non-aggregated (grouping-key) values and sum the
+ * per-row edge count within each group, which is correct both with and without a row-multiplying clause upstream.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6629UnwindOptionalMatchAggregationScopeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-unwind-optional-count-6629").create();
+    database.transaction(() -> {
+      database.getSchema().createVertexType("X");
+      database.getSchema().createEdgeType("L");
+
+      final MutableVertex x1 = database.newVertex("X").set("_id", "x1").save();
+      final MutableVertex x2 = database.newVertex("X").set("_id", "x2").save();
+      x1.newEdge("L", x2);
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @Test
+  void unwindThenOptionalMatchCollapsesToOneGroupWithSummedCount() {
+    // The reported witness: UNWIND fans x1 out into 2 rows; each row's OPTIONAL MATCH finds the
+    // same edge, so the WITH boundary must collapse them into ONE row with c=2 (matching Neo4j/
+    // Memgraph/FalkorDB), not two rows with c=1 each.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:X {_id:'x1'}) UNWIND [1, 2] AS u OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN a, c");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(2L);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void unwindThenOptionalMatchWithNoMatchesCollapsesToOneGroupWithZeroCount() {
+    // Control 3 from the issue: zero optional matches must still be ONE group with c=0, not one
+    // zero-count row per UNWIND element.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:X {_id:'x2'}) UNWIND [1, 2] AS u OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN a, c");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(0L);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void optionalMatchWithoutUnwindStillAggregatesToOneRow() {
+    // Control 1 from the issue: the same aggregation without UNWIND already collapsed correctly -
+    // must keep doing so.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:X {_id:'x1'}) OPTIONAL MATCH (a)-[:L]->(m:X) WITH a, count(m) AS c RETURN a, c");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(1L);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void unwindWithoutOptionalMatchStillAggregatesToOneRow() {
+    // Control 2 from the issue: UNWIND followed by a plain count(*) (no OPTIONAL MATCH, so no
+    // CountEdgesStep fusion at all) already collapsed correctly - must keep doing so.
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:X {_id:'x1'}) UNWIND [1, 2] AS u WITH a, count(*) AS c RETURN a, c");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Long>getProperty("c")).isEqualTo(2L);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+
+  @Test
+  void unwindBeforeChainedOptionalMatchCountAggregatesAcrossUnwoundRows() {
+    // Same collapse-of-grouping-boundary bug, but through CountChainedEdgesStep (two consecutive
+    // OPTIONAL MATCH clauses fused into one chained edge count) rather than CountEdgesStep.
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Question");
+      database.getSchema().createVertexType("Answer");
+      database.getSchema().createVertexType("Comment");
+      database.getSchema().createEdgeType("HAS_ANSWER");
+      database.getSchema().createEdgeType("HAS_COMMENT");
+
+      final MutableVertex q1 = database.newVertex("Question").set("id", 1).save();
+      final MutableVertex a1 = database.newVertex("Answer").set("id", 1).save();
+      q1.newEdge("HAS_ANSWER", a1);
+      for (int i = 0; i < 3; i++) {
+        final MutableVertex c = database.newVertex("Comment").set("id", 100 + i).save();
+        a1.newEdge("HAS_COMMENT", c);
+      }
+    });
+
+    // UNWIND fans q1 out into 2 rows before the chained OPTIONAL MATCH; each row finds all 3
+    // comments through the HAS_ANSWER -> HAS_COMMENT chain, so the total must be 2 * 3 = 6, in
+    // ONE row per question.
+    final ResultSet rs = database.query("opencypher",
+        """
+        MATCH (q:Question) UNWIND [1, 2] AS u \
+        OPTIONAL MATCH (q)-[:HAS_ANSWER]->(a) \
+        OPTIONAL MATCH (a)-[:HAS_COMMENT]->(x) \
+        WITH q, count(x) AS cnt \
+        RETURN q.id AS qid, cnt""");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Integer>getProperty("qid")).isEqualTo(1);
+    assertThat(row.<Long>getProperty("cnt")).isEqualTo(6L);
+    assertThat(rs.hasNext()).isFalse();
+    rs.close();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6629: `MATCH (a) UNWIND [...] AS u OPTIONAL MATCH (a)-[:L]->(m) WITH a, count(m) AS c RETURN a, c` returned one row per UNWIND element (each carrying a per-row count) instead of one grouped row with the total, disagreeing with Neo4j/Memgraph/FalkorDB.

Root cause: the planner fuses `OPTIONAL MATCH ... WITH x, count(y) AS c` into a direct edge count (`CountEdgesStep`, and for two consecutive `OPTIONAL MATCH` clauses, `CountChainedEdgesStep`) to avoid materializing the matched vertices. Both steps emitted one output row per **input** row instead of aggregating, on the unstated assumption that exactly one input row reaches them per distinct bound-vertex value. A row-multiplying clause upstream - UNWIND, or an earlier fan-out MATCH hop - breaks that assumption, so the WITH aggregation boundary was silently lost.

- Both steps now group their input rows by the WITH clause's grouping-key values and **sum** the per-row edge count within each group - correct with or without a row-multiplying clause upstream.
- This also let me drop the `boundVertexInGroupingKeys` guard the planner used to bail out of the optimization for a narrower instance of the same problem (issue #3399, still covered by `CountEdgesOptimizationTest`): true grouping handles that case too, so the optimization now also applies (and is now correct) where it previously had to fall back to the general `GroupByAggregationStep`.
- Extracted the grouping-key value/hashCode/equals helper (previously a private nested class duplicated ad hoc) into a shared `GroupKeyValues`, now reused by `GroupByAggregationStep`, `CountEdgesStep`, and `CountChainedEdgesStep`.

## Test plan

- [x] New regression test `Issue6629UnwindOptionalMatchAggregationScopeTest` covering the reported witness query, both controls from the issue (no-UNWIND, UNWIND-without-OPTIONAL-MATCH), the zero-match case, and an UNWIND-before-chained-OPTIONAL-MATCH case (`CountChainedEdgesStep` path)
- [x] Updated `CountEdgesOptimizationTest` (issue #3399 regression) to reflect that the optimization now applies and is correct for that case too
- [x] `mvn -o -pl engine -am test -Dtest='com.arcadedb.query.opencypher.**'` - 8869 tests, 0 failures
- [x] Compared against Neo4j semantics for all four scenarios from the issue (matches expected results exactly)