### PR TITLE
fix(#6461): re-resolve a MERGE anchor vertex before enumerating its edges

### DIFF
--- a/docs/6461-merge-anchor-stale-edge-list.md
+++ b/docs/6461-merge-anchor-stale-edge-list.md
@@ -70,3 +70,34 @@ pass after the fix.
   `Issue6602MergeAfterEmptyMatchCardinalityTest` (7) + `MergeInsertSlowdownTest` (1) +
   `RefactorMergeNodesTest` (13): all green, no regressions.
 - Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`/`slow`/`vector` lanes): see below.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6652
+
+## Review cycles
+
+- **Cycle 1** - head SHA `0e7de9f6` (push `2026-08-23T20:28:24Z`). Polled all three review surfaces
+  (`reviews[]`, inline `pulls/6652/comments`, and `claude`-authored PR issue comments newer than the push)
+  for the full 15-minute per-iteration window: no review landed on any surface.
+  - Cross-checked against the Actions run directly: `Claude Code Review` workflow run
+    [32664545721](https://github.com/ArcadeData/arcadedb/actions/runs/32664545721) triggered on this SHA,
+    ran to completion (`status=completed`, `conclusion=success`, 28 turns, ~186s), and its own log shows
+    `permission_denials_count: 6` and a final "No buffered inline comments" from the
+    post-buffered-inline-comments step - i.e. the bot's run finished without ever posting a top-level
+    `gh pr comment`, despite `Bash(gh pr comment:*)` being in its allowed-tools list. This is not a slow-bot
+    case (the workflow itself finished in ~5 minutes and never posted); as of this update, over 11 hours have
+    passed since the push with still no comment on the PR from `claude`.
+  - No code changes were made this cycle since no review feedback was ever received to act on.
+
+## Deferred items
+
+None - no review comments were received to categorize.
+
+## Final state
+
+**timeout** - the `claude` review bot's workflow run completed without posting a review comment on head
+SHA `0e7de9f6`. The PR is left open with the fix as pushed. This looks like the same class of infra issue
+tracked in `reference_review_bot_can_time_out_before_posting` (bot completes without posting, rather than
+never running at all) and may warrant a manual `@claude review` comment or maintainer trigger to get a
+review on this PR.

--- a/docs/6461-merge-anchor-stale-edge-list.md
+++ b/docs/6461-merge-anchor-stale-edge-list.md
@@ -1,0 +1,72 @@
+# Issue #6461: MERGE duplicates a relationship (and its far endpoint) when the anchor vertex was bound earlier in the same query
+
+## Root cause
+
+`MergeStep.executeMerge` wraps each row it processes in its own
+`database.transaction(() -> {...}, true)` call (added for #6367's auto-retry). When the caller has no
+outer transaction open - an unwrapped autocommit call, exactly the shape `BoltNetworkExecutor.handleRun`
+uses, and the shape a raw `database.command(...)` call has - each row's MERGE owns and commits its own
+transaction.
+
+The anchor vertex instance a row carries (bound by an earlier `MATCH`, or reused across `UNWIND` rows of
+the same MERGE clause) was loaded before that row's own transaction started. Once a **prior** row's MERGE
+appends the first edge in a given direction to that vertex - the one write that rewrites the vertex
+record's edge-list head pointer - the row's own in-memory instance still reflects the pre-append state.
+`findAllMatchingPaths` (via `traverseFromAnchor`) and `traverseFromNode` both took that instance straight
+from the row and called `vertex.getEdges(...)` on it directly, so the match half of a later row misses the
+edge/node a previous row already created and its create half runs, producing a duplicate.
+
+Confirmed empirically to be **still present at HEAD** before this fix (not masked by the existing
+`getMostUpdatedVertex`/transaction-record-cache mechanism, which only helps when the reader and the writer
+share the same `TransactionContext` - not the case here, since each unwrapped row commits and starts a new
+one).
+
+Over HTTP this is invisible: `DatabaseAbstractHandler.executeInTransaction()` wraps the *entire* autocommit
+command in one outer transaction, so every row's MERGE simply joins it and shares its transaction-local
+record cache - which is also why the pre-existing `MergeBoundAnchorRegression` tests (issue #4226) never
+caught this: they all wrap their MERGE call in an explicit `db.transaction(() -> ...)`.
+
+## Fix
+
+`MergeStep` re-resolves a bound anchor vertex to its latest committed state, via
+`context.getDatabase().lookupByRID(rid, true)`, right before its edges are enumerated - mirroring
+`SetStep.reloadLatestDoc()` (issue #5227). Two call sites needed it:
+
+- `findAllMatchingPaths`: the anchor vertex read from `baseResult` before it is handed to
+  `traverseFromAnchor` (the `anchorIdx > 0`, no-usable-index path).
+- `traverseFromNode`: the vertex resolved from the row's own binding (`forcedVertex == null`, i.e. the
+  node-0 anchor case reached when `anchorIdx == 0` or no anchor was found at all) before
+  `traverseEdgesFromVertex` walks it.
+
+A new private helper, `reloadAnchorVertex(Vertex)`, does the reload and is a no-op (returns the input
+unchanged) when the vertex has no identity yet (not persisted) or was concurrently deleted, leaving the
+existing not-found handling downstream to react to that.
+
+`tryFindPathByIndexSeek`'s own read of the anchor was left alone: it only uses the anchor for an identity
+`equals()` check against the freshly-index-resolved candidate's own (already fresh) edge list, never for
+edge enumeration on the anchor itself - which is exactly why the unique-index path was never affected by
+this bug in the first place (as the issue's "masked when indexed" note observes).
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java`, two cases,
+both driven through unwrapped `database.command(...)` calls (no outer `database.transaction()`), matching
+the shape that actually exposes the bug:
+
+- `unwindMergeReusingBoundAnchorDoesNotDuplicateEdgeOrFarEndpoint` - the issue's realistic repro
+  (`MATCH ... UNWIND [10,10,20] AS cid MERGE (p)-[:HAS]->(c:Chi {id:cid})`); asserts 2 edges and one `Chi`
+  node per distinct id.
+- `repeatedMergeOnSameBoundPairDoesNotDuplicateEdge` - the issue's minimal form
+  (`MATCH (a),(b) MERGE (a)-[:L]->(b) MERGE (a)-[:L]->(b)`); asserts exactly 1 edge.
+
+Both fail on pre-fix `MergeStep` (3 edges / 2 edges respectively, matching the issue's reported counts) and
+pass after the fix.
+
+## Verification
+
+- `Issue6461MergeAnchorStaleEdgeListTest` (new): 2/2 pass.
+- `OpenCypherMergeTest` (46 tests, all `@Nested` regression groups including `MergeBoundAnchorRegression`
+  for #4226) + `OpenCypherMergeActionsTest` (13) + `Issue6367MergeStepAutoRetryTest` (1) +
+  `Issue6602MergeAfterEmptyMatchCardinalityTest` (7) + `MergeInsertSlowdownTest` (1) +
+  `RefactorMergeNodesTest` (13): all green, no regressions.
+- Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`/`slow`/`vector` lanes): see below.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.Record;
+import com.arcadedb.database.RID;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
@@ -386,7 +387,8 @@ public class MergeStep extends AbstractExecutionStep {
       return results;
     }
 
-    final Vertex anchorVertex = (Vertex) baseResult.getProperty(pathPattern.getNode(anchorIdx).getVariable());
+    // #6461: reload before walking its edges below - see reloadAnchorVertex.
+    final Vertex anchorVertex = reloadAnchorVertex((Vertex) baseResult.getProperty(pathPattern.getNode(anchorIdx).getVariable()));
     traverseFromAnchor(pathPattern, anchorIdx, anchorVertex, copyResult(baseResult), results);
     return results;
   }
@@ -733,7 +735,10 @@ public class MergeStep extends AbstractExecutionStep {
       if (bound instanceof Vertex v) {
         if (vertex != null && !vertex.equals(v))
           return;
-        vertex = v;
+        // #6461: vertex == null here means v is the row's own anchor instance (forcedVertex is only
+        // ever non-null when this node was just reached via a live edge traversal below, which is
+        // already fresh) - reload it before its edges are enumerated below. See reloadAnchorVertex.
+        vertex = vertex == null ? reloadAnchorVertex(v) : v;
       }
     }
 
@@ -1105,6 +1110,37 @@ public class MergeStep extends AbstractExecutionStep {
       // Record may have been removed or be inaccessible
     }
     return null;
+  }
+
+  /**
+   * Re-resolves a bound anchor vertex to its latest committed state before its edges are enumerated
+   * (issue #6461). {@code executeMerge} wraps each row in its own {@code database.transaction(..., true)}
+   * (see that method's Javadoc / issue #6367); when the caller has no outer transaction open, each row's
+   * MERGE owns and commits its own transaction. A vertex instance the row carries - bound by an earlier
+   * MATCH, or reused across UNWIND rows of the same MERGE - was loaded before its row's transaction
+   * started, so once a PRIOR row's MERGE appends the first edge in a direction to it (the one write that
+   * rewrites the vertex record's edge-list head pointer) the row's own instance still reflects the
+   * pre-append state and a direct {@code vertex.getEdges(...)} on it would miss that edge.
+   * <p>
+   * {@code database.lookupByRID} re-reads that RID - the current transaction's cache first, the page
+   * store otherwise - so it observes the latest COMMITTED state regardless of which transaction wrote it,
+   * unlike the row's own possibly-stale instance. Mirrors {@code SetStep.reloadLatestDoc} (issue #5227).
+   *
+   * @return the reloaded vertex, or {@code anchor} unchanged if it has no identity yet (not persisted) or
+   * was concurrently deleted (left for the ordinary not-found handling downstream to react to)
+   */
+  private Vertex reloadAnchorVertex(final Vertex anchor) {
+    if (anchor == null)
+      return null;
+    final RID rid = anchor.getIdentity();
+    if (rid == null)
+      return anchor;
+    try {
+      final Record fresh = context.getDatabase().lookupByRID(rid, true);
+      return fresh instanceof Vertex v ? v : anchor;
+    } catch (final RecordNotFoundException e) {
+      return anchor;
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6461MergeAnchorStaleEdgeListTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6461: MERGE of a relationship duplicates it (and, for an unbound far
+ * endpoint, its far endpoint) when the anchor vertex was bound earlier in the same query.
+ * <p>
+ * {@code MergeStep.executeMerge} wraps each row it processes in {@code database.transaction(..., true)}
+ * (see the class Javadoc on that method / issue #6367). When the caller has no outer transaction open -
+ * an unwrapped autocommit call, exactly the shape {@code BoltNetworkExecutor.handleRun} uses, and the
+ * shape a raw engine {@code database.command(...)} call has - each row's MERGE owns and commits its own
+ * transaction. The anchor vertex instance the row carries (bound by an earlier {@code MATCH}, or reused
+ * across {@code UNWIND} rows of the same MERGE) was loaded before that per-row transaction started, so
+ * once a prior row's MERGE appends the FIRST edge in a direction to it - the one write that rewrites the
+ * vertex record's edge-list head pointer - the row's own instance still reflects the pre-append state.
+ * {@code findAllMatchingPaths}/{@code traverseFromNode} trusted that instance and enumerated its edges
+ * directly, missing the edge/node a previous row already created and creating a duplicate.
+ * <p>
+ * Over HTTP this is invisible: {@code DatabaseAbstractHandler.executeInTransaction()} wraps the whole
+ * autocommit command in one outer transaction, so every row's MERGE simply joins it and shares its
+ * transaction-local record cache. These tests reproduce the unwrapped shape directly against the engine.
+ */
+class Issue6461MergeAnchorStaleEdgeListTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-6461-merge-anchor-stale-edge-list").create();
+    database.getSchema().createVertexType("Par");
+    database.getSchema().createVertexType("Chi");
+    database.getSchema().createVertexType("A");
+    database.getSchema().createEdgeType("HAS");
+    database.getSchema().createEdgeType("L");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * Realistic repro from the issue: an anchor bound once by MATCH, then reused by MERGE across several
+   * UNWIND rows, some of which resolve to the same not-yet-existing child. The second `cid=10` row must
+   * see the child/edge the first row created instead of creating a duplicate.
+   */
+  @Test
+  void unwindMergeReusingBoundAnchorDoesNotDuplicateEdgeOrFarEndpoint() {
+    database.command("opencypher", "CREATE (p:Par {id:1})");
+
+    database.command("opencypher",
+        "MATCH (p:Par {id:1}) UNWIND [10,10,20] AS cid MERGE (p)-[:HAS]->(c:Chi {id:cid})");
+
+    final ResultSet edgeCount = database.query("opencypher", "MATCH (:Par)-[r:HAS]->(:Chi) RETURN count(r) AS c");
+    assertThat(edgeCount.next().<Number>getProperty("c").longValue()).isEqualTo(2);
+
+    final Map<Object, Long> childCountsById = new HashMap<>();
+    final ResultSet children = database.query("opencypher", "MATCH (c:Chi) RETURN c.id AS id, count(*) AS c");
+    while (children.hasNext()) {
+      final Result r = children.next();
+      childCountsById.put(r.getProperty("id"), ((Number) r.getProperty("c")).longValue());
+    }
+    assertThat(childCountsById).containsEntry(10L, 1L).containsEntry(20L, 1L);
+  }
+
+  /**
+   * Minimal form from the issue: two MERGE clauses on the same already-bound pair in one query must
+   * match the same edge the second time round, not create a second one.
+   */
+  @Test
+  void repeatedMergeOnSameBoundPairDoesNotDuplicateEdge() {
+    database.command("opencypher", "CREATE (a:A {n:'a'})");
+    database.command("opencypher", "CREATE (b:A {n:'b'})");
+
+    database.command("opencypher",
+        "MATCH (a:A {n:'a'}),(b:A {n:'b'}) MERGE (a)-[:L]->(b) MERGE (a)-[:L]->(b)");
+
+    final ResultSet edgeCount = database.query("opencypher", "MATCH (:A)-[r:L]->(:A) RETURN count(r) AS c");
+    assertThat(edgeCount.next().<Number>getProperty("c").longValue()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes MERGE of a relationship duplicating it (and, for an unbound far endpoint, its far endpoint) when
the anchor vertex was bound earlier in the same query.

`MergeStep.executeMerge` wraps each row it processes in its own `database.transaction(..., true)` call
(added for #6367's auto-retry). When the caller has no outer transaction open - an unwrapped autocommit
call, exactly the shape `BoltNetworkExecutor.handleRun` uses, and the shape a raw
`database.command(...)` call has - each row's MERGE owns and commits its own transaction.

The anchor vertex instance a row carries (bound by an earlier `MATCH`, or reused across `UNWIND` rows of
the same MERGE) was loaded before that row's own transaction started. Once a **prior** row's MERGE
appends the first edge in a given direction to that vertex - the one write that rewrites the vertex
record's edge-list head pointer - the row's own in-memory instance still reflects the pre-append state.
`findAllMatchingPaths` (via `traverseFromAnchor`) and `traverseFromNode` both took that instance straight
from the row and called `vertex.getEdges(...)` on it directly, so the match half of a later row misses
the edge/node a previous row already created and its create half runs, producing a duplicate.

This is not caught by the existing `getMostUpdatedVertex`/transaction-record-cache mechanism
(`ImmutableVertex.getEdges` already consults it), because that only helps when the reader and the writer
share the same `TransactionContext` - not the case here, since each unwrapped row commits and starts a
new one.

Over HTTP this is invisible: `DatabaseAbstractHandler.executeInTransaction()` wraps the *entire*
autocommit command in one outer transaction, so every row's MERGE simply joins it and shares its
transaction-local record cache - which is also why the pre-existing `MergeBoundAnchorRegression` tests
(#4226) never caught this: they all wrap their MERGE call in an explicit `db.transaction(() -> ...)`.

**Fix**: `MergeStep` re-resolves a bound anchor vertex to its latest committed state, via
`context.getDatabase().lookupByRID(rid, true)`, right before its edges are enumerated - mirroring
`SetStep.reloadLatestDoc()` (#5227). Two call sites needed it:

- `findAllMatchingPaths`: the anchor vertex read from `baseResult` before it is handed to
  `traverseFromAnchor` (the `anchorIdx > 0`, no-usable-index path).
- `traverseFromNode`: the vertex resolved from the row's own binding (the node-0 anchor case, reached
  when `anchorIdx == 0` or no anchor was found at all) before `traverseEdgesFromVertex` walks it.

`tryFindPathByIndexSeek`'s own read of the anchor was left alone: it only uses the anchor for an identity
`equals()` check against the freshly-index-resolved candidate's own (already fresh) edge list, never for
edge enumeration on the anchor itself - which is exactly why the unique-index path was never affected by
this bug (as the issue's "masked when indexed" note observes).

## Motivation

Issue #6461: MERGE idempotency is broken on the common un-indexed graph-building path whenever the
anchor is bound earlier in the same query and the write isn't wrapped in an outer transaction (Bolt
autocommit, or any raw `database.command(...)` caller).

## Related issues

Closes #6461

## Additional Notes

Root-cause analysis and verification log: see `docs/6461-merge-anchor-stale-edge-list.md` in this branch.

No deferred review items yet; this section will be updated if any review feedback is deferred during the
automated review loop.

## Test plan

- [x] New regression test `Issue6461MergeAnchorStaleEdgeListTest` (2 cases, both driven through
  unwrapped `database.command(...)` calls matching the shape that exposes the bug):
  - `unwindMergeReusingBoundAnchorDoesNotDuplicateEdgeOrFarEndpoint` - the issue's realistic repro
    (`MATCH ... UNWIND [10,10,20] AS cid MERGE (p)-[:HAS]->(c:Chi {id:cid})`); asserts 2 edges and one
    `Chi` node per distinct id.
  - `repeatedMergeOnSameBoundPairDoesNotDuplicateEdge` - the issue's minimal form
    (`MATCH (a),(b) MERGE (a)-[:L]->(b) MERGE (a)-[:L]->(b)`); asserts exactly 1 edge.
  - Both fail on pre-fix `MergeStep` (3 edges / 2 edges respectively, matching the issue's reported
    counts) and pass after the fix.
- [x] `OpenCypherMergeTest` (46 tests across all `@Nested` regression groups, including
  `MergeBoundAnchorRegression` for #4226) + `OpenCypherMergeActionsTest` (13) +
  `Issue6367MergeStepAutoRetryTest` (1) + `Issue6602MergeAfterEmptyMatchCardinalityTest` (7) +
  `MergeInsertSlowdownTest` (1) + `RefactorMergeNodesTest` (13): all green, no regressions.
- [x] Full `com.arcadedb.query.opencypher.**` package (excluding `benchmark`/`slow`/`vector` lanes):
  8884 tests, 0 failures, 0 errors, 98 skipped (pre-existing skips, unrelated to this change).

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
