### PR TITLE
fix(#6584): document CommandRequest.limit in the OpenAPI spec

### DIFF
--- a/docs/6584-command-request-limit-field.md
+++ b/docs/6584-command-request-limit-field.md
@@ -1,0 +1,71 @@
+# Issue #6584 — OpenAPI: CommandRequest omits 'limit', which PostCommandHandler honors
+
+## Root cause
+
+`server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java`
+declares two request schemas for the two `POST` command/query endpoints:
+
+- `createQueryRequestSchema()` — declares `command`, `language`, `params`,
+  `serializer`, and `limit`.
+- `createCommandRequestSchema()` — declares only `command`, `language`, `params`.
+
+Both `/api/v1/query/{database}` and `/api/v1/command/{database}` are served by
+`PostCommandHandler.execute()` (`PostQueryHandler` extends `PostCommandHandler` and
+overrides only `executeCommand()`, not `execute()`), which reads and honors a `limit`
+field from the request body identically for both endpoints:
+
+```java
+final Integer requestLimit = optionalIntField(requestMap, "limit");
+...
+final int autoLimit = requestLimit != null ? applyMaxResultRows(requestLimit, maxResultRows) : getDefaultRowLimit();
+```
+
+So the command endpoint accepts and honors `limit` exactly like the query endpoint, but
+the OpenAPI contract never told a generated client that. This is the second instance of
+this class of asymmetry between `CommandRequest` and `QueryRequest` — #6562 was the
+first, where `CommandRequest` omitted the required `language` field.
+
+## Affected components
+
+- `server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java`
+  (`createCommandRequestSchema()`)
+
+## Expected vs actual behavior
+
+- **Expected**: `CommandRequest` documents a `limit` field, mirroring
+  `QueryRequest`'s, since the same handler code path honors it identically for both
+  endpoints.
+- **Actual**: `CommandRequest` has no `limit` property, so a client generated strictly
+  from the OpenAPI contract has no typed way to cap a command's result set, even though
+  the server supports it.
+
+## Fix
+
+Added a `limit` property to `createCommandRequestSchema()` in `CoreApiSpec.java`,
+using the same description/example as `QueryRequest`'s `limit` property (the behavior
+is identical because both endpoints share `PostCommandHandler.execute()`).
+
+## Scope note
+
+The issue body also suggests auditing the rest of `CommandRequest` against
+`PostCommandHandler` "in the same pass". `PostCommandHandler.execute()` also reads
+`serializer`, `profileExecution`, `typeHints`, and `awaitResponse` from the request
+body, none of which are declared on `QueryRequest` either (only `serializer` is, on
+`QueryRequest`). Broadening either schema to cover all of those is a larger, separate
+change with its own design questions (e.g. whether `awaitResponse` and `typeHints`
+make sense to advertise on the query endpoint), so it is intentionally left out of this
+fix and left for a dedicated follow-up issue, consistent with how #6562 scoped itself to
+just the `language` field.
+
+## Tests
+
+Added `commandRequestDeclaresLimitMatchingQueryRequest()` to
+`server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java`,
+following the existing `commandRequestDeclaresLanguageAsRequired()` pattern:
+asserts `CommandRequest` declares a `limit` property, and that its type/description
+matches `QueryRequest`'s `limit` property (same underlying behavior, same contract
+language).
+
+## Test results
+
+See "Review cycles" section below for the verification run once implemented.

--- a/docs/6584-command-request-limit-field.md
+++ b/docs/6584-command-request-limit-field.md
@@ -68,4 +68,42 @@ language).
 
 ## Test results
 
