### PR TITLE
fix(#6631): scope OpenCypher DELETE/FOREACH eager-materialization to its own WITH segment

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1422,6 +1422,7 @@ public class CypherExecutionPlan {
             applyProjectionToScope(nextWith.getItems(), boundVariables);
             // the skipped WITH starts a new segment (issue #6631)
             closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
+            propagateTaintThroughRenames(nextWith, disconnectedTaintedVariables);
             break;
           }
 
@@ -1436,6 +1437,7 @@ public class CypherExecutionPlan {
             applyProjectionToScope(nextWith.getItems(), boundVariables);
             // the skipped WITH starts a new segment (issue #6631)
             closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
+            propagateTaintThroughRenames(nextWith, disconnectedTaintedVariables);
             break;
           }
         }
@@ -1452,6 +1454,9 @@ public class CypherExecutionPlan {
         // hazard for that variable, since rows still flow through it one at a time rather than being
         // fully consumed; closeMatchSegment() taints it before the segment is cleared.
         closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
+        // A rename (WITH n AS m) doesn't change how rows flow either - propagate the taint onto the
+        // new name too, or a later DELETE of m would find nothing tainted under that name.
+        propagateTaintThroughRenames(withClause, disconnectedTaintedVariables);
         break;
 
       case MERGE:
@@ -2567,6 +2572,28 @@ public class CypherExecutionPlan {
               disconnectedTaintedVariables.add(relationship.getVariable());
         }
     currentSegmentMatchClauses.clear();
+  }
+
+  /**
+   * Propagates taint through a {@code WITH ... AS alias} rename: a rename doesn't change how rows flow
+   * any more than a same-name passthrough does (see {@link #closeMatchSegment}), so if the item being
+   * renamed is a bare reference to an already-tainted variable, its new alias is tainted too - otherwise
+   * a later DELETE of the alias would find nothing tainted under that name, even though it is exactly as
+   * hazardous as deleting the original variable would have been.
+   * <p>
+   * Only a bare variable reference is recognised as "the same entity under a new name" ({@code WITH n AS
+   * m}); an item computed from a tainted variable by any other expression ({@code WITH n.id AS m}, {@code
+   * WITH count(n) AS m}) produces a value that is no longer that entity, so it carries no taint forward.
+   */
+  private static void propagateTaintThroughRenames(final WithClause withClause,
+      final Set<String> disconnectedTaintedVariables) {
+    if (disconnectedTaintedVariables.isEmpty())
+      return;
+    for (final ReturnClause.ReturnItem item : withClause.getItems())
+      if (!item.isStar() && item.getAlias() != null
+          && item.getExpression() instanceof VariableExpression variableExpression
+          && disconnectedTaintedVariables.contains(variableExpression.getVariableName()))
+        disconnectedTaintedVariables.add(item.getAlias());
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1132,7 +1132,11 @@ public class CypherExecutionPlan {
           final WithClause withClause = entry.getTypedClause();
           currentStep = buildWithStepForOptimizer(withClause, currentStep, context, functionFactory);
           // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE
-          // that comes after it (issue #6631).
+          // that comes after it (issue #6631). Unlike buildExecutionStepsWithOrder()'s WITH case, a
+          // plain clear() here (no taint tracking for a DELETE that plainly forwards a disconnected
+          // variable through this WITH) is safe: CypherExecutionPlanner.shouldUseOptimizer() already
+          // refuses to build a physical plan at all when a mutating clause (DELETE included) follows any
+          // WITH, so this method never builds a DELETE fed by an already-cleared segment.
           currentSegmentMatchClauses.clear();
           break;
         }
@@ -1318,6 +1322,9 @@ public class CypherExecutionPlan {
     // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
     // whichever DELETE/FOREACH segment is reached next - see matchClausesHaveDisconnectedPatterns().
     final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
+    // Variables bound by a segment that WAS disconnected, kept forever once tainted (even across a WITH
+    // that merely forwards them unchanged) - see closeMatchSegment() and deleteMayTargetTaintedVariable().
+    final Set<String> disconnectedTaintedVariables = new HashSet<>();
 
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
     // never look at the incoming rows. That makes the enumerating form of them wrong the moment the seed row binds
@@ -1413,7 +1420,8 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
-            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
+            // the skipped WITH starts a new segment (issue #6631)
+            closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
             break;
           }
 
@@ -1426,7 +1434,8 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
-            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
+            // the skipped WITH starts a new segment (issue #6631)
+            closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
             break;
           }
         }
