### PR TITLE
fix(#6579): native select limit(0) counts 0, not 1

### DIFF
--- a/docs/6579-native-select-limit-0-count.md
+++ b/docs/6579-native-select-limit-0-count.md
@@ -52,3 +52,16 @@ issue:
 - `mvn -pl engine -am test -Dtest='Select*Test'` - 315/315 pass (all native-select and SQL select suites)
 - `mvn -pl engine -am test -Dtest=Issue6565SelectIndexCandidateLimitTest` - 20/20 pass (adjacent
   candidate-cap logic touched by the same class, per the issue's own cross-reference to #6571/#6565)
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/6683
+
+## Review cycles
+
+- **Cycle 1** - head `e718976202d273e2d9c2957fa35d1956e5416177`. `claude` review: no blocking issues;
+  confirmed the reorder is correct, confirmed `limit > 0` behavior is unchanged by hand-tracing, and noted
+  the already-safe indexed-cursor path (`MultiIndexCursor` stops before pulling any candidate for
+  `limit(0)`). One optional nit: add an assertion pinning that indexed-cursor path against a future
+  regression in `computeExactCandidateLimit()`. Applied (see `okCountWithLimitZero`'s third assertion,
+  `.where().property("id").eq().value(5).limit(0).count()`); no deferred items.

--- a/docs/6579-native-select-limit-0-count.md
+++ b/docs/6579-native-select-limit-0-count.md
@@ -65,3 +65,19 @@ https://github.com/ArcadeData/arcadedb/pull/6683
   `limit(0)`). One optional nit: add an assertion pinning that indexed-cursor path against a future
   regression in `computeExactCandidateLimit()`. Applied (see `okCountWithLimitZero`'s third assertion,
   `.where().property("id").eq().value(5).limit(0).count()`); no deferred items.
+- **Cycle 2** - head `bc85c6c51f9abaea4317eabdd6ee97019d77ae73`. `claude` review found a real regression
+  the cycle-1 fix introduced: the pre-increment `limit == 0` guard, on its own, moves the `break` so it
+  only fires from inside the `evaluateWhere()` match branch - so once `limit` is reached, the loop can
+  only stop on the *next* matching record, not the current one. With a selective WHERE and no
+  `(limit+1)`th match, `.where(...).limit(N).count()` degrades from an early-exit scan into a full scan of
+  the rest of the type. None of the existing tests caught it because they all use a WHERE matching every
+  row (or a unique-indexed single hit), so there's always an "(N+1)th" match available - and the returned
+  count is identical either way, only the number of records scanned changes. Verified the analysis by hand
+  and by reproducing it (temporarily reverting to the single-check version and confirming the suggested
+  regression test goes red). Fixed by restoring the original post-increment `count >= limit` check
+  alongside the new pre-increment one (the post-check is what gives the same-iteration early exit for
+  `limit > 0`; the pre-check only ever fires for `limit == 0`, since `count` can't reach a `limit > 0`
+  without the post-check already breaking the loop first). Added
+  `okCountWithLimitStopsEarlyDespiteReorder()` (also suggested by the review) to pin `evaluatedRecords` for
+  a `WHERE` with exactly one match followed by 500 non-matching records - proved it fails against the
+  single-check version before restoring the fix. No deferred items.

--- a/docs/6579-native-select-limit-0-count.md
+++ b/docs/6579-native-select-limit-0-count.md
@@ -1,0 +1,54 @@
+# Issue #6579: Native select `.limit(0)` returns count 1 instead of 0
+
+## Root cause
+
+`SelectExecutor.executeCount()` incremented `count` before comparing it against `select.limit`:
+
+```java
+count++;
+if (select.limit > -1 && count >= select.limit)
+  break;
+```
+
+For `limit == 0`, the first matching record already bumped `count` to `1` before the `count >= limit`
+(`1 >= 0`) check ever got a chance to see `limit == 0` - so the wrong value (`1`) was already counted by
+the time the loop broke.
+
+## Fix
+
+Reordered the check to run before the increment (`engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java`,
+`executeCount()`):
+
+```java
+if (select.limit > -1 && count >= select.limit)
+  break;
+if (filterOutRecords != null)
+  filterOutRecords.add(record.getIdentity());
+count++;
+```
+
+## Investigated but not affected
+
+The issue asked to also check `SelectIterator`'s `hasNext()`/`fetchNext()` path (used by `.documents()`/
+`.vertices()`/etc.). Traced it: the constructor only consumes `skip` records (0 iterations when
+`skip == 0`), and `hasNext()` checks `returned >= (long) limit + skip` **before** calling `fetchNext()`.
+For `limit == 0, skip == 0` that is `0 >= 0`, true, so `hasNext()` returns `false` immediately without
+ever pulling a record. Same reasoning holds for the `ORDER BY` materialization path
+(`fetchResultInCaseOfOrderBy()`), whose `end = min(materialized.size(), skip + limit)` is `0` for
+`limit == 0`. Confirmed with the existing `okLimit`/`okSkip` tests plus manual review - no code change
+needed there.
+
+## Test
+
+Added `SelectExecutionTest.okCountWithLimitZero()` (TDD: written first, confirmed red against the
+pre-fix code with `expected: 0L but was: 1L`, green after the fix). Covers both repro shapes from the
+issue:
+- no-`WHERE` (unindexed full-type-scan) path
+- `AND`-shaped `WHERE` (the uncapped fallback path)
+
+## Verification
+
+- `mvn -pl engine -am test -Dtest=SelectExecutionTest` - 26/26 pass
+- `mvn -pl engine -am test -Dtest='Select*Test'` - 315/315 pass (all native-select and SQL select suites)
+- `mvn -pl engine -am test -Dtest=Issue6565SelectIndexCandidateLimitTest` - 20/20 pass (adjacent
+  candidate-cap logic touched by the same class, per the issue's own cross-reference to #6571/#6565)

--- a/docs/6579-native-select-limit-0-count.md
+++ b/docs/6579-native-select-limit-0-count.md
@@ -81,3 +81,14 @@ https://github.com/ArcadeData/arcadedb/pull/6683
   `okCountWithLimitStopsEarlyDespiteReorder()` (also suggested by the review) to pin `evaluatedRecords` for
   a `WHERE` with exactly one match followed by 500 non-matching records - proved it fails against the
   single-check version before restoring the fix. No deferred items.
+- **Cycle 3** - head `4bf062d2382389b447e92a52c76ae6f4277be852`. `claude` review: clean approval. Manually
+  re-traced the pre/post-increment control flow for `limit == 0`, `limit > 0`, and `skip` interaction and
+  confirmed all three are correct; called out `okCountWithLimitStopsEarlyDespiteReorder` as "the right way
+  to catch a 'correct count, wrong complexity' regression that a value-only assertion would miss". One
+  non-blocking style nit (the new inline comment is long/all-caps, though consistent with the file's
+  existing `#6565`/`#5662` comment convention) - no action needed. No correctness, performance, or
+  security issues found; working tree stays clean. **Final state: clean-approval.**
+
+## Deferred items
+
+None.

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -98,11 +98,13 @@ public class SelectExecutor {
             skipped++;
             continue;
           }
+          // #6579: THE LIMIT MUST BE CHECKED BEFORE INCREMENTING count, NOT AFTER - OTHERWISE limit(0) COUNTS THE
+          // FIRST MATCH (count REACHES 1) BEFORE count >= limit (1 >= 0) EVER GETS THE CHANCE TO STOP THE LOOP
+          if (select.limit > -1 && count >= select.limit)
+            break;
           if (filterOutRecords != null)
             filterOutRecords.add(record.getIdentity());
           count++;
-          if (select.limit > -1 && count >= select.limit)
-            break;
         }
       }
       return count;

