### PR TITLE
fix(#6467,#6470): surface silent scanType() bucket failures; document async success-callback durability

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -482,9 +482,12 @@ public interface DatabaseAsyncExecutor {
    * <p>
    * Since each worker crosses its own {@link #setCommitEvery(int)} boundary independently, this callback can now be
    * invoked far more often, and concurrently from multiple worker threads, than when it fired only at shutdown and
-   * from {@link #waitCompletion()}. The registered {@link OkCallback} must be thread-safe.
+   * from {@link #waitCompletion()}. The registered {@link OkCallback} must be thread-safe, and is invoked
+   * synchronously on the committing worker's own thread at every one of those boundaries - a slow or blocking
+   * callback directly throttles that worker's batch throughput, so keep it cheap.
    *
-   * @param callback Callback invoked every time this executor's shared batch transaction commits; must be thread-safe
+   * @param callback Callback invoked every time this executor's shared batch transaction commits; must be
+   *                 thread-safe and cheap, since it runs synchronously on the committing worker's thread
    */
   void onOk(OkCallback callback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -97,6 +97,11 @@ public interface DatabaseAsyncExecutor {
    * Schedules the scan of the records contained in all the buckets defined by a type. This operation scans in sequence each bucket looking for documents, vertices and edges.
    * For each record found a call to #DocumentCallback.onRecord is invoked. If the callback returns false, the scan is terminated, otherwise it continues to
    * the next record.
+   * <p>
+   * If a bucket's own scan fails (I/O error, corruption - as opposed to a per-record error, which is instead routed
+   * to {@code errorRecordCallback} in the overload below), every other bucket is still scanned to completion and the
+   * failure is then rethrown from this call (wrapped in {@link com.arcadedb.exception.DatabaseOperationException} for
+   * a {@code RuntimeException}, raw for an {@code Error}) rather than being silently swallowed (issue #6467).
    *
    * @param typeName    The name of the type
    * @param polymorphic true if the records of all the subtypes must be included, otherwise only the records strictly contained in the #typeName
@@ -109,12 +114,17 @@ public interface DatabaseAsyncExecutor {
    * Schedules the scan of the records contained in all the buckets defined by a type. This operation scans in sequence each bucket looking for documents, vertices and edges.
    * For each record found a call to #DocumentCallback.onRecord is invoked. If the callback returns false, the scan is terminated, otherwise it continues to
    * the next record.
+   * <p>
+   * If a bucket's own scan fails (I/O error, corruption - as opposed to a per-record error, which is instead routed
+   * to {@code errorRecordCallback}), every other bucket is still scanned to completion and the failure is then
+   * rethrown from this call (wrapped in {@link com.arcadedb.exception.DatabaseOperationException} for a
+   * {@code RuntimeException}, raw for an {@code Error}) rather than being silently swallowed (issue #6467).
    *
    * @param typeName            The name of the type
    * @param polymorphic         true if the records of all the subtypes must be included, otherwise only the records strictly contained in the #typeName
    *                            will be scanned
    * @param callback            Callback to handle the loaded record document. Returns false to interrupt the scan operation, otherwise true to continue till the end
-   * @param errorRecordCallback Callback used in case of error during the scan
+   * @param errorRecordCallback Callback used in case of a per-record error during the scan
    */
   void scanType(String typeName, boolean polymorphic, DocumentCallback callback, ErrorRecordCallback errorRecordCallback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -461,8 +461,18 @@ public interface DatabaseAsyncExecutor {
    * fires only once that batch has actually committed. A caller that must know a specific write is durable, rather
    * than merely applied, should register this callback (or call {@link #waitCompletion()}) rather than rely on
    * timing alone.
+   * <p>
+   * "Committed" here means WAL-durable and replay-safe on the next open, which is all a commit guarantees under the
+   * default {@link #setTransactionSync(WALFile.FlushType)} setting of {@code NO} - no {@code fsync} happens at that
+   * point, so the write can still be lost to a power loss or OS crash (though not to a JVM crash or restart) unless
+   * {@code setTransactionSync(YES_NOMETADATA)}/{@code YES_FULL} is configured. A caller that needs the stronger,
+   * disk-durability guarantee must opt into that setting explicitly; this callback's timing does not change with it.
+   * <p>
+   * Since each worker crosses its own {@link #setCommitEvery(int)} boundary independently, this callback can now be
+   * invoked far more often, and concurrently from multiple worker threads, than when it fired only at shutdown and
+   * from {@link #waitCompletion()}. The registered {@link OkCallback} must be thread-safe.
    *
-   * @param callback Callback invoked every time this executor's shared batch transaction commits
+   * @param callback Callback invoked every time this executor's shared batch transaction commits; must be thread-safe
    */
   void onOk(OkCallback callback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -162,17 +162,24 @@ public interface DatabaseAsyncExecutor {
 
   /**
    * Schedules the request to create a record. If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * The callback fires as soon as the create is applied to the worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can fail and roll the whole batch back, discarding this
+   * record even though the callback already fired (issue #6470). Register {@link #onOk(OkCallback)} (or call
+   * {@link #waitCompletion()}) for a signal that fires only once the batch has actually committed.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void createRecord(MutableDocument record, NewRecordCallback newRecordCallback);
 
   /**
    * Schedules the request to create a record. If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * See {@link #createRecord(MutableDocument, NewRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback     Callback invoked in case of error
    */
   void createRecord(MutableDocument record, NewRecordCallback newRecordCallback, final ErrorCallback errorCallback);
@@ -180,52 +187,70 @@ public interface DatabaseAsyncExecutor {
   /**
    * Schedules the request to create a record in a specific bucket. The bucket must be one defined in the schema to store the records of the current type.
    * If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * See {@link #createRecord(MutableDocument, NewRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void createRecord(Record record, String bucketName, NewRecordCallback newRecordCallback);
 
   /**
    * Schedules the request to create a record in a specific bucket. The bucket must be one defined in the schema to store the records of the current type.
    * If the record is created successfully, the callback @{@link NewRecordCallback} is executed.
+   * <p>
+   * See {@link #createRecord(MutableDocument, NewRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record            Record to create
-   * @param newRecordCallback Callback invoked after the record has been created
+   * @param newRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback     Callback invoked in case of error
    */
   void createRecord(Record record, String bucketName, NewRecordCallback newRecordCallback, final ErrorCallback errorCallback);
 
   /**
    * Schedules the request to update a record. If the record is updated successfully, the callback @{@link UpdatedRecordCallback} is executed.
+   * <p>
+   * The callback fires as soon as the update is applied to the worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can fail and roll the whole batch back, undoing this update
+   * even though the callback already fired (issue #6470). Register {@link #onOk(OkCallback)} (or call
+   * {@link #waitCompletion()}) for a signal that fires only once the batch has actually committed.
    *
    * @param record               Record to update
-   * @param updateRecordCallback Callback invoked after the record has been updated
+   * @param updateRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void updateRecord(MutableDocument record, UpdatedRecordCallback updateRecordCallback);
 
   /**
    * Schedules the request to update a record. If the record is updated successfully, the callback @{@link UpdatedRecordCallback} is executed.
+   * <p>
+   * See {@link #updateRecord(MutableDocument, UpdatedRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record               Record to update
-   * @param updateRecordCallback Callback invoked after the record has been updated
+   * @param updateRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback        Callback invoked in case of error
    */
   void updateRecord(MutableDocument record, UpdatedRecordCallback updateRecordCallback, final ErrorCallback errorCallback);
 
   /**
    * Schedules the request to delete a record. If the record is deleted successfully, the callback @{@link DeletedRecordCallback} is executed.
+   * <p>
+   * The callback fires as soon as the delete is applied to the worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can fail and roll the whole batch back, undoing this delete
+   * even though the callback already fired (issue #6470). Register {@link #onOk(OkCallback)} (or call
+   * {@link #waitCompletion()}) for a signal that fires only once the batch has actually committed.
    *
    * @param record               Record to delete
-   * @param deleteRecordCallback Callback invoked after the record has been deleted
+   * @param deleteRecordCallback Callback invoked after the record has been applied to the current batch
    */
   void deleteRecord(Record record, DeletedRecordCallback deleteRecordCallback);
 
   /**
    * Schedules the request to delete a record. If the record is deleted successfully, the callback @{@link DeletedRecordCallback} is executed.
+   * <p>
+   * See {@link #deleteRecord(Record, DeletedRecordCallback)} for when the callback fires relative to durability.
    *
    * @param record               Record to delete
-   * @param deleteRecordCallback Callback invoked after the record has been deleted
+   * @param deleteRecordCallback Callback invoked after the record has been applied to the current batch
    * @param errorCallback        Callback invoked in case of error
    */
   void deleteRecord(Record record, DeletedRecordCallback deleteRecordCallback, final ErrorCallback errorCallback);
@@ -424,9 +449,20 @@ public interface DatabaseAsyncExecutor {
   void setTransactionSync(WALFile.FlushType transactionSync);
 
   /**
-   * Defines a global callback to handle all the returns from asynchronous operations completed without errors.
+   * Defines a global callback invoked every time this executor's shared batch transaction actually commits: at the
+   * periodic {@link #setCommitEvery(int)} boundary, when a durability setting
+   * ({@link #setTransactionUseWAL(boolean)}/{@link #setTransactionSync(WALFile.FlushType)}) changes mid-batch, when a
+   * worker shuts down, and at the barrier {@link #waitCompletion()}/{@link #waitCompletion(long)} relies on.
+   * <p>
+   * This is the durability signal for {@link #createRecord}/{@link #updateRecord}/{@link #deleteRecord}: their own
+   * per-record callback (e.g. {@link NewRecordCallback}) fires as soon as the write is applied to the worker's
+   * current batch, which is not necessarily durable yet - a later task in the same still-open batch can fail and
+   * roll the whole batch back, undoing an op whose callback already fired (issue #6470). This callback, by contrast,
+   * fires only once that batch has actually committed. A caller that must know a specific write is durable, rather
+   * than merely applied, should register this callback (or call {@link #waitCompletion()}) rather than rely on
+   * timing alone.
    *
-   * @param callback Callback invoked when an asynchronous operation succeeds
+   * @param callback Callback invoked every time this executor's shared batch transaction commits
    */
   void onOk(OkCallback callback);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -449,10 +449,12 @@ public interface DatabaseAsyncExecutor {
   void setTransactionSync(WALFile.FlushType transactionSync);
 
   /**
-   * Defines a global callback invoked every time this executor's shared batch transaction actually commits: at the
-   * periodic {@link #setCommitEvery(int)} boundary, when a durability setting
-   * ({@link #setTransactionUseWAL(boolean)}/{@link #setTransactionSync(WALFile.FlushType)}) changes mid-batch, when a
-   * worker shuts down, and at the barrier {@link #waitCompletion()}/{@link #waitCompletion(long)} relies on.
+   * Defines a global callback invoked at every point a worker's shared batch transaction can commit: the periodic
+   * {@link #setCommitEvery(int)} boundary, when a durability setting
+   * ({@link #setTransactionUseWAL(boolean)}/{@link #setTransactionSync(WALFile.FlushType)}) changes mid-batch, and
+   * the barrier {@link #waitCompletion()}/{@link #waitCompletion(long)} relies on. A worker also invokes it
+   * unconditionally on shutdown, even when it had nothing left to commit, so a shutdown firing is not on its own
+   * proof that a write became durable at that moment.
    * <p>
    * This is the durability signal for {@link #createRecord}/{@link #updateRecord}/{@link #deleteRecord}: their own
    * per-record callback (e.g. {@link NewRecordCallback}) fires as soon as the write is applied to the worker's

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -422,6 +422,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
             // is durable), this fires only once the commit above has actually happened. Before this it fired only
             // at shutdown and from the waitCompletion() marker, so a long-running worker that kept hitting this
             // periodic boundary never told an onOk() listener anything until it stopped.
+            //
+            // onOk() only ever swallows an Exception thrown by the registered callback, not an Error - one would
+            // propagate out of this block with the commit above already done but database.begin() below not yet
+            // reached. Harmless: the next task's own `!database.isTransactionActive()` check in this same method
+            // begins a fresh transaction regardless, exactly as it would if this worker had never held one open.
             onOk();
             database.begin();
             // TransactionContext.begin()/reset() never reset useWAL/walFlush, so the stamp above would

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -64,6 +64,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
@@ -416,6 +417,12 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
           if (database.isTransactionActive() && count % commitEvery == 0) {
             database.commit();
+            // #6470: the executor-wide onOk() callback is the durability signal for this batch - unlike a record
+            // op's own success callback (which reports the write applied to the still-open batch, not yet that it
+            // is durable), this fires only once the commit above has actually happened. Before this it fired only
+            // at shutdown and from the waitCompletion() marker, so a long-running worker that kept hitting this
+            // periodic boundary never told an onOk() listener anything until it stopped.
+            onOk();
             database.begin();
             // TransactionContext.begin()/reset() never reset useWAL/walFlush, so the stamp above would
             // "happen to" survive this cycle via object reuse even without this - re-applied explicitly
@@ -491,6 +498,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       try {
         database.commit();
+        // #6470: another real commit of the shared batch, so the executor-wide durability signal fires here too.
+        onOk();
       } catch (final Throwable e) {
         // This commit closes out EARLIER tasks' accumulated work, not the task that triggered this check -
         // which has not run yet - so the failure must not be attributed to it: left uncaught, the caller's
@@ -1205,14 +1214,27 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       final List<Bucket> buckets = type.getBuckets(polymorphic);
       final CountDownLatch semaphore = new CountDownLatch(buckets.size());
+      // #6467: shared across every bucket's task, so a bucket-level failure (I/O, corruption) is not silently
+      // dropped: without it, the failing task's own exception went only to the (typically unset) executor-wide
+      // onErrorCallback while completed() still counted the bucket down, so this method returned as if the whole
+      // type had been scanned.
+      final AtomicReference<Throwable> firstError = new AtomicReference<>();
 
       for (final Bucket b : buckets) {
         final int slot = getSlot(b.getFileId());
-        scheduleTask(slot, new DatabaseAsyncScanBucket(semaphore, callback, errorRecordCallback, b), true,
+        scheduleTask(slot, new DatabaseAsyncScanBucket(semaphore, callback, errorRecordCallback, b, firstError), true,
             backPressurePercentage);
       }
 
       semaphore.await();
+
+      // Rethrown here (rather than wrapped directly) so the generic catch below wraps it exactly like any other
+      // failure of this method, instead of nesting two DatabaseOperationExceptions with the same message.
+      final Throwable error = firstError.get();
+      if (error instanceof final RuntimeException re)
+        throw re;
+      if (error instanceof final Error err)
+        throw err;
 
     } catch (final Exception e) {
       throw new DatabaseOperationException(

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1228,8 +1228,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       semaphore.await();
 
-      // Rethrown here (rather than wrapped directly) so the generic catch below wraps it exactly like any other
-      // failure of this method, instead of nesting two DatabaseOperationExceptions with the same message.
+      // Rethrown here (rather than wrapped directly) so a RuntimeException is wrapped by the generic catch below
+      // exactly like any other failure of this method, instead of nesting two DatabaseOperationExceptions with the
+      // same message. An Error is deliberately NOT caught there (Error does not extend Exception) and so escapes
+      // this method raw and unwrapped - the existing convention elsewhere in this class of never dressing up an
+      // Error, kept intentionally rather than an oversight.
       final Throwable error = firstError.get();
       if (error instanceof final RuntimeException re)
         throw re;

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
@@ -26,32 +26,50 @@ import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.ErrorRecordCallback;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DatabaseAsyncScanBucket implements DatabaseAsyncTask {
-  public final CountDownLatch      semaphore;
-  public final DocumentCallback    userCallback;
-  public final ErrorRecordCallback errorRecordCallback;
-  public final Bucket              bucket;
+  public final CountDownLatch             semaphore;
+  public final DocumentCallback           userCallback;
+  public final ErrorRecordCallback        errorRecordCallback;
+  public final Bucket                     bucket;
+  // #6467: shared by every DatabaseAsyncScanBucket task of one scanType() call, so it can rethrow a bucket-level
+  // failure after every bucket has been drained instead of silently returning a partial scan. Null when a caller
+  // constructs the task directly without going through scanType() and does not care about that (kept optional
+  // rather than required, since scanning a single bucket in isolation needs nothing beyond what execute() itself
+  // already reports through the worker's own rollback/logging/onError handling).
+  public final AtomicReference<Throwable> firstError;
 
   public DatabaseAsyncScanBucket(final CountDownLatch semaphore, final DocumentCallback userCallback, final ErrorRecordCallback errorRecordCallback,
-      final Bucket bucket) {
+      final Bucket bucket, final AtomicReference<Throwable> firstError) {
     this.semaphore = semaphore;
     this.userCallback = userCallback;
     this.errorRecordCallback = errorRecordCallback;
     this.bucket = bucket;
+    this.firstError = firstError;
   }
 
   @Override
   public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
-    bucket.scan((rid, view) -> {
-      if (async.isShutdown())
-        return false;
+    try {
+      bucket.scan((rid, view) -> {
+        if (async.isShutdown())
+          return false;
 
-      final Record record = database.getRecordFactory()
-          .newImmutableRecord(database, database.getSchema().getType(database.getSchema().getTypeNameByBucketId(rid.getBucketId())), rid, view, null);
+        final Record record = database.getRecordFactory()
+            .newImmutableRecord(database, database.getSchema().getType(database.getSchema().getTypeNameByBucketId(rid.getBucketId())), rid, view, null);
 
-      return userCallback.onRecord((Document) record);
-    }, errorRecordCallback);
+        return userCallback.onRecord((Document) record);
+      }, errorRecordCallback);
+    } catch (final RuntimeException | Error e) {
+      // #6467: a bucket-level failure (I/O, corruption) used to be swallowed here - routed only to the executor-wide
+      // onErrorCallback (typically unset) while completed() still counted this bucket down, so scanType() returned
+      // as if every bucket had been scanned. Captured here so scanType() can rethrow it once every bucket is done,
+      // then rethrown so the worker's own rollback/logging/onError handling in executeTask() still runs unchanged.
+      if (firstError != null)
+        firstError.compareAndSet(null, e);
+      throw e;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
@@ -24,9 +24,11 @@ import com.arcadedb.database.DocumentCallback;
 import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.ErrorRecordCallback;
+import com.arcadedb.log.LogManager;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 public class DatabaseAsyncScanBucket implements DatabaseAsyncTask {
   public final CountDownLatch             semaphore;
@@ -66,8 +68,13 @@ public class DatabaseAsyncScanBucket implements DatabaseAsyncTask {
       // onErrorCallback (typically unset) while completed() still counted this bucket down, so scanType() returned
       // as if every bucket had been scanned. Captured here so scanType() can rethrow it once every bucket is done,
       // then rethrown so the worker's own rollback/logging/onError handling in executeTask() still runs unchanged.
-      if (firstError != null)
-        firstError.compareAndSet(null, e);
+      if (firstError != null && !firstError.compareAndSet(null, e))
+        // A DIFFERENT bucket's failure already won the race to be the one scanType() rethrows: this one would
+        // otherwise vanish with no trace at all, even though it could be a distinct root cause (e.g. one bucket
+        // hitting an I/O error and another independently corrupted).
+        LogManager.instance().log(this, Level.SEVERE,
+            "Bucket '%s' failed during a parallel scan, but another bucket's failure will be the one reported to the caller",
+            e, bucket.getName());
       throw e;
     }
   }

--- a/engine/src/main/java/com/arcadedb/database/async/DeletedRecordCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DeletedRecordCallback.java
@@ -26,5 +26,10 @@ import com.arcadedb.database.Record;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public interface DeletedRecordCallback {
+  /**
+   * Invoked once the delete has been applied to the async worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can still fail and roll it back (issue #6470). See
+   * {@link DatabaseAsyncExecutor#onOk(OkCallback)} for a signal that fires only once the batch actually commits.
+   */
   void call(Record newRecord);
 }

--- a/engine/src/main/java/com/arcadedb/database/async/NewRecordCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/NewRecordCallback.java
@@ -23,5 +23,10 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
 @ExcludeFromJacocoGeneratedReport
 public interface NewRecordCallback {
+  /**
+   * Invoked once the record has been applied to the async worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can still fail and roll it back (issue #6470). See
+   * {@link DatabaseAsyncExecutor#onOk(OkCallback)} for a signal that fires only once the batch actually commits.
+   */
   void call(Record newRecord);
 }

--- a/engine/src/main/java/com/arcadedb/database/async/OkCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/OkCallback.java
@@ -22,5 +22,10 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
 @ExcludeFromJacocoGeneratedReport
 public interface OkCallback {
+  /**
+   * Invoked by {@link DatabaseAsyncExecutor#onOk(OkCallback)}, potentially concurrently from multiple worker
+   * threads (each worker crosses its own batch-commit boundary independently) - implementations must be
+   * thread-safe.
+   */
   void call();
 }

--- a/engine/src/main/java/com/arcadedb/database/async/UpdatedRecordCallback.java
+++ b/engine/src/main/java/com/arcadedb/database/async/UpdatedRecordCallback.java
@@ -28,5 +28,10 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
  */
 @ExcludeFromJacocoGeneratedReport
 public interface UpdatedRecordCallback {
+  /**
+   * Invoked once the update has been applied to the async worker's current batch transaction, which is not yet
+   * durable: a later task in the same still-open batch can still fail and roll it back (issue #6470). See
+   * {@link DatabaseAsyncExecutor#onOk(OkCallback)} for a signal that fires only once the batch actually commits.
+   */
   void call(Record newRecord);
 }

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -134,12 +134,15 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
   }
 
   /**
-   * End-to-end: {@code LocalBucket.scan()} always rethrows a {@link DatabaseIsReadOnlyException} raised by the
-   * user's per-record callback regardless of whether an {@code errorRecordCallback} is set - a deliberate
-   * abort-the-whole-scan signal, and the real, reachable analogue of "a bucket's scan throws (I/O / corruption)"
-   * the issue describes, as opposed to an ordinary per-record error (which already correctly routes through
-   * {@code errorRecordCallback} and is not what this test is about). Two buckets are used so the fix's per-bucket
-   * capture is proven to still let the OTHER bucket be scanned to completion.
+   * End-to-end: {@code LocalBucket.scan()} rethrows a {@link DatabaseIsReadOnlyException} raised by the user's
+   * per-record callback rather than routing it through {@code errorRecordCallback} - a deliberate abort-the-whole-
+   * scan signal, and the real, reachable analogue of "a bucket's scan throws (I/O / corruption)" the issue
+   * describes, as opposed to an ordinary per-record error (which already correctly routes through
+   * {@code errorRecordCallback} and is not what this test is about). This test uses no {@code errorRecordCallback}
+   * (the 3-arg {@code scanType()} overload), which is exactly the case that always rethrows; a non-null one that
+   * returns {@code true} for this exception would too, but one that returns {@code false} would instead stop the
+   * scan without rethrowing. Two buckets are used so the fix's per-bucket capture is proven to still let the OTHER
+   * bucket be scanned to completion.
    */
   @Test
   void scanTypePropagatesABucketLevelFailureInsteadOfReturningAPartialScan() {

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -153,9 +153,9 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
         allIds.add(database.newDocument(TYPE).set("id", i).save().getIdentity());
     });
 
-    final Set<RID>            scannedIds     = ConcurrentHashMap.newKeySet();
-    final AtomicInteger       scanned        = new AtomicInteger();
-    final AtomicReference<Integer> failingBucketId = new AtomicReference<>();
+    final Set<RID>      scannedIds      = ConcurrentHashMap.newKeySet();
+    final AtomicInteger scanned         = new AtomicInteger();
+    final AtomicInteger failingBucketId = new AtomicInteger(-1);
 
     assertThatThrownBy(() -> database.async().scanType(TYPE, true, record -> {
       scannedIds.add(record.getIdentity());

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.engine.ErrorRecordCallback;
+import com.arcadedb.engine.RawRecordCallback;
+import com.arcadedb.exception.DatabaseIsReadOnlyException;
+import com.arcadedb.exception.DatabaseOperationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for #6467: {@link DatabaseAsyncExecutorImpl#scanType} must not return successfully when one of
+ * its per-bucket tasks fails with a bucket-level (as opposed to per-record) exception - that used to be swallowed,
+ * routed only to the (typically unset) executor-wide error callback while the per-bucket latch still counted down,
+ * so the caller saw a silently partial scan.
+ */
+class Issue6467ScanTypeBucketFailureTest extends TestHelper {
+
+  private static final String TYPE = "Issue6467Item";
+
+  /**
+   * Direct unit test of the fix's mechanism: a bucket whose {@code scan()} throws must have that exception captured
+   * into the shared holder AND rethrown (so the existing per-task rollback/logging in the worker still runs
+   * unchanged), and {@code completed()} must still fire so a caller blocked in {@code scanType()} is never left
+   * hanging on a failed bucket.
+   */
+  @Test
+  void failingBucketScanIsCapturedRethrownAndStillCompletes() {
+    final RuntimeException injected = new RuntimeException("simulated bucket I/O failure");
+
+    final Bucket brokenBucket = new Bucket() {
+      @Override
+      public RID createRecord(final Record record, final boolean discardRecordAfter) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void updateRecord(final Record record, final boolean discardRecordAfter) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public com.arcadedb.database.Binary getRecord(final RID rid) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean existsRecord(final RID rid) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void deleteRecord(final RID rid) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void deleteRecord(final RID rid, final boolean force) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void scan(final RawRecordCallback callback, final ErrorRecordCallback errorRecordCallback) {
+        throw injected;
+      }
+
+      @Override
+      public Iterator<Record> iterator() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Iterator<Record> inverseIterator() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public long count() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public int getFileId() {
+        return 0;
+      }
+
+      @Override
+      public String getName() {
+        return "brokenBucket";
+      }
+    };
+
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final CountDownLatch             latch      = new CountDownLatch(1);
+    final DatabaseAsyncScanBucket task = new DatabaseAsyncScanBucket(latch, record -> true, null, brokenBucket, firstError);
+
+    assertThatThrownBy(() -> task.execute(null, null)).isSameAs(injected);
+    assertThat(firstError.get()).isSameAs(injected);
+
+    task.completed();
+    assertThat(latch.getCount()).isZero();
+  }
+
+  /**
+   * End-to-end: {@code LocalBucket.scan()} always rethrows a {@link DatabaseIsReadOnlyException} raised by the
+   * user's per-record callback regardless of whether an {@code errorRecordCallback} is set - a deliberate
+   * abort-the-whole-scan signal, and the real, reachable analogue of "a bucket's scan throws (I/O / corruption)"
+   * the issue describes, as opposed to an ordinary per-record error (which already correctly routes through
+   * {@code errorRecordCallback} and is not what this test is about). Two buckets are used so the fix's per-bucket
+   * capture is proven to still let the OTHER bucket be scanned to completion.
+   */
+  @Test
+  void scanTypePropagatesABucketLevelFailureInsteadOfReturningAPartialScan() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE, 2);
+      for (int i = 0; i < 20; i++)
+        database.newDocument(TYPE).set("id", i).save();
+    });
+
+    final AtomicInteger scanned = new AtomicInteger();
+
+    assertThatThrownBy(() -> database.async().scanType(TYPE, true, record -> {
+      if (scanned.incrementAndGet() == 5)
+        throw new DatabaseIsReadOnlyException("simulated bucket-level scan failure");
+      return true;
+    })).isInstanceOf(DatabaseOperationException.class);
+
+    // The failing bucket aborts after its 5th record, but the other bucket must still be drained to completion
+    // instead of the whole scan silently stopping - proving scanType() no longer just swallows the failure.
+    assertThat(scanned.get()).isGreaterThanOrEqualTo(5);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -60,7 +60,47 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
   void failingBucketScanIsCapturedRethrownAndStillCompletes() {
     final RuntimeException injected = new RuntimeException("simulated bucket I/O failure");
 
-    final Bucket brokenBucket = new Bucket() {
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final CountDownLatch             latch      = new CountDownLatch(1);
+    final DatabaseAsyncScanBucket task =
+        new DatabaseAsyncScanBucket(latch, record -> true, null, brokenBucket("brokenBucket", injected), firstError);
+
+    assertThatThrownBy(() -> task.execute(null, null)).isSameAs(injected);
+    assertThat(firstError.get()).isSameAs(injected);
+
+    task.completed();
+    assertThat(latch.getCount()).isZero();
+  }
+
+  /**
+   * A second bucket failing after {@code firstError} is already claimed must not be silently dropped: it loses the
+   * {@code compareAndSet} race to be the one {@code scanType()} rethrows, but is still logged, and its own task
+   * still rethrows so the worker's own rollback/logging/{@code onError} handling runs for it too. No real
+   * concurrency is needed to exercise this deterministically: {@code compareAndSet}'s outcome depends only on
+   * {@code firstError}'s current value, so calling the two tasks sequentially against one shared holder reproduces
+   * the "already claimed" branch exactly as a genuine race would.
+   */
+  @Test
+  void aSecondConcurrentlyFailingBucketLosesTheRaceButIsStillRethrown() {
+    final RuntimeException firstFailure  = new RuntimeException("first bucket failure");
+    final RuntimeException secondFailure = new RuntimeException("second bucket failure");
+
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final DatabaseAsyncScanBucket taskA =
+        new DatabaseAsyncScanBucket(new CountDownLatch(1), record -> true, null, brokenBucket("bucketA", firstFailure), firstError);
+    final DatabaseAsyncScanBucket taskB =
+        new DatabaseAsyncScanBucket(new CountDownLatch(1), record -> true, null, brokenBucket("bucketB", secondFailure), firstError);
+
+    assertThatThrownBy(() -> taskA.execute(null, null)).isSameAs(firstFailure);
+    assertThat(firstError.get()).isSameAs(firstFailure);
+
+    // taskB still rethrows its OWN exception even though it lost the race to populate firstError.
+    assertThatThrownBy(() -> taskB.execute(null, null)).isSameAs(secondFailure);
+    assertThat(firstError.get()).as("the first bucket's failure is still the one scanType() will report").isSameAs(firstFailure);
+  }
+
+  private static Bucket brokenBucket(final String name, final RuntimeException toThrow) {
+    return new Bucket() {
       @Override
       public RID createRecord(final Record record, final boolean discardRecordAfter) {
         throw new UnsupportedOperationException();
@@ -93,7 +133,7 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
 
       @Override
       public void scan(final RawRecordCallback callback, final ErrorRecordCallback errorRecordCallback) {
-        throw injected;
+        throw toThrow;
       }
 
       @Override
@@ -118,19 +158,9 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
 
       @Override
       public String getName() {
-        return "brokenBucket";
+        return name;
       }
     };
-
-    final AtomicReference<Throwable> firstError = new AtomicReference<>();
-    final CountDownLatch             latch      = new CountDownLatch(1);
-    final DatabaseAsyncScanBucket task = new DatabaseAsyncScanBucket(latch, record -> true, null, brokenBucket, firstError);
-
-    assertThatThrownBy(() -> task.execute(null, null)).isSameAs(injected);
-    assertThat(firstError.get()).isSameAs(injected);
-
-    task.completed();
-    assertThat(latch.getCount()).isZero();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6467ScanTypeBucketFailureTest.java
@@ -28,7 +28,11 @@ import com.arcadedb.exception.DatabaseIsReadOnlyException;
 import com.arcadedb.exception.DatabaseOperationException;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -139,22 +143,31 @@ class Issue6467ScanTypeBucketFailureTest extends TestHelper {
    */
   @Test
   void scanTypePropagatesABucketLevelFailureInsteadOfReturningAPartialScan() {
+    final List<RID> allIds = new ArrayList<>();
     database.transaction(() -> {
       database.getSchema().createDocumentType(TYPE, 2);
       for (int i = 0; i < 20; i++)
-        database.newDocument(TYPE).set("id", i).save();
+        allIds.add(database.newDocument(TYPE).set("id", i).save().getIdentity());
     });
 
-    final AtomicInteger scanned = new AtomicInteger();
+    final Set<RID>            scannedIds     = ConcurrentHashMap.newKeySet();
+    final AtomicInteger       scanned        = new AtomicInteger();
+    final AtomicReference<Integer> failingBucketId = new AtomicReference<>();
 
     assertThatThrownBy(() -> database.async().scanType(TYPE, true, record -> {
-      if (scanned.incrementAndGet() == 5)
+      scannedIds.add(record.getIdentity());
+      if (scanned.incrementAndGet() == 5) {
+        failingBucketId.set(record.getIdentity().getBucketId());
         throw new DatabaseIsReadOnlyException("simulated bucket-level scan failure");
+      }
       return true;
     })).isInstanceOf(DatabaseOperationException.class);
 
-    // The failing bucket aborts after its 5th record, but the other bucket must still be drained to completion
-    // instead of the whole scan silently stopping - proving scanType() no longer just swallows the failure.
-    assertThat(scanned.get()).isGreaterThanOrEqualTo(5);
+    // Every record that lives in a DIFFERENT bucket than the one that failed must have been scanned: that bucket's
+    // task is unaffected by the other one's exception and must still drain to completion, rather than the whole
+    // scan silently stopping partway through (which is the exact bug #6467 is about).
+    final List<RID> otherBucketIds = allIds.stream().filter(rid -> rid.getBucketId() != failingBucketId.get()).toList();
+    assertThat(otherBucketIds).isNotEmpty();
+    assertThat(scannedIds).containsAll(otherBucketIds);
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.database.async;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.RID;
+import com.arcadedb.engine.WALFile;
 import com.arcadedb.event.AfterRecordCreateListener;
 import org.junit.jupiter.api.Test;
 
@@ -129,5 +130,41 @@ class Issue6470AsyncSuccessCallbackDurabilityTest extends TestHelper {
     assertThat(onOkInvocations.get()).isGreaterThanOrEqualTo(2);
 
     database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(12));
+  }
+
+  /**
+   * The other real commit point {@code onOk()} was extended to cover: a durability-setting change
+   * ({@code setTransactionSync}/{@code setTransactionUseWAL}) mid-batch forces the worker to commit its
+   * already-open transaction under its OLD flags before applying the new ones - see
+   * {@code DatabaseAsyncExecutorImpl.closeTransactionBoundaryIfDurabilityPolicyChanged()}.
+   */
+  @Test
+  void executorWideOnOkFiresAtTheDurabilityPolicyBoundary() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1));
+    // Large enough that the periodic commitEvery boundary this test is NOT about never fires here.
+    database.async().setCommitEvery(100);
+
+    final AtomicInteger  onOkInvocations = new AtomicInteger();
+    final CountDownLatch fired           = new CountDownLatch(1);
+    database.async().onOk(() -> {
+      onOkInvocations.incrementAndGet();
+      fired.countDown();
+    });
+
+    // Single bucket, so both creates land on the same worker in submission order: the 1st opens a
+    // transaction stamped with the CURRENT durability flags and leaves it open (commitEvery is nowhere
+    // near reached); the flag flip in between is picked up only when the 2nd create is dispatched, at
+    // which point that still-open transaction's stamped flags no longer match and must be committed first.
+    database.async().createRecord(database.newDocument(TYPE), null);
+    database.async().setTransactionSync(WALFile.FlushType.YES_NOMETADATA);
+    database.async().createRecord(database.newDocument(TYPE), null);
+
+    assertThat(fired.await(30, TimeUnit.SECONDS))
+        .as("onOk() must fire when a durability-setting change forces a boundary commit mid-batch")
+        .isTrue();
+
+    database.async().waitCompletion();
+    assertThat(onOkInvocations.get()).isGreaterThanOrEqualTo(1);
+    database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(2));
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/Issue6470AsyncSuccessCallbackDurabilityTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
+import com.arcadedb.event.AfterRecordCreateListener;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for #6470: an async {@code createRecord}/{@code updateRecord}/{@code deleteRecord}'s own success
+ * callback (e.g. {@link NewRecordCallback}) fires as soon as the write is applied to the worker's current batch
+ * transaction, which is not necessarily durable yet - a later sibling failure in the same still-open batch can still
+ * roll the whole thing back, discarding a write whose callback already fired.
+ * <p>
+ * That per-record timing is unchanged by this fix (and is exercised, unchanged, by
+ * {@code Issue6281AsyncBatchIndexBuildTest} and others that rely on it as a "this task has run" signal rather than a
+ * durability signal - changing it broke that suite). What was missing, and what {@code Issue6470} is actually about,
+ * is a reliable way to know a write IS durable: {@link DatabaseAsyncExecutor#onOk(OkCallback)} - previously fired
+ * only at executor shutdown and from the {@code waitCompletion()} marker - now also fires at the periodic
+ * {@code setCommitEvery(int)} boundary and at a durability-setting boundary commit, so it is a complete signal for
+ * every point this shared batch can actually commit.
+ */
+class Issue6470AsyncSuccessCallbackDurabilityTest extends TestHelper {
+
+  private static final String TYPE = "Issue6470Item";
+
+  /**
+   * Documents the (intentional, unchanged) provisional nature of the per-record callback: it fires for the 1st and
+   * 2nd creates below even though the 3rd's failure rolls the whole still-open batch back and discards them.
+   */
+  @Test
+  void perRecordCallbackFiresBeforeTheBatchIsNecessarilyDurable() {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1));
+
+    final AtomicInteger errors    = new AtomicInteger();
+    final List<RID>     confirmed = new CopyOnWriteArrayList<>();
+
+    // Keyed off content rather than a raw listener-call count, so the trigger is unambiguous regardless of how many
+    // times the engine happens to invoke an after-create listener per create.
+    final AfterRecordCreateListener throwOnMarked = record -> {
+      if ("fail".equals(((Document) record).getString("marker")))
+        throw new RuntimeException("injected error on third create");
+    };
+
+    database.async().setCommitEvery(10);
+    database.async().onError(e -> errors.incrementAndGet());
+
+    database.getEvents().registerListener(throwOnMarked);
+    try {
+      // 1st and 2nd creates succeed and stay in the still-open batch; the 3rd's listener throws, rolling the whole
+      // batch back (1st and 2nd included); the 4th runs in the fresh transaction begun after that rollback.
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "ok"), r -> confirmed.add(r.getIdentity()));
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "ok"), r -> confirmed.add(r.getIdentity()));
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "fail"), r -> confirmed.add(r.getIdentity()));
+      database.async().createRecord(database.newDocument(TYPE).set("marker", "ok"), r -> confirmed.add(r.getIdentity()));
+
+      database.async().waitCompletion();
+    } finally {
+      database.getEvents().unregisterListener(throwOnMarked);
+    }
+
+    assertThat(errors.get()).isEqualTo(1);
+
+    // By design: the per-record callback already fired for the 1st and 2nd creates too, even though the 3rd's
+    // failure rolled the whole still-open batch back and discarded them - it reports "applied", not "durable".
+    assertThat(confirmed).hasSize(3);
+
+    // Only the 4th create - the one in the fresh transaction begun after the rollback - actually exists.
+    database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(1));
+  }
+
+  /**
+   * The actual fix: {@code onOk()} now fires at the periodic {@code commitEvery} boundary, so a caller has a
+   * reliable durability signal without needing to wait for the executor to go idle or shut down.
+   */
+  @Test
+  void executorWideOnOkFiresAtThePeriodicCommitBoundary() throws Exception {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE, 1));
+
+    database.async().setCommitEvery(5);
+
+    final CountDownLatch firstBoundaryCommitted = new CountDownLatch(1);
+    final AtomicInteger  onOkInvocations        = new AtomicInteger();
+    database.async().onOk(() -> {
+      onOkInvocations.incrementAndGet();
+      firstBoundaryCommitted.countDown();
+    });
+
+    for (int i = 0; i < 12; i++)
+      database.async().createRecord(database.newDocument(TYPE), null);
+
+    // Proves the periodic commitEvery boundary itself signals durability - not just the final waitCompletion()
+    // marker, which has not been called yet at this point.
+    assertThat(firstBoundaryCommitted.await(30, TimeUnit.SECONDS))
+        .as("onOk() must fire at the periodic commitEvery boundary, before waitCompletion() is even called")
+        .isTrue();
+
+    database.async().waitCompletion();
+
+    // 12 creates over a batch of 5 cross the periodic boundary twice (at the 5th and 10th), so at least 2 by the
+    // time the loop above already observed 1 of them. (waitCompletion()'s own completion marker also triggers onOk()
+    // on every worker, including idle ones, so the final count is not asserted precisely here.)
+    assertThat(onOkInvocations.get()).isGreaterThanOrEqualTo(2);
+
+    database.transaction(() -> assertThat(database.countType(TYPE, true)).isEqualTo(12));
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #6467: `DatabaseAsyncExecutor.scanType()` returned successfully even when a bucket's scan threw a bucket-level failure (I/O, corruption) - the exception went only to the (typically unset) executor-wide error callback while the per-bucket latch still counted down, so the caller got a silently partial scan. `DatabaseAsyncScanBucket` now captures the first such failure into a shared holder and rethrows it (so the existing per-task rollback/logging/onError handling still runs unchanged); `scanType()` rethrows it, wrapped, once every bucket has been drained. A second, concurrently-failing bucket's exception is now logged rather than silently discarded.
- Addresses #6470: an async `createRecord`/`updateRecord`/`deleteRecord`'s own success callback fires as soon as the write is applied to the worker's current batch transaction, which is not yet durable - a later sibling failure in the same still-open batch can still roll it back, discarding a write whose callback already fired.

## Behavior changes for existing callers
- `scanType()` (both overloads) can now throw where it previously returned silently on a bucket-level failure - documented on both methods.
- `onOk(OkCallback)` can now fire far more often, and concurrently from multiple worker threads, instead of ~once (effectively single-threaded) at shutdown/`waitCompletion()`. No caller in this repo relies on the old cadence, but any external code registering an `OkCallback` assuming single/terminal invocation should be reviewed - the callback must now be thread-safe (documented on `OkCallback`/`onOk(OkCallback)`).

## Design note on #6470
The issue's literal suggestion (defer the per-record callback until the batch commits) was implemented and fully tested, but breaks `Issue6281AsyncBatchIndexBuildTest` and others that deliberately rely on the callback firing immediately as a "this task has run" signal (independent of durability) to construct a "processed but not yet committed" state for a different regression. Per-record callback timing is therefore left unchanged. Instead:
- The executor-wide `onOk(OkCallback)` - previously firing only at worker shutdown and from the `waitCompletion()` marker - now also fires at the periodic `commitEvery` boundary and at a durability-setting boundary commit, making it a complete, reliable durability signal for every point the shared batch can actually commit ("durable" meaning WAL-replay-safe under the executor's durability settings, not necessarily fsync'd to disk unless `setTransactionSync()` is configured for that - documented on `onOk(OkCallback)`).
- `DatabaseAsyncExecutor` and the `NewRecordCallback`/`UpdatedRecordCallback`/`DeletedRecordCallback` interfaces now document this explicitly, pointing callers who need a durability guarantee at `onOk(OkCallback)`/`waitCompletion()` instead of the per-record callback.

## Test plan
- [x] New regression test `Issue6467ScanTypeBucketFailureTest`: a unit test of `DatabaseAsyncScanBucket`'s capture/rethrow mechanism, plus an end-to-end test using a real bucket scan abort (`DatabaseIsReadOnlyException`, which `LocalBucket.scan()` always rethrows past its per-record error handling) proving `scanType()` now raises instead of silently returning, and that every record in the *other* (non-failing) bucket is still scanned to completion.
- [x] New regression test `Issue6470AsyncSuccessCallbackDurabilityTest`: documents the (intentional) provisional nature of the per-record callback, and proves the executor-wide `onOk()` now fires at the periodic `commitEvery` boundary before `waitCompletion()` is even called.
- [x] Full async test package (27 classes) + related scanType/CRUD/transaction tests: 134/134 pass, no regressions.
- [x] `mvn -pl engine -am compile`/`test-compile` clean.

https://github.com/ArcadeData/arcadedb/issues/6467
https://github.com/ArcadeData/arcadedb/issues/6470