### PR TITLE
fix(#6575): refuse an index cursor for a leaf directly under NOT

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectExecutor.java
@@ -571,6 +571,16 @@ public class SelectExecutor {
     if (!CURSOR_BUILDABLE_OPERATORS.contains(node.operator))
       return;
 
+    if (node.getParent().operator == SelectOperator.not)
+      // #6575: A LEAF DIRECTLY UNDER not WOULD OTHERWISE BUILD A "POSITIVE" CURSOR FOR THE UN-NEGATED CONDITION
+      // (E.G. AN eq CURSOR FOR NOT a = 'x' YIELDS THE RECORDS WHERE a = 'x' IS TRUE) - evaluateWhere() THEN
+      // REJECTS EVERY ONE OF THOSE CANDIDATES SINCE THEY ALL SATISFY THE POSITIVE CONDITION BY CONSTRUCTION, SO
+      // THE QUERY WOULD SILENTLY RETURN ZERO ROWS INSTEAD OF "EVERY RECORD WHERE a != 'x'". isTheNodeFullyIndexed()
+      // STILL SETS node.index HERE (SEE ITS not BRANCH), SO REFUSE THE CURSOR HERE INSTEAD, THE SAME WAY
+      // is_null/is_not_null LEAVES ARE ALREADY EXCLUDED THERE. NEITHER A FLUENT .not() NOR Select.json() REACH THIS
+      // TODAY, BUT THE DEFENSIVE POSTURE MUST HOLD THE MOMENT EITHER PATH OPENS UP.
+      return;
+
     if (node.getParent().operator == SelectOperator.or) {
       // UNDER AN 'OR' OPERATOR: BOTH SIDES MUST BE INDEXED, OTHERWISE CANNOT USE INDEXES
       if (node != node.getParent().right) {

--- a/engine/src/test/java/com/arcadedb/query/select/SelectNotWrappedIndexedLeafTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectNotWrappedIndexedLeafTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.select;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.MultiIndexCursor;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * https://github.com/ArcadeData/arcadedb/issues/6575
+ * <p>
+ * {@code SelectOperator.not} has no fluent entry point on the {@code Select} builder today (no {@code .not()} method
+ * exists on {@code SelectWhereLeftBlock}/{@code SelectWhereOperatorBlock}/etc.), so the where-tree in these tests is
+ * built by hand, the same technique already used by
+ * {@code Issue6565SelectIndexCandidateLimitTest#notLeafIsNeverTreatedAsExactlyIndexed} and
+ * {@code SelectCompositeIndexTest#compositeIndexNotUsedWithNotInTheConjunction} - neither of which happens to cover
+ * this defect: the first only asserts the candidate cap stays {@code -1}, and the second returns a {@code null}
+ * cursor only because neither of its two properties has a standalone index, not because the code excludes a leaf
+ * under {@code not}.
+ * <p>
+ * {@code isTheNodeFullyIndexed()} walks through a {@code not} node the same way it walks through {@code and}/{@code
+ * or}, setting {@code node.index} on the leaf underneath exactly as it would for a plain, un-negated leaf.
+ * {@code filterWithIndexesFinalNode()} then had no special case for a {@code not} parent (only {@code or} and
+ * {@code and} are handled), so for a where-tree shaped {@code NOT (a = 'x')} against a standalone index on
+ * {@code a}, it built {@code node.index.get(new Object[]{"x"})} - a cursor of the records where {@code a = 'x'}
+ * <b>is</b> true, the exact opposite of what {@code NOT (a = 'x')} should select. {@code evaluateWhere()} would then
+ * reject every one of those candidates (they all satisfy the positive condition by construction), so the query
+ * silently returned zero rows instead of "every record where {@code a != 'x'}".
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SelectNotWrappedIndexedLeafTest extends TestHelper {
+
+  public SelectNotWrappedIndexedLeafTest() {
+    autoStartTx = true;
+  }
+
+  @Override
+  protected void beginTest() {
+    final var t = database.getSchema().createDocumentType("T");
+    t.createProperty("a", Type.STRING);
+    t.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "a");
+
+    database.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        final var d = database.newDocument("T");
+        d.set("a", i == 0 ? "x" : "y");
+        d.save();
+      }
+    });
+  }
+
+  @Test
+  void notWrappedIndexedEqLeafBuildsNoCursor() {
+    // NOT (a = 'x'): 'a' HAS A STANDALONE INDEX, SO isTheNodeFullyIndexed() SETS node.index ON THE LEAF EXACTLY AS
+    // IT WOULD FOR A PLAIN 'a = x'. filterWithIndexesFinalNode() MUST REFUSE TO BUILD A CURSOR FOR IT ANYWAY, SINCE
+    // A CURSOR HERE WOULD YIELD THE RECORDS WHERE a = 'x' IS TRUE - THE OPPOSITE OF WHAT NOT (a = 'x') SELECTS.
+    final Select select = database.select().fromType("T");
+    final SelectTreeNode eqLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "x");
+    select.rootTreeElement = new SelectTreeNode(eqLeaf, SelectOperator.not, null);
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      // A null CURSOR MEANS execute() FALLS BACK TO A FULL TYPE SCAN, WHICH IS THE ONLY SAFE OPTION HERE - A CAP
+      // WOULD REQUIRE THE (WRONG) POSITIVE CURSOR THIS TEST EXISTS TO REJECT.
+      assertThat((Object) cursor).isNull();
+      assertThat(executor.metrics().get("usedIndexes")).isEqualTo(0);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+
+  @Test
+  void notWrappedIndexedLeafUnderAndStillBuildsNoCursorForTheNegatedSide() {
+    // NOT (a = 'x') AND a = 'y': THE and's LEFT CHILD IS A not NODE, NOT A BARE LEAF - filterWithIndexes() RECURSES
+    // THROUGH IT AND filterWithIndexesFinalNode() MUST STILL REFUSE THE CURSOR FOR THE LEAF UNDERNEATH, WHILE THE
+    // RIGHT (UN-NEGATED) LEAF IS FREE TO GET ITS OWN CURSOR AS USUAL.
+    final Select select = database.select().fromType("T");
+    final SelectTreeNode notEqXLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "x");
+    final SelectTreeNode notEqX = new SelectTreeNode(notEqXLeaf, SelectOperator.not, null);
+    final SelectTreeNode eqYLeaf = new SelectTreeNode(new SelectPropertyValue("a"), SelectOperator.eq, "y");
+    select.rootTreeElement = new SelectTreeNode(notEqX, SelectOperator.and, eqYLeaf);
+
+    final SelectExecutor executor = new SelectExecutor(select);
+    final MultiIndexCursor cursor = executor.lookForIndexes();
+    try {
+      // ONLY THE RIGHT (UN-NEGATED) LEAF CONTRIBUTED A CURSOR
+      assertThat(executor.metrics().get("usedIndexes")).isEqualTo(1);
+    } finally {
+      if (cursor != null)
+        cursor.close();
+    }
+  }
+}


### PR DESCRIPTION
Closes #6575

## Summary

`SelectExecutor.filterWithIndexesFinalNode()` had no special case for a `not` parent operator (only `or` and `and` were handled). `isTheNodeFullyIndexed()` still sets `node.index` on a leaf under `not` exactly as it would for a plain, un-negated leaf, so `filterWithIndexesFinalNode()` would build a "positive" cursor for the un-negated condition - e.g. an `eq` cursor for `NOT (a = 'x')` yields the records where `a = 'x'` **is** true, the exact opposite of what `NOT (a = 'x')` should select. `evaluateWhere()` then rejects every one of those candidates since they all satisfy the positive condition by construction, so the query would silently return zero rows instead of "every record where `a != 'x'`".

`SelectOperator.not` has no fluent entry point on the `Select` builder today (no `.not()` method on `SelectWhereLeftBlock`/`SelectWhereOperatorBlock`/etc.), and `Select.json()` - the only other path that can reach `setLogic(SelectOperator.not)` via its `parseJsonCondition()` - is only ever called from test code, not from any HTTP handler or wire-protocol module. So this defect is not reachable by any real client today. It was spotted during code review on #6571 and filed proactively so it would not be forgotten once either path (a future `.not()` builder method, or `Select.json()` being wired into a handler that accepts client-supplied condition JSON) opens up.

The fix applies the "simplest" of the two remediations the issue proposed: refuse to build a cursor for a leaf whose parent operator is `not`, the same way `is_null`/`is_not_null` leaves are already excluded in `isTheNodeFullyIndexed()`. Since `not` is not reachable today, falling back to a full-table scan is not a real-world performance regression.

### Related but out of scope

While tracing this, `SelectOperator.not.eval()` itself looks separately broken - unlike `and`/`or`, it never evaluates its child subtree (`SelectExecutor.evaluateValue(record, left)`); it compares the raw, unevaluated `left` field (typically a `SelectTreeNode` instance) against `Boolean.FALSE` by reference, which is essentially always `false`. This is a pre-existing, separate defect independent of the index-cursor layer this PR fixes, and is left for a follow-up issue before any future work adds a fluent `.not()` entry point.

## Test plan

- [x] New regression test `SelectNotWrappedIndexedLeafTest` (in `engine/src/test/java/com/arcadedb/query/select/`), built by hand the same way the two adjacent existing hand-built-tree tests already do (there is no fluent `.not()` yet):
  - `notWrappedIndexedEqLeafBuildsNoCursor` - `NOT (a = 'x')` against a standalone index on `a` must not produce a cursor (`lookForIndexes()` returns `null`, `usedIndexes == 0`). Fails before the fix (a non-null cursor was returned).
  - `notWrappedIndexedLeafUnderAndStillBuildsNoCursorForTheNegatedSide` - `NOT (a = 'x') AND a = 'y'` must only use the un-negated side's cursor (`usedIndexes == 1`). Fails before the fix (`usedIndexes == 2`).
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.query.select.*Test'` - all green, including the pre-existing `Issue6565SelectIndexCandidateLimitTest.notLeafIsNeverTreatedAsExactlyIndexed` and `SelectCompositeIndexTest.compositeIndexNotUsedWithNotInTheConjunction`, which construct adjacent `not` trees but did not cover this defect.
- [x] `mvn -pl engine -am test -Dtest='com.arcadedb.query.sql.executor.SelectStatementExecutionTest,com.arcadedb.query.sql.executor.SelectIndexRangeWithDeletesTest'` - all green (no regression in the SQL executor's own index-selection path).
- [x] `mvn -pl engine -am compile` - clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved indexed query handling for unsupported operators and negated conditions.
  - Ensured queries fall back to scanning when an index cannot be used safely.
  - Prevented unnecessary counting when a query limit is zero or already reached.

- **Tests**
  - Added coverage for negated indexed conditions and mixed indexed/non-indexed queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->