-See "Review cycles" section below for the verification run once implemented.
+- `mvn -pl server -am test -Dtest=CoreApiSpecTest` — 23/23 pass (new test proven to
+  fail against `main` first, then pass after the fix).
+- `mvn -pl server -am test -Dtest=PostCommandHandlerAutoLimitTest,PostCommandHandlerLargeContentTest,AbstractQueryHandlerTypedJsonMarkersTest`
+  — all pass (regression check on related handler behavior).
+- `PostCommandHandlerDecodeTest.javaScriptFunctionWithLogicalAndOperatorViaHTTP` fails
+  in this environment with "HTTP Port 2480 not available" — a pre-existing local port
+  conflict (another process already bound to 2480), unrelated to this change: the test
+  spins its own embedded server and doesn't touch the OpenAPI spec at all.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6682
+
+## Review cycles
+
+- **Cycle 1** — head `9bdf75e40b34617346e6fb00d8337e1269882d1a` (the fix commit).
+  `claude` bot review (posted as a PR issue comment, per this org's review-bot
+  behavior): **LGTM**, zero actionable items. It independently verified the root-cause
+  claim by reading `PostCommandHandler.execute()` directly, confirmed the added
+  `limit` property is "byte-for-byte identical" to `QueryRequest`'s, and called the
+  new test well-targeted ("asserts equality of type/description ... so it will
+  actually catch future divergence, not just absence"). Its one note - a shared
+  helper/constant so the `limit` property text can't drift between the two schemas
+  again - is explicitly framed as "not required for this fix" and "could be deferred
+  to whenever the broader ... parity audit ... happens", which is exactly the
+  follow-up already named in this PR's "Scope note" above. No code change applied;
+  working tree stayed empty. Treated as a clean approval.
+
+## Deferred items
+
+None requiring separate tracking. The reviewer's one optional suggestion (a shared
+`limit`-property helper to prevent `QueryRequest`/`CommandRequest` drift structurally)
+overlaps entirely with the broader `CommandRequest`/`QueryRequest` parity audit already
+called out in this doc's "Scope note" section as future follow-up work, so it is not
+duplicated into a separate notes file.
+
+## Final state
+
+`clean-approval` — 1 review cycle, LGTM, no code changes requested.

--- a/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/openapi/CoreApiSpec.java
@@ -593,6 +593,17 @@ public class CoreApiSpec implements OpenApiContributor {
         {"$bytes": "<base64>"} for byte[] (standard or URL-safe base64), \
         {"$int8": [v0, v1, ...]} for byte[] from integers in [-128, 127] (used to send \
         INT8-encoded vectors to LSM_VECTOR indexes without a float32 round-trip)."""));
+    // PostQueryHandler extends PostCommandHandler and overrides only executeCommand(), not execute(), so
+    // both /api/v1/query/{database} and /api/v1/command/{database} honor 'limit' identically (issue #6584).
+    schema.addProperty("limit", SpecBuilders.integer(
+        """
+        Maximum number of rows to serialize into the response. When omitted, a LIMIT stated by the query is \
+        honored as written and only a query stating none is capped by the server default \
+        ('arcadedb.server.httpQueryDefaultLimit'). Use -1 for no cap. The response always reports the cap \
+        that was applied ('limit'), how many rows it carries ('returned') and whether rows were left \
+        behind ('truncated'). No value here can widen a single response past the server's hard ceiling \
+        ('arcadedb.server.httpQueryMaxResultRows'): a result that would exceed it is refused with 413 \
+        instead of being truncated.""").example(100));
     schema.setRequired(List.of("command", "language"));
     return schema;
   }

--- a/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/openapi/CoreApiSpecTest.java
@@ -301,6 +301,34 @@ class CoreApiSpecTest {
   }
 
   @Test
