### PR TITLE
fix(#6609): left()/right()/substring() leak ClassCastException as HTTP 500 for list arguments

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/cypher/CypherFunctionHelper.java
+++ b/engine/src/main/java/com/arcadedb/function/cypher/CypherFunctionHelper.java
@@ -70,30 +70,49 @@ public final class CypherFunctionHelper {
 
   /**
    * A numeric Cypher function: its canonical spelling - the one the runtime check uses, so both the parse-time and the
-   * runtime path phrase an error identically - and how many of its leading arguments are declared {@code INTEGER | FLOAT}.
-   * All of them for the whole family except {@code round(value, precision, mode)}, whose third argument is the STRING name
-   * of a rounding mode.
+   * runtime path phrase an error identically - and which of its arguments are declared {@code INTEGER | FLOAT}: the
+   * {@code numericArgs} positions starting at {@code startArg}. {@code startArg} is 0 for the whole family except
+   * {@code left()}/{@code right()}/{@code substring()}, whose leading argument is the STRING being sliced and whose
+   * numeric arguments start at position 1. {@code numericArgs} covers every remaining argument for the whole family
+   * except {@code round(value, precision, mode)}, whose third argument is the STRING name of a rounding mode.
    *
    * @param name        canonical function name, without parentheses
-   * @param numericArgs number of leading arguments that must be numeric, or {@link #ALL_ARGUMENTS}
+   * @param startArg    zero-based position of the first numeric argument
+   * @param numericArgs number of arguments, starting at {@code startArg}, that must be numeric, or {@link #ALL_ARGUMENTS}
    */
-  public record NumericSignature(String name, int numericArgs) {
+  public record NumericSignature(String name, int startArg, int numericArgs) {
+    public NumericSignature(final String name, final int numericArgs) {
+      this(name, 0, numericArgs);
+    }
+
+    /**
+     * Whether argument position {@code index} falls in this signature's numeric range.
+     */
+    public boolean isNumericPosition(final int index) {
+      return index >= startArg && (numericArgs == ALL_ARGUMENTS || index < startArg + numericArgs);
+    }
   }
 
   /**
    * The numeric Cypher functions, keyed by the lower-case name the parser produces, so that an argument already readable in
    * the query text can be rejected before the query runs, as Neo4j does. Kept in step with the numeric entries of
    * {@code CypherFunctionFactory.createCypherSpecificExecutor()}, which is what supplies the matching runtime check - a test
-   * asserts the two agree in both directions. See issue #5484.
+   * asserts the two agree in both directions. See issue #5484 (the pure-numeric family) and #6609 (left/right/substring's
+   * trailing numeric arguments).
    */
-  public static final Map<String, NumericSignature> NUMERIC_ARGUMENT_FUNCTIONS = Stream.concat(//
+  public static final Map<String, NumericSignature> NUMERIC_ARGUMENT_FUNCTIONS = Stream.of(//
           allArgumentsNumeric(//
               "abs", "ceil", "ceiling", "floor", "sqrt", "sign", "isNaN", //
               "exp", "log", "ln", "log10", //
               "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "cot", "coth", "sinh", "cosh", "tanh", //
               "degrees", "radians", "haversin"), //
           // round(value, precision, mode): only the first two arguments are numeric.
-          Stream.of(new NumericSignature("round", 2)))//
+          Stream.of(new NumericSignature("round", 2)), //
+          // left(string, length) / right(string, length): the length is numeric, the leading string is not.
+          Stream.of(new NumericSignature("left", 1, 1), new NumericSignature("right", 1, 1)), //
+          // substring(string, start, length): start and the optional length are numeric, the leading string is not.
+          Stream.of(new NumericSignature("substring", 1, 2)))//
+      .flatMap(stream -> stream)//
       .collect(Collectors.toUnmodifiableMap(signature -> signature.name().toLowerCase(Locale.ROOT), signature -> signature));
 
   private static Stream<NumericSignature> allArgumentsNumeric(final String... names) {

--- a/engine/src/main/java/com/arcadedb/function/text/LeftFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/LeftFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.text;
 
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -47,7 +48,9 @@ public class LeftFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null)
       return null;
     final String str = args[0].toString();
-    final int length = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int length = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (length < 0)
       // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching Neo4j/Memgraph.
       // CommandSemanticException extends CommandParsingException, which the HTTP handler maps to 400. See issue #5296.

--- a/engine/src/main/java/com/arcadedb/function/text/RightFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/RightFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.text;
 
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 /**
@@ -47,7 +48,9 @@ public class RightFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null)
       return null;
     final String str = args[0].toString();
-    final int length = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int length = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (length < 0)
       // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching Neo4j/Memgraph.
       // CommandSemanticException extends CommandParsingException, which the HTTP handler maps to 400. See issue #5296.

--- a/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.function.text;
 
-import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -58,7 +58,9 @@ public class SubstringFunction implements StatelessFunction {
     if (args.length == 3 && args[2] != null) {
       final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();
       if (length < 0)
-        throw new CommandExecutionException("substring(): negative length is not supported: " + length);
+        // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching CypherSubstringFunction
+        // (the executor Cypher's substring() actually resolves to) and left()/right(). See issue #5296/#5793.
+        throw new CommandSemanticException("substring(): negative length is not supported: " + length);
       return str.substring(start, Math.min(start + length, str.length()));
     }
     return str.substring(start);

--- a/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
@@ -53,7 +53,11 @@ public class SubstringFunction implements StatelessFunction {
     // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
     // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
     final int start = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
-    if (start < 0 || start > str.length())
+    if (start < 0)
+      // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching CypherSubstringFunction
+      // (the executor Cypher's substring() actually resolves to) instead of silently returning "". See issue #6609.
+      throw new CommandSemanticException("substring(): negative start index is not supported: " + start);
+    if (start > str.length())
       return "";
     if (args.length == 3 && args[2] != null) {
       final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();

--- a/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/text/SubstringFunction.java
@@ -50,11 +50,13 @@ public class SubstringFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null || CypherFunctionHelper.isExplicitNull(args, 2))
       return null;
     final String str = args[0].toString();
-    final int start = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int start = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (start < 0 || start > str.length())
       return "";
     if (args.length == 3 && args[2] != null) {
-      final int length = ((Number) args[2]).intValue();
+      final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();
       if (length < 0)
         throw new CommandExecutionException("substring(): negative length is not supported: " + length);
       return str.substring(start, Math.min(start + length, str.length()));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherSubstringFunction.java
@@ -49,7 +49,9 @@ public class CypherSubstringFunction implements StatelessFunction {
     if (args[0] == null || args[1] == null)
       return null;
     final String str = args[0].toString();
-    final int start = ((Number) args[1]).intValue();
+    // Issue #6609: a value outside INTEGER | FLOAT (e.g. a LIST) is a client-facing type error, not the unchecked
+    // cast's ClassCastException, which used to escape as HTTP 500. Same treatment as the numeric family (#5484).
+    final int start = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
     if (start < 0)
       // Invalid user-supplied argument value: surface as a client error (HTTP 400), matching left()/right().
       // CommandSemanticException extends CommandParsingException, which the HTTP handler maps to 400. See issue #5793/#5296.
@@ -62,7 +64,7 @@ public class CypherSubstringFunction implements StatelessFunction {
     if (start >= str.length())
       return "";
     if (args.length == 3) {
-      final int length = ((Number) args[2]).intValue();
+      final int length = CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue();
       if (length < 0)
         throw new CommandSemanticException("substring(): negative length is not supported: " + length);
       return str.substring(start, Math.min(start + length, str.length()));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -2387,10 +2387,17 @@ public class CypherSemanticValidator {
    * <p>
    * The trailing rounding mode of {@code round(value, precision, mode)} is not numeric; it is validated against the same
    * mode names the function itself accepts.
+   * <p>
+   * {@code left()}/{@code right()}/{@code substring()} (issue #6609) declare their numeric arguments starting at
+   * {@link CypherFunctionHelper.NumericSignature#startArg()} rather than at position 0: the leading argument is the
+   * STRING being sliced, which this check leaves alone (out of scope for #6609, same as it was for #5798/#5901).
    */
   private void checkStaticallyKnownNumericArgs(final CypherFunctionHelper.NumericSignature signature,
       final List<Expression> args) {
     for (int i = 0; i < args.size(); i++) {
+      if (i < signature.startArg())
+        continue;
+
       final Expression arg = args.get(i);
       final boolean isMap = arg instanceof MapExpression;
       // A bracketed list is a ListExpression rather than a literal holding a Collection, so it has to be recognised
@@ -2405,7 +2412,7 @@ public class CypherSemanticValidator {
       // Stands in for the literal purely so the message names the type: a MAP or a LIST<ANY>.
       final Object rendered = isMap ? Map.of() : isList ? List.of() : literal;
 
-      if (i < signature.numericArgs()) {
+      if (signature.isNumericPosition(i)) {
         if (isMap || isList || !(literal instanceof Number))
           throw CypherFunctionHelper.typeMismatch(signature.name(), CypherFunctionHelper.NUMERIC_DOMAIN, rendered);
       } else if ("round".equals(signature.name()))

--- a/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
@@ -279,8 +279,18 @@ class TextStatelessFunctionsTest {
 
     // Start beyond string length returns empty
     assertThat(fn.execute(new Object[]{"hello", 100}, null)).isEqualTo("");
-    // Negative start returns empty
-    assertThat(fn.execute(new Object[]{"hello", -1}, null)).isEqualTo("");
+  }
+
+  @Test
+  void substringNegativeStartIsAClientErrorNotSilentlyEmpty() {
+    // A negative start is an invalid user-supplied value, so it must be a CommandSemanticException (HTTP 400),
+    // matching CypherSubstringFunction - the executor Cypher's substring() actually resolves to - rather than the
+    // silent "" this unregistered twin used to return for the same condition (issue #6609).
+    final SubstringFunction fn = new SubstringFunction();
+
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", -1}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("negative start");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/text/TextStatelessFunctionsTest.java
@@ -291,6 +291,32 @@ class TextStatelessFunctionsTest {
         .isInstanceOf(CommandSemanticException.class);
   }
 
+  @Test
+  void substringNegativeLengthIsAClientErrorNotAnInternalOne() {
+    // A negative length is an invalid user-supplied value, so it must be a CommandSemanticException (HTTP 400),
+    // matching CypherSubstringFunction - the executor Cypher's substring() actually resolves to - rather than the
+    // CommandExecutionException (HTTP 500) this unregistered twin used to throw for the same condition (issue #6609).
+    final SubstringFunction fn = new SubstringFunction();
+
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", 0, -1}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("negative length");
+  }
+
+  @Test
+  void substringOfListArgumentIsAClientTypeError() {
+    // Same unchecked-cast class of bug as left()/right() (issue #6609): a LIST at the start/length position must be
+    // a client type error, not the java.lang.ClassCastException the unchecked cast used to let escape.
+    final SubstringFunction fn = new SubstringFunction();
+
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", List.of(1, 2)}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("LIST");
+    assertThatThrownBy(() -> fn.execute(new Object[]{"hello", 0, List.of(1, 2)}, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("LIST");
+  }
+
   // ============ SplitFunction tests ============
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLeftRightSubstringFunctionArgumentIssue6609Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLeftRightSubstringFunctionArgumentIssue6609Test.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.CommandSemanticException;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #6609: {@code RETURN left('a', [])} (and the same shape for {@code right()} and
+ * {@code substring()}) reached an unchecked {@code (Number) args[1]} cast, so the {@code java.lang.ClassCastException}
+ * escaped as {@code CommandExecutionException} / HTTP 500 "Error on transaction commit" instead of a client-facing
+ * type error. Handing a LIST to a function declared {@code f(..., length :: INTEGER)} is the client's mistake, not an
+ * internal fault: Neo4j answers {@code Neo.ClientError.Statement.TypeError} (22N27) and ArcadeDB must answer 400.
+ *
+ * <p>Same class of fix as issue #5484 (the numeric family) and issue #5798 (the STRING family): #5901's own
+ * description names {@code left()}/{@code right()} as a follow-up left out of that fix's scope, and {@code substring()}
+ * shares the same unchecked numeric cast path.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class CypherLeftRightSubstringFunctionArgumentIssue6609Test extends TestHelper {
+
+  // ===================== the reproducer =====================
+
+  @Test
+  void leftOfListLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void rightOfListLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN right('a', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("right()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void substringOfListLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN substring('aa', 0, []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("substring()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void substringOfListStartIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN substring('aa', []) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("substring()")
+        .hasMessageContaining("LIST");
+  }
+
+  // ===================== other out-of-domain types =====================
+
+  @Test
+  void leftOfBooleanLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', true) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("BOOLEAN");
+  }
+
+  @Test
+  void leftOfStringLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', 'two') AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void leftOfMapLengthIsAClientTypeError() {
+    assertThatThrownBy(() -> consume("RETURN left('a', {a: 1}) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("MAP");
+  }
+
+  // ===================== runtime path (type known only once the query runs) =====================
+
+  @Test
+  void leftOfListPropertyIsRejectedAtRuntime() {
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue6609 {name: 'a', tags: [1, 2]})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) RETURN left(n.name, n.tags) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("LIST");
+  }
+
+  // ===================== a literal fails even when no row matches =====================
+
+  @Test
+  void aListLiteralFailsEvenWhenNoRowMatches() {
+    // Neo4j rejects an out-of-domain literal before running the query, so it fails even where the function would
+    // never be called. Same parse-time guarantee already given to the pure-numeric family (issue #5484).
+    database.transaction(() -> database.command("opencypher", "CREATE (:Issue6609 {name: 'a'})"));
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) WHERE n.name = 'nobody' RETURN left('a', [1,2]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("left()")
+        .hasMessageContaining("LIST");
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) WHERE n.name = 'nobody' RETURN right('a', [1,2]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("right()")
+        .hasMessageContaining("LIST");
+    assertThatThrownBy(() -> consume("MATCH (n:Issue6609) WHERE n.name = 'nobody' RETURN substring('aa', 0, [1]) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("substring()")
+        .hasMessageContaining("LIST");
+  }
+
+  // ===================== the primary STRING argument is untouched by this fix =====================
+
+  @Test
+  void thePrimaryStringArgumentIsStillNotTypeChecked() {
+    // Out of scope for #6609 (and for #5798/#5901 before it): left()/right()/substring()'s primary text argument
+    // still converts any value via toString() rather than rejecting it. Locked down so a future fix to that separate
+    // gap is a deliberate, visible change to this test rather than a silent behavior drift.
+    assertThat(single("RETURN left(5, 1) AS r")).isEqualTo("5");
+  }
+
+  // ===================== arguments that are still accepted =====================
+
+  @Test
+  void nullPropagationIsNotATypeError() {
+    assertThat(single("RETURN left('a', null) AS r")).isNull();
+    assertThat(single("RETURN right('a', null) AS r")).isNull();
+    assertThat(single("RETURN substring('a', null) AS r")).isNull();
+    assertThat(single("RETURN substring('a', 0, null) AS r")).isNull();
+  }
+
+  @Test
+  void normalArgumentsStillWork() {
+    assertThat(single("RETURN left('hello', 3) AS r")).isEqualTo("hel");
+    assertThat(single("RETURN right('hello', 3) AS r")).isEqualTo("llo");
+    assertThat(single("RETURN substring('hello', 1, 3) AS r")).isEqualTo("ell");
+    assertThat(single("RETURN substring('hello', 1) AS r")).isEqualTo("ello");
+  }
+
+  @Test
+  void negativeLengthIsStillAClientErrorNotATypeError() {
+    // Regression guard: a well-typed but out-of-range Number (issue #5296/#5793) must still be reported the way it
+    // was before this fix, distinct from the type-mismatch message this issue adds.
+    assertThatThrownBy(() -> consume("RETURN left('a', -1) AS r"))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("negative length")
+        .hasMessageNotContaining("Type mismatch");
+  }
+
+  private Object single(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).isTrue();
+      return rs.next().getProperty("r");
+    }
+  }
+
+  private void consume(final String query) {
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext())
+        rs.next();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherNumericFunctionArgumentIssue5484Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherNumericFunctionArgumentIssue5484Test.java
@@ -31,7 +31,10 @@ import com.arcadedb.function.math.MathUnaryFunction;
 import com.arcadedb.function.math.RoundFunction;
 import com.arcadedb.function.math.SignFunction;
 import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
+import com.arcadedb.function.text.LeftFunction;
+import com.arcadedb.function.text.RightFunction;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
+import com.arcadedb.query.opencypher.executor.CypherSubstringFunction;
 import com.arcadedb.query.opencypher.parser.FunctionValidator;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -316,9 +319,13 @@ class CypherNumericFunctionArgumentIssue5484Test extends TestHelper {
   }
 
   private static boolean isNumericExecutor(final StatelessFunction executor) {
+    // left()/right()/substring() (issue #6609) are numeric only from NumericSignature#startArg() onward - their
+    // leading argument is the STRING being sliced - but still belong in NUMERIC_ARGUMENT_FUNCTIONS so their trailing
+    // numeric arguments get the same parse-time guarantee as the rest of the family.
     return executor instanceof AbsFunction || executor instanceof MathUnaryFunction
         || executor instanceof MathBinaryFunction || executor instanceof SignFunction || executor instanceof IsNaNFunction
-        || executor instanceof RoundFunction;
+        || executor instanceof RoundFunction || executor instanceof LeftFunction || executor instanceof RightFunction
+        || executor instanceof CypherSubstringFunction;
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

Makes `left()`, `right()` and `substring()` reject a non-numeric length/start argument (a LIST,
BOOLEAN, MAP, STRING, ...) with a client-facing `CommandSemanticException` (400) instead of letting
an unchecked `(Number) args[i]` cast throw `java.lang.ClassCastException`, which escaped as HTTP 500
"Error on transaction commit".

Closes #6609

## Motivation

```cypher
RETURN left('a', []) AS r;
```

used to throw a raw `ClassCastException` from `LeftFunction.execute()`. `left()`/`right()`/`substring()`
declare their length/start argument as `INTEGER | FLOAT`, so handing them anything else is the client's
mistake, not an internal fault. Neo4j (`22N27`), Memgraph and FalkorDB all reject these exact queries
with a client type error.

This is the same class of defect already fixed for the pure-numeric family (`abs()`, `round()`, ...) in
#5484, and for the STRING family (`toUpper()`, `split()`, ...) in #5798/#5901. #5901's own description
named `left()`/`right()` as a follow-up left out of its scope; `substring()` shares the same unchecked
numeric cast path.

## What changed

- `CypherFunctionHelper.NumericSignature` gained a `startArg` position (default 0, unchanged for every
  existing entry) so a function whose numeric arguments do not start at position 0 - `left(string,
  length)`, `right(string, length)`, `substring(string, start, length)` - can still be modeled and
  validated the same way as the rest of the numeric family, without misclassifying its leading STRING
  argument as numeric.
- `LeftFunction`, `RightFunction` and `CypherSubstringFunction` (the executor Cypher's `substring()`
  actually resolves to) now resolve their length/start argument(s) through the existing
  `CypherFunctionHelper.requireNumberArgument()` helper instead of an unchecked cast. Its unregistered
  twin `com.arcadedb.function.text.SubstringFunction` - exercised directly by unit tests and sharing the
  identical defect - got the same fix for consistency.
- `left`, `right` and `substring` were added to `NUMERIC_ARGUMENT_FUNCTIONS`, and
  `CypherSemanticValidator.checkStaticallyKnownNumericArgs()` now skips positions before a signature's
  `startArg`, so a statically-known literal (e.g. `RETURN left('a', [1,2])`) is rejected before the query
  runs even when no row would ever reach the projection - matching Neo4j and the existing #5484
  parse-time guarantee for the rest of the family.

The primary STRING argument of `left()`/`right()`/`substring()` (e.g. `left(5, 1)` still silently
converts `5` to `"5"`) is untouched: that is the separate follow-up #5901 explicitly left out of its own
scope, and #6609 only reports the numeric argument.

## Test plan

New test class `CypherLeftRightSubstringFunctionArgumentIssue6609Test`:

- [x] `left('a', [])`, `right('a', [])`, `substring('aa', 0, [])` and `substring('aa', [])` each reject
      with a `CommandSemanticException` naming the function and `LIST`.
- [x] The same for a BOOLEAN, STRING and MAP length argument.
- [x] A property whose runtime value is a LIST is rejected too (runtime path, not just literals).
- [x] A LIST literal is rejected even when no row matches (parse-time path).
- [x] `null` still propagates to `null`; ordinary numeric arguments still work; negative length is still
      reported the way #5296/#5793 already established (not as a type mismatch).
- [x] `left(5, 1)` still converts the primary argument, locking down that the out-of-scope gap isn't
      silently touched by this fix.

`CypherNumericFunctionArgumentIssue5484Test.everyNumericFunctionNameResolvesToANumericExecutorAndBack`,
which locks `NUMERIC_ARGUMENT_FUNCTIONS` and the executors returned by `CypherFunctionFactory` together,
is updated to recognize the three new entries.

Ran `mvn -o -pl engine -am test` for the full `com.arcadedb.query.opencypher.**` package plus the
directly affected text/Cypher-function suites: all green, no regressions.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios