### PR TITLE
fix(#6598): narrow DatabaseRID.asVertex()'s catch to ClassCastException

### DIFF
--- a/docs/6598-database-rid-asvertex-broad-catch.md
+++ b/docs/6598-database-rid-asvertex-broad-catch.md
@@ -1,0 +1,63 @@
+# #6598 - `DatabaseRID.asVertex(boolean)` reports every failure as "record not found"
+
+## Root cause
+
+`DatabaseRID.asVertex(boolean)` (`engine/src/main/java/com/arcadedb/database/DatabaseRID.java`) caught
+`Exception` broadly around `database.lookupByRID(...)` and rewrapped anything that was not already a
+`RecordNotFoundException` into one. Its sibling, `RID.asVertex(boolean)`, only ever caught `ClassCastException`
+(a RID that names a record which exists but is not a `Vertex`). The broad catch was introduced when
+`DatabaseRID` was added in 7d7d7aac6 and widened `ClassCastException` to `Exception` in the process.
+
+Consequences of the broad catch:
+- A `SecurityException` (permission denial) was reported to the caller as "record not found" - a healthy,
+  present record the caller simply was not allowed to read looked like data corruption.
+- A `ConcurrentModificationException` (`extends NeedRetryException`) - e.g. from `loadMultiPageRecord`
+  exhausting `TX_RETRIES` on a multi-page vertex body - silently became a non-retryable
+  `RecordNotFoundException`. The retry machinery never saw it, and the caller concluded the vertex was gone
+  when it was merely contended.
+
+## Affected component
+
+`engine/src/main/java/com/arcadedb/database/DatabaseRID.java` - `asVertex(boolean)`.
+
+## Fix
+
+Narrowed the catch from `Exception` to `ClassCastException`, matching `RID.asVertex(boolean)` exactly (the
+`RecordNotFoundException` passthrough arm is unchanged). This restores the pre-`DatabaseRID` behaviour and
+removes the whole class of masking. `asDocument`/`asEdge` in the same class already have no try/catch at all,
+so this also brings `asVertex` back in line with its neighbours.
+
+Per the issue's own preference ordering, this only applies fix (1) - the narrower catch. Fix (2) (also
+converting the surviving `ClassCastException` -> `RecordNotFoundException` translation into a message that
+names the actual type found) is explicitly called out in the issue as a separate behaviour-changing decision
+and is out of scope here.
+
+Items 2 (`ACCESS.DELETE_RECORD`'s past-tense wire name `deletedRecord`) and 3 (a note that #6491's diagnosis
+basis moved) are explicitly the "latent trap" / "pointer" halves of #6598, not "the one worth acting on" -
+left untouched, as the issue itself recommends.
+
+## Test plan
+
+New test: `engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVertexBroadCatchTest.java`
+
+- Unit level (Mockito stub of `BasicDatabase`, isolates the catch contract from which engine code path
+  happens to raise each exception today):
+  - `aSecurityExceptionFromLookupSurvivesAsVertexUnwrapped` - a `SecurityException` from `lookupByRID`
+    reaches the caller unwrapped, not as `RecordNotFoundException`.
+  - `aRetryableConflictFromLookupSurvivesAsVertexUnwrapped` - a `ConcurrentModificationException` reaches
+    the caller unwrapped and stays a `NeedRetryException`.
+  - `aRecordNotFoundExceptionFromLookupIsRethrownAsIs` - unchanged passthrough behaviour.
+  - `aRecordThatIsNotAVertexStillReportsAsNotFound` - the one case `asVertex()` is meant to translate (a
+    `ClassCastException` because the record is not a `Vertex`) still becomes `RecordNotFoundException`.
+- End-to-end: `aPermissionDenialReachedThroughAsVertexIsNotReportedAsRecordNotFound` - a real database, a
+  principal granted `deleteRecord` but not `readRecord` (the exact scenario reported in the issue, reused
+  from #6586's `aPrincipalWithoutReadPermissionCannotReachTheDeleteAtAll` fixture pattern), reached through
+  `guarded[0].asVertex()` - the shortcut ordinary caller code uses, as opposed to `lookupByRID` directly,
+  which #6586's test used specifically to sidestep this bug.
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest=Issue6598DatabaseRidAsVertexBroadCatchTest` (new test, RED before the fix,
+  GREEN after).
+- Existing regression suite for the family this belongs to: `Issue6586MissingVertexDiagnosisTest`,
+  `Issue6572*`, `Issue4501*` (bucket-gone RID), run to confirm no regression.

--- a/docs/6598-database-rid-asvertex-broad-catch.md
+++ b/docs/6598-database-rid-asvertex-broad-catch.md
@@ -57,7 +57,31 @@ New test: `engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVert
 
 ## Verification
 
-- `mvn -pl engine -am test -Dtest=Issue6598DatabaseRidAsVertexBroadCatchTest` (new test, RED before the fix,
-  GREEN after).
-- Existing regression suite for the family this belongs to: `Issue6586MissingVertexDiagnosisTest`,
-  `Issue6572*`, `Issue4501*` (bucket-gone RID), run to confirm no regression.
+- `mvn -pl engine -am test -Dtest=Issue6598DatabaseRidAsVertexBroadCatchTest` - RED before the fix (3 of 5
+  assertions failed: the `SecurityException` and `ConcurrentModificationException` passthrough unit tests,
+  plus the end-to-end permission scenario), GREEN after.
+- `mvn -pl engine -am test -Dtest=Issue6598DatabaseRidAsVertexBroadCatchTest,DatabaseRIDTest,Issue6586MissingVertexDiagnosisTest,Issue6572DanglingVertexReferenceTest`
+  - 32 tests, 0 failures.
+- `mvn -pl engine -am test -Dtest=Issue687ClassCastEdgeCheckTest,Issue5279ConcurrentUpdateTest,RecordNotMaterialisedTest`
+  - 21 tests, 0 failures.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6681
+
+## Review cycles
+
+- Cycle 1: head `5ae25f9d0b` - claude bot review (issue comment, posted 2026-08-24T15:08:23Z): "looks
+  correct, safe, and ready to merge pending CI." No actionable items - two minor/non-blocking observations
+  only (a note that any other `RuntimeException` besides `SecurityException`/`ConcurrentModificationException`
+  now also propagates unwrapped, which is the intended, matching-`RID.asVertex()` behavior; and a sanity-check
+  suggestion on the end-to-end test's `factory.close()` after `restricted.drop()`, which the reviewer itself
+  judged "almost certainly fine"). Working tree stayed clean - no code change made in response.
+
+## Deferred items
+
+None. Both of the bot's observations were non-blocking FYI notes, not requests for a code change.
+
+## Final state
+
+clean-approval (cycle 1 of 4 max).

--- a/engine/src/main/java/com/arcadedb/database/DatabaseRID.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseRID.java
@@ -75,7 +75,7 @@ public class DatabaseRID extends RID {
       return (Vertex) database.lookupByRID(this, loadContent);
     } catch (final RecordNotFoundException e) {
       throw e;
-    } catch (final Exception e) {
+    } catch (final ClassCastException e) {
       throw new RecordNotFoundException("Record " + this + " not found", this, e);
     }
   }

