### PR TITLE
fix(#6462): close cross-slot bidirectional edge races in waitCompletion() and BucketIndexBuilder

### DIFF
--- a/docs/6462-async-cross-slot-bidirectional-edge-wait.md
+++ b/docs/6462-async-cross-slot-bidirectional-edge-wait.md
@@ -1,0 +1,77 @@
+# Issue #6462: async cross-slot bidirectional edge - waitCompletion() / quiesceAsync() races
+
+## Root cause
+
+`DatabaseAsyncExecutorImpl.newEdge()` schedules the incoming-edge cascade task for a bidirectional
+cross-slot edge onto the **destination** worker's slot from **inside** the source task's own
+callback (`CreateEdgeAsyncTask`'s completion callback schedules `CreateIncomingEdgeAsyncTask`). That
+means the cascade can land on the destination worker strictly *after* that worker has already
+answered "I'm done" to a concurrent caller, in two different mechanisms:
+
+1. **`DatabaseAsyncExecutorImpl.waitCompletion(long)`** placed exactly one completion marker per
+   worker in a single pass. If the destination worker was idle, its marker could fire before the
+   cascade (still queued behind the still-running source task on a different worker) ever landed on
+   it - so the method could return "all done" while the in-edge was still pending.
+   `LocalDatabase.waitForAsyncCompletion()` already re-scans with a `do { ... } while
+   (isAsyncProcessing())` loop for exactly this reason (issue #6281), but that loop lives one level
+   above the executor - a caller reaching `waitCompletion()` directly through the public
+   `DatabaseAsyncExecutor` API bypassed it entirely.
+2. **`BucketIndexBuilder.create()`** calls `database.quiesceAsync()` (which parks every worker) but,
+   unlike `TypeIndexBuilder` and `RebuildIndexStatement`, never calls
+   `database.waitForAsyncCompletion()` first. A destination worker parked while idle does not wait
+   for a cascade that lands on it afterwards, so the scan underneath the quiescence can run before
+   that cascade's write is committed - the built index misses the entry until a later, unrelated
+   drain catches it up.
+
+## Fix
+
+1. `DatabaseAsyncExecutorImpl.waitCompletion(long)` (`engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java`):
+   the marker-placement body was extracted into a private `waitCompletionOnePass(...)`, and the public
+   method now loops `do { ... } while (isProcessing())`, mirroring the pattern
+   `LocalDatabase.waitForAsyncCompletion()` has used since #6281. This closes the race for every
+   direct caller of the public API, not only callers that happen to go through `LocalDatabase`.
+2. `BucketIndexBuilder.create()` (`engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java`):
+   added a `database.waitForAsyncCompletion()` call immediately before `database.quiesceAsync()`,
+   matching the pattern already used by `TypeIndexBuilder` (line ~207) and `RebuildIndexStatement`
+   (line ~146). By the time the quiescence starts, the executor is genuinely idle rather than racing
+   it.
+
+Both fixes are the minimal, precedented options from the issue's own "Suggested fix" list (options 1
+and 3); the more invasive option (reworking `quiesceWorkers()`'s park scheduling itself) was not
+needed once the drain happens first.
+
+## Tests
+
+- `engine/src/test/java/com/arcadedb/database/async/Issue6462CrossSlotWaitCompletionMissesCascadeTest.java`:
+  reproduces the `waitCompletion()` race with a plain task scheduled directly at the slot level (no
+  graph API, no dependency on which slot a RID happens to hash to) that, from inside its own
+  execution, schedules a follow-up task onto a different worker - mirroring `newEdge()`'s callback
+  shape. The follow-up is held open with a latch so the buggy and fixed behaviour are distinguished
+  deterministically (by what has/has not happened when `waitCompletion()` returns), not by timing.
+  Verified TDD-style: fails against the pre-fix code (`Expecting value to be false but was true`),
+  passes after the fix.
+- `engine/src/test/java/com/arcadedb/index/Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest.java`:
+  same reduction applied to `BucketIndexBuilder.create()` - a source task on one worker creates a
+  record targeting the OTHER worker's bucket from inside its own execution once released, and the
+  index build runs concurrently. Asserts that by the time `create()` returns, both the record and its
+  index entry are already present - not merely "eventually" once a later drain catches up. Verified
+  TDD-style: fails 3/3 runs against the pre-fix code (`expected: 1L but was: 0L`), passes 3/3 after.
+
+Both tests were run repeatedly (3x) against both the pre-fix and post-fix code to confirm they are
+not vacuously passing and are not flaky.
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest='com.arcadedb.database.async.**,com.arcadedb.index.Issue6303*,com.arcadedb.index.Issue6462*' -DexcludedGroups=benchmark,slow,vector` - 69 tests, 0 failures.
+- `mvn -pl engine -am test -Dtest='com.arcadedb.index.**,com.arcadedb.schema.**,com.arcadedb.graph.**' -DexcludedGroups=benchmark,slow,vector` - 2213 tests, 0 failures (covers `AsyncWaitCompletionTimeoutTest`, `Issue6303AsyncQuiesceTest`, `AsyncCrossSlotSchedulingDeadlockTest`, and every index/schema/graph regression test in the module).
+- `mvn -pl engine -am compile` - clean.
+
+## Scope not addressed
+
+`DatabaseAsyncExecutorImpl.quiesceWorkers()` itself (the park-task machinery `quiesceAsync()` is built
+on) was left untouched. Draining first, as both fixes now do, removes the specific race the issue
+describes without needing to change that already carefully-reasoned, heavily-reviewed method (#6303).
+A caller who reaches `quiesceAsync()` directly without draining first (bypassing both
+`BucketIndexBuilder`/`TypeIndexBuilder`/`RebuildIndexStatement`, all of which now drain first) could
+still hit a variant of the destination-worker-parked-early race; no such direct caller exists in the
+codebase today.

--- a/docs/6462-async-cross-slot-bidirectional-edge-wait.md
+++ b/docs/6462-async-cross-slot-bidirectional-edge-wait.md
@@ -66,6 +66,37 @@ not vacuously passing and are not flaky.
 - `mvn -pl engine -am test -Dtest='com.arcadedb.index.**,com.arcadedb.schema.**,com.arcadedb.graph.**' -DexcludedGroups=benchmark,slow,vector` - 2213 tests, 0 failures (covers `AsyncWaitCompletionTimeoutTest`, `Issue6303AsyncQuiesceTest`, `AsyncCrossSlotSchedulingDeadlockTest`, and every index/schema/graph regression test in the module).
 - `mvn -pl engine -am compile` - clean.
 
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6651
+
+## Review cycles
+
+- **Cycle 1** - head `1cb89451075f1409aa37a71de8c678a430acbeb9`: `claude[bot]` reviewed via issue
+  comment. Verdict: "No blocking issues found." Traced the happens-before chain of the
+  `waitCompletion()` fix independently and confirmed it sound; confirmed the `BucketIndexBuilder`
+  fix mirrors `TypeIndexBuilder`/`RebuildIndexStatement` exactly; confirmed both tests avoid
+  timing-based flakiness (latch/`completedTaskCount` polling, the one `Thread.sleep` only widens a
+  race window rather than gating an assertion, so worst case it fails to reproduce and passes
+  vacuously rather than failing falsely). One **non-blocking** observation, skipped (see below).
+  No code changes required - working tree stayed clean this cycle - so this is a clean approval on
+  cycle 1.
+
+### Deferred / skipped review items
+
+- **Skipped (nitpick, optional, explicitly non-blocking):** the reviewer noted that
+  `LocalDatabase.waitForAsyncCompletion()`'s own `do { ... } while (isAsyncProcessing())` loop
+  (#6281) is now a "loop-around-a-loop" on top of `waitCompletion()`'s new internal loop, and
+  suggested a possible follow-up to simplify it back to a single call. Not applied: the reviewer
+  itself flagged this as conditional on "not complicating the interrupt-handling special case"
+  `LocalDatabase.waitForAsyncCompletion()` currently has, explicitly called it harmless, and it
+  touches a different, separately-reasoned method than either of the two changes this issue is
+  about. Left as a possible future cleanup rather than folded into this fix.
+
+## Final state
+
+clean-approval (1 cycle)
+
 ## Scope not addressed
 
 `DatabaseAsyncExecutorImpl.quiesceWorkers()` itself (the park-task machinery `quiesceAsync()` is built

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -748,6 +748,34 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       timeout = Long.MAX_VALUE;
     final long beginTime = System.currentTimeMillis();
 
+    // LOOPED, not a single pass (issue #6462). One marker per worker answers about a snapshot taken
+    // at the moment each marker is OFFERED - not one consistent instant across every worker, because
+    // the offers are not simultaneous. A bidirectional cross-slot edge schedules its incoming-edge
+    // cascade task onto the DESTINATION worker from INSIDE the source task's own callback
+    // (DatabaseAsyncExecutorImpl#newEdge), so the cascade can land on that worker AFTER its marker
+    // already fired - the source worker's own marker, still queued behind the still-running source
+    // task, is the only thing left for a single pass to wait on, and once IT completes (the moment
+    // the source task's execute() returns, having already scheduled the cascade) this method could
+    // return with the cascade merely scheduled, not executed. LocalDatabase#waitForAsyncCompletion()
+    // has always re-scanned with exactly this do-while for the same reason (issue #6281); this method
+    // promises the identical thing in its own javadoc ("waits for the completion of all pending
+    // operations") and needs the identical loop to keep that promise for a caller who reaches it
+    // directly instead of through LocalDatabase.
+    do {
+      if (!waitCompletionOnePass(beginTime, timeout))
+        return false;
+    } while (isProcessing());
+
+    return true;
+  }
+
+  /**
+   * One marker-per-worker pass of {@link #waitCompletion(long)}: waits for everything queued or
+   * executing on every worker <b>at the moment each marker is offered</b> to finish. See that
+   * method's javadoc for why a single pass is not, on its own, a sound answer to "has everything
+   * finished".
+   */
+  private boolean waitCompletionOnePass(final long beginTime, final long timeout) {
     // FIRST, because an async command can submit async record tasks of its own and those must end up behind the
     // markers below rather than in front of them (issue #6303, item 3). Costs nothing when nothing was dispatched.
     if (!awaitCommands(beginTime, timeout))

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -89,6 +89,17 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
     // async worker is still holding in its open batch, and produce the same silently incomplete index #6281 is about.
     // Holding it twice on the paths that already do is free: quiescence is reentrant per thread.
     //
+    // DRAINED FIRST, exactly as TypeIndexBuilder and RebuildIndexStatement already do, and not merely as a copy of
+    // their comment (issue #6462). A bidirectional cross-slot edge schedules its incoming-edge cascade task onto the
+    // destination worker from INSIDE the source task's own callback (DatabaseAsyncExecutorImpl#newEdge), which can
+    // still be sitting queued - unscheduled or unexecuted - at the instant quiesceAsync() below hands out its park
+    // tasks: a park already confirmed on that destination worker does not wait for a cascade that lands on it
+    // afterwards, so the scan below could run without ever seeing that edge's IN side. waitForAsyncCompletion()'s own
+    // re-scan loop (issue #6281) is what closes that window - it does not return until a whole pass finds nothing
+    // left to drain, cascades included - so quiesceAsync() then starts from an executor that is genuinely idle rather
+    // than racing it.
+    database.waitForAsyncCompletion();
+
     // A QUIESCENCE AND NOT JUST THE BARRIER OF #6281 (issue #6303, item 2). The barrier answers about the past, and
     // that is only half of what a build needs: the other half is that nothing writes DURING the scan. This method
     // used to reach for that half with a pause task per worker, scheduled and forgotten - the boolean scheduleTask

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6462CrossSlotWaitCompletionMissesCascadeTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6462CrossSlotWaitCompletionMissesCascadeTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6462: a bidirectional cross-slot edge schedules its incoming-edge cascade
+ * task onto the DESTINATION worker's slot from INSIDE the source task's own callback -
+ * {@code DatabaseAsyncExecutorImpl.newEdge()} schedules {@code CreateIncomingEdgeAsyncTask} onto
+ * {@code destinationSlot} from inside {@code CreateEdgeAsyncTask}'s completion callback - i.e.
+ * AFTER the destination worker may already have confirmed a completion marker to a concurrent
+ * {@link DatabaseAsyncExecutorImpl#waitCompletion(long)} caller. The public {@code waitCompletion()}
+ * promises to wait "for the completion of all pending operations" ({@link DatabaseAsyncExecutor})
+ * but placed exactly one marker per worker in a single pass, with no way to notice a task that
+ * landed on a worker AFTER that worker's own marker had already fired.
+ * <p>
+ * This reproduces the shape without touching the graph API at all: a plain task on worker 0 that,
+ * once released, schedules a follow-up task onto worker 1 from inside its own execution - mirroring
+ * {@code CreateEdgeAsyncTask}'s callback scheduling {@code CreateIncomingEdgeAsyncTask}. The
+ * follow-up is held open with a latch so the buggy and fixed behaviour can be told apart
+ * deterministically (by what has and has not happened when {@code waitCompletion()} returns) rather
+ * than by timing.
+ */
+class Issue6462CrossSlotWaitCompletionMissesCascadeTest extends TestHelper {
+
+  @Test
+  @Timeout(30)
+  void waitCompletionMustNotReturnBeforeACrossSlotCascadeTaskCompletes() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the fresh pair of workers is used regardless of any prior level.
+    async.recreateThreadsForTests();
+
+    final CountDownLatch sourceTaskRunning = new CountDownLatch(1);
+    final CountDownLatch releaseSourceTask = new CountDownLatch(1);
+    final CountDownLatch cascadeStarted    = new CountDownLatch(1);
+    final CountDownLatch releaseCascade    = new CountDownLatch(1);
+    final AtomicBoolean  cascadeCompleted  = new AtomicBoolean(false);
+
+    // SOURCE TASK on slot 0 - mirrors CreateEdgeAsyncTask: once released, it schedules a follow-up
+    // task onto slot 1 FROM INSIDE its own execution, exactly as newEdge()'s cross-slot callback
+    // schedules CreateIncomingEdgeAsyncTask onto the destination slot.
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        sourceTaskRunning.countDown();
+        awaitLatch(releaseSourceTask);
+
+        async.scheduleTask(1, new DatabaseAsyncTask() {
+          @Override
+          public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+            cascadeStarted.countDown();
+            awaitLatch(releaseCascade);
+            cascadeCompleted.set(true);
+          }
+
+          @Override
+          public boolean requiresActiveTx() {
+            return false;
+          }
+        }, true, 0);
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    }, true, 0);
+
+    assertThat(sourceTaskRunning.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // AT THIS POINT: worker 0's queue holds the still-blocked source task; worker 1 is completely
+    // idle. This is exactly the state waitCompletion() sees when it places one marker per worker in
+    // a single pass: worker 1's marker has nothing ahead of it and is free to fire long before the
+    // source task's callback ever reaches the line that schedules the cascade onto worker 1.
+    final CountDownLatch waitCompletionReturned = new CountDownLatch(1);
+    final AtomicBoolean  waitCompletionResult   = new AtomicBoolean();
+    final Thread waiter = new Thread(() -> {
+      waitCompletionResult.set(async.waitCompletion(20_000));
+      waitCompletionReturned.countDown();
+    }, "waitCompletion-caller");
+    waiter.setDaemon(true);
+    waiter.start();
+
+    // Worker 1's marker must have fired before the source task is released - proven with the same
+    // observable worker 1's completed-task counter already used elsewhere in this suite
+    // (AsyncHelpingSlowPeerProgressTest), never a fixed sleep: nothing but waitCompletion()'s own
+    // marker can complete on worker 1 before this point.
+    final DatabaseAsyncExecutorImpl.AsyncThread worker1 = findWorkerThread(db, 1);
+    final long deadline = System.currentTimeMillis() + 10_000;
+    while (worker1.completedTaskCount == 0) {
+      if (System.currentTimeMillis() > deadline)
+        throw new AssertionError("Worker 1's completion marker never fired");
+      Thread.sleep(5);
+    }
+
+    // waitCompletion() must still be waiting on worker 0 at this point (its own trailing marker sits
+    // behind the still-blocked source task) - true regardless of the fix.
+    assertThat(waitCompletionReturned.getCount()).as("waitCompletion() must still be waiting on worker 0").isEqualTo(1L);
+
+    // RELEASE THE SOURCE TASK: it now schedules the cascade onto worker 1, whose own marker has
+    // ALREADY fired - the exact race #6462 describes - and then finishes, letting worker 0's own
+    // trailing marker run.
+    releaseSourceTask.countDown();
+
+    assertThat(cascadeStarted.await(10, TimeUnit.SECONDS)).as("the cascade task must be scheduled and started").isTrue();
+
+    // THE ASSERTION: with the cascade deliberately held open, a waitCompletion() that returns now
+    // provably returned before "all pending operations" completed - the bug (#6462). The fix must
+    // block here until the cascade is released below.
+    assertThat(waitCompletionReturned.await(500, TimeUnit.MILLISECONDS))
+        .as("waitCompletion() must not return while a cross-slot cascade task scheduled from another task's own "
+            + "callback is still running")
+        .isFalse();
+
+    releaseCascade.countDown();
+
+    assertThat(waitCompletionReturned.await(10, TimeUnit.SECONDS)).as("waitCompletion() must eventually return").isTrue();
+    assertThat(waitCompletionResult.get()).as("waitCompletion() must report success, not a timeout").isTrue();
+    assertThat(cascadeCompleted.get()).as("the cascade must have completed by the time waitCompletion() returned").isTrue();
+
+    waiter.join(5000);
+  }
+
+  private static void awaitLatch(final CountDownLatch latch) {
+    try {
+      if (!latch.await(20, TimeUnit.SECONDS))
+        throw new AssertionError("Latch never released within 20s");
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+
+  private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
+    final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
+    return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().equals(name)).findFirst()
+        .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
+import com.arcadedb.database.async.DatabaseAsyncTask;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #6462, the {@code BucketIndexBuilder} half: {@code quiesceAsync()} parks each
+ * worker once its OWN queue is drained, but a task still mid-flight on a DIFFERENT worker can
+ * schedule a follow-up onto an already-parked worker's queue from inside its own execution - exactly
+ * what a bidirectional cross-slot edge does ({@code DatabaseAsyncExecutorImpl#newEdge} schedules the
+ * incoming-edge task onto the destination slot from inside the source task's own callback). The
+ * follow-up then sits queued behind the park, uncommitted and invisible, while a
+ * {@code BucketIndexBuilder} scan concurrent with it runs anyway - the built index misses the entry.
+ * <p>
+ * Reduced to a plain task scheduled directly at the slot level (as
+ * {@code AsyncCrossSlotSchedulingDeadlockTest} and {@code Issue6303AsyncQuiesceTest} already do)
+ * rather than through the graph API: a task on one worker, still blocked, that - once released -
+ * creates a record targeting the OTHER worker's bucket from inside its own execution, mirroring the
+ * shape exactly without depending on which slot a given RID happens to hash to.
+ */
+class Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void bucketIndexBuildMustNotMissARecordFromACrossSlotCascadeStillInFlight() throws Exception {
+    final DatabaseInternal            db    = (DatabaseInternal) database;
+    final DatabaseAsyncExecutorImpl   async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+
+    database.transaction(() -> database.getSchema().createDocumentType("V", 1).createProperty("id", Type.INTEGER));
+
+    final Bucket vBucket  = database.getSchema().getType("V").getBuckets(false).get(0);
+    final int    destSlot = async.getSlot(vBucket.getFileId());
+    final int    sourceSlot = 1 - destSlot;
+
+    final CountDownLatch sourceTaskRunning = new CountDownLatch(1);
+    final CountDownLatch releaseSourceTask = new CountDownLatch(1);
+    final CountDownLatch cascadeCreated    = new CountDownLatch(1);
+
+    // SOURCE TASK on the OTHER slot - mirrors CreateEdgeAsyncTask: once released, it creates a
+    // record targeting the index's own bucket FROM INSIDE its own execution, exactly as newEdge()'s
+    // cross-slot callback schedules CreateIncomingEdgeAsyncTask onto the destination slot.
+    async.scheduleTask(sourceSlot, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        sourceTaskRunning.countDown();
+        awaitLatch(releaseSourceTask);
+
+        final MutableDocument v = database.newDocument("V");
+        v.set("id", 42);
+        database.async().createRecord(v, record -> cascadeCreated.countDown());
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    }, true, 0);
+
+    assertThat(sourceTaskRunning.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Runs the build concurrently, on its own thread: it must block until the source task (still
+    // held below) and whatever it schedules have fully drained.
+    final AtomicReference<com.arcadedb.index.Index> builtIndex = new AtomicReference<>();
+    final CountDownLatch                            buildDone  = new CountDownLatch(1);
+    final Thread builder = new Thread(() -> {
+      try {
+        builtIndex.set(database.getSchema().buildBucketIndex("V", vBucket.getName(), new String[] { "id" })
+            .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create());
+      } finally {
+        buildDone.countDown();
+      }
+    }, "index-builder");
+    builder.setDaemon(true);
+    builder.start();
+
+    // Widens the window a real cross-slot edge would leave open: with the pre-#6462-fix code,
+    // quiesceAsync() parks the (idle, nothing queued yet) destination worker essentially instantly
+    // once the build starts above - far under this bound - so releasing the source task only after
+    // this sleep reliably reproduces the race rather than depending on it by luck.
+    Thread.sleep(300);
+
+    releaseSourceTask.countDown();
+
+    // NOT gated on cascadeCreated: that latch only counts down once the cross-slot record's own async
+    // task has actually EXECUTED and committed - which, for the very race under test, may not happen
+    // until after quiesceAsync() has already released the workers. Waiting for it first would silently
+    // wait out the bug. buildDone is the only synchronization point that matters here: create() cannot
+    // even reach its quiesceAsync() call's parked.await() until the source task has finished (its own
+    // trailing park sits queued behind it), so by the time create() returns, the cross-slot record has
+    // at least been SCHEDULED - the question the assertions below answer is whether it was also seen.
+    assertThat(buildDone.await(30, TimeUnit.SECONDS)).as("the index build must complete").isTrue();
+    builder.join(5000);
+
+    // THE ASSERTION: a record whose cross-slot creation was already scheduled before the build even
+    // started quiescing must be visible in both the type and the freshly built index the INSTANT
+    // create() returns - not eventually, once some later drain happens to catch it up. That "eventually"
+    // is exactly the silently incomplete index #6462 is about: a caller reading right after the DDL
+    // statement returns must not see a database that has not caught up with its own recent past.
+    assertThat(builtIndex.get()).as("the build must have produced an index").isNotNull();
+    assertThat(database.countType("V", false))
+        .as("a record whose cross-slot creation was already scheduled before the build started quiescing must be "
+            + "committed by the time the build - a DDL statement - returns")
+        .isEqualTo(1);
+    assertThat(builtIndex.get().countEntries())
+        .as("a record created by a cross-slot cascade still in flight when the build started must not be missing "
+            + "from the built index")
+        .isEqualTo(1);
+
+    // Sanity: the record is not permanently lost either way - only the timing guarantee is under test.
+    assertThat(cascadeCreated.await(10, TimeUnit.SECONDS)).as("the cross-slot record must eventually be created")
+        .isTrue();
+  }
+
+  private static void awaitLatch(final CountDownLatch latch) {
+    try {
+      if (!latch.await(20, TimeUnit.SECONDS))
+        throw new AssertionError("Latch never released within 20s");
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes two races caused by the same root cause: `DatabaseAsyncExecutorImpl.newEdge()` schedules a
bidirectional cross-slot edge's incoming-edge cascade task onto the *destination* worker's slot from
*inside* the source task's own completion callback - i.e. potentially after that worker has already
answered a concurrent caller's "am I done?" check.

1. **`DatabaseAsyncExecutorImpl.waitCompletion(long)`** placed exactly one completion marker per
   worker in a single pass. If the destination worker was idle, its marker could fire before the
   cascade (still queued behind the still-running source task on a different worker) ever landed on
   it, so the method could return `true` ("all pending operations" complete) while the in-edge was
   still pending. Fixed by wrapping the marker-placement logic (extracted into
   `waitCompletionOnePass`) in a `do { ... } while (isProcessing())` loop - the same re-scan pattern
   `LocalDatabase.waitForAsyncCompletion()` has used since #6281, now applied at the level of the
   public API method itself so a caller reaching it directly is covered too.
2. **`BucketIndexBuilder.create()`** called `database.quiesceAsync()` without draining first, unlike
   `TypeIndexBuilder` and `RebuildIndexStatement` (both of which call
   `database.waitForAsyncCompletion()` immediately before quiescing). A destination worker parked
   while idle does not wait for a cascade landing on it afterwards, so the scan running under the
   quiescence could complete before that cascade's write was committed - the freshly built index
   would miss the entry until an unrelated later drain caught it up. Fixed by adding the same
   `waitForAsyncCompletion()` call before `quiesceAsync()`.

Both are the minimal, precedented fixes from the issue's own "Suggested fix" list; the more invasive
option (reworking `quiesceWorkers()`'s park-task scheduling itself) was not needed once both callers
drain first.

## Motivation

Closes #6462.

## Related issues

Closes #6462

## Additional Notes

Both regression tests reduce the cross-slot shape to plain tasks scheduled directly at the slot
level (as `AsyncCrossSlotSchedulingDeadlockTest` and `Issue6303AsyncQuiesceTest` already do), rather
than going through the graph API, so they don't depend on which slot a given RID happens to hash to
and stay fast/deterministic:

- `Issue6462CrossSlotWaitCompletionMissesCascadeTest`: a task on worker 0 that, once released,
  schedules a follow-up task onto worker 1 from inside its own execution. The follow-up is held open
  with a latch so the buggy/fixed behaviour is told apart by what has (not) happened when
  `waitCompletion()` returns, not by timing. Verified TDD-style: fails against the pre-fix code
  (`Expecting value to be false but was true`), passes after.
- `Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest`: a task on one worker creates a record
  targeting the *other* worker's bucket from inside its own execution once released, concurrently
  with an index build on that bucket. Asserts the record and its index entry are both already
  present the instant `create()` returns - not merely "eventually". Verified TDD-style: fails 3/3
  runs against the pre-fix code (`expected: 1L but was: 0L`), passes 3/3 after.

`DatabaseAsyncExecutorImpl.quiesceWorkers()` itself was left untouched - draining first removes the
race without touching that already carefully-reasoned, heavily-reviewed method (#6303). See the
tracking doc (`docs/6462-async-cross-slot-bidirectional-edge-wait.md`) for the full analysis and
verification runs.

## Test plan

- [x] `Issue6462CrossSlotWaitCompletionMissesCascadeTest` - new, fails pre-fix / passes post-fix
- [x] `Issue6462BucketIndexBuilderMissesCrossSlotCascadeTest` - new, fails pre-fix / passes post-fix
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.database.async.**,com.arcadedb.index.Issue6303*,com.arcadedb.index.Issue6462*' -DexcludedGroups=benchmark,slow,vector` - 69 tests, 0 failures
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.index.**,com.arcadedb.schema.**,com.arcadedb.graph.**' -DexcludedGroups=benchmark,slow,vector` - 2213 tests, 0 failures (covers `AsyncWaitCompletionTimeoutTest`'s timeout-budget contract, `Issue6303AsyncQuiesceTest`'s quiesce contract, and every index/schema/graph regression test in the module)
- [x] `mvn -pl engine -am compile` - clean

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