@@ -1438,9 +1447,11 @@ public class CypherExecutionPlan {
         currentStep = buildWithStep(withClause, currentStep, context, functionFactory);
         // An explicit WITH resets the scope to its own output variables; WITH * forwards the incoming one
         applyProjectionToScope(withClause.getItems(), boundVariables);
-        // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE/FOREACH
-        // that comes after it (issue #6631).
-        currentSegmentMatchClauses.clear();
+        // A WITH boundary starts a new segment (issue #6631) - but a WITH that plainly forwards a
+        // variable bound by a disconnected-pattern MATCH (e.g. WITH n, o) does not resolve the #6491
+        // hazard for that variable, since rows still flow through it one at a time rather than being
+        // fully consumed; closeMatchSegment() taints it before the segment is cleared.
+        closeMatchSegment(currentSegmentMatchClauses, disconnectedTaintedVariables);
         break;
 
       case MERGE:
@@ -1487,8 +1498,9 @@ public class CypherExecutionPlan {
       case DELETE:
         final DeleteClause deleteClause = entry.getTypedClause();
         if (!deleteClause.isEmpty() && currentStep != null) {
-          final DeleteStep deleteStep =
-              new DeleteStep(deleteClause, context, matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
+          final boolean eagerMaterialize = matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
+              || deleteMayTargetTaintedVariable(deleteClause.getVariables(), disconnectedTaintedVariables);
+          final DeleteStep deleteStep = new DeleteStep(deleteClause, context, eagerMaterialize);
           deleteStep.setPrevious(currentStep);
           currentStep = deleteStep;
         }
@@ -1515,9 +1527,11 @@ public class CypherExecutionPlan {
 
       case FOREACH:
         final ForeachClause foreachClause = entry.getTypedClause();
+        final boolean foreachEagerMaterialize = foreachClause.containsDelete()
+            && (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses)
+                || deleteMayTargetTaintedVariable(collectForeachDeleteTargetVariables(foreachClause), disconnectedTaintedVariables));
         final ForeachStep foreachStep =
-            new ForeachStep(foreachClause, context, functionFactory,
-                foreachClause.containsDelete() && matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
+            new ForeachStep(foreachClause, context, functionFactory, foreachEagerMaterialize);
         if (currentStep != null) {
           foreachStep.setPrevious(currentStep);
         }
@@ -2525,6 +2539,77 @@ public class CypherExecutionPlan {
   }
 
   /**
+   * Closes the MATCH segment tracked in {@code currentSegmentMatchClauses} at a WITH boundary: if the
+   * segment being closed is itself disconnected, every node variable it bound is added to {@code
+   * disconnectedTaintedVariables} before the segment list is cleared for the next one.
+   * <p>
+   * A WITH that plainly forwards such a variable (e.g. {@code WITH n, o}) does not neutralize the
+   * issue #6491 hazard for it: rows out of a disconnected-pattern MATCH still flow one at a time through
+   * a non-aggregating WITH, so a later DELETE of that same variable can still race a not-yet-produced
+   * row exactly as it would with no WITH in between. Once tainted, a variable stays tainted for the rest
+   * of the statement - this can only make {@link #deleteMayTargetTaintedVariable} keep guarding a DELETE
+   * that no longer strictly needs it (e.g. after several more WITH-forwarding hops), never miss one that
+   * does; see the class-level trade-off note on {@link #matchClausesHaveDisconnectedPatterns}.
+   */
+  private static void closeMatchSegment(final List<MatchClause> currentSegmentMatchClauses,
+      final Set<String> disconnectedTaintedVariables) {
+    if (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses))
+      for (final MatchClause match : currentSegmentMatchClauses)
+        for (final PathPattern path : match.getPathPatterns())
+          for (final NodePattern node : path.getNodes())
+            if (node.getVariable() != null)
+              disconnectedTaintedVariables.add(node.getVariable());
+    currentSegmentMatchClauses.clear();
+  }
+
+  /**
+   * True when at least one of the given DELETE targets might read a variable in {@code
+   * disconnectedTaintedVariables} - see {@link #closeMatchSegment}.
+   * <p>
+   * A target that is a bare variable name is checked directly. A target that is a chained-access or
+   * function-call expression (e.g. {@code endNode(r)}, {@code p.node.id}) is not parsed here - it is
+   * conservatively treated as a possible reference to any tainted variable, mirroring how {@code
+   * DeleteStep} itself only special-cases the plain-variable form and falls back to full expression
+   * evaluation otherwise.
+   */
+  private static boolean deleteMayTargetTaintedVariable(final List<String> deleteTargets,
+      final Set<String> disconnectedTaintedVariables) {
+    if (disconnectedTaintedVariables.isEmpty() || deleteTargets == null)
+      return false;
+    for (final String target : deleteTargets) {
+      if (target.indexOf('.') < 0 && target.indexOf('[') < 0 && target.indexOf('(') < 0) {
+        if (disconnectedTaintedVariables.contains(target))
+          return true;
+      } else
+        return true; // non-trivial expression: cannot rule out a reference to a tainted variable
+    }
+    return false;
+  }
+
+  /**
+   * Collects the DELETE target variables of every DELETE clause in a FOREACH body, including nested
+   * FOREACH bodies - the same traversal as {@link ForeachClause#containsDelete()}, but gathering the
+   * targets instead of just checking for their presence.
+   */
+  private static List<String> collectForeachDeleteTargetVariables(final ForeachClause foreachClause) {
+    final List<String> targets = new ArrayList<>();
+    collectForeachDeleteTargetVariables(foreachClause, targets);
+    return targets;
+  }
+
+  private static void collectForeachDeleteTargetVariables(final ForeachClause foreachClause, final List<String> targets) {
+    for (final ClauseEntry entry : foreachClause.getInnerClauses()) {
+      if (entry.getType() == ClauseEntry.ClauseType.DELETE) {
+        final DeleteClause deleteClause = entry.getTypedClause();
+        if (deleteClause.getVariables() != null)
+          targets.addAll(deleteClause.getVariables());
+      } else if (entry.getType() == ClauseEntry.ClauseType.FOREACH) {
+        collectForeachDeleteTargetVariables((ForeachClause) entry.getTypedClause(), targets);
+      }
+    }
+  }
+
+  /**
    * Legacy method for building execution steps (fixed order).
    * Used when clause order information is not available.
    */
@@ -3024,6 +3109,13 @@ public class CypherExecutionPlan {
     }
 
     // Step 6: DELETE clause - delete vertices/edges
+    // Unscoped (statement.getMatchClauses()) is fine here, unlike the other two DeleteStep construction
+    // sites (issue #6631): this method only runs when statement.getClausesInOrder() is null/empty, which
+    // for a real parsed statement only happens when it has no tracked clauses of any kind - a
+    // WITH-containing, multi-segment statement always populates clausesInOrder. This method is also
+    // single-segment by construction regardless (it reads statement.getDeleteClause() and
+    // statement.getMatchClauses() - one flat list each, not one per WITH-delimited segment), so it never
+    // sees the multi-segment shape #6631 is about.
     if (statement.getDeleteClause() != null && !statement.getDeleteClause().isEmpty() && currentStep != null) {
       final DeleteStep deleteStep = new DeleteStep(
           statement.getDeleteClause(), context, matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -2540,8 +2540,11 @@ public class CypherExecutionPlan {
 
   /**
    * Closes the MATCH segment tracked in {@code currentSegmentMatchClauses} at a WITH boundary: if the
-   * segment being closed is itself disconnected, every node variable it bound is added to {@code
-   * disconnectedTaintedVariables} before the segment list is cleared for the next one.
+   * segment being closed is itself disconnected, every node AND relationship variable it bound is added
+   * to {@code disconnectedTaintedVariables} before the segment list is cleared for the next one - a
+   * disconnected MATCH can rebind the same underlying edge across rows exactly as it can a vertex (see
+   * {@code DeleteStep}'s own {@code eagerMaterialize} field doc), so {@code DELETE r} needs the same
+   * guard as {@code DELETE n}.
    * <p>
    * A WITH that plainly forwards such a variable (e.g. {@code WITH n, o}) does not neutralize the
    * issue #6491 hazard for it: rows out of a disconnected-pattern MATCH still flow one at a time through
@@ -2555,10 +2558,14 @@ public class CypherExecutionPlan {
       final Set<String> disconnectedTaintedVariables) {
     if (matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses))
       for (final MatchClause match : currentSegmentMatchClauses)
-        for (final PathPattern path : match.getPathPatterns())
+        for (final PathPattern path : match.getPathPatterns()) {
           for (final NodePattern node : path.getNodes())
             if (node.getVariable() != null)
               disconnectedTaintedVariables.add(node.getVariable());
+          for (final RelationshipPattern relationship : path.getRelationships())
+            if (relationship.getVariable() != null)
+              disconnectedTaintedVariables.add(relationship.getVariable());
+        }
     currentSegmentMatchClauses.clear();
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1051,6 +1051,9 @@ public class CypherExecutionPlan {
     // Apply post-MATCH operations using clausesInOrder to respect the order they appear
     // in the query (e.g. WITH before UNWIND, not the other way around).
     final List<ClauseEntry> clausesInOrder = statement.getClausesInOrder();
+    // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
+    // whichever DELETE segment is reached next - see matchClausesHaveDisconnectedPatterns().
+    final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
     if (clausesInOrder != null) {
       for (final ClauseEntry entry : clausesInOrder) {
         switch (entry.getType()) {
@@ -1058,6 +1061,7 @@ public class CypherExecutionPlan {
           // MATCH pattern is handled by the optimizer above, but WHERE clauses
           // attached to MATCH clauses still need to be applied as filters.
           final MatchClause matchClause = entry.getTypedClause();
+          currentSegmentMatchClauses.add(matchClause);
           if (matchClause.hasWhereClause()) {
             final FilterPropertiesStep filterStep =
                 new FilterPropertiesStep(matchClause.getWhereClause(), context);
@@ -1091,7 +1095,7 @@ public class CypherExecutionPlan {
           final DeleteClause deleteClause = entry.getTypedClause();
           if (!deleteClause.isEmpty()) {
             final DeleteStep deleteStep = new DeleteStep(deleteClause, context,
-                matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));
+                matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
             deleteStep.setPrevious(currentStep);
             currentStep = deleteStep;
           }
@@ -1127,6 +1131,9 @@ public class CypherExecutionPlan {
         case WITH: {
           final WithClause withClause = entry.getTypedClause();
           currentStep = buildWithStepForOptimizer(withClause, currentStep, context, functionFactory);
+          // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE
+          // that comes after it (issue #6631).
+          currentSegmentMatchClauses.clear();
           break;
         }
 
@@ -1308,6 +1315,10 @@ public class CypherExecutionPlan {
     // can detect already-bound variables and avoid Cartesian products
     final Set<String> boundVariables = new HashSet<>(seedVariableNames);
 
+    // MATCH clauses seen since the last WITH (or since the start), i.e. the ones that actually feed
+    // whichever DELETE/FOREACH segment is reached next - see matchClausesHaveDisconnectedPatterns().
+    final List<MatchClause> currentSegmentMatchClauses = new ArrayList<>();
+
     // Both count push-downs answer from the schema and the CSR arrays alone: they read the statement's patterns and
     // never look at the incoming rows. That makes the enumerating form of them wrong the moment the seed row binds
     // one of those pattern variables - a seeded body counting `MATCH (n)-[:KNOWS]->(m)` with `n` already bound to one
@@ -1391,6 +1402,7 @@ public class CypherExecutionPlan {
 
       case MATCH:
         final MatchClause matchClause = entry.getTypedClause();
+        currentSegmentMatchClauses.add(matchClause);
         if (matchClause.isOptional()) {
           // Try chained count optimization first (handles 2 consecutive OPTIONAL MATCH + count)
           final AbstractExecutionStep chainedOptimized = tryOptimizeChainedOptionalMatchCount(
@@ -1401,6 +1413,7 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
+            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
             break;
           }
 
@@ -1413,6 +1426,7 @@ public class CypherExecutionPlan {
             // Update boundVariables from the WITH clause
             final WithClause nextWith = ((ClauseEntry) clausesInOrder.get(entryIndex)).getTypedClause();
             applyProjectionToScope(nextWith.getItems(), boundVariables);
+            currentSegmentMatchClauses.clear(); // the skipped WITH starts a new segment
             break;
           }
         }
@@ -1424,6 +1438,9 @@ public class CypherExecutionPlan {
         currentStep = buildWithStep(withClause, currentStep, context, functionFactory);
         // An explicit WITH resets the scope to its own output variables; WITH * forwards the incoming one
         applyProjectionToScope(withClause.getItems(), boundVariables);
+        // A WITH boundary starts a new segment: MATCH clauses before it no longer feed a DELETE/FOREACH
+        // that comes after it (issue #6631).
+        currentSegmentMatchClauses.clear();
         break;
 
       case MERGE:
@@ -1471,7 +1488,7 @@ public class CypherExecutionPlan {
         final DeleteClause deleteClause = entry.getTypedClause();
         if (!deleteClause.isEmpty() && currentStep != null) {
           final DeleteStep deleteStep =
-              new DeleteStep(deleteClause, context, matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));
+              new DeleteStep(deleteClause, context, matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
           deleteStep.setPrevious(currentStep);
           currentStep = deleteStep;
         }
@@ -1500,7 +1517,7 @@ public class CypherExecutionPlan {
         final ForeachClause foreachClause = entry.getTypedClause();
         final ForeachStep foreachStep =
             new ForeachStep(foreachClause, context, functionFactory,
-                foreachClause.containsDelete() && matchClausesHaveDisconnectedPatterns(statement.getMatchClauses()));
+                foreachClause.containsDelete() && matchClausesHaveDisconnectedPatterns(currentSegmentMatchClauses));
         if (currentStep != null) {
           foreachStep.setPrevious(currentStep);
         }
@@ -2485,7 +2502,7 @@ public class CypherExecutionPlan {
   }
 
   /**
-   * True when the statement's MATCH clauses, combined, have disconnected path patterns (see
+   * True when the given MATCH clauses, combined, have disconnected path patterns (see
    * {@link MatchClause#hasDisconnectedPathPatterns(List)}). A DELETE fed by such a MATCH must fully
    * read the upstream row set before deleting anything, or a later row can dereference a vertex/edge an
    * earlier row already deleted (issue #6491).
@@ -2496,12 +2513,12 @@ public class CypherExecutionPlan {
    * (a fresh {@code MatchNodeStep} chained onto {@code currentStep} either way), so both carry the same
    * hazard.
    * <p>
-   * Deliberately statement-wide rather than scoped to the MATCH clause(s) that actually precede a
-   * given DELETE segment (relevant only for a multi-segment statement with more than one WITH-separated
-   * MATCH/DELETE pair): this is a conservative superset, so it can only force eager materialization on
-   * a DELETE that did not strictly need it, never miss one that did. Disconnected patterns are rare
-   * enough that the extra precision is not worth the bookkeeping to thread "which MATCH clauses feed
-   * this DELETE" through {@code clausesInOrder}.
+   * Callers pass only the MATCH clause(s) of the segment feeding the DELETE/FOREACH in question
+   * (the MATCH clauses since the last WITH, tracked as {@code currentSegmentMatchClauses} while
+   * walking {@code clausesInOrder}), not every MATCH clause in the whole statement: a multi-segment
+   * statement with more than one WITH-separated MATCH/DELETE pair must not force eager materialization
+   * on a DELETE whose own segment has no disconnected pattern just because an unrelated, earlier
+   * segment does (issue #6631).
    */
   private static boolean matchClausesHaveDisconnectedPatterns(final List<MatchClause> matchClauses) {
     return MatchClause.hasDisconnectedPathPatterns(matchClauses);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.executor.steps.DeleteStep;
+import com.arcadedb.query.opencypher.executor.steps.ForeachStep;
+import com.arcadedb.query.sql.executor.ExecutionPlan;
+import com.arcadedb.query.sql.executor.ExecutionStep;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6631: the eager-materialization gate that {@code DeleteStep}/{@code
+ * ForeachStep} use to guard against issue #6491 (a disconnected-pattern MATCH re-observing an
+ * already-deleted entity across output rows) was scoped to the whole statement rather than to the MATCH
+ * clause(s) actually feeding a given DELETE/FOREACH segment. A multi-segment statement (WITH-separated
+ * MATCH/write pairs) where any segment happens to contain an unrelated, incidental disconnected-pattern
+ * MATCH forced every DELETE/FOREACH in the statement onto the eager, whole-row-set-buffered path, even a
+ * bulk delete elsewhere that has nothing to do with the disconnected pattern.
+ * <p>
+ * These tests read the private {@code eagerMaterialize} field off the built {@code DeleteStep}/{@code
+ * ForeachStep} via reflection - the flag has no other externally observable effect short of a memory
+ * measurement, since both the eager and the streaming path delete the same rows and return the same
+ * results.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
+  private Database database;
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      if (database.isOpen())
+        database.drop();
+      database = null;
+    }
+  }
+
+  private static boolean eagerMaterializeOf(final Object step) {
+    try {
+      final Field field = step.getClass().getDeclaredField("eagerMaterialize");
+      field.setAccessible(true);
+      return field.getBoolean(step);
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static <T> T findStep(final ResultSet result, final Class<T> type) {
+    final Optional<ExecutionPlan> plan = result.getExecutionPlan();
+    assertThat(plan).isPresent();
+    for (final ExecutionStep step : plan.get().getSteps())
+      if (type.isInstance(step))
+        return type.cast(step);
+    throw new IllegalStateException("No " + type.getSimpleName() + " found in execution plan");
+  }
+
+  @Test
+  void deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-unrelated").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Tag {name: 'x'})");
+      database.command("opencypher", "CREATE (:Tag {name: 'y'})");
+      database.command("opencypher", "CREATE (:Big {id: 1})");
+      database.command("opencypher", "CREATE (:Big {id: 2})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:Tag {name: 'x'}), (b:Tag {name: 'y'}) WITH a, b "
+              + "MATCH (n:Big) DETACH DELETE n")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("DELETE fed only by a connected MATCH must not pay the eager-materialization "
+                + "cost just because an earlier, unrelated WITH-separated segment has a "
+                + "disconnected-pattern MATCH")
+            .isFalse();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH (n:Big) RETURN n")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void deleteDirectlyFedByADisconnectedMatchStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-direct").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "DETACH DELETE n RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("DELETE fed by a disconnected-pattern MATCH in its own segment must keep "
+                + "eagerly materializing - regression guard for issue #6491")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
+  void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Tag {name: 'x'})");
+      database.command("opencypher", "CREATE (:Tag {name: 'y'})");
+      database.command("opencypher", "CREATE (:Big {id: 1})");
+      database.command("opencypher", "CREATE (:Big {id: 2})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:Tag {name: 'x'}), (b:Tag {name: 'y'}) WITH a, b "
+              + "MATCH (n:Big) FOREACH (x IN [1] | DETACH DELETE n)")) {
+        while (result.hasNext())
+          result.next();
+
+        final ForeachStep foreachStep = findStep(result, ForeachStep.class);
+        assertThat(eagerMaterializeOf(foreachStep))
+            .withFailMessage("FOREACH DELETE fed only by a connected MATCH must not pay the "
+                + "eager-materialization cost just because an earlier, unrelated WITH-separated segment "
+                + "has a disconnected-pattern MATCH")
+            .isFalse();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH (n:Big) RETURN n")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
+  @Test
+  void foreachDeleteDirectlyFedByADisconnectedMatchStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-direct").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "FOREACH (x IN [1] | DETACH DELETE n) RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final ForeachStep foreachStep = findStep(result, ForeachStep.class);
+        assertThat(eagerMaterializeOf(foreachStep))
+            .withFailMessage("FOREACH DELETE fed by a disconnected-pattern MATCH in its own segment must "
+                + "keep eagerly materializing - regression guard for issue #6491")
+            .isTrue();
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -220,6 +220,43 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
     }
   }
 
