### PR TITLE
fix(#6607): honour TransactionContext in gRPC insertStream and bulkInsert

### DIFF
--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2342,16 +2342,40 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     ProtocolContext.set("grpc");
     try {
-      final InsertOptions opts = defaults(req.getOptions()); // apply defaults (batch size, tx mode, etc.)
+      final boolean hasTx = req.hasTransaction();
+      final String incomingTxId = hasTx ? req.getTransaction().getTransactionId() : "";
+      final TransactionContext txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
 
-      try (InsertContext ctx = new InsertContext(opts)) {
+      if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+        resp.onError(unknownTransactionStatus(incomingTxId).asException());
+        return;
+      }
 
-        Counts totals = insertRows(ctx, req.getRowsList().iterator());
+      final InsertOptions opts = defaults(req.getOptions());
 
-        ctx.flushCommit(true);
-
-        resp.onNext(ctx.summary(totals, started));
-        resp.onCompleted();
+      if (txCtx != null) {
+        // External transaction — run on the transaction's dedicated thread
+        try {
+          InsertSummary summary = txCtx.executor.submit(() -> {
+            try (InsertContext ctx = new InsertContext(txCtx.db, opts)) {
+              Counts totals = insertRows(ctx, req.getRowsList().iterator());
+              ctx.flushCommit(true); // no-op in external tx mode
+              return ctx.summary(totals, started);
+            }
+          }).get();
+          resp.onNext(summary);
+          resp.onCompleted();
+        } catch (ExecutionException e) {
+          resp.onError(Status.INTERNAL.withDescription(
+              "bulkInsert: " + (e.getCause() != null ? e.getCause().getMessage() : e.getMessage())).asException());
+        }
+      } else {
+        try (InsertContext ctx = new InsertContext(opts)) {
+          Counts totals = insertRows(ctx, req.getRowsList().iterator());
+          ctx.flushCommit(true);
+          resp.onNext(ctx.summary(totals, started));
+          resp.onCompleted();
+        }
       }
     } catch (Exception e) {
       resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + e.getMessage()).asException());
@@ -2431,8 +2455,29 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             if (!c.getDatabase().isEmpty())
               effective = effective.toBuilder().setDatabase(c.getDatabase()).build();
 
+            // Issue #6607: honour TransactionContext on the first chunk
+            final boolean hasTx = c.hasTransaction();
+            final String incomingTxId = hasTx ? c.getTransaction().getTransactionId() : "";
+            final TransactionContext txCtx = resolveAuthorizedTransaction(incomingTxId, c.getCredentials());
+
+            if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
+              streamFailed.set(true);
+              totals.received += c.getRowsCount();
+              totals.err(-1, "UNKNOWN_TRANSACTION", "Unknown or expired transaction id: " + incomingTxId, "");
+              if (!cancelled.get())
+                call.request(1);
+              return;
+            }
+
             // Create and cache context
-            ctx = new InsertContext(effective); // begins tx if PER_STREAM / PER_BATCH per your logic
+            if (txCtx != null) {
+              // External transaction — build InsertContext with the transaction's database.
+              // The InsertContext skips begin/commit/rollback; the external TransactionContext
+              // manages the lifecycle on its dedicated executor thread.
+              ctx = new InsertContext(txCtx.db, effective);
+            } else {
+              ctx = new InsertContext(effective); // begins tx if PER_STREAM / PER_BATCH per your logic
+            }
 
             ctxRef.set(ctx);
 
@@ -3952,6 +3997,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // Mutable latch (single-stream, no concurrent access): set once after the "out/in in
     // update_columns ignored for edges" warning fires so it is logged at most once per stream.
     boolean warnedEdgeEndpointUpdateCols;
+    final boolean externalTransaction;
 
     long startedAt;
 
@@ -3977,6 +4023,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       this.keyColsSet = Set.copyOf(this.keyCols);
 
       this.updateCols = opts.getUpdateColumnsOnConflictList();
