### PR TITLE
fix: DISTINCT/UNION key collisions, WITH * internal vars, missing command-timeout guard on plain scans

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
+++ b/engine/src/main/java/com/arcadedb/function/DistinctNumericKey.java
@@ -21,6 +21,8 @@ package com.arcadedb.function;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -87,17 +89,25 @@ public final class DistinctNumericKey {
   }
 
   /**
-   * Builds a composite string key from {@code names}, in iteration order, by rendering each name's
-   * canonicalized value as {@code name=value|}. Shared by every Cypher duplicate-elimination step
-   * (RETURN DISTINCT, WITH DISTINCT, UNION) that dedups on a set of named values, so the
-   * {@link #canonicalize(Object)} behavior - including the RID canonicalization above - only needs
-   * to be applied in one place. Callers control ordering (and hence key stability across rows) by
-   * choosing what {@code names} they pass; this method does not sort or otherwise reorder it.
+   * Builds a composite key from {@code names}, in iteration order, as a flat {@code [name, value, name,
+   * value, ...]} list of each name paired with its canonicalized value. Shared by every Cypher
+   * duplicate-elimination step (RETURN DISTINCT, WITH DISTINCT, UNION) that dedups on a set of named
+   * values, so the {@link #canonicalize(Object)} behavior - including the RID canonicalization above -
+   * only needs to be applied in one place. Callers control ordering (and hence key stability across
+   * rows) by choosing what {@code names} they pass; this method does not sort or otherwise reorder it.
+   * <p>
+   * The key is a {@link List}, not a delimited string: {@link List#equals(Object)} compares elements
+   * structurally, so a value whose canonicalized {@code toString()} happens to contain a delimiter
+   * character can never collide with a differently-shaped row the way a rendered {@code name=value|}
+   * string could (issue #6540) - e.g. one property {@code a = "1|b=2"} and two properties
+   * {@code a=1, b=2} used to both render as {@code "a=1|b=2|"}.
    */