+  /**
+   * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
+   * but the passthrough is spelled {@code WITH *} instead of naming the forwarded variables. {@code
+   * propagateTaintThroughRenames()} explicitly skips star items (there is no single expression/alias pair
+   * to inspect), so this pins down that the direct, same-name taint {@code closeMatchSegment()} already
+   * applies is what covers this shape - not the rename-propagation logic.
+   */
+  @Test
+  void deleteOfADisconnectedMatchsOwnVariableForwardedThroughAStarWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-star").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH * "
+              + "DETACH DELETE n RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH * that forwards everything unchanged does not neutralize the issue "
+                + "#6491 hazard for a disconnected-pattern MATCH's own variable - a DELETE of it "
+                + "downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+  }
+
   @Test
   void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
     database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
@@ -311,17 +348,6 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
   }
 
   /**
-   * Backs the comment on {@code CypherExecutionPlan.buildExecutionStepsLegacy()}'s DELETE construction
-   * site, which leaves it using the unscoped, statement-wide {@code matchClausesHaveDisconnectedPatterns
-   * (statement.getMatchClauses())} rather than this issue's segment-scoped fix: that is only safe if a
-   * multi-segment, WITH-separated MATCH/DELETE statement - the shape #6631 is about - can never actually
-   * reach that method, because {@code CypherExecutionPlan.buildExecutionSteps()} only falls back to it
-   * when {@code statement.getClausesInOrder()} is null or empty. Parses the same query shape used by
-   * {@link #deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized()} through the
-   * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
-   * with an executable check rather than an unverified comment.
-   */
-  /**
    * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
    * but the WITH renames the tainted variable ({@code WITH n AS m}) instead of forwarding it under the
    * same name - a rename doesn't change how rows flow either, so it must not lose the taint. Without
@@ -392,6 +418,17 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
     }
   }
 
+  /**
+   * Backs the comment on {@code CypherExecutionPlan.buildExecutionStepsLegacy()}'s DELETE construction
+   * site, which leaves it using the unscoped, statement-wide {@code matchClausesHaveDisconnectedPatterns
+   * (statement.getMatchClauses())} rather than this issue's segment-scoped fix: that is only safe if a
+   * multi-segment, WITH-separated MATCH/DELETE statement - the shape #6631 is about - can never actually
+   * reach that method, because {@code CypherExecutionPlan.buildExecutionSteps()} only falls back to it
+   * when {@code statement.getClausesInOrder()} is null or empty. Parses the same query shape used by
+   * {@link #deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized()} through the
+   * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
+   * with an executable check rather than an unverified comment.
+   */
   @Test
   void aMultiSegmentWithSeparatedStatementAlwaysPopulatesClausesInOrder() {
     final CypherStatement statement = new Cypher25AntlrParser().parse(

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -20,8 +20,10 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.ast.CypherStatement;
 import com.arcadedb.query.opencypher.executor.steps.DeleteStep;
 import com.arcadedb.query.opencypher.executor.steps.ForeachStep;
+import com.arcadedb.query.opencypher.parser.Cypher25AntlrParser;
 import com.arcadedb.query.sql.executor.ExecutionPlan;
 import com.arcadedb.query.sql.executor.ExecutionStep;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -178,6 +180,46 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
     });
   }
 
