### PR TITLE
fix(#6463): INSERT INTO ... CONTENT :param inserts all list items, not just the first

### DIFF
--- a/docs/6463-insert-content-listparam-only-first.md
+++ b/docs/6463-insert-content-listparam-only-first.md
@@ -1,0 +1,88 @@
+# Issue #6463: `INSERT INTO ... CONTENT :listParam` inserts only the first list item
+
+## Summary
+
+`INSERT INTO <type> CONTENT :param` where the bound parameter is a `java.util.List` silently
+inserted only the **first** element of the list, with no error, unlike the equivalent JSON-array
+literal form (`CONTENT [{...}, {...}, ...]`), which creates one record per item.
+
+## Root cause
+
+`InsertExecutionPlanner.handleCreateRecord()` decides how many empty records `CreateRecordStep`
+should create (`tot`) by inspecting the parsed `InsertBody`:
+
+```java
+int tot = 1;
+if (body.getValueExpressions() != null && ...) tot = body.getValueExpressions().size();
+else if (body.getJsonArrayContent() != null && ...) tot = body.getJsonArrayContent().items.size();
+```
+
+There was no branch for a `CONTENT :param` **input parameter**, so `tot` stayed `1` regardless of
+what the parameter resolved to. `UpdateContentStep.handleContent()` already knew how to drain a
+`List`-valued parameter item by item (`parameterArray.get(arrayIndex++)`), but with `tot == 1` it
+was only ever driven once per upstream record, so items `1..n-1` were silently dropped.
+
+## Fix
+
+Input parameters are already bound into the `CommandContext` by the time the execution plan is
+built (`InsertStatement.execute()` calls `context.setInputParameters(...)` before
+`createExecutionPlan(context)`), so the fix resolves the `CONTENT` parameter at plan-build time and
+sizes `tot` from it when it is a non-empty `List`, mirroring the existing `getJsonArrayContent()`
+branch. A `Map`/`Document`-valued parameter (single record) is unaffected.
+
+`CreateVertexExecutionPlanner`/`CreateEdgeExecutionPlanner` extend `InsertExecutionPlanner` and
+reuse `handleCreateRecord()` unchanged, so `CREATE VERTEX/EDGE ... CONTENT :param` get the fix for
+free - confirmed with a dedicated test added during review (see cycle 2 below).
+
+## Deliberately unchanged edge case
+
+An empty-list `CONTENT :param` keeps `tot = 1` (one near-empty record created), matching the
+pre-existing behavior of an empty JSON-array literal (the `items.size() > 0` guard on the
+`getJsonArrayContent()` branch). This PR does not change that. Pinned by a dedicated test added
+during review (cycle 2).
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6647
+
+## Review cycles
+
+- **Cycle 1** - head `60fe0c0362` (initial push). Bot review (PR issue comment, no commit SHA -
+  https://github.com/ArcadeData/arcadedb/pull/6647#issuecomment posted 2026-08-23T20:22:47Z):
+  "No blocking issues found." One actionable-and-clear item: a positional-parameter (`?`) variant
+  of the `CONTENT :param` list case wasn't covered (only the named `:people` form was). Applied -
+  added `insertContentWithPositionalListParamCreatesOneRecordPerItem`. Two non-blocking notes
+  skipped with rationale: (a) `Set`/other `Collection`-valued `CONTENT` params fall through to
+  `tot = 1`, explicitly called out by the reviewer as pre-existing, symmetric with
+  `UpdateContentStep`'s existing `List`-only special case, and not a regression from this PR; (b)
+  style/consistency observations with no requested action. Response commit `9dfd443bc2`.
+- **Cycle 2** - head `9dfd443bc2`. Bot review (2026-08-24T07:27:47Z): "Nice, focused fix... My only
+  suggestion is the two small test additions noted above... neither blocks merging as-is." Two
+  actionable-and-clear items, both verified against the code before applying: (a) the
+  intentionally-unchanged empty-list edge case had no test pinning it down - applied
+  `insertContentWithEmptyListParamStillCreatesOneRecord`, confirmed by tracing
+  `UpdateContentStep.handleContent()` (an empty list never matches any of its branches, so the
+  record is created with no properties set, count stays 1); (b) `CREATE VERTEX ... CONTENT :param`
+  with a list was only covered "incidentally" via the shared planner code path, not with a
+  dedicated test - applied `createVertexContentWithListParamCreatesOneVertexPerItem`, after
+  verifying `CreateVertexExecutionPlanner extends InsertExecutionPlanner` and reuses
+  `handleCreateRecord()` unchanged. One non-blocking note skipped with rationale: resolving the
+  content parameter twice (once to size `tot`, once again in `UpdateContentStep` to drain it) is a
+  small duplication the reviewer itself called "not a real performance concern" - threading the
+  resolved list through would add complexity to a plan-build-time-only path for negligible gain.
+  Response commit `c48e7e5d35`.
+- **Cycle 3** - head `c48e7e5d35`. Bot review (2026-08-24T07:32:01Z): "No blocking issues found.
+  Nice, minimal fix..." No new actionable items - both prior minor observations (Collection-typed
+  params, double parameter resolution) were reduced to explicit "pre-existing limitation this fix
+  doesn't need to address" / "not worth optimizing." No code changes this cycle - clean approval.
+
+## Deferred items
+
+None. Every actionable-and-clear review item was applied within its cycle; every skipped item had
+an explicit non-blocking rationale from the reviewer itself (pre-existing/symmetric behavior, or
+an admitted non-concern), so nothing was deferred to a separate notes file.
+
+## Final state
+
+`clean-approval` after 3 review cycles (within `--max-cycles=4`). Merge is the developer's
+responsibility; this PR has not been merged.

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
@@ -131,6 +131,14 @@ public class InsertExecutionPlanner {
       tot = body.getValueExpressions().size();
     else if (body != null && body.getJsonArrayContent() != null && body.getJsonArrayContent().items.size() > 0)
       tot = body.getJsonArrayContent().items.size();
+    else if (body != null && body.getContentInputParam() != null) {
+      // A CONTENT input parameter that resolves to a List must create one record per item, exactly like the
+      // JSON-array literal form above (#6463). The parameter is already bound in the context by the time the
+      // execution plan is created (see InsertStatement.execute), so it can be sized here rather than deferred.
+      final Object paramValue = body.getContentInputParam().getValue(context.getInputParameters());
+      if (paramValue instanceof List<?> list && !list.isEmpty())
+        tot = list.size();
+    }
 
     if (targetType == null && targetBucket != null) {
       // #5636: the `else bucket = null` arm below makes this guard reachable, but ONLY for the case where no name

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
@@ -92,6 +92,33 @@ public class InsertContentListParamTest extends TestHelper {
   }
 
   @Test
+  void insertContentWithPositionalListParamCreatesOneRecordPerItem() {
+    final String typeName = "Issue6463PositionalPerson";
+    database.getSchema().createDocumentType(typeName);
+
+    final List<Map<String, Object>> people = new ArrayList<>();
+    for (final String name : List.of("x", "y", "z")) {
+      final Map<String, Object> item = new LinkedHashMap<>();
+      item.put("name", name);
+      people.add(item);
+    }
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT ?", (Object) people);
+
+    final List<String> insertedNames = new ArrayList<>();
+    while (result.hasNext())
+      insertedNames.add(result.next().<String>getProperty("name"));
+    result.close();
+
+    assertThat(insertedNames).containsExactlyInAnyOrder("x", "y", "z");
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(3L);
+    count.close();
+  }
+
+  @Test
   void insertContentWithSingleMapParamStillCreatesOneRecord() {
     final String typeName = "Issue6463MapParam";
     database.getSchema().createDocumentType(typeName);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
@@ -137,4 +137,65 @@ public class InsertContentListParamTest extends TestHelper {
     assertThat(result.hasNext()).isFalse();
     result.close();
   }
+
+  /**
+   * An empty-list {@code CONTENT :param} deliberately keeps the pre-existing {@code tot = 1} sizing of the
+   * equivalent empty JSON-array literal ({@code CONTENT []}), rather than creating zero records. This pins that
+   * documented edge case down (see the PR description for #6463).
+   */
+  @Test
+  void insertContentWithEmptyListParamStillCreatesOneRecord() {
+    final String typeName = "Issue6463EmptyListParam";
+    database.getSchema().createDocumentType(typeName);
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", new ArrayList<Map<String, Object>>());
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :people", params);
+
+    assertThat(result.hasNext()).isTrue();
+    result.next();
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(1L);
+    count.close();
+  }
+
+  /**
+   * {@code CreateVertexExecutionPlanner} extends {@link InsertExecutionPlanner} and reuses its
+   * {@code handleCreateRecord()} unchanged, so {@code CREATE VERTEX ... CONTENT :param} with a {@link List}-valued
+   * parameter must get the same one-record-per-item fix as plain {@code INSERT}.
+   */
+  @Test
+  void createVertexContentWithListParamCreatesOneVertexPerItem() {
+    final String typeName = "Issue6463Vertex";
+    database.getSchema().createVertexType(typeName);
+
+    final List<Map<String, Object>> people = new ArrayList<>();
+    for (final String name : List.of("v1", "v2", "v3")) {
+      final Map<String, Object> item = new LinkedHashMap<>();
+      item.put("name", name);
+      people.add(item);
+    }
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", people);
+
+    final ResultSet result = database.command("sql", "CREATE VERTEX " + typeName + " CONTENT :people", params);
+
+    final List<String> insertedNames = new ArrayList<>();
+    while (result.hasNext())
+      insertedNames.add(result.next().<String>getProperty("name"));
+    result.close();
+
+    assertThat(insertedNames).containsExactlyInAnyOrder("v1", "v2", "v3");
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(3L);
+    count.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces and verifies the fix for issue #6463: {@code INSERT INTO ... CONTENT :param} silently
+ * inserted only the first element of a {@link List} bound parameter, unlike the equivalent JSON-array
+ * literal form which creates one record per item.
+ */
+public class InsertContentListParamTest extends TestHelper {
+
+  public InsertContentListParamTest() {
+    autoStartTx = true;
+  }
+
+  @Test
+  void insertContentWithListParamCreatesOneRecordPerItem() {
+    final String typeName = "Issue6463Person";
+    database.getSchema().createDocumentType(typeName);
+
+    final List<Map<String, Object>> people = new ArrayList<>();
+    for (final String name : List.of("a", "b", "c")) {
+      final Map<String, Object> item = new LinkedHashMap<>();
+      item.put("name", name);
+      people.add(item);
+    }
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", people);
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :people", params);
+
+    final List<String> insertedNames = new ArrayList<>();
+    while (result.hasNext())
+      insertedNames.add(result.next().<String>getProperty("name"));
+    result.close();
+
+    assertThat(insertedNames).containsExactlyInAnyOrder("a", "b", "c");
+
+    final ResultSet count = database.query("sql", "SELECT count(*) as total FROM " + typeName);
+    assertThat(count.hasNext()).isTrue();
+    assertThat(count.next().<Long>getProperty("total")).isEqualTo(3L);
+    count.close();
+  }
+
+  @Test
+  void insertContentWithSingleElementListParamStillCreatesOneRecord() {
+    final String typeName = "Issue6463SingleItem";
+    database.getSchema().createDocumentType(typeName);
+
+    final Map<String, Object> item = new LinkedHashMap<>();
+    item.put("name", "solo");
+    final List<Map<String, Object>> people = new ArrayList<>(List.of(item));
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("people", people);
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :people", params);
+
+    assertThat(result.hasNext()).isTrue();
+    final Result inserted = result.next();
+    assertThat(inserted.<String>getProperty("name")).isEqualTo("solo");
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
+  void insertContentWithSingleMapParamStillCreatesOneRecord() {
+    final String typeName = "Issue6463MapParam";
+    database.getSchema().createDocumentType(typeName);
+
+    final Map<String, Object> content = new LinkedHashMap<>();
+    content.put("name", "mapParam");
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("content", content);
+
+    final ResultSet result = database.command("sql", "INSERT INTO " + typeName + " CONTENT :content", params);
+
+    assertThat(result.hasNext()).isTrue();
+    final Result inserted = result.next();
+    assertThat(inserted.<String>getProperty("name")).isEqualTo("mapParam");
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes `INSERT INTO <Type> CONTENT :param` silently inserting only the **first** element when the bound parameter `:param` is a `java.util.List`, instead of one record per list item (the behavior of the equivalent JSON-array literal form, `INSERT INTO <Type> CONTENT [{...}, {...}, ...]`).

Closes #6463

## Root cause

`InsertExecutionPlanner.handleCreateRecord()` decides how many empty records `CreateRecordStep` should create (`tot`) by inspecting the parsed `InsertBody`:

```java
int tot = 1;
if (body.getValueExpressions() != null && ...) tot = body.getValueExpressions().size();
else if (body.getJsonArrayContent() != null && ...) tot = body.getJsonArrayContent().items.size();
```

There was no branch for a `CONTENT :param` **input parameter**, so `tot` stayed `1` regardless of what the parameter resolved to. `UpdateContentStep.handleContent()` already knew how to drain a `List`-valued parameter item by item (`parameterArray.get(arrayIndex++)`), but it is only ever driven once per upstream record, so with `tot == 1` only the first item was ever consumed — the rest were silently dropped.

The input parameters are already bound into the `CommandContext` by the time the execution plan is built (`InsertStatement.execute()` calls `context.setInputParameters(...)` before `createExecutionPlan(context)`), so the fix resolves the `CONTENT` parameter at plan-build time and sizes `tot` from it when it is a non-empty `List`, mirroring the existing `getJsonArrayContent()` branch. A `Map`/`Document`-valued parameter (single record) is unaffected — it still produces exactly one record, as before.

## Motivation

Reported as #6463 by @ruispereira: a batch `INSERT INTO Person CONTENT :people` with `:people` bound to a 3-element list produced only 1 vertex, with no error, no warning, and no exception — a silent under-insert.

## Related issues

Closes #6463

## Test plan

- [x] Added `engine/src/test/java/com/arcadedb/query/sql/executor/InsertContentListParamTest.java`:
  - `insertContentWithListParamCreatesOneRecordPerItem` — reproduces the issue: binds a 3-element `List<Map<String,Object>>` and asserts all 3 records are created (this test fails on `main`, inserting only 1 record, and passes with this fix).
  - `insertContentWithSingleElementListParamStillCreatesOneRecord` — a 1-element list still yields exactly 1 record.
  - `insertContentWithSingleMapParamStillCreatesOneRecord` — the pre-existing `Map`-valued `CONTENT :param` form (single record) is unaffected.
- [x] `mvn test -pl engine -am -Dtest=InsertContentListParamTest` — 3/3 pass.
- [x] Regression sweep, all green with this change: `InsertContentEmptyArrayTest`, `UpdateContentArrayTest`, `InsertExecutionStepTest`, `InsertGraphIndexTest`, `InsertReturnTest`, `InsertStatementExecutionTest`, `InsertStatementTest`.
- [x] Full `com.arcadedb.query.sql.executor.*Test` package: 1535 tests, 0 failures, 0 errors, 5 skipped.

## Additional Notes

An empty-list `CONTENT :param` is intentionally left at `tot = 1` (no records created from an empty list body), matching the existing behavior of an empty JSON-array literal (`getJsonArrayContent().items.size() > 0` guard) — this PR does not change that edge case.

## Checklist

- [x] I have run the build using `mvn clean package` command (module-scoped `mvn test -pl engine -am`, per repo `CLAUDE.md` guidance)
- [x] My unit tests cover both failure and success scenarios