-  public static String buildKey(final Iterable<String> names, final Function<String, Object> valueOf) {
-    final StringBuilder keyBuilder = new StringBuilder();
-    for (final String name : names)
-      keyBuilder.append(name).append('=').append(canonicalize(valueOf.apply(name))).append('|');
-    return keyBuilder.toString();
+  public static List<Object> buildKey(final Iterable<String> names, final Function<String, Object> valueOf) {
+    final List<Object> key = new ArrayList<>();
+    for (final String name : names) {
+      key.add(name);
+      key.add(canonicalize(valueOf.apply(name)));
+    }
+    return key;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ProjectReturnStep.java
@@ -80,7 +80,7 @@ public class ProjectReturnStep extends AbstractExecutionStep {
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
       private boolean finished = false;
-      private final Set<String> seenResults = distinct ? new HashSet<>() : null;
+      private final Set<List<Object>> seenResults = distinct ? new HashSet<>() : null;
 
       @Override
       public boolean hasNext() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
@@ -75,7 +75,7 @@ public class UnionStep extends AbstractExecutionStep {
       private ResultSet currentResultSet = null;
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
-      private final Set<String> seenResults = removeDuplicates ? new HashSet<>() : null;
+      private final Set<List<Object>> seenResults = removeDuplicates ? new HashSet<>() : null;
       private boolean finished = false;
 
       @Override
@@ -131,7 +131,7 @@ public class UnionStep extends AbstractExecutionStep {
 
               // Apply deduplication for UNION (not UNION ALL)
               if (removeDuplicates) {
-                final String resultKey = buildResultKey(result);
+                final List<Object> resultKey = buildResultKey(result);
                 if (seenResults.contains(resultKey))
                   continue; // Skip duplicate
                 seenResults.add(resultKey);
@@ -151,7 +151,7 @@ public class UnionStep extends AbstractExecutionStep {
        * DistinctNumericKey so numerically-equal values (issue #5789) and graph-element references
        * sharing one RID (issue #6488) collapse together.
        */
-      private String buildResultKey(final Result result) {
+      private List<Object> buildResultKey(final Result result) {
         return DistinctNumericKey.buildKey(result.getPropertyNames(), result::getProperty);
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
@@ -19,6 +19,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.function.DistinctNumericKey;
+import com.arcadedb.query.opencypher.InternalVariables;
 import com.arcadedb.query.opencypher.LoadCSVRowContext;
 import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.ReturnClause;
@@ -79,7 +80,7 @@ public class WithStep extends AbstractExecutionStep {
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
       private boolean finished = false;
-      private final Set<String> seenResults = withClause.isDistinct() ? new HashSet<>() : null;
+      private final Set<List<Object>> seenResults = withClause.isDistinct() ? new HashSet<>() : null;
       private int skipped = 0;
       private int returned = 0;
 
@@ -188,7 +189,14 @@ public class WithStep extends AbstractExecutionStep {
               // renders as a placeholder instead of the actual values, so two references to the
               // very same record can render two different strings depending on load state alone
               // (issue #6488).
-              final String resultKey = DistinctNumericKey.buildKey(new TreeSet<>(projectedResult.getPropertyNames()), projectedResult::getProperty);
+              // WITH * forwards every property from the input row, including the executor's own
+              // internal bindings for anonymous pattern elements; those must not affect distinctness,
+              // the same reasoning ProjectReturnStep already applies to RETURN DISTINCT * (issue
+              // #5444), or two rows that only differ by such a binding would wrongly stay distinct
+              // (issue #6541).
+              final List<String> names = new TreeSet<>(projectedResult.getPropertyNames()).stream()
+                  .filter(name -> !InternalVariables.isInternal(name)).toList();
+              final List<Object> resultKey = DistinctNumericKey.buildKey(names, projectedResult::getProperty);
               if (seenResults.contains(resultKey))
                 continue;
               seenResults.add(resultKey);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
@@ -62,6 +62,9 @@ public class FetchFromClusterExecutionStep extends AbstractExecutionStep {
   @Override
   public ResultSet syncPull(final CommandContext context, final int nRecords) throws TimeoutException {
     pullPrevious(context, nRecords);
+    // A blocking consumer (aggregation, ORDER BY, DISTINCT) with no WHERE to guard can otherwise drain
+    // the whole bucket past arcadedb.command.timeout without anything ever checking it (issue #6465).
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
     final long begin = context.isProfiling() ? System.nanoTime() : 0;
     try {
       if (iterator == null) {
@@ -112,6 +115,8 @@ public class FetchFromClusterExecutionStep extends AbstractExecutionStep {
           try {
             if (nFetched >= nRecords)
               throw new NoSuchElementException();
+
+            guard.check();
 
 //            if (ORDER_DESC == order && !iterator.hasPrevious()) {
 //              throw new NoSuchElementException();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -103,6 +103,10 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     init(context.getDatabase());
 
+    // A blocking consumer (aggregation, ORDER BY, DISTINCT) with no WHERE to guard can otherwise drain
+    // the whole index past arcadedb.command.timeout without anything ever checking it (issue #6465).
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
+
     return new ResultSet() {
       int localCount = 0;
 
@@ -121,6 +125,8 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       public Result next() {
         if (!hasNext())
           throw new NoSuchElementException();
+
+        guard.check();
 
         final long begin = context.isProfiling() ? System.nanoTime() : 0;
         try {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromRidsStep.java
@@ -69,6 +69,10 @@ public class FetchFromRidsStep extends AbstractExecutionStep {
       this.rids = SelectExecutionPlanner.resolveRidEqualityOrInListAtRuntime(ridCondition, context);
       iterator = this.rids.iterator();
     }
+    // A RID list dominated by missing/deleted entries scans the whole list inside one fetchNext() call, the
+    // same class of unbounded-inner-loop gap ScanWithFilterStep guards for a WHERE that rejects everything
+    // (issue #6465).
+    final WorkGuard guard = WorkGuard.forCommandDeadline(context);
     return new ResultSet() {
       int internalNext = 0;
 
@@ -77,6 +81,7 @@ public class FetchFromRidsStep extends AbstractExecutionStep {
           return;
         }
         while (iterator.hasNext()) {
+          guard.check();
           final RID nextRid = iterator.next();
           if (nextRid == null)
             continue;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6540DistinctKeyDelimiterCollisionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6540DistinctKeyDelimiterCollisionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6540: {@code ProjectReturnStep}, {@code UnionStep} and {@code WithStep} built their
+ * DISTINCT/UNION deduplication key by concatenating {@code name=value|} for every projected property
+ * into one string. A projected value whose rendering itself contains {@code =} or {@code |} could make
+ * two genuinely different rows concatenate to the same key string and get wrongly collapsed - e.g. a
+ * single property {@code a = "1|b=2"} and two properties {@code a=1, b=2} both used to render as
+ * {@code "a=1|b=2|"}.
+ * <p>
+ * {@code UNION} is the clearest way to put two differently-shaped rows (one column vs. two columns)
+ * through the same dedup key, since a plain {@code RETURN}/{@code WITH} fixes its column set for every
+ * row of a single branch.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6540DistinctKeyDelimiterCollisionTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/issue-6540-distinct-key-collision");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  /**
+   * The reported case, verbatim: a single string property that happens to look like a rendered
+   * {@code name=value|name=value|} key must not collide with an unrelated two-property row.
+   */
+  @Test
+  void unionDoesNotCollapseDifferentlyShapedRowsThatRenderToTheSameDelimitedString() {
+    // Both branches write "RETURN *", so the parse-time column-name check that UNION otherwise
+    // enforces (all branches must share the same return column names) passes trivially - but the
+    // *actual* per-row property sets still differ at runtime, exactly like the reported example.
+    final List<Result> rows = new ArrayList<>();
+    try (ResultSet rs = database.query("cypher", """
+        WITH '1|b=2' AS a RETURN *
+        UNION
+        WITH 1 AS a, 2 AS b RETURN *""")) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+
+    assertThat(rows).hasSize(2);
+    assertThat(rows).anySatisfy(row -> {
+      assertThat(row.getPropertyNames()).containsExactly("a");
+      assertThat(row.<String>getProperty("a")).isEqualTo("1|b=2");
+    });
+    assertThat(rows).anySatisfy(row -> {
+      assertThat(row.getPropertyNames()).containsExactlyInAnyOrder("a", "b");
+      assertThat(row.<Number>getProperty("a").intValue()).isEqualTo(1);
+      assertThat(row.<Number>getProperty("b").intValue()).isEqualTo(2);
+    });
+  }
+
+  /**
+   * Sanity check: two rows that really do carry equal names/values must still collapse under UNION's
+   * implicit DISTINCT.
+   */
+  @Test
+  void unionStillCollapsesTrueDuplicates() {
+    final List<Result> rows = new ArrayList<>();
+    try (ResultSet rs = database.query("cypher", """
+        RETURN 1 AS a, 2 AS b
+        UNION
+        RETURN 1 AS a, 2 AS b""")) {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    }
+    assertThat(rows).hasSize(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue6541WithDistinctStarInternalVariablesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue6541WithDistinctStarInternalVariablesTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6541: same class of bug as #5444 ({@link Issue5444ReturnStarInternalVariablesTest}), but for
+ * {@code WITH *} instead of {@code RETURN *}. The executor binds anonymous pattern elements to
+ * generated variables ({@code   __anon0}, ...) that a query never named; {@code WithStep}'s
+ * {@code WITH *} branch forwards them unfiltered, and its {@code DISTINCT} key-building loop counted
+ * them too, so two rows that only differ by such a hidden binding wrongly stayed distinct.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6541WithDistinctStarInternalVariablesTest {
+  private static final String DATABASE_PATH = "./target/databases/issue-6541-with-distinct-star";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DATABASE_PATH).create();
+    database.getSchema().createVertexType("Node").createProperty("id", Type.STRING);
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Node").set("id", "hub").save();
+      for (final String id : List.of("a", "b")) {
+        final MutableVertex leaf = database.newVertex("Node").set("id", id).save();
+        leaf.newEdge("LINK", hub, true, (Object[]) null).save();
+      }
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null)
+      database.drop();
+  }
+
+  /**
+   * The anonymous source node differs between the two matched paths, but only {@code hub} is ever
+   * returned: {@code WITH DISTINCT *} must collapse the two rows to one, the same way
+   * {@code RETURN DISTINCT *} already does for #5444.
+   */
+  @Test
+  void withDistinctStarIgnoresTheHiddenVariables() {
+    final List<String> ids = new ArrayList<>();
+    try (ResultSet resultSet = database.query("opencypher",
+        "MATCH (:Node)-[:LINK]->(hub:Node) WHERE hub.id = 'hub' WITH DISTINCT * RETURN hub.id AS id")) {
+      while (resultSet.hasNext())
+        ids.add(resultSet.next().getProperty("id"));
+    }
+    assertThat(ids).containsExactly("hub");
+  }
+
+  /**
+   * {@code WITH *} still forwards every in-scope variable downstream (only the DISTINCT key ignores
+   * the internal ones), so a plain, non-distinct {@code WITH *} keeps behaving exactly as before.
+   */
+  @Test
+  void withStarStillForwardsNamedVariables() {
+    try (ResultSet resultSet = database.query("opencypher",
+        "MATCH (hub:Node) WHERE hub.id = 'hub' WITH * RETURN hub.id AS id")) {
+      assertThat(resultSet.hasNext()).isTrue();
+      assertThat(resultSet.next().<String>getProperty("id")).isEqualTo("hub");
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6465PlainScanSourcesHonourCommandDeadlineTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/Issue6465PlainScanSourcesHonourCommandDeadlineTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.index.RangeIndex;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #6465: a WHERE-less aggregation/ORDER BY/DISTINCT over a plain scan drains the whole type
+ * server-side with nothing consulting {@code arcadedb.command.timeout}. {@code ScanWithFilterStep} and
+ * {@code FilterStep} (used when a WHERE exists) already guard their loop with
+ * {@link WorkGuard#forCommandDeadline(CommandContext)}; the plain scan sources - reached whenever there
+ * is no WHERE to build a filtered step from - carried no such guard, so a blocking consumer downstream
+ * (aggregation, {@code ORDER BY}, {@code DISTINCT}) could run past the configured deadline unbounded by
+ * anything but the data size.
+ * <p>
+ * Rather than reproducing that with a dataset large enough to outrun a real deadline under wall-clock
+ * timing (flaky across machines), each test here pins an already-expired deadline directly on the
+ * {@link CommandContext} - the same technique
+ * {@code Issue6266CommandTimeoutCoverageTest#aPinnedDeadlineIsHonouredWhateverItsValue} uses - and drains
+ * the guarded step directly, so the assertion is deterministic: the very first record the step tries to
+ * hand back must instead raise a {@link TimeoutException}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6465PlainScanSourcesHonourCommandDeadlineTest {
+
+  @Test
+  void fetchFromClusterExecutionStepHonoursAnExpiredDeadline() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanType");
+      type.createProperty("value", Long.class);
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newDocument("PlainScanType").set("value", (long) i).save();
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+      context.setCommandDeadline(System.currentTimeMillis() - 1, "an already expired deadline");
+
+      final FetchFromClusterExecutionStep step = new FetchFromClusterExecutionStep(type.getFirstBucketId(), context);
+      final ResultSet result = step.syncPull(context, 100);
+
+      assertThatThrownBy(() -> drain(result))
+          .as("a plain bucket scan with no WHERE must still stop at the command deadline")
+          .isInstanceOf(TimeoutException.class)
+          .hasMessageContaining("an already expired deadline");
+    });
+  }
+
+  @Test
+  void fetchFromIndexStepHonoursAnExpiredDeadline() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanIndexType");
+      type.createProperty("value", Long.class);
+      final TypeIndex index = type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "value");
+
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newDocument("PlainScanIndexType").set("value", (long) i).save();
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+      context.setCommandDeadline(System.currentTimeMillis() - 1, "an already expired deadline");
+
+      // No condition: a full, unfiltered ascending scan of the index - the DISTINCT/ORDER BY fast path.
+      final FetchFromIndexValuesStep step = new FetchFromIndexValuesStep((RangeIndex) index, true, context);
+      final ResultSet result = step.syncPull(context, 100);
+
+      assertThatThrownBy(() -> drain(result))
+          .as("a full index scan with no WHERE must still stop at the command deadline")
+          .isInstanceOf(TimeoutException.class)
+          .hasMessageContaining("an already expired deadline");
+    });
+  }
+
+  @Test
+  void fetchFromRidsStepHonoursAnExpiredDeadline() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanRidType");
+      type.createProperty("value", Long.class);
+
+      final List<RID> rids = new ArrayList<>();
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          rids.add(db.newDocument("PlainScanRidType").set("value", (long) i).save().getIdentity());
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+      context.setCommandDeadline(System.currentTimeMillis() - 1, "an already expired deadline");
+
+      final FetchFromRidsStep step = new FetchFromRidsStep(rids, context);
+      final ResultSet result = step.syncPull(context, 100);
+
+      assertThatThrownBy(() -> drain(result))
+          .as("a RID-list scan with no WHERE must still stop at the command deadline")
+          .isInstanceOf(TimeoutException.class)
+          .hasMessageContaining("an already expired deadline");
+    });
+  }
+
+  /**
+   * Sanity check: with no deadline configured (the default), every guarded step still returns every row -
+   * the guard must cost nothing more than a comparison when disabled, never change the result.
+   */
+  @Test
+  void unguardedScansAreUnaffectedWhenNoDeadlineIsConfigured() throws Exception {
+    TestHelper.executeInNewDatabase(db -> {
+      final DocumentType type = db.getSchema().createDocumentType("PlainScanNoDeadlineType");
+      type.createProperty("value", Long.class);
+      db.transaction(() -> {
+        for (int i = 0; i < 10; i++)
+          db.newDocument("PlainScanNoDeadlineType").set("value", (long) i).save();
+      });
+
+      final BasicCommandContext context = new BasicCommandContext();
+      context.setDatabase(db);
+
+      final FetchFromClusterExecutionStep step = new FetchFromClusterExecutionStep(type.getFirstBucketId(), context);
+      assertThat(drain(step.syncPull(context, 100))).hasSize(10);
+    });
+  }
+
+  private static List<Result> drain(final ResultSet resultSet) {
+    final List<Result> rows = new ArrayList<>();
+    while (resultSet.hasNext())
+      rows.add(resultSet.next());
+    return rows;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6541, #6540, #6465 - three small, related issues flagged during code review of #6538/#6571. #6465 is separate (WorkGuard gap) but batched in since it's a similarly self-contained, simple fix.

**#6541 - `WITH DISTINCT *` doesn't filter internal/anonymous pattern variables**
`WithStep`'s DISTINCT key-building loop counted the executor's internal anonymous-pattern bindings (`  src0`, `  __anon0`, ...), so `WITH DISTINCT *` could fail to collapse two logically-identical rows that only differ by such a hidden binding - the same class of bug #5444 already fixed for `RETURN DISTINCT *`. Mirrors that precedent: filter with `InternalVariables.isInternal()` when building the key. Left `projectResult()`'s `WITH *` forwarding itself untouched (still copies internal bindings downstream) since later steps in the same query may depend on them for pattern continuation - only the *distinctness key* needs to ignore them, exactly as `ProjectReturnStep` already does.

**#6540 - DISTINCT/UNION string-concatenated keys can collide on delimiter characters**
`ProjectReturnStep`, `UnionStep` and `WithStep` all built their dedup key via `DistinctNumericKey.buildKey()`, which rendered `name=value|` pairs into one string. A projected value whose own rendering contains `=` or `|` could make two differently-shaped rows concatenate to the same string (e.g. one property `a = "1|b=2"` and two properties `a=1, b=2` both rendered as `"a=1|b=2|"`). `buildKey()` now returns a structured `List<[name, value, name, value, ...]>` instead of a string - equality is element-wise, so no delimiter collision is possible - fixing all three call sites from the one shared utility.

**#6465 - WHERE-less aggregation/ORDER BY/DISTINCT over a plain scan ignores `arcadedb.command.timeout`**
`ScanWithFilterStep`/`FilterStep` (used when a WHERE exists) already guard their loop with `WorkGuard.forCommandDeadline()`. The plain scan sources reached when there's no WHERE to build a filtered step from carried no such guard, so a blocking consumer downstream (aggregation, `ORDER BY`, `DISTINCT`) could drain a whole type/index/RID-list past the configured deadline, bounded only by data size. Added the same guard to the three *leaf* scan implementations: `FetchFromClusterExecutionStep`, `FetchFromIndexStep`, `FetchFromRidsStep`. `FetchFromTypeExecutionStep` and `FetchFromClustersExecutionStep` compose `FetchFromClusterExecutionStep` sub-steps, and `FetchFromIndexValuesStep` extends `FetchFromIndexStep` without overriding `syncPull`, so all six classes named in the issue are covered.

**#6578 - not fixed in this PR.** Re-verified the issue's own reachability analysis against current `main`: `Select.property(String)` still has no way to produce the `" by item"/" by key"/" by value"`-suffixed index lookup key `TypeIndexBuilder` uses, so the `in_op` nested-cursor hazard it describes is still not reachable via the documented native `Select` API. Left as-is per the "no defensive code for scenarios that can't happen" convention; posted the re-verification as a comment on the issue and left it open as the tracking placeholder it was filed as.

## Test plan

- [x] New regression tests, each confirmed to fail against the pre-fix code and pass after the fix:
  - `Issue6541WithDistinctStarInternalVariablesTest` (2 tests)
  - `Issue6540DistinctKeyDelimiterCollisionTest` (2 tests) - the UNION repro uses two `RETURN *` branches so the parse-time "same column names" check passes while the actual per-row property sets still differ, exactly reproducing the reported shape
  - `Issue6465PlainScanSourcesHonourCommandDeadlineTest` (4 tests) - pins an already-expired deadline directly on a `CommandContext` and drains each guarded step, so the assertion is deterministic rather than relying on wall-clock timing against a large dataset
- [x] Full `com.arcadedb.query.opencypher.**` package (8000+ tests, including the openCypher TCK suite: 3897 scenarios, 0 failures) passes
- [x] Full `com.arcadedb.query.sql.executor.**` package passes
- [x] `mvn -pl engine -am compile test-compile` clean

🤖 CI will run the full lane matrix on this PR - waiting on that before merge.