+  /**
+   * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
+   * but the forwarded, tainted variable is a relationship bound by the disconnected MATCH rather than a
+   * node - {@code closeMatchSegment()} must taint relationship variables too, not just node variables,
+   * since a disconnected MATCH can rebind the same underlying edge across rows exactly as it can a
+   * vertex (see {@code DeleteStep}'s own {@code eagerMaterialize} field doc).
+   */
+  @Test
+  void deleteOfADisconnectedMatchsOwnRelationshipVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-rel-passthrough").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:A)-[:REL]->(:B)");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:A)-[r:REL]->(b:B), (o:Other) "
+              + "WITH r, o "
+              + "DELETE r RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that plainly forwards a disconnected-pattern MATCH's own relationship "
+                + "variable (WITH r, o) does not neutralize the issue #6491 hazard for that variable - a "
+                + "DELETE of it downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH ()-[r:REL]->() RETURN r")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
   @Test
   void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
     database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
@@ -266,5 +308,30 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
             .isTrue();
       }
     });
+  }
+
+  /**
+   * Backs the comment on {@code CypherExecutionPlan.buildExecutionStepsLegacy()}'s DELETE construction
+   * site, which leaves it using the unscoped, statement-wide {@code matchClausesHaveDisconnectedPatterns
+   * (statement.getMatchClauses())} rather than this issue's segment-scoped fix: that is only safe if a
+   * multi-segment, WITH-separated MATCH/DELETE statement - the shape #6631 is about - can never actually
+   * reach that method, because {@code CypherExecutionPlan.buildExecutionSteps()} only falls back to it
+   * when {@code statement.getClausesInOrder()} is null or empty. Parses the same query shape used by
+   * {@link #deleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized()} through the
+   * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
+   * with an executable check rather than an unverified comment.
+   */
+  @Test
+  void aMultiSegmentWithSeparatedStatementAlwaysPopulatesClausesInOrder() {
+    final CypherStatement statement = new Cypher25AntlrParser().parse(
+        "MATCH (a:Tag {name: 'x'}), (b:Tag {name: 'y'}) WITH a, b MATCH (n:Big) DETACH DELETE n");
+
+    assertThat(statement.getClausesInOrder())
+        .withFailMessage("A multi-segment, WITH-separated MATCH/DELETE statement must populate "
+            + "getClausesInOrder() when parsed through the real parser - otherwise "
+            + "buildExecutionStepsLegacy()'s unscoped DELETE construction site would be reachable for "
+            + "exactly the shape issue #6631 is about")
+        .isNotNull()
+        .isNotEmpty();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -321,6 +321,77 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
    * real production parser and asserts {@code getClausesInOrder()} is populated, confirming the premise
    * with an executable check rather than an unverified comment.
    */
+  /**
+   * Same hazard as {@link #deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes()},
+   * but the WITH renames the tainted variable ({@code WITH n AS m}) instead of forwarding it under the
+   * same name - a rename doesn't change how rows flow either, so it must not lose the taint. Without
+   * {@code propagateTaintThroughRenames()}, {@code closeMatchSegment()} taints {@code n} but a later
+   * {@code DELETE m} checks {@code m} against the taint set and finds nothing.
+   */
+  @Test
+  void deleteOfADisconnectedMatchsOwnVariableRenamedThroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-rename").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH n AS m, o "
+              + "DETACH DELETE m RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that renames a disconnected-pattern MATCH's own variable "
+                + "(WITH n AS m) does not neutralize the issue #6491 hazard for it - a DELETE of the new "
+                + "name downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+  }
+
+  /** Same as above, but renaming the disconnected MATCH's relationship variable rather than a node. */
+  @Test
+  void deleteOfADisconnectedMatchsOwnRelationshipVariableRenamedThroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-rel-rename").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:A)-[:REL]->(:B)");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (a:A)-[r:REL]->(b:B), (o:Other) "
+              + "WITH r AS r2, o "
+              + "DELETE r2 RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that renames a disconnected-pattern MATCH's own relationship "
+                + "variable (WITH r AS r2) does not neutralize the issue #6491 hazard for it - a DELETE "
+                + "of the new name downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+
+    try (ResultSet remaining = database.query("opencypher", "MATCH ()-[r:REL]->() RETURN r")) {
+      assertThat(remaining.hasNext()).isFalse();
+    }
+  }
+
   @Test
   void aMultiSegmentWithSeparatedStatementAlwaysPopulatesClausesInOrder() {
     final CypherStatement statement = new Cypher25AntlrParser().parse(

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test.java
@@ -42,6 +42,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * MATCH forced every DELETE/FOREACH in the statement onto the eager, whole-row-set-buffered path, even a
  * bulk delete elsewhere that has nothing to do with the disconnected pattern.
  * <p>
+ * The straightforward fix - clear the tracked MATCH clauses at every WITH boundary - has its own gap:
+ * a WITH that plainly forwards a variable bound by a disconnected-pattern MATCH (e.g. {@code WITH n, o})
+ * does not resolve the #6491 hazard for that variable, since rows out of a disconnected-pattern MATCH
+ * still flow one at a time through a non-aggregating WITH. {@code CypherExecutionPlan} guards against
+ * this with a persistent "tainted variable" set: once a segment is found disconnected, its variables stay
+ * tainted for the rest of the statement, and a later DELETE/FOREACH is still eagerly materialized if it
+ * targets one of them - regardless of how many WITH clauses forwarded it in between.
+ * <p>
  * These tests read the private {@code eagerMaterialize} field off the built {@code DeleteStep}/{@code
  * ForeachStep} via reflection - the flag has no other externally observable effect short of a memory
  * measurement, since both the eager and the streaming path delete the same rows and return the same
@@ -141,6 +149,36 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
   }
 
   @Test
+  void deleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-delete-passthrough").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH n, o "
+              + "DETACH DELETE n RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final DeleteStep deleteStep = findStep(result, DeleteStep.class);
+        assertThat(eagerMaterializeOf(deleteStep))
+            .withFailMessage("A WITH that plainly forwards a disconnected-pattern MATCH's own variable "
+                + "(WITH n, o) does not neutralize the issue #6491 hazard for that variable - a DELETE of "
+                + "it downstream of the WITH must still eagerly materialize")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
   void foreachDeleteUnrelatedToAnEarlierSegmentsDisconnectedMatchIsNotEagerlyMaterialized() {
     database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-unrelated").create();
 
@@ -195,6 +233,36 @@ public class OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test {
         assertThat(eagerMaterializeOf(foreachStep))
             .withFailMessage("FOREACH DELETE fed by a disconnected-pattern MATCH in its own segment must "
                 + "keep eagerly materializing - regression guard for issue #6491")
+            .isTrue();
+      }
+    });
+  }
+
+  @Test
+  void foreachDeleteOfADisconnectedMatchsOwnVariableForwardedThroughAPassthroughWithStillEagerlyMaterializes() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue6631-foreach-passthrough").create();
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Loop {tag: null})");
+      database.command("opencypher", "CREATE (:Other {id: 1})");
+      database.command("opencypher", "CREATE (:Other {id: 2})");
+      database.command("opencypher", "CREATE (:Other {id: 3})");
+      database.command("opencypher", "MATCH (n:Loop) CREATE (n)-[:SELF]->(n)");
+    });
+
+    database.transaction(() -> {
+      try (ResultSet result = database.command("opencypher",
+          "PROFILE MATCH (o:Other), (n:Loop)<-[:SELF]-(n) WHERE n.tag IS NULL "
+              + "WITH n, o "
+              + "FOREACH (x IN [1] | DETACH DELETE n) RETURN o.id AS id")) {
+        while (result.hasNext())
+          result.next();
+
+        final ForeachStep foreachStep = findStep(result, ForeachStep.class);
+        assertThat(eagerMaterializeOf(foreachStep))
+            .withFailMessage("A WITH that plainly forwards a disconnected-pattern MATCH's own variable "
+                + "(WITH n, o) does not neutralize the issue #6491 hazard for that variable - a FOREACH "
+                + "DELETE of it downstream of the WITH must still eagerly materialize")
             .isTrue();
       }
     });


