### PR TITLE
fix(#6464): classify array binary type from component type, not first element

### DIFF
--- a/docs/6464-empty-primitive-array-round-trips-list.md
+++ b/docs/6464-empty-primitive-array-round-trips-list.md
@@ -86,3 +86,66 @@ The issue's repro and suggested fix are both scoped to the five numeric `ARRAY_O
 (`SHORT`/`INTEGER`/`LONG`/`FLOAT`/`DOUBLE`). `byte[]` is unaffected by the original bug (handled
 earlier in `getTypeFromValue` as `TYPE_BINARY`, unconditionally, regardless of emptiness) and is out
 of scope here.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6649
+
+## Review cycles
+
+- **Cycle 1** - head `f8bb9109` (PR open). `claude` bot review (posted as a PR issue comment, no
+  commit SHA - see note below) found one real bug: `getTypeFromValue()` classified any
+  `Short[]/Integer[]/Long[]/Float[]/Double[]` as `TYPE_ARRAY_OF_*` purely from component type,
+  regardless of content, but `BinarySerializer.serializeValue()`'s new `TYPE_ARRAY_OF_*` branches
+  unbox each wrapper element with an enhanced for-loop (`for (final Integer v : ints)
+  content.putNumber(v)`), which auto-unboxes and throws an uncaught `NullPointerException` on a
+  `null` element. Reachable via the ordinary public API for a schemaless property
+  (`doc.set("someIntArrayProp", new Integer[]{1, null, 3})`). **Verified** by reading
+  `BinarySerializer.java:663-720` - confirmed the auto-unboxing NPE is real for all five wrapper
+  types. **Applied**: added `BinaryTypes.arrayHasNullElement()` and fell back to `TYPE_LIST` in
+  `getTypeFromValue()` whenever a wrapper array contains a `null` element (the reviewer's first
+  suggested option - mirrors the pre-existing `Object[]` fallback and keeps the pre-#6464 behavior
+  for this case unchanged). Added regression test
+  `boxedPrimitiveArrayWithNullElementFallsBackToListInsteadOfNPE` covering the classifier and a full
+  serialize/deserialize round trip. Verification: `BinarySerializerTest` 20/20,
+  `com.arcadedb.serializer.**` + `com.arcadedb.schema.**` 621/621, `BUILD SUCCESS`. Pushed as
+  `ce4942b`.
+- **Cycle 2** - head `ce4942b`. `claude` bot review (PR issue comment) confirmed the
+  `arrayHasNullElement` fallback closes the NPE gap and the new regression test pins it; traced the
+  schema-declared-property path (`Type.convert()`'s `requireNonNullNumber`/`narrowToIntegral`) and
+  confirmed the null-fallback in this PR matters for schemaless properties and other
+  direct-serialization callers, which is the scope the added test exercises. **No blocking issues
+  found.** Three items raised, all explicitly non-blocking and left as-is (see below) - no code
+  change made this cycle, working tree stayed clean.
+
+### Nitpicks raised in cycle 2, not actioned (reviewer marked all three non-blocking)
+
+- `Type.TYPES_BY_USERTYPE` has no entries for the boxed wrapper array classes
+  (`Short[].class`/`Integer[].class`/...), only their primitive counterparts. Reviewer: "not touched
+  by this PR and not a regression... possibly worth a follow-up issue if that path exists." No such
+  call site was identified as in-scope for this issue; left as a possible future follow-up, not filed
+  separately since it is speculative ("if that path exists").
+- The five-way `componentType == X.class ? arrayHasNullElement(...) : ...` chain in
+  `getTypeFromValue()` repeats the same ternary shape and could be a small helper. Reviewer's own
+  words: "a nitpick, not a blocker... matches the existing style of the surrounding if/else chain."
+  Left as-is - the current form stays consistent with the chain's existing if/else style, which the
+  reviewer confirmed is more readable than the alternative here.
+- `Byte[]` (boxed) still falls through to `TYPE_LIST`, unlike the other four wrapper types. Reviewer:
+  "consistent with the stated scoping, just flagging it's not 'fixed' by symmetry." `byte[]`/`Byte[]`
+  were explicitly out of scope for issue #6464 from the start (see "Scope not addressed" above,
+  `byte[]` is handled earlier as `TYPE_BINARY` and was never affected by the original bug) - no change
+  needed.
+
+### Note on the review-polling bug this run started from
+
+Cycle 1's review (`f8bb9109`, 2026-08-23T20:28:27Z) was originally missed by a version of this skill's
+Phase 3a that only polled `reviews[]` and inline PR comments (both keyed by commit SHA) - the `claude`
+bot on this repo posts its review as a plain PR **issue comment** with no SHA at all. That polling gap
+is fixed in the current skill (adds a third surface: `gh pr view --json comments`, filtered to
+`claude`-authored comments newer than the push timestamp). Both cycles in this run were detected
+correctly by the fixed polling on the first or near-first poll.
+
+## Final state
+
+`clean-approval` - cycle 2 review found no blocking issues and required no further changes. Ready
+for developer review and merge (merge intentionally not performed by this skill).

--- a/docs/6464-empty-primitive-array-round-trips-list.md
+++ b/docs/6464-empty-primitive-array-round-trips-list.md
@@ -1,0 +1,88 @@
+# Issue #6464: Empty typed primitive-array property round-trips to an ArrayList, not an array
+
+## Summary
+
+`BinaryTypes.getTypeFromValue()` decided the binary type of a Java array from its **first element**:
+for a primitive array (`int[]`, `short[]`, `long[]`, `float[]`, `double[]`), the first element was
+sniffed with a pattern-match `switch`, and an empty array's "first element" is `null`, which fell
+through to `TYPE_LIST`. So the same property's runtime type after a reload depended on whether it
+happened to be empty: `new int[0]` round-tripped as an `ArrayList`, `new int[]{1,2}` round-tripped
+as `int[]`. `(int[]) doc.get("arr")` threw `ClassCastException` only in the empty case.
+
+For a boxed wrapper array (`Integer[]`, `Long[]`, `Short[]`, `Float[]`, `Double[]`) the code took the
+non-primitive-component-type branch unconditionally and always returned `TYPE_LIST`, regardless of
+content or of any declared `ARRAY_OF_*` schema property.
+
+## Fix
+
+`BinaryTypes.getTypeFromValue()` (`engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java`)
+now decides the `TYPE_ARRAY_OF_*` binary type from the array's **declared component type**
+(`value.getClass().getComponentType()`), matched against both the primitive class (`short.class`,
+`int.class`, ...) and its wrapper (`Short.class`, `Integer.class`, ...), instead of from the first
+element:
+
+- An empty primitive array now keeps its `TYPE_ARRAY_OF_*` type - the component type is known
+  regardless of length, so emptiness no longer collapses it to `TYPE_LIST`.
+- A boxed wrapper array (`Integer[]`, ...) is now also classified `TYPE_ARRAY_OF_*`, matching what
+  `Type.ARRAY_OF_INTEGERS` et al. already accept as an alternate input class
+  (`new Class<?>[] { int[].class, Integer[].class }` in `Type.java`) and already declare as their
+  canonical Java class (`int[].class`, not `Integer[].class`).
+- A heterogeneous `Object[]` (e.g. `list.toArray()`, whose component type is `Object`, not a numeric
+  wrapper) is unaffected and still classifies as `TYPE_LIST` - it only takes the new branches when the
+  array's *declared* component type is one of the five numeric primitives or their wrappers.
+
+`BinarySerializer.serializeValue()`'s five `TYPE_ARRAY_OF_*` cases used
+`java.lang.reflect.Array.getShort/getInt/getLong/getFloat/getDouble()`, which **reject** a boxed
+wrapper array with `IllegalArgumentException: Argument is not an array of primitive type` (verified
+with a standalone repro). Since a wrapper array can now reach these cases, each one branches on
+`instanceof <primitive>[]` and keeps the direct primitive read on that path (no behavior or
+performance change for the existing primitive-array path), falling back to an explicit
+`(Wrapper[]) value` unboxing loop only for the wrapper-array path. Deserialization is unchanged: all
+five `TYPE_ARRAY_OF_*` cases already produced a primitive array, so a boxed `Integer[]` property now
+round-trips as `int[]`, consistent with `Type.ARRAY_OF_INTEGERS.getJavaClass() == int[].class`.
+
+The now-unused `java.lang.reflect.Array` import was removed from `BinaryTypes.java` (still used
+elsewhere in `BinarySerializer.java`).
+
+## Why existing `Object[]` tests were unaffected
+
+`BinarySerializerTest.listPropertiesInDocument` sets `"arrayOfIntegers"` (etc.) to
+`listOfIntegers.toArray()`. `List.toArray()` returns `Object[]` regardless of the list's generic
+type - the array's actual `getComponentType()` is `Object.class`, not `Integer.class` - so that test
+continues to hit the `TYPE_LIST` branch exactly as before. Only an array whose *declared* component
+type is a genuine `Integer[]`/`Short[]`/etc. (e.g. `new Integer[]{1,2,3}` or
+`list.toArray(new Integer[0])`) is affected by the fix.
+
+## Tests added (`engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java`)
+
+- `emptyPrimitiveArrayKeepsItsArrayType` - asserts `BinaryTypes.getTypeFromValue()` classifies
+  `new short[0]`/`int[0]`/`long[0]`/`float[0]`/`double[0]` as the matching `TYPE_ARRAY_OF_*`, then a
+  full serialize/deserialize round trip confirms each reloads as the same empty primitive array type
+  (not `ArrayList`).
+- `boxedPrimitiveArraysSerializeAsTypedArrays` - same classifier assertion for empty
+  `Short[]`/`Integer[]`/`Long[]`/`Float[]`/`Double[]`, then a round trip with populated boxed arrays
+  confirms they reload as the corresponding primitive array with the same values.
+
+Both were confirmed **red** before the fix (`expected: 23 but was: 16`, i.e. `TYPE_LIST` instead of
+the declared `TYPE_ARRAY_OF_*`) and green after.
+
+## Verification run
+
+- `BinarySerializerTest`: 19/19 passed (2 new + all pre-existing, including
+  `arraysOfPrimitive` and `listPropertiesInDocument` which exercise the paths this fix must not
+  regress).
+- `com.arcadedb.serializer.**` + `com.arcadedb.schema.**`: 620/620 passed.
+- `com.arcadedb.index.vector.**` + `com.arcadedb.index.sparsevector.**` (excluding
+  `benchmark,vector,slow` lanes): 410/410 passed - these exercise `float[]`/`double[]` embeddings
+  heavily and confirm the primitive fast path is untouched.
+- `JavaBinarySerializerTest` + `com.arcadedb.graph.GraphBatch*Test`: 26/26 passed - the other caller
+  of `BinaryTypes.getTypeFromValue`/`BinarySerializer.serializeValue`.
+- `com.arcadedb.database.**` (excluding `benchmark,vector,slow`): 282/282 passed, 1 pre-existing
+  skip unrelated to this change.
+
+## Scope not addressed
+
+The issue's repro and suggested fix are both scoped to the five numeric `ARRAY_OF_*` types
+(`SHORT`/`INTEGER`/`LONG`/`FLOAT`/`DOUBLE`). `byte[]` is unaffected by the original bug (handled
+earlier in `getTypeFromValue` as `TYPE_BINARY`, unconditionally, regardless of emptiness) and is out
+of scope here.

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -652,38 +652,71 @@ public class BinarySerializer {
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_SHORTS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Array.getShort(value, i));
+      // `Array.getShort()` is the fast primitive-array path: java.lang.reflect.Array's typed getters reject a boxed
+      // Short[] with IllegalArgumentException ("not an array of primitive type"), so a wrapper array - now also
+      // classified TYPE_ARRAY_OF_SHORTS, issue #6464 - is unboxed explicitly instead.
+      if (value instanceof short[] shorts) {
+        content.putUnsignedNumber(shorts.length);
+        for (final short v : shorts)
+          content.putNumber(v);
+      } else {
+        final Short[] shorts = (Short[]) value;
+        content.putUnsignedNumber(shorts.length);
+        for (final Short v : shorts)
+          content.putNumber(v);
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_INTEGERS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Array.getInt(value, i));
+      if (value instanceof int[] ints) {
+        content.putUnsignedNumber(ints.length);
+        for (final int v : ints)
+          content.putNumber(v);
+      } else {
+        final Integer[] ints = (Integer[]) value;
+        content.putUnsignedNumber(ints.length);
+        for (final Integer v : ints)
+          content.putNumber(v);
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_LONGS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Array.getLong(value, i));
+      if (value instanceof long[] longs) {
+        content.putUnsignedNumber(longs.length);
+        for (final long v : longs)
+          content.putNumber(v);
+      } else {
+        final Long[] longs = (Long[]) value;
+        content.putUnsignedNumber(longs.length);
+        for (final Long v : longs)
+          content.putNumber(v);
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_FLOATS: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Float.floatToIntBits(Array.getFloat(value, i)));
+      if (value instanceof float[] floats) {
+        content.putUnsignedNumber(floats.length);
+        for (final float v : floats)
+          content.putNumber(Float.floatToIntBits(v));
+      } else {
+        final Float[] floats = (Float[]) value;
+        content.putUnsignedNumber(floats.length);
+        for (final Float v : floats)
+          content.putNumber(Float.floatToIntBits(v));
+      }
       break;
     }
     case BinaryTypes.TYPE_ARRAY_OF_DOUBLES: {
-      final int length = Array.getLength(value);
-      content.putUnsignedNumber(length);
-      for (int i = 0; i < length; ++i)
-        content.putNumber(Double.doubleToLongBits(Array.getDouble(value, i)));
+      if (value instanceof double[] doubles) {
+        content.putUnsignedNumber(doubles.length);
+        for (final double v : doubles)
+          content.putNumber(Double.doubleToLongBits(v));
+      } else {
+        final Double[] doubles = (Double[]) value;
+        content.putUnsignedNumber(doubles.length);
+        for (final Double v : doubles)
+          content.putNumber(Double.doubleToLongBits(v));
+      }
       break;
     }
     default:

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
@@ -179,17 +179,33 @@ public class BinaryTypes {
       // SAME PROPERTY'S RUNTIME TYPE DEPENDED ON WHETHER IT HAPPENED TO BE EMPTY (ISSUE #6464). THE COMPONENT TYPE
       // ALSO COVERS A BOXED WRAPPER ARRAY (Short[]/Integer[]/Long[]/Float[]/Double[]) SUPPLIED FOR A DECLARED
       // ARRAY_OF_* PROPERTY, WHICH WAS PREVIOUSLY ALWAYS DOWNGRADED TO TYPE_LIST REGARDLESS OF CONTENT.
+      //
+      // A WRAPPER ARRAY CAN HOLD A null ELEMENT (A PRIMITIVE ARRAY CANNOT), AND BinarySerializer's
+      // TYPE_ARRAY_OF_* BRANCHES UNBOX EACH ELEMENT WITH AN ENHANCED FOR-LOOP, WHICH WOULD THROW AN UNCAUGHT NPE ON
+      // A null ENTRY. FALL BACK TO TYPE_LIST WHEN A WRAPPER ARRAY CONTAINS ANY null ELEMENT: TYPE_LIST SERIALIZES
+      // EACH ELEMENT INDIVIDUALLY WITH ITS OWN TYPE_NULL TAG, WHICH IS EXACTLY HOW SUCH AN ARRAY WAS HANDLED
+      // BEFORE #6464 AND KEEPS THAT CASE BACKWARD COMPATIBLE.
       final Class<?> componentType = value.getClass().getComponentType();
-      if (componentType == short.class || componentType == Short.class)
+      if (componentType == short.class)
         type = TYPE_ARRAY_OF_SHORTS;
-      else if (componentType == int.class || componentType == Integer.class)
+      else if (componentType == Short.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_SHORTS;
+      else if (componentType == int.class)
         type = TYPE_ARRAY_OF_INTEGERS;
-      else if (componentType == long.class || componentType == Long.class)
+      else if (componentType == Integer.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_INTEGERS;
+      else if (componentType == long.class)
         type = TYPE_ARRAY_OF_LONGS;
-      else if (componentType == float.class || componentType == Float.class)
+      else if (componentType == Long.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_LONGS;
+      else if (componentType == float.class)
         type = TYPE_ARRAY_OF_FLOATS;
-      else if (componentType == double.class || componentType == Double.class)
+      else if (componentType == Float.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_FLOATS;
+      else if (componentType == double.class)
         type = TYPE_ARRAY_OF_DOUBLES;
+      else if (componentType == Double.class)
+        type = arrayHasNullElement((Object[]) value) ? TYPE_LIST : TYPE_ARRAY_OF_DOUBLES;
       else
         type = TYPE_LIST;
 
@@ -222,6 +238,18 @@ public class BinaryTypes {
     }
 
     return type;
+  }
+
+  /**
+   * Scans a boxed wrapper array (Short[]/Integer[]/Long[]/Float[]/Double[]) for a null element. Used by
+   * {@link #getTypeFromValue(Object, Property)} to decide whether the array is safe to classify as one of the
+   * TYPE_ARRAY_OF_* binary types, whose serializer unboxes every element and would NPE on a null one.
+   */
+  private static boolean arrayHasNullElement(final Object[] array) {
+    for (final Object element : array)
+      if (element == null)
+        return true;
+    return false;
   }
 
   public static int getTypeSize(final byte type) {

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
@@ -29,7 +29,6 @@ import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.DateUtils;
 import org.locationtech.spatial4j.shape.Shape;
 
-import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -175,17 +174,23 @@ public class BinaryTypes {
         // SERIALIZE THE RESULT AS A MAP
         type = TYPE_MAP;
     } else if (value.getClass().isArray()) {
-      if (value.getClass().getComponentType().isPrimitive()) {
-        final Object firstElement = Array.getLength(value) > 0 ? Array.get(value, 0) : null;
-        type = switch (firstElement) {
-          case Short i -> TYPE_ARRAY_OF_SHORTS;
-          case Integer i -> TYPE_ARRAY_OF_INTEGERS;
-          case Long l -> TYPE_ARRAY_OF_LONGS;
-          case Float v -> TYPE_ARRAY_OF_FLOATS;
-          case Double v -> TYPE_ARRAY_OF_DOUBLES;
-          case null, default -> TYPE_LIST;
-        };
-      } else
+      // DECIDE THE BINARY TYPE FROM THE ARRAY'S DECLARED COMPONENT TYPE, NOT FROM ITS FIRST ELEMENT: SNIFFING THE
+      // FIRST ELEMENT MADE AN EMPTY PRIMITIVE ARRAY (WHOSE "FIRST ELEMENT" IS null) FALL BACK TO TYPE_LIST, SO THE
+      // SAME PROPERTY'S RUNTIME TYPE DEPENDED ON WHETHER IT HAPPENED TO BE EMPTY (ISSUE #6464). THE COMPONENT TYPE
+      // ALSO COVERS A BOXED WRAPPER ARRAY (Short[]/Integer[]/Long[]/Float[]/Double[]) SUPPLIED FOR A DECLARED
+      // ARRAY_OF_* PROPERTY, WHICH WAS PREVIOUSLY ALWAYS DOWNGRADED TO TYPE_LIST REGARDLESS OF CONTENT.
+      final Class<?> componentType = value.getClass().getComponentType();
+      if (componentType == short.class || componentType == Short.class)
+        type = TYPE_ARRAY_OF_SHORTS;
+      else if (componentType == int.class || componentType == Integer.class)
+        type = TYPE_ARRAY_OF_INTEGERS;
+      else if (componentType == long.class || componentType == Long.class)
+        type = TYPE_ARRAY_OF_LONGS;
+      else if (componentType == float.class || componentType == Float.class)
+        type = TYPE_ARRAY_OF_FLOATS;
+      else if (componentType == double.class || componentType == Double.class)
+        type = TYPE_ARRAY_OF_DOUBLES;
+      else
         type = TYPE_LIST;
 
     } else if (value instanceof Iterable)

--- a/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
@@ -471,6 +471,45 @@ class BinarySerializerTest extends TestHelper {
   }
 
   @Test
+  void boxedPrimitiveArrayWithNullElementFallsBackToListInsteadOfNPE() throws Exception {
+    // A WRAPPER ARRAY CONTAINING A null ELEMENT MUST NOT BE CLASSIFIED AS A TYPE_ARRAY_OF_* BINARY TYPE: THAT
+    // SERIALIZER UNBOXES EACH ELEMENT WITH AN ENHANCED FOR-LOOP AND WOULD NPE ON THE null ENTRY (REGRESSION GUARD
+    // FOR THE REVIEW COMMENT ON ISSUE #6464 / PR #6649).
+    assertThat(BinaryTypes.getTypeFromValue(new Short[] { 1, null, 3 }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Integer[] { 1, null, 3 }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Long[] { 1L, null, 3L }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Float[] { 1.1f, null, 3.3f }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+    assertThat(BinaryTypes.getTypeFromValue(new Double[] { 1.1, null, 3.3 }, null)).isEqualTo(BinaryTypes.TYPE_LIST);
+
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Test");
+      database.commit();
+
+      final Integer[] withNull = { 1, null, 3 };
+
+      database.begin();
+      final MutableDocument v = database.newDocument("Test");
+
+      v.set("someIntArrayProp", withNull);
+
+      // MUST NOT THROW: BEFORE THIS FIX, SERIALIZING A BOXED WRAPPER ARRAY WITH A null ELEMENT THREW AN UNCAUGHT NPE
+      final Binary buffer = serializer.serialize((DatabaseInternal) database, v);
+
+      final ByteBuffer buffer2 = ByteBuffer.allocate((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue());
+      buffer2.put(buffer.toByteArray());
+      buffer2.flip();
+
+      final Binary buffer3 = new Binary(buffer2);
+      buffer3.getByte(); // SKIP RECORD TYPE
+      final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
+
+      assertThat((List<Object>) record2.get("someIntArrayProp")).containsExactly(1, null, 3);
+    });
+  }
+
+  @Test
   void mapPropertiesInDocument() throws Exception {
     final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
 

--- a/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
@@ -361,6 +361,115 @@ class BinarySerializerTest extends TestHelper {
     });
   }
 
+  /**
+   * Issue #6464: an EMPTY typed primitive-array property used to round-trip to an empty {@code ArrayList} instead
+   * of an array, because {@link BinaryTypes#getTypeFromValue(Object, com.arcadedb.schema.Property)} decided the
+   * binary type of a primitive array from its FIRST element - a {@code null} for an empty array - rather than from
+   * the array's component type. So the runtime type of the same property depended on whether it happened to be
+   * empty. Asserted both via the direct classifier ({@link BinaryTypes#getTypeFromValue}) and via a full
+   * serialize/deserialize round trip.
+   */
+  @Test
+  void emptyPrimitiveArrayKeepsItsArrayType() throws Exception {
+    assertThat(BinaryTypes.getTypeFromValue(new short[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_SHORTS);
+    assertThat(BinaryTypes.getTypeFromValue(new int[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_INTEGERS);
+    assertThat(BinaryTypes.getTypeFromValue(new long[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_LONGS);
+    assertThat(BinaryTypes.getTypeFromValue(new float[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_FLOATS);
+    assertThat(BinaryTypes.getTypeFromValue(new double[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_DOUBLES);
+
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Test");
+      database.commit();
+
+      database.begin();
+      final MutableDocument v = database.newDocument("Test");
+
+      v.set("arrayOfIntegers", new int[0]);
+      v.set("arrayOfLongs", new long[0]);
+      v.set("arrayOfShorts", new short[0]);
+      v.set("arrayOfFloats", new float[0]);
+      v.set("arrayOfDoubles", new double[0]);
+
+      final Binary buffer = serializer.serialize((DatabaseInternal) database, v);
+
+      final ByteBuffer buffer2 = ByteBuffer.allocate((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue());
+      buffer2.put(buffer.toByteArray());
+      buffer2.flip();
+
+      final Binary buffer3 = new Binary(buffer2);
+      buffer3.getByte(); // SKIP RECORD TYPE
+      final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
+
+      assertThat(record2.get("arrayOfIntegers")).isInstanceOf(int[].class);
+      assertThat((int[]) record2.get("arrayOfIntegers")).isEmpty();
+      assertThat(record2.get("arrayOfLongs")).isInstanceOf(long[].class);
+      assertThat((long[]) record2.get("arrayOfLongs")).isEmpty();
+      assertThat(record2.get("arrayOfShorts")).isInstanceOf(short[].class);
+      assertThat((short[]) record2.get("arrayOfShorts")).isEmpty();
+      assertThat(record2.get("arrayOfFloats")).isInstanceOf(float[].class);
+      assertThat((float[]) record2.get("arrayOfFloats")).isEmpty();
+      assertThat(record2.get("arrayOfDoubles")).isInstanceOf(double[].class);
+      assertThat((double[]) record2.get("arrayOfDoubles")).isEmpty();
+    });
+  }
+
+  /**
+   * Issue #6464: a boxed {@code Short[]/Integer[]/Long[]/Float[]/Double[]} value was always classified
+   * {@code TYPE_LIST} regardless of content, so it silently downgraded to a {@code List} on read even though the
+   * equivalent primitive array (or a non-empty one, before the fix above) round-tripped as an array. The array's
+   * wrapper component type is now enough on its own to pick the matching {@code TYPE_ARRAY_OF_*} binary type, and
+   * it deserializes as the canonical primitive array - matching what {@code Type.ARRAY_OF_INTEGERS} et al. already
+   * declare as their Java class ({@code int[].class}, not {@code Integer[].class}).
+   */
+  @Test
+  void boxedPrimitiveArraysSerializeAsTypedArrays() throws Exception {
+    assertThat(BinaryTypes.getTypeFromValue(new Short[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_SHORTS);
+    assertThat(BinaryTypes.getTypeFromValue(new Integer[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_INTEGERS);
+    assertThat(BinaryTypes.getTypeFromValue(new Long[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_LONGS);
+    assertThat(BinaryTypes.getTypeFromValue(new Float[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_FLOATS);
+    assertThat(BinaryTypes.getTypeFromValue(new Double[0], null)).isEqualTo(BinaryTypes.TYPE_ARRAY_OF_DOUBLES);
+
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Test");
+      database.commit();
+
+      final Short[] boxedShorts = { 1, 2, 3 };
+      final Integer[] boxedIntegers = { 1, 2, 3 };
+      final Long[] boxedLongs = { 1L, 2L, 3L };
+      final Float[] boxedFloats = { 1.1f, 2.2f, 3.3f };
+      final Double[] boxedDoubles = { 1.1, 2.2, 3.3 };
+
+      database.begin();
+      final MutableDocument v = database.newDocument("Test");
+
+      v.set("arrayOfShorts", boxedShorts);
+      v.set("arrayOfIntegers", boxedIntegers);
+      v.set("arrayOfLongs", boxedLongs);
+      v.set("arrayOfFloats", boxedFloats);
+      v.set("arrayOfDoubles", boxedDoubles);
+
+      final Binary buffer = serializer.serialize((DatabaseInternal) database, v);
+
+      final ByteBuffer buffer2 = ByteBuffer.allocate((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue());
+      buffer2.put(buffer.toByteArray());
+      buffer2.flip();
+
+      final Binary buffer3 = new Binary(buffer2);
+      buffer3.getByte(); // SKIP RECORD TYPE
+      final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
+
+      assertThat((short[]) record2.get("arrayOfShorts")).containsExactly((short) 1, (short) 2, (short) 3);
+      assertThat((int[]) record2.get("arrayOfIntegers")).containsExactly(1, 2, 3);
+      assertThat((long[]) record2.get("arrayOfLongs")).containsExactly(1L, 2L, 3L);
+      assertThat((float[]) record2.get("arrayOfFloats")).containsExactly(1.1f, 2.2f, 3.3f);
+      assertThat((double[]) record2.get("arrayOfDoubles")).containsExactly(1.1, 2.2, 3.3);
+    });
+  }
+
   @Test
   void mapPropertiesInDocument() throws Exception {
     final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());


### PR DESCRIPTION
## What does this PR do?

Fixes `BinaryTypes.getTypeFromValue()` so a typed primitive/wrapper array's binary storage type is
decided from the array's **declared component type**, not from its first element.

Previously, an empty primitive array (`new int[0]`) had a `null` "first element", which fell through
to `TYPE_LIST` - so the same property's runtime type after a reload depended on whether it happened
to be empty (`(int[]) doc.get("arr")` threw `ClassCastException` only in the empty case, while a
non-empty `int[]{1,2}` round-tripped correctly). A boxed wrapper array (`Integer[]`, `Long[]`, ...)
was unconditionally classified `TYPE_LIST` regardless of content or of a declared `ARRAY_OF_*`
schema property.

`BinarySerializer.serializeValue()`'s `TYPE_ARRAY_OF_*` cases used
`java.lang.reflect.Array.getShort/getInt/getLong/getFloat/getDouble()`, which reject a boxed wrapper
array with `IllegalArgumentException`. Since a wrapper array can now reach these cases, each one
branches on `instanceof <primitive>[]` and keeps the direct primitive read on that path (no
performance change for existing primitive-array serialization - vector-index workloads store
embeddings this way), falling back to explicit unboxing only for a genuine wrapper array.
Deserialization is unchanged - all five cases already produced primitive arrays, so a boxed
`Integer[]` now round-trips as `int[]`, matching `Type.ARRAY_OF_INTEGERS.getJavaClass() ==
int[].class`.

A heterogeneous `Object[]` (e.g. `list.toArray()`, whose actual component type is `Object`, not a
numeric wrapper, per Java's type erasure) is unaffected and still classifies as `TYPE_LIST`.

## Motivation

Issue #6464 report: the runtime type of an `ARRAY_OF_*` property silently changed depending on
whether the array happened to be empty, and boxed wrapper arrays for the same property type were
always downgraded to a `List`.

## Related issues

Closes #6464

## Additional Notes

Full analysis, the reasoning behind each design choice, and the verification log are in
`docs/6464-empty-primitive-array-round-trips-list.md` in this branch.

Out of scope: `byte[]` was never affected (handled earlier in `getTypeFromValue` as `TYPE_BINARY`
unconditionally), matching the issue's own scoping.

## Test plan

- [x] `BinarySerializerTest` (19/19, incl. 2 new regression tests: `emptyPrimitiveArrayKeepsItsArrayType`,
      `boxedPrimitiveArraysSerializeAsTypedArrays` - both confirmed red before the fix)
- [x] `com.arcadedb.serializer.**` + `com.arcadedb.schema.**` (620/620)
- [x] `com.arcadedb.index.vector.**` + `com.arcadedb.index.sparsevector.**`, excluding the
      `benchmark`/`vector`/`slow` lanes (410/410) - these exercise `float[]`/`double[]` embeddings
      heavily and confirm the primitive fast path is untouched
- [x] `JavaBinarySerializerTest` + `com.arcadedb.graph.GraphBatch*Test` (26/26) - the other caller of
      the same classifier/serializer methods
- [x] `com.arcadedb.database.**`, excluding `benchmark`/`vector`/`slow` (282/282, 1 pre-existing
      unrelated skip)

## Checklist

- [x] I have run the build using `mvn clean package` command (via `mvn -pl engine -am test`, see test
      plan above)
- [x] My unit tests cover both failure and success scenarios