--- a/engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVertexBroadCatchTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVertexBroadCatchTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.security.SecurityDatabaseUser;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * #6598 item 1: {@link DatabaseRID#asVertex(boolean)} used to catch every {@code Exception} out of
+ * {@code lookupByRID} and rewrap it as {@link RecordNotFoundException}, so a permission denial or a retryable
+ * conflict was reported to the caller as "record not found" - a healthy, present record that simply could not be
+ * reached for a reason that had nothing to do with it being missing.
+ * <p>
+ * Its sibling {@link RID#asVertex(boolean)} was never widened this way: it only ever caught {@link ClassCastException}
+ * (a RID that names a record which is not a vertex). {@link DatabaseRID#asVertex(boolean)} must behave the same.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6598DatabaseRidAsVertexBroadCatchTest {
+
+  // ---------------------------------------------------------------------------------------------------------
+  // Unit level: pins the catch contract directly against a stubbed BasicDatabase, independent of which engine
+  // code path happens to raise each exception today.
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aSecurityExceptionFromLookupSurvivesAsVertexUnwrapped() {
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final SecurityException denial = new SecurityException("User 'test' is not allowed to readRecord");
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenThrow(denial);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).as("a permission denial must not be reported as a missing record")
+        .isInstanceOf(SecurityException.class)
+        .isNotInstanceOf(RecordNotFoundException.class)
+        .isSameAs(denial);
+  }
+
+  @Test
+  void aRetryableConflictFromLookupSurvivesAsVertexUnwrapped() {
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final ConcurrentModificationException conflict = new ConcurrentModificationException("retry me");
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenThrow(conflict);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).as("a retryable conflict must keep being retryable, not become a permanent not-found")
+        .isInstanceOf(NeedRetryException.class)
+        .isNotInstanceOf(RecordNotFoundException.class)
+        .isSameAs(conflict);
+  }
+
+  @Test
+  void aRecordNotFoundExceptionFromLookupIsRethrownAsIs() {
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final RecordNotFoundException notFound = new RecordNotFoundException("Record " + rid + " not found", rid);
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenThrow(notFound);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).isSameAs(notFound);
+  }
+
+  @Test
+  void aRecordThatIsNotAVertexStillReportsAsNotFound() {
+    // A ClassCastException is the one case asVertex() is meant to translate: the record exists, but is not a
+    // Vertex. Preserved exactly as RID.asVertex(boolean) already behaves.
+    final BasicDatabase database = mock(BasicDatabase.class);
+    final DatabaseRID rid = new DatabaseRID(database, 0, 0L);
+    final Document notAVertex = mock(Document.class);
+    when(database.lookupByRID(any(RID.class), anyBoolean())).thenAnswer(invocation -> notAVertex);
+
+    final Throwable thrown = catchThrowable(() -> rid.asVertex(true));
+
+    assertThat(thrown).isInstanceOf(RecordNotFoundException.class);
+    assertThat(((RecordNotFoundException) thrown).getRID()).isEqualTo(rid);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------
+  // End-to-end: the exact scenario reported in #6598 - a principal granted deleteRecord but not readRecord,
+  // reaching the vertex through DatabaseRID.asVertex() (the shortcut ordinary caller code uses) rather than
+  // lookupByRID directly (which #6586's test used specifically to avoid this bug).
+  // ---------------------------------------------------------------------------------------------------------
+
+  @Test
+  void aPermissionDenialReachedThroughAsVertexIsNotReportedAsRecordNotFound() {
+    final String path = "target/databases/Issue6598PermissionProbe";
+
+    final DatabaseFactory factory = new DatabaseFactory(path).setSecurity(db -> {
+    });
+    if (factory.exists())
+      factory.open().drop();
+
+    final Database restricted = factory.create();
+    try {
+      restricted.transaction(() -> restricted.getSchema().createVertexType("Guarded", 1));
+
+      final RID[] guarded = new RID[1];
+      restricted.transaction(() -> {
+        final MutableVertex v = restricted.newVertex("Guarded");
+        v.save();
+        guarded[0] = v.getIdentity();
+      });
+      assertThat(guarded[0]).as("BaseRecord.upgradeRID must hand back a DatabaseRID for this test to mean anything")
+          .isInstanceOf(DatabaseRID.class);
+
+      final Set<SecurityDatabaseUser.ACCESS> granted = EnumSet.of(SecurityDatabaseUser.ACCESS.DELETE_RECORD);
+      DatabaseContext.INSTANCE.getContext(restricted.getDatabasePath()).setCurrentUser(userGranting(granted));
+
+      final Throwable thrown = catchThrowable(
+          () -> restricted.transaction(() -> guarded[0].asVertex(), false, 1));
+
+      assertThat(thrown).as("a healthy record denied by permissions must not be reported as missing: %s", thrown)
+          .isInstanceOf(SecurityException.class)
+          .isNotInstanceOf(RecordNotFoundException.class);
+    } finally {
+      DatabaseContext.INSTANCE.getContext(restricted.getDatabasePath()).setCurrentUser(null);
+      restricted.drop();
+      factory.close();
+    }
+  }
+
+  /** A principal that allows the database wholesale and exactly {@code granted} on every file. */
+  private static SecurityDatabaseUser userGranting(final Set<SecurityDatabaseUser.ACCESS> granted) {
+    return new SecurityDatabaseUser() {
+      @Override
+      public String getName() {
+        return "restricted";
+      }
+
+      @Override
+      public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
+        return true;
+      }
+
+      @Override
+      public boolean requestAccessOnFile(final int fileId, final ACCESS access) {
+        return granted.contains(access);
+      }
+
+      @Override
+      public long getResultSetLimit() {
+        return -1L;
+      }
+
+      @Override
+      public long getReadTimeout() {
+        return -1L;
+      }
+    };
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Narrows `DatabaseRID.asVertex(boolean)`'s catch from `Exception` to `ClassCastException`, matching its
sibling `RID.asVertex(boolean)` exactly.

Before this change, any failure `database.lookupByRID(...)` raised other than `RecordNotFoundException` was
rewrapped as `RecordNotFoundException`, so:
- A `SecurityException` (permission denial) was reported as "record not found" - a healthy, present record
  the caller simply lacked permission to read looked like data corruption.
- A `ConcurrentModificationException` (`extends NeedRetryException`, e.g. from `loadMultiPageRecord`
  exhausting `TX_RETRIES` on a multi-page vertex body) silently became a non-retryable
  `RecordNotFoundException` - the retry machinery never saw it, and the caller concluded the vertex was gone
  when it was merely contended.

`RID.asVertex(boolean)` was never widened this way - it only ever caught `ClassCastException` (a RID that
names a record which exists but is not a `Vertex`). `DatabaseRID` was introduced later
(7d7d7aac6, "using new DatabaseRID to user API -> improve backward compatibility") and the catch was widened
from `ClassCastException` to `Exception` in the process; `asDocument`/`asEdge` in the same class have no
try/catch at all, so the broad catch was one method out of step with its neighbours and its own predecessor.

## Motivation

Filed as item 1 of #6598, discovered while writing the permission test for #6586: a principal granted
`deleteRecord` but not `readRecord`, reaching a healthy vertex through `rid.asVertex()`, got
`RecordNotFoundException: Record #1:0 not found` instead of the `SecurityException` that actually happened.
`rid.asVertex()` is used widely across the SQL and Cypher executors, so the surface is not small.

Per the issue's own preference ordering, this PR applies only fix (1) - the narrower catch. Fix (2)
(further changing the surviving `ClassCastException` -> `RecordNotFoundException` translation to name the
actual type found) is explicitly flagged in the issue as its own, separate behaviour-changing decision and is
out of scope here. Items 2 (`ACCESS.DELETE_RECORD`'s past-tense wire name) and 3 (a note that #6491's
diagnosis basis moved) are the issue's own "latent trap" / "pointer" halves, not "the one worth acting on" -
left untouched.

## Related issues

Closes #6598 (item 1 only; items 2 and 3 are informational/latent and not addressed by this PR).

## Additional Notes

New test: `engine/src/test/java/com/arcadedb/database/Issue6598DatabaseRidAsVertexBroadCatchTest.java`

- Unit level (Mockito stub of `BasicDatabase`, isolating the catch contract from whichever engine path
  happens to raise each exception today):
  - a `SecurityException` from `lookupByRID` reaches the caller unwrapped, not as `RecordNotFoundException`
  - a `ConcurrentModificationException` reaches the caller unwrapped and stays a `NeedRetryException`
  - a `RecordNotFoundException` from `lookupByRID` is rethrown as-is (unchanged passthrough)
  - a record that is not a `Vertex` (`ClassCastException`) still reports as `RecordNotFoundException` -
    the one translation `asVertex()` is meant to do, preserved exactly
- End-to-end: a real database, a principal granted `deleteRecord` but not `readRecord` (the exact scenario
  from the issue, reusing #6586's `aPrincipalWithoutReadPermissionCannotReachTheDeleteAtAll` fixture
  pattern), reached through `guarded[0].asVertex()` directly (the shortcut ordinary caller code uses),
  confirming the `SecurityException` now survives.

Verified no regression by also running the closely related suites that already exercise
`DatabaseRID`/`RID.asVertex()` and the multi-page/permission/CME paths it touches:
`DatabaseRIDTest`, `Issue6586MissingVertexDiagnosisTest`, `Issue6572DanglingVertexReferenceTest`,
`Issue687ClassCastEdgeCheckTest`, `Issue5279ConcurrentUpdateTest`, `RecordNotMaterialisedTest` - 53 tests
total (new test class + these), all green.

## Test plan

- [x] New test class RED against the pre-fix broad catch (3 of 5 assertions failed exactly as expected: the
  `SecurityException` and `ConcurrentModificationException` passthrough cases, plus the end-to-end permission
  scenario), GREEN after the fix.
- [x] `mvn -pl engine -am test -Dtest=Issue6598DatabaseRidAsVertexBroadCatchTest,DatabaseRIDTest,Issue6586MissingVertexDiagnosisTest,Issue6572DanglingVertexReferenceTest`
  - 32 tests, 0 failures.
- [x] `mvn -pl engine -am test -Dtest=Issue687ClassCastEdgeCheckTest,Issue5279ConcurrentUpdateTest,RecordNotMaterialisedTest`
  - 21 tests, 0 failures.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertex conversion error handling so security and retryable failures are preserved instead of being reported as missing records.
  * Continued to report non-vertex records as not found.
  * Preserved existing record-not-found errors without altering their type.

* **Tests**
  * Added regression and end-to-end coverage for exception propagation, permissions, and vertex conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->