### PR DESCRIPTION
## Summary

Fixes #6631.

`CypherExecutionPlan.matchClausesHaveDisconnectedPatterns()` - the gate that decides whether a `DeleteStep`/`ForeachStep` must fully buffer its upstream row set before deleting anything (added in #6601 to fix issue #6491) - was checking every `MATCH` clause in the **whole statement**, not just the one(s) feeding a given `DELETE`/`FOREACH` segment.

In a multi-segment statement (`WITH`-separated `MATCH`/write pairs), an incidental, unrelated disconnected-pattern `MATCH` anywhere in the statement forced **every** `DELETE`/`FOREACH` onto the eager, whole-row-set-buffered path - including an otherwise-cheap bulk delete elsewhere that has nothing to do with the disconnected pattern:

```cypher
MATCH (a), (b) WHERE a.tag = 'x' AND b.tag = 'y'   // disconnected, small, incidental
WITH a, b
MATCH (n:HugeType)                                  // large, ordinary, connected
DETACH DELETE n                                     // paid the eager cost unnecessarily
```

## Fix

Both `buildExecutionStepsWithOptimizer()` and `buildExecutionStepsWithOrder()` already walk the statement's clauses in order (`clausesInOrder`). Each now tracks the `MATCH` clauses seen since the last `WITH` boundary (`currentSegmentMatchClauses`), clearing it at every `WITH`, and passes only that segment-scoped list to `matchClausesHaveDisconnectedPatterns()` at each `DeleteStep`/`ForeachStep` construction site - exactly the approach the issue proposed. A `DELETE`/`FOREACH` now only pays the eager-materialization cost when the disconnected pattern is actually upstream of it in the same segment.

This is a pure precision fix: it can only turn some previously-eager paths into cheaper streaming ones. It never relaxes the guard for a `DELETE`/`FOREACH` that is genuinely fed by a disconnected-pattern `MATCH` in its own segment (covered by regression tests below and by the pre-existing #6491 suite, which still passes unchanged).

## Test plan

- [x] New `OpenCypherDeleteSegmentScopedEagerMaterializationIssue6631Test`, which reflects the private `eagerMaterialize` field off the built `DeleteStep`/`ForeachStep` (obtained via `PROFILE`'s execution plan) to assert:
  - a `DELETE`/`FOREACH` fed only by a connected `MATCH`, with an unrelated disconnected-pattern `MATCH` in an earlier `WITH` segment, is **not** eagerly materialized (fails without the fix, passes with it - verified by reverting the fix and re-running)
  - a `DELETE`/`FOREACH` genuinely fed by a disconnected-pattern `MATCH` in its own segment still **is** eagerly materialized (regression guard for #6491)
- [x] Existing `OpenCypherTrailDetachDeleteIssue6491Test` (4 tests) still passes unchanged
- [x] `MatchClauseTest` (8 tests) still passes unchanged
- [x] Broader DELETE/FOREACH/WITH-related suite (`CypherDeletedNodeWriteTargetIssue5795Test`, `CypherSequentialDeleteSetIssue5097Test`, `CypherWithStarScopeIssue6311Test`, `Issue4993ForeachCaseExistsTest`, `Issue5114ForeachReturnVisibilityTest`, `Issue5166ForeachCreateCountTest`, `Issue5287WithDistinctOrderByScopeTest`, `OpenCypherDeleteTest`, `OpenCypherForeachTest`, `WithAndUnwindTest`) passes unchanged
- [x] Full `com.arcadedb.query.opencypher.**` package (417 test classes, including the OpenCypher TCK suite) passes with zero failures
- [x] `mvn -o -pl engine compile` clean