+      this.externalTransaction = false;
 
       if (!opts.getValidateOnly()) {
         if (opts.getTransactionMode() == TransactionMode.PER_STREAM || opts.getTransactionMode() == TransactionMode.PER_BATCH
@@ -3995,6 +4042,22 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         abortTransaction();
         throw e;
       }
+    }
+
+    /**
+     * Constructs an InsertContext that uses the given database (typically from an external
+     * {@link TransactionContext}) instead of resolving one from the options. The caller is
+     * responsible for managing the transaction lifecycle: begin/commit/rollback are skipped.
+     */
+    InsertContext(final Database externalDb, final InsertOptions opts) {
+      this.opts = opts;
+      this.db = externalDb;
+      this.externalTransaction = true;
+      this.keyCols = opts.getKeyColumnsList();
+      this.keyColsSet = Set.copyOf(this.keyCols);
+      this.updateCols = opts.getUpdateColumnsOnConflictList();
+      // Skip db.begin() — the external transaction is already active on the executor thread.
+      // Skip captureTransaction() — the external TransactionContext manages its own lifecycle.
     }
 
     /**
@@ -4079,6 +4142,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     void flushCommit(boolean end) {
 
+      if (externalTransaction)
+        return; // external transaction owns commit/rollback
+
       if (opts.getValidateOnly()) {
         if (end) {
           db.rollback();
@@ -4151,6 +4217,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
      */
     @Override
     public void close() {
+      if (externalTransaction)
+        return; // external transaction owns cleanup
       final boolean hadTransaction = tx != null;
       try {
         if (hadTransaction) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2344,7 +2344,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     try {
       final boolean hasTx = req.hasTransaction();
       final String incomingTxId = hasTx ? req.getTransaction().getTransactionId() : "";
-      final TransactionContext txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
+      // Resolved outside the outer catch below so a StatusRuntimeException it throws (e.g.
+      // PERMISSION_DENIED/UNAUTHENTICATED from authorizeTransactionAccess) reaches the client as-is
+      // instead of being downgraded to Status.INTERNAL, mirroring createRecord/updateRecord/etc.
+      final TransactionContext txCtx;
+      try {
+        txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
+      } catch (final StatusRuntimeException e) {
+        resp.onError(e);
+        return;
+      }
 
       if (isUnknownSuppliedTransaction(incomingTxId, txCtx)) {
         resp.onError(unknownTransactionStatus(incomingTxId).asException());
@@ -2399,6 +2408,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     final AtomicBoolean cancelled = new AtomicBoolean(false);
     final AtomicReference<InsertContext> ctxRef = new AtomicReference<>();
+
+    // Issue #6607: the external TransactionContext resolved on the first chunk, cached so every later
+    // chunk can dispatch its insertRows() call onto the transaction's dedicated executor thread. Null
+    // when there is no external transaction (ctx.externalTransaction == false).
+    final AtomicReference<TransactionContext> extTxCtxRef = new AtomicReference<>();
 
     // Issue #4806: set when a chunk fails at the transaction level (e.g. a mid-stream commit that
     // rolled the transaction back). Once set, no further rows are inserted: the stream just drains
@@ -2479,6 +2493,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               ctx = new InsertContext(effective); // begins tx if PER_STREAM / PER_BATCH per your logic
             }
 
+            extTxCtxRef.set(txCtx);
             ctxRef.set(ctx);
 
             firstOptsRef.set(effective);
@@ -2504,7 +2519,22 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           }
 
           // -------- Insert rows for this chunk --------
-          Counts cts = insertRows(ctxRef.get(), c.getRowsList().iterator());
+          final InsertContext runCtx = ctxRef.get();
+          final Counts cts;
+          if (runCtx.externalTransaction) {
+            // Issue #6607: dispatch onto the external transaction's dedicated executor thread, the
+            // same way every other transaction-scoped RPC (bulkInsert, createRecord, executeCommand,
+            // ...) does. ArcadeDB transactions are bound to the calling thread via the DatabaseContext
+            // ThreadLocal, so inserting on whichever pool thread onNext happens to run on left the
+            // external transaction not actually active there.
+            try {
+              cts = extTxCtxRef.get().executor.submit(() -> insertRows(runCtx, c.getRowsList().iterator())).get();
+            } catch (final ExecutionException ee) {
+              final Throwable cause = ee.getCause();
+              throw cause instanceof Exception ex ? ex : ee;
+            }
+          } else
+            cts = insertRows(runCtx, c.getRowsList().iterator());
           totals.add(cts);
         } catch (Exception e) {
           // Issue #4806: per-row errors are handled row-by-row inside insertRows, so an exception

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2365,9 +2365,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       if (txCtx != null) {
         // External transaction — run on the transaction's dedicated thread
         try {
-          InsertSummary summary = txCtx.executor.submit(() -> {
+          final InsertSummary summary = txCtx.executor.submit(() -> {
             try (InsertContext ctx = new InsertContext(txCtx.db, opts)) {
-              Counts totals = insertRows(ctx, req.getRowsList().iterator());
+              final Counts totals = insertRows(ctx, req.getRowsList().iterator());
               ctx.flushCommit(true); // no-op in external tx mode
               return ctx.summary(totals, started);
             }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6607InsertStreamExternalTransactionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6607InsertStreamExternalTransactionIT.java
@@ -25,6 +25,8 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -203,6 +205,107 @@ public class Issue6607InsertStreamExternalTransactionIT extends BaseGraphServerT
       }
     } finally {
       service.close();
+    }
+  }
+
+  /**
+   * {@code bulkInsert}'s external-transaction path only had authorization-status coverage before this
+   * PR; it never had a rollback/commit lifecycle test the way {@code insertStream} now does above.
+   * Rows inserted via {@code bulkInsert} under an external transaction must not survive its rollback.
+   */
+  @Test
+  void bulkInsertWithExternalTransactionRowsDoNotSurviveRollback() throws Exception {
+    final String typeName = "Issue6607BulkExtTxRollback_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+
+      final List<GrpcRecord> records = new ArrayList<>();
+      for (int i = 0; i < 10; i++)
+        records.add(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+
+      final BulkInsertRequest request = BulkInsertRequest.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .build())
+          .addAllRows(records)
+          .build();
+
+      final CapturingInsertSummaryObserver resp = new CapturingInsertSummaryObserver();
+      service.bulkInsert(request, resp);
+
+      assertThat(resp.errorRef.get()).isNull();
+      assertThat(resp.summaryRef.get()).isNotNull();
+      assertThat(resp.summaryRef.get().getInserted()).isEqualTo(10);
+
+      final RollbackTransactionResponse rollback = rollbackTransaction(service, txId);
+      assertThat(rollback.getRolledBack()).isTrue();
+
+      assertThat(countRows(typeName))
+          .as("rows bulk-inserted under an external transaction must not survive its rollback")
+          .isZero();
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  /**
+   * Sanity companion: {@code bulkInsert} rows under an external transaction must still commit normally.
+   */
+  @Test
+  void bulkInsertWithExternalTransactionRowsPersistOnCommit() throws Exception {
+    final String typeName = "Issue6607BulkExtTxCommit_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+
+      final List<GrpcRecord> records = new ArrayList<>();
+      for (int i = 0; i < 7; i++)
+        records.add(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+
+      final BulkInsertRequest request = BulkInsertRequest.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .build())
+          .addAllRows(records)
+          .build();
+
+      final CapturingInsertSummaryObserver resp = new CapturingInsertSummaryObserver();
+      service.bulkInsert(request, resp);
+
+      assertThat(resp.errorRef.get()).isNull();
+      assertThat(resp.summaryRef.get().getInserted()).isEqualTo(7);
+
+      final AtomicReference<CommitTransactionResponse> commitRef = new AtomicReference<>();
+      service.commitTransaction(
+          CommitTransactionRequest.newBuilder()
+              .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+              .setCredentials(credentials())
+              .build(),
+          capturing(commitRef));
+      assertThat(commitRef.get().getSuccess()).isTrue();
+
+      assertThat(countRows(typeName)).isEqualTo(7L);
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
     }
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6607InsertStreamExternalTransactionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue6607InsertStreamExternalTransactionIT.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #6607: {@code insertStream} resolves an external transaction context on
+ * the first chunk but never dispatches the actual row insertion onto that transaction's dedicated
+ * executor thread the way every other
+ * transaction-scoped RPC ({@code bulkInsert}, {@code createRecord}, {@code executeCommand}, ...) does.
+ * Because ArcadeDB transactions are bound to the calling thread via the {@code DatabaseContext}
+ * {@code ThreadLocal}, inserting on the wrong thread means the external transaction is not actually
+ * active there, so the rows are written outside it (auto-committing independently) and survive a
+ * rollback of the transaction the client believes wraps them.
+ */
+public class Issue6607InsertStreamExternalTransactionIT extends BaseGraphServerTest {
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private GrpcValue stringValue(final String s) {
+    return GrpcValue.newBuilder().setStringValue(s).build();
+  }
+
+  private long countRows(final String typeName) {
+    return getServer(0).getDatabase(getDatabaseName())
+        .query("sql", "SELECT count(*) AS total FROM " + typeName).next().<Long>getProperty("total");
+  }
+
+  /**
+   * Rows streamed under an external transaction must not survive a rollback of that transaction:
+   * the whole point of passing a {@code transaction_id} is that the caller controls commit/rollback.
+   */
+  @Test
+  void rowsStreamedUnderExternalTransactionDoNotSurviveRollback() throws Exception {
+    final String typeName = "Issue6607ExtTxRollback_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+      assertThat(txId).isNotBlank();
+
+      final RecordingResponseObserver resp = new RecordingResponseObserver();
+      final StreamObserver<InsertChunk> req = service.insertStream(resp);
+
+      final InsertChunk.Builder chunk = InsertChunk.newBuilder()
+          .setSessionId("issue-6607-rollback")
+          .setChunkSeq(0)
+          .setLast(true)
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+          // Top-level chunk credentials, distinct from InsertOptions.credentials: resolveAuthorizedTransaction()
+          // authorizes the external-transaction path off THIS field (see InsertChunk.credentials in the proto).
+          .setCredentials(credentials())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .build());
+      for (int i = 0; i < 25; i++)
+        chunk.addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+
+      req.onNext(chunk.build());
+      req.onCompleted();
+
+      final InsertSummary summary = resp.summaryRef.get();
+      assertThat(summary).isNotNull();
+      assertThat(summary.getInserted()).isEqualTo(25);
+      assertThat(summary.getFailed()).isZero();
+
+      // The rows are visible inside the still-open external transaction before it is rolled back...
+      final RollbackTransactionResponse rollback = rollbackTransaction(service, txId);
+      assertThat(rollback.getSuccess()).isTrue();
+      assertThat(rollback.getRolledBack()).isTrue();
+
+      // ...but once rolled back, none of them may have survived outside it.
+      assertThat(countRows(typeName))
+          .as("rows streamed under an external transaction must not survive its rollback")
+          .isZero();
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  /**
+   * Sanity companion to the rollback test above: rows streamed under an external transaction must still
+   * commit normally when the client commits it, so the fix does not just make everything vanish.
+   */
+  @Test
+  void rowsStreamedUnderExternalTransactionPersistOnCommit() throws Exception {
+    final String typeName = "Issue6607ExtTxCommit_" + System.currentTimeMillis();
+    getServer(0).getDatabase(getDatabaseName()).command("sql", "CREATE DOCUMENT TYPE " + typeName);
+
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+
+      final RecordingResponseObserver resp = new RecordingResponseObserver();
+      final StreamObserver<InsertChunk> req = service.insertStream(resp);
+
+      final InsertChunk.Builder chunk = InsertChunk.newBuilder()
+          .setSessionId("issue-6607-commit")
+          .setChunkSeq(0)
+          .setLast(true)
+          .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+          // Top-level chunk credentials, distinct from InsertOptions.credentials: resolveAuthorizedTransaction()
+          // authorizes the external-transaction path off THIS field (see InsertChunk.credentials in the proto).
+          .setCredentials(credentials())
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .build());
+      for (int i = 0; i < 12; i++)
+        chunk.addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("v" + i)).build());
+
+      req.onNext(chunk.build());
+      req.onCompleted();
+
+      final InsertSummary summary = resp.summaryRef.get();
+      assertThat(summary).isNotNull();
+      assertThat(summary.getInserted()).isEqualTo(12);
+
+      final AtomicReference<CommitTransactionResponse> commitRef = new AtomicReference<>();
+      service.commitTransaction(
+          CommitTransactionRequest.newBuilder()
+              .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+              .setCredentials(credentials())
+              .build(),
+          capturing(commitRef));
+      assertThat(commitRef.get().getSuccess()).isTrue();
+
+      assertThat(countRows(typeName)).isEqualTo(12L);
+    } finally {
+      service.close();
+      getServer(0).getDatabase(getDatabaseName()).command("sql", "DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  /**
+   * Companion regression test for a status-code-fidelity defect found while reviewing #6607:
+   * {@code bulkInsert}'s call to {@code resolveAuthorizedTransaction()} used to sit inside the method's
+   * outer {@code catch (Exception e)}, which unconditionally rewraps everything as {@code Status.INTERNAL}
+   * - so a real {@code PERMISSION_DENIED}/{@code UNAUTHENTICATED} rejection from authorizing the external
+   * transaction was silently downgraded, hiding the real cause from the client.
+   */
+  @Test
+  void bulkInsertWithExternalTransactionBadCredentialsPreservesRealStatusCode() throws Exception {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService(getDatabaseName(), getServer(0));
+    try {
+      final BeginTransactionResponse begin = beginTransaction(service);
+      final String txId = begin.getTransactionId();
+      try {
+        final BulkInsertRequest request = BulkInsertRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(DatabaseCredentials.newBuilder().setUsername("root").setPassword("definitely-wrong-password").build())
+            .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+            .setOptions(InsertOptions.newBuilder().setDatabase(getDatabaseName()).setTargetClass("Person").build())
+            .build();
+
+        final CapturingInsertSummaryObserver resp = new CapturingInsertSummaryObserver();
+        service.bulkInsert(request, resp);
+
+        assertThat(resp.errorRef.get())
+            .as("a bad-credentials rejection must reach the client unmodified, not be downgraded to Status.INTERNAL")
+            .isInstanceOf(StatusRuntimeException.class);
+        assertThat(((StatusRuntimeException) resp.errorRef.get()).getStatus().getCode())
+            .isIn(Status.Code.PERMISSION_DENIED, Status.Code.UNAUTHENTICATED);
+      } finally {
+        rollbackTransaction(service, txId);
+      }
+    } finally {
+      service.close();
+    }
+  }
+
+  private BeginTransactionResponse beginTransaction(final ArcadeDbGrpcService service) {
+    final AtomicReference<BeginTransactionResponse> ref = new AtomicReference<>();
+    service.beginTransaction(
+        BeginTransactionRequest.newBuilder().setDatabase(getDatabaseName()).setCredentials(credentials()).build(),
+        capturing(ref));
+    return ref.get();
+  }
+
+  private RollbackTransactionResponse rollbackTransaction(final ArcadeDbGrpcService service, final String txId) {
+    final AtomicReference<RollbackTransactionResponse> ref = new AtomicReference<>();
+    service.rollbackTransaction(
+        RollbackTransactionRequest.newBuilder()
+            .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+            .setCredentials(credentials())
+            .build(),
+        capturing(ref));
+    return ref.get();
+  }
+
+  private <T> StreamObserver<T> capturing(final AtomicReference<T> ref) {
+    return new StreamObserver<>() {
+      @Override public void onNext(final T value) { ref.set(value); }
+      @Override public void onError(final Throwable t) { throw new RuntimeException(t); }
+      @Override public void onCompleted() { }
+    };
+  }
+
+  /**
+   * Minimal {@link StreamObserver} double for the unary {@code bulkInsert} handler that records
+   * either the {@link InsertSummary} it emits or the {@link Throwable} passed to {@code onError},
+   * without throwing - so a test can assert on the captured status after the call returns instead of
+   * having to unwind a thrown exception.
+   */
+  private static final class CapturingInsertSummaryObserver implements StreamObserver<InsertSummary> {
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+    final AtomicReference<Throwable>     errorRef   = new AtomicReference<>();
+
+    @Override public void onNext(final InsertSummary value) { summaryRef.set(value); }
+    @Override public void onError(final Throwable t) { errorRef.set(t); }
+    @Override public void onCompleted() { }
+  }
+
+  /**
+   * Minimal {@link ServerCallStreamObserver} double for the client-streaming {@code insertStream}
+   * handler that captures the single {@link InsertSummary} it emits.
+   */
+  private static final class RecordingResponseObserver extends ServerCallStreamObserver<InsertSummary> {
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+
+    @Override public void onNext(final InsertSummary value) { summaryRef.set(value); }
+    @Override public void onError(final Throwable t) { }
+    @Override public void onCompleted() { }
+
+    @Override public boolean isCancelled() { return false; }
+    @Override public void setOnCancelHandler(final Runnable onCancelHandler) { }
+    @Override public void setCompression(final String compression) { }
+    @Override public boolean isReady() { return true; }
+    @Override public void setOnReadyHandler(final Runnable onReadyHandler) { }
+    @Override public void request(final int count) { }
+    @Override public void setMessageCompression(final boolean enable) { }
+    @Override public void disableAutoInboundFlowControl() { }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #6607 — both `insertStream` and `bulkInsert` declare a `TransactionContext` field in their protobuf message but never read it. Writes issued through these RPCs were committed independently of the caller's transaction, surviving a rollback.

## Changes

### InsertContext (inner class)
- Added `externalTransaction` boolean field
- Existing constructor sets `externalTransaction = false`
- New constructor `InsertContext(Database externalDb, InsertOptions opts)` for external transaction mode — skips `db.begin()`, `flushCommit()` and `close()` cleanup because the external `TransactionContext` owns the lifecycle

### bulkInsert (unary RPC)
- Resolves `BulkInsertRequest.transaction` via `resolveAuthorizedTransaction()`
- When a valid external transaction is present, submits the insert work to the transaction's dedicated executor thread (`txCtx.executor.submit()`), following the same pattern as `executeCommand`/`executeQuery`
- `InsertContext` is created with `txCtx.db` and external mode (no begin/commit)
- Unknown/expired transaction ids are rejected with `FAILED_PRECONDITION`

### insertStream (streaming RPC)
- On the first chunk, resolves `InsertChunk.transaction` via `resolveAuthorizedTransaction()`
- When a valid external transaction is present, creates `InsertContext` with `txCtx.db` and external mode
- Unknown/expired transaction ids set `streamFailed` and record the error, allowing the stream to drain gracefully

## Notes
- The `InsertContext` constructor does not need `ExecutionException` or `import java.util.concurrent.ExecutionException` — already imported in the file
- The `ExternalTransaction` mode is intentionally minimal: no begin/commit/rollback, no `captureTransaction()` — the external `TransactionContext` manages its own thread and lifecycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - gRPC bulk and streaming inserts can now participate in externally managed transactions.
  - Inserted records remain available after a successful commit and are removed when the transaction is rolled back.
- **Bug Fixes**
  - Invalid, expired, or unauthorized transaction identifiers are now handled explicitly.
  - Authentication and permission errors return the appropriate status codes.
  - Insert operations no longer unintentionally open, commit, roll back, or close externally managed transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->