### PR TITLE
fix(#6678,#6677,#6672): volatile polymorphic bucket cache; unchecked Number casts; Double.MIN_VALUE max seed

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/agg/AggMaxItems.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggMaxItems.java
@@ -66,7 +66,7 @@ public class AggMaxItems extends AbstractAggFunction {
       return result;
     }
 
-    double maxValue = Double.MIN_VALUE;
+    double maxValue = Double.NEGATIVE_INFINITY; // NOT Double.MIN_VALUE, which is the smallest POSITIVE double (issue #6672)
     final List<Object> maxItems = new ArrayList<>();
 
     for (int i = 0; i < values.size(); i++) {

--- a/engine/src/main/java/com/arcadedb/function/agg/AggNth.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggNth.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.agg;
 
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.List;
@@ -54,7 +55,7 @@ public class AggNth extends AbstractAggFunction {
       return null;
 
     final List<Object> list = toObjectList(args[0]);
-    final int index = ((Number) args[1]).intValue();
+    final int index = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
 
     if (index < 0 || index >= list.size())
       return null;

--- a/engine/src/main/java/com/arcadedb/function/agg/AggSlice.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggSlice.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.agg;
 
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.Collections;
@@ -55,8 +56,9 @@ public class AggSlice extends AbstractAggFunction {
       return null;
 
     final List<Object> list = toObjectList(args[0]);
-    final int from = args[1] != null ? ((Number) args[1]).intValue() : 0;
-    final int to = args.length > 2 && args[2] != null ? ((Number) args[2]).intValue() : list.size();
+    final int from = args[1] != null ? CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue() : 0;
+    final int to = args.length > 2 && args[2] != null ?
+        CypherFunctionHelper.requireNumberArgument(args[2], getName()).intValue() : list.size();
 
     if (from >= list.size() || from >= to)
       return Collections.emptyList();

--- a/engine/src/main/java/com/arcadedb/function/agg/AggStatistics.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/AggStatistics.java
@@ -70,7 +70,7 @@ public class AggStatistics extends AbstractAggFunction {
     final long count = values.size();
     double sum = 0.0;
     double min = Double.MAX_VALUE;
-    double max = Double.MIN_VALUE;
+    double max = Double.NEGATIVE_INFINITY; // NOT Double.MIN_VALUE, which is the smallest POSITIVE double (issue #6672)
 
     for (final Double value : values) {
       sum += value;

--- a/engine/src/main/java/com/arcadedb/function/agg/PercentileContFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/PercentileContFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.agg;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class PercentileContFunction implements StatelessFunction {
     if (percentile < 0) {
       if (args[1] == null)
         throw new CommandExecutionException("percentileCont() percentile argument must not be null");
-      percentile = ((Number) args[1]).doubleValue();
+      percentile = CypherFunctionHelper.requireNumberArgument(args[1], getName()).doubleValue();
       if (percentile < 0.0 || percentile > 1.0)
         throw new CommandExecutionException("NumberOutOfRange: percentile must be between 0.0 and 1.0, got: " + percentile);
     }

--- a/engine/src/main/java/com/arcadedb/function/agg/PercentileDiscFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/agg/PercentileDiscFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.agg;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class PercentileDiscFunction implements StatelessFunction {
     if (percentile < 0) {
       if (args[1] == null)
         throw new CommandExecutionException("percentileDisc() percentile argument must not be null");
-      percentile = ((Number) args[1]).doubleValue();
+      percentile = CypherFunctionHelper.requireNumberArgument(args[1], getName()).doubleValue();
       if (percentile < 0.0 || percentile > 1.0)
         throw new CommandExecutionException("NumberOutOfRange: percentile must be between 0.0 and 1.0, got: " + percentile);
     }

--- a/engine/src/main/java/com/arcadedb/function/vector/VectorCreateFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/vector/VectorCreateFunction.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.vector;
 
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.cypher.CypherFunctionHelper;
 import com.arcadedb.index.vector.VectorUtils;
 import com.arcadedb.query.sql.executor.CommandContext;
 
@@ -59,7 +60,7 @@ public class VectorCreateFunction implements StatelessFunction {
 
     // Validate dimension if provided
     if (args.length >= 2 && args[1] != null) {
-      final int expectedDimension = ((Number) args[1]).intValue();
+      final int expectedDimension = CypherFunctionHelper.requireNumberArgument(args[1], getName()).intValue();
       if (result.length != expectedDimension)
         throw new CommandExecutionException(
             "Vector dimension mismatch: expected " + expectedDimension + " but got " + result.length);

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -66,9 +66,12 @@ public class LocalDocumentType implements DocumentType {
   protected final RecordEventsRegistry              events                       = new RecordEventsRegistry();
   protected final Map<String, Object>               custom                       = new HashMap<>();
   protected       List<Bucket>                      buckets                      = new ArrayList<>();
-  protected       List<Bucket>                      cachedPolymorphicBuckets     = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
+  // Copy-on-write reassigned under schema mutation and read lock-free by query planning (getBuckets(true)/
+  // getBucketIds(true)): volatile so a planning thread has a happens-before edge against a concurrent
+  // ALTER TYPE ... BUCKET, matching the LocalSchema.bucketId2TypeMap publication pattern (issue #6678).
+  protected volatile List<Bucket>                   cachedPolymorphicBuckets     = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
   protected       List<Integer>                     bucketIds                    = new ArrayList<>();
-  protected       List<Integer>                     cachedPolymorphicBucketIds   = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
+  protected volatile List<Integer>                  cachedPolymorphicBucketIds   = new ArrayList<>(); // PRE COMPILED LIST TO SPEED UP RUN-TIME OPERATIONS
   protected       BucketSelectionStrategy           bucketSelectionStrategy      = new RoundRobinBucketSelectionStrategy();
   protected       Set<String>                       propertiesWithDefaultDefined = Collections.emptySet();
   // Map: primary bucket id -> external bucket id. Populated lazily when the first EXTERNAL property is

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -825,6 +825,22 @@ class CypherBuiltInFunctionsTest extends TestHelper {
   }
 
   @Test
+  void aggSliceDefaultsFromToZeroWhenNull() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.slice");
+    @SuppressWarnings("unchecked")
+    final List<Object> result = (List<Object>) fn.execute(new Object[] { List.of(1, 2, 3, 4, 5), null, 3 }, null);
+    assertThat(result).isEqualTo(List.of(1, 2, 3));
+  }
+
+  @Test
+  void aggSliceDefaultsToToListSizeWhenOmitted() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.slice");
+    @SuppressWarnings("unchecked")
+    final List<Object> result = (List<Object>) fn.execute(new Object[] { List.of(1, 2, 3, 4, 5), 2 }, null);
+    assertThat(result).isEqualTo(List.of(3, 4, 5));
+  }
+
+  @Test
   void aggMedian() {
     final StatelessFunction fn = CypherFunctionRegistry.get("agg.median");
     // Odd number of elements

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -25,8 +25,11 @@ import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.function.Function;
 import com.arcadedb.function.FunctionRegistry;
 import com.arcadedb.function.StatelessFunction;
+import com.arcadedb.function.agg.PercentileContFunction;
+import com.arcadedb.function.agg.PercentileDiscFunction;
 import com.arcadedb.function.procedure.Procedure;
 import com.arcadedb.function.procedure.ProcedureRegistry;
+import com.arcadedb.function.vector.VectorCreateFunction;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.function.CypherFunctionRegistry;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
@@ -884,6 +887,96 @@ class CypherBuiltInFunctionsTest extends TestHelper {
     @SuppressWarnings("unchecked")
     final List<Object> items = (List<Object>) result.get("items");
     assertThat(items).hasSize(2).contains("c", "e");
+  }
+
+  // Issue #6672: agg.statistics()/agg.maxItems() seeded their running max with Double.MIN_VALUE, the smallest
+  // POSITIVE double (~4.9E-324), not the most-negative double. For a dataset whose true maximum is <= 0 the seed
+  // was never beaten, so agg.statistics() reported a bogus tiny-positive max and agg.maxItems() returned a bogus
+  // value with an empty items list.
+  @Test
+  void aggStatisticsMaxOfAllNegativeValuesIsTheActualMaximum() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.statistics");
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { List.of(-5.0, -3.0, -1.0) }, null);
+
+    assertThat(result.get("max")).isEqualTo(-1.0);
+    assertThat(result.get("min")).isEqualTo(-5.0);
+  }
+
+  @Test
+  void aggStatisticsMaxOfAllZeroValuesIsZero() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.statistics");
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { List.of(0.0, 0.0, 0.0) }, null);
+
+    assertThat(result.get("max")).isEqualTo(0.0);
+  }
+
+  @Test
+  void aggMaxItemsOfAllNegativeValuesReturnsTheActualMaximumAndItsItems() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.maxItems");
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(
+        new Object[] { List.of(-5.0, -3.0, -1.0), List.of("a", "b", "c") }, null);
+
+    assertThat(result.get("value")).isEqualTo(-1.0);
+    @SuppressWarnings("unchecked")
+    final List<Object> items = (List<Object>) result.get("items");
+    assertThat(items).containsExactly("c");
+  }
+
+  // Issue #6677: several functions cast a positional argument to (Number) with no type check, so a non-numeric
+  // argument threw a raw ClassCastException (HTTP 500) instead of a clean client type error. Fixed by routing
+  // through CypherFunctionHelper.requireNumberArgument(), the same mechanism #6609 introduced for left/right/substring.
+  // (RangeFunction, also named in #6677, already validated its arguments before this issue was filed - see #5909 -
+  // so it is not part of this fix.)
+  @Test
+  void aggNthOfNonNumericIndexIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.nth");
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of("a", "b", "c"), List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("agg.nth()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void aggSliceOfNonNumericBoundIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("agg.slice");
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of(1, 2, 3), "not-a-number", 2 }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("agg.slice()")
+        .hasMessageContaining("STRING");
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of(1, 2, 3), 0, "not-a-number" }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("agg.slice()")
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  void percentileContOfNonNumericPercentileIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = new PercentileContFunction();
+    assertThatThrownBy(() -> fn.execute(new Object[] { 3.0, List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("percentileCont()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void percentileDiscOfNonNumericPercentileIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = new PercentileDiscFunction();
+    assertThatThrownBy(() -> fn.execute(new Object[] { 3.0, List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("percentileDisc()")
+        .hasMessageContaining("LIST");
+  }
+
+  @Test
+  void vectorCreateOfNonNumericDimensionIsAClientTypeErrorNotAClassCastException() {
+    final StatelessFunction fn = new VectorCreateFunction();
+    assertThatThrownBy(() -> fn.execute(new Object[] { List.of(1.0, 2.0), List.of() }, null))
+        .isInstanceOf(CommandSemanticException.class)
+        .hasMessageContaining("vector_create()")
+        .hasMessageContaining("LIST");
   }
 
   // ===================== NODE FUNCTION TESTS =====================

--- a/engine/src/test/java/com/arcadedb/schema/Issue6678PolymorphicBucketCacheVisibilityTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/Issue6678PolymorphicBucketCacheVisibilityTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.Bucket;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #6678: {@code LocalDocumentType.cachedPolymorphicBuckets}/{@code cachedPolymorphicBucketIds} are published
+ * by copy-on-write reassignment ({@code addBucketInternal}, {@code removeBucket}, {@code updatePolymorphicBucketsCache})
+ * but read lock-free on the query-planning hot path ({@code getBuckets(true)}/{@code getBucketIds(true)}). A plain
+ * (non-{@code volatile}) field gives the Java Memory Model no happens-before edge between a schema-mutation thread's
+ * reassignment and a planning thread's read, so the planner is not guaranteed to ever observe a concurrent
+ * {@code ALTER TYPE ... BUCKET} - the same publication gap the sibling {@code LocalSchema.bucketId2TypeMap} pattern
+ * exists to avoid.
+ * <p>
+ * The fix makes both fields {@code volatile}. The first test pins the fix itself, so a future edit cannot silently
+ * drop the modifier. The second is a functional regression for the concrete scenario: adding/removing a bucket
+ * must be reflected by {@code getBuckets(true)}/{@code getBucketIds(true)} immediately afterward.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue6678PolymorphicBucketCacheVisibilityTest extends TestHelper {
+
+  @Test
+  void cachedPolymorphicFieldsMustBeVolatileForCrossThreadPlanningReads() throws NoSuchFieldException {
+    final Field buckets = LocalDocumentType.class.getDeclaredField("cachedPolymorphicBuckets");
+    final Field bucketIds = LocalDocumentType.class.getDeclaredField("cachedPolymorphicBucketIds");
+
+    assertThat(Modifier.isVolatile(buckets.getModifiers()))
+        .as("cachedPolymorphicBuckets is copy-on-write reassigned under schema mutation and read lock-free by "
+            + "query planning - it must be volatile so planning threads have a happens-before edge against the "
+            + "writer (issue #6678)")
+        .isTrue();
+    assertThat(Modifier.isVolatile(bucketIds.getModifiers()))
+        .as("cachedPolymorphicBucketIds is copy-on-write reassigned under schema mutation and read lock-free by "
+            + "query planning - it must be volatile so planning threads have a happens-before edge against the "
+            + "writer (issue #6678)")
+        .isTrue();
+  }
+
+  @Test
+  void addingThenRemovingABucketIsReflectedByThePolymorphicCache() {
+    database.transaction(() -> database.getSchema().createDocumentType("Product", 1));
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().getType("Product");
+      final int before = type.getBuckets(true).size();
+
+      final Bucket newBucket = database.getSchema().createBucket("Product_extra");
+      type.addBucket(newBucket);
+
+      assertThat(type.getBuckets(true)).hasSize(before + 1).contains(newBucket);
+      assertThat(type.getBucketIds(true)).contains(newBucket.getFileId());
+
+      type.removeBucket(newBucket);
+
+      assertThat(type.getBuckets(true)).hasSize(before).doesNotContain(newBucket);
+      assertThat(type.getBucketIds(true)).doesNotContain(newBucket.getFileId());
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Three simple, independently-verified fixes.

### #6678 - `LocalDocumentType.cachedPolymorphicBuckets`/`cachedPolymorphicBucketIds` are non-volatile
Both fields are copy-on-write reassigned by `addBucketInternal`/`removeBucket`/`updatePolymorphicBucketsCache` under schema mutation, but read lock-free on the query-planning hot path (`getBuckets(true)`/`getBucketIds(true)`). A plain field gives the JMM no happens-before edge between a schema-mutation thread and a planning thread, so a planner is not guaranteed to observe a concurrent `ALTER TYPE ... BUCKET` - the same publication gap the sibling `LocalSchema.bucketId2TypeMap` pattern exists to avoid. Fixed by marking both fields `volatile`.

### #6677 - unchecked `(Number)` casts leak `ClassCastException` as HTTP 500
`agg.nth`, `agg.slice`, `percentileCont`, `percentileDisc` and `vector_create` cast a positional argument to `(Number)` with no type check, so a non-numeric argument (e.g. `agg.nth(list, [])`) threw a raw `ClassCastException` instead of a clean client type error. Routed through `CypherFunctionHelper.requireNumberArgument()`, the same mechanism #6609 introduced for `left`/`right`/`substring`.

`RangeFunction`, also named in the issue, was **not** changed: it already validates every argument before casting (fixed by #5909, an ancestor of the commit the issue cites as HEAD), so `range([1], 3)` already raises a clean `CommandSemanticException` today. That part of the issue was stale.

### #6672 - `agg.statistics`/`agg.maxItems` seed their max with `Double.MIN_VALUE`
`Double.MIN_VALUE` is the smallest **positive** double (~4.9E-324), not the most-negative double. For any dataset whose true maximum is `<= 0`, the seed is never beaten, so `agg.statistics()` reports a bogus tiny-positive max and `agg.maxItems()` returns a bogus value with an **empty** items list. Seeded with `Double.NEGATIVE_INFINITY` instead, matching the correct pattern already used by the sibling `AggMinItems` (which seeds `Double.MAX_VALUE`).

## Test plan
- [x] `Issue6678PolymorphicBucketCacheVisibilityTest`: reflection test pins the `volatile` modifier + functional regression that add/remove-bucket is reflected in the polymorphic cache
- [x] `CypherBuiltInFunctionsTest`: new tests for all three issues (type-error assertions for the five cast sites, correct max/items for negative-only and all-zero datasets)
- [x] Full `engine` module test suite for `com.arcadedb.schema.**`, `com.arcadedb.function.**` and the relevant OpenCypher function suites: 1826/1826 passing, 0 failures
- [x] `mvn -o -pl engine -am compile`: clean

## Notes
- Each issue was independently verified against the actual HEAD source before fixing (see PR description above) - not applied blindly from the issue report.
- Neo4j comparison: `percentileCont`/`percentileDisc` are standard OpenCypher aggregating functions; Neo4j answers a client type error for a non-numeric percentile argument (`Neo.ClientError.Statement.TypeError`), matching this fix's behavior. `agg.*` and `vector_create` are ArcadeDB-specific extensions with no Neo4j equivalent to compare against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected maximum calculations for aggregate functions when all values are negative or zero.
  * Improved validation and error handling for numeric arguments in aggregate, percentile, and vector functions.
  * Preserved expected slice behavior when boundaries are omitted or null.
  * Ensured polymorphic bucket changes are reflected reliably during concurrent query planning.
* **Tests**
  * Added regression coverage for negative-value aggregates, slice boundaries, invalid function arguments, and polymorphic bucket cache visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->