### PR TITLE
fix(#6533,#6534): accumulate asyncParallelLevel; close the quiesce/resize race

### DIFF
--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -187,7 +187,11 @@ public class Profiler {
       final DatabaseAsyncExecutorImpl async = asyncIfExists(db);
       final DatabaseAsyncExecutorImpl.DBAsyncStats asyncStats = async != null ? async.getStats() : null;
       acc[STAT_ASYNC_QUEUE] += asyncStats != null ? asyncStats.queueSize : 0L;
-      acc[STAT_ASYNC_PARALLEL] = async != null ? async.getParallelLevel() : 0L;
+      // #6533: this used to be a plain assignment, so with more than one database open the exported reading was
+      // whichever database the identity-hashed iteration happened to visit last - not a sum, and unstable between
+      // consecutive scrapes of an unchanged server. Summed like every other entry in this array: the JVM-wide
+      // question this answers is "how many async worker threads does this process have", matching asyncQueueLength.
+      acc[STAT_ASYNC_PARALLEL] += async != null ? async.getParallelLevel() : 0L;
       acc[STAT_ASYNC_RETIRING] += asyncStats != null ? asyncStats.retiringWorkers : 0L;
     }
     return acc;

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -2369,7 +2369,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // The cost is symmetric: an administrative resize now waits behind an index build for as long as the build's
     // own quiescence takes, bounded by {@link #quiesceTimeoutMillis()}. That is the correct precedence - a resize is
     // an administrative convenience, a scan under a torn view is a wrong answer - and it was already true in the
-    // other direction (a quiescence already waited behind a resize's own bounded drain).
+    // other direction (a quiescence already waited behind a resize's own bounded drain). One reachable shape of that
+    // wait (code review, PR #6661): a worker task that calls {@code setParallelLevel()} on its OWN executor while a
+    // quiescence started by someone else is in progress now blocks on {@code resizeLock} for up to
+    // {@code quiesceTimeoutMillis()} (60s by default) rather than only the previous brief scheduling-loop window -
+    // and that worker being blocked also means it never reaches the queued park task this quiescence is waiting on,
+    // so the two time out together rather than deadlocking. Nothing built into the engine does this (compaction and
+    // index builds never call {@code setParallelLevel()}); it is the same category of unusual call as the self-join
+    // {@link #awaitRetiredThreads(AsyncThread[])} already guards against, just bounded instead of unrecoverable.
     //
     // What is NOT closed: a worker a PRIOR shrink retired and left draining past its own {@code shutdownJoinTimeoutMs}
     // budget is alive but off the published array and not in this quiescence's snapshot, so it is not parked by it -

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -2427,19 +2427,24 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       return held;
 
     } finally {
+      // FAILURE PATH: let go of any worker that reached its park task before the failure - and do it BEFORE
+      // releasing resizeLock below - so the invariant the success path relies on holds on this path too: by the
+      // time resizeLock is released, every worker this quiescence touched is either still fully live (never
+      // reached the park task) or has already been let go, never one caught mid-release, still blocked on a latch
+      // that only this method can count down.
+      if (!handedOver && release != null)
+        release.countDown();
+
       // Released here regardless of outcome, INCLUDING success: by this point every worker snapshotted above has
-      // already confirmed parked (or the method is throwing), so a resize that starts the instant this unlocks can
-      // only retire or create workers this quiescence never promised to cover - see the class comment above.
-      // Holding it any longer, for the life of the handle the caller gets back, would put every later resize behind
-      // however long the caller keeps the scan open, which is not what "bounded by the quiesce timeout" means.
+      // already confirmed parked, or - on the failure path - just been released above, so a resize that starts the
+      // instant this unlocks can only retire or create workers this quiescence never promised to cover - see the
+      // class comment above. Holding it any longer, for the life of the handle the caller gets back, would put
+      // every later resize behind however long the caller keeps the scan open, which is not what "bounded by the
+      // quiesce timeout" means.
       resizeLock.unlock();
-      if (!handedOver) {
-        // Nothing owns the release, so it happens here: any worker that reached its park task before the failure is
-        // let go, and the lock goes back so the next caller can try.
-        if (release != null)
-          release.countDown();
+      if (!handedOver)
+        // The lock goes back so the next caller can try.
         quiesceLock.unlock();
-      }
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -141,6 +141,12 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * Serializes {@link #setParallelLevel(int)} against itself, and is held for the WHOLE resize - the publish AND
    * the wait for whatever the publish retired (issue #6526 review, point 2).
    * <p>
+   * Since issue #6534 it has a second holder with a different bound: {@link #quiesceWorkers()} takes it for its
+   * WHOLE quiescence too - the park-task scheduling AND the wait for every worker to confirm parked - not only the
+   * scheduling loop. So contention on this lock can now mean either a resize waiting on
+   * {@code shutdownJoinTimeoutMs} (10s default) or a quiescence waiting on {@link #quiesceTimeoutMillis()} (60s
+   * default); see the javadoc of both methods for why each holds it that long.
+   * <p>
    * The drain wait cannot be taken under {@code lifecycleLock}: that lock is what a concurrent {@code close()} or
    * {@code kill()} needs to force the very workers being waited for, so holding it across the wait would make the
    * wait the thing that prevents its own end. But releasing every lock leaves a second resize free to grow the pool

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1604,12 +1604,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * runs on. Bounded and loud (that timeout is logged at WARNING) rather than silent, and the alternative - waiting
    * without a bound - makes an administrative call hostage to a worker wedged in user code.
    * <p>
-   * <b>What it does not do.</b> A retired worker is not parked by a {@link #quiesceWorkers()} that is already in
-   * progress - the park task would land behind the exit marker on its queue - so an index build racing a shrink can
-   * still see a draining worker write under its scan. That is the same residual {@code quiesceWorkers()} already
-   * names for workers created after its own check, it is narrower here than it was under the teardown (the wait
-   * above closes it for anything that starts after the resize returns), and closing it properly means gating the
-   * async lifecycle on the quiescence, which is a lock on a path an index build has to race a resize to reach.
+   * <b>What it does not do (issue #6534, mostly closed).</b> {@code quiesceWorkers()} now takes {@code resizeLock}
+   * for its whole quiescence, not only the scheduling loop, so this method cannot publish a shrink - or a grow -
+   * while a quiescence is in progress: either blocks on {@code resizeLock} until the other finishes. The residual
+   * that survives is narrower than a plain race: a worker THIS resize retired and left draining past its own
+   * {@code shutdownJoinTimeoutMs} budget (the paragraph above) is alive, off the published array, and not covered by
+   * a quiescence that starts afterwards - the park task would land behind the exit marker already queued on it,
+   * which would never run. That corner needs the wedged worker to finish or be {@code kill()}ed, not a lock.
    */
   @Override
   public void setParallelLevel(final int parallelLevel) {
@@ -2352,8 +2353,40 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // parked on a latch nobody will ever count down is lost until the database closes, which is a worse outcome than
     // the failure that got us there.
     CountDownLatch release = null;
+
+    // HELD FOR THE WHOLE QUIESCENCE (issue #6534), not just the scheduling loop below. A shrinking
+    // setParallelLevel() also holds this lock across its own publish-and-wait, so as long as this method holds it
+    // too, no worker this quiescence is about to snapshot can be retired - or created by a concurrent grow - between
+    // the read of executorThreads and the moment every one of them has confirmed parked:
+    // <ul>
+    //   <li>a SHRINK cannot start while this is held, so a worker cannot leave the array unparked mid-quiescence;
+    //   the residual this closes is the one named on {@link #setParallelLevel(int)}: an index build that used to be
+    //   able to start while a shrink was draining and scan data a retired, unparked worker was still writing;</li>
+    //   <li>a GROW cannot start either, so a worker created after the snapshot below - which this quiescence could
+    //   never have parked, since it schedules exactly {@code threads.length} park tasks against that snapshot - no
+    //   longer exists to write anything unparked under the scan.</li>
+    // </ul>
+    // The cost is symmetric: an administrative resize now waits behind an index build for as long as the build's
+    // own quiescence takes, bounded by {@link #quiesceTimeoutMillis()}. That is the correct precedence - a resize is
+    // an administrative convenience, a scan under a torn view is a wrong answer - and it was already true in the
+    // other direction (a quiescence already waited behind a resize's own bounded drain).
+    //
+    // What is NOT closed: a worker a PRIOR shrink retired and left draining past its own {@code shutdownJoinTimeoutMs}
+    // budget is alive but off the published array and not in this quiescence's snapshot, so it is not parked by it -
+    // the corner {@code setParallelLevel()}'s javadoc names as "wedged inside user code", which this quiescence
+    // cannot help either since a park task behind that worker's already-queued {@code FORCE_EXIT} would never run.
+    //
+    // Lock order is quiesceLock (held) -> resizeLock -> lifecycleLock, and nothing takes them the other way round:
+    // setParallelLevel() never touches quiesceLock, and close()/kill() take only lifecycleLock.
+    resizeLock.lock();
     try {
-      final CountDownLatch parked;
+      final AsyncThread[] threads = executorThreads;
+      if (threads == null || threads.length == 0) {
+        // Shut down between the check above and here: nothing to park, and the lock this holds is given back by
+        // the handle like any other.
+        handedOver = true;
+        return new HeldQuiesce(null, true);
+      }
 
       // ONE PARK TASK PER WORKER, which needs the pool it is sized against to be the pool the tasks are scheduled
       // onto (#6526 review round 8). scheduleTask() re-reads executorThreads on every call, and since #6526 a slot
@@ -2363,41 +2396,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       // duplicates queued behind it never run: a latch sized for the old pool that can no longer reach zero, and a
       // caller - an index build - that waits out the whole quiesce timeout before failing. Measured: 60s and a
       // NeedRetryException where the answer should have been immediate.
-      //
-      // So the READ AND THE LOOP ARE BOTH INSIDE resizeLock, not just the loop: a snapshot taken outside it is
-      // already stale by the time the lock is acquired, which is the same bug one window earlier.
-      //
-      // Held for that ONLY, not for the quiescence: a shrink that lands afterwards is harmless, because the park
-      // task is already ahead of the exit marker on the retired worker's queue and still runs, counts down and
-      // parks. Keeping the lock any longer would put an administrative resize behind a whole index build.
-      //
-      // Lock order is quiesceLock (held) -> resizeLock -> lifecycleLock, and nothing takes them the other way
-      // round: setParallelLevel() never touches quiesceLock, and close()/kill() take only lifecycleLock.
-      resizeLock.lock();
-      try {
-        final AsyncThread[] threads = executorThreads;
-        if (threads == null || threads.length == 0) {
-          // Shut down between the check above and here: nothing to park, and the lock this holds is given back by
-          // the handle like any other.
-          handedOver = true;
-          return new HeldQuiesce(null, true);
-        }
+      final CountDownLatch parked = new CountDownLatch(threads.length);
+      release = new CountDownLatch(1);
 
-        parked = new CountDownLatch(threads.length);
-        release = new CountDownLatch(1);
-
-        for (int i = 0; i < threads.length; i++)
-          // waitIfQueueIsFull, so a busy worker is queued behind rather than skipped: an unparked worker is exactly
-          // the hole this method exists to close, and a `false` here would be one - which is why the old call
-          // site's discarded boolean mattered. Any refusal (a worker that has shut down) throws, and the finally
-          // below releases whatever was already parked.
-          if (!scheduleTask(i, new DatabaseAsyncParkWorker(parked, release), true, 0))
-            throw new NeedRetryException(
-                "Cannot quiesce the asynchronous executor of database '" + database.getName() + "': worker " + i
-                    + " refused the park task");
-      } finally {
-        resizeLock.unlock();
-      }
+      for (int i = 0; i < threads.length; i++)
+        // waitIfQueueIsFull, so a busy worker is queued behind rather than skipped: an unparked worker is exactly
+        // the hole this method exists to close, and a `false` here would be one - which is why the old call
+        // site's discarded boolean mattered. Any refusal (a worker that has shut down) throws, and the finally
+        // below releases whatever was already parked.
+        if (!scheduleTask(i, new DatabaseAsyncParkWorker(parked, release), true, 0))
+          throw new NeedRetryException(
+              "Cannot quiesce the asynchronous executor of database '" + database.getName() + "': worker " + i
+                  + " refused the park task");
 
       final long timeout = quiesceTimeoutMillis();
       try {
@@ -2417,6 +2427,12 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       return held;
 
     } finally {
+      // Released here regardless of outcome, INCLUDING success: by this point every worker snapshotted above has
+      // already confirmed parked (or the method is throwing), so a resize that starts the instant this unlocks can
+      // only retire or create workers this quiescence never promised to cover - see the class comment above.
+      // Holding it any longer, for the life of the handle the caller gets back, would put every later resize behind
+      // however long the caller keeps the scan open, which is not what "bounded by the quiesce timeout" means.
+      resizeLock.unlock();
       if (!handedOver) {
         // Nothing owns the release, so it happens here: any worker that reached its park task before the failure is
         // let go, and the lock goes back so the next caller can try.

--- a/engine/src/test/java/com/arcadedb/Issue6533ProfilerAsyncParallelLevelTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue6533ProfilerAsyncParallelLevelTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6533: {@code Profiler.collectDatabaseStats()} folded every open database's stat into
+ * one accumulator with {@code +=}, except {@code asyncParallelLevel}, which was a plain assignment. With more than
+ * one database open, the exported reading was whichever database the identity-hashed iteration visited last - not a
+ * sum - and could change between consecutive scrapes of an otherwise unchanged server, since {@code IdentityHashMap}
+ * iteration order depends on identity hash codes that vary per run.
+ * <p>
+ * Asserts both that the reading is the SUM across the open databases (not one of them) and that it is STABLE across
+ * repeated {@code toJSON()} calls, since the failure mode this guards against is instability, not merely a wrong
+ * one-off value.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6533ProfilerAsyncParallelLevelTest {
+
+  private static final String DB_PATH_1 = "target/databases/issue6533-profiler-async-parallel-1";
+  private static final String DB_PATH_2 = "target/databases/issue6533-profiler-async-parallel-2";
+
+  @Test
+  void asyncParallelLevelIsTheSumAcrossOpenDatabasesAndStaysStable() {
+    FileUtils.deleteRecursively(new File(DB_PATH_1));
+    FileUtils.deleteRecursively(new File(DB_PATH_2));
+
+    try (final DatabaseFactory factory1 = new DatabaseFactory(DB_PATH_1);
+         final DatabaseFactory factory2 = new DatabaseFactory(DB_PATH_2)) {
+
+      final long baseline = profilerAsyncParallelLevel();
+
+      final Database db1 = factory1.create();
+      final Database db2 = factory2.create();
+      try {
+        final DatabaseAsyncExecutorImpl async1 = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) db1).async();
+        final DatabaseAsyncExecutorImpl async2 = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) db2).async();
+
+        // Two DIFFERENT levels, so an assignment that merely picked "whichever was visited last" would read as one
+        // of these two values rather than their sum, and could flip between them across scrapes.
+        async1.setParallelLevel(3);
+        async2.setParallelLevel(5);
+
+        final long expected = baseline + 3 + 5;
+
+        // Read several times: the bug was not a wrong single snapshot but an UNSTABLE one across scrapes of an
+        // unchanged server (IdentityHashMap iteration order depends on identity hash codes).
+        for (int i = 0; i < 5; i++)
+          assertThat(profilerAsyncParallelLevel())
+              .as("asyncParallelLevel must be the sum across every open database, not whichever one iteration " +
+                  "happened to visit last, and must stay stable across repeated scrapes")
+              .isEqualTo(expected);
+      } finally {
+        db1.drop();
+        db2.drop();
+      }
+
+      assertThat(profilerAsyncParallelLevel())
+          .as("closing both databases must remove their contribution from the JVM-wide reading")
+          .isEqualTo(baseline);
+    }
+  }
+
+  private static long profilerAsyncParallelLevel() {
+    return Profiler.INSTANCE.toJSON().getJSONObject("asyncParallelLevel").getLong("count", -1L);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.database.async;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -47,7 +48,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class Issue6534QuiesceResizeRaceTest extends TestHelper {
 
+  // The 3s polling window below (code review, PR #6661) puts this on the slower end - comparable to the
+  // WORKER_HOLD_MS-scale tests in Issue6526AsyncExecutorFollowUpsTest, which carry the same tag.
   @Test
+  @Tag("slow")
   @Timeout(60)
   void aGrowCannotPublishWhileAQuiescenceIsStillWaitingOnABusyWorker() throws Exception {
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
@@ -90,18 +90,21 @@ class Issue6534QuiesceResizeRaceTest extends TestHelper {
     }, "issue6534-quiescer");
     quiescer.start();
 
-    // Give the quiescer time to acquire resizeLock, snapshot the pool and schedule its park task - which now sits
-    // queued behind the busy task above and cannot run until releaseTask counts down.
-    Thread.sleep(300);
-
     final Thread grower = new Thread(() -> async.setParallelLevel(3), "issue6534-grower");
     grower.start();
 
-    // The grow must still be blocked on resizeLock: give it a moment, then confirm it has NOT published yet.
-    Thread.sleep(300);
-    assertThat(async.getThreadCount())
-        .as("a grow must not publish a new pool size while a quiescence is still waiting on a busy worker to park")
-        .isEqualTo(1);
+    // Polled rather than a single check after a fixed sleep (code review, PR #6661): a one-shot check could flake
+    // on a slow/contended runner that had not yet let the quiescer reach resizeLock.lock() and schedule its park
+    // task within the sleep window, reporting a false pass rather than exercising the race. Sampling continuously
+    // over a generous window means the assertion only ever fails when the grow ACTUALLY published early - which is
+    // the regression this test exists to catch - not when the scheduler was merely slow to run the quiescer.
+    final long deadline = System.currentTimeMillis() + 3_000;
+    while (System.currentTimeMillis() < deadline) {
+      assertThat(async.getThreadCount())
+          .as("a grow must not publish a new pool size while a quiescence is still waiting on a busy worker to park")
+          .isEqualTo(1);
+      Thread.sleep(20);
+    }
     assertThat(quiesceReturned.getCount()).as("the quiescence itself must still be waiting too").isEqualTo(1L);
 
     // Let the busy task finish: its park task can now run, count down the latch and let the quiescence complete.

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6534QuiesceResizeRaceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6534: {@code quiesceWorkers()} used to release {@code resizeLock} right after
+ * scheduling its park tasks, BEFORE waiting for them to be confirmed. A concurrent {@code setParallelLevel()} GROW
+ * landing in that window published brand-new workers that this quiescence's park latch was never sized to include -
+ * so the quiescence could confirm "everything is parked" and hand back a clean barrier while a worker that came into
+ * existence a moment earlier was free to write, entirely unparked. An index build reading right after would then be
+ * scanning under a torn view, precisely the failure {@code quiesceWorkers()} exists to prevent (#6281).
+ * <p>
+ * The fix holds {@code resizeLock} for the WHOLE quiescence (scheduling AND the await), not just the scheduling
+ * loop, so a concurrent {@code setParallelLevel()} - grow or shrink - cannot publish anything until every worker this
+ * quiescence knows about has confirmed parked. This test pins that: a grow attempted while the quiescence is
+ * genuinely stuck waiting on a busy worker must not be able to publish its new pool size until the quiescence
+ * itself completes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6534QuiesceResizeRaceTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void aGrowCannotPublishWhileAQuiescenceIsStillWaitingOnABusyWorker() throws Exception {
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) ((DatabaseInternal) database).async();
+    async.setParallelLevel(1);
+
+    // Occupies the only worker so the park task the quiescence schedules behind it cannot run until this is
+    // released - which is what keeps the quiescence stuck in parked.await() for as long as this test needs.
+    final CountDownLatch taskStarted = new CountDownLatch(1);
+    final CountDownLatch releaseTask = new CountDownLatch(1);
+    assertThat(async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal db) {
+        taskStarted.countDown();
+        try {
+          assertThat(releaseTask.await(30, TimeUnit.SECONDS)).isTrue();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public void completed() {
+      }
+    }, true, 0)).isTrue();
+    assertThat(taskStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+    final AtomicReference<Throwable> quiesceFailure = new AtomicReference<>();
+    final CountDownLatch quiesceReturned = new CountDownLatch(1);
+    // quiesceLock is a plain ReentrantLock, so the handle it hands out must be closed by the SAME thread that
+    // acquired it - the quiescer below both opens and closes it, never the main test thread.
+    final CountDownLatch closeQuiesce = new CountDownLatch(1);
+    final Thread quiescer = new Thread(() -> {
+      try (final AsyncQuiesce quiesce = async.quiesceWorkers()) {
+        quiesceReturned.countDown();
+        assertThat(closeQuiesce.await(30, TimeUnit.SECONDS)).isTrue();
+      } catch (final Throwable e) {
+        quiesceFailure.set(e);
+        quiesceReturned.countDown();
+      }
+    }, "issue6534-quiescer");
+    quiescer.start();
+
+    // Give the quiescer time to acquire resizeLock, snapshot the pool and schedule its park task - which now sits
+    // queued behind the busy task above and cannot run until releaseTask counts down.
+    Thread.sleep(300);
+
+    final Thread grower = new Thread(() -> async.setParallelLevel(3), "issue6534-grower");
+    grower.start();
+
+    // The grow must still be blocked on resizeLock: give it a moment, then confirm it has NOT published yet.
+    Thread.sleep(300);
+    assertThat(async.getThreadCount())
+        .as("a grow must not publish a new pool size while a quiescence is still waiting on a busy worker to park")
+        .isEqualTo(1);
+    assertThat(quiesceReturned.getCount()).as("the quiescence itself must still be waiting too").isEqualTo(1L);
+
+    // Let the busy task finish: its park task can now run, count down the latch and let the quiescence complete.
+    releaseTask.countDown();
+
+    assertThat(quiesceReturned.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(quiesceFailure.get()).isNull();
+
+    closeQuiesce.countDown();
+    quiescer.join(30_000);
+    assertThat(quiescer.isAlive()).isFalse();
+    assertThat(quiesceFailure.get()).isNull();
+
+    grower.join(30_000);
+    assertThat(grower.isAlive()).as("the grow must not hang once the quiescence releases resizeLock").isFalse();
+    assertThat(async.getThreadCount()).as("the grow must have published once it was finally allowed to").isEqualTo(3);
+  }
+}


### PR DESCRIPTION
## Summary

- **#6533**: `Profiler.collectDatabaseStats()` folded every open database's stat into one accumulator with `+=`, except `asyncParallelLevel`, which was a plain assignment. With more than one database open, the exported reading (and its Studio / `GET /server` surface) was whichever database the identity-hashed iteration happened to visit last - not a sum - and could change between consecutive scrapes of an otherwise unchanged server. Fixed to `+=`, matching every other entry in the array.
- **#6534**: `quiesceWorkers()` released `resizeLock` right after scheduling its park tasks, before waiting for them to be confirmed parked. A concurrent `setParallelLevel()` **grow** landing in that window published brand-new workers this quiescence's park latch was never sized to include, so the quiescence could confirm "everything is parked" and hand back a clean barrier while an unparked worker was free to write - an index build reading right after would scan under a torn view (the exact failure #6281 exists to prevent). `resizeLock` is now held for the whole quiescence (scheduling **and** the await), matching what `setParallelLevel()` already does across its own publish-and-wait, so a concurrent resize cannot publish anything until every worker this quiescence knows about has confirmed parked. Javadoc on both methods updated to describe the residual that remains (a worker a *prior* shrink already gave up waiting on, past its own `shutdownJoinTimeoutMs`).
- **#6535**: closed as a documented accepted residual, not implemented. It's the same shrink-drain window from a different angle: a producer's fresh `getSlot()` can route to a survivor while the retired worker is still draining that bucket's queued tasks, so the two can briefly write the same bucket's pages. The issue's own analysis (confirmed before starting this work) is that every closing fix is materially riskier than the cost it removes: refusing producers during the drain reintroduces the #6505 incident, dropping the retired worker's queued work loses writes silently, and both remaining candidate directions (a per-bucket handover map, or a two-phase queue-transfer shrink) add real complexity to `getSlot()`/`scheduleTask()` - the lock-free scheduling hot path - for a cost that is already bounded, self-correcting, and covered end-to-end by the async retry path plus a pinning regression test (`Issue6526AsyncExecutorFollowUpsTest.aProducerPinnedToOneBucketKeepsWorkingAcrossAShrink`). Rationale posted on the issue.

## Test plan

- [x] `Issue6533ProfilerAsyncParallelLevelTest`: two databases at different parallel levels open; asserts the profiler reading is their **sum**, not either individual value, stable across repeated `toJSON()` calls. Verified it fails (`expected 8, was 3`) against the pre-fix assignment and passes with the fix.
- [x] `Issue6534QuiesceResizeRaceTest`: pins a worker in a long-running task so the quiescence's own park task queues behind it, then attempts a concurrent grow; asserts the grow cannot publish a new pool size until the quiescence completes. Verified it fails (`expected 1, was 3`) against the pre-fix code and passes with the fix.
- [x] Existing `Issue6526AsyncExecutorFollowUpsTest` (all resize/quiesce interaction tests), `Issue6303AsyncQuiesceTest` (index-build quiescence), `ProfilerTest`, `Issue5636ProfilerMonotonicTest` - all green, no regressions.
- [x] `mvn -o -pl engine -am compile` clean.

https://claude.ai/code/session_01Ho2s8oThF2cuitxbMsuD86

Fixes #6533
Fixes #6534
