### PR TITLE
test(#6667): regression test for vertex-rename edge-bucket naming

### DIFF
--- a/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
@@ -1,0 +1,54 @@
+package com.arcadedb.schema;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Standalone reproduction of the exact scenario reported in https://github.com/ArcadeData/arcadedb/issues/6667:
+ * a vertex type rename must not corrupt the type's edge-chunk bucket names, or an edge insert on the renamed
+ * type afterward fails with SchemaException. Kept separate from {@link TypeRenameComponentNamingTest} because it
+ * mirrors the issue's own reproducer verbatim.
+ */
+class Issue6667ReproTest {
+  private static final String DB_PATH = "target/databases/issue6667repro";
+
+  @AfterEach
+  void cleanup() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void renamedVertexTypeCanStillInsertEdges() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    try (DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
+      try (Database db = factory.create()) {
+        db.getSchema().createVertexType("Person");
+        db.getSchema().createEdgeType("Knows");
+
+        db.transaction(() -> {
+          MutableVertex v1 = db.newVertex("Person").set("uid", "a").save();
+          MutableVertex v2 = db.newVertex("Person").set("uid", "b").save();
+          v1.newEdge("Knows", v2).save();
+        });
+
+        db.getSchema().getType("Person").rename("Human");
+
+        db.transaction(() -> {
+          MutableVertex v3 = db.newVertex("Human").set("uid", "c").save();
+          MutableVertex v4 = db.newVertex("Human").set("uid", "d").save();
+          v3.newEdge("Knows", v4).save();
+        });
+
+        assertThat(db.countType("Human", true)).isEqualTo(4L);
+      }
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6667ReproTest.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.arcadedb.schema;
 
-import com.arcadedb.database.Database;
+import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
-import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,40 +29,51 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Standalone reproduction of the exact scenario reported in https://github.com/ArcadeData/arcadedb/issues/6667:
  * a vertex type rename must not corrupt the type's edge-chunk bucket names, or an edge insert on the renamed
  * type afterward fails with SchemaException. Kept separate from {@link TypeRenameComponentNamingTest} because it
- * mirrors the issue's own reproducer verbatim.
+ * mirrors the issue's own reproducer verbatim, including the restart step the issue's suggested fix #4 calls
+ * out ("insert an edge, restart, insert another edge, and assert the bucket names follow the convention").
+ * <p>
+ * Extends {@link TestHelper} so {@code afterTest()} runs {@code CHECK DATABASE} on teardown: the failure mode
+ * this test guards against is bucket/file corruption, which a cached record count would not necessarily surface.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class Issue6667ReproTest {
-  private static final String DB_PATH = "target/databases/issue6667repro";
-
-  @AfterEach
-  void cleanup() {
-    FileUtils.deleteRecursively(new File(DB_PATH));
-  }
+class Issue6667ReproTest extends TestHelper {
 
   @Test
   void renamedVertexTypeCanStillInsertEdges() {
-    FileUtils.deleteRecursively(new File(DB_PATH));
-    try (DatabaseFactory factory = new DatabaseFactory(DB_PATH)) {
-      try (Database db = factory.create()) {
-        db.getSchema().createVertexType("Person");
-        db.getSchema().createEdgeType("Knows");
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("Knows");
 
-        db.transaction(() -> {
-          MutableVertex v1 = db.newVertex("Person").set("uid", "a").save();
-          MutableVertex v2 = db.newVertex("Person").set("uid", "b").save();
-          v1.newEdge("Knows", v2).save();
-        });
+    database.transaction(() -> {
+      final MutableVertex v1 = database.newVertex("Person").set("uid", "a").save();
+      final MutableVertex v2 = database.newVertex("Person").set("uid", "b").save();
+      v1.newEdge("Knows", v2).save();
+    });
 
-        db.getSchema().getType("Person").rename("Human");
+    database.getSchema().getType("Person").rename("Human");
 
-        db.transaction(() -> {
-          MutableVertex v3 = db.newVertex("Human").set("uid", "c").save();
-          MutableVertex v4 = db.newVertex("Human").set("uid", "d").save();
-          v3.newEdge("Knows", v4).save();
-        });
+    database.transaction(() -> {
+      final MutableVertex v3 = database.newVertex("Human").set("uid", "c").save();
+      final MutableVertex v4 = database.newVertex("Human").set("uid", "d").save();
+      v3.newEdge("Knows", v4).save();
+    });
 
-        assertThat(db.countType("Human", true)).isEqualTo(4L);
-      }
-    }
+    assertThat(database.query("sql", "select from Human").stream().count()).isEqualTo(4L);
+
+    final String databasePath = database.getDatabasePath();
+    database.close();
+    database = new DatabaseFactory(databasePath).open();
+
+    database.transaction(() -> {
+      final MutableVertex v5 = database.newVertex("Human").set("uid", "e").save();
+      final MutableVertex v6 = database.newVertex("Human").set("uid", "f").save();
+      v5.newEdge("Knows", v6).save();
+    });
+
+    assertThat(database.query("sql", "select from Human").stream().count()).isEqualTo(6L);
+
+    final var edgeBuckets = database.getSchema().getType("Human").getInvolvedBuckets().stream()
+        .map(b -> b.getName()).filter(n -> n.endsWith("_out_edges") || n.endsWith("_in_edges")).toList();
+    assertThat(edgeBuckets).containsExactlyInAnyOrder("Human_0_out_edges", "Human_0_in_edges");
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #6667 - already resolved on `main` before this issue was filed; no production code change was needed
- The reported bug (vertex-type rename corrupts `_out_edges`/`_in_edges` chunk bucket names and files, breaking every edge insert on the renamed type) was real against `26.7.2`/`26.8.1`, but was already fixed by #6099 (deterministic component file-name derivation in `PaginatedComponentFile`) and #6206 (bucket-name rebasing via `LocalSchema.rebaseComponentName()` in `LocalVertexType.rename()`), both merged after the `26.8.1` tag
- Adds `Issue6667ReproTest`, which mirrors the issue's own reproducer verbatim (rename `Person` -> `Human`, insert an edge on the renamed type) for direct traceability, on top of the existing broad coverage in `TypeRenameComponentNamingTest`

## Test plan
- [x] `Issue6667ReproTest#renamedVertexTypeCanStillInsertEdges` passes on `main`
- [x] `TypeRenameComponentNamingTest` (existing coverage, including underscore-containing type names and vertex/edge bucket renaming) passes on `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for renaming a vertex type and creating related edges before and after a database restart.
  * Verifies that six renamed vertices remain queryable after subsequent updates.
  * Confirms that newly created edges use the expected bucket names.
  * Added consistent database setup and cleanup handling for reliable test execution.
  * Included licensing and explanatory documentation for the regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->