+  void commandRequestDeclaresLimitMatchingQueryRequest() {
+    // Issue #6584: PostQueryHandler extends PostCommandHandler and overrides only executeCommand(),
+    // so both /api/v1/query/{database} and /api/v1/command/{database} run through the very same
+    // execute() and honor an optional 'limit' field identically. QueryRequest documents it; CommandRequest
+    // did not, leaving a client generated strictly from the contract with no typed way to cap a command's
+    // result set even though the server supports it.
+    final Schema<?> commandRequest = openAPI.getComponents().getSchemas().get("CommandRequest");
+    final Schema<?> queryRequest = openAPI.getComponents().getSchemas().get("QueryRequest");
+
+    assertThat(commandRequest.getProperties())
+        .as("PostCommandHandler.execute() reads an optional 'limit' field for both the command and "
+            + "query endpoints, so CommandRequest must declare it exactly like QueryRequest does")
+        .containsKey("limit");
+
+    final Schema<?> commandLimit = (Schema<?>) commandRequest.getProperties().get("limit");
+    final Schema<?> queryLimit = (Schema<?>) queryRequest.getProperties().get("limit");
+
+    assertThat(commandLimit.getType())
+        .as("CommandRequest.limit must be typed the same as QueryRequest.limit: both feed the same "
+            + "optionalIntField(requestMap, \"limit\") call")
+        .isEqualTo(queryLimit.getType());
+    assertThat(commandLimit.getDescription())
+        .as("the two endpoints share the exact same limit/truncation semantics, so the contract text "
+            + "must not diverge and confuse a reader of the generated docs")
+        .isEqualTo(queryLimit.getDescription());
+  }
+
+  @Test
   void getQuery404DoesNotClaimTheStaleSessionCasePostAndCommandDo() {
     final Operation get = openAPI.getPaths().get("/api/v1/query/{database}/{language}/{command}").getGet();
 


### PR DESCRIPTION
Closes #6584

## Summary

`PostCommandHandler.execute()` reads and honors an optional `limit` field from the
request body. `PostQueryHandler` extends `PostCommandHandler` and overrides only
`executeCommand()`, not `execute()`, so `/api/v1/query/{database}` and
`/api/v1/command/{database}` both go through the exact same code path and honor
`limit` identically. `QueryRequest` documented `limit` in the OpenAPI spec;
`CommandRequest` did not, so a client generated strictly from the contract had no
typed way to cap a command's result set even though the server supported it. This is
the second instance of this asymmetry between the two schemas: #6562 was the first,
where `CommandRequest` omitted the required `language` field.

The fix adds a `limit` property to `createCommandRequestSchema()` in
`CoreApiSpec.java`, using the exact same description and example as
`QueryRequest`'s `limit` property, since the underlying behavior is identical.

### Scope note

The issue body also suggests auditing the rest of `CommandRequest` against
`PostCommandHandler` "in the same pass". `PostCommandHandler.execute()` also reads
`serializer`, `profileExecution`, `typeHints`, and `awaitResponse` from the request
body; none of those are declared on `QueryRequest` either (only `serializer` is).
Broadening either schema to cover all of those is a larger, separate change with its
own design questions (e.g. whether `awaitResponse`/`typeHints` make sense on the
query endpoint), so it's intentionally left out of this fix, consistent with how
#6562 scoped itself to just the `language` field. Full detail in
`docs/6584-command-request-limit-field.md`.

## Test plan

- [x] Added `commandRequestDeclaresLimitMatchingQueryRequest()` to
      `CoreApiSpecTest`, asserting `CommandRequest` declares a `limit` property
      whose type and description match `QueryRequest`'s `limit` property.
- [x] Confirmed the new test fails against `main` (proves the gap) and passes after
      the fix.
- [x] `mvn -pl server -am test -Dtest=CoreApiSpecTest` — 23/23 pass.
- [x] `mvn -pl server -am test -Dtest=PostCommandHandlerAutoLimitTest,PostCommandHandlerLargeContentTest,AbstractQueryHandlerTypedJsonMarkersTest` — all pass (regression check on related handler behavior).
- [ ] `PostCommandHandlerDecodeTest` has one pre-existing failure in this environment (`HTTP Port 2480 not available` — a local server already bound to 2480), unrelated to this change; it does not touch the OpenAPI schema at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented the optional `limit` parameter for command requests in the OpenAPI specification.
  - Clarified default behavior, unlimited mode, response metadata, and request-limit errors.
  - Noted that the limit applies to both query and command POST endpoints.
  - Improved API discoverability and consistency for clients using command requests.

- **Tests**
  - Added coverage verifying consistent `limit` field documentation across command and query requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->