--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -98,13 +98,21 @@ public class SelectExecutor {
             skipped++;
             continue;
           }
-          // #6579: THE LIMIT MUST BE CHECKED BEFORE INCREMENTING count, NOT AFTER - OTHERWISE limit(0) COUNTS THE
-          // FIRST MATCH (count REACHES 1) BEFORE count >= limit (1 >= 0) EVER GETS THE CHANCE TO STOP THE LOOP
+          // #6579: A PRE-INCREMENT GUARD IS NEEDED FOR limit == 0 - OTHERWISE THE FIRST MATCH BUMPS count TO 1
+          // BEFORE count >= limit (1 >= 0) EVER GETS THE CHANCE TO STOP THE LOOP. THIS GUARD ALONE CAN ONLY EVER
+          // FIRE FOR limit == 0 THOUGH: FOR ANY limit > 0, count NEVER REACHES limit WITHOUT THE POST-INCREMENT
+          // CHECK BELOW ALREADY BREAKING THE LOOP FIRST - SO KEEPING THAT SECOND CHECK IS NOT REDUNDANT, IT IS
+          // WHAT PRESERVES THE SAME-ITERATION EARLY EXIT FOR limit > 0 (A REVIEW CAUGHT DROPPING IT: WITHOUT IT,
+          // ONCE THE LIMIT IS REACHED THE LOOP CAN ONLY BREAK ON THE *NEXT* MATCHING RECORD - VIA THE break BEING
+          // NESTED INSIDE THIS evaluateWhere() BRANCH - SO A SELECTIVE WHERE WITH NO (limit+1)TH MATCH DEGRADES A
+          // BOUNDED count() INTO A FULL SCAN OF THE REST OF THE TYPE)
           if (select.limit > -1 && count >= select.limit)
             break;
           if (filterOutRecords != null)
             filterOutRecords.add(record.getIdentity());
           count++;
