### PR TITLE
fix(#6577): OR with a non-cursor-buildable operator (NEQ/LIKE/ILIKE) silently drops rows

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -49,6 +49,15 @@ public class SelectExecutor {
   // skip) TO A MultiIndexCursor
   int             indexCandidateLimit = -1;
 
+  // #6577: THE SINGLE SOURCE OF TRUTH FOR "WHICH OPERATORS CAN filterWithIndexesFinalNode() ACTUALLY TURN INTO AN
+  // IndexCursor" - isTheNodeFullyIndexed() MUST TREAT EXACTLY THIS SET, AND NO MORE, AS "THIS LEAF IS INDEXED".
+  // TREATING A WIDER SET AS INDEXED IS WHAT LET #6577 THROUGH: A neq/like/ilike LEAF PASSED THE "UNDER AN or, BOTH
+  // SIDES MUST BE INDEXED" GATE (BECAUSE ITS PROPERTY HAD AN INDEX) BUT THEN filterWithIndexesFinalNode()'S SWITCH
+  // FELL THROUGH TO A BARE return WITH NO CURSOR - SO THE WHOLE BRANCH SILENTLY CONTRIBUTED ZERO ROWS INSTEAD OF
+  // JUST RUNNING LESS EFFICIENTLY. KEEP BOTH CALL SITES READING THIS ONE FIELD SO THEY CANNOT DRIFT APART AGAIN.
+  private static final Set<SelectOperator> CURSOR_BUILDABLE_OPERATORS = EnumSet.of(SelectOperator.eq, SelectOperator.in_op,
+      SelectOperator.between, SelectOperator.gt, SelectOperator.ge, SelectOperator.lt, SelectOperator.le);
+
   static class IndexInfo {
     public final Index   index;
     public final String  property;
@@ -242,9 +251,10 @@ public class SelectExecutor {
       if (!cursors.isEmpty())
         return new MultiIndexCursor(cursors, indexCandidateLimit, true);
 
-      // NO CURSOR WAS ACTUALLY BUILT (E.G. A BARE neq/like/ilike LEAF: "INDEXED" PER isTheNodeFullyIndexed()'S LOOSER
-      // CHECK - SEE #6577 - BUT filterWithIndexesFinalNode()'S switch DOESN'T HANDLE THE OPERATOR), SO NO CAP WAS
-      // EVER APPLIED EITHER: RESET THE TEST-VISIBLE FIELD RATHER THAN LEAVE IT HOLDING A MISLEADING FINITE VALUE
+      // NO CURSOR WAS ACTUALLY BUILT (E.G. A BARE is_null/is_not_null/neq/like/ilike LEAF, WHICH isTheNodeFullyIndexed()
+      // CORRECTLY REFUSES TO TREAT AS INDEXED - SEE #6577 - SO node.index STAYS null AND filterWithIndexesFinalNode()
+      // NEVER RUNS), SO NO CAP WAS EVER APPLIED EITHER: RESET THE TEST-VISIBLE FIELD RATHER THAN LEAVE IT HOLDING A
+      // MISLEADING FINITE VALUE
       indexCandidateLimit = -1;
     }
     return null;
@@ -499,11 +509,9 @@ public class SelectExecutor {
     if (node == null)
       return null;
 
-    // node.index != null MEANS "isTheNodeFullyIndexed() FOUND AN INDEX ON THIS LEAF'S PROPERTY", NOT "THIS LEAF'S
-    // OPERATOR ACTUALLY PRODUCES A CURSOR" - IT'S SET FOR neq/like/ilike TOO (SEE #6577). HARMLESS TODAY BECAUSE A
-    // BARE SUCH LEAF STILL PRODUCES NO CURSOR IN filterWithIndexesFinalNode()'S switch, SO cursors STAYS EMPTY AND
-    // lookForIndexes() RETURNS null BEFORE ANY (WRONGLY-COMPUTED) CAP IS EVER USED - BUT #6577 IS WHERE TO FIX THIS
-    // AT THE SOURCE, NOT HERE
+    // node.index != null MEANS "isTheNodeFullyIndexed() FOUND AN INDEX ON THIS LEAF'S PROPERTY AND ITS OPERATOR IS
+    // CURSOR-BUILDABLE" (SEE CURSOR_BUILDABLE_OPERATORS, FIXED BY #6577) - SO A BARE neq/like/ilike LEAF NO LONGER
+    // REACHES HERE WITH node.index SET, AND THIS METHOD DOESN'T NEED TO KNOW ABOUT THAT DISTINCTION ITSELF.
     if (!(node.left instanceof SelectTreeNode))
       return node.index != null ? node : null;
 
@@ -545,6 +553,12 @@ public class SelectExecutor {
 
   private void filterWithIndexesFinalNode(final SelectTreeNode node, final List<IndexCursor> cursors) {
     if (node.index == null)
+      return;
+
+    // #6577: node.index != null ONLY MEANS THE PROPERTY HAS AN INDEX, NOT THAT THIS OPERATOR CAN BE TURNED INTO A
+    // CURSOR - isTheNodeFullyIndexed() NOW GUARDS AGAINST THIS TOO (SEE CURSOR_BUILDABLE_OPERATORS), BUT THIS CHECK
+    // STAYS AS A CHEAP DEFENSIVE MIRROR OF THE SWITCH BELOW IN CASE THAT INVARIANT IS EVER LOOSENED ELSEWHERE.
+    if (!CURSOR_BUILDABLE_OPERATORS.contains(node.operator))
       return;
 
     if (node.getParent().operator == SelectOperator.or) {
@@ -637,7 +651,11 @@ public class SelectExecutor {
       return true;
 
     if (!(node.left instanceof SelectTreeNode)) {
-      if (node.operator == SelectOperator.is_null || node.operator == SelectOperator.is_not_null)
+      // #6577: A LEAF IS "INDEXED" ONLY WHEN filterWithIndexesFinalNode()'S SWITCH CAN ACTUALLY BUILD A CURSOR FOR
+      // ITS OPERATOR - is_null/is_not_null WERE THE ONLY EXCLUSION HERE BEFORE, BUT neq/like/ilike NEVER PRODUCE A
+      // CURSOR EITHER (SEE CURSOR_BUILDABLE_OPERATORS). A neq/like/ilike LEAF MUST FALL BACK TO A FULL SCAN, SAME AS
+      // is_null/is_not_null, RATHER THAN LET AN or SIBLING TREAT IT AS INDEXED AND SILENTLY DROP ITS MATCHES.
+      if (!CURSOR_BUILDABLE_OPERATORS.contains(node.operator))
         return false;
 
       if (!(node.right instanceof SelectPropertyValue)) {

--- a/engine/src/test/java/com/arcadedb/query/select/Issue6577OrWithNonCursorBuildableOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/Issue6577OrWithNonCursorBuildableOperatorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6577
+ * <p>
+ * {@code SelectExecutor.isTheNodeFullyIndexed()} (used by {@code filterWithIndexesFinalNode()}'s "under an OR, both
+ * sides must be indexed" gate) only excluded {@code is_null}/{@code is_not_null} from "this leaf is indexed" -
+ * every other operator on an indexed property, including {@code neq}/{@code like}/{@code ilike}, was treated as
+ * indexed as long as the property itself had an index. But {@code filterWithIndexesFinalNode()}'s cursor-building
+ * switch only knows how to build a cursor for {@code eq}/{@code in_op}/{@code between}/{@code gt}/{@code ge}/
+ * {@code lt}/{@code le} - a {@code neq}/{@code like}/{@code ilike} leaf silently contributed zero cursors while
+ * still passing the "both sides indexed" gate for its {@code or} sibling. The result: for
+ * {@code a != 'x' OR n = -1}, the {@code eq} leaf's cursor alone became the WHOLE candidate stream, and every
+ * record matching only the {@code neq} branch was silently dropped - not "evaluated less efficiently", genuinely
+ * missing from the result.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue6577OrWithNonCursorBuildableOperatorTest extends TestHelper {
+
+  private static final int ROWS = 1000;
+
+  public Issue6577OrWithNonCursorBuildableOperatorTest() {
+    autoStartTx = true;
+  }
+
+  @Override
+  protected void beginTest() {
+    final var t = database.getSchema().createDocumentType("T");
+    t.createProperty("a", Type.STRING);
+    t.createProperty("n", Type.INTEGER);
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "a");
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "n");
+
+    database.transaction(() -> {
+      for (int i = 0; i < ROWS; i++)
+        database.newDocument("T").set("a", "x", "n", i).save();
+    });
+  }
+
+  @Test
+  void orWithNeqOnOneSideMustNotDropTheOtherBranch() {
+    // EVERY ROW HAS a = "x" != "nonexistent", SO THE neq BRANCH ALONE ALREADY MATCHES ALL ROWS
+    final long count = database.select().fromType("T").where()//
+        .property("a").neq().value("nonexistent")//
+        .or().property("n").eq().value(-1).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithNeqOnOneSideMustNotDropTheOtherBranchReversed() {
+    // SAME SHAPE, neq ON THE RIGHT-HAND SIDE OF THE or INSTEAD OF THE LEFT
+    final long count = database.select().fromType("T").where()//
+        .property("n").eq().value(-1)//
+        .or().property("a").neq().value("nonexistent").count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithLikeOnOneSideMustNotDropTheOtherBranch() {
+    final long count = database.select().fromType("T").where()//
+        .property("a").like().value("x")//
+        .or().property("n").eq().value(-1).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithIlikeOnOneSideMustNotDropTheOtherBranch() {
+    final long count = database.select().fromType("T").where()//
+        .property("a").ilike().value("X")//
+        .or().property("n").eq().value(-1).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+
+  @Test
+  void orWithNeqOnBothSidesFallsBackToFullScanCorrectly() {
+    // NEITHER SIDE IS CURSOR-BUILDABLE, SO THIS MUST FALL ALL THE WAY BACK TO A FULL SCAN - STILL CORRECT
+    final long count = database.select().fromType("T").where()//
+        .property("a").neq().value("nonexistent")//
+        .or().property("n").neq().value(-999999).count();
+
+    assertThat(count).isEqualTo(ROWS);
+  }
+}


### PR DESCRIPTION
Closes #6577

## Summary

`SelectExecutor.isTheNodeFullyIndexed()` (used by `filterWithIndexesFinalNode()`'s "under an `OR`, both sides must be indexed" gate) only excluded `is_null`/`is_not_null` from "this leaf is indexed" - every other operator on an indexed property, including `neq`/`like`/`ilike`, was treated as indexed as long as the *property* had an index. But `filterWithIndexesFinalNode()`'s cursor-building `switch` only knows how to build a cursor for `eq`/`in_op`/`between`/`gt`/`ge`/`lt`/`le`; a `neq`/`like`/`ilike` leaf falls through to a bare `return` and contributes no cursor at all.

So for `a != 'nonexistent' OR n = -1`: the "both sides indexed" gate passed (both properties have indexes), the `neq` leaf silently contributed zero cursors, and the `eq` leaf's cursor alone became the entire candidate stream - every record matching only the `neq` branch was silently dropped from the result. This is a missing-rows correctness bug, not a performance one.

The fix extracts the operator set `filterWithIndexesFinalNode()` can actually turn into a cursor (`eq`, `in_op`, `between`, `gt`, `ge`, `lt`, `le`) into one shared `CURSOR_BUILDABLE_OPERATORS` field, and has `isTheNodeFullyIndexed()` key its "is this leaf indexed" check off that same set instead of the narrower `is_null`/`is_not_null` exclusion - mirroring the suggested fix in the issue so the two call sites can no longer independently drift apart the way this bug happened in the first place. `filterWithIndexesFinalNode()` also gets a cheap defensive early-return against the same set, as a mirror of its own `switch` in case the invariant is ever loosened elsewhere.

A `neq`/`like`/`ilike` leaf under an `OR` now correctly falls back to a full scan for that branch (which `isTheNodeFullyIndexed()`'s `or` case already unions with `||`, so the overall query still uses whatever index it can and only loses the "both sides indexed" fast path) instead of silently losing rows.

## Test plan

New regression test `Issue6577OrWithNonCursorBuildableOperatorTest` (`engine/src/test/java/com/arcadedb/query/select/`), reproducing the issue's exact scenario plus siblings:
- `orWithNeqOnOneSideMustNotDropTheOtherBranch` - the issue's repro (`a != 'nonexistent' OR n = -1`), asserts all 1000 rows are returned.
- `orWithNeqOnOneSideMustNotDropTheOtherBranchReversed` - same shape with `neq` on the right-hand side of the `or`.
- `orWithLikeOnOneSideMustNotDropTheOtherBranch` / `orWithIlikeOnOneSideMustNotDropTheOtherBranch` - same defect via `like`/`ilike`.
- `orWithNeqOnBothSidesFallsBackToFullScanCorrectly` - both branches non-cursor-buildable, verifying the pre-existing full-scan fallback stays correct.

Verified:
- [x] All 5 new tests fail against `main` (`0L` instead of `1000L`) before the fix, confirming they reproduce the bug.
- [x] All 5 new tests pass after the fix.
- [x] Full `com.arcadedb.query.select` package regression suite (115 tests across `Issue6565SelectIndexCandidateLimitTest`, `SelectCompositeIndexTest`, `SelectExecutionTest`, `SelectIndexExecutionTest`, `SelectOperatorsExtendedTest`, `SelectOrderByTest`, `SelectParallelIteratorTest`, `SelectTraversalTest`, `SelectVectorTest`, plus the new test) passes with no regressions.
- [x] `mvn -pl engine -am compile` succeeds cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query results for `OR` conditions involving `neq`, `like`, and `ilike` operators.
  * These queries now correctly evaluate all matching records instead of incorrectly returning incomplete or empty results.
* **Tests**
  * Added regression coverage for indexed string and integer fields, including varied operator and condition ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->