### PR TITLE
fix(#6638): date.truncate() family returns HTTP 400 not 500 for incompatible temporal argument

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/temporal/DateTimeTruncateFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/temporal/DateTimeTruncateFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.temporal;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.opencypher.temporal.CypherDate;
@@ -70,7 +70,9 @@ public class DateTimeTruncateFunction implements StatelessFunction {
     else if (args[1] instanceof LocalDate)
       dt = ((LocalDate) args[1]).atStartOfDay(ZoneOffset.UTC);
     else
-      throw new CommandExecutionException("datetime.truncate() second argument must be a temporal value");
+      // Not a recognized temporal value: determined entirely by the supplied argument, so it is a client error
+      // (HTTP 400) rather than a CommandExecutionException (HTTP 500). See issue #6638.
+      throw new CommandSemanticException("datetime.truncate() second argument must be a temporal value");
     LocalDateTime truncated = TemporalUtil.truncateLocalDateTime(dt.toLocalDateTime(), unit);
     ZoneId zone = dt.getZone();
     // An explicitly written null adjustment map propagates, like every argument before it; only an omitted one means

--- a/engine/src/main/java/com/arcadedb/function/temporal/DateTruncateFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/temporal/DateTruncateFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.temporal;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.opencypher.temporal.CypherDate;
@@ -67,7 +67,9 @@ public class DateTruncateFunction implements StatelessFunction {
     else if (args[1] instanceof LocalDateTime)
       date = ((LocalDateTime) args[1]).toLocalDate();
     else
-      throw new CommandExecutionException("date.truncate() second argument must be a temporal value with a date");
+      // Not a date-bearing temporal value: determined entirely by the supplied argument, so it is a client error
+      // (HTTP 400) rather than a CommandExecutionException (HTTP 500). See issue #6638.
+      throw new CommandSemanticException("date.truncate() second argument must be a temporal value with a date");
     LocalDate truncated = TemporalUtil.truncateDate(date, unit);
     // An explicitly written null adjustment map propagates, like every argument before it; only an omitted one means
     // "no adjustment" (issue #5629). This sits after the unit and the temporal value have been validated, so a bad unit

--- a/engine/src/main/java/com/arcadedb/function/temporal/LocalDateTimeTruncateFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/temporal/LocalDateTimeTruncateFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.temporal;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.opencypher.temporal.CypherDate;
@@ -67,7 +67,9 @@ public class LocalDateTimeTruncateFunction implements StatelessFunction {
     else if (args[1] instanceof LocalDate)
       dt = ((LocalDate) args[1]).atStartOfDay();
     else
-      throw new CommandExecutionException("localdatetime.truncate() second argument must be a temporal value");
+      // Not a recognized temporal value: determined entirely by the supplied argument, so it is a client error
+      // (HTTP 400) rather than a CommandExecutionException (HTTP 500). See issue #6638.
+      throw new CommandSemanticException("localdatetime.truncate() second argument must be a temporal value");
     LocalDateTime truncated = TemporalUtil.truncateLocalDateTime(dt, unit);
     // An explicitly written null adjustment map propagates, like every argument before it; only an omitted one means
     // "no adjustment" (issue #5629). This sits after the unit and the temporal value have been validated, so a bad unit

--- a/engine/src/main/java/com/arcadedb/function/temporal/LocalTimeTruncateFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/temporal/LocalTimeTruncateFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.temporal;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.opencypher.temporal.CypherDateTime;
@@ -65,7 +65,9 @@ public class LocalTimeTruncateFunction implements StatelessFunction {
     else if (args[1] instanceof CypherDateTime)
       time = ((CypherDateTime) args[1]).getValue().toLocalTime();
     else
-      throw new CommandExecutionException("localtime.truncate() second argument must be a temporal value with a time");
+      // Not a time-bearing temporal value: determined entirely by the supplied argument, so it is a client error
+      // (HTTP 400) rather than a CommandExecutionException (HTTP 500). See issue #6638.
+      throw new CommandSemanticException("localtime.truncate() second argument must be a temporal value with a time");
     LocalTime truncated = TemporalUtil.truncateLocalTime(time, unit);
     // An explicitly written null adjustment map propagates, like every argument before it; only an omitted one means
     // "no adjustment" (issue #5629). This sits after the unit and the temporal value have been validated, so a bad unit

--- a/engine/src/main/java/com/arcadedb/function/temporal/TimeTruncateFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/temporal/TimeTruncateFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.temporal;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.opencypher.temporal.CypherDateTime;
@@ -67,7 +67,9 @@ public class TimeTruncateFunction implements StatelessFunction {
     else if (args[1] instanceof CypherLocalDateTime)
       time = ((CypherLocalDateTime) args[1]).getValue().toLocalTime().atOffset(ZoneOffset.UTC);
     else
-      throw new CommandExecutionException("time.truncate() second argument must be a temporal value with a time");
+      // Not a time-bearing temporal value: determined entirely by the supplied argument, so it is a client error
+      // (HTTP 400) rather than a CommandExecutionException (HTTP 500). See issue #6638.
+      throw new CommandSemanticException("time.truncate() second argument must be a temporal value with a time");
     LocalTime truncated = TemporalUtil.truncateLocalTime(time.toLocalTime(), unit);
     ZoneOffset offset = time.getOffset();
     // An explicitly written null adjustment map propagates, like every argument before it; only an omitted one means

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionArgumentValidationIssue6638Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionArgumentValidationIssue6638Test.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6638: the truncate family ({@code date.truncate()}, {@code time.truncate()},
+ * {@code localtime.truncate()}, {@code datetime.truncate()}, {@code localdatetime.truncate()}) answered HTTP 500
+ * via a bare {@link com.arcadedb.exception.CommandExecutionException} when the second argument was not a
+ * compatible temporal value, instead of the client-facing {@link CommandSemanticException} (HTTP 400) that
+ * sibling argument-validation paths already returned since #5794/#5909 and #5910.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherFunctionArgumentValidationIssue6638Test extends TestHelper {
+
+  @Test
+  void dateTruncateWithATimeValueIsAClientError() {
+    // A TIME value has no DATE component: date.truncate() cannot truncate it.
+    assertThatThrownBy(() -> consume("RETURN date.truncate('hour', time('12:31:14Z')) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("date.truncate()")
+        .hasMessageContaining("date");
+  }
+
+  @Test
+  void dateTruncateWithANonTemporalArgumentIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN date.truncate('year', 42) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("date.truncate()");
+  }
+
+  @Test
+  void timeTruncateWithADateValueIsAClientError() {
+    // A DATE value has no TIME component: time.truncate() cannot truncate it.
+    assertThatThrownBy(() -> consume("RETURN time.truncate('hour', date('1984-10-11')) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("time.truncate()")
+        .hasMessageContaining("time");
+  }
+
+  @Test
+  void localTimeTruncateWithADateValueIsAClientError() {
+    // A DATE value has no TIME component: localtime.truncate() cannot truncate it. (A DATETIME value IS
+    // accepted here, its time-of-day extracted, the same way date.truncate() accepts a DATETIME/LOCALDATETIME
+    // and extracts its date - see the "still succeeds" control below.)
+    assertThatThrownBy(() -> consume("RETURN localtime.truncate('hour', date('1984-10-11')) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("localtime.truncate()")
+        .hasMessageContaining("time");
+  }
+
+  @Test
+  void dateTimeTruncateWithALocalTimeValueIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN datetime.truncate('hour', localtime('12:31:14')) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("datetime.truncate()");
+  }
+
+  @Test
+  void localDateTimeTruncateWithANonTemporalArgumentIsAClientError() {
+    assertThatThrownBy(() -> consume("RETURN localdatetime.truncate('hour', 42) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("localdatetime.truncate()");
+  }
+
+  // ===================== valid-input controls: confirm the fix does not disturb success paths =====================
+
+  @Test
+  void validInputsStillSucceed() {
+    assertThat(single("RETURN date.truncate('year', date('1984-10-11')) AS r").toString()).isEqualTo("1984-01-01");
+    assertThat(single("RETURN date.truncate('year', date('1984-10-11'), null) AS r")).isNull();
+    assertThat(single("RETURN time.truncate('hour', time('12:31:14Z')) AS r")).isNotNull();
+    assertThat(single("RETURN localtime.truncate('hour', localtime('12:31:14')) AS r")).isNotNull();
+    assertThat(single("RETURN datetime.truncate('hour', datetime('1984-10-11T12:31:14Z')) AS r")).isNotNull();
+    assertThat(single("RETURN localdatetime.truncate('hour', localdatetime('1984-10-11T12:31:14')) AS r")).isNotNull();
+    // A DATETIME carries a time-of-day, so localtime.truncate() accepts it and extracts that component,
+    // consistent with date.truncate() accepting a DATETIME/LOCALDATETIME and extracting its date.
+    assertThat(single("RETURN localtime.truncate('hour', datetime('1984-10-11T12:31:14Z')) AS r").toString()).isEqualTo("12:00");
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherOptionalArgumentNullIssue5629Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherOptionalArgumentNullIssue5629Test.java
@@ -19,7 +19,6 @@
 package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.text.SubstringFunction;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -190,8 +189,9 @@ class CypherOptionalArgumentNullIssue5629Test extends TestHelper {
     // client-facing one - a separate defect, so this asserts only that the check is reached, not the class it uses.
     assertThatThrownBy(() -> consume("RETURN date.truncate('fortnight', date('1984-10-11'), null) AS r"))
         .hasMessageContaining("fortnight");
+    // The second-argument type check is a client error (HTTP 400), fixed in #6638.
     assertThatThrownBy(() -> consume("RETURN date.truncate('year', 'not a date', null) AS r"))
-        .isInstanceOf(CommandExecutionException.class);
+        .isInstanceOf(CommandSemanticException.class);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #6638. The truncate family (`date.truncate()`, `time.truncate()`, `localtime.truncate()`,
`datetime.truncate()`, `localdatetime.truncate()`) threw a bare `CommandExecutionException` (HTTP 500)
when the second argument was not a compatible temporal value (e.g. a `TIME` into `date.truncate()`, or
a non-temporal value like an integer), instead of a client-facing HTTP 400.

The failure is determined entirely by the supplied argument and cannot succeed on an unchanged retry,
so it is a client error, not a server fault - the same class of defect already fixed for the sibling
temporal constructors in #5909 (issue #5794) and #5910. This PR applies the same established fix:
switch the five throw sites from `CommandExecutionException` to `CommandSemanticException` (a subclass
of `CommandParsingException`, which `AbstractServerHttpHandler.sendMappedErrorResponse()` maps to
HTTP 400).

- `RETURN date.truncate('hour', time('12:31:14Z'))` -> now `CommandSemanticException` (400), was `CommandExecutionException` (500)
- `RETURN date.truncate('year', 42)` -> now 400, was 500
- `RETURN time.truncate('hour', date('1984-10-11'))` -> now 400, was 500
- `RETURN datetime.truncate('hour', localtime('12:31:14'))` -> now 400, was 500
- `RETURN localdatetime.truncate('hour', 42)` -> now 400, was 500

One reproduction step from the issue, `localtime.truncate('hour', datetime(...))`, does not actually
reproduce against current `main`: `LocalTimeTruncateFunction` already accepts a `CypherDateTime` and
extracts its time-of-day component, the same way `date.truncate()` accepts a `DATETIME`/`LOCALDATETIME`
and extracts its date. That is intentional, consistent behavior across the whole truncate family, not
the type-mismatch bug the issue describes - so the real analogous type-mismatch case for
`localtime.truncate()` is a `DATE` value (which has no time component at all), and that is what the
added test exercises and confirms was broken (fixed).

Valid inputs and null-timezone propagation (issue #5629) continue to work unchanged; a pre-existing
test (`CypherOptionalArgumentNullIssue5629Test`) that documented the old 500 behavior for this exact
path is updated to assert the new, correct 400.

## Files changed

- `engine/src/main/java/com/arcadedb/function/temporal/DateTruncateFunction.java`
- `engine/src/main/java/com/arcadedb/function/temporal/TimeTruncateFunction.java`
- `engine/src/main/java/com/arcadedb/function/temporal/LocalTimeTruncateFunction.java`
- `engine/src/main/java/com/arcadedb/function/temporal/DateTimeTruncateFunction.java`
- `engine/src/main/java/com/arcadedb/function/temporal/LocalDateTimeTruncateFunction.java`
- `engine/src/test/java/com/arcadedb/query/opencypher/CypherFunctionArgumentValidationIssue6638Test.java` (new)
- `engine/src/test/java/com/arcadedb/query/opencypher/CypherOptionalArgumentNullIssue5629Test.java`

## Test plan

- [x] New regression test `CypherFunctionArgumentValidationIssue6638Test` (7 tests): all five truncate
      functions reject an incompatible temporal/non-temporal argument with `CommandSemanticException`,
      plus a `validInputsStillSucceed()` control covering every function and the intentional
      cross-type extraction (`localtime.truncate()` + `DATETIME`).
- [x] Updated `CypherOptionalArgumentNullIssue5629Test` to assert the corrected exception type.
- [x] Full `com.arcadedb.query.opencypher.**` package (unit tests + OpenCypher TCK, 3897 scenarios):
      0 failures, no regressions.