+          if (select.limit > -1 && count >= select.limit)
+            break;
         }
       }
       return count;

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -461,6 +461,22 @@ public class SelectExecutionTest extends TestHelper {
         .where().property("name").eq().value("John").limit(10).count()).isEqualTo(10);
   }
 
+  /**
+   * Issue #6579: {@code limit(0)} must count 0, not 1, when at least one record matches. Covers both the
+   * no-WHERE (unindexed full-type-scan) path and an AND-shaped WHERE (the uncapped fallback path), since
+   * {@code SelectExecutor.executeCount()} used to increment {@code count} before comparing it to
+   * {@code select.limit}, so the very first match was counted before the {@code count >= limit} check
+   * ever saw {@code limit == 0}.
+   */
+  @Test
+  void okCountWithLimitZero() {
+    assertThat(database.select().fromType("Vertex").limit(0).count()).isEqualTo(0);
+
+    assertThat(database.select().fromType("Vertex")//
+        .where().property("name").eq().value("John")//
+        .and().property("name").isNotNull().limit(0).count()).isEqualTo(0);
+  }
+
   @Test
   void okCountCompiled() {
     final SelectCompiled compiled = database.select().fromType("Vertex")//

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -483,6 +483,37 @@ public class SelectExecutionTest extends TestHelper {
         .where().property("id").eq().value(5).limit(0).count()).isEqualTo(0);
   }
 
