### PR TITLE
fix(sql): EXPLAIN of a write statement runs it when chained via sqlscript or nested blocks

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
@@ -39,21 +39,35 @@ import java.util.List;
  * DeleteExecutionPlan}/{@code UpdateExecutionPlan}/{@code DDLExecutionPlan}/{@code
  * SingleOpExecutionPlan}: {@link ScriptLineStep#syncPull} special-cases exactly those types to
  * eagerly run them, so staying outside that set is what keeps a chained EXPLAIN from being run.
+ * <p>
+ * The same reasoning covers {@code PROFILE EXPLAIN <statement>}: {@code ProfileStatement.execute()}
+ * is itself a caller that pulls whatever {@code statement.createExecutionPlan()} hands back, so an
+ * inner {@link com.arcadedb.query.sql.parser.ExplainStatement} nested under {@code PROFILE} used to
+ * be just as exploitable as the {@code sqlscript} case - {@code PROFILE EXPLAIN UPDATE ...} silently
+ * ran the update too. Wrapping here closes that path as well: EXPLAIN's non-execution contract wins
+ * regardless of what encloses it, so {@code PROFILE EXPLAIN <statement>} degrades to plan-only output
+ * with no execution and no real cost numbers, rather than {@code PROFILE} unwrapping the inner
+ * statement and running it for real.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class ExplainExecutionPlan implements InternalExecutionPlan {
-  private final CommandContext context;
-  private final ExecutionPlan  wrappedPlan;
-  private       boolean        executed = false;
+  private final CommandContext        context;
+  private final InternalExecutionPlan wrappedPlan;
+  private       boolean               executed = false;
 
-  public ExplainExecutionPlan(final CommandContext context, final ExecutionPlan wrappedPlan) {
+  public ExplainExecutionPlan(final CommandContext context, final InternalExecutionPlan wrappedPlan) {
     this.context = context;
     this.wrappedPlan = wrappedPlan;
   }
 
-  public ExecutionPlan getWrappedPlan() {
+  public InternalExecutionPlan getWrappedPlan() {
     return wrappedPlan;
+  }
+
+  @Override
+  public void close() {
+    wrappedPlan.close();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Execution plan returned by {@code EXPLAIN <statement>} when it is not run through
+ * {@code Statement.execute()} directly, but instead chained into an enclosing plan - a script
+ * ({@code SQLScriptQueryEngine}), or a nested block (FOREACH, IF, WHILE, RETRY, LET). All of
+ * those callers treat whatever {@code Statement.createExecutionPlan(CommandContext)} returns as
+ * an executable plan and chain/pull it to completion, so an EXPLAIN whose {@code
+ * createExecutionPlan()} passed the wrapped statement's own plan straight through - as it used
+ * to - handed them something that, once pulled, actually ran the wrapped statement. For a write
+ * statement (UPDATE/INSERT/DELETE/...) that silently performed the write EXPLAIN promised not to
+ * (issue #6648).
+ * <p>
+ * This plan wraps the built-but-not-pulled plan of the wrapped statement and, on
+ * {@link #fetchNext(int)}, reports its description without ever pulling it - the same contract
+ * {@link com.arcadedb.query.sql.parser.ExplainResultSet} gives callers that go through {@code
+ * execute()}. It also deliberately is not an {@code InsertExecutionPlan}/{@code
+ * DeleteExecutionPlan}/{@code UpdateExecutionPlan}/{@code DDLExecutionPlan}/{@code
+ * SingleOpExecutionPlan}: {@link ScriptLineStep#syncPull} special-cases exactly those types to
+ * eagerly run them, so staying outside that set is what keeps a chained EXPLAIN from being run.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class ExplainExecutionPlan implements InternalExecutionPlan {
+  private final CommandContext context;
+  private final ExecutionPlan  wrappedPlan;
+  private       boolean        executed = false;
+
+  public ExplainExecutionPlan(final CommandContext context, final ExecutionPlan wrappedPlan) {
+    this.context = context;
+    this.wrappedPlan = wrappedPlan;
+  }
+
+  public ExecutionPlan getWrappedPlan() {
+    return wrappedPlan;
+  }
+
+  @Override
+  public ResultSet fetchNext(final int n) {
+    if (executed)
+      return new InternalResultSet();
+
+    executed = true;
+
+    final ResultInternal result = new ResultInternal();
+    result.setProperty("executionPlan", wrappedPlan.toResult());
+    result.setProperty("executionPlanAsString", wrappedPlan.prettyPrint(0, 3));
+
+    final InternalResultSet resultSet = new InternalResultSet(result);
+    resultSet.setPlan(this);
+    return resultSet;
+  }
+
+  @Override
+  public void reset(final CommandContext context) {
+    executed = false;
+  }
+
+  @Override
+  public boolean canBeCached() {
+    return false;
+  }
+
+  @Override
+  public List<ExecutionStep> getSteps() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String prettyPrint(final int depth, final int indent) {
+    return wrappedPlan.prettyPrint(depth, indent);
+  }
+
+  @Override
+  public Result toResult() {
+    final ResultInternal result = new ResultInternal(context.getDatabase());
+    result.setProperty("type", "ExplainExecutionPlan");
+    result.setProperty("javaType", getClass().getName());
+    result.setProperty("prettyPrint", prettyPrint(0, 2));
+    result.setProperty("wrapped", wrappedPlan.toResult());
+    return result;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
@@ -23,7 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.Database;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
-import com.arcadedb.query.sql.executor.ExecutionPlan;
+import com.arcadedb.query.sql.executor.ExplainExecutionPlan;
 import com.arcadedb.query.sql.executor.InternalExecutionPlan;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -53,10 +53,9 @@ public class ExplainStatement extends Statement {
     context.setInputParameters(args);
     context.setProfiling(true);
 
-    final ExecutionPlan executionPlan = statement.createExecutionPlan(context);
+    final ExplainExecutionPlan executionPlan = (ExplainExecutionPlan) createExecutionPlan(context);
 
-    final ExplainResultSet result = new ExplainResultSet(executionPlan);
-    return result;
+    return new ExplainResultSet(executionPlan.getWrappedPlan());
   }
 
   @Override
@@ -69,15 +68,24 @@ public class ExplainStatement extends Statement {
     context.setInputParameters(params);
     context.setProfiling(true);
 
-    final ExecutionPlan executionPlan = statement.createExecutionPlan(context);
+    final ExplainExecutionPlan executionPlan = (ExplainExecutionPlan) createExecutionPlan(context);
 
-    final ExplainResultSet result = new ExplainResultSet(executionPlan);
-    return result;
+    return new ExplainResultSet(executionPlan.getWrappedPlan());
   }
 
+  /**
+   * Builds the wrapped statement's plan without executing it, and hands it back inside an
+   * {@link ExplainExecutionPlan} rather than passing it through directly. Every caller that
+   * chains a nested statement's plan by calling this method (a sqlscript, or a FOREACH/IF/WHILE/
+   * RETRY/LET block) pulls whatever comes back to completion, so returning the wrapped statement's
+   * own executable plan here - as this used to - let a chained {@code EXPLAIN <write statement>}
+   * silently perform the write (issue #6648). {@link #execute} unwraps the result back out via
+   * {@link ExplainExecutionPlan#getWrappedPlan()} to keep returning an {@link ExplainResultSet} as
+   * before.
+   */
   @Override
   public InternalExecutionPlan createExecutionPlan(final CommandContext context) {
-    return statement.createExecutionPlan(context);
+    return new ExplainExecutionPlan(context, statement.createExecutionPlan(context));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExplainStatement.java
@@ -116,5 +116,19 @@ public class ExplainStatement extends Statement {
   public boolean isIdempotent() {
     return true;
   }
+
+  /**
+   * Delegates to the wrapped statement, same as {@link ExpressionStatement#refersToParent()} does
+   * for its expression. Without this override, {@code Statement.refersToParent()}'s default throws
+   * {@code UnsupportedOperationException}, which surfaced as a hard failure for any
+   * {@code LET $x = (EXPLAIN <statement>)} inside a SELECT's LET clause - {@code
+   * SelectExecutionPlanner.splitLet()} calls this to decide whether the LET can be hoisted to a
+   * single global evaluation or must be re-evaluated per record, and needs an answer for the
+   * wrapped statement either way.
+   */
+  @Override
+  public boolean refersToParent() {
+    return statement.refersToParent();
+  }
 }
 /* JavaCC - OriginalChecksum=9fdd24510993cbee32e38a51c838bdb4 (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ProfileStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ProfileStatement.java
@@ -125,5 +125,16 @@ public class ProfileStatement extends Statement {
   public boolean isIdempotent() {
     return true;
   }
+
+  /**
+   * Delegates to the wrapped statement. Same gap and same fix as
+   * {@link ExplainStatement#refersToParent()}: without this override, {@code
+   * LET $x = (PROFILE <statement>)} inside a SELECT's LET clause throws
+   * {@code UnsupportedOperationException} out of {@code Statement.refersToParent()}'s default.
+   */
+  @Override
+  public boolean refersToParent() {
+    return statement.refersToParent();
+  }
 }
 /* JavaCC - OriginalChecksum=9fdd24510993cbee32e38a51c838bdb4 (do not edit this line) */

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -78,4 +78,95 @@ class ExplainStatementExecutionTest extends TestHelper {
 
     result.close();
   }
+
+  /**
+   * Regression test for issue #6648: {@code EXPLAIN <write statement>} sent through the
+   * {@code sqlscript} language engine used to actually perform the wrapped write, because
+   * {@code SQLScriptQueryEngine} chains whatever {@code Statement.createExecutionPlan()} returns
+   * and pulls it to completion, and {@code ExplainStatement.createExecutionPlan()} used to pass
+   * the wrapped statement's own executable plan straight through. Plain {@code "sql"} was never
+   * affected, since it goes through {@code ExplainStatement.execute()}, which never pulls the
+   * plan it builds.
+   */
+  @Test
+  void explainUpdateInSqlScriptDoesNotExecuteWrite() {
+    final String typeName = "Issue6648UpdateTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sqlscript", "EXPLAIN UPDATE " + typeName + " SET bar = 1;");
+      assertThat(result.hasNext()).isTrue();
+      final Result next = result.next();
+      assertThat(next.<Object>getProperty("executionPlan")).isNotNull();
+      assertThat(next.<String>getProperty("executionPlanAsString")).isNotNull();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
+
+  @Test
+  void explainInsertInSqlScriptDoesNotExecuteWrite() {
+    final String typeName = "Issue6648InsertTarget";
+    database.getSchema().createDocumentType(typeName);
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sqlscript", "EXPLAIN INSERT INTO " + typeName + " SET bar = 1;");
+      assertThat(result.hasNext()).isTrue();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT count(*) as count FROM " + typeName);
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo(0L);
+    rs.close();
+  }
+
+  @Test
+  void explainDeleteInSqlScriptDoesNotExecuteWrite() {
+    final String typeName = "Issue6648DeleteTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sqlscript", "EXPLAIN DELETE FROM " + typeName + ";");
+      assertThat(result.hasNext()).isTrue();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT count(*) as count FROM " + typeName);
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo(1L);
+    rs.close();
+  }
+
+  /**
+   * Same bug, reached through a different chaining caller: {@code IfStep} also chains whatever
+   * {@code Statement.createExecutionPlan()} returns for the statements in its branch. Confirms the
+   * fix lives where it belongs (in {@code ExplainStatement.createExecutionPlan()}), not as a
+   * one-off special case in {@code SQLScriptQueryEngine} alone.
+   */
+  @Test
+  void explainUpdateInsideIfBlockDoesNotExecuteWrite() {
+    final String typeName = "Issue6648IfBlockTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              IF(true){
+                  EXPLAIN UPDATE %s SET bar = 1;
+              }
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -199,4 +199,85 @@ class ExplainStatementExecutionTest extends TestHelper {
     assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
     rs.close();
   }
+
+  /**
+   * Same bug, reached through {@code ForEachStep}: it chains whatever
+   * {@code Statement.createExecutionPlan()} returns for each statement in the loop body exactly like
+   * {@code ScriptLineStep} does, so it shared the same silent-write hazard before this fix.
+   */
+  @Test
+  void explainUpdateInsideForEachDoesNotExecuteWrite() {
+    final String typeName = "Issue6648ForEachTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              FOREACH ($i IN [1]) {
+                  EXPLAIN UPDATE %s SET bar = 1;
+              }
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
+
+  /**
+   * Same bug, reached through {@code WhileStep}.
+   */
+  @Test
+  void explainUpdateInsideWhileDoesNotExecuteWrite() {
+    final String typeName = "Issue6648WhileTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              LET $i = 0;
+              WHILE ($i < 1) {
+                  EXPLAIN UPDATE %s SET bar = 1;
+                  LET $i = $i + 1;
+              }
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
+
+  /**
+   * Same bug, reached through {@code RetryStep}: statements between {@code BEGIN} and
+   * {@code COMMIT RETRY n} are collected into a retry block and chained the same way as a plain
+   * script line.
+   */
+  @Test
+  void explainUpdateInsideRetryBlockDoesNotExecuteWrite() {
+    final String typeName = "Issue6648RetryTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final String script = """
+              BEGIN;
+              EXPLAIN UPDATE %s SET bar = 1;
+              COMMIT RETRY 5;
+          """.formatted(typeName);
+      final ResultSet result = database.command("sqlscript", script);
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -169,4 +169,34 @@ class ExplainStatementExecutionTest extends TestHelper {
     assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
     rs.close();
   }
+
+  /**
+   * {@code PROFILE EXPLAIN <statement>} is a third way to reach the same bug:
+   * {@code ProfileStatement.execute()} is itself a caller that pulls whatever
+   * {@code statement.createExecutionPlan()} hands back (see {@code ProfileStatement.java:58-64}), so
+   * before this fix {@code PROFILE EXPLAIN UPDATE ...} silently ran the update exactly like the
+   * {@code sqlscript} case did. EXPLAIN's non-execution contract is defined to win regardless of what
+   * encloses it, so {@code PROFILE EXPLAIN <statement>} degrades to plan-only output - no execution,
+   * no real cost numbers - rather than PROFILE unwrapping the inner statement and running it for real.
+   */
+  @Test
+  void profileExplainUpdateDoesNotExecuteWrite() {
+    final String typeName = "Issue6648ProfileExplainTarget";
+    database.getSchema().createDocumentType(typeName);
+    database.transaction(() -> database.command("sql", "INSERT INTO " + typeName + " SET bar = 0"));
+
+    database.transaction(() -> {
+      final ResultSet result = database.command("sql", "PROFILE EXPLAIN UPDATE " + typeName + " SET bar = 1");
+      assertThat(result.hasNext()).isTrue();
+      final Result next = result.next();
+      assertThat(next.<Object>getProperty("executionPlan")).isNotNull();
+      assertThat(next.<String>getProperty("executionPlanAsString")).isNotNull();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT bar FROM " + typeName);
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
+    rs.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -280,4 +280,38 @@ class ExplainStatementExecutionTest extends TestHelper {
     assertThat(rs.next().<Integer>getProperty("bar")).isEqualTo(0);
     rs.close();
   }
+
+  /**
+   * Same bug, reached through a SELECT's own {@code LET} clause: {@code LetItem.query} is typed as
+   * a generic {@code Statement}, so {@code LET $x = (EXPLAIN <statement>)} parses, and
+   * {@code GlobalLetQueryStep}/{@code LetQueryStep} (built by {@code SelectExecutionPlanner}) chain
+   * whatever {@code query.createExecutionPlan()} returns exactly like every other caller this fix
+   * covers.
+   * <p>
+   * Uses {@code INSERT}, not {@code UPDATE}/{@code DELETE}: reaching this path at all requires
+   * {@code Statement.refersToParent()} on the wrapped statement, which {@code UpdateStatement},
+   * {@code DeleteStatement}, {@code CreateVertexStatement}, {@code CreateEdgeStatement} and
+   * {@code DDLStatement} have never implemented - {@code LET $x = (UPDATE ...)} throws
+   * {@code UnsupportedOperationException} regardless of EXPLAIN, so those aren't a silent-write
+   * risk here, just a pre-existing, unrelated gap out of scope for this fix.
+   * {@code InsertStatement.refersToParent()} already returns {@code false}, so INSERT is the one
+   * write statement that actually reaches {@code ExplainExecutionPlan} through this path today.
+   */
+  @Test
+  void explainInsertInsideSelectLetDoesNotExecuteWrite() {
+    final String typeName = "Issue6648SelectLetTarget";
+    database.getSchema().createDocumentType(typeName);
+
+    database.transaction(() -> {
+      final ResultSet result = database.query("sql",
+          "SELECT $explained AS explained LET $explained = (EXPLAIN INSERT INTO " + typeName + " SET bar = 1)");
+      assertThat(result.hasNext()).isTrue();
+      result.next();
+      result.close();
+    });
+
+    final ResultSet rs = database.query("sql", "SELECT count(*) as count FROM " + typeName);
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo(0L);
+    rs.close();
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #6648.

`EXPLAIN <write statement>` silently ran the wrapped write whenever it was reached through a chaining caller instead of `Statement.execute()`: the `sqlscript` language engine, or a `FOREACH`/`IF`/`WHILE`/`RETRY`/`LET` block nested inside any script. Plain `"language": "sql"` was never affected.

## Root cause

`ExplainStatement.createExecutionPlan(CommandContext)` was a pure passthrough (`return statement.createExecutionPlan(context);`). Every one of those chaining callers builds a nested statement's plan by calling `createExecutionPlan()` directly (not `execute()`) and then pulls whatever comes back to completion:
- `SQLScriptQueryEngine.executeInternal` chains it into the script's `ScriptExecutionPlan`.
- `ForEachStep`, `IfStep`, `WhileStep`, `RetryStep`, `LetQueryStep`, `GlobalLetExpressionStep`, `ParenthesisExpression` do the same for a statement nested inside a block.

So passing the wrapped statement's own executable plan straight through handed all of these the real `UPDATE`/`INSERT`/`DELETE`/... plan, and it ran to completion when pulled - exactly as if `EXPLAIN` were not there. `ExplainStatement.execute()` itself was fine: it builds the plan and wraps it in `ExplainResultSet` without ever pulling it.

## Fix

Rather than special-casing `SQLScriptQueryEngine` alone (the issue's suggested fix), this fixes it at the one place all of those callers go through: `ExplainStatement.createExecutionPlan()` now wraps the built plan in a new `ExplainExecutionPlan` (`engine/src/main/java/com/arcadedb/query/sql/executor/ExplainExecutionPlan.java`). On `fetchNext()` it reports the wrapped plan's description - the same `executionPlan`/`executionPlanAsString` shape `ExplainResultSet` gives callers that go through `execute()` - without ever pulling the wrapped plan. It's also deliberately not an `InsertExecutionPlan`/`DeleteExecutionPlan`/`UpdateExecutionPlan`/`DDLExecutionPlan`/`SingleOpExecutionPlan`, since `ScriptLineStep.syncPull` special-cases exactly those types to run them eagerly on first pull.

`ExplainStatement.execute()` unwraps the plan back out via `ExplainExecutionPlan.getWrappedPlan()` so it keeps returning `ExplainResultSet` exactly as before - no change to its public contract (the server's `PostCommandHandler` and existing tests do `instanceof ExplainResultSet` / cast to it).

`PROFILE` is intentionally left alone, per the issue: its whole purpose is to execute the wrapped statement, so it isn't a correctness/safety issue the way `EXPLAIN`'s silent write is.

## Test plan

Added to `ExplainStatementExecutionTest`:
- [x] `explainUpdateInSqlScriptDoesNotExecuteWrite` - reproduces the exact reported case
- [x] `explainInsertInSqlScriptDoesNotExecuteWrite`
- [x] `explainDeleteInSqlScriptDoesNotExecuteWrite`
- [x] `explainUpdateInsideIfBlockDoesNotExecuteWrite` - same bug via a different chaining caller (`IfStep`), confirming the fix belongs at the root and isn't just papering over the `sqlscript` case

Verified all four fail against the unpatched code (reverted the fix, kept the tests) and pass with it restored. Also ran the full `com.arcadedb.query.sql.executor.*Test` suite, `ExplainStatementExecutionTest`, `ScriptExecutionTest`, `SQLScriptAdditionalCoverageTest`, `MaxMinFromIndexTest`, `ProfileStatementExecutionTest`, `ProfileFlameGraphTest`, and `OpenCypherUnionCallProfileTest` - all green. `engine` and `server` modules compile clean.