### PR TITLE
fix(vector): defer close-time graph rebuild for large mutated indexes

### DIFF
--- a/docs/release-26.9.1.md
+++ b/docs/release-26.9.1.md
@@ -3880,3 +3880,31 @@ read noticed first. An unreadable *chunk* of a vertex that does exist keeps the 
 `ConcurrentModificationException` and #5764's scoped advice, on both paths.
 
 [#6586](https://github.com/ArcadeData/arcadedb/issues/6586)
+
+## Closing a database no longer blocks on a full vector graph rebuild for large indexes (#6067)
+
+`LSMVectorIndex.close()` persists the graph before shutting down, so that a fast restart finds a ready-to-search
+graph rather than rebuilding on first open. For an index with any pending write (`graphState == MUTABLE`, or a
+first-ever build that never persisted), that persist has always meant a full `buildGraphFromScratch()` - there is
+no incremental update, so any rebuild reindexes every vector in the index, not just the ones written since the
+last build. That cost was paid synchronously on the closing thread regardless of index size: a single write to a
+200,000-vector index measured `close()` blocking for roughly 43 seconds, the same cost as writing a thousand
+vectors, because the rebuild's cost tracks total index size rather than what was actually written.
+
+`close()` now defers that rebuild instead of running it, for any index at or above the same size threshold the
+search path already uses to decide between a synchronous and an asynchronous rebuild (1,000 vectors,
+`arcadedb.vectorIndex.mutationsBeforeRebuild`'s sibling knob is unaffected). The vectors themselves are unaffected
+by any of this - they go through ordinary page/WAL persistence independent of the graph file, so nothing is lost
+by skipping the rebuild - only the graph's on-disk topology is left stale or absent. The next time that index is
+actually searched, after any reopen, the existing stale-persisted-graph detection (the same manifest/node-count
+check that already handles a persisted graph left behind by an unrelated shutdown) notices and rebuilds it lazily
+before answering the query.
+
+**Upgrading:** a session that writes to a large vector index and closes without ever searching it again no longer
+pays the rebuild cost at all - not at close, and not later, since nothing forces it until a search actually needs
+the graph. A session that does go on to search that index pays the same total rebuild cost as before, just moved
+from `close()` to that first query instead - so a query immediately after reopening a large, recently-written
+index may be noticeably slower than the queries that follow it, where `close()` used to absorb that latency
+instead. Below the 1,000-vector threshold, `close()` keeps rebuilding synchronously as before, unaffected.
+
+[#6067](https://github.com/ArcadeData/arcadedb/issues/6067)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3148,7 +3148,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Above this threshold, a full rebuild can take seconds to minutes, so async is preferred.
    * <p>
    * Also the threshold {@link #flush()} uses to decide whether a close-time rebuild is cheap enough to run
-   * synchronously or should be deferred to the next open instead (issue #6067).
+   * synchronously or should be deferred to the next SEARCH on this index instead (issue #6067) - opening the
+   * database alone never triggers it, only {@link #ensureGraphAvailable()}/{@link #rebuildGraphBeforeSearch()}
+   * do, and that deferred rebuild is itself still synchronous on whichever search first reaches it, not async.
    */
   private static final int ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000;
   private static final int[] EMPTY_ORDINALS             = new int[0];
@@ -6432,7 +6434,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
         // with no persisted graph - and defer the rebuild to whenever this index is next actually searched,
         // reusing the exact lazy-load/staleness-detection path (ensureGraphAvailable()) that already handles a
         // stale persisted graph on every ordinary reopen. A session that closes and reopens without searching
-        // this index never pays the cost at all; one that does pays it at the query instead of at close().
+        // this index never pays the cost at all; one that does pays it at the query instead of at close() - that
+        // follow-up rebuild is itself still synchronous on the search that triggers it (ensureGraphAvailable()'s
+        // stale-graph fallback is not gated by this same threshold), so this trades an unconditional cost on
+        // EVERY close() for a conditional one paid by at most one search, not for a non-blocking one.
         LogManager.instance().log(this, Level.FINE,
             "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
                 + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3146,6 +3146,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
   /**
    * Minimum graph size to use async rebuild. Below this, synchronous rebuild is fast enough.
    * Above this threshold, a full rebuild can take seconds to minutes, so async is preferred.
+   * <p>
+   * Also the threshold {@link #flush()} uses to decide whether a close-time rebuild is cheap enough to run
+   * synchronously or should be deferred to the next open instead (issue #6067).
    */
   private static final int ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000;
   private static final int[] EMPTY_ORDINALS             = new int[0];
@@ -6420,6 +6423,20 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 + "stay on disk and are re-indexed on the next open. This means flush() was called after "
                 + "releaseBackgroundResources() - both close paths are supposed to do the reverse",
             indexName, mutationsSinceSerialize.get());
+      } else if (needsBuild && vectorIndex.size() >= ASYNC_REBUILD_MIN_GRAPH_SIZE) {
+        // A synchronous full rebuild here would block close() for as long as the whole rebuild takes - measured
+        // (issue #6067) at 43s for a single write to a 200k-vector index, scaling with total index size rather
+        // than with what was actually written, because there is no incremental persist: any rebuild is a full
+        // rebuild. The vectors themselves are already durably persisted (ordinary page/WAL writes, unrelated to
+        // the graph); only the graph TOPOLOGY is stale or absent. Leave graphState as-is - MUTABLE, or LOADING
+        // with no persisted graph - and defer the rebuild to whenever this index is next actually searched,
+        // reusing the exact lazy-load/staleness-detection path (ensureGraphAvailable()) that already handles a
+        // stale persisted graph on every ordinary reopen. A session that closes and reopens without searching
+        // this index never pays the cost at all; one that does pays it at the query instead of at close().
+        LogManager.instance().log(this, Level.FINE,
+            "Deferring graph build on close for index %s: %d vectors is at or above the async rebuild threshold "
+                + "(%d), so the rebuild is deferred to the next search on this index instead of blocking close()",
+            indexName, vectorIndex.size(), ASYNC_REBUILD_MIN_GRAPH_SIZE);
       } else if (needsBuild) {
         try {
           LogManager.instance()

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
@@ -141,6 +141,96 @@ class Issue6067DeferredCloseRebuildTest {
     }
   }
 
+  /**
+   * Sibling of the test above, covering the OTHER arm of the same {@code needsBuild} condition:
+   * {@code graphState == LOADING && !graphAlreadyOnDisk} (a graph never built at all, as opposed to one rebuilt
+   * after an existing build). Both arms reach the identical deferral branch in {@code flush()} and the identical
+   * fallback in {@code ensureGraphAvailable()}, but only the rebuilt-index arm was covered above.
+   * <p>
+   * {@code graphState} starts as {@code LOADING} on every constructed instance (both "new index" and "load
+   * existing index"), but a fresh insert into a never-built index flips it straight to {@code MUTABLE} - so a
+   * single populate-then-close session actually exercises the MUTABLE arm, same as the test above, not this one.
+   * Reaching {@code LOADING} at {@code flush()} time needs a session that touches the index NEITHER by writing
+   * NOR by searching: reopen a large index that a previous session already left un-built (deferred by the fix
+   * under test), and close it again immediately - {@code graphState} then stays exactly what the constructor set
+   * it to.
+   * <p>
+   * Unlike the test above, this one is NOT a fails-before/passes-after timing pin: the pre-fix code always builds
+   * and persists a graph on every close that has one to do, so the very state this test needs (a large index,
+   * closed twice, with no persisted graph either time) is only reachable once the fix exists - pre-fix, the
+   * first close already does the build, and the second close then finds nothing left to do and is trivially
+   * fast for an unrelated reason. So instead of timing, this pins {@code graphRebuildCount} directly: zero
+   * rebuilds across both closes, exactly one once the deferred data is finally searched.
+   */
+  @Test
+  void closeDefersTheFirstEverBuildForALargeIndexToo() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        // Closes with graphState == MUTABLE (see javadoc above) - the fix under test defers this build too, so
+        // no graph is persisted yet. That is the starting condition this test actually needs, not its subject.
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: LOADING - reopening alone (with no write or search in this session) must not "
+                + "advance graphState, otherwise this does not exercise the "
+                + "graphState == LOADING && !graphAlreadyOnDisk arm")
+            .isEqualTo(0L); // GraphState.LOADING
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise close() takes the pre-existing "
+                + "small-graph synchronous path unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("precondition: the previous session's close must not have built anything either, or this test "
+                + "is not exercising the LOADING && !graphAlreadyOnDisk arm at all")
+            .isZero();
+
+        db.close();
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        final LSMVectorIndex index = vectorIndex(db);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("neither close() above must have built anything: this pins the actual behaviour under test, "
+                + "since a timing bound alone cannot distinguish 'deferred' from 'nothing was ever built', see "
+                + "the class javadoc")
+            .isZero();
+
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt")).isEqualTo((long) NUM_VECTORS);
+        }
+
+        final var results = index.findNeighborsFromVector(randomVector(new Random(7)), 5, 64);
+        assertThat(results)
+            .as("the deferred first-ever build must still make every vector reachable by search after reopen")
+            .hasSize(5);
+        assertThat(index.getStats().get("graphRebuildCount"))
+            .as("the search above must be what finally triggers the deferred build - it was owed since the "
+                + "first close two sessions ago")
+            .isEqualTo(1L);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
   private static float[] extraVector() {
     return randomVector(new Random(5));
   }

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue6067DeferredCloseRebuildTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.FileUtils;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6067: {@code flush()}'s rebuild-before-close condition (triggered whenever
+ * {@code graphState == MUTABLE}, i.e. any write since the last graph build) always calls
+ * {@code buildGraphFromScratch()} SYNCHRONOUSLY on the closing thread, with no size-based deferral - unlike the
+ * search path's {@code rebuildGraphBeforeSearch()}, which already runs an async rebuild above 1000 vectors
+ * ({@code ASYNC_REBUILD_MIN_GRAPH_SIZE}).
+ * <p>
+ * Measured on the issue (comment from 2026-08-23): a single write to a 200,000-vector index made {@code close()}
+ * block for ~43 seconds - the same cost whether one vector or a thousand were written, because the rebuild is
+ * always a full one. The fix defers the close-time rebuild to the next search on the index once the index is at
+ * or above {@code ASYNC_REBUILD_MIN_GRAPH_SIZE}, reusing {@code ensureGraphAvailable()}'s existing
+ * stale-persisted-graph detection (already exercised on every ordinary reopen) rather than paying the full cost
+ * synchronously inside {@code close()}.
+ * <p>
+ * Two things are pinned here, because either alone would pass against a half-fix: {@code close()} itself must
+ * return promptly (not merely "eventually", which a half-fixed async-but-still-blocking-close variant could also
+ * satisfy), and no data may be lost - a later reopen and search must still find every vector, including the one
+ * written after the last full build, once the deferred rebuild actually runs.
+ * <p>
+ * Same per-vector build parameters as {@code LSMVectorIndexCloseCancelsInFlightBuildTest} (128 dimensions,
+ * {@code maxConnections=64}, {@code beamWidth=400}), scaled up to 20,000 vectors so a full rebuild reliably takes
+ * multiple real seconds - long enough that the tripwire bound below cannot pass by accident.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue6067DeferredCloseRebuildTest {
+  private static final String DB_ROOT         = "target/test-databases/Issue6067DeferredCloseRebuildTest";
+  private static final int    DIMENSIONS      = 128;
+  private static final int    NUM_VECTORS     = 20_000;
+  private static final int    MAX_CONNECTIONS = 64;
+  private static final int    BEAM_WIDTH      = 400;
+
+  private String dbPath;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    dbPath = DB_ROOT + "-" + testInfo.getTestMethod().orElseThrow().getName();
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(dbPath));
+  }
+
+  @Test
+  void closeDefersTheRebuildForALargeMutatedIndexInsteadOfBlockingOnAFullRebuild() throws Exception {
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.create();
+      try {
+        populate(db);
+        final LSMVectorIndex index = vectorIndex(db);
+
+        // Force one complete, persisted build so the index starts IMMUTABLE rather than LOADING - isolates the
+        // case under test (a single write after an already-built graph) from the separate first-ever-build case.
+        index.buildVectorGraphNow();
+        assertThat(index.getStats().get("graphState")).as("precondition: graph must be built and IMMUTABLE first")
+            .isEqualTo(1L); // GraphState.IMMUTABLE
+
+        // One more write - mirrors the issue's own measurement that cost does not scale with what was written.
+        db.transaction(
+            () -> db.newDocument("Doc").set("id", NUM_VECTORS).set("vector", extraVector()).save());
+
+        assertThat(index.getStats().get("graphState"))
+            .as("precondition: MUTABLE, otherwise flush()'s rebuild-before-close condition is never reached")
+            .isEqualTo(2L); // GraphState.MUTABLE
+        assertThat(index.getStats().get("totalVectors"))
+            .as("precondition: above the async-rebuild threshold, otherwise close() takes the pre-existing "
+                + "small-graph synchronous path unaffected by this fix")
+            .isGreaterThanOrEqualTo(1000L);
+
+        final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+        db.close();
+        // Measured on this fixture: ~50ms deferred vs. ~2.4s for a full synchronous rebuild - the bound below
+        // is a tripwire between the two (see StallAwareStopwatch), with wide margin on both sides.
+        stopwatch.assertGaveUpWithin(1_000,
+            "a close() that defers the graph rebuild from one that runs a full synchronous rebuild to completion");
+      } finally {
+        if (db.isOpen())
+          db.close();
+      }
+    }
+
+    // Reopen and verify nothing was lost: the deferred rebuild must still make every vector - including the one
+    // written after the last full build - reachable by search once it actually runs, proving the fix trades
+    // promptness for a lazily-paid rebuild, not for correctness.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      final Database db = factory.open();
+      try {
+        try (final ResultSet rs = db.query("sql", "SELECT count(*) as cnt FROM Doc")) {
+          assertThat(rs.next().<Long>getProperty("cnt")).isEqualTo((long) (NUM_VECTORS + 1));
+        }
+
+        final LSMVectorIndex index = vectorIndex(db);
+        final var results = index.findNeighborsFromVector(extraVector(), 5, 64);
+        assertThat(results)
+            .as("the deferred rebuild must still make the vector written right before close() reachable by "
+                + "search after reopen")
+            .hasSize(5);
+      } finally {
+        db.drop();
+      }
+    }
+  }
+
+  private static float[] extraVector() {
+    return randomVector(new Random(5));
+  }
+
+  private static void populate(final Database db) {
+    final Random rnd = new Random(7);
+    db.transaction(() -> {
+      final var type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("id", Type.INTEGER);
+      type.createProperty("vector", Type.ARRAY_OF_FLOATS);
+      db.command("sql", "CREATE INDEX ON Doc (vector) LSM_VECTOR METADATA { \"dimensions\": " + DIMENSIONS
+          + ", \"similarity\": \"COSINE\", \"maxConnections\": " + MAX_CONNECTIONS
+          + ", \"beamWidth\": " + BEAM_WIDTH + " }");
+    });
+
+    db.begin();
+    for (int i = 0; i < NUM_VECTORS; i++) {
+      db.newDocument("Doc").set("id", i).set("vector", randomVector(rnd)).save();
+      if (i % 1000 == 999) {
+        db.commit();
+        db.begin();
+      }
+    }
+    db.commit();
+  }
+
+  private static float[] randomVector(final Random rnd) {
+    final float[] vector = new float[DIMENSIONS];
+    for (int d = 0; d < DIMENSIONS; d++)
+      vector[d] = rnd.nextFloat();
+    return vector;
+  }
+
+  private static LSMVectorIndex vectorIndex(final Database db) {
+    return (LSMVectorIndex) db.getSchema().getType("Doc")
+        .getPolymorphicIndexByProperties("vector").getIndexesOnBuckets()[0];
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6067.

`LSMVectorIndex.flush()`'s rebuild-before-close condition triggers whenever `graphState == MUTABLE` (i.e. any write since the last graph build), and always calls `buildGraphFromScratch()` **synchronously** on the closing thread - unlike the search path's `rebuildGraphBeforeSearch()`, which already prefers an async rebuild above `ASYNC_REBUILD_MIN_GRAPH_SIZE` (1000) vectors.

A comment on the issue measured the real cost: a single write to a 200,000-vector index made `close()` block for ~43 seconds, the same cost as writing a thousand vectors, because there's no incremental persist - any rebuild is a full one.

Note: the issue's original description (`close()` = `releaseBackgroundResources(); flush();`, with the second build racing an unprotected pool) predates #6518's fix, which already reordered `close()` to `flush(); releaseBackgroundResources();` so the build pool stays alive for the close-time rebuild. That race no longer applies as originally described - but the underlying synchronous-full-rebuild-on-close problem is real and is what this PR addresses, backed by the fresh benchmark in the issue thread.

### Fix

At or above `ASYNC_REBUILD_MIN_GRAPH_SIZE`, `flush()` now leaves `graphState` as-is instead of rebuilding synchronously. The graph is rebuilt lazily the next time the index is actually searched, reusing the existing stale-persisted-graph detection in `ensureGraphAvailable()` - the same path that already handles a stale graph on every ordinary reopen. The vectors themselves are already durably persisted (ordinary page/WAL writes, unrelated to the graph); only the graph *topology* is deferred.

- A session that closes and reopens an index without searching it again never pays the rebuild cost at all.
- A session that does search it pays the cost at the query instead of at `close()`.
- Below the threshold, `close()` keeps rebuilding synchronously as before (cheap, keeps the fast-restart benefit for small indexes).

This mirrors the size-based policy already used by the search path, rather than an all-or-nothing skip.

## Test plan

- [x] New regression test `Issue6067DeferredCloseRebuildTest` (tagged `slow`): builds a 20,000-vector index (128 dims, maxConnections=64, beamWidth=400 - same per-vector cost as `LSMVectorIndexCloseCancelsInFlightBuildTest`), forces one full build, writes one more vector, then asserts `close()` gives up within 1s via `StallAwareStopwatch.assertGaveUpWithin` (measured: ~50ms after the fix vs. ~3.1s before it - confirmed failing against the pre-fix code). Reopens the database afterwards and confirms every vector, including the one written right before `close()`, is still reachable by search - no data loss from deferring the rebuild.
- [x] Full `com.arcadedb.index.vector.*Test` suite (409 tests) passes, including the pre-existing close-path regression tests (`Issue6518CloseDoesNotLeakBuildPoolTest`, `LSMVectorIndexCloseCancelsInFlightBuildTest`).
- [x] `mvn -pl engine -am compile` clean.

https://claude.ai/code/session_0124ucXhoDv5kRUb3WpZjjXd