+  /**
+   * Issue #6579 review follow-up: the {@code limit == 0} fix must not turn {@code limit > 0} into a full
+   * scan. {@code executeCount()}'s {@code break} only fires from inside the {@code evaluateWhere()} match
+   * branch, so if the pre-increment {@code count >= limit} guard added for {@code limit == 0} were the
+   * <i>only</i> check, the loop could only stop on the <i>next</i> matching record after the limit was
+   * reached - degrading into a full scan whenever no such record exists. This pins the same-iteration
+   * early exit by asserting on {@code evaluatedRecords} directly: with exactly one matching record
+   * followed by 500 non-matching ones (an unindexed, full-type-scan WHERE, so every visited record goes
+   * through {@code evaluateWhere()}), a {@code limit(1)} count must stop right after that one match, not
+   * walk the other 500.
+   */
+  @Test
+  void okCountWithLimitStopsEarlyDespiteReorder() {
+    database.getSchema().createDocumentType("Issue6579EarlyExit");
+    database.transaction(() -> {
+      database.newDocument("Issue6579EarlyExit").set("flag", true).save();
+      for (int i = 0; i < 500; i++)
+        database.newDocument("Issue6579EarlyExit").set("flag", false).save();
+    });
+
+    final Select select = database.select().fromType("Issue6579EarlyExit")//
+        .where().property("flag").eq().value(true).limit(1);
+    select.compile();
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    assertThat(executor.executeCount()).isEqualTo(1);
+    assertThat((Long) executor.metrics().get("evaluatedRecords")).as(
+        "evaluatedRecords must stay near the single match, not walk the 500 non-matching records after it")
+        .isLessThan(10L);
+  }
+
   @Test
   void okCountCompiled() {
     final SelectCompiled compiled = database.select().fromType("Vertex")//

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -475,6 +475,12 @@ public class SelectExecutionTest extends TestHelper {
     assertThat(database.select().fromType("Vertex")//
         .where().property("name").eq().value("John")//
         .and().property("name").isNotNull().limit(0).count()).isEqualTo(0);
+
+    // PINS THE ALREADY-SAFE INDEXED-CURSOR PATH TOO (id IS UNIQUE-INDEXED, SEE beginTest()): MultiIndexCursor
+    // ALREADY STOPS BEFORE ANY CANDIDATE IS PULLED FOR limit(0), SO THIS GUARDS AGAINST A FUTURE REGRESSION IN
+    // computeExactCandidateLimit()'S CAP LOGIC, NOT AGAINST THE BUG THIS TEST OTHERWISE EXERCISES
+    assertThat(database.select().fromType("Vertex")//
+        .where().property("id").eq().value(5).limit(0).count()).isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

Fixes `SelectExecutor.executeCount()` (native Java select API, `database.select()...`) so that
`.limit(0).count()` returns `0` instead of `1` when at least one record matches. The loop incremented
`count` before comparing it against `select.limit`, so the first matching record was already counted by
the time `count >= limit` (`1 >= 0`) got a chance to break the loop.

```java
// before
count++;
if (select.limit > -1 && count >= select.limit)
  break;

// after
if (select.limit > -1 && count >= select.limit)
  break;
if (filterOutRecords != null)
  filterOutRecords.add(record.getIdentity());
count++;
```

Both repro shapes from the issue are covered: the no-`WHERE` (unindexed full-type-scan) path and an
`AND`-shaped `WHERE` (the uncapped fallback path).

I also traced the "worth checking" follow-up the issue raised about `SelectIterator`'s
`hasNext()`/`fetchNext()` path used by `.documents()`/`.vertices()`/etc: it does **not** have the
analogous bug. `hasNext()` already checks `returned >= (long) limit + skip` *before* calling
`fetchNext()`, so for `limit == 0, skip == 0` it evaluates `0 >= 0` and returns `false` without ever
pulling a record. The `ORDER BY` materialization path (`fetchResultInCaseOfOrderBy()`) is likewise safe:
its `end = min(materialized.size(), skip + limit)` is `0` for `limit == 0`. No change was needed there;
details and the existing tests that back this up are in the tracking doc.

## Motivation

Reported by @lvca as a follow-up from #6571's review (root cause and both repro cases were already
diagnosed in the issue).

## Related issues

Closes #6579

## Additional Notes

Tracking doc: `docs/6579-native-select-limit-0-count.md`.

## Test plan

- [x] New regression test `SelectExecutionTest.okCountWithLimitZero()`, written first and confirmed red
      against the pre-fix code (`expected: 0L but was: 1L`), green after the fix.
- [x] `mvn -pl engine -am test -Dtest=SelectExecutionTest` - 26/26 pass
- [x] `mvn -pl engine -am test -Dtest='Select*Test'` - 315/315 pass (all native-select and SQL select
      suites)
- [x] `mvn -pl engine -am test -Dtest=Issue6565SelectIndexCandidateLimitTest` - 20/20 pass (adjacent
      candidate-cap logic in the same class, per the issue's own cross-reference to #6571/#6565)

## Checklist

- [x] I have compiled and run the targeted `engine` test suites listed above (not a full
      `mvn clean package`, to keep the change scoped and fast to verify)
- [x] My unit tests cover both failure and success scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `count()` queries with `limit(0)` incorrectly returning one result.
  - Ensured zero-limit queries consistently return a count of zero across indexed, filtered, and unfiltered queries.
  - Improved limited count queries so they stop processing once the requested positive limit is reached.

- **Documentation**
  - Added documentation covering the issue, affected query scenarios, fix details, and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->