### PR TITLE
fix(#6459): graph pathfinding honours arcadedb.command.timeout

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -35,6 +35,7 @@ import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.utility.FileUtils;
 
 import java.util.HashMap;
@@ -159,6 +160,11 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     final Vertex start = paramSourceVertex;
     final Vertex goal = paramDestinationVertex;
 
+    // Neither maxDepth (defaults to Long.MAX_VALUE) nor graph exhaustion is a bound the caller controls, so
+    // arcadedb.command.timeout has to be consulted from inside this loop like every other graph-driven
+    // algorithm (issue #6459) - astar()/dijkstra() previously had no timeout/interrupt check at all.
+    final WorkGuard guard = WorkGuard.forCommand(ctx, NAME + "()");
+
     open.add(start);
 
     // The cost of going from start to start is zero.
@@ -167,6 +173,8 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     fScore.put(start, getHeuristicCost(start, null, goal, ctx));
 
     while (!open.isEmpty()) {
+      guard.check();
+
       Vertex current = open.poll();
 
       // we discussed about this feature in https://github.com/orientechnologies/orientdb/pull/6002#issuecomment-212492687

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -36,6 +36,7 @@ import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.function.sql.math.SQLFunctionMathAbstract;
+import com.arcadedb.query.sql.executor.WorkGuard;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
 
@@ -203,6 +204,12 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
     shortestPathContext.queueRight.add(shortestPathContext.destinationVertex);
     shortestPathContext.rightVisited.add(shortestPathContext.destinationVertex.getIdentity());
 
+    // With no maxDepth (the default) the only bound left is graph exhaustion, and arcadedb.command.timeout was
+    // never consulted here - only the thread-interrupt check below, which needs an explicit cancel rather than
+    // the configured timeout (issue #6459). The deadline is checked once per BFS layer, matching the
+    // per-layer granularity already used by the Cypher unconstrained allShortestPaths() BFS.
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     int depth = 1;
     while (true) {
       if (shortestPathContext.maxDepth != null && shortestPathContext.maxDepth <= depth) {
@@ -213,6 +220,7 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
 
       if (Thread.interrupted())
         throw new CommandExecutionException("The shortestPath() function has been interrupted");
+      guard.check();
 
       List<RID> neighborIdentity;
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ShortestPathExpression.java
@@ -143,7 +143,7 @@ public class ShortestPathExpression implements Expression {
     if (constraint != null) {
       final String[] typesArray = edgeTypes == null || edgeTypes.isEmpty() ? null : edgeTypes.toArray(new String[0]);
       final List<Object> filtered = ShortestPathStep.computeFilteredShortestPath(startVertex, endVertex,
-          traversalDirection, typesArray, constraint);
+          traversalDirection, typesArray, constraint, context);
       if (filtered == null || filtered.isEmpty())
         return allPaths ? new ArrayList<>() : null;
       // allShortestPaths() in expression position still yields the single shortest path found, matching the

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -216,7 +216,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
     // matching edges only.
     final EdgeConstraint constraint = edgeConstraint(inputResult, context);
     if (constraint != null)
-      return computeFilteredShortestPath(source, target, patternDirection(), patternEdgeTypesArray(), constraint);
+      return computeFilteredShortestPath(source, target, patternDirection(), patternEdgeTypesArray(), constraint, context);
 
     // Collect every relationship type declared in the pattern. Variable-length type alternation
     // (e.g. [:R1|R2*]) is expressed as a single relationship with multiple types - all of them
@@ -290,7 +290,7 @@ public class ShortestPathStep extends AbstractExecutionStep {
     final EdgeConstraint constraint = edgeConstraint(inputResult, context);
     if (constraint != null)
       return computeFilteredAllShortestPaths(source, target, patternDirection(), patternEdgeTypesArray(), constraint,
-          context.getDatabase());
+          context.getDatabase(), context);
 
     final List<String> edgeTypes;
     if (pattern.getRelationshipCount() > 0 && pattern.getRelationship(0).hasTypes())
@@ -526,9 +526,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * with different property values are disambiguated correctly.
    *
    * @param edgeTypes restrict edges to these types, or null/empty to allow any type
+   * @param context   the command context the deadline is read from; {@code null} leaves only the interrupt check
+   *                  (issue #6459 - this constrained BFS previously consulted neither, unlike the unconstrained
+   *                  frontier walk it falls back from)
    */
   public static List<Object> computeFilteredShortestPath(final Vertex source, final Vertex target,
-      final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint) {
+      final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint,
+      final CommandContext context) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -548,9 +552,12 @@ public class ShortestPathStep extends AbstractExecutionStep {
     Deque<Vertex> frontier = new ArrayDeque<>();
     frontier.add(source);
 
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     while (!frontier.isEmpty()) {
       if (Thread.interrupted())
         throw new CommandExecutionException("The shortestPath() function has been interrupted");
+      guard.check();
 
       final Deque<Vertex> next = new ArrayDeque<>();
       for (final Vertex v : frontier) {
@@ -606,10 +613,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
    * distinct paths OpenCypher requires.
    *
    * @param edgeTypes restrict edges to these types, or null/empty to allow any type
+   * @param context   the command context the deadline is read from; {@code null} leaves only the interrupt check
+   *                  (issue #6459 - this constrained BFS previously consulted neither, unlike the unconstrained
+   *                  layered BFS it falls back from)
    */
   public static List<List<Object>> computeFilteredAllShortestPaths(final Vertex source, final Vertex target,
       final Vertex.DIRECTION direction, final String[] edgeTypes, final EdgeConstraint constraint,
-      final Database database) {
+      final Database database, final CommandContext context) {
     final RID sourceRid = source.getIdentity();
     final RID targetRid = target.getIdentity();
     if (sourceRid.equals(targetRid)) {
@@ -630,9 +640,12 @@ public class ShortestPathStep extends AbstractExecutionStep {
     int currentDepth = 0;
     int foundDepth = -1;
 
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     while (!currentLayer.isEmpty()) {
       if (Thread.interrupted())
         throw new CommandExecutionException("The allShortestPaths() function has been interrupted");
+      guard.check();
 
       if (foundDepth >= 0 && currentDepth >= foundDepth)
         break;

--- a/engine/src/test/java/com/arcadedb/query/Issue6459GraphPathfindingCommandTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/query/Issue6459GraphPathfindingCommandTimeoutTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.StallAwareStopwatch;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for issue #6459 - {@code arcadedb.command.timeout} is purely cooperative, but the graph
+ * path-finding functions consulted it nowhere: {@code astar()}/{@code dijkstra()} had no deadline or interrupt
+ * check at all, SQL {@code shortestPath()} checked only a thread interrupt (never the deadline), and the Cypher
+ * constrained {@code shortestPath()}/{@code allShortestPaths()} BFS (the edge-property / inline-{@code WHERE}
+ * fallback) did the same - unlike the unconstrained BFS right next to it, which was already guarded.
+ * <p>
+ * Each test below reuses the graph shape proven effective by {@link Issue6266CommandTimeoutCoverageTest}: a
+ * 20,000-node ring with two chords per node (out-degree 3, so every node has both directions once the edges are
+ * made bidirectional). One pass over a graph this size costs seconds, comfortably clearing the 50 ms deadline used
+ * here by orders of magnitude - so a check placed inside the loop aborts almost immediately and one placed nowhere
+ * (or only between unrelated checkpoints) runs to graph exhaustion first, which is exactly the distinction the
+ * issue is about.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6459GraphPathfindingCommandTimeoutTest {
+  private static final int NODES = 20_000;
+  /** A vertex with no edges at all: astar()/dijkstra() can never reach it, so they have to exhaust the whole
+   *  20,000-node component before giving up - unless the deadline stops them first. */
+  private static final int UNREACHABLE_IDX = NODES;
+
+  private static final String DB_PATH = "./target/databases/test-issue-6459-pathfinding-command-timeout";
+
+  private static Database database;
+  private static RID[]     nodeRid;
+  private static RID       unreachableRid;
+  /** A second ring, the same size and shape as the first but sharing no edge with it, so a bidirectional
+   *  meet-in-the-middle BFS between the two components can never meet: each side has to exhaust its own
+   *  20,000-node component before its frontier goes empty. A far-but-reachable pair on ONE chorded ring does
+   *  not do this - the out-degree-3 branching plus the two long chords give it small-world diameter, so a
+   *  bidirectional search finds a real path within a handful of layers regardless of the guard. */
+  private static RID[]     otherComponentRid;
+
+  @BeforeAll
+  static void setup() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node").createProperty("v", Type.INTEGER);
+    database.getSchema().createEdgeType("LINK");
+    database.getSchema().getType("Node").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "v");
+
+    nodeRid = new RID[NODES];
+    otherComponentRid = new RID[NODES];
+
+    database.transaction(() -> {
+      nodeRid = buildRing(NODES, 0);
+      otherComponentRid = buildRing(NODES, NODES + 1);
+
+      unreachableRid = database.newVertex("Node").set("v", UNREACHABLE_IDX).save().getIdentity();
+    });
+  }
+
+  /**
+   * Ring plus two chords per node, exactly as {@link Issue6266CommandTimeoutCoverageTest}: out-degree 3, and
+   * bidirectional (the {@code true} argument) so every node also has in-edges. {@code vBase} offsets the {@code v}
+   * property so two rings built back to back get disjoint values and share no vertex.
+   */
+  private static RID[] buildRing(final int size, final int vBase) {
+    final MutableVertex[] vertices = new MutableVertex[size];
+    for (int i = 0; i < size; i++)
+      vertices[i] = database.newVertex("Node").set("v", vBase + i).save();
+
+    for (int i = 0; i < size; i++) {
+      vertices[i].newEdge("LINK", vertices[(i + 1) % size], true, new Object[] { "w", 1.0 }).save();
+      vertices[i].newEdge("LINK", vertices[(i + 7) % size], true, new Object[] { "w", 1.0 }).save();
+      vertices[i].newEdge("LINK", vertices[(i + 31) % size], true, new Object[] { "w", 1.0 }).save();
+    }
+
+    final RID[] rids = new RID[size];
+    for (int i = 0; i < size; i++)
+      rids[i] = vertices[i].getIdentity();
+    return rids;
+  }
+
+  @AfterAll
+  static void teardown() {
+    if (database != null)
+      database.drop();
+  }
+
+  @AfterEach
+  void resetTimeout() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, 0L);
+    // A test that arms the interrupt flag must not leave it set for whatever runs next on this thread.
+    Thread.interrupted();
+  }
+
+  // ── astar() / dijkstra(): had no timeout or interrupt check at all ────────
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void astarHonoursTheCommandTimeoutOnAnUnreachableDestination() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainSql(
+        "select expand(astar(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
+        .as("astar() previously consulted neither the deadline nor a thread interrupt, so it explored the "
+            + "whole reachable component before ever answering")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "astar() aborted from inside its main loop, not after exhausting the graph");
+  }
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void dijkstraHonoursTheCommandTimeoutOnAnUnreachableDestination() {
+    // dijkstra() delegates straight to a fresh SQLFunctionAstar, so it shares the fix as well as the bug.
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainSql(
+        "select expand(dijkstra(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
+        .as("dijkstra() must not survive its own unreachable-destination search past the deadline")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "dijkstra() aborted from inside astar()'s main loop");
+  }
+
+  @Test
+  void astarStillReturnsTheCorrectPathWhenNothingAborts() {
+    final List<Result> rows = drainSql("select expand(astar(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))");
+    assertThat(rows).as("a healthy call must still find a path once the guard is in place").isNotEmpty();
+    assertThat(rows.getFirst().getIdentity()).contains(nodeRid[0]);
+  }
+
+  @Test
+  void dijkstraStillReturnsTheCorrectPathWhenNothingAborts() {
+    final List<Result> rows = drainSql("select expand(dijkstra(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))");
+    assertThat(rows).as("a healthy call must still find a path once the guard is in place").isNotEmpty();
+    assertThat(rows.getFirst().getIdentity()).contains(nodeRid[0]);
+  }
+
+  @Test
+  @Timeout(30)
+  void astarStopsOnAThreadInterruptEvenWithoutADeadline() {
+    // Before this fix astar() consulted no interrupt either - a caller had no way at all to cancel a run.
+    Thread.currentThread().interrupt();
+
+    assertThatThrownBy(() -> drainSql("select expand(astar(" + nodeRid[0] + ", " + unreachableRid + ", 'w'))"))
+        .as("astar() must be at least abortable via an explicit cancel")
+        .hasStackTraceContaining("astar() has been interrupted");
+  }
+
+  // ── SQL shortestPath(): checked Thread.interrupted() but never the deadline ─
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void sqlShortestPathHonoursTheCommandTimeoutOnAnUnreachableDestination() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    // Both endpoints sit on a fully separate ring: the search can never meet, so walkLeft/walkRight together
+    // have to exhaust both 20,000-node components before the outer loop notices the frontiers are empty -
+    // unless the deadline stops them first.
+    assertThatThrownBy(() -> drainSql(
+        "select expand(shortestPath(" + nodeRid[0] + ", " + otherComponentRid[0] + "))"))
+        .as("shortestPath() checked Thread.interrupted() but never arcadedb.command.timeout")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "the bidirectional BFS aborted from inside walkLeft/walkRight's caller");
+  }
+
+  @Test
+  void sqlShortestPathStillReturnsAPathWhenNothingAborts() {
+    final List<Result> rows = drainSql("select expand(shortestPath(" + nodeRid[0] + ", " + nodeRid[3] + "))");
+    assertThat(rows).as("a healthy call must still find a path once the guard is in place").isNotEmpty();
+  }
+
+  // ── Cypher MATCH shortestPath()/allShortestPaths(): the constrained BFS ────
+  // fallback (an inline WHERE or property map on the relationship) had neither check, unlike the unconstrained
+  // BFS right next to it.
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void cypherConstrainedShortestPathHonoursTheCommandTimeout() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = shortestPath((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", NODES / 2)))
+        .as("an inline WHERE forces the edge-aware BFS (computeFilteredShortestPath), which consulted neither "
+            + "check before this fix")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "the constrained frontier walk aborted from inside its own loop");
+  }
+
+  @Test
+  @Tag("slow")
+  @Timeout(120)
+  void cypherConstrainedAllShortestPathsHonoursTheCommandTimeout() {
+    setTimeout(50);
+
+    final StallAwareStopwatch stopwatch = StallAwareStopwatch.start();
+    assertThatThrownBy(() -> drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = allShortestPaths((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", NODES / 2)))
+        .as("computeFilteredAllShortestPaths shares the same gap as its computeFilteredShortestPath sibling")
+        .hasStackTraceContaining(GlobalConfiguration.COMMAND_TIMEOUT.getKey());
+    stopwatch.assertGaveUpWithin(60_000L, "the constrained layered BFS aborted from inside its own loop");
+  }
+
+  @Test
+  void cypherShortestPathFormsStillReturnCorrectPathsWhenNothingAborts() {
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = shortestPath((a)-[:LINK*]-(b)) RETURN p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the unconstrained MATCH form must still find a path")
+        .isNotEmpty();
+
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = shortestPath((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the constrained MATCH form (inline WHERE) must still find a path")
+        .isNotEmpty();
+
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}), p = allShortestPaths((a)-[r:LINK* WHERE r.w > 0]-(b)) RETURN p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the constrained allShortestPaths() form must still find at least one path")
+        .isNotEmpty();
+
+    assertThat(drainCypher(
+        "MATCH (a:Node {v: $src}), (b:Node {v: $dst}) RETURN shortestPath((a)-[r:LINK* WHERE r.w > 0]-(b)) AS p",
+        Map.of("src", 0, "dst", 3)))
+        .as("the RETURN-position expression form (ShortestPathExpression) shares the same fix")
+        .isNotEmpty();
+  }
+
+  // ── The default, disabled by default, leaves every form alone ─────────────
+
+  @Test
+  void theDisabledDefaultLeavesEveryFormAlone() {
+    assertThat(database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMAND_TIMEOUT))
+        .as("the setting is off by default, so none of the checks added for this issue may fire")
+        .isZero();
+
+    assertThat(drainSql("select expand(astar(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))")).isNotEmpty();
+    assertThat(drainSql("select expand(dijkstra(" + nodeRid[0] + ", " + nodeRid[3] + ", 'w'))")).isNotEmpty();
+    assertThat(drainSql("select expand(shortestPath(" + nodeRid[0] + ", " + nodeRid[3] + "))")).isNotEmpty();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private static void setTimeout(final long millis) {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMAND_TIMEOUT, millis);
+  }
+
+  private static List<Result> drainSql(final String query) {
+    return drain("sql", query, Map.of());
+  }
+
+  private static List<Result> drainCypher(final String query) {
+    return drain("opencypher", query, Map.of());
+  }
+
+  private static List<Result> drainCypher(final String query, final Map<String, Object> params) {
+    return drain("opencypher", query, params);
+  }
+
+  private static List<Result> drain(final String language, final String query, final Map<String, Object> params) {
+    final List<Result> rows = new java.util.ArrayList<>();
+    try (final ResultSet rs = params.isEmpty() ? database.query(language, query) : database.query(language, query, params)) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+    return rows;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

`astar()`/`dijkstra()`, SQL `shortestPath()`, and the Cypher constrained `shortestPath()`/`allShortestPaths()`
BFS now consult `arcadedb.command.timeout` (and, for `astar()`/`dijkstra()`, a thread interrupt) inside their
hot loops, using the existing `WorkGuard` helper the way the already-guarded siblings next to each of them do.

- `SQLFunctionAstar.internalExecute` takes a `WorkGuard.forCommand(ctx, "astar()")` and checks it once per
  popped node. `SQLFunctionDijkstra` delegates straight to a fresh `SQLFunctionAstar`, so it shares the fix
  as well as the bug it had.
- `SQLFunctionShortestPath.execute`'s main loop takes a `WorkGuard.forCommandDeadline(context)` and checks it
  alongside the `Thread.interrupted()` check that was already there (that one only ever caught an explicit
  cancel, never the configured timeout).
- `ShortestPathStep.computeFilteredShortestPath` and `computeFilteredAllShortestPaths` (the edge-property /
  inline-`WHERE` constrained BFS fallback used by both the `MATCH p = shortestPath(...)` step and the
  `RETURN shortestPath(...)` expression form) now take a `CommandContext` parameter and guard their frontier
  loop exactly like the unconstrained BFS sitting right next to each of them already does.

## Motivation

`arcadedb.command.timeout` is purely cooperative - no watchdog interrupts the query thread, only a loop that
consults the deadline can be stopped. None of the graph path-finding entry points did, so `astar()`/
`dijkstra()` and both SQL and Cypher `shortestPath()`/`allShortestPaths()` could pin a query thread
indefinitely (exploring the whole reachable component, or worse) despite a configured timeout - see the
repro steps on the issue.

## Related issues

Closes #6459

## Additional Notes

New regression test: `engine/src/test/java/com/arcadedb/query/Issue6459GraphPathfindingCommandTimeoutTest.java`.
It reuses the graph shape `Issue6266CommandTimeoutCoverageTest` already proved effective (a 20,000-node ring
with two chords per node) plus a second, fully disconnected copy of that ring for the bidirectional SQL
`shortestPath()` case - a reachable-but-far-apart pair on one chorded ring turned out to have small-world
diameter (the out-degree-3 branching plus the two long chords let a bidirectional search meet within a
handful of layers), so the test needed a pair that can never meet, matching the issue's own "explores the
whole reachable component" framing.

Before trusting the test, I temporarily reverted the four source changes in the worktree and reran it: rather
than a clean assertion failure, the unguarded search accumulated enough live state to OOM-crash the forked
test JVM - strong independent evidence the loops really were unbounded. With the fix restored all 11 tests in
the new class pass in under 2 seconds, and the existing astar/dijkstra/shortestPath/Cypher-shortestPath test
classes plus the related `WorkGuard`/`arcadedb.command.timeout` coverage suites (`Issue6302AlgoGraphDrivenWorkGuardTest`,
`Issue6266CommandTimeoutCoverageTest`, `Issue6304TimeoutFollowUpsTest`, `Issue6264AlgoIterationKnobGuardTest`,
`Issue6216AlgoWorkKnobBoundsTest`, `Issue6295AlgoUnguardedPhaseTest`) all still pass (one apsp deadline test in
that last group failed once under heavy parallel-build load on this machine and passed cleanly standalone -
unrelated code path, pre-existing timing sensitivity documented in that test's own class comment, not touched
by this change).

`computeFilteredShortestPath`/`computeFilteredAllShortestPaths` are public static methods that gained a
trailing `CommandContext` parameter; both of their call sites (`ShortestPathStep` itself and
`ShortestPathExpression`) are updated, and a repo-wide grep plus a full `mvn -am compile` confirm there are no
other callers.

## Checklist

- [x] I have run the build using `mvn clean package` command (scoped: `mvn -pl engine -am test-compile` plus
  targeted `mvn -pl engine test` runs - see Additional Notes)
- [x] My unit tests cover